### PR TITLE
Reduce remaining action uses when clicking the use button

### DIFF
--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -3,8 +3,8 @@ import type { Sense } from "@actor/creature/sense.ts";
 import { isReallyPC } from "@actor/helpers.ts";
 import { MODIFIER_TYPES, createProficiencyModifier } from "@actor/modifiers.ts";
 import { SheetClickActionHandlers } from "@actor/sheet/base.ts";
-import { ActorSheetDataPF2e, InventoryItem } from "@actor/sheet/data-types.ts";
-import { condenseSenses } from "@actor/sheet/helpers.ts";
+import { AbilityViewData, ActorSheetDataPF2e, InventoryItem } from "@actor/sheet/data-types.ts";
+import { condenseSenses, createAbilityViewData } from "@actor/sheet/helpers.ts";
 import { AttributeString, SaveType, SkillSlug } from "@actor/types.ts";
 import { ATTRIBUTE_ABBREVIATIONS } from "@actor/values.ts";
 import type {
@@ -19,7 +19,7 @@ import type {
 } from "@item";
 import { ItemPF2e, ItemProxyPF2e } from "@item";
 import { TraitToggleViewData } from "@item/ability/trait-toggles.ts";
-import { ActionCost, Frequency, ItemSourcePF2e } from "@item/base/data/index.ts";
+import { ItemSourcePF2e } from "@item/base/data/index.ts";
 import { isSpellConsumable } from "@item/consumable/spell-consumables.ts";
 import { CoinsPF2e } from "@item/physical/coins.ts";
 import { MagicTradition } from "@item/spell/types.ts";
@@ -34,7 +34,6 @@ import { CheckDC } from "@system/degree-of-success.ts";
 import {
     ErrorPF2e,
     fontAwesomeIcon,
-    getActionGlyph,
     getActionIcon,
     htmlClosest,
     htmlQuery,
@@ -462,17 +461,14 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
                 return item.system.selfEffect?.img ?? actionIcon;
             })();
 
