### PR TITLE
Remove some invalid traits

### DIFF
--- a/packs/adventure-specific-actions/holy-light.json
+++ b/packs/adventure-specific-actions/holy-light.json
@@ -61,9 +61,7 @@
             }
         ],
         "traits": {
-            "value": [
-                "good"
-            ]
+            "value": []
         }
     },
     "type": "action"

--- a/packs/bestiary-family-ability-glossary/lich-steal-soul.json
+++ b/packs/bestiary-family-ability-glossary/lich-steal-soul.json
@@ -22,8 +22,7 @@
         "traits": {
             "rarity": "common",
             "value": [
-                "arcane",
-                "evil"
+                "arcane"
             ]
         }
     },

--- a/packs/blood-lords-bestiary/unstable-fiendflame-cage.json
+++ b/packs/blood-lords-bestiary/unstable-fiendflame-cage.json
@@ -28,10 +28,7 @@
                 "traits": {
                     "rarity": "common",
                     "value": [
-                        "divine",
-                        "evil",
-                        "good",
-                        "lawful"
+                        "divine"
                     ]
                 }
             },
@@ -71,7 +68,7 @@
                 "title": "Pathfinder #186: Ghost King's Rage"
             },
             "reset": "<p>The trap resets after 24 hours.</p>",
-            "routine": "<p>(2 actions) On its initiative, the Fiendflame Cage uses 1 action to release a wave of hellfire, dealing @Damage[(2d10+12)[evil],(2d10+12)[fire]]{2d10+12 evil damage and 2d10+12 fire damage} to all creatures in a @Template[burst|distance:15]{15-foot-radius burst} (@Check[reflex|dc:47|basic]). The Fiendflame Cage uses its second action to release a wave of holy light, dealing @Damage[(2d10+12)[good],(2d10+12)[fire]]{2d10+12 good damage and 2d10+12 fire damage} to all creatures in a @Template[burst|distance:15]{15-foot-radius burst} (@Check[reflex|dc:47|basic]).</p>"
+            "routine": "<p>(2 actions) On its initiative, the Fiendflame Cage uses 1 action to release a wave of hellfire, dealing @Damage[(2d10+12)[spirit],(2d10+12)[fire]|traits:unholy]{2d10+12 spirit damage and 2d10+12 fire damage} to all creatures in a @Template[burst|distance:15]{15-foot-radius burst} (@Check[reflex|dc:47|basic]). The Fiendflame Cage uses its second action to release a wave of holy light, dealing @Damage[(2d10+12)[spirit],(2d10+12)[fire]|traits:holy]{2d10+12 spirit damage and 2d10+12 fire damage} to all creatures in a @Template[burst|distance:15]{15-foot-radius burst} (@Check[reflex|dc:47|basic]).</p>"
         },
         "saves": {
             "fortitude": {


### PR DESCRIPTION
They caused warnings when the sheets were opened.
Also fix damage for Unstable Fiendflame Cage's routine.