### PR TITLE
Use UUID-based Choice Set for condensed equipment effects

### DIFF
--- a/packs/equipment-effects/effect-antidote.json
+++ b/packs/equipment-effects/effect-antidote.json
@@ -30,11 +30,7 @@
                                 "or": [
                                     "parent:origin:item:slug:antidote-lesser",
                                     {
-                                        "nor": [
-                                            "parent:origin:item:slug:antidote-greater",
-                                            "parent:origin:item:slug:antidote-major",
-                                            "parent:origin:item:slug:antidote-moderate"
-                                        ]
+                                        "not": "parent:origin:item"
                                     }
                                 ]
                             }
@@ -47,11 +43,7 @@
                                 "or": [
                                     "parent:origin:item:slug:antidote-moderate",
                                     {
-                                        "nor": [
-                                            "parent:origin:item:slug:antidote-greater",
-                                            "parent:origin:item:slug:antidote-lesser",
-                                            "parent:origin:item:slug:antidote-major"
-                                        ]
+                                        "not": "parent:origin:item"
                                     }
                                 ]
                             }
@@ -64,11 +56,7 @@
                                 "or": [
                                     "parent:origin:item:slug:antidote-greater",
                                     {
-                                        "nor": [
-                                            "parent:origin:item:slug:antidote-moderate",
-                                            "parent:origin:item:slug:antidote-lesser",
-                                            "parent:origin:item:slug:antidote-major"
-                                        ]
+                                        "not": "parent:origin:item"
                                     }
                                 ]
                             }
@@ -81,11 +69,7 @@
                                 "or": [
                                     "parent:origin:item:slug:antidote-major",
                                     {
-                                        "nor": [
-                                            "parent:origin:item:slug:antidote-greater",
-                                            "parent:origin:item:slug:antidote-lesser",
-                                            "parent:origin:item:slug:antidote-moderate"
-                                        ]
+                                        "not": "parent:origin:item"
                                     }
                                 ]
                             }

--- a/packs/equipment-effects/effect-antidote.json
+++ b/packs/equipment-effects/effect-antidote.json
@@ -22,9 +22,9 @@
         },
         "rules": [
             {
+                "adjustName": false,
                 "choices": [
                     {
-                        "label": "PF2E.SpecificRule.Equipment.Antidote.Lesser",
                         "predicate": [
                             {
                                 "or": [
@@ -39,10 +39,9 @@
                                 ]
                             }
                         ],
-                        "value": 2
+                        "value": "Compendium.pf2e.equipment-srd.Item.Antidote (Lesser)"
                     },
                     {
-                        "label": "PF2E.SpecificRule.Equipment.Antidote.Moderate",
                         "predicate": [
                             {
                                 "or": [
@@ -57,10 +56,9 @@
                                 ]
                             }
                         ],
-                        "value": 3
+                        "value": "Compendium.pf2e.equipment-srd.Item.Antidote (Moderate)"
                     },
                     {
-                        "label": "PF2E.SpecificRule.Equipment.Antidote.Greater",
                         "predicate": [
                             {
                                 "or": [
@@ -75,10 +73,9 @@
                                 ]
                             }
                         ],
-                        "value": 4
+                        "value": "Compendium.pf2e.equipment-srd.Item.Antidote (Greater)"
                     },
                     {
-                        "label": "PF2E.SpecificRule.Equipment.Antidote.Major",
                         "predicate": [
                             {
                                 "or": [
@@ -93,12 +90,12 @@
                                 ]
                             }
                         ],
-                        "value": 4
+                        "value": "Compendium.pf2e.equipment-srd.Item.Antidote (Major)"
                     }
                 ],
-                "flag": "antidote",
                 "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.Prompt.EquipmentVariety"
+                "prompt": "PF2E.SpecificRule.Prompt.EquipmentVariety",
+                "rollOption": "antidote"
             },
             {
                 "key": "FlatModifier",
@@ -106,8 +103,34 @@
                     "item:trait:poison"
                 ],
                 "selector": "fortitude",
+                "slug": "antidote-bonus",
                 "type": "item",
-                "value": "@item.flags.pf2e.rulesSelections.antidote"
+                "value": 2
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "upgrade",
+                "predicate": [
+                    "antidote:antidote-moderate"
+                ],
+                "selector": "fortitude",
+                "slug": "antidote-bonus",
+                "value": 3
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "upgrade",
+                "predicate": [
+                    {
+                        "or": [
+                            "antidote:antidote-greater",
+                            "antidote:antidote-major"
+                        ]
+                    }
+                ],
+                "selector": "fortitude",
+                "slug": "antidote-bonus",
+                "value": 4
             }
         ],
         "start": {

--- a/packs/equipment-effects/effect-antiplague.json
+++ b/packs/equipment-effects/effect-antiplague.json
@@ -30,11 +30,7 @@
                                 "or": [
                                     "parent:origin:item:slug:antiplague-lesser",
                                     {
-                                        "nor": [
-                                            "parent:origin:item:slug:antiplague-greater",
-                                            "parent:origin:item:slug:antiplague-major",
-                                            "parent:origin:item:slug:antiplague-moderate"
-                                        ]
+                                        "not": "parent:origin:item"
                                     }
                                 ]
                             }
@@ -47,11 +43,7 @@
                                 "or": [
                                     "parent:origin:item:slug:antiplague-moderate",
                                     {
-                                        "nor": [
-                                            "parent:origin:item:slug:antiplague-lesser",
-                                            "parent:origin:item:slug:antiplague-greater",
-                                            "parent:origin:item:slug:antiplague-major"
-                                        ]
+                                        "not": "parent:origin:item"
                                     }
                                 ]
                             }
@@ -64,11 +56,7 @@
                                 "or": [
                                     "parent:origin:item:slug:antiplague-greater",
                                     {
-                                        "nor": [
-                                            "parent:origin:item:slug:antiplague-lesser",
-                                            "parent:origin:item:slug:antiplague-moderate",
-                                            "parent:origin:item:slug:antiplague-major"
-                                        ]
+                                        "not": "parent:origin:item"
                                     }
                                 ]
                             }
