### PR TITLE
Organize character feat collection classes and interfaces

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -4,7 +4,7 @@ import type { ActorPF2e } from "@actor";
 import type { Action } from "@actor/actions/index.ts";
 import type { AutomaticBonusProgression } from "@actor/character/automatic-bonus-progression.ts";
 import type { ElementalBlast } from "@actor/character/elemental-blast.ts";
-import type { FeatGroupOptions } from "@actor/character/feats.ts";
+import type { FeatGroupData } from "@actor/character/feats/index.ts";
 import type { CheckModifier, ModifierPF2e, ModifierType, StatisticModifier } from "@actor/modifiers.ts";
 import type { ItemPF2e, PhysicalItemPF2e } from "@item";
 import type { ConditionSource } from "@item/condition/data.ts";
@@ -135,7 +135,7 @@ interface GamePF2e
             campaign: {
                 feats: {
                     enabled: boolean;
-                    sections: FeatGroupOptions[];
+                    sections: FeatGroupData[];
                 };
                 languages: LanguageSettings;
             };
@@ -303,7 +303,7 @@ declare global {
         get(module: "pf2e", setting: "worldClock.worldCreatedOn"): string;
 
         get(module: "pf2e", setting: "campaignFeats"): boolean;
-        get(module: "pf2e", setting: "campaignFeatSections"): FeatGroupOptions[];
+        get(module: "pf2e", setting: "campaignFeatSections"): FeatGroupData[];
         get(module: "pf2e", setting: "campaignType"): string;
 
         get(module: "pf2e", setting: "activeParty"): string;

--- a/src/module/actor/army/document.ts
+++ b/src/module/actor/army/document.ts
@@ -1,4 +1,4 @@
-import { FeatGroup } from "@actor/character/feats.ts";
+import { FeatGroup } from "@actor/character/feats/index.ts";
 import { Sense } from "@actor/creature/sense.ts";
 import { ActorInitiative } from "@actor/initiative.ts";
 import { ModifierPF2e } from "@actor/modifiers.ts";

--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -72,7 +72,7 @@ import {
     MartialProficiency,
     WeaponGroupProficiencyKey,
 } from "./data.ts";
-import { CharacterFeats } from "./feats.ts";
+import { CharacterFeats } from "./feats/index.ts";
 import {
     PCAttackTraitHelpers,
     WeaponAuxiliaryAction,

--- a/src/module/actor/character/feats/collection.ts
+++ b/src/module/actor/character/feats/collection.ts
@@ -116,8 +116,8 @@ class CharacterFeats<TActor extends CharacterPF2e> extends Collection<FeatGroup<
         }
     }
 
