### PR TITLE
Recharge turn and round abilities as the encounter changes turns

### DIFF
--- a/src/module/actor/spellcasting.ts
+++ b/src/module/actor/spellcasting.ts
@@ -2,12 +2,13 @@ import type { ActorPF2e } from "@actor";
 import type { ConsumablePF2e, SpellPF2e } from "@item";
 import { SpellcastingEntryPF2e } from "@item";
 import { SpellCollection } from "@item/spellcasting-entry/collection.ts";
-import { SpellcastingEntrySource } from "@item/spellcasting-entry/index.ts";
 import { RitualSpellcasting } from "@item/spellcasting-entry/rituals.ts";
 import { TRICK_MAGIC_SKILLS, TrickMagicItemEntry } from "@item/spellcasting-entry/trick.ts";
 import { BaseSpellcastingEntry } from "@item/spellcasting-entry/types.ts";
 import { Statistic } from "@system/statistic/statistic.ts";
 import { DelegatedCollection, ErrorPF2e, tupleHasValue } from "@util";
+import { CreatureSource } from "./data/index.ts";
+import { ActorCommitData } from "./types.ts";
 
 export class ActorSpellcasting<TActor extends ActorPF2e> extends DelegatedCollection<BaseSpellcastingEntry<TActor>> {
     /** The base casting proficiency, off of which spellcasting builds */
@@ -73,7 +74,7 @@ export class ActorSpellcasting<TActor extends ActorPF2e> extends DelegatedCollec
         return !!spell && this.some((e) => e.canCast(spell, { origin: item }));
     }
 