@@ -81,11 +69,7 @@
                                 "or": [
                                     "parent:origin:item:slug:antiplague-major",
                                     {
-                                        "nor": [
-                                            "parent:origin:item:slug:antiplague-lesser",
-                                            "parent:origin:item:slug:antiplague-greater",
-                                            "parent:origin:item:slug:antiplague-moderate"
-                                        ]
+                                        "not": "parent:origin:item"
                                     }
                                 ]
                             }

--- a/packs/equipment-effects/effect-antiplague.json
+++ b/packs/equipment-effects/effect-antiplague.json
@@ -22,9 +22,9 @@
         },
         "rules": [
             {
+                "adjustName": false,
                 "choices": [
                     {
-                        "label": "PF2E.SpecificRule.Equipment.Antiplague.Lesser",
                         "predicate": [
                             {
                                 "or": [
@@ -39,66 +39,63 @@
                                 ]
                             }
                         ],
-                        "value": 2
+                        "value": "Compendium.pf2e.equipment-srd.Item.Antiplague (Lesser)"
                     },
                     {
-                        "label": "PF2E.SpecificRule.Equipment.Antiplague.Moderate",
                         "predicate": [
                             {
                                 "or": [
                                     "parent:origin:item:slug:antiplague-moderate",
                                     {
                                         "nor": [
-                                            "parent:origin:item:slug:antiplague-greater",
                                             "parent:origin:item:slug:antiplague-lesser",
+                                            "parent:origin:item:slug:antiplague-greater",
                                             "parent:origin:item:slug:antiplague-major"
                                         ]
                                     }
                                 ]
                             }
                         ],
-                        "value": 3
+                        "value": "Compendium.pf2e.equipment-srd.Item.Antiplague (Moderate)"
                     },
                     {
-                        "label": "PF2E.SpecificRule.Equipment.Antiplague.Greater",
                         "predicate": [
                             {
                                 "or": [
                                     "parent:origin:item:slug:antiplague-greater",
                                     {
                                         "nor": [
-                                            "parent:origin:item:slug:antiplague-moderate",
                                             "parent:origin:item:slug:antiplague-lesser",
+                                            "parent:origin:item:slug:antiplague-moderate",
                                             "parent:origin:item:slug:antiplague-major"
                                         ]
                                     }
                                 ]
                             }
                         ],
-                        "value": 4
+                        "value": "Compendium.pf2e.equipment-srd.Item.Antiplague (Greater)"
                     },
                     {
-                        "label": "PF2E.SpecificRule.Equipment.Antiplague.Major",
                         "predicate": [
                             {
                                 "or": [
                                     "parent:origin:item:slug:antiplague-major",
                                     {
                                         "nor": [
-                                            "parent:origin:item:slug:antiplague-greater",
                                             "parent:origin:item:slug:antiplague-lesser",
+                                            "parent:origin:item:slug:antiplague-greater",
                                             "parent:origin:item:slug:antiplague-moderate"
                                         ]
                                     }
                                 ]
                             }
                         ],
-                        "value": 4
+                        "value": "Compendium.pf2e.equipment-srd.Item.Antiplague (Major)"
                     }
                 ],
-                "flag": "antiplague",
                 "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.Prompt.EquipmentVariety"
+                "prompt": "PF2E.SpecificRule.Prompt.EquipmentVariety",
+                "rollOption": "antiplague"
             },
             {
                 "key": "FlatModifier",
@@ -106,8 +103,34 @@
                     "item:trait:disease"
                 ],
                 "selector": "fortitude",
+                "slug": "antiplague-bonus",
                 "type": "item",
-                "value": "@item.flags.pf2e.rulesSelections.antiplague"
+                "value": 2
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "upgrade",
+                "predicate": [
+                    "antiplague:antiplague-moderate"
+                ],
+                "selector": "fortitude",
+                "slug": "antiplague-bonus",
+                "value": 3
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "upgrade",
+                "predicate": [
+                    {
+                        "or": [
+                            "antiplague:antiplague-greater",
+                            "antiplague:antiplague-major"
+                        ]
+                    }
+                ],
+                "selector": "fortitude",
+                "slug": "antiplague-bonus",
+                "value": 4
             }
         ],
         "start": {

--- a/packs/equipment-effects/effect-blood-booster.json
+++ b/packs/equipment-effects/effect-blood-booster.json
@@ -30,10 +30,7 @@
                                 "or": [
                                     "parent:origin:item:slug:blood-booster-lesser",
                                     {
-                                        "nor": [
-                                            "parent:origin:item:slug:blood-booster-moderate",
-                                            "parent:origin:item:slug:blood-booster-greater"
-                                        ]
+                                        "not": "parent:origin:item"
                                     }
                                 ]
                             }
@@ -46,10 +43,7 @@
                                 "or": [
                                     "parent:origin:item:slug:blood-booster-moderate",
                                     {
-                                        "nor": [
-                                            "parent:origin:item:slug:blood-booster-lesser",
-                                            "parent:origin:item:slug:blood-booster-greater"
-                                        ]
+                                        "not": "parent:origin:item"
                                     }
                                 ]
                             }
@@ -62,10 +56,7 @@
                                 "or": [
                                     "parent:origin:item:slug:blood-booster-greater",
                                     {
-                                        "nor": [
-                                            "parent:origin:item:slug:blood-booster-lesser",
-                                            "parent:origin:item:slug:blood-booster-moderate"
-                                        ]
+                                        "not": "parent:origin:item"
                                     }
                                 ]
                             }

