### PR TITLE
In `/act` ensure DC has correct metagame visibility

### DIFF
--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -452,7 +452,8 @@ class TextEditorPF2e extends TextEditor {
             element.appendChild(text);
 
             // difficulty class
-            const visibility = (params["show-dc"] || (game.pf2e.settings.metagame.dcs ? "all" : "gm")).trim().toLowerCase();
+            const visibility = (params["show-dc"] || (game.pf2e.settings.metagame.dcs ? "all" : "gm"))
+                .trim().toLowerCase();
             const showDC =
                 (visibility === "all" && game.pf2e.settings.metagame.dcs) ||
                 (["all", "gm"].includes(visibility) && game.user.isGM);

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -453,7 +453,8 @@ class TextEditorPF2e extends TextEditor {
 
             // difficulty class
             const visibility = (params["show-dc"] || (game.pf2e.settings.metagame.dcs ? "all" : "gm"))
-                .trim().toLowerCase();
+                .trim()
+                .toLowerCase();
             const showDC =
                 (visibility === "all" && game.pf2e.settings.metagame.dcs) ||
                 (["all", "gm"].includes(visibility) && game.user.isGM);

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -452,7 +452,7 @@ class TextEditorPF2e extends TextEditor {
             element.appendChild(text);
 
             // difficulty class
-            const visibility = (params["show-dc"] || "all").trim().toLowerCase();
+            const visibility = (params["show-dc"] || (game.pf2e.settings.metagame.dcs ? "all" : "gm")).trim().toLowerCase();
             const showDC =
                 (visibility === "all" && game.pf2e.settings.metagame.dcs) ||
                 (["all", "gm"].includes(visibility) && game.user.isGM);


### PR DESCRIPTION
This ensure that the DC is displayed correctly in `[[\act ...]]` blocks so that the DC isn't shown to players if the metagame option is not ticked.

Fixes #16932