### PR TITLE
Fix selectors of Curse of Ancestral Meddling

### DIFF
--- a/packs/feat-effects/effect-curse-of-ancestral-meddling.json
+++ b/packs/feat-effects/effect-curse-of-ancestral-meddling.json
@@ -374,7 +374,7 @@
                         ]
                     }
                 ],
-                "selector": [
+                "selectors": [
                     "skill-check",
                     "perception"
                 ],


### PR DESCRIPTION
Fixed the `selector` key of one `AdjustModifier` rule element. 
`"selector":["skill-check","perception"` became `this.selectors = "skill-check, perception"`.