--- a/packs/equipment-effects/effect-blood-booster.json
+++ b/packs/equipment-effects/effect-blood-booster.json
@@ -81,18 +81,21 @@
                 "adjustName": false,
                 "choices": [
                     {
+                        "label": "5",
                         "predicate": [
                             "blood-booster:blood-booster-lesser"
                         ],
                         "value": 5
                     },
                     {
+                        "label": "10",
                         "predicate": [
                             "blood-booster:blood-booster-moderate"
                         ],
                         "value": 10
                     },
                     {
+                        "label": "20",
                         "predicate": [
                             "blood-booster:blood-booster-greater"
                         ],

--- a/packs/equipment-effects/effect-blood-booster.json
+++ b/packs/equipment-effects/effect-blood-booster.json
@@ -78,37 +78,28 @@
                 "rollOption": "blood-booster"
             },
             {
-                "adjustName": false,
-                "choices": [
-                    {
-                        "label": "5",
-                        "predicate": [
-                            "blood-booster:blood-booster-lesser"
-                        ],
-                        "value": 5
-                    },
-                    {
-                        "label": "10",
-                        "predicate": [
-                            "blood-booster:blood-booster-moderate"
-                        ],
-                        "value": 10
-                    },
-                    {
-                        "label": "20",
-                        "predicate": [
-                            "blood-booster:blood-booster-greater"
-                        ],
-                        "value": 20
-                    }
+                "key": "Resistance",
+                "predicate": [
+                    "blood-booster:blood-booster-lesser"
                 ],
-                "flag": "bloodBooster",
-                "key": "ChoiceSet"
+                "type": "bleed",
+                "value": 5
             },
             {
                 "key": "Resistance",
+                "predicate": [
+                    "blood-booster:blood-booster-moderate"
+                ],
                 "type": "bleed",
-                "value": "@item.flags.pf2e.rulesSelections.bloodBooster"
+                "value": 10
+            },
+            {
+                "key": "Resistance",
+                "predicate": [
+                    "blood-booster:blood-booster-greater"
+                ],
+                "type": "bleed",
+                "value": 20
             },
             {
                 "definition": [
@@ -117,8 +108,37 @@
                 ],
                 "key": "Resistance",
                 "label": "PF2E.IWR.Custom.PersistentPoison",
+                "predicate": [
+                    "blood-booster:blood-booster-lesser"
+                ],
                 "type": "custom",
-                "value": "@item.flags.pf2e.rulesSelections.bloodBooster"
+                "value": 5
+            },
+            {
+                "definition": [
+                    "damage:category:persistent",
+                    "damage:type:poison"
+                ],
+                "key": "Resistance",
+                "label": "PF2E.IWR.Custom.PersistentPoison",
+                "predicate": [
+                    "blood-booster:blood-booster-moderate"
+                ],
+                "type": "custom",
+                "value": 10
+            },
+            {
+                "definition": [
+                    "damage:category:persistent",
+                    "damage:type:poison"
+                ],
+                "key": "Resistance",
+                "label": "PF2E.IWR.Custom.PersistentPoison",
+                "predicate": [
+                    "blood-booster:blood-booster-greater"
+                ],
+                "type": "custom",
+                "value": 20
             },
             {
                 "itemType": "condition",

--- a/packs/equipment-effects/effect-blood-booster.json
+++ b/packs/equipment-effects/effect-blood-booster.json
@@ -22,9 +22,9 @@
         },
         "rules": [
             {
+                "adjustName": false,
                 "choices": [
                     {
-                        "label": "PF2E.SpecificRule.Equipment.BloodBooster.Lesser",
                         "predicate": [
                             {
                                 "or": [
@@ -38,10 +38,9 @@
                                 ]
                             }
                         ],
-                        "value": 5
+                        "value": "Compendium.pf2e.equipment-srd.Item.Blood Booster (Lesser)"
                     },
                     {
-                        "label": "PF2E.SpecificRule.Equipment.BloodBooster.Moderate",
                         "predicate": [
                             {
                                 "or": [
@@ -55,10 +54,9 @@
                                 ]
                             }
                         ],
-                        "value": 10
+                        "value": "Compendium.pf2e.equipment-srd.Item.Blood Booster (Moderate)"
                     },
                     {
-                        "label": "PF2E.SpecificRule.Equipment.BloodBooster.Greater",
                         "predicate": [
                             {
                                 "or": [
@@ -72,12 +70,37 @@
                                 ]
                             }
                         ],
+                        "value": "Compendium.pf2e.equipment-srd.Item.Blood Booster (Greater)"
+                    }
+                ],
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.EquipmentVariety",
+                "rollOption": "blood-booster"
+            },
+            {
+                "adjustName": false,
+                "choices": [
+                    {
+                        "predicate": [
+                            "blood-booster:blood-booster-lesser"
+                        ],
+                        "value": 5
+                    },
+                    {
+                        "predicate": [
+                            "blood-booster:blood-booster-moderate"
+                        ],
+                        "value": 10
+                    },
+                    {
+                        "predicate": [
+                            "blood-booster:blood-booster-greater"
+                        ],
                         "value": 20
                     }
                 ],
                 "flag": "bloodBooster",
-                "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.Prompt.EquipmentVariety"
+                "key": "ChoiceSet"
             },
             {
                 "key": "Resistance",

--- a/packs/equipment-effects/effect-bombers-eye-elixir.json
+++ b/packs/equipment-effects/effect-bombers-eye-elixir.json
@@ -50,12 +50,14 @@
                 "adjustName": false,
                 "choices": [
                     {
+                        "label": "1",
                         "predicate": [
                             "bombers-eye-elixir:bombers-eye-elixir-lesser"
                         ],
                         "value": 1
                     },
                     {
+                        "label": "2",
                         "predicate": [
                             "bombers-eye-elixir:bombers-eye-elixir-greater"
                         ],

--- a/packs/equipment-effects/effect-bombers-eye-elixir.json
+++ b/packs/equipment-effects/effect-bombers-eye-elixir.json
@@ -46,26 +46,22 @@
                 "rollOption": "bombers-eye-elixir"
             },
             {
-                "actorFlag": true,
-                "adjustName": false,
-                "choices": [
-                    {
-                        "label": "PF2E.SpecificRule.Numbers.One",
-                        "predicate": [
-                            "bombers-eye-elixir:bombers-eye-elixir-lesser"
-                        ],
-                        "value": 1
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Numbers.Two",
-                        "predicate": [
-                            "bombers-eye-elixir:bombers-eye-elixir-greater"
-                        ],
-                        "value": 2
-                    }
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.bombersEyeElixir",
+                "predicate": [
+                    "bombers-eye-elixir:bombers-eye-elixir-lesser"
                 ],
-                "flag": "bombersEyeElixir",
-                "key": "ChoiceSet"
+                "value": 1
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.bombersEyeElixir",
+                "predicate": [
+                    "bombers-eye-elixir:bombers-eye-elixir-greater"
+                ],
+                "value": 2
             },
             {
                 "key": "EphemeralEffect",

--- a/packs/equipment-effects/effect-bombers-eye-elixir.json
+++ b/packs/equipment-effects/effect-bombers-eye-elixir.json
@@ -50,14 +50,14 @@
                 "adjustName": false,
                 "choices": [
                     {
-                        "label": "1",
+                        "label": "PF2E.SpecificRule.Numbers.One",
                         "predicate": [
                             "bombers-eye-elixir:bombers-eye-elixir-lesser"
                         ],
                         "value": 1
                     },
                     {
-                        "label": "2",
+                        "label": "PF2E.SpecificRule.Numbers.Two",
                         "predicate": [
                             "bombers-eye-elixir:bombers-eye-elixir-greater"
                         ],

--- a/packs/equipment-effects/effect-bombers-eye-elixir.json
+++ b/packs/equipment-effects/effect-bombers-eye-elixir.json
@@ -22,31 +22,48 @@
         },
         "rules": [
             {
-                "actorFlag": true,
                 "adjustName": false,
                 "choices": [
                     {
-                        "label": "PF2E.SpecificRule.Equipment.BombersEyeElixir.Lesser",
                         "predicate": [
                             {
                                 "not": "parent:origin:item:slug:bombers-eye-elixir-greater"
                             }
                         ],
-                        "value": 1
+                        "value": "Compendium.pf2e.equipment-srd.Item.Bomber's Eye Elixir (Lesser)"
                     },
                     {
-                        "label": "PF2E.SpecificRule.Equipment.BombersEyeElixir.Greater",
                         "predicate": [
                             {
                                 "not": "parent:origin:item:slug:bombers-eye-elixir-lesser"
                             }
                         ],
+                        "value": "Compendium.pf2e.equipment-srd.Item.Bomber's Eye Elixir (Greater)"
+                    }
+                ],
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.EquipmentVariety",
+                "rollOption": "bombers-eye-elixir"
+            },
+            {
+                "actorFlag": true,
+                "adjustName": false,
+                "choices": [
+                    {
+                        "predicate": [
+                            "bombers-eye-elixir:bombers-eye-elixir-lesser"
+                        ],
+                        "value": 1
+                    },
+                    {
+                        "predicate": [
+                            "bombers-eye-elixir:bombers-eye-elixir-greater"
+                        ],
                         "value": 2
                     }
                 ],
                 "flag": "bombersEyeElixir",
-                "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.Prompt.EquipmentVariety"
+                "key": "ChoiceSet"
             },
             {
                 "key": "EphemeralEffect",

--- a/packs/equipment-effects/effect-elixir-of-life.json
+++ b/packs/equipment-effects/effect-elixir-of-life.json
@@ -25,14 +25,13 @@
                 "adjustName": false,
                 "choices": [
                     {
-                        "label": "PF2E.SpecificRule.Equipment.ElixirOfLife.MinorOrLesser",
                         "predicate": [
                             {
                                 "or": [
                                     "parent:origin:item:slug:elixir-of-life-minor",
-                                    "parent:origin:item:slug:elixir-of-life-lesser",
                                     {
                                         "nor": [
+                                            "parent:origin:item:slug:elixir-of-life-lesser",
                                             "parent:origin:item:slug:elixir-of-life-moderate",
                                             "parent:origin:item:slug:elixir-of-life-greater",
                                             "parent:origin:item:slug:elixir-of-life-major",
@@ -42,18 +41,17 @@
                                 ]
                             }
                         ],
-                        "value": 1
+                        "value": "Compendium.pf2e.equipment-srd.Item.Elixir of Life (Minor)"
                     },
                     {
-                        "label": "PF2E.SpecificRule.Equipment.ElixirOfLife.ModerateOrGreater",
                         "predicate": [
                             {
                                 "or": [
-                                    "parent:origin:item:slug:elixir-of-life-moderate",
-                                    "parent:origin:item:slug:elixir-of-life-greater",
+                                    "parent:origin:item:slug:elixir-of-life-lesser",
                                     {
                                         "nor": [
                                             "parent:origin:item:slug:elixir-of-life-minor",
+                                            "parent:origin:item:slug:elixir-of-life-moderate",
                                             "parent:origin:item:slug:elixir-of-life-lesser",
                                             "parent:origin:item:slug:elixir-of-life-major",
                                             "parent:origin:item:slug:elixir-of-life-true"
@@ -62,10 +60,47 @@
                                 ]
                             }
                         ],
-                        "value": 2
+                        "value": "Compendium.pf2e.equipment-srd.Item.Elixir of Life (Lesser)"
                     },
                     {
-                        "label": "PF2E.SpecificRule.Equipment.ElixirOfLife.Major",
+                        "predicate": [
+                            {
+                                "or": [
+                                    "parent:origin:item:slug:elixir-of-life-moderate",
+                                    {
+                                        "nor": [
+                                            "parent:origin:item:slug:elixir-of-life-minor",
+                                            "parent:origin:item:slug:elixir-of-life-lesser",
+                                            "parent:origin:item:slug:elixir-of-life-greater",
+                                            "parent:origin:item:slug:elixir-of-life-major",
+                                            "parent:origin:item:slug:elixir-of-life-true"
+                                        ]
+                                    }
+                                ]
+                            }
+                        ],
+                        "value": "Compendium.pf2e.equipment-srd.Item.Elixir of Life (Moderate)"
+                    },
+                    {
+                        "predicate": [
+                            {
+                                "or": [
+                                    "parent:origin:item:slug:elixir-of-life-greater",
+                                    {
+                                        "nor": [
+                                            "parent:origin:item:slug:elixir-of-life-minor",
+                                            "parent:origin:item:slug:elixir-of-life-lesser",
+                                            "parent:origin:item:slug:elixir-of-life-moderate",
+                                            "parent:origin:item:slug:elixir-of-life-major",
+                                            "parent:origin:item:slug:elixir-of-life-true"
+                                        ]
+                                    }
+                                ]
+                            }
+                        ],
+                        "value": "Compendium.pf2e.equipment-srd.Item.Elixir of Life (Greater)"
+                    },
+                    {
                         "predicate": [
                             {
                                 "or": [
@@ -82,10 +117,9 @@
                                 ]
                             }
                         ],
-                        "value": 3
+                        "value": "Compendium.pf2e.equipment-srd.Item.Elixir of Life (Major)"
                     },
                     {
-                        "label": "PF2E.SpecificRule.Equipment.ElixirOfLife.True",
                         "predicate": [
                             {
                                 "or": [
@@ -102,11 +136,12 @@
                                 ]
                             }
                         ],
-                        "value": 4
+                        "value": "Compendium.pf2e.equipment-srd.Item.Elixir of Life (True)"
                     }
                 ],
-                "flag": "bonus",
-                "key": "ChoiceSet"
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.EquipmentVariety",
+                "rollOption": "consumable"
             },
             {
                 "key": "FlatModifier",
@@ -119,8 +154,44 @@
                     }
                 ],
                 "selector": "saving-throw",
+                "slug": "elixir-of-life-bonus",
                 "type": "item",
-                "value": "@item.flags.pf2e.rulesSelections.bonus"
+                "value": 1
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "upgrade",
+                "predicate": [
+                    {
+                        "or": [
+                            "elixir-of-life:elixir-of-life-moderate",
+                            "elixir-of-life:elixir-of-life-greater"
+                        ]
+                    }
+                ],
+                "selector": "saving-throw",
+                "slug": "elixir-of-life-bonus",
+                "value": 2
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "upgrade",
+                "predicate": [
+                    "elixir-of-life:elixir-of-life-major"
+                ],
+                "selector": "saving-throw",
+                "slug": "elixir-of-life-bonus",
+                "value": 3
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "upgrade",
+                "predicate": [
+                    "elixir-of-life:elixir-of-life-true"
+                ],
+                "selector": "saving-throw",
+                "slug": "elixir-of-life-bonus",
+                "value": 4
             }
         ],
         "start": {

--- a/packs/equipment-effects/effect-elixir-of-life.json
+++ b/packs/equipment-effects/effect-elixir-of-life.json
@@ -141,7 +141,7 @@
                 ],
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.EquipmentVariety",
-                "rollOption": "consumable"
+                "rollOption": "elixir-of-life"
             },
             {
                 "key": "FlatModifier",

--- a/packs/equipment-effects/effect-elixir-of-life.json
+++ b/packs/equipment-effects/effect-elixir-of-life.json
@@ -30,13 +30,7 @@
                                 "or": [
                                     "parent:origin:item:slug:elixir-of-life-minor",
                                     {
-                                        "nor": [
-                                            "parent:origin:item:slug:elixir-of-life-lesser",
-                                            "parent:origin:item:slug:elixir-of-life-moderate",
-                                            "parent:origin:item:slug:elixir-of-life-greater",
-                                            "parent:origin:item:slug:elixir-of-life-major",
-                                            "parent:origin:item:slug:elixir-of-life-true"
-                                        ]
+                                        "not": "parent:origin:item"
                                     }
                                 ]
                             }
@@ -49,13 +43,7 @@
                                 "or": [
                                     "parent:origin:item:slug:elixir-of-life-lesser",
                                     {
-                                        "nor": [
-                                            "parent:origin:item:slug:elixir-of-life-minor",
-                                            "parent:origin:item:slug:elixir-of-life-moderate",
-                                            "parent:origin:item:slug:elixir-of-life-lesser",
-                                            "parent:origin:item:slug:elixir-of-life-major",
-                                            "parent:origin:item:slug:elixir-of-life-true"
-                                        ]
+                                        "not": "parent:origin:item"
                                     }
                                 ]
                             }
@@ -68,13 +56,7 @@
                                 "or": [
                                     "parent:origin:item:slug:elixir-of-life-moderate",
                                     {
-                                        "nor": [
-                                            "parent:origin:item:slug:elixir-of-life-minor",
-                                            "parent:origin:item:slug:elixir-of-life-lesser",
-                                            "parent:origin:item:slug:elixir-of-life-greater",
-                                            "parent:origin:item:slug:elixir-of-life-major",
-                                            "parent:origin:item:slug:elixir-of-life-true"
-                                        ]
+                                        "not": "parent:origin:item"
                                     }
                                 ]
                             }
@@ -87,13 +69,7 @@
                                 "or": [
                                     "parent:origin:item:slug:elixir-of-life-greater",
                                     {
-                                        "nor": [
-                                            "parent:origin:item:slug:elixir-of-life-minor",
-                                            "parent:origin:item:slug:elixir-of-life-lesser",
-                                            "parent:origin:item:slug:elixir-of-life-moderate",
-                                            "parent:origin:item:slug:elixir-of-life-major",
-                                            "parent:origin:item:slug:elixir-of-life-true"
-                                        ]
+                                        "not": "parent:origin:item"
                                     }
                                 ]
                             }
@@ -106,13 +82,7 @@
                                 "or": [
                                     "parent:origin:item:slug:elixir-of-life-major",
                                     {
-                                        "nor": [
-                                            "parent:origin:item:slug:elixir-of-life-minor",
-                                            "parent:origin:item:slug:elixir-of-life-lesser",
-                                            "parent:origin:item:slug:elixir-of-life-moderate",
-                                            "parent:origin:item:slug:elixir-of-life-greater",
-                                            "parent:origin:item:slug:elixir-of-life-true"
-                                        ]
+                                        "not": "parent:origin:item"
                                     }
                                 ]
                             }
@@ -125,13 +95,7 @@
                                 "or": [
                                     "parent:origin:item:slug:elixir-of-life-true",
                                     {
-                                        "nor": [
-                                            "parent:origin:item:slug:elixir-of-life-minor",
-                                            "parent:origin:item:slug:elixir-of-life-lesser",
-                                            "parent:origin:item:slug:elixir-of-life-moderate",
-                                            "parent:origin:item:slug:elixir-of-life-greater",
-                                            "parent:origin:item:slug:elixir-of-life-major"
-                                        ]
+                                        "not": "parent:origin:item"
                                     }
                                 ]
                             }

--- a/packs/equipment-effects/effect-healers-gel.json
+++ b/packs/equipment-effects/effect-healers-gel.json
@@ -30,10 +30,7 @@
                                 "or": [
                                     "parent:origin:item:slug:healers-gel-lesser",
                                     {
-                                        "nor": [
-                                            "parent:origin:item:slug:healers-gel-greater",
-                                            "parent:origin:item:slug:healers-gel-moderate"
-                                        ]
+                                        "not": "parent:origin:item"
                                     }
                                 ]
                             }
@@ -46,10 +43,7 @@
                                 "or": [
                                     "parent:origin:item:slug:healers-gel-moderate",
                                     {
-                                        "nor": [
-                                            "parent:origin:item:slug:healers-gel-greater",
-                                            "parent:origin:item:slug:healers-gel-lesser"
-                                        ]
+                                        "not": "parent:origin:item"
                                     }
                                 ]
                             }
@@ -62,10 +56,7 @@
                                 "or": [
                                     "parent:origin:item:slug:healers-gel-greater",
                                     {
-                                        "nor": [
-                                            "parent:origin:item:slug:healers-gel-lesser",
-                                            "parent:origin:item:slug:healers-gel-moderate"
-                                        ]
+                                        "not": "parent:origin:item"
                                     }
                                 ]
                             }

--- a/packs/equipment-effects/effect-healers-gel.json
+++ b/packs/equipment-effects/effect-healers-gel.json
@@ -25,7 +25,6 @@
                 "adjustName": false,
                 "choices": [
                     {
-                        "label": "PF2E.SpecificRule.Equipment.HealersGel.Lesser",
                         "predicate": [
                             {
                                 "or": [
@@ -39,10 +38,9 @@
                                 ]
                             }
                         ],
-                        "value": 5
+                        "value": "Compendium.pf2e.equipment-srd.Item.Healer's Gel (Lesser)"
                     },
                     {
-                        "label": "PF2E.SpecificRule.Equipment.HealersGel.Moderate",
                         "predicate": [
                             {
                                 "or": [
@@ -56,10 +54,9 @@
                                 ]
                             }
                         ],
-                        "value": 10
+                        "value": "Compendium.pf2e.equipment-srd.Item.Healer's Gel (Moderate)"
                     },
                     {
-                        "label": "PF2E.SpecificRule.Equipment.HealersGel.Greater",
                         "predicate": [
                             {
                                 "or": [
@@ -73,16 +70,33 @@
                                 ]
                             }
                         ],
-                        "value": 15
+                        "value": "Compendium.pf2e.equipment-srd.Item.Healer's Gel (Greater)"
                     }
                 ],
-                "flag": "healersGel",
                 "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.Prompt.EquipmentVariety"
+                "prompt": "PF2E.SpecificRule.Prompt.EquipmentVariety",
+                "rollOption": "healers-gel"
             },
             {
                 "key": "TempHP",
-                "value": "@item.flags.pf2e.rulesSelections.healersGel"
+                "predicate": [
+                    "healers-gel:healers-gel-lesser"
+                ],
+                "value": 5
+            },
+            {
+                "key": "TempHP",
+                "predicate": [
+                    "healers-gel:healers-gel-moderate"
+                ],
+                "value": 10
+            },
+            {
+                "key": "TempHP",
+                "predicate": [
+                    "healers-gel:healers-gel-greater"
+                ],
+                "value": 15
             }
         ],
         "start": {

--- a/packs/equipment-effects/effect-life-shot.json
+++ b/packs/equipment-effects/effect-life-shot.json
@@ -25,14 +25,13 @@
                 "adjustName": false,
                 "choices": [
                     {
-                        "label": "PF2E.SpecificRule.Equipment.LifeShot.MinorOrLesser",
                         "predicate": [
                             {
                                 "or": [
                                     "parent:origin:item:slug:life-shot-minor",
-                                    "parent:origin:item:slug:life-shot-lesser",
                                     {
                                         "nor": [
+                                            "parent:origin:item:slug:life-shot-lesser",
                                             "parent:origin:item:slug:life-shot-moderate",
                                             "parent:origin:item:slug:life-shot-greater",
                                             "parent:origin:item:slug:life-shot-major",
@@ -42,19 +41,18 @@
                                 ]
                             }
                         ],
-                        "value": 1
+                        "value": "Compendium.pf2e.equipment-srd.Item.Life Shot (Minor)"
                     },
                     {
-                        "label": "PF2E.SpecificRule.Equipment.LifeShot.ModerateOrGreater",
                         "predicate": [
                             {
                                 "or": [
-                                    "parent:origin:item:slug:life-shot-moderate",
-                                    "parent:origin:item:slug:life-shot-greater",
+                                    "parent:origin:item:slug:life-shot-lesser",
                                     {
                                         "nor": [
                                             "parent:origin:item:slug:life-shot-minor",
-                                            "parent:origin:item:slug:life-shot-lesser",
+                                            "parent:origin:item:slug:life-shot-moderate",
+                                            "parent:origin:item:slug:life-shot-greater",
                                             "parent:origin:item:slug:life-shot-major",
                                             "parent:origin:item:slug:life-shot-true"
                                         ]
@@ -62,10 +60,47 @@
                                 ]
                             }
                         ],
-                        "value": 2
+                        "value": "Compendium.pf2e.equipment-srd.Item.Life Shot (Lesser)"
                     },
                     {
-                        "label": "PF2E.SpecificRule.Equipment.LifeShot.Major",
+                        "predicate": [
+                            {
+                                "or": [
+                                    "parent:origin:item:slug:life-shot-moderate",
+                                    {
+                                        "nor": [
+                                            "parent:origin:item:slug:life-shot-minor",
+                                            "parent:origin:item:slug:life-shot-lesser",
+                                            "parent:origin:item:slug:life-shot-greater",
+                                            "parent:origin:item:slug:life-shot-major",
+                                            "parent:origin:item:slug:life-shot-true"
+                                        ]
+                                    }
+                                ]
+                            }
+                        ],
+                        "value": "Compendium.pf2e.equipment-srd.Item.Life Shot (Moderate)"
+                    },
+                    {
+                        "predicate": [
+                            {
+                                "or": [
+                                    "parent:origin:item:slug:life-shot-greater",
+                                    {
+                                        "nor": [
+                                            "parent:origin:item:slug:life-shot-minor",
+                                            "parent:origin:item:slug:life-shot-lesser",
+                                            "parent:origin:item:slug:life-shot-moderate",
+                                            "parent:origin:item:slug:life-shot-major",
+                                            "parent:origin:item:slug:life-shot-true"
+                                        ]
+                                    }
+                                ]
+                            }
+                        ],
+                        "value": "Compendium.pf2e.equipment-srd.Item.Life Shot (Greater)"
+                    },
+                    {
                         "predicate": [
                             {
                                 "or": [
@@ -82,10 +117,9 @@
                                 ]
                             }
                         ],
-                        "value": 3
+                        "value": "Compendium.pf2e.equipment-srd.Item.Life Shot (Major)"
                     },
                     {
-                        "label": "PF2E.SpecificRule.Equipment.LifeShot.True",
                         "predicate": [
                             {
                                 "or": [
@@ -102,11 +136,11 @@
                                 ]
                             }
                         ],
-                        "value": 4
+                        "value": "Compendium.pf2e.equipment-srd.Item.Life Shot (True)"
                     }
                 ],
-                "flag": "bonus",
-                "key": "ChoiceSet"
+                "key": "ChoiceSet",
+                "rollOption": "life-shot"
             },
             {
                 "key": "FlatModifier",
@@ -119,8 +153,44 @@
                     }
                 ],
                 "selector": "saving-throw",
+                "slug": "life-shot-bonus",
                 "type": "item",
-                "value": "@item.flags.pf2e.rulesSelections.bonus"
+                "value": 1
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "upgrade",
+                "predicate": [
+                    {
+                        "or": [
+                            "life-shot:life-shot-moderate",
+                            "life-shot:life-shot-greater"
+                        ]
+                    }
+                ],
+                "selector": "saving-throw",
+                "slug": "life-shot-bonus",
+                "value": 2
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "upgrade",
+                "predicate": [
+                    "life-shot:life-shot-major"
+                ],
+                "selector": "saving-throw",
+                "slug": "life-shot-bonus",
+                "value": 3
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "upgrade",
+                "predicate": [
+                    "life-shot:life-shot-true"
+                ],
+                "selector": "saving-throw",
+                "slug": "life-shot-bonus",
+                "value": 4
             }
         ],
         "start": {

--- a/packs/equipment-effects/effect-life-shot.json
+++ b/packs/equipment-effects/effect-life-shot.json
@@ -30,13 +30,7 @@
                                 "or": [
                                     "parent:origin:item:slug:life-shot-minor",
                                     {
-                                        "nor": [
-                                            "parent:origin:item:slug:life-shot-lesser",
-                                            "parent:origin:item:slug:life-shot-moderate",
-                                            "parent:origin:item:slug:life-shot-greater",
-                                            "parent:origin:item:slug:life-shot-major",
-                                            "parent:origin:item:slug:life-shot-true"
-                                        ]
+                                        "not": "parent:origin:item"
                                     }
                                 ]
                             }
