### PR TITLE
Improve automation of bloody debilitation

### DIFF
--- a/packs/classfeatures/debilitating-strike.json
+++ b/packs/classfeatures/debilitating-strike.json
@@ -260,6 +260,17 @@
                 "selector": "strike-damage",
                 "text": "<p>@Localize[PF2E.SpecificRule.Rogue.Debilitation.Trigger]</p>\n<p>@Localize[PF2E.SpecificRule.Rogue.Debilitation.Weakness.Note]</p>",
                 "title": "PF2E.SpecificRule.Rogue.Debilitation.Title"
+            },
+            {
+                "diceNumber": 3,
+                "dieSize": "d6",
+                "damageType": "bleed",
+                "key": "DamageDice",
+                "predicate": [
+                    "debilitation:bloody",
+                    "target:condition:off-guard"
+                ],
+                "selector": "strike-damage"
             }
         ],
         "traits": {


### PR DESCRIPTION
<img width="312" alt="Screenshot 2024-10-21 at 01 02 25" src="https://github.com/user-attachments/assets/4740d306-0e50-4df8-9c37-952890d33008">

Predicates are same as for Note