### PR TITLE
Add basic support for physical implement items for Thaumaturge

### DIFF
--- a/packs/classfeatures/amulet.json
+++ b/packs/classfeatures/amulet.json
@@ -28,6 +28,71 @@
             {
                 "key": "GrantItem",
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Amulet's Abeyance"
+            },
+            {
+                "adjustName": false,
+                "choices": [
+                    {
+                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Grant",
+                        "value": "granted"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Pick",
+                        "value": "picked"
+                    }
+                ],
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Prompt",
+                "rollOption": "amulet-implement-origin"
+            },
+            {
+                "adjustName": false,
+                "choices": {
+                    "ownedItems": true,
+                    "types": [
+                        "equipment"
+                    ]
+                },
+                "flag": "implement",
+                "key": "ChoiceSet",
+                "predicate": [
+                    "amulet-implement-origin:picked"
+                ],
+                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.InventoryPrompt"
+            },
+            {
+                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "amulet-implement-origin:picked"
+                ],
+                "property": "other-tags",
+                "value": "implement:amulet"
+            },
+            {
+                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
+                "key": "ItemAlteration",
+                "mode": "override",
+                "predicate": [
+                    "amulet-implement-origin:picked"
+                ],
+                "property": "rarity",
+                "value": "unique"
+            },
+            {
+                "alterations": [
+                    {
+                        "mode": "add",
+                        "property": "other-tags",
+                        "value": "implement:amulet"
+                    }
+                ],
+                "key": "GrantItem",
+                "predicate": [
+                    "amulet-implement-origin:granted"
+                ],
+                "uuid": "Compendium.pf2e.equipment-srd.Item.Amulet Implement"
             }
         ],
         "traits": {

--- a/packs/classfeatures/amulet.json
+++ b/packs/classfeatures/amulet.json
@@ -30,68 +30,8 @@
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Amulet's Abeyance"
             },
             {
-                "adjustName": false,
-                "choices": [
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Grant",
-                        "value": "granted"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Pick",
-                        "value": "picked"
-                    }
-                ],
-                "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Prompt",
-                "rollOption": "amulet-implement-origin"
-            },
-            {
-                "adjustName": false,
-                "choices": {
-                    "ownedItems": true,
-                    "types": [
-                        "equipment"
-                    ]
-                },
-                "flag": "implement",
-                "key": "ChoiceSet",
-                "predicate": [
-                    "amulet-implement-origin:picked"
-                ],
-                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.InventoryPrompt"
-            },
-            {
-                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
-                "key": "ItemAlteration",
-                "mode": "add",
-                "predicate": [
-                    "amulet-implement-origin:picked"
-                ],
-                "property": "other-tags",
-                "value": "implement:amulet"
-            },
-            {
-                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
-                "key": "ItemAlteration",
-                "mode": "override",
-                "predicate": [
-                    "amulet-implement-origin:picked"
-                ],
-                "property": "rarity",
-                "value": "unique"
-            },
-            {
-                "alterations": [
-                    {
-                        "mode": "add",
-                        "property": "other-tags",
-                        "value": "implement:amulet"
-                    }
-                ],
+                "allowDuplicate": false,
                 "key": "GrantItem",
-                "predicate": [
-                    "amulet-implement-origin:granted"
-                ],
                 "uuid": "Compendium.pf2e.equipment-srd.Item.Amulet Implement"
             }
         ],

--- a/packs/classfeatures/bell.json
+++ b/packs/classfeatures/bell.json
@@ -28,6 +28,71 @@
             {
                 "key": "GrantItem",
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Ring Bell"
+            },
+            {
+                "adjustName": false,
+                "choices": [
+                    {
+                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Grant",
+                        "value": "granted"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Pick",
+                        "value": "picked"
+                    }
+                ],
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Prompt",
+                "rollOption": "bell-implement-origin"
+            },
+            {
+                "adjustName": false,
+                "choices": {
+                    "ownedItems": true,
+                    "types": [
+                        "equipment"
+                    ]
+                },
+                "flag": "implement",
+                "key": "ChoiceSet",
+                "predicate": [
+                    "bell-implement-origin:picked"
+                ],
+                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.InventoryPrompt"
+            },
+            {
+                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "bell-implement-origin:picked"
+                ],
+                "property": "other-tags",
+                "value": "implement:bell"
+            },
+            {
+                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
+                "key": "ItemAlteration",
+                "mode": "override",
+                "predicate": [
+                    "bell-implement-origin:picked"
+                ],
+                "property": "rarity",
+                "value": "unique"
+            },
+            {
+                "alterations": [
+                    {
+                        "mode": "add",
+                        "property": "other-tags",
+                        "value": "implement:bell"
+                    }
+                ],
+                "key": "GrantItem",
+                "predicate": [
+                    "bell-implement-origin:granted"
+                ],
+                "uuid": "Compendium.pf2e.equipment-srd.Item.Bell Implement"
             }
         ],
         "traits": {

--- a/packs/classfeatures/bell.json
+++ b/packs/classfeatures/bell.json
@@ -30,68 +30,8 @@
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Ring Bell"
             },
             {
-                "adjustName": false,
-                "choices": [
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Grant",
-                        "value": "granted"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Pick",
-                        "value": "picked"
-                    }
-                ],
-                "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Prompt",
-                "rollOption": "bell-implement-origin"
-            },
-            {
-                "adjustName": false,
-                "choices": {
-                    "ownedItems": true,
-                    "types": [
-                        "equipment"
-                    ]
-                },
-                "flag": "implement",
-                "key": "ChoiceSet",
-                "predicate": [
-                    "bell-implement-origin:picked"
-                ],
-                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.InventoryPrompt"
-            },
-            {
-                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
-                "key": "ItemAlteration",
-                "mode": "add",
-                "predicate": [
-                    "bell-implement-origin:picked"
-                ],
-                "property": "other-tags",
-                "value": "implement:bell"
-            },
-            {
-                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
-                "key": "ItemAlteration",
-                "mode": "override",
-                "predicate": [
-                    "bell-implement-origin:picked"
-                ],
-                "property": "rarity",
-                "value": "unique"
-            },
-            {
-                "alterations": [
-                    {
-                        "mode": "add",
-                        "property": "other-tags",
-                        "value": "implement:bell"
-                    }
-                ],
+                "allowDuplicate": false,
                 "key": "GrantItem",
-                "predicate": [
-                    "bell-implement-origin:granted"
-                ],
                 "uuid": "Compendium.pf2e.equipment-srd.Item.Bell Implement"
             }
         ],