@@ -49,13 +43,7 @@
                                 "or": [
                                     "parent:origin:item:slug:life-shot-lesser",
                                     {
-                                        "nor": [
-                                            "parent:origin:item:slug:life-shot-minor",
-                                            "parent:origin:item:slug:life-shot-moderate",
-                                            "parent:origin:item:slug:life-shot-greater",
-                                            "parent:origin:item:slug:life-shot-major",
-                                            "parent:origin:item:slug:life-shot-true"
-                                        ]
+                                        "not": "parent:origin:item"
                                     }
                                 ]
                             }
@@ -68,13 +56,7 @@
                                 "or": [
                                     "parent:origin:item:slug:life-shot-moderate",
                                     {
-                                        "nor": [
-                                            "parent:origin:item:slug:life-shot-minor",
-                                            "parent:origin:item:slug:life-shot-lesser",
-                                            "parent:origin:item:slug:life-shot-greater",
-                                            "parent:origin:item:slug:life-shot-major",
-                                            "parent:origin:item:slug:life-shot-true"
-                                        ]
+                                        "not": "parent:origin:item"
                                     }
                                 ]
                             }
@@ -87,13 +69,7 @@
                                 "or": [
                                     "parent:origin:item:slug:life-shot-greater",
                                     {
-                                        "nor": [
-                                            "parent:origin:item:slug:life-shot-minor",
-                                            "parent:origin:item:slug:life-shot-lesser",
-                                            "parent:origin:item:slug:life-shot-moderate",
-                                            "parent:origin:item:slug:life-shot-major",
-                                            "parent:origin:item:slug:life-shot-true"
-                                        ]
+                                        "not": "parent:origin:item"
                                     }
                                 ]
                             }
