### PR TITLE
Identify the correct statistic when using a pre-existing roll for initiative

### DIFF
--- a/src/module/actor/initiative.ts
+++ b/src/module/actor/initiative.ts
@@ -74,7 +74,7 @@ class ActorInitiative {
         // Update the tracker unless requested not to
         const updateTracker = args.updateTracker ?? true;
         if (updateTracker) {
-            combatant.encounter.setInitiative(combatant.id, roll.total);
+            combatant.encounter.setInitiative(combatant.id, roll.total, this.statistic.base?.slug);
         }
 
         return { combatant, roll };

--- a/src/module/apps/sidebar/chat-log.ts
+++ b/src/module/apps/sidebar/chat-log.ts
@@ -328,7 +328,11 @@ class ChatLogPF2e extends ChatLog<ChatMessagePF2e> {
         const combatant = await CombatantPF2e.fromActor(actor);
         if (!combatant) return;
         const value = message.rolls.at(0)?.total ?? 0;
-        await combatant.encounter.setInitiative(combatant.id, value);
+        await combatant.encounter.setInitiative(
+            combatant.id,
+            value,
+            (message.flags.pf2e.modifierName as string) ?? undefined,
+        );
 
         ui.notifications.info(
             game.i18n.format("PF2E.Encounter.InitiativeSet", { actor: token.name, initiative: value }),

--- a/src/module/apps/sidebar/chat-log.ts
+++ b/src/module/apps/sidebar/chat-log.ts
@@ -331,7 +331,7 @@ class ChatLogPF2e extends ChatLog<ChatMessagePF2e> {
         await combatant.encounter.setInitiative(
             combatant.id,
             value,
-            (message.flags.pf2e.modifierName as string) ?? undefined,
+            message.flags.pf2e.modifierName ? String(message.flags.pf2e.modifierName) : undefined,
         );
 
         ui.notifications.info(

--- a/src/module/encounter/document.ts
+++ b/src/module/encounter/document.ts
@@ -9,8 +9,7 @@ import { calculateXP } from "@scripts/macros/index.ts";
 import { ThreatRating } from "@scripts/macros/xp/index.ts";
 import * as R from "remeda";
 import type { CombatantFlags, CombatantPF2e, RolledCombatant } from "./combatant.ts";
-import { setHasElement } from "@util";
-import { CORE_SKILL_SLUGS } from "@actor/values.ts";
+import { objectHasKey } from "@util";
 
 class EncounterPF2e extends Combat {
     /** Has this document completed `DataModel` initialization? */
@@ -222,7 +221,7 @@ class EncounterPF2e extends Combat {
                     id: combatant.id,
                     value,
                     statistic:
-                        setHasElement(CORE_SKILL_SLUGS, statistic) || statistic === "perception"
+                        objectHasKey(CONFIG.PF2E.skills, statistic) || statistic === "perception"
                             ? statistic
                             : combatant.actor.system.initiative.statistic || "perception",
                 },

--- a/src/module/encounter/document.ts
+++ b/src/module/encounter/document.ts
@@ -9,6 +9,8 @@ import { calculateXP } from "@scripts/macros/index.ts";
 import { ThreatRating } from "@scripts/macros/xp/index.ts";
 import * as R from "remeda";
 import type { CombatantFlags, CombatantPF2e, RolledCombatant } from "./combatant.ts";
+import { setHasElement } from "@util";
+import { CORE_SKILL_SLUGS } from "@actor/values.ts";
 
 class EncounterPF2e extends Combat {
     /** Has this document completed `DataModel` initialization? */
@@ -212,14 +214,17 @@ class EncounterPF2e extends Combat {
         if (this.turn !== null) await this.update({ turn: this.turns.findIndex((c) => c.id === currentId) });
     }
 
-    override async setInitiative(id: string, value: number): Promise<void> {
+    override async setInitiative(id: string, value: number, statistic?: string): Promise<void> {
         const combatant = this.combatants.get(id, { strict: true });
         if (combatant.actor?.isOfType("character", "npc")) {
             return this.setMultipleInitiatives([
                 {
                     id: combatant.id,
                     value,
-                    statistic: combatant.actor.system.initiative.statistic || "perception",
+                    statistic:
+                        setHasElement(CORE_SKILL_SLUGS, statistic) || statistic === "perception"
+                            ? statistic
+                            : combatant.actor.system.initiative.statistic || "perception",
                 },
             ]);
         }


### PR DESCRIPTION
This allows you to set the initiative statistic for a combatant when setting there initiative. By default it uses whatever statistic their initiative is set on the actor and defaults to perception. This is a problem when setting the initiative via a chat message because it doesn't set the statistic to whatever they actually rolled, so if they rolled stealth and set that as their initiative it sets their combatant's initiative statistic to whatever is set on the actor. The same applies to `ActorInitiative` where it doesn't base along the base statistic so it ends up doing the same default.

Lastly there is a fail safe built in that requires the string being passed in to be a core skill or perception, if it's not it defaults to the old behaviour.

Fixes #16821 