### PR TITLE
Fix vision on some FOTRP NPCs

### DIFF
--- a/packs/fists-of-the-ruby-phoenix-bestiary/ghost-monk.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/ghost-monk.json
@@ -415,7 +415,11 @@
         "perception": {
             "details": "",
             "mod": 18,
-            "senses": []
+            "senses": [
+                {
+                    "type": "darkvision"
+                }
+            ]
         },
         "resources": {},
         "saves": {

--- a/packs/fists-of-the-ruby-phoenix-bestiary/ji-yook-level-9.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/ji-yook-level-9.json
@@ -993,7 +993,11 @@
         "perception": {
             "details": "",
             "mod": 19,
-            "senses": []
+            "senses": [
+                {
+                    "type": "low-light-vision"
+                }
+            ]
         },
         "resources": {
             "focus": {

--- a/packs/fists-of-the-ruby-phoenix-bestiary/kannitri.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/kannitri.json
@@ -370,7 +370,11 @@
         "perception": {
             "details": "",
             "mod": 26,
-            "senses": []
+            "senses": [
+                {
+                    "type": "darkvision"
+                }
+            ]
         },
         "resources": {},
         "saves": {

--- a/packs/fists-of-the-ruby-phoenix-bestiary/old-man-statue.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/old-man-statue.json
@@ -722,7 +722,11 @@
         "perception": {
             "details": "",
             "mod": 24,
-            "senses": []
+            "senses": [
+                {
+                    "type": "darkvision"
+                }
+            ]
         },
         "resources": {
             "focus": {

--- a/packs/fists-of-the-ruby-phoenix-bestiary/takatorra-level-9.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/takatorra-level-9.json
@@ -489,7 +489,11 @@
         "perception": {
             "details": "",
             "mod": 20,
-            "senses": []
+            "senses": [
+                {
+                    "type": "low-light-vision"
+                }
+            ]
         },
         "resources": {},
         "saves": {

--- a/packs/fists-of-the-ruby-phoenix-bestiary/yabin-the-just-level-9.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/yabin-the-just-level-9.json
@@ -2396,7 +2396,11 @@
         "perception": {
             "details": "",
             "mod": 18,
-            "senses": []
+            "senses": [
+                {
+                    "type": "low-light-vision"
+                }
+            ]
         },
         "resources": {
             "focus": {


### PR DESCRIPTION
Some Chapter 1, Book 1 NPCs were missing correct vision types from the book. The higher level versions are already correct.