--- a/packs/classfeatures/chalice.json
+++ b/packs/classfeatures/chalice.json
@@ -28,6 +28,71 @@
             {
                 "key": "GrantItem",
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Drink from the Chalice"
+            },
+            {
+                "adjustName": false,
+                "choices": [
+                    {
+                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Grant",
+                        "value": "granted"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Pick",
+                        "value": "picked"
+                    }
+                ],
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Prompt",
+                "rollOption": "chalice-implement-origin"
+            },
+            {
+                "adjustName": false,
+                "choices": {
+                    "ownedItems": true,
+                    "types": [
+                        "equipment"
+                    ]
+                },
+                "flag": "implement",
+                "key": "ChoiceSet",
+                "predicate": [
+                    "chalice-implement-origin:picked"
+                ],
+                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.InventoryPrompt"
+            },
+            {
+                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "chalice-implement-origin:picked"
+                ],
+                "property": "other-tags",
+                "value": "implement:chalice"
+            },
+            {
+                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
+                "key": "ItemAlteration",
+                "mode": "override",
+                "predicate": [
+                    "chalice-implement-origin:picked"
+                ],
+                "property": "rarity",
+                "value": "unique"
+            },
+            {
+                "alterations": [
+                    {
+                        "mode": "add",
+                        "property": "other-tags",
+                        "value": "implement:chalice"
+                    }
+                ],
+                "key": "GrantItem",
+                "predicate": [
+                    "chalice-implement-origin:granted"
+                ],
+                "uuid": "Compendium.pf2e.equipment-srd.Item.Chalice Implement"
             }
         ],
         "traits": {

--- a/packs/classfeatures/chalice.json
+++ b/packs/classfeatures/chalice.json
@@ -30,68 +30,8 @@
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Drink from the Chalice"
             },
             {
-                "adjustName": false,
-                "choices": [
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Grant",
-                        "value": "granted"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Pick",
-                        "value": "picked"
-                    }
-                ],
-                "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Prompt",
-                "rollOption": "chalice-implement-origin"
-            },
-            {
-                "adjustName": false,
-                "choices": {
-                    "ownedItems": true,
-                    "types": [
-                        "equipment"
-                    ]
-                },
-                "flag": "implement",
-                "key": "ChoiceSet",
-                "predicate": [
-                    "chalice-implement-origin:picked"
-                ],
-                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.InventoryPrompt"
-            },
-            {
-                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
-                "key": "ItemAlteration",
-                "mode": "add",
-                "predicate": [
-                    "chalice-implement-origin:picked"
-                ],
-                "property": "other-tags",
-                "value": "implement:chalice"
-            },
-            {
-                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
-                "key": "ItemAlteration",
-                "mode": "override",
-                "predicate": [
-                    "chalice-implement-origin:picked"
-                ],
-                "property": "rarity",
-                "value": "unique"
-            },
-            {
-                "alterations": [
-                    {
-                        "mode": "add",
-                        "property": "other-tags",
-                        "value": "implement:chalice"
-                    }
-                ],
+                "allowDuplicate": false,
                 "key": "GrantItem",
-                "predicate": [
-                    "chalice-implement-origin:granted"
-                ],
                 "uuid": "Compendium.pf2e.equipment-srd.Item.Chalice Implement"
             }
         ],

--- a/packs/classfeatures/lantern.json
+++ b/packs/classfeatures/lantern.json
@@ -24,7 +24,73 @@
             "remaster": false,
             "title": "Pathfinder Dark Archive"
         },
-        "rules": [],
+        "rules": [
+            {
+                "adjustName": false,
+                "choices": [
+                    {
+                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Grant",
+                        "value": "granted"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Pick",
+                        "value": "picked"
+                    }
+                ],
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Prompt",
+                "rollOption": "lantern-implement-origin"
+            },
+            {
+                "adjustName": false,
+                "choices": {
+                    "ownedItems": true,
+                    "types": [
+                        "equipment"
+                    ]
+                },
+                "flag": "implement",
+                "key": "ChoiceSet",
+                "predicate": [
+                    "lantern-implement-origin:picked"
+                ],
+                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.InventoryPrompt"
+            },
+            {
+                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "lantern-implement-origin:picked"
+                ],
+                "property": "other-tags",
+                "value": "implement:lantern"
+            },
+            {
+                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
+                "key": "ItemAlteration",
+                "mode": "override",
+                "predicate": [
+                    "lantern-implement-origin:picked"
+                ],
+                "property": "rarity",
+                "value": "unique"
+            },
+            {
+                "alterations": [
+                    {
+                        "mode": "add",
+                        "property": "other-tags",
+                        "value": "implement:lantern"
+                    }
+                ],
+                "key": "GrantItem",
+                "predicate": [
+                    "lantern-implement-origin:granted"
+                ],
+                "uuid": "Compendium.pf2e.equipment-srd.Item.Lantern Implement"
+            }
+        ],
         "traits": {
             "otherTags": [
                 "thaumaturge-implement"

--- a/packs/classfeatures/lantern.json
+++ b/packs/classfeatures/lantern.json
@@ -26,68 +26,8 @@
         },
         "rules": [
             {
-                "adjustName": false,
-                "choices": [
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Grant",
-                        "value": "granted"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Pick",
-                        "value": "picked"
-                    }
-                ],
-                "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Prompt",
-                "rollOption": "lantern-implement-origin"
-            },
-            {
-                "adjustName": false,
-                "choices": {
-                    "ownedItems": true,
-                    "types": [
-                        "equipment"
-                    ]
-                },
-                "flag": "implement",
-                "key": "ChoiceSet",
-                "predicate": [
-                    "lantern-implement-origin:picked"
-                ],
-                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.InventoryPrompt"
-            },
-            {
-                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
-                "key": "ItemAlteration",
-                "mode": "add",
-                "predicate": [
-                    "lantern-implement-origin:picked"
-                ],
-                "property": "other-tags",
-                "value": "implement:lantern"
-            },
-            {
-                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
-                "key": "ItemAlteration",
-                "mode": "override",
-                "predicate": [
-                    "lantern-implement-origin:picked"
-                ],
-                "property": "rarity",
-                "value": "unique"
-            },
-            {
-                "alterations": [
-                    {
-                        "mode": "add",
-                        "property": "other-tags",
-                        "value": "implement:lantern"
-                    }
-                ],
+                "allowDuplicate": false,
                 "key": "GrantItem",
-                "predicate": [
-                    "lantern-implement-origin:granted"
-                ],
                 "uuid": "Compendium.pf2e.equipment-srd.Item.Lantern Implement"
             }
         ],

--- a/packs/classfeatures/mirror.json
+++ b/packs/classfeatures/mirror.json
@@ -28,6 +28,71 @@
             {
                 "key": "GrantItem",
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Mirror's Reflection"
+            },
+            {
+                "adjustName": false,
+                "choices": [
+                    {
+                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Grant",
+                        "value": "granted"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Pick",
+                        "value": "picked"
+                    }
+                ],
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Prompt",
+                "rollOption": "mirror-implement-origin"
+            },
+            {
+                "adjustName": false,
+                "choices": {
+                    "ownedItems": true,
+                    "types": [
+                        "equipment"
+                    ]
+                },
+                "flag": "implement",
+                "key": "ChoiceSet",
+                "predicate": [
+                    "mirror-implement-origin:picked"
+                ],
+                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.InventoryPrompt"
+            },
+            {
+                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "mirror-implement-origin:picked"
+                ],
+                "property": "other-tags",
+                "value": "implement:mirror"
+            },
+            {
+                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
+                "key": "ItemAlteration",
+                "mode": "override",
+                "predicate": [
+                    "mirror-implement-origin:picked"
+                ],
+                "property": "rarity",
+                "value": "unique"
+            },
+            {
+                "alterations": [
+                    {
+                        "mode": "add",
+                        "property": "other-tags",
+                        "value": "implement:mirror"
+                    }
+                ],
+                "key": "GrantItem",
+                "predicate": [
+                    "mirror-implement-origin:granted"
+                ],
+                "uuid": "Compendium.pf2e.equipment-srd.Item.Mirror Implement"
             }
         ],
         "traits": {

--- a/packs/classfeatures/mirror.json
+++ b/packs/classfeatures/mirror.json
@@ -30,68 +30,8 @@
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Mirror's Reflection"
             },
             {
-                "adjustName": false,
-                "choices": [
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Grant",
-                        "value": "granted"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Pick",
-                        "value": "picked"
-                    }
-                ],
-                "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Prompt",
-                "rollOption": "mirror-implement-origin"
-            },
-            {
-                "adjustName": false,
-                "choices": {
-                    "ownedItems": true,
-                    "types": [
-                        "equipment"
-                    ]
-                },
-                "flag": "implement",
-                "key": "ChoiceSet",
-                "predicate": [
-                    "mirror-implement-origin:picked"
-                ],
-                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.InventoryPrompt"
-            },
-            {
-                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
-                "key": "ItemAlteration",
-                "mode": "add",
-                "predicate": [
-                    "mirror-implement-origin:picked"
-                ],
-                "property": "other-tags",
-                "value": "implement:mirror"
-            },
-            {
-                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
-                "key": "ItemAlteration",
-                "mode": "override",
-                "predicate": [
-                    "mirror-implement-origin:picked"
-                ],
-                "property": "rarity",
-                "value": "unique"
-            },
-            {
-                "alterations": [
-                    {
-                        "mode": "add",
-                        "property": "other-tags",
-                        "value": "implement:mirror"
-                    }
-                ],
+                "allowDuplicate": false,
                 "key": "GrantItem",
-                "predicate": [
-                    "mirror-implement-origin:granted"
-                ],
                 "uuid": "Compendium.pf2e.equipment-srd.Item.Mirror Implement"
             }
         ],