-    createGroup(options: FeatGroupData): this {
-        return this.set(options.id, new FeatGroup(this.actor, options));
+    createGroup(data: FeatGroupData): this {
+        return this.set(data.id, new FeatGroup(this.actor, data));
     }
 
     /** Inserts a feat into the character. If groupId is empty string, it's a bonus feat. */

--- a/src/module/actor/character/feats/group.ts
+++ b/src/module/actor/character/feats/group.ts
@@ -1,0 +1,162 @@
+import type { ActorPF2e } from "@actor";
+import type { FeatPF2e, HeritagePF2e, ItemPF2e } from "@item";
+import type { FeatOrFeatureCategory } from "@item/feat/index.ts";
+import { sluggify, tupleHasValue } from "@util/misc.ts";
+import type { FeatGroupData, FeatLike, FeatSlot } from "./types.ts";
+
+class FeatGroup<TActor extends ActorPF2e = ActorPF2e, TItem extends FeatLike = FeatPF2e> {
+    actor: TActor;
+
+    id: string;
+    label: string;
+    feats: (FeatSlot<TItem> | FeatNotSlot<TItem>)[] = [];
+    /** Whether the feats are slotted by level or free-form */
+    slotted = false;
+    /** Will move to sheet data later */
+    featFilter: string[];
+
+    /** Feat Types that are supported */
+    supported: FeatOrFeatureCategory[] = [];
+
+    /** Lookup for the slots themselves */
+    slots: Record<string, FeatSlot<TItem> | undefined> = {};
+
+    /** This groups level for the purpose of showing feats. Usually equal to actor level */
+    level: number;
+
+    constructor(actor: TActor, data: FeatGroupData, options: { level?: number } = {}) {
+        this.actor = actor;
+        this.id = data.id;
+        this.label = data.label;
+        this.level = options.level ?? actor.level;
+        this.supported = data.supported ?? [];
+        this.featFilter = Array.from(
+            new Set([this.supported.map((s) => `category-${s}`), data.featFilter ?? []].flat()),
+        );
+
+        if (data.slots) {
+            this.slotted = true;
+            for (const slotOption of data.slots) {
+                const slotData =
+                    typeof slotOption === "number"
+                        ? { id: `${this.id}-${slotOption}`, level: slotOption, label: slotOption.toString() }
+                        : typeof slotOption === "string"
+                          ? { id: `${this.id}-${sluggify(slotOption)}`, level: null, label: slotOption }
+                          : slotOption;
+                if (typeof slotData.level === "number" && slotData.level > this.level) {
+                    continue;
+                }
+
+                const slot = { ...slotData, level: slotData.level ?? null, children: [] };
+                this.feats.push(slot);
+                this.slots[slot.id] = slot;
+            }
+        }
+    }
+
+    /** Is this category slotted and without any empty slots */
+    get isFull(): boolean {
+        return this.slotted && Object.values(this.slots).every((s) => !!s?.feat);
+    }
+
+    /** Assigns a feat to its correct slot during data preparation, returning true if successful */
+    assignFeat(feat: TItem): boolean {
+        const slotId =
+            feat.isOfType("feat") && feat.system.location === this.id
+                ? (feat.system.level.taken?.toString() ?? "")
+                : (feat.system.location ?? "");
+        const slot: FeatSlot<TItem> | undefined = this.slots[slotId];
+        if (!slot && this.slotted) return false;
+
+        if (slot?.feat) {
+            console.debug(`PF2e System | Multiple feats with same index: ${feat.name}, ${slot.feat.name}`);
+            return false;
+        }
+
+        const childSlots = this.#getChildSlots(feat);
+        if (slot) {
+            slot.feat = feat;
+            slot.children = childSlots;
+        } else {
+            const label = feat.category === "classfeature" ? (feat.system.level?.value.toString() ?? null) : null;
+            this.feats.push({ feat, label, children: childSlots });
+        }
+        feat.group = this;
+
+        return true;
+    }
+
+    #getChildSlots(feat: Maybe<ItemPF2e>): FeatSlot<FeatPF2e<ActorPF2e> | HeritagePF2e<ActorPF2e>>[] {
+        if (!feat?.isOfType("feat")) return [];
+
+        return feat.grants.map((grant): FeatSlot<FeatPF2e<ActorPF2e> | HeritagePF2e<ActorPF2e>> => {
+            return {
+                id: grant.id,
+                label: null,
+                level: grant.system.level?.taken ?? null,
+                feat: grant,
+                children: this.#getChildSlots(grant),
+            };
+        });
+    }
+
+    isFeatValid(feat: TItem): boolean {
+        return this.supported.length === 0 || tupleHasValue(this.supported, feat.category);
+    }
+
+    /** Adds a new feat to the actor, or reorders an existing one, into the correct slot */
+    async insertFeat(feat: TItem, slotId: Maybe<string> = null): Promise<ItemPF2e<TActor>[]> {
+        const slot = this.slots[slotId ?? ""];
+        const location = this.slotted || this.id === "bonus" ? (slot?.id ?? null) : this.id;
+        const existing = this.actor.items.filter(
+            (i): i is FeatLike<TActor> => isFeatLike(i) && i.system.location === location,
+        );
+        const isFeatValidInSlot = this.isFeatValid(feat);
+        const alreadyHasFeat = this.actor.items.has(feat.id);
+
+        const changed: ItemPF2e<TActor>[] = [];
+
+        // If this is a new feat, create a new feat item on the actor first
+        if (!alreadyHasFeat && (isFeatValidInSlot || !location)) {
+            const source = fu.mergeObject(feat.toObject(), {
+                system: { location, level: { taken: slot?.level ?? this.actor.level } },
+            });
+            changed.push(...(await this.actor.createEmbeddedDocuments("Item", [source])));
+            const label = game.i18n.localize(this.label);
+            ui.notifications.info(game.i18n.format("PF2E.Item.Feat.Info.Added", { item: feat.name, category: label }));
+        }
+
+        // Determine what feats we have to move around
+        const locationUpdates: { _id: string; "system.location": string | null }[] = this.slotted
+            ? existing.map((f) => ({
+                  _id: f.id,
+                  "system.location": null,
+                  ...("taken" in (feat._source.system.level ?? {}) ? { "system.level.-=taken": null } : {}),
+              }))
+            : [];
+        if (alreadyHasFeat && isFeatValidInSlot) {
+            locationUpdates.push({
+                _id: feat.id,
+                "system.location": location,
+                ...(slot?.level && feat.isOfType("feat") ? { "system.level.taken": slot.level } : {}),
+            });
+        }
+
+        if (locationUpdates.length > 0) {
+            changed.push(...(await this.actor.updateEmbeddedDocuments("Item", locationUpdates)));
+        }
+
+        return changed;
+    }
+}
+
+interface FeatNotSlot<T extends FeatLike = FeatPF2e> {
+    feat: T;
+    children: FeatSlot<FeatLike | HeritagePF2e>[];
+}
+
+function isFeatLike<TActor extends ActorPF2e | null>(item: ItemPF2e<TActor>): item is FeatLike<TActor> {
+    return "category" in item && "location" in item.system && "isFeat" in item && "isFeature" in item;
+}
+
+export { FeatGroup };

