### PR TITLE
Initial implementation of SpecialResource rule element

### DIFF
--- a/src/module/actor/character/data.ts
+++ b/src/module/actor/character/data.ts
@@ -405,16 +405,17 @@ interface CharacterCraftingData {
     entries: Record<string, Partial<CraftingAbilityData>>;
 }
 
-interface CharacterResources extends CreatureResources {
+type CharacterResources = CreatureResources & {
     /** The current and maximum number of hero points */
     heroPoints: ValueAndMax;
     /** The current number of focus points and pool size */
     focus: ValueAndMax & { cap: number };
     /** The current and maximum number of invested items */
     investiture: ValueAndMax;
+    // Will be removed in a future update
     crafting: { infusedReagents: ValueAndMax };
     resolve?: ValueAndMax;
-}
+};
 
 interface CharacterPerceptionData extends CreaturePerceptionData {
     rank: ZeroToFour;

--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -583,18 +583,6 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
             this.toggleInitiativeLink();
         });
 
-        // Adjust Hero Points
-        const heroPointsPips = htmlQuery(html, "[data-action=adjust-hero-points]");
-        heroPointsPips?.addEventListener("click", async () => {
-            const newValue = Math.min(this.actor.heroPoints.value + 1, this.actor.heroPoints.max);
-            await this.actor.update({ "system.resources.heroPoints.value": newValue });
-        });
-        heroPointsPips?.addEventListener("contextmenu", async (event) => {
-            event.preventDefault();
-            const newValue = Math.max(this.actor.heroPoints.value - 1, 0);
-            await this.actor.update({ "system.resources.heroPoints.value": newValue });
-        });
-
         $html.find(".adjust-item-stat").on("click contextmenu", (event) => this.#onClickAdjustItemStat(event));
         $html.find(".adjust-item-stat-select").on("change", (event) => this.#onChangeAdjustItemStat(event));
 
@@ -738,21 +726,6 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
 
         // SPELLCASTING
         const castingPanel = htmlQuery(html, ".tab[data-tab=spellcasting]");
-
-        // Focus pool pips
-        const focusPips = htmlQueryAll(castingPanel, ".focus-pool");
-        if (focusPips.length > 0) {
-            const listener = (event: Event) => {
-                const change = event.type === "click" ? 1 : -1;
-                const points = this.actor.system.resources.focus.value + change;
-                this.actor.update({ "system.resources.focus.value": points });
-            };
-
-            for (const pips of focusPips) {
-                pips.addEventListener("click", listener);
-                pips.addEventListener("contextmenu", listener);
-            }
-        }
 
         // Update all "normal" spellcasting entries
         for (const select of htmlQueryAll<HTMLSelectElement>(html, "select[data-action=update-spellcasting-rank]")) {

--- a/src/module/actor/creature/data.ts
+++ b/src/module/actor/creature/data.ts
@@ -187,6 +187,7 @@ interface CreatureInitiativeSource {
 interface CreatureResources extends CreatureResourcesSource {
     /** The current number of focus points and pool size */
     focus?: ValueAndMax & { cap: number };
+    [key: string]: ValueAndMax | undefined;
 }
 
 enum VisionLevels {

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -347,7 +347,7 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
 
                 const value = (() => {
                     const value =
-                        element instanceof HTMLInputElement && element.type === "checbox"
+                        element instanceof HTMLInputElement && element.type === "checkbox"
                             ? element.checked
                             : element.value;
                     if (typeof value === "boolean") return value;

--- a/src/module/actor/spellcasting.ts
+++ b/src/module/actor/spellcasting.ts
@@ -136,6 +136,6 @@ export class ActorSpellcasting<TActor extends ActorPF2e> extends DelegatedCollec
         });
 
         const actorUpdates = this.refocus({ all: true });
-        return { itemUpdates, actorUpdates };
+        return { actorUpdates, itemCreates: [], itemUpdates };
     }
 }

--- a/src/module/actor/types.ts
+++ b/src/module/actor/types.ts
@@ -2,6 +2,7 @@ import type * as ActorInstance from "@actor";
 import type { ActorPF2e } from "@actor";
 import type { ItemPF2e } from "@item";
 import type { EffectTrait } from "@item/abstract-effect/types.ts";
+import { ItemSourcePF2e } from "@item/base/data/index.ts";
 import type { ItemInstances } from "@item/types.ts";
 import type { RollNotePF2e } from "@module/notes.ts";
 import type { ItemAlteration } from "@module/rules/rule-element/item-alteration/alteration.ts";
@@ -91,8 +92,9 @@ interface AuraAppearanceData {
     } | null;
 }
 
-interface ActorCommitData<T extends ActorPF2e> {
+interface ActorCommitData<T extends ActorPF2e = ActorPF2e> {
     actorUpdates: DeepPartial<T["_source"]> | null;
+    itemCreates: PreCreate<ItemSourcePF2e>[];
     itemUpdates: EmbeddedDocumentUpdateData[];
 }
 

--- a/src/module/rules/index.ts
+++ b/src/module/rules/index.ts
@@ -33,6 +33,7 @@ import { RollNoteRuleElement } from "./rule-element/roll-note.ts";
 import { RollOptionRuleElement } from "./rule-element/roll-option/rule-element.ts";
 import { RollTwiceRuleElement } from "./rule-element/roll-twice.ts";
 import { SenseRuleElement } from "./rule-element/sense.ts";
+import { SpecialResourceRuleElement } from "./rule-element/special-resource.ts";
 import { SpecialStatisticRuleElement } from "./rule-element/special-statistic.ts";
 import { StrikeRuleElement } from "./rule-element/strike.ts";
 import { StrikingRuleElement } from "./rule-element/striking.ts";
@@ -81,6 +82,7 @@ class RuleElements {
         RollOption: RollOptionRuleElement,
         RollTwice: RollTwiceRuleElement,
         Sense: SenseRuleElement,
+        SpecialResource: SpecialResourceRuleElement,
         SpecialStatistic: SpecialStatisticRuleElement,
         Strike: StrikeRuleElement,
         Striking: StrikingRuleElement,

--- a/src/module/rules/rule-element/special-resource.ts
+++ b/src/module/rules/rule-element/special-resource.ts
@@ -1,0 +1,188 @@
+import type { ActorType, CreaturePF2e } from "@actor";
+import type { CharacterResources } from "@actor/character/data.ts";
+import { applyActorUpdate } from "@actor/helpers.ts";
+import type { ActorCommitData } from "@actor/types.ts";
+import { PhysicalItemPF2e } from "@item";
+import type { PhysicalItemSource } from "@item/base/data/index.ts";
+import { sluggify } from "@util";
+import type { NumberField, StringField } from "types/foundry/common/data/fields.js";
+import { createBatchRuleElementUpdate } from "../helpers.ts";
+import { type RuleElementOptions, RuleElementPF2e } from "./base.ts";
+import { ResolvableValueField, type RuleElementSchema, type RuleElementSource } from "./data.ts";
+
+const INVALID_RESOURCES: (keyof CharacterResources)[] = [
+    "crafting",
+    "focus",
+    "heroPoints",
+    "investiture",
+    "infusedReagents",
+    "resolve",
+];
+
+class SpecialResourceRuleElement extends RuleElementPF2e<SpecialResourceSchema> {
+    protected static override validActorTypes: ActorType[] = ["character"];
+
+    constructor(source: SpecialResourceSource, options: RuleElementOptions) {
+        super(source, options);
+        if (this.invalid) return;
+
+        this.slug ??= this.item.slug ?? sluggify(this.item.name);
+        if (INVALID_RESOURCES.includes(this.slug)) {
+            this.failValidation("slug: invalid value");
+        }
+
+        // Keep a record of the resource for blacklisting and redirection purposes
+        // Also prepare a basic version for active effect like modification
+        if (!this.ignored && !(this.slug in this.actor.synthetics.resources)) {
+            this.actor.synthetics.resources[this.slug] = this;
+            this.actor.system.resources[this.slug] = fu.mergeObject(this.actor.system.resources[this.slug] ?? {}, {
+                value: 0,
+                max: Number(this.resolveValue(this.max)) || 0,
+            });
+        }
+    }
+
+    /** Updates the rule element's max value to match alterations such as by ActiveEffectLike, and snapshots the resolved value */
+    #updateMax() {
+        const thisMax = Number(this.resolveValue(this.max));
+        const existingMax = this.actor.system.resources[this.slug]?.max ?? 0;
+        this.max = Math.max(thisMax, existingMax);
+    }
+
+    /** Updates the remaining number of this resource. Where it updates depends on the type */
+    async update(value: number, options: { save: false }): Promise<ActorCommitData>;
+    async update(value: number, options?: { save?: true }): Promise<void>;
+    async update(value: number, { save = true }: { save?: boolean } = {}): Promise<void | ActorCommitData> {
+        const data: ActorCommitData<CreaturePF2e> = {
+            actorUpdates: null,
+            itemCreates: [],
+            itemUpdates: [],
+        };
+
+        if (this.itemUUID) {
+            // Find an existing item to update or create a new one
+            const uuid = this.resolveInjectedProperties(this.itemUUID);
+            const existing = this.actor.items.find((i) => i.sourceId === uuid);
+            if (existing) {
+                if (existing.isOfType("physical") && existing.quantity !== value) {
+                    data.itemUpdates.push({ _id: existing.id, system: { quantity: value } });
+                }
+            } else {
+                const source = await this.#createItem(uuid);
+                if (source) {
+                    source.system.quantity = value;
+                    data.itemCreates.push(source);
+                }
+            }
+        } else {
+            // update all rule elements with this same resource
+            const allRules = this.actor.rules.filter(
+                (r): r is SpecialResourceRuleElement => r.key === "SpecialResource" && r.slug === this.slug,
+            );
+            data.itemUpdates.push(...createBatchRuleElementUpdate(allRules, { value }));
+        }
+
+        if (save) {
+            await applyActorUpdate(this.actor, data);
+        } else {
+            return data;
+        }
+    }
+
+    /** If an item uuid is specified, create it */
+    override async preCreate(args: RuleElementPF2e.PreCreateParams): Promise<void> {
+        if (this.invalid) return;
+
+        this.#updateMax();
+        if (this.itemUUID) {
+            const uuid = this.resolveInjectedProperties(this.itemUUID);
+            const itemExists = this.actor.items.some((i) => i.sourceId === uuid);
+            if (!itemExists && uuid) {
+                const source = await this.#createItem(uuid);
+                if (source) args.pendingItems.push(source);
+            }
+        }
+    }
+
+    async #createItem(uuid: string): Promise<PhysicalItemSource | null> {
+        const grantedItem: ClientDocument | null = await (async () => {
+            try {
+                return (await fromUuid(uuid))?.clone() ?? null;
+            } catch (error) {
+                console.error(error);
+                return null;
+            }
+        })();
+
+        // todo: set grant item flags
+        if (grantedItem instanceof PhysicalItemPF2e) {
+            const grantedSource = grantedItem.toObject();
+            grantedSource._id = fu.randomID();
+            grantedSource.system.quantity = this.max;
+            return grantedSource;
+        } else {
+            this.failValidation("itemUUID must refer to a physical item");
+            return null;
+        }
+    }
+
+    override beforePrepareData(): void {
+        if (this.ignored) return;
+        this.#updateMax();
+    }
+
+    override afterPrepareData(): void {
+        if (this.ignored) return;
+
+        const max = this.actor.system.resources[this.slug]?.max ?? 0;
+        const initial = this.initial ?? max;
+
+        const actor = this.actor;
+        this.value = Math.min(this.value ?? initial, max);
+        const existing = actor.system.resources[this.slug];
+        if (existing) {
+            existing.value = this.value;
+            existing.max = Math.max(max, existing.max);
+        }
+    }
+
+    static override defineSchema(): SpecialResourceSchema {
+        const fields = foundry.data.fields;
+        return {
+            ...super.defineSchema(),
+            initial: new fields.NumberField({ required: false, nullable: false, initial: undefined }),
+            value: new fields.NumberField({ required: false, nullable: false, initial: undefined }),
+            max: new ResolvableValueField({ required: true, nullable: false }),
+            itemUUID: new fields.StringField({
+                required: false,
+                nullable: false,
+                blank: false,
+                initial: undefined,
+                label: "PF2E.UUID.Label",
+            }),
+        };
+    }
+}
+
+interface SpecialResourceRuleElement
+    extends RuleElementPF2e<SpecialResourceSchema>,
+        Omit<ModelPropsFromSchema<SpecialResourceSchema>, "label"> {
+    slug: string;
+    max: number;
+    get actor(): CreaturePF2e;
+}
+
+type SpecialResourceSource = RuleElementSource & { value?: unknown };
+
+type SpecialResourceSchema = RuleElementSchema & {
+    /** The initial value of this resource. Defaults to max if there is a max, otherwise 0 */
+    initial: NumberField<number, number, false, false>;
+    /** Current value. If not set, defaults to null */
+    value: NumberField<number, number, false, false>;
+    /** The maximum value attainable for this resource. */
+    max: ResolvableValueField<true, false>;
+    /** If this represents a physical resource, the UUID of the item to create */
+    itemUUID: StringField<string, string, false, false, false>;
+};
+
+export { SpecialResourceRuleElement };

--- a/src/module/rules/synthetics.ts
+++ b/src/module/rules/synthetics.ts
@@ -24,6 +24,7 @@ import type { Statistic } from "@system/statistic/index.ts";
 import type { TokenSource } from "types/foundry/common/documents/token.d.ts";
 import type { DamageAlteration } from "./rule-element/damage-alteration/alteration.ts";
 import type { Suboption } from "./rule-element/roll-option/data.ts";
+import { SpecialResourceRuleElement } from "./rule-element/special-resource.ts";
 
 /** Defines a list of data provided by rule elements that an actor can pull from during its data preparation lifecycle */
 interface RuleElementSynthetics<TActor extends ActorPF2e = ActorPF2e> {
@@ -43,6 +44,7 @@ interface RuleElementSynthetics<TActor extends ActorPF2e = ActorPF2e> {
     modifiers: ModifierSynthetics;
     movementTypes: { [K in MovementType]?: DeferredMovementType[] };
     multipleAttackPenalties: Record<string, MAPSynthetic[]>;
+    resources: Record<string, SpecialResourceRuleElement>;
     rollNotes: Record<string, RollNotePF2e[]>;
     rollSubstitutions: Record<string, RollSubstitution[]>;
     rollTwice: Record<string, RollTwiceSynthetic[]>;

--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -191,11 +191,13 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
     override getBarAttribute(barName: string, options?: { alternative?: string }): TokenResourceData | null {
         const attribute = super.getBarAttribute(barName, options);
         if (!attribute) return null;
+
         const isStaminaOrResolve =
             ["attributes.hp.sp", "resources.resolve"].includes(attribute.attribute) &&
             game.pf2e.settings.variants.stamina;
+        const isSpecialResource = /^resources\.([\w-]+)/.test(attribute.attribute);
         const isShieldHP = attribute.attribute === "attributes.shield.hp" && !!this.actor?.attributes.shield?.itemId;
-        if (isStaminaOrResolve || isShieldHP) {
+        if (isStaminaOrResolve || isSpecialResource || isShieldHP) {
             attribute.editable = true;
         }
 

--- a/src/styles/actor/character/_sidebar.scss
+++ b/src/styles/actor/character/_sidebar.scss
@@ -22,7 +22,6 @@ aside {
 
     input[type="number"] {
         color: var(--text-light);
-        font-size: var(--font-size-28);
         font-weight: initial;
         line-height: 1em;
         text-align: center;
@@ -237,6 +236,10 @@ aside {
                 display: grid;
                 grid-template-columns: repeat(3, 1fr);
                 justify-content: space-evenly;
+
+                input {
+                    font-size: var(--font-size-28);
+                }
 
                 .container {
                     text-align: center;
@@ -487,6 +490,25 @@ aside {
                     justify-content: center;
                     margin-top: var(--space-4);
                 }
+            }
+        }
+
+        .special-resource {
+            align-items: baseline;
+            font-size: var(--font-size-16);
+            flex-wrap: nowrap;
+            line-height: 1.25;
+            .label {
+                flex: 1;
+                font-weight: initial;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
+            input {
+                width: 3ch;
+                text-align: end;
+                margin-right: var(--space-2);
             }
         }
 

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -85,6 +85,7 @@
                     "HitPointsSingle": "{hitPoints} hit point restored.",
                     "InfusedReagents": "Infused reagents restored.",
                     "Resolve": "Resolve restored.",
+                    "Resource": "{name} restored.",
                     "SpellSlots": "All spell slots restored.",
                     "StaminaPoints": "Stamina points restored.",
                     "TemporaryItems": "Temporary items removed.",

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -1671,6 +1671,7 @@
             "RollOption": "Roll Option",
             "RollTwice": "Roll Twice",
             "Sense": "Sense",
+            "SpecialResource": "Special Resource",
             "SpecialStatistic": "Special Statistic",
             "Strike": "Strike",
             "Striking": "Striking",

--- a/static/templates/actors/character/partials/header.hbs
+++ b/static/templates/actors/character/partials/header.hbs
@@ -5,7 +5,7 @@
         </h1>
         <div class="dots">
             <span class="label">{{localize "PF2E.HeroPointsLabel"}}</span>
-            <span data-action="adjust-hero-points" data-tooltip="{{data.resources.heroPoints.hover}}">
+            <span data-action="adjust-resource" data-resource="heroPoints" data-tooltip="{{data.resources.heroPoints.hover}}">
                 {{#times data.resources.heroPoints.max}}
                     {{#if (gt @root.data.resources.heroPoints.value this)}}
                         <i class="fa-solid fa-hospital-symbol"></i>

--- a/static/templates/actors/character/partials/sidebar.hbs
+++ b/static/templates/actors/character/partials/sidebar.hbs
@@ -195,6 +195,21 @@
     {{> "systems/pf2e/templates/actors/partials/modifiers-tooltip.hbs" title="PF2E.ArmorClassLabel"}}
 {{/with}}
 
+{{#if specialResources}}
+    <header>
+        <h2>Special Resources</h2>
+    </header>
+    <ol>
+        {{#each specialResources as |resource|}}
+            <li class="special-resource">
+                <span class="label">{{resource.label}}</span>
+                <input type="number" data-resource="{{resource.slug}}" value="{{resource.value}}" />
+                / {{resource.max}}
+            </li>
+        {{/each}}
+    </ol>
+{{/if}}
+
 {{!-- Perception --}}
 <header>
     <h2>{{localize "PF2E.PerceptionHeader"}}</h2>

--- a/static/templates/actors/character/tabs/spellcasting.hbs
+++ b/static/templates/actors/character/tabs/spellcasting.hbs
@@ -82,7 +82,7 @@
                         {{/if}}
 
                         {{#if entry.isFocusPool}}
-                            <section class="focus-pool">
+                            <section class="focus-pool" data-action="adjust-resource" data-resource="focus">
                                 <span class="pips">
                                     {{#times @root.data.resources.focus.max}}
                                         <i class="{{#if (gt @root.data.resources.focus.value this)}}fa-solid fa-dot-circle{{else}}fa-regular fa-circle{{/if}}"></i>


### PR DESCRIPTION
While it is functional, it is still a work in progress, and will need to be run through a bit of rigor to be as good as it can be. The physical item binding, while *generally* functional, is untested and will be completed during the crafting rework. Token bar updates work though, as does updating the max via AELike rule elements.

These bits of functionality are missing or spotty:
1) Slugs are hyphen cased, and included in system.resources as is. This becomes awkward when you have `system.resources.heroPoints` and `system.resources.vitality-network`. We could make them bactrian in system.resources and kebab in synthetics.resources, which is a bit weird to me, but perhaps its fine to others?
2) They aren't shown for npcs yet. I'd like to get them shiny in character first.
3) It assumes full regeneration during daily prep. I'm not sure of a good syntax for configuring it.
4) itemUUID? itemUuid? item?
5) They always display in the sidebar as input fields. We may want pip displays for some. I can't think of a good syntax.
6) Localization

![image](https://github.com/user-attachments/assets/75313228-4066-474d-8560-5a4ee1028670)