@@ -106,13 +82,7 @@
                                 "or": [
                                     "parent:origin:item:slug:life-shot-major",
                                     {
-                                        "nor": [
-                                            "parent:origin:item:slug:life-shot-minor",
-                                            "parent:origin:item:slug:life-shot-lesser",
-                                            "parent:origin:item:slug:life-shot-moderate",
-                                            "parent:origin:item:slug:life-shot-greater",
-                                            "parent:origin:item:slug:life-shot-true"
-                                        ]
+                                        "not": "parent:origin:item"
                                     }
                                 ]
                             }
@@ -125,13 +95,7 @@
                                 "or": [
                                     "parent:origin:item:slug:life-shot-true",
                                     {
-                                        "nor": [
-                                            "parent:origin:item:slug:life-shot-minor",
-                                            "parent:origin:item:slug:life-shot-lesser",
-                                            "parent:origin:item:slug:life-shot-moderate",
-                                            "parent:origin:item:slug:life-shot-greater",
-                                            "parent:origin:item:slug:life-shot-major"
-                                        ]
+                                        "not": "parent:origin:item"
                                     }
                                 ]
                             }

--- a/packs/equipment-effects/effect-mudrock-snare.json
+++ b/packs/equipment-effects/effect-mudrock-snare.json
@@ -36,7 +36,6 @@
                         "value": "critical-failure"
                     }
                 ],