--- a/packs/classfeatures/regalia.json
+++ b/packs/classfeatures/regalia.json
@@ -26,68 +26,8 @@
         },
         "rules": [
             {
-                "adjustName": false,
-                "choices": [
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Grant",
-                        "value": "granted"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Pick",
-                        "value": "picked"
-                    }
-                ],
-                "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Prompt",
-                "rollOption": "regalia-implement-origin"
-            },
-            {
-                "adjustName": false,
-                "choices": {
-                    "ownedItems": true,
-                    "types": [
-                        "equipment"
-                    ]
-                },
-                "flag": "implement",
-                "key": "ChoiceSet",
-                "predicate": [
-                    "regalia-implement-origin:picked"
-                ],
-                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.InventoryPrompt"
-            },
-            {
-                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
-                "key": "ItemAlteration",
-                "mode": "add",
-                "predicate": [
-                    "regalia-implement-origin:picked"
-                ],
-                "property": "other-tags",
-                "value": "implement:regalia"
-            },
-            {
-                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
-                "key": "ItemAlteration",
-                "mode": "override",
-                "predicate": [
-                    "regalia-implement-origin:picked"
-                ],
-                "property": "rarity",
-                "value": "unique"
-            },
-            {
-                "alterations": [
-                    {
-                        "mode": "add",
-                        "property": "other-tags",
-                        "value": "implement:regalia"
-                    }
-                ],
+                "allowDuplicate": false,
                 "key": "GrantItem",
-                "predicate": [
-                    "regalia-implement-origin:granted"
-                ],
                 "uuid": "Compendium.pf2e.equipment-srd.Item.Regalia Implement"
             }
         ],

--- a/packs/classfeatures/regalia.json
+++ b/packs/classfeatures/regalia.json
@@ -24,7 +24,73 @@
             "remaster": false,
             "title": "Pathfinder Dark Archive"
         },
-        "rules": [],
+        "rules": [
+            {
+                "adjustName": false,
+                "choices": [
+                    {
+                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Grant",
+                        "value": "granted"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Pick",
+                        "value": "picked"
+                    }
+                ],
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Prompt",
+                "rollOption": "regalia-implement-origin"
+            },
+            {
+                "adjustName": false,
+                "choices": {
+                    "ownedItems": true,
+                    "types": [
+                        "equipment"
+                    ]
+                },
+                "flag": "implement",
+                "key": "ChoiceSet",
+                "predicate": [
+                    "regalia-implement-origin:picked"
+                ],
+                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.InventoryPrompt"
+            },
+            {
+                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "regalia-implement-origin:picked"
+                ],
+                "property": "other-tags",
+                "value": "implement:regalia"
+            },
+            {
+                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
+                "key": "ItemAlteration",
+                "mode": "override",
+                "predicate": [
+                    "regalia-implement-origin:picked"
+                ],
+                "property": "rarity",
+                "value": "unique"
+            },
+            {
+                "alterations": [
+                    {
+                        "mode": "add",
+                        "property": "other-tags",
+                        "value": "implement:regalia"
+                    }
+                ],
+                "key": "GrantItem",
+                "predicate": [
+                    "regalia-implement-origin:granted"
+                ],
+                "uuid": "Compendium.pf2e.equipment-srd.Item.Regalia Implement"
+            }
+        ],
         "traits": {
             "otherTags": [
                 "thaumaturge-implement"

--- a/packs/classfeatures/tome.json
+++ b/packs/classfeatures/tome.json
@@ -24,7 +24,73 @@
             "remaster": false,
             "title": "Pathfinder Dark Archive"
         },
-        "rules": [],
+        "rules": [
+            {
+                "adjustName": false,
+                "choices": [
+                    {
+                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Grant",
+                        "value": "granted"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Pick",
+                        "value": "picked"
+                    }
+                ],
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Prompt",
+                "rollOption": "tome-implement-origin"
+            },
+            {
+                "adjustName": false,
+                "choices": {
+                    "ownedItems": true,
+                    "types": [
+                        "equipment"
+                    ]
+                },
+                "flag": "implement",
+                "key": "ChoiceSet",
+                "predicate": [
+                    "tome-implement-origin:picked"
+                ],
+                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.InventoryPrompt"
+            },
+            {
+                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "tome-implement-origin:picked"
+                ],
+                "property": "other-tags",
+                "value": "implement:tome"
+            },
+            {
+                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
+                "key": "ItemAlteration",
+                "mode": "override",
+                "predicate": [
+                    "tome-implement-origin:picked"
+                ],
+                "property": "rarity",
+                "value": "unique"
+            },
+            {
+                "alterations": [
+                    {
+                        "mode": "add",
+                        "property": "other-tags",
+                        "value": "implement:tome"
+                    }
+                ],
+                "key": "GrantItem",
+                "predicate": [
+                    "tome-implement-origin:granted"
+                ],
+                "uuid": "Compendium.pf2e.equipment-srd.Item.Tome Implement"
+            }
+        ],
         "traits": {
             "otherTags": [
                 "thaumaturge-implement"

--- a/packs/classfeatures/tome.json
+++ b/packs/classfeatures/tome.json
@@ -26,68 +26,8 @@
         },
         "rules": [
             {
-                "adjustName": false,
-                "choices": [
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Grant",
-                        "value": "granted"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Pick",
-                        "value": "picked"
-                    }
-                ],
-                "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Prompt",
-                "rollOption": "tome-implement-origin"
-            },
-            {
-                "adjustName": false,
-                "choices": {
-                    "ownedItems": true,
-                    "types": [
-                        "equipment"
-                    ]
-                },
-                "flag": "implement",
-                "key": "ChoiceSet",
-                "predicate": [
-                    "tome-implement-origin:picked"
-                ],
-                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.InventoryPrompt"
-            },
-            {
-                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
-                "key": "ItemAlteration",
-                "mode": "add",
-                "predicate": [
-                    "tome-implement-origin:picked"
-                ],
-                "property": "other-tags",
-                "value": "implement:tome"
-            },
-            {
-                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
-                "key": "ItemAlteration",
-                "mode": "override",
-                "predicate": [
-                    "tome-implement-origin:picked"
-                ],
-                "property": "rarity",
-                "value": "unique"
-            },
-            {
-                "alterations": [
-                    {
-                        "mode": "add",
-                        "property": "other-tags",
-                        "value": "implement:tome"
-                    }
-                ],
+                "allowDuplicate": false,
                 "key": "GrantItem",
-                "predicate": [
-                    "tome-implement-origin:granted"
-                ],
                 "uuid": "Compendium.pf2e.equipment-srd.Item.Tome Implement"
             }
         ],