--- a/src/module/actor/character/feats/index.ts
+++ b/src/module/actor/character/feats/index.ts
@@ -1,0 +1,3 @@
+export * from "./collection.ts";
+export * from "./group.ts";
+export * from "./types.ts";

--- a/src/module/actor/character/feats/types.ts
+++ b/src/module/actor/character/feats/types.ts
@@ -1,0 +1,39 @@
+import type { ActorPF2e } from "@actor/base.ts";
+import type { FeatPF2e, HeritagePF2e, ItemPF2e } from "@item";
+import type { ItemSystemData } from "@item/base/data/index.ts";
+import type { FeatOrFeatureCategory } from "@item/feat/types.ts";
+import type { FeatGroup } from "./group.ts";
+
+/** Any document that is similar enough to a feat/feature to be used as a feat for the purposes of feat groups */
+interface FeatLike<TParent extends ActorPF2e | null = ActorPF2e | null> extends ItemPF2e<TParent> {
+    category: string;
+    group: FeatGroup<NonNullable<TParent>, this> | null;
+    isFeat: boolean;
+    isFeature: boolean;
+    system: ItemSystemData & {
+        location: string | null;
+    };
+}
+
+/** Data that defines how a feat group is structured */
+interface FeatGroupData {
+    id: string;
+    label: string;
+    featFilter?: string[];
+    supported?: FeatOrFeatureCategory[];
+    slots?: (FeatSlotCreationData | string | number)[];
+}
+
+interface FeatSlot<TItem extends FeatLike | HeritagePF2e = FeatPF2e> {
+    id: string;
+    label?: Maybe<string>;
+    level: number | null;
+    feat?: Maybe<TItem>;
+    children: FeatSlot<FeatLike | HeritagePF2e>[];
+}
+
+interface FeatSlotCreationData extends Omit<FeatSlot, "children" | "feat" | "level"> {
+    level?: Maybe<number>;
+}
+
+export type { FeatGroupData, FeatLike, FeatSlot, FeatSlotCreationData };

--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -65,7 +65,7 @@ import {
 } from "./data.ts";
 import { CharacterPF2e } from "./document.ts";
 import { ElementalBlast, ElementalBlastConfig } from "./elemental-blast.ts";
-import { FeatGroup } from "./feats.ts";
+import type { FeatGroup } from "./feats/index.ts";
 import { PCSheetTabManager } from "./tab-manager.ts";
 import { CHARACTER_SHEET_TABS } from "./values.ts";
 

--- a/src/module/actor/party/kingdom/model.ts
+++ b/src/module/actor/party/kingdom/model.ts
@@ -1,5 +1,5 @@
 import { ActorPF2e, type ArmyPF2e } from "@actor";
-import { FeatGroup } from "@actor/character/feats.ts";
+import { FeatGroup } from "@actor/character/feats/index.ts";
 import { MODIFIER_TYPES, ModifierPF2e, RawModifier, createProficiencyModifier } from "@actor/modifiers.ts";
 import { CampaignFeaturePF2e, ItemPF2e } from "@item";
 import { ItemType } from "@item/base/data/index.ts";