-                "flag": "mudRockSnare",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.DegreeOfSuccess",
                 "rollOption": "mudrock-snare"

--- a/packs/equipment/elixir-of-life-moderate.json
+++ b/packs/equipment/elixir-of-life-moderate.json
@@ -15,7 +15,7 @@
             "type": "untyped"
         },
         "description": {
-            "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> (manipulate)</p><hr /><p>Elixirs of life accelerate a living creature's natural healing processes and immune system. Upon drinking this elixir, you regain @Damage[(5d6+12)[healing]]Hit Points and gain +2 item bonus to saving throws against diseases and poisons for 10 minutes.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Elixir of Life]</p>"
+            "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> (manipulate)</p><hr /><p>Elixirs of life accelerate a living creature's natural healing processes and immune system. Upon drinking this elixir, you regain @Damage[(5d6+12)[healing]] Hit Points and gain +2 item bonus to saving throws against diseases and poisons for 10 minutes.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Elixir of Life]</p>"
         },
         "hardness": 0,
         "hp": {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -3045,12 +3045,6 @@
                     "StrawberryLabel": "Strawberry",
                     "VanillaLabel": "Vanilla"
                 },
-                "ElixirOfLife": {
-                    "Major": "Major Elixir of Life",
-                    "MinorOrLesser": "Minor or Lesser Elixir of Life",
-                    "ModerateOrGreater": "Moderate or Greater Elixir of Life",
-                    "True": "True Elixir of Life"
-                },
                 "EnergizingLattice": {
                     "Note": "If your Strike fails, but doesn't critically fail, the target still takes half the @Damage[6d6[force]]{force damage}.",
                     "RollOptionLabel": "Energizing Lattice — Release energy"

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2915,18 +2915,6 @@
                 "AmphisbaenaHandwraps": {
                     "TwinVenomStrikeLabel": "Amphisbaena Handwraps - Twin Venom Strike"
                 },
-                "Antidote": {
-                    "Lesser": "Lesser Antidote",
-                    "Greater": "Greater Antidote",
-                    "Major": "Major Antidote",
-                    "Moderate": "Moderate Antidote"
-                },
-                "Antiplague": {
-                    "Lesser": "Lesser Antiplague",
-                    "Greater": "Greater Antiplague",
-                    "Major": "Major Antiplague",
-                    "Moderate": "Moderate Antiplague"
-                },
                 "ArachnidHarness": {
                     "ClimbWithAllLimbs": "Climb with all limbs"
                 },
@@ -2936,11 +2924,6 @@
                 },
                 "BlackScorpionStingmace": {
                     "BlackScorpionVenomNote": "<p>On a critical hit, the target is exposed to black scorpion venom.</p>\n<p><strong>Black Scorpion Venom</strong> (poison)</p>\n<p><strong>Saving Throw</strong> @Check[fortitude|dc:36]</p>\n<p><strong>Maximum Duration</strong> 6 rounds</p>\n<p><strong>Stage 1</strong> @Damage[2d12[poison]] damage and @UUID[Compendium.pf2e.conditionitems.Item.i3OJZU2nk64Df3xm]{Clumsy 2} (1 round)</p>\n<p><strong>Stage 2</strong> @Damage[3d12[poison]] damage, clumsy 2, and @UUID[Compendium.pf2e.conditionitems.Item.xYTAsEpcJE1Ccni3]{Slowed 1} (1 round)</p>\n<p><strong>Stage 3</strong> @Damage[4d12[poison]] damage, @UUID[Compendium.pf2e.conditionitems.Item.i3OJZU2nk64Df3xm]{Clumsy 4}, and @UUID[Compendium.pf2e.conditionitems.Item.xYTAsEpcJE1Ccni3]{Slowed 2} (1 round).</p>"
-                },
-                "BloodBooster": {
-                    "Greater": "Greater Blood Booster",
-                    "Lesser": "Lesser Blood Booster",
-                    "Moderate": "Moderate Blood Booster"
                 },
                 "BoastfulHunter": {
                     "BoredLabel": "The Boastful Hunter is Bored",
@@ -2955,10 +2938,6 @@
                         "Major": "Major",
                         "Moderate": "Moderate"
                     }