--- a/packs/classfeatures/wand.json
+++ b/packs/classfeatures/wand.json
@@ -28,6 +28,85 @@
             {
                 "key": "GrantItem",
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Fling Magic"
+            },
+            {
+                "adjustName": false,
+                "choices": [
+                    {
+                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Grant",
+                        "value": "granted"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Pick",
+                        "value": "picked"
+                    }
+                ],
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Prompt",
+                "rollOption": "wand-implement-origin"
+            },
+            {
+                "adjustName": false,
+                "choices": {
+                    "ownedItems": true,
+                    "predicate": [
+                        {
+                            "or": [
+                                "item:type:equipment",
+                                {
+                                    "and": [
+                                        "item:type:consumable",
+                                        "item:trait:wand"
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "types": [
+                        "equipment",
+                        "consumable"
+                    ]
+                },
+                "flag": "implement",
+                "key": "ChoiceSet",
+                "predicate": [
+                    "wand-implement-origin:picked"
+                ],
+                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.InventoryPrompt"
+            },
+            {
+                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "wand-implement-origin:picked"
+                ],
+                "property": "other-tags",
+                "value": "implement:wand"
+            },
+            {
+                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
+                "key": "ItemAlteration",
+                "mode": "override",
+                "predicate": [
+                    "wand-implement-origin:picked"
+                ],
+                "property": "rarity",
+                "value": "unique"
+            },
+            {
+                "alterations": [
+                    {
+                        "mode": "add",
+                        "property": "other-tags",
+                        "value": "implement:wand"
+                    }
+                ],
+                "key": "GrantItem",
+                "predicate": [
+                    "wand-implement-origin:granted"
+                ],
+                "uuid": "Compendium.pf2e.equipment-srd.Item.Wand Implement"
             }
         ],
         "traits": {

--- a/packs/classfeatures/wand.json
+++ b/packs/classfeatures/wand.json
@@ -30,68 +30,8 @@
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Fling Magic"
             },
             {
-                "adjustName": false,
-                "choices": [
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Grant",
-                        "value": "granted"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Pick",
-                        "value": "picked"
-                    }
-                ],
-                "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Prompt",
-                "rollOption": "wand-implement-origin"
-            },
-            {
-                "adjustName": false,
-                "choices": {
-                    "ownedItems": true,
-                    "types": [
-                        "equipment"
-                    ]
-                },
-                "flag": "implement",
-                "key": "ChoiceSet",
-                "predicate": [
-                    "wand-implement-origin:picked"
-                ],
-                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.InventoryPrompt"
-            },
-            {
-                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
-                "key": "ItemAlteration",
-                "mode": "add",
-                "predicate": [
-                    "wand-implement-origin:picked"
-                ],
-                "property": "other-tags",
-                "value": "implement:wand"
-            },
-            {
-                "itemId": "{item|flags.pf2e.rulesSelections.implement}",
-                "key": "ItemAlteration",
-                "mode": "override",
-                "predicate": [
-                    "wand-implement-origin:picked"
-                ],
-                "property": "rarity",
-                "value": "unique"
-            },
-            {
-                "alterations": [
-                    {
-                        "mode": "add",
-                        "property": "other-tags",
-                        "value": "implement:wand"
-                    }
-                ],
+                "allowDuplicate": false,
                 "key": "GrantItem",
-                "predicate": [
-                    "wand-implement-origin:granted"
-                ],
                 "uuid": "Compendium.pf2e.equipment-srd.Item.Wand Implement"
             }
         ],

--- a/packs/classfeatures/wand.json
+++ b/packs/classfeatures/wand.json
@@ -49,22 +49,8 @@
                 "adjustName": false,
                 "choices": {
                     "ownedItems": true,
-                    "predicate": [
-                        {
-                            "or": [
-                                "item:type:equipment",
-                                {
-                                    "and": [
-                                        "item:type:consumable",
-                                        "item:trait:wand"
-                                    ]
-                                }
-                            ]
-                        }
-                    ],
                     "types": [
-                        "equipment",
-                        "consumable"
+                        "equipment"
                     ]
                 },
                 "flag": "implement",

--- a/packs/classfeatures/weapon.json
+++ b/packs/classfeatures/weapon.json
@@ -35,10 +35,7 @@
                     "filter": [
                         "item:usage:hands:1",
                         {
-                            "nor": [
-                                "item:trait:consumable",
-                                "item:magical"
-                            ]
+                            "not": "item:trait:consumable"
                         }
                     ],
                     "itemType": "weapon"
@@ -48,13 +45,6 @@
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
             {
-                "alterations": [
-                    {
-                        "mode": "override",
-                        "property": "rarity",
-                        "value": "unique"
-                    }
-                ],
                 "flag": "weaponImplement",
                 "key": "GrantItem",
                 "track": true,
@@ -82,7 +72,7 @@
                 "value": [
                     {
                         "divider": true,
-                        "text": "PF2E.SpecificRule.Thaumaturge.Implement.Description.Weapon"
+                        "text": "@Embed[Compendium.pf2e.classfeatures.Item.YiDkrwaxiF7Gao7y inline]"
                     }
                 ]
             }

--- a/packs/classfeatures/weapon.json
+++ b/packs/classfeatures/weapon.json
@@ -33,10 +33,12 @@
                 "adjustName": false,
                 "choices": {
                     "filter": [
-                        "item:level:0",
                         "item:usage:hands:1",
                         {
-                            "not": "item:trait:consumable"
+                            "nor": [
+                                "item:trait:consumable",
+                                "item:magical"
+                            ]
                         }
                     ],
                     "itemType": "weapon"
@@ -61,6 +63,13 @@
             {
                 "key": "RollOption",
                 "option": "implement-held",
+                "predicate": [
+                    "weapon-implement:equipped"
+                ]
+            },
+            {
+                "key": "RollOption",
+                "option": "implement:weapon:equipped",
                 "predicate": [
                     "weapon-implement:equipped"
                 ]

--- a/packs/classfeatures/weapon.json
+++ b/packs/classfeatures/weapon.json
@@ -28,6 +28,98 @@
             {
                 "key": "GrantItem",
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Implement's Interruption"
+            },
+            {
+                "adjustName": false,
+                "choices": [
+                    {
+                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Grant",
+                        "value": "granted"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Pick",
+                        "value": "picked"
+                    }
+                ],
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Prompt",
+                "rollOption": "weapon-implement-origin"
+            },
+            {
+                "adjustName": false,
+                "choices": {
+                    "ownedItems": true,
+                    "predicate": [
+                        "item:usage:hands:1"
+                    ],
+                    "types": [
+                        "weapon"
+                    ]
+                },
+                "flag": "pickedImplement",
+                "key": "ChoiceSet",
+                "predicate": [
+                    "weapon-implement-origin:picked"
+                ],
+                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.InventoryPrompt"
+            },
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        "item:level:0",
+                        "item:usage:hands:1",
+                        {
+                            "not": "item:trait:consumable"
+                        }
+                    ],
+                    "itemType": "weapon"
+                },
+                "flag": "grantedImplement",
+                "key": "ChoiceSet",
+                "predicate": [
+                    "weapon-implement-origin:granted"
+                ],
+                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.InventoryPrompt"
+            },
+            {
+                "itemId": "{item|flags.pf2e.rulesSelections.pickedImplement}",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "weapon-implement-origin:picked"
+                ],
+                "property": "other-tags",
+                "value": "implement:weapon"
+            },
+            {
+                "itemId": "{item|flags.pf2e.rulesSelections.pickedImplement}",
+                "key": "ItemAlteration",
+                "mode": "override",
+                "predicate": [
+                    "weapon-implement-origin:picked"
+                ],
+                "property": "rarity",
+                "value": "unique"
+            },
+            {
+                "alterations": [
+                    {
+                        "mode": "add",
+                        "property": "other-tags",
+                        "value": "implement:weapon"
+                    },
+                    {
+                        "mode": "override",
+                        "property": "rarity",
+                        "value": "unique"
+                    }
+                ],
+                "key": "GrantItem",
+                "predicate": [
+                    "weapon-implement-origin:granted"
+                ],
+                "uuid": "{item|flags.pf2e.rulesSelections.grantedImplement}"
             }
         ],
         "traits": {

--- a/packs/classfeatures/weapon.json
+++ b/packs/classfeatures/weapon.json
@@ -31,40 +31,6 @@
             },
             {
                 "adjustName": false,
-                "choices": [
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Grant",
-                        "value": "granted"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Pick",
-                        "value": "picked"
-                    }
-                ],
-                "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.Prompt",
-                "rollOption": "weapon-implement-origin"
-            },
-            {
-                "adjustName": false,
-                "choices": {
-                    "ownedItems": true,
-                    "predicate": [
-                        "item:usage:hands:1"
-                    ],
-                    "types": [
-                        "weapon"
-                    ]
-                },
-                "flag": "pickedImplement",
-                "key": "ChoiceSet",
-                "predicate": [
-                    "weapon-implement-origin:picked"
-                ],
-                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.InventoryPrompt"
-            },
-            {
-                "adjustName": false,
                 "choices": {
                     "filter": [
                         "item:level:0",
@@ -75,51 +41,41 @@
                     ],
                     "itemType": "weapon"
                 },
-                "flag": "grantedImplement",
+                "flag": "weaponImplement",
                 "key": "ChoiceSet",
-                "predicate": [
-                    "weapon-implement-origin:granted"
-                ],
-                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.ChoiceSet.PhysicalImplement.InventoryPrompt"
-            },
-            {
-                "itemId": "{item|flags.pf2e.rulesSelections.pickedImplement}",
-                "key": "ItemAlteration",
-                "mode": "add",
-                "predicate": [
-                    "weapon-implement-origin:picked"
-                ],
-                "property": "other-tags",
-                "value": "implement:weapon"
-            },
-            {
-                "itemId": "{item|flags.pf2e.rulesSelections.pickedImplement}",
-                "key": "ItemAlteration",
-                "mode": "override",
-                "predicate": [
-                    "weapon-implement-origin:picked"
-                ],
-                "property": "rarity",
-                "value": "unique"
+                "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
             {
                 "alterations": [
-                    {
-                        "mode": "add",
-                        "property": "other-tags",
-                        "value": "implement:weapon"
-                    },
                     {
                         "mode": "override",
                         "property": "rarity",
                         "value": "unique"
                     }
                 ],
+                "flag": "weaponImplement",
                 "key": "GrantItem",
+                "track": true,
+                "uuid": "{item|flags.pf2e.rulesSelections.weaponImplement}"
+            },
+            {
+                "key": "RollOption",
+                "option": "implement-held",
                 "predicate": [
-                    "weapon-implement-origin:granted"
-                ],
-                "uuid": "{item|flags.pf2e.rulesSelections.grantedImplement}"
+                    "weapon-implement:equipped"
+                ]
+            },
+            {
+                "itemId": "{item|flags.pf2e.itemGrants.weaponImplement.id}",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "property": "description",
+                "value": [
+                    {
+                        "divider": true,
+                        "text": "PF2E.SpecificRule.Thaumaturge.Implement.Description.Weapon"
+                    }
+                ]
             }
         ],
         "traits": {

--- a/packs/equipment/amulet-implement.json
+++ b/packs/equipment/amulet-implement.json
@@ -9,7 +9,7 @@
         },
         "containerId": null,
         "description": {
-            "value": "<p>Amulets are items carried for good luck and protection. Your amulet might be a magical diagram, a religious symbol, a preserved body part such as a rabbit’s foot, or a lucky coin. Amulet implements are associated with the harrow suit of shields and the astrological signs of the bridge and the ogre.</p>"
+            "value": "<p>@Embed[Compendium.pf2e.classfeatures.Item.PoclGJ7BCEyIuqJe inline]</p>"
         },
         "hardness": 0,
         "hp": {
@@ -44,7 +44,7 @@
         ],
         "size": "med",
         "traits": {
-            "rarity": "unique",
+            "rarity": "common",
             "value": []
         },
         "usage": {

--- a/packs/equipment/amulet-implement.json
+++ b/packs/equipment/amulet-implement.json
@@ -39,7 +39,7 @@
             },
             {
                 "key": "RollOption",
-                "option": "amulet-implement:equipped"
+                "option": "implement:amulet:equipped"
             }
         ],
         "size": "med",