-            const traits = item.system.traits.value;
-
-            const action: ActionSheetData = {
-                ...R.pick(item, ["id", "name", "actionCost", "frequency"]),
+            const action: CharacterAbilityViewData = {
+                ...createAbilityViewData(item),
                 img,
-                glyph: getActionGlyph(item.actionCost),
                 feat: item.isOfType("feat") ? item : null,
                 toggles: item.system.traits.toggles.getSheetData(),
-                hasEffect: !!item.system.selfEffect,
             };
 
+            const traits = item.system.traits.value;
             if (traits.includes("exploration")) {
                 const active = actor.system.exploration.includes(item.id);
                 action.exploration = { active };
@@ -1617,12 +1613,12 @@ interface CharacterSheetData<TActor extends CharacterPF2e = CharacterPF2e> exten
     hasNormalSpellcasting: boolean;
     tabVisibility: CharacterSheetTabVisibility;
     actions: {
-        encounter: Record<"action" | "reaction" | "free", { label: string; actions: ActionSheetData[] }>;
+        encounter: Record<"action" | "reaction" | "free", { label: string; actions: CharacterAbilityViewData[] }>;
         exploration: {
-            active: ActionSheetData[];
-            other: ActionSheetData[];
+            active: CharacterAbilityViewData[];
+            other: CharacterAbilityViewData[];
         };
-        downtime: ActionSheetData[];
+        downtime: CharacterAbilityViewData[];
     };
     feats: FeatGroup[];
     elementalBlasts: ElementalBlastSheetConfig[];
@@ -1646,19 +1642,12 @@ interface SpeedSheetData {
     breakdown: string | null;
 }
 
-interface ActionSheetData {
-    id: string;
-    name: string;
-    img: string;
-    glyph: string | null;
-    actionCost: ActionCost | null;
-    frequency: Frequency | null;
+interface CharacterAbilityViewData extends AbilityViewData {
     feat: FeatPF2e | null;
     toggles: TraitToggleViewData[];
     exploration?: {
         active: boolean;
     };
-    hasEffect: boolean;
 }
 
 interface ClassDCSheetData extends ClassDCData {

--- a/src/module/actor/familiar/sheet.ts
+++ b/src/module/actor/familiar/sheet.ts
@@ -3,8 +3,8 @@ import { CreatureSheetData } from "@actor/creature/index.ts";
 import { CreatureSheetPF2e } from "@actor/creature/sheet.ts";
 import { SheetClickActionHandlers } from "@actor/sheet/base.ts";
 import { AbilityViewData } from "@actor/sheet/data-types.ts";
+import { createAbilityViewData } from "@actor/sheet/helpers.ts";
 import { StatisticTraceData } from "@system/statistic/index.ts";
-import { getActionGlyph, traitSlugToObject } from "@util";
 import { eventToRollParams } from "@util/sheet.ts";
 import * as R from "remeda";
 import type { FamiliarPF2e } from "./document.ts";
@@ -62,21 +62,7 @@ export class FamiliarSheetPF2e<TActor extends FamiliarPF2e> extends CreatureShee
                     this.actor.itemTypes.action,
                     (a) => a.name,
                     (a) => a.sort,
-                ).map((item) => {
-                    const traits = item.system.traits.value.map((t) => traitSlugToObject(t, CONFIG.PF2E.actionTraits));
-                    return {
-                        id: item.id,
-                        name: item.name,
-                        glyph: getActionGlyph(item.actionCost) || null,
-                        frequency: item.system.frequency || null,
-                        traits,
-                        has: {
-                            aura: item.traits.has("aura") || item.system.rules.some((r) => r.key === "Aura"),
-                            deathNote: item.system.deathNote,
-                            selfEffect: !!item.system.selfEffect,
-                        },
-                    };
-                }),
+                ).map((item) => createAbilityViewData(item)),
             },
             master: this.actor.master,
             masters,

--- a/src/module/actor/npc/sheet.ts
+++ b/src/module/actor/npc/sheet.ts
@@ -3,6 +3,7 @@ import { CreatureSheetPF2e, type CreatureSheetData } from "@actor/creature/sheet
 import { ModifierPF2e } from "@actor/modifiers.ts";
 import { NPCSkillsEditor } from "@actor/npc/skills-editor.ts";
 import { SheetClickActionHandlers } from "@actor/sheet/base.ts";
+import { createAbilityViewData } from "@actor/sheet/helpers.ts";
 import { RecallKnowledgePopup } from "@actor/sheet/popups/recall-knowledge-popup.ts";
 import { MovementType } from "@actor/types.ts";
 import { ATTRIBUTE_ABBREVIATIONS, MOVEMENT_TYPES, SAVE_TYPES } from "@actor/values.ts";
@@ -12,7 +13,6 @@ import { DicePF2e } from "@scripts/dice.ts";
 import type { HTMLTagifyTagsElement } from "@system/html-elements/tagify-tags.ts";
 import type { StatisticRollParameters } from "@system/statistic/index.ts";
 import {
-    getActionGlyph,
     htmlClosest,
     htmlQuery,
     htmlQueryAll,
@@ -369,17 +369,8 @@ class NPCSheetPF2e extends AbstractNPCSheet {
         );
 
         for (const item of abilities) {
-            const traits = item.system.traits.value.map((t) => traitSlugToObject(t, CONFIG.PF2E.actionTraits));
-            const glyph = getActionGlyph(item.actionCost);
-            const actionGroup = glyph ? "active" : "passive";
-            const frequency = item.system?.frequency || null;
-            const has = {
-                aura: item.traits.has("aura") || item.system.rules.some((r) => r.key === "Aura"),
-                deathNote: item.system.deathNote,
-                selfEffect: !!item.system.selfEffect,
-            };
-
-            actions[actionGroup].actions.push({ id: item.id, name: item.name, glyph, traits, frequency, has });
+            const actionGroup = item.actionCost ? "active" : "passive";
+            actions[actionGroup].actions.push(createAbilityViewData(item));
         }
 
         sheetData.attacks = attacks;

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -13,7 +13,7 @@ import type { Coins } from "@item/physical/data.ts";
 import { detachSubitem } from "@item/physical/helpers.ts";
 import { DENOMINATIONS, PHYSICAL_ITEM_TYPES } from "@item/physical/values.ts";
 import { DropCanvasItemDataPF2e } from "@module/canvas/drop-canvas-data.ts";
-import { createSelfEffectMessage } from "@module/chat-message/helpers.ts";
+import { createUseActionMessage } from "@module/chat-message/helpers.ts";
 import { createSheetTags, maintainFocusInRender } from "@module/sheet/helpers.ts";
 import { DamageRoll } from "@system/damage/roll.ts";
 import type { StatisticRollParameters } from "@system/statistic/statistic.ts";
@@ -568,7 +568,7 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
                 const itemId = htmlClosest(anchor, "[data-item-id]")?.dataset.itemId;
                 const item = this.actor.items.get(itemId, { strict: true });
                 if (item.isOfType("action", "feat")) {
-                    return createSelfEffectMessage(item, eventToRollMode(event));
+                    return createUseActionMessage(item, eventToRollMode(event));
                 }
             },
             // INVENTORY

--- a/src/module/actor/sheet/data-types.ts
+++ b/src/module/actor/sheet/data-types.ts
@@ -68,9 +68,11 @@ interface ActorSheetDataPF2e<TActor extends ActorPF2e> extends ActorSheetData<TA
 interface AbilityViewData {
     id: string;
     name: string;
+    img: string;
     traits: TraitViewData[];
     glyph: string | null;
     frequency: Frequency | null;
+    usable: boolean;
     has: {
         aura: boolean;
         deathNote: boolean;

--- a/src/module/actor/vehicle/sheet.ts
+++ b/src/module/actor/vehicle/sheet.ts
@@ -1,9 +1,9 @@
-import { ActorSheetDataPF2e } from "@actor/sheet/data-types.ts";
+import { AbilityViewData, ActorSheetDataPF2e } from "@actor/sheet/data-types.ts";
+import { createAbilityViewData } from "@actor/sheet/helpers.ts";
 import { VehiclePF2e } from "@actor/vehicle/index.ts";
-import { AbilityItemPF2e, ItemPF2e } from "@item";
-import { ActionCost, Frequency } from "@item/base/data/system.ts";
+import { ItemPF2e } from "@item";
 import { AdjustedValue, getAdjustedValue } from "@module/sheet/helpers.ts";
-import { ErrorPF2e, getActionGlyph, getActionIcon, htmlClosest, htmlQuery, htmlQueryAll } from "@util";
+import { ErrorPF2e, getActionIcon, htmlClosest, htmlQuery, htmlQueryAll } from "@util";
 import { ActorSheetPF2e } from "../sheet/base.ts";
 
 export class VehicleSheetPF2e extends ActorSheetPF2e<VehiclePF2e> {
@@ -29,27 +29,17 @@ export class VehicleSheetPF2e extends ActorSheetPF2e<VehiclePF2e> {
         };
 
         for (const item of this.actor.itemTypes.action.sort((a, b) => a.sort - b.sort)) {
-            const itemData = item.toObject(false);
-            const { actionCost, frequency } = item;
-            const actionType = actionCost?.type ?? "free";
-
-            const img = ((): ImageFilePath => {
-                const actionIcon = getActionIcon(item.actionCost);
-                const defaultIcon = ItemPF2e.getDefaultArtwork(item._source).img;
-                if (item.isOfType("action") && ![actionIcon, defaultIcon].includes(item.img)) {
-                    return item.img;
-                }
-                return item.system.selfEffect?.img ?? actionIcon;
-            })();
-
+            const actionType = item.actionCost?.type ?? "free";
             actions[actionType].actions.push({
-                ...itemData,
-                id: item.id,
-                img,
-                actionCost,
-                glyph: actionCost ? getActionGlyph(actionCost) : null,
-                frequency,
-                hasEffect: !!item.system.selfEffect,
+                ...createAbilityViewData(item),
+                img: ((): ImageFilePath => {
+                    const actionIcon = getActionIcon(item.actionCost);
+                    const defaultIcon = ItemPF2e.getDefaultArtwork(item._source).img;
+                    if (item.isOfType("action") && ![actionIcon, defaultIcon].includes(item.img)) {
+                        return item.img;
+                    }
+                    return item.system.selfEffect?.img ?? actionIcon;
+                })(),
             });
         }
 
@@ -123,12 +113,4 @@ interface VehicleSheetData extends ActorSheetDataPF2e<VehiclePF2e> {
     emitsSoundOptions: FormSelectOption[];
 }
 
-type ActionsSheetData = Record<"action" | "reaction" | "free", { label: string; actions: ActionSheetData[] }>;
-
-interface ActionSheetData extends RawObject<AbilityItemPF2e> {
-    id: string;
-    actionCost: ActionCost | null;
-    glyph: string | null;
-    frequency: Frequency | null;
-    hasEffect: boolean;
-}
+type ActionsSheetData = Record<"action" | "reaction" | "free", { label: string; actions: AbilityViewData[] }>;

--- a/src/scripts/macros/hotbar.ts
+++ b/src/scripts/macros/hotbar.ts
@@ -4,7 +4,7 @@ import { ElementalBlast } from "@actor/character/elemental-blast.ts";
 import type { ConditionPF2e, EffectPF2e } from "@item";
 import { EffectTrait } from "@item/abstract-effect/types.ts";
 import { ChatMessagePF2e } from "@module/chat-message/document.ts";
-import { createSelfEffectMessage } from "@module/chat-message/helpers.ts";
+import { createUseActionMessage } from "@module/chat-message/helpers.ts";
 import { MacroPF2e } from "@module/macro.ts";
 import { objectHasKey } from "@util";
 
@@ -22,8 +22,8 @@ export async function rollItemMacro(itemId: string, event: Event | null = null):
         return null;
     }
 
-    if (item.isOfType("action", "feat") && item.system.selfEffect) {
-        return createSelfEffectMessage(item);
+    if (item.isOfType("action", "feat")) {
+        return createUseActionMessage(item);
     }
 
     // Trigger the item roll

--- a/static/templates/actors/npc/partials/action.hbs
+++ b/static/templates/actors/npc/partials/action.hbs
@@ -25,13 +25,11 @@
             <a data-action="delete-item" data-tooltip="Delete"><i class="fa-solid fa-fw fa-trash"></i></a>
         {{/if}}
     </div>
-    {{#if (or action.frequency action.has.selfEffect)}}
+    {{#if action.usable}}
         <div class="button-group">
-            {{#if action.has.selfEffect}}
-                <button type="button" class="use-action" data-action="use-action">
-                    <span>{{localize "PF2E.Action.Use"}}</span>
-                </button>
-            {{/if}}
+            <button type="button" class="use-action" data-action="use-action">
+                <span>{{localize "PF2E.Action.Use"}}</span>
+            </button>
             {{#if action.frequency}}
                 <div class="frequency">
                     <input type="number" value="{{action.frequency.value}}" data-item-id="{{action.id}}" data-item-property="system.frequency.value" />

--- a/static/templates/actors/partials/action.hbs
+++ b/static/templates/actors/partials/action.hbs
@@ -20,7 +20,7 @@
     </h4>
 
     <div class="button-group">
-        {{#if action.hasEffect}}
+        {{#if action.usable}}
             <button type="button" class="use-action" data-action="use-action">
                 <span>{{localize "PF2E.Action.Use"}}</span>
                 <span class="action-glyph">{{action.glyph}}</span>


### PR DESCRIPTION
This adds a use button to every action with a frequency, though since collapsed preview messages are expressly codified as "self-effect" chat messages even down to the message type, these messages do not show a collapsed preview at this time. It also does not prevent using the ability once there are no uses remaining, though I will definitely do that once we have regeneration for per round and per turn abilities.