-                },
-                "BombersEyeElixir": {
-                    "Greater": "Greater Bomber's Eye Elixir",
-                    "Lesser": "Lesser Bomber's Eye Elixir"
                 },
                 "BravosBrew": {
                     "Greater": {
@@ -3066,22 +3045,11 @@
                     "TitanicLabel": "Titanic",
                     "WyrmhideLabel": "Wyrmhide"
                 },
-                "HealersGel": {
-                    "Greater": "Greater Healer's Gel",
-                    "Lesser": "Lesser Healer's Gel",
-                    "Moderate": "Moderate Healer's Gel"
-                },
                 "HolyWater": {
                     "Note": "Can damage only creatures with the unholy trait."
                 },
                 "HumbugPocket": {
                     "ConcealAnObjectLabel": "Humbug Pocket (Conceal an Object in the Pocket)"
-                },
-                "LifeShot": {
-                    "Major": "Major Life Shot",
-                    "MinorOrLesser": "Minor or Lesser Life Shot",
-                    "ModerateOrGreater": "Moderate or Greater Life Shot",
-                    "True": "True Life Shot"
                 },
                 "LionsShield": {
                     "LionsBiteLabel": "Lion's Bite",


### PR DESCRIPTION
This approach would allow us to skip having to add all these names to the localization file. The changes aren't live yet, so should be fine to remove too.

I'm not 100% sold on `elixir-of-life:elixir-of-life-variety` as a roll option, but I can't think of any alternatives.