--- a/packs/equipment/amulet-implement.json
+++ b/packs/equipment/amulet-implement.json
@@ -1,0 +1,46 @@
+{
+    "_id": "GbR8rgZMCVBn3Evb",
+    "img": "icons/commodities/treasure/token-gold-gem-purple.webp",
+    "name": "Amulet Implement",
+    "system": {
+        "baseItem": null,
+        "bulk": {
+            "value": 0
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p>Amulets are items carried for good luck and protection. Your amulet might be a magical diagram, a religious symbol, a preserved body part such as a rabbit’s foot, or a lucky coin. Amulet implements are associated with the harrow suit of shields and the astrological signs of the bridge and the ogre.</p>"
+        },
+        "hardness": 0,
+        "hp": {
+            "max": 0,
+            "value": 0
+        },
+        "level": {
+            "value": 0
+        },
+        "material": {
+            "grade": null,
+            "type": null
+        },
+        "price": {
+            "value": {}
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Dark Archive"
+        },
+        "quantity": 1,
+        "rules": [],
+        "size": "med",
+        "traits": {
+            "rarity": "unique",
+            "value": []
+        },
+        "usage": {
+            "value": "held-in-one-hand"
+        }
+    },
+    "type": "equipment"
+}

--- a/packs/equipment/amulet-implement.json
+++ b/packs/equipment/amulet-implement.json
@@ -32,7 +32,16 @@
             "title": "Pathfinder Dark Archive"
         },
         "quantity": 1,
-        "rules": [],
+        "rules": [
+            {
+                "key": "RollOption",
+                "option": "implement-held"
+            },
+            {
+                "key": "RollOption",
+                "option": "amulet-implement:equipped"
+            }
+        ],
         "size": "med",
         "traits": {
             "rarity": "unique",

--- a/packs/equipment/bell-implement.json
+++ b/packs/equipment/bell-implement.json
@@ -39,7 +39,7 @@
             },
             {
                 "key": "RollOption",
-                "option": "bell-implement:equipped"
+                "option": "implement:bell:equipped"
             }
         ],
         "size": "med",

--- a/packs/equipment/bell-implement.json
+++ b/packs/equipment/bell-implement.json
@@ -9,7 +9,7 @@
         },
         "containerId": null,
         "description": {
-            "value": "<p>Bells symbolize the power that sounds and emotions hold over others, soothing with one tone and startling with another. Bells, drums, finger cymbals, and other percussion instruments are most typical, but these implements can be any type of portable musical instrument that is played with one hand. Bell implements are associated with the astrological signs of the daughter and the blossom.</p>"
+            "value": "<p>@Embed[Compendium.pf2e.classfeatures.Item.DK1LCE5pd0YCY11c inline]</p>"
         },
         "hardness": 0,
         "hp": {
@@ -44,7 +44,7 @@
         ],
         "size": "med",
         "traits": {
-            "rarity": "unique",
+            "rarity": "common",
             "value": []
         },
         "usage": {

--- a/packs/equipment/bell-implement.json
+++ b/packs/equipment/bell-implement.json
@@ -32,7 +32,16 @@
             "title": "Pathfinder Dark Archive"
         },
         "quantity": 1,
