### PR TITLE
Restore Fire Shield's Rules Elements to function properly

### DIFF
--- a/packs/spell-effects/spell-effect-fire-shield.json
+++ b/packs/spell-effects/spell-effect-fire-shield.json
@@ -112,7 +112,7 @@
                 "domain": "all",
                 "key": "RollOption",
                 "label": "PF2E.SpecificRule.FireShield.DefendingAgainstWaterLabel",
-                "option": "water-trait",
+                "option": "defend-against",
                 "toggleable": true
             },
             {
@@ -120,8 +120,9 @@
                 "mode": "multiply",
                 "path": "system.attributes.shield.hardness",
                 "predicate": [
-                    "item:trait:water"
+                    "defend-against"
                 ],
+                "priority": 60,
                 "value": 0.5
             },
             {

--- a/packs/spell-effects/spell-effect-fire-shield.json
+++ b/packs/spell-effects/spell-effect-fire-shield.json
@@ -112,7 +112,7 @@
                 "domain": "all",
                 "key": "RollOption",
                 "label": "PF2E.SpecificRule.FireShield.DefendingAgainstWaterLabel",
-                "option": "defend-against",
+                "option": "fire-shield-against-water",
                 "toggleable": true
             },
             {
@@ -120,7 +120,7 @@
                 "mode": "multiply",
                 "path": "system.attributes.shield.hardness",
                 "predicate": [
-                    "defend-against"
+                    "fire-shield-against-water"
                 ],
                 "priority": 60,
                 "value": 0.5


### PR DESCRIPTION
- Change the RE to once again use the toggle as "Fake Shields" do not read/interpret incoming damage