### PR TITLE
Add Note for Envenom Companion

### DIFF
--- a/packs/spell-effects/spell-effect-envenom-companion.json
+++ b/packs/spell-effects/spell-effect-envenom-companion.json
@@ -57,6 +57,16 @@
                 }
             },
             {
+                "key": "Note",
+                "predicate": [
+                    "first-hit",
+                    "unarmed"
+                ],
+                "selector": "strike-damage",
+                "text": "A creature that is damaged by this poison must attempt @Check[fortitude]",
+                "title": "Envenom Companion"
+            },
+            {
                 "domain": "damage",
                 "key": "RollOption",
                 "label": "First hit of the round",

--- a/packs/spell-effects/spell-effect-envenom-companion.json
+++ b/packs/spell-effects/spell-effect-envenom-companion.json
@@ -62,7 +62,7 @@
                     "first-hit"
                 ],
                 "selector": "unarmed-damage",
-                "text": "PF2E.SpecificRule.EnvenomCompanion.SavingThrow",
+                "text": "PF2E.SpecificRule.EnvenomCompanion.DamageNote",
                 "title": "{item|name}"
             },
             {

--- a/packs/spell-effects/spell-effect-envenom-companion.json
+++ b/packs/spell-effects/spell-effect-envenom-companion.json
@@ -62,7 +62,7 @@
                     "first-hit"
                 ],
                 "selector": "unarmed-damage",
-                "text": "A creature that is damaged by this poison must attempt @Check[fortitude]",
+                "text": "PF2E.SpecificRule.EnvenomCompanion.SavingThrow",
                 "title": "{item|name}"
             },
             {

--- a/packs/spell-effects/spell-effect-envenom-companion.json
+++ b/packs/spell-effects/spell-effect-envenom-companion.json
@@ -59,10 +59,9 @@
             {
                 "key": "Note",
                 "predicate": [
-                    "first-hit",
-                    "unarmed"
+                    "first-hit"
                 ],
-                "selector": "strike-damage",
+                "selector": "unarmed-damage",
                 "text": "A creature that is damaged by this poison must attempt @Check[fortitude]",
                 "title": "{item|name}"
             },

--- a/packs/spell-effects/spell-effect-envenom-companion.json
+++ b/packs/spell-effects/spell-effect-envenom-companion.json
@@ -64,7 +64,7 @@
                 ],
                 "selector": "strike-damage",
                 "text": "A creature that is damaged by this poison must attempt @Check[fortitude]",
-                "title": "Envenom Companion"
+                "title": "{item|name}"
             },
             {
                 "domain": "damage",

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2891,7 +2891,7 @@
                 }
             },
             "EnvenomCompanion": {
-                "SavingThrow": "A creature that is damaged by this poison must attempt @Check[fortitude|traits:poison]"
+                "SavingThrow": "A creature that is damaged by this poison must attempt @Check[fortitude|traits:poison]. On a failure, it's also @UUID[Compendium.pf2e.conditionitems.Item.Clumsy]{Clumsy 1} for 1 round."
             },
             "Equipment": {
                 "AlchemistGoggles": {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2891,7 +2891,7 @@
                 }
             },
             "EnvenomCompanion": {
-                "SavingThrow": "A creature that is damaged by this poison must attempt @Check[fortitude|traits:poison]. On a failure, it's also @UUID[Compendium.pf2e.conditionitems.Item.Clumsy]{Clumsy 1} for 1 round."
+                "DamageNote": "A creature that is damaged by this poison must attempt @Check[fortitude|traits:poison]. On a failure, it's also @UUID[Compendium.pf2e.conditionitems.Item.Clumsy]{Clumsy 1} for 1 round."
             },
             "Equipment": {
                 "AlchemistGoggles": {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2891,7 +2891,7 @@
                 }
             },
             "EnvenomCompanion": {
-                "DamageNote": "A creature that is damaged by this poison must attempt @Check[fortitude|traits:poison]. On a failure, it's also @UUID[Compendium.pf2e.conditionitems.Item.Clumsy]{Clumsy 1} for 1 round."
+                "DamageNote": "A creature that is damaged by this poison must attempt a @Check[fortitude|traits:poison] save. On a failure, it's also @UUID[Compendium.pf2e.conditionitems.Item.i3OJZU2nk64Df3xm]{Clumsy 1} for 1 round."
             },
             "Equipment": {
                 "AlchemistGoggles": {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2890,6 +2890,9 @@
                     "Note": "When in a forest or jungle environment, if you roll a critical failure on a Survival skill check to Sense Direction, Subsist, or Cover Tracks, you get a failure instead, and if you roll a success, you get a critical success instead."
                 }
             },
+            "EnvenomCompanion": {
+                "SavingThrow": "A creature that is damaged by this poison must attempt @Check[fortitude|traits:poison]"
+            },
             "Equipment": {
                 "AlchemistGoggles": {
                     "RollOptionLabel": "Failed Strike with an alchemical bomb"


### PR DESCRIPTION
Text from spell

```
A creature that is damaged by this poison must attempt a Fortitude save
```

Old & New message


<img width="301" alt="image" src="https://github.com/user-attachments/assets/98f6714a-35c4-42e4-bcb5-bd50a1fc04d0">
<img width="297" alt="image" src="https://github.com/user-attachments/assets/e6398f65-f7a1-48b5-b729-987af28883e1">