-        "rules": [],
+        "rules": [
+            {
+                "key": "RollOption",
+                "option": "implement-held"
+            },
+            {
+                "key": "RollOption",
+                "option": "bell-implement:equipped"
+            }
+        ],
         "size": "med",
         "traits": {
             "rarity": "unique",

--- a/packs/equipment/bell-implement.json
+++ b/packs/equipment/bell-implement.json
@@ -1,0 +1,46 @@
+{
+    "_id": "f0A1zqCFiUJuXc9U",
+    "img": "icons/tools/instruments/bell-gold.webp",
+    "name": "Bell Implement",
+    "system": {
+        "baseItem": null,
+        "bulk": {
+            "value": 0
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p>Bells symbolize the power that sounds and emotions hold over others, soothing with one tone and startling with another. Bells, drums, finger cymbals, and other percussion instruments are most typical, but these implements can be any type of portable musical instrument that is played with one hand. Bell implements are associated with the astrological signs of the daughter and the blossom.</p>"
+        },
+        "hardness": 0,
+        "hp": {
+            "max": 0,
+            "value": 0
+        },
+        "level": {
+            "value": 0
+        },
+        "material": {
+            "grade": null,
+            "type": null
+        },
+        "price": {
+            "value": {}
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Dark Archive"
+        },
+        "quantity": 1,
+        "rules": [],
+        "size": "med",
+        "traits": {
+            "rarity": "unique",
+            "value": []
+        },
+        "usage": {
+            "value": "held-in-one-hand"
+        }
+    },
+    "type": "equipment"
+}

--- a/packs/equipment/chalice-implement.json
+++ b/packs/equipment/chalice-implement.json
@@ -1,0 +1,46 @@
+{
+    "_id": "FodtZGtCsH9NDXlC",
+    "img": "icons/containers/kitchenware/goblet-jeweled-red.webp",
+    "name": "Chalice Implement",
+    "system": {
+        "baseItem": null,
+        "bulk": {
+            "value": 0
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p>Chalice implements are vessels that fill with liquid, associating them with healing, nourishment, and life. Your chalice might be a traditional cup or goblet, but it could also be a small amphora, a polished gourd, or even a hollowed-out skull. Chalice implements are associated with the astrological signs of the mother and the newlyweds, as well as the sea dragon.</p>"
+        },
+        "hardness": 0,
+        "hp": {
+            "max": 0,
+            "value": 0
+        },
+        "level": {
+            "value": 0
+        },
+        "material": {
+            "grade": null,
+            "type": null
+        },
+        "price": {
+            "value": {}
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Dark Archive"
+        },
+        "quantity": 1,
+        "rules": [],
+        "size": "med",
+        "traits": {
+            "rarity": "unique",
+            "value": []
+        },
+        "usage": {
+            "value": "held-in-one-hand"
+        }
+    },
+    "type": "equipment"
+}

--- a/packs/equipment/chalice-implement.json
+++ b/packs/equipment/chalice-implement.json
@@ -9,7 +9,7 @@
         },
         "containerId": null,
         "description": {
-            "value": "<p>Chalice implements are vessels that fill with liquid, associating them with healing, nourishment, and life. Your chalice might be a traditional cup or goblet, but it could also be a small amphora, a polished gourd, or even a hollowed-out skull. Chalice implements are associated with the astrological signs of the mother and the newlyweds, as well as the sea dragon.</p>"
+            "value": "<p>@Embed[Compendium.pf2e.classfeatures.Item.1vgFGSnn0DIBmK7j inline]</p>"
         },
         "hardness": 0,
         "hp": {
@@ -44,7 +44,7 @@
         ],
         "size": "med",
         "traits": {
-            "rarity": "unique",
+            "rarity": "common",
             "value": []
         },
         "usage": {

--- a/packs/equipment/chalice-implement.json
+++ b/packs/equipment/chalice-implement.json
@@ -32,7 +32,16 @@
             "title": "Pathfinder Dark Archive"
         },
         "quantity": 1,
-        "rules": [],
+        "rules": [
+            {
+                "key": "RollOption",
+                "option": "implement-held"
+            },
+            {
+                "key": "RollOption",
+                "option": "chalice-implement:equipped"
+            }
+        ],
         "size": "med",
         "traits": {
             "rarity": "unique",

--- a/packs/equipment/chalice-implement.json
+++ b/packs/equipment/chalice-implement.json
@@ -39,7 +39,7 @@
             },
             {
                 "key": "RollOption",
-                "option": "chalice-implement:equipped"
+                "option": "implement:chalice:equipped"
             }
         ],
         "size": "med",

--- a/packs/equipment/lantern-implement.json
+++ b/packs/equipment/lantern-implement.json
@@ -32,7 +32,16 @@
             "title": "Pathfinder Dark Archive"
         },
         "quantity": 1,
-        "rules": [],
+        "rules": [
+            {
+                "key": "RollOption",
+                "option": "implement-held"
+            },
+            {
+                "key": "RollOption",
+                "option": "lantern-implement:equipped"
+            }
+        ],
         "size": "med",
         "traits": {
             "rarity": "unique",

--- a/packs/equipment/lantern-implement.json
+++ b/packs/equipment/lantern-implement.json
@@ -1,0 +1,46 @@
+{
+    "_id": "AtiSK2lwEi25f3PT",
+    "img": "icons/magic/light/light-lantern-lit-white.webp",
+    "name": "Lantern Implement",
+    "system": {
+        "baseItem": null,
+        "bulk": {
+            "value": 0
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p>Lantern implements shine the light of revelation to part shadows and expose truth. You might use a common glass lantern, torch, paper lantern, or other similar light source. Lantern implements are associated with the harrow suit of stars and the astrological signs of the lantern bearer and the archer.</p>"
+        },
+        "hardness": 0,
+        "hp": {
+            "max": 0,
+            "value": 0
+        },
+        "level": {
+            "value": 0
+        },
+        "material": {
+            "grade": null,
+            "type": null
+        },
+        "price": {
+            "value": {}
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Dark Archive"
+        },
+        "quantity": 1,
+        "rules": [],
+        "size": "med",
+        "traits": {
+            "rarity": "unique",
+            "value": []
+        },
+        "usage": {
+            "value": "held-in-one-hand"
+        }
+    },
+    "type": "equipment"
+}

--- a/packs/equipment/lantern-implement.json
+++ b/packs/equipment/lantern-implement.json
@@ -39,7 +39,7 @@
             },
             {
                 "key": "RollOption",
-                "option": "lantern-implement:equipped"
+                "option": "implement:lantern:equipped"
             }
         ],
         "size": "med",