@@ -451,24 +451,33 @@ class Kingdom extends DataModel<PartyPF2e, KingdomSchema> implements PartyCampai
             .fill(0)
             .map((_, idx) => idx + 1)
             .filter((idx) => idx % 2 === 0);
-        this.features = new FeatGroup(this.actor, {
-            id: "features",
-            label: "Kingdom Features",
-            level: this.level,
-        });
-        this.feats = new FeatGroup(this.actor, {
-            id: "kingdom",
-            label: "Kingdom Feats",
-            slots: [{ id: "government", label: "G" }, ...evenLevels],
-            featFilter: ["traits-kingdom"],
-            level: this.level,
-        });
-        this.bonusFeats = new FeatGroup(this.actor, {
-            id: "bonus",
-            label: "PF2E.FeatBonusHeader",
-            featFilter: ["traits-kingdom"],
-            level: this.level,
-        });
+        this.features = new FeatGroup(
+            this.actor,
+            {
+                id: "features",
+                label: "Kingdom Features",
+            },
+            { level: this.level },
+        );
+        this.feats = new FeatGroup(
+            this.actor,
+            {
+                id: "kingdom",
+                label: "Kingdom Feats",
+                slots: [{ id: "government", label: "G" }, ...evenLevels],
+                featFilter: ["traits-kingdom"],
+            },
+            { level: this.level },
+        );
+        this.bonusFeats = new FeatGroup(
+            this.actor,
+            {
+                id: "bonus",
+                label: "PF2E.FeatBonusHeader",
+                featFilter: ["traits-kingdom"],
+            },
+            { level: this.level },
+        );
 
         // Assign feats and features
         const allFeatures = this.actor.itemTypes.campaignFeature;

--- a/src/module/actor/party/kingdom/sheet.ts
+++ b/src/module/actor/party/kingdom/sheet.ts
@@ -1,5 +1,5 @@
 import { ActorPF2e, ArmyPF2e, CreaturePF2e, type PartyPF2e } from "@actor";
-import { FeatGroup } from "@actor/character/feats.ts";
+import type { FeatGroup } from "@actor/character/feats/index.ts";
 import { MODIFIER_TYPES } from "@actor/modifiers.ts";
 import { ActorSheetPF2e, SheetClickActionHandlers } from "@actor/sheet/base.ts";
 import { ActorSheetDataPF2e } from "@actor/sheet/data-types.ts";

--- a/src/module/item/campaign-feature/document.ts
+++ b/src/module/item/campaign-feature/document.ts
@@ -1,5 +1,5 @@
 import type { ActorPF2e } from "@actor";
-import type { FeatGroup } from "@actor/character/feats.ts";
+import type { FeatGroup } from "@actor/character/feats/index.ts";
 import { ItemPF2e } from "@item";
 import { normalizeActionChangeData } from "@item/ability/helpers.ts";
 import { ActionCost, Frequency } from "@item/base/data/index.ts";

--- a/src/module/item/class/document.ts
+++ b/src/module/item/class/document.ts
@@ -1,6 +1,6 @@
 import type { ActorPF2e, CharacterPF2e } from "@actor";
 import { ClassDCData } from "@actor/character/data.ts";
-import { FeatSlotCreationData } from "@actor/character/feats.ts";
+import type { FeatSlotCreationData } from "@actor/character/feats/index.ts";
 import { SaveType } from "@actor/types.ts";
 import { SAVE_TYPES } from "@actor/values.ts";
 import { ABCItemPF2e, FeatPF2e } from "@item";

--- a/src/module/item/feat/document.ts
+++ b/src/module/item/feat/document.ts
@@ -1,6 +1,6 @@
 import type { ActorPF2e } from "@actor";
 import { ClassDCData } from "@actor/character/data.ts";
-import type { FeatGroup } from "@actor/character/feats.ts";
+import type { FeatGroup } from "@actor/character/feats/index.ts";
 import type { SenseData } from "@actor/creature/index.ts";
 import { ItemPF2e, type HeritagePF2e } from "@item";
 import { getActionCostRollOptions, normalizeActionChangeData, processSanctification } from "@item/ability/helpers.ts";


### PR DESCRIPTION
There is only one actual change here. FeatGroupOptions split into FeatGroupData and options. Level is used by kingmaker to pass in the level of the kingdom instead of the actor's level, but it was not part of the actual structural metadata. That is not the sort of data we'd want to store in the campaign feat settings when we finally make a UI for it, so I split it off.