### PR TITLE
Fix ItemAlteration removing the wrong trait if it does not exist

### DIFF
--- a/src/module/rules/rule-element/item-alteration/alteration.ts
+++ b/src/module/rules/rule-element/item-alteration/alteration.ts
@@ -384,7 +384,8 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
                 if (this.mode === "add") {
                     if (!traits.includes(newValue)) traits.push(newValue);
                 } else if (["subtract", "remove"].includes(this.mode)) {
-                    traits.splice(traits.indexOf(newValue), 1);
+                    const index = traits.indexOf(newValue);
+                    if (index >= 0) traits.splice(index, 1);
                 }
                 return;
             }


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/16730