--- a/packs/equipment/lantern-implement.json
+++ b/packs/equipment/lantern-implement.json
@@ -1,6 +1,6 @@
 {
     "_id": "AtiSK2lwEi25f3PT",
-    "img": "icons/magic/light/light-lantern-lit-white.webp",
+    "img": "icons/sundries/lights/lantern-iron-lit-yellow.webp",
     "name": "Lantern Implement",
     "system": {
         "baseItem": null,
@@ -9,7 +9,7 @@
         },
         "containerId": null,
         "description": {
-            "value": "<p>Lantern implements shine the light of revelation to part shadows and expose truth. You might use a common glass lantern, torch, paper lantern, or other similar light source. Lantern implements are associated with the harrow suit of stars and the astrological signs of the lantern bearer and the archer.</p>"
+            "value": "<p>@Embed[Compendium.pf2e.classfeatures.Item.AltwHU7hCqTwpn48 inline]</p>"
         },
         "hardness": 0,
         "hp": {
@@ -44,7 +44,7 @@
         ],
         "size": "med",
         "traits": {
-            "rarity": "unique",
+            "rarity": "common",
             "value": []
         },
         "usage": {

--- a/packs/equipment/mirror-implement.json
+++ b/packs/equipment/mirror-implement.json
@@ -1,0 +1,46 @@
+{
+    "_id": "NpNDlH8YE2i67vQV",
+    "img": "icons/commodities/treasure/token-silver-blue.webp",
+    "name": "Mirror Implement",
+    "system": {
+        "baseItem": null,
+        "bulk": {
+            "value": 0
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p>Mirror implements represent misdirection, illusion, and sleight of hand, bending and shifting a perspective and the way you look at things. While larger mirrors hold the same mystic connotations, thaumaturges always choose small, portable, handheld mirrors as implements so they can use them easily while adventuring. Mirror implements are associated with the harrow suit of keys, and the astrological signs of the stranger and the swallow.</p>"
+        },
+        "hardness": 0,
+        "hp": {
+            "max": 0,
+            "value": 0
+        },
+        "level": {
+            "value": 0
+        },
+        "material": {
+            "grade": null,
+            "type": null
+        },
+        "price": {
+            "value": {}
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Dark Archive"
+        },
+        "quantity": 1,
+        "rules": [],
+        "size": "med",
+        "traits": {
+            "rarity": "unique",
+            "value": []
+        },
+        "usage": {
+            "value": "held-in-one-hand"
+        }
+    },
+    "type": "equipment"
+}

--- a/packs/equipment/mirror-implement.json
+++ b/packs/equipment/mirror-implement.json
@@ -9,7 +9,7 @@
         },
         "containerId": null,
         "description": {
-            "value": "<p>Mirror implements represent misdirection, illusion, and sleight of hand, bending and shifting a perspective and the way you look at things. While larger mirrors hold the same mystic connotations, thaumaturges always choose small, portable, handheld mirrors as implements so they can use them easily while adventuring. Mirror implements are associated with the harrow suit of keys, and the astrological signs of the stranger and the swallow.</p>"
+            "value": "<p>@Embed[Compendium.pf2e.classfeatures.Item.N6KvTbaRsphc0Ymb inline]</p>"
         },
         "hardness": 0,
         "hp": {
@@ -44,7 +44,7 @@
         ],
         "size": "med",
         "traits": {
-            "rarity": "unique",
+            "rarity": "common",
             "value": []
         },
         "usage": {

--- a/packs/equipment/mirror-implement.json
+++ b/packs/equipment/mirror-implement.json
@@ -32,7 +32,16 @@
             "title": "Pathfinder Dark Archive"
         },
         "quantity": 1,
-        "rules": [],
+        "rules": [
+            {
+                "key": "RollOption",
+                "option": "implement-held"
+            },
+            {
+                "key": "RollOption",
+                "option": "mirror-implement:equipped"
+            }
+        ],
         "size": "med",
         "traits": {
             "rarity": "unique",

--- a/packs/equipment/mirror-implement.json
+++ b/packs/equipment/mirror-implement.json
@@ -39,7 +39,7 @@
             },
             {
                 "key": "RollOption",
-                "option": "mirror-implement:equipped"
+                "option": "implement:mirror:equipped"
             }
         ],
         "size": "med",

--- a/packs/equipment/regalia-implement.json
+++ b/packs/equipment/regalia-implement.json
@@ -1,0 +1,46 @@
+{
+    "_id": "7FzmHy7PugYNGkoX",
+    "img": "icons/sundries/flags/banner-symbol-eye-purple.webp",
+    "name": "Regalia Implement",
+    "system": {
+        "baseItem": null,
+        "bulk": {
+            "value": 0
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p>Regalia implements represent rulership, leadership, and social connections. While they differ in shape depending on regional customs and markers used to signify authority, common regalia implements are scepters, jeweled orbs, and heraldic banners. Regalia implements are associated with the harrow suit of crowns and the astrological signs of the patriarch and the sovereign dragon.</p>"
+        },
+        "hardness": 0,
+        "hp": {
+            "max": 0,
+            "value": 0
+        },
+        "level": {
+            "value": 0
+        },
+        "material": {
+            "grade": null,
+            "type": null
+        },
+        "price": {
+            "value": {}
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Dark Archive"
+        },
+        "quantity": 1,
+        "rules": [],
+        "size": "med",
+        "traits": {
+            "rarity": "unique",
+            "value": []
+        },
+        "usage": {
+            "value": "held-in-one-hand"
+        }
+    },
+    "type": "equipment"
+}

--- a/packs/equipment/regalia-implement.json
+++ b/packs/equipment/regalia-implement.json
@@ -9,7 +9,7 @@
         },
         "containerId": null,
         "description": {
-            "value": "<p>Regalia implements represent rulership, leadership, and social connections. While they differ in shape depending on regional customs and markers used to signify authority, common regalia implements are scepters, jeweled orbs, and heraldic banners. Regalia implements are associated with the harrow suit of crowns and the astrological signs of the patriarch and the sovereign dragon.</p>"
+            "value": "<p>@Embed[Compendium.pf2e.classfeatures.Item.DhdLzrcMvB93Rjmt inline]</p>"
         },
         "hardness": 0,
         "hp": {
@@ -44,7 +44,7 @@
         ],
         "size": "med",
         "traits": {
-            "rarity": "unique",
+            "rarity": "common",
             "value": []
         },
         "usage": {

--- a/packs/equipment/regalia-implement.json
+++ b/packs/equipment/regalia-implement.json
@@ -39,7 +39,7 @@
             },
             {
                 "key": "RollOption",
-                "option": "regalia-implement:equipped"
+                "option": "implement:regalia:equipped"
             }
         ],
         "size": "med",

--- a/packs/equipment/regalia-implement.json
+++ b/packs/equipment/regalia-implement.json
@@ -1,6 +1,6 @@
 {
     "_id": "7FzmHy7PugYNGkoX",
-    "img": "icons/sundries/flags/banner-symbol-eye-purple.webp",
+    "img": "icons/commodities/gems/pearl-red-gold.webp",
     "name": "Regalia Implement",
     "system": {
         "baseItem": null,
@@ -32,7 +32,16 @@
             "title": "Pathfinder Dark Archive"
         },
         "quantity": 1,
-        "rules": [],
+        "rules": [
+            {
+                "key": "RollOption",
+                "option": "implement-held"
+            },
+            {
+                "key": "RollOption",
+                "option": "regalia-implement:equipped"
+            }
+        ],
         "size": "med",
         "traits": {
             "rarity": "unique",

--- a/packs/equipment/tome-implement.json
+++ b/packs/equipment/tome-implement.json
@@ -1,0 +1,46 @@
+{
+    "_id": "V9mhR91d2qWa3dGh",
+    "img": "icons/sundries/books/book-symbol-yellow-grey.webp",
+    "name": "Tome Implement",
+    "system": {
+        "baseItem": null,
+        "bulk": {
+            "value": 0
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p>Tome implements embody lost knowledge and otherworldly insights. While a weathered book is most common, tome implements can have as many different form factors as there are ways to store knowledge, from carved clay tablets to bundles of knotted cords. Tome implements are associated with the harrow suit of books and the astrological signs of the stargazer and the underworld dragon.</p>"
+        },
+        "hardness": 0,
+        "hp": {
+            "max": 0,
+            "value": 0
+        },
+        "level": {
+            "value": 0
+        },
+        "material": {
+            "grade": null,
+            "type": null
+        },
+        "price": {
+            "value": {}
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Dark Archive"
+        },
+        "quantity": 1,
+        "rules": [],
+        "size": "med",
+        "traits": {
+            "rarity": "unique",
+            "value": []
+        },
+        "usage": {
+            "value": "held-in-one-hand"
+        }
+    },
+    "type": "equipment"
+}

--- a/packs/equipment/tome-implement.json
+++ b/packs/equipment/tome-implement.json
@@ -32,7 +32,16 @@
             "title": "Pathfinder Dark Archive"
         },
         "quantity": 1,
-        "rules": [],
+        "rules": [
+            {
+                "key": "RollOption",
+                "option": "implement-held"
+            },
+            {
+                "key": "RollOption",
+                "option": "tome-implement:equipped"
+            }
+        ],
         "size": "med",
         "traits": {
             "rarity": "unique",

--- a/packs/equipment/tome-implement.json
+++ b/packs/equipment/tome-implement.json
@@ -39,7 +39,7 @@
             },
             {
                 "key": "RollOption",
-                "option": "tome-implement:equipped"
+                "option": "implement:wand:equipped"
             }
         ],
         "size": "med",

