### PR TITLE
Brush up rule elements on Monstrous Peacemaker

### DIFF
--- a/packs/feats/monstrous-peacemaker.json
+++ b/packs/feats/monstrous-peacemaker.json
@@ -28,23 +28,12 @@
             {
                 "key": "FlatModifier",
                 "predicate": [
-                    {
-                        "not": "target:trait:humanoid"
-                    }
+                    "monstrous-peacemaker"
                 ],
-                "selector": "diplomacy",
-                "type": "circumstance",
-                "value": 1
-            },
-            {
-                "key": "FlatModifier",
-                "predicate": [
-                    {
-                        "not": "target:trait:humanoid"
-                    },
-                    "action:sense-motive"
+                "selector": [
+                    "diplomacy",
+                    "perception"
                 ],
-                "selector": "perception",
                 "type": "circumstance",
                 "value": 1
             }


### PR DESCRIPTION
Before it was just default on for all rolls from the skills tab, since they don't get target info.