-    refocus(options: { all?: boolean } = {}): { "system.resources.focus.value": number } | null {
+    refocus(options: { all?: boolean } = {}): DeepPartial<CreatureSource> | null {
         if (!options.all) {
             throw ErrorPF2e("Actors do not currently support regular refocusing");
         }
@@ -84,7 +85,7 @@ export class ActorSpellcasting<TActor extends ActorPF2e> extends DelegatedCollec
             const rechargeFocus = focus?.max && focus.value < focus.max;
             if (focus && rechargeFocus) {
                 focus.value = focus.max;
-                return { "system.resources.focus.value": focus.value };
+                return { system: { resources: { focus: { value: focus.value } } } };
             }
         }
 
@@ -95,10 +96,7 @@ export class ActorSpellcasting<TActor extends ActorPF2e> extends DelegatedCollec
      * Recharges all spellcasting entries based on the type of entry it is
      * @todo Support a timespan property of some sort and handle 1/hour innate spells
      */
-    recharge(): {
-        itemUpdates: ((Record<string, unknown> | Partial<SpellcastingEntrySource>) & { _id: string })[];
-        actorUpdates: { "system.resources.focus.value": number } | null;
-    } {
+    recharge(): ActorCommitData<TActor["_source"]> {
         type SpellcastingUpdate = EmbeddedDocumentUpdateData | EmbeddedDocumentUpdateData[];
 
         const itemUpdates = this.contents.flatMap((entry): SpellcastingUpdate => {
@@ -109,7 +107,7 @@ export class ActorSpellcasting<TActor extends ActorPF2e> extends DelegatedCollec
             if (entry.isInnate) {
                 return entry.spells.map((spell) => {
                     const value = spell.system.location.uses?.max ?? 1;
-                    return { _id: spell.id, "system.location.uses.value": value };
+                    return { _id: spell.id, system: { location: { uses: { value } } } };
                 });
             }
 
@@ -131,7 +129,7 @@ export class ActorSpellcasting<TActor extends ActorPF2e> extends DelegatedCollec
             }
 
             if (updated) {
-                return { _id: entry.id, "system.slots": slots };
+                return { _id: entry.id, system: { slots } };
             }
 
             return [];

--- a/src/module/actor/types.ts
+++ b/src/module/actor/types.ts
@@ -10,7 +10,7 @@ import type { immunityTypes, resistanceTypes, weaknessTypes } from "@scripts/con
 import type { DamageRoll } from "@system/damage/roll.ts";
 import type { DegreeOfSuccessString } from "@system/degree-of-success.ts";
 import type { Predicate } from "@system/predication.ts";
-import { ActorSourcePF2e } from "./data/index.ts";
+import type { ActorSourcePF2e } from "./data/index.ts";
 import type {
     ACTOR_TYPES,
     ATTRIBUTE_ABBREVIATIONS,

--- a/src/module/actor/types.ts
+++ b/src/module/actor/types.ts
@@ -10,6 +10,7 @@ import type { immunityTypes, resistanceTypes, weaknessTypes } from "@scripts/con
 import type { DamageRoll } from "@system/damage/roll.ts";
 import type { DegreeOfSuccessString } from "@system/degree-of-success.ts";
 import type { Predicate } from "@system/predication.ts";
+import { ActorSourcePF2e } from "./data/index.ts";
 import type {
     ACTOR_TYPES,
     ATTRIBUTE_ABBREVIATIONS,
@@ -91,6 +92,19 @@ interface AuraAppearanceData {
     } | null;
 }
 
+interface ActorCommitData<T extends ActorSourcePF2e> {
+    actorUpdates: DeepPartial<T> | null;
+    itemUpdates: EmbeddedDocumentUpdateData[];
+}
+
+interface ActorRechargeData<T extends ActorSourcePF2e> extends ActorCommitData<T> {
+    affected: {
+        frequencies: boolean;
+        spellSlots: boolean;
+        resources: string[];
+    };
+}
+
 /* -------------------------------------------- */
 /*  Attack Rolls                                */
 /* -------------------------------------------- */
@@ -120,8 +134,10 @@ type IWRType = ImmunityType | WeaknessType | ResistanceType;
 
 export type {
     ActorAlliance,
+    ActorCommitData,
     ActorDimensions,
     ActorInstances,
+    ActorRechargeData,
     ActorType,
     ApplyDamageParams,
     AttributeString,
@@ -130,8 +146,8 @@ export type {
     AuraEffectData,
     DCSlug,
     EmbeddedItemInstances,
-    IWRType,
     ImmunityType,
+    IWRType,
     MovementType,
     ResistanceType,
     SaveType,

--- a/src/module/encounter/combatant.ts
+++ b/src/module/encounter/combatant.ts
@@ -244,11 +244,18 @@ class CombatantPF2e<
      */
     async #performActorUpdates(event: "initiative-roll" | "turn-start"): Promise<void> {
         const actor = this.actor;
+        if (!actor) return;
+
         const actorUpdates: Record<string, unknown> = {};
-        for (const rule of actor?.rules ?? []) {
+        for (const rule of actor.rules ?? []) {
             await rule.onUpdateEncounter?.({ event, actorUpdates });
         }
-        await actor?.update(actorUpdates);
+        await actor.update(actorUpdates);
+
+        // Refresh usages of any abilities with round durations
+        if (event === "turn-start") {
+            await actor.recharge({ duration: "round" });
+        }
     }
 
     /* -------------------------------------------- */

--- a/src/module/encounter/document.ts
+++ b/src/module/encounter/document.ts
@@ -311,6 +311,13 @@ class EncounterPF2e extends Combat {
                         await combatant.startTurn();
                     }
                 }
+
+                // Update all per turn abilities by other combatants
+                for (const otherCombatant of this.combatants) {
+                    if (combatant !== otherCombatant) {
+                        otherCombatant.actor?.recharge({ duration: "turn" });
+                    }
+                }
             }
 
             // Reset all participating actors' data to get updated encounter roll options


### PR DESCRIPTION
There is a very strange bug where the self effect image disappears until next re-render if the ability got updated. It seems to be an issue with the fallback uuid sync fallback, so I'll leave that to shark to figure out as he's more familiar with that side of things.

Merging this or the special resource branch will necessitate updating the other. That's fine by me though.