--- a/packs/equipment/tome-implement.json
+++ b/packs/equipment/tome-implement.json
@@ -9,7 +9,7 @@
         },
         "containerId": null,
         "description": {
-            "value": "<p>Tome implements embody lost knowledge and otherworldly insights. While a weathered book is most common, tome implements can have as many different form factors as there are ways to store knowledge, from carved clay tablets to bundles of knotted cords. Tome implements are associated with the harrow suit of books and the astrological signs of the stargazer and the underworld dragon.</p>"
+            "value": "<p>@Embed[Compendium.pf2e.classfeatures.Item.MyN1cQgE0HsLF20e inline]</p>"
         },
         "hardness": 0,
         "hp": {
@@ -44,7 +44,7 @@
         ],
         "size": "med",
         "traits": {
-            "rarity": "unique",
+            "rarity": "common",
             "value": []
         },
         "usage": {

--- a/packs/equipment/wand-implement.json
+++ b/packs/equipment/wand-implement.json
@@ -9,7 +9,7 @@
         },
         "containerId": null,
         "description": {
-            "value": "<p>Wand implements are short, lightweight batons, usually made of wood but often incorporating other materials. Due to their association with spellcasters, wand implements are connected to magic and its practice, as well as the direction and manipulation of energy. Wand implements are associated with the astrological signs of the thrush and the sky dragon.</p>"
+            "value": "<p>@Embed[Compendium.pf2e.classfeatures.Item.pDxdE8S8QJV2PGiB inline]</p>"
         },
         "hardness": 0,
         "hp": {
@@ -44,7 +44,7 @@
         ],
         "size": "med",
         "traits": {
-            "rarity": "unique",
+            "rarity": "common",
             "value": []
         },
         "usage": {

--- a/packs/equipment/wand-implement.json
+++ b/packs/equipment/wand-implement.json
@@ -39,7 +39,7 @@
             },
             {
                 "key": "RollOption",
-                "option": "wand-implement:equipped"
+                "option": "implement:wand:equipped"
             }
         ],
         "size": "med",

--- a/packs/equipment/wand-implement.json
+++ b/packs/equipment/wand-implement.json
@@ -1,0 +1,46 @@
+{
+    "_id": "ZjApNlusD5oZkPTJ",
+    "img": "icons/weapons/wands/wand-skull-feathers.webp",
+    "name": "Wand Implement",
+    "system": {
+        "baseItem": null,
+        "bulk": {
+            "value": 0
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p>Wand implements are short, lightweight batons, usually made of wood but often incorporating other materials. Due to their association with spellcasters, wand implements are connected to magic and its practice, as well as the direction and manipulation of energy. Wand implements are associated with the astrological signs of the thrush and the sky dragon.</p>"
+        },
+        "hardness": 0,
+        "hp": {
+            "max": 0,
+            "value": 0
+        },
+        "level": {
+            "value": 0
+        },
+        "material": {
+            "grade": null,
+            "type": null
+        },
+        "price": {
+            "value": {}
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Dark Archive"
+        },
+        "quantity": 1,
+        "rules": [],
+        "size": "med",
+        "traits": {
+            "rarity": "unique",
+            "value": []
+        },
+        "usage": {
+            "value": "held-in-one-hand"
+        }
+    },
+    "type": "equipment"
+}

--- a/packs/equipment/wand-implement.json
+++ b/packs/equipment/wand-implement.json
@@ -32,7 +32,16 @@
             "title": "Pathfinder Dark Archive"
         },
         "quantity": 1,
-        "rules": [],
+        "rules": [
+            {
+                "key": "RollOption",
+                "option": "implement-held"
+            },
+            {
+                "key": "RollOption",
+                "option": "wand-implement:equipped"
+            }
+        ],
         "size": "med",
         "traits": {
             "rarity": "unique",

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -5681,6 +5681,16 @@
                     "Amulet": "Amulet",
                     "Bell": "Bell",
                     "Chalice": "Chalice",
+                    "ChoiceSet": {
+                        "AdeptPrompt": "Select your adept implement.",
+                        "ParagonPrompt": "Select your paragon implement.",
+                        "PhysicalImplement": {
+                            "InventoryPrompt": "Select an item to be your implement.",
+                            "Grant": "Receive an implement",
+                            "Pick": "Pick from inventory",
+                            "Prompt": "Receive an implement or pick an item from your inventory?"
+                        }
+                    },
                     "Lantern": "Lantern",
                     "Mirror": "Mirror",
                     "Regalia": "Regalia",

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -5682,8 +5682,6 @@
                     "Bell": "Bell",
                     "Chalice": "Chalice",
                     "ChoiceSet": {
-                        "AdeptPrompt": "Select your adept implement.",
-                        "ParagonPrompt": "Select your paragon implement.",
                         "PhysicalImplement": {
                             "InventoryPrompt": "Select an item to be your implement.",
                             "Grant": "Receive an implement",

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -5681,9 +5681,6 @@
                     "Amulet": "Amulet",
                     "Bell": "Bell",
                     "Chalice": "Chalice",
-                    "Description": {
-                        "Weapon": "This item is an implement. Weapon implements are the most direct and confrontational, representing battle, struggle, and potentially violence."
-                    },
                     "Lantern": "Lantern",
                     "Mirror": "Mirror",
                     "Regalia": "Regalia",

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -5681,13 +5681,8 @@
                     "Amulet": "Amulet",
                     "Bell": "Bell",
                     "Chalice": "Chalice",
-                    "ChoiceSet": {
-                        "PhysicalImplement": {
-                            "InventoryPrompt": "Select an item to be your implement.",
-                            "Grant": "Receive an implement",
-                            "Pick": "Pick from inventory",
-                            "Prompt": "Receive an implement or pick an item from your inventory?"
-                        }
+                    "Description": {
+                        "Weapon": "This item is an implement. Weapon implements are the most direct and confrontational, representing battle, struggle, and potentially violence."
                     },
                     "Lantern": "Lantern",
                     "Mirror": "Mirror",


### PR DESCRIPTION
Either grant a generic implement item, or tag an existing item as an implement. No automation yet, but the plan is to add suboptions to denote which implement is being held, and leverage that for automation from there.

Tagging @mysurvive, your input would be appreciated here! Trying to take some stuff off your plate.