### PR TITLE
Ignore disabled region behaviors when determining effect on actors

### DIFF
--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -280,7 +280,7 @@ function createEnvironmentRollOptions(actor: ActorPF2e): Record<string, boolean>
             if (token.elevation < bottom || token.elevation > top) continue;
 
             const environmentBehaviors = region.behaviors.filter(
-                (b): b is EnvironmentRegionBehavior<RegionDocumentPF2e<ScenePF2e>> => b.type === "environment",
+                (b): b is EnvironmentRegionBehavior<RegionDocumentPF2e<ScenePF2e>> => b.type === "environment" && b.active,
             );
             for (const behavior of environmentBehaviors) {
                 const system = behavior.system;

--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -281,7 +281,7 @@ function createEnvironmentRollOptions(actor: ActorPF2e): Record<string, boolean>
 
             const environmentBehaviors = region.behaviors.filter(
                 (b): b is EnvironmentRegionBehavior<RegionDocumentPF2e<ScenePF2e>> =>
-                    b.type === "environment" && b.active,
+                    !b.disabled && b.type === "environment",
             );
             for (const behavior of environmentBehaviors) {
                 const system = behavior.system;

--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -280,7 +280,8 @@ function createEnvironmentRollOptions(actor: ActorPF2e): Record<string, boolean>
             if (token.elevation < bottom || token.elevation > top) continue;
 
             const environmentBehaviors = region.behaviors.filter(
-                (b): b is EnvironmentRegionBehavior<RegionDocumentPF2e<ScenePF2e>> => b.type === "environment" && b.active,
+                (b): b is EnvironmentRegionBehavior<RegionDocumentPF2e<ScenePF2e>> =>
+                    b.type === "environment" && b.active,
             );
             for (const behavior of environmentBehaviors) {
                 const system = behavior.system;

--- a/src/module/canvas/ruler.ts
+++ b/src/module/canvas/ruler.ts
@@ -148,13 +148,13 @@ class RulerPF2e<TToken extends TokenPF2e | null = TokenPF2e | null> extends Rule
                 .filter(
                     (r) =>
                         r.document.behaviors.some(
-                            (b) => !b.disabled && b.type === "environmentFeature" && b.system.terrain.difficult > 0,
+                            (b) => !b.disabled && b.type === "environmentFeature" && b.active && b.system.terrain.difficult > 0,
                         ) && token.testInsideRegion(r, toPoint),
                 )
                 .flatMap((r) =>
                     r.document.behaviors.filter(
                         (b): b is EnvironmentFeatureRegionBehavior<RegionDocumentPF2e<ScenePF2e>> =>
-                            !b.disabled && b.type === "environmentFeature" && b.system.terrain.difficult > 0,
+                            !b.disabled && b.type === "environmentFeature" && b.active && b.system.terrain.difficult > 0,
                     ),
                 );
 

--- a/src/module/canvas/ruler.ts
+++ b/src/module/canvas/ruler.ts
@@ -148,20 +148,13 @@ class RulerPF2e<TToken extends TokenPF2e | null = TokenPF2e | null> extends Rule
                 .filter(
                     (r) =>
                         r.document.behaviors.some(
-                            (b) =>
-                                !b.disabled &&
-                                b.type === "environmentFeature" &&
-                                b.active &&
-                                b.system.terrain.difficult > 0,
+                            (b) => !b.disabled && b.type === "environmentFeature" && b.system.terrain.difficult > 0,
                         ) && token.testInsideRegion(r, toPoint),
                 )
                 .flatMap((r) =>
                     r.document.behaviors.filter(
                         (b): b is EnvironmentFeatureRegionBehavior<RegionDocumentPF2e<ScenePF2e>> =>
-                            !b.disabled &&
-                            b.type === "environmentFeature" &&
-                            b.active &&
-                            b.system.terrain.difficult > 0,
+                            !b.disabled && b.type === "environmentFeature" && b.system.terrain.difficult > 0,
                     ),
                 );
 

--- a/src/module/canvas/ruler.ts
+++ b/src/module/canvas/ruler.ts
@@ -148,13 +148,20 @@ class RulerPF2e<TToken extends TokenPF2e | null = TokenPF2e | null> extends Rule
                 .filter(
                     (r) =>
                         r.document.behaviors.some(
-                            (b) => !b.disabled && b.type === "environmentFeature" && b.active && b.system.terrain.difficult > 0,
+                            (b) =>
+                                !b.disabled &&
+                                b.type === "environmentFeature" &&
+                                b.active &&
+                                b.system.terrain.difficult > 0,
                         ) && token.testInsideRegion(r, toPoint),
                 )
                 .flatMap((r) =>
                     r.document.behaviors.filter(
                         (b): b is EnvironmentFeatureRegionBehavior<RegionDocumentPF2e<ScenePF2e>> =>
-                            !b.disabled && b.type === "environmentFeature" && b.active && b.system.terrain.difficult > 0,
+                            !b.disabled &&
+                            b.type === "environmentFeature" &&
+                            b.active &&
+                            b.system.terrain.difficult > 0,
                     ),
                 );
 

--- a/src/module/scene/document.ts
+++ b/src/module/scene/document.ts
@@ -93,7 +93,7 @@ class ScenePF2e extends Scene {
 
     /** Check for tokens that moved into or out of difficult terrain and reset their respective actors */
     #refreshTerrainAwareness(): void {
-        if (this.regions.some((r) => r.behaviors.some((b) => b.type === "environmentFeature"))) {
+        if (this.regions.some((r) => r.behaviors.some((b) => b.type === "environmentFeature" && b.active))) {
             for (const token of this.tokens.filter((t) => t.isLinked)) {
                 const rollOptionsAll = token.actor?.rollOptions.all ?? {};
                 const actorDifficultTerrain = rollOptionsAll["self:position:difficult-terrain"]

--- a/src/module/scene/document.ts
+++ b/src/module/scene/document.ts
@@ -93,7 +93,7 @@ class ScenePF2e extends Scene {
 
     /** Check for tokens that moved into or out of difficult terrain and reset their respective actors */
     #refreshTerrainAwareness(): void {
-        if (this.regions.some((r) => r.behaviors.some((b) => b.type === "environmentFeature" && b.active))) {
+        if (this.regions.some((r) => r.behaviors.some((b) => !b.disabled && b.type === "environmentFeature"))) {
             for (const token of this.tokens.filter((t) => t.isLinked)) {
                 const rollOptionsAll = token.actor?.rollOptions.all ?? {};
                 const actorDifficultTerrain = rollOptionsAll["self:position:difficult-terrain"]

--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -113,7 +113,7 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
             .map((r) =>
                 r.behaviors.filter(
                     (b): b is EnvironmentFeatureRegionBehavior<RegionDocumentPF2e<TParent>> =>
-                        b.type === "environmentFeature" && b.system.terrain.difficult > 0,
+                        b.type === "environmentFeature" && b.active && b.system.terrain.difficult > 0,
                 ),
             )
             .flat()

--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -113,7 +113,7 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
             .map((r) =>
                 r.behaviors.filter(
                     (b): b is EnvironmentFeatureRegionBehavior<RegionDocumentPF2e<TParent>> =>
-                        b.type === "environmentFeature" && b.active && b.system.terrain.difficult > 0,
+                        !b.disabled && b.type === "environmentFeature" && b.system.terrain.difficult > 0,
                 ),
             )
             .flat()

--- a/src/scripts/hooks/canvas-ready.ts
+++ b/src/scripts/hooks/canvas-ready.ts
@@ -38,7 +38,9 @@ export const CanvasReady = {
                 if (game.ready) {
                     if (
                         hasSceneTerrains ||
-                        (token.document.regions ?? []).some((r) => r.behaviors.some((b) => b.type === "environment" && b.active))
+                        (token.document.regions ?? []).some((r) =>
+                            r.behaviors.some((b) => b.type === "environment" && b.active),
+                        )
                     ) {
                         token.actor?.reset();
                     }

--- a/src/scripts/hooks/canvas-ready.ts
+++ b/src/scripts/hooks/canvas-ready.ts
@@ -39,7 +39,7 @@ export const CanvasReady = {
                     if (
                         hasSceneTerrains ||
                         (token.document.regions ?? []).some((r) =>
-                            r.behaviors.some((b) => b.type === "environment" && b.active),
+                            r.behaviors.some((b) => !b.disabled && b.type === "environment"),
                         )
                     ) {
                         token.actor?.reset();

--- a/src/scripts/hooks/canvas-ready.ts
+++ b/src/scripts/hooks/canvas-ready.ts
@@ -38,7 +38,7 @@ export const CanvasReady = {
                 if (game.ready) {
                     if (
                         hasSceneTerrains ||
-                        (token.document.regions ?? []).some((r) => r.behaviors.some((b) => b.type === "environment"))
+                        (token.document.regions ?? []).some((r) => r.behaviors.some((b) => b.type === "environment" && b.active))
                     ) {
                         token.actor?.reset();
                     }

--- a/src/scripts/hooks/ready.ts
+++ b/src/scripts/hooks/ready.ts
@@ -136,7 +136,7 @@ export const Ready = {
             const hasSceneEnvironments = !!game.scenes.viewed?.flags.pf2e.environmentTypes?.length;
             for (const token of game.scenes.active?.tokens ?? []) {
                 const inEnvironmentRegion = !!token.regions?.some((r) =>
-                    r.behaviors.some((b) => ["environment", "environmentFeature"].includes(b.type) && b.active),
+                    r.behaviors.some((b) => !b.disabled && ["environment", "environmentFeature"].includes(b.type)),
                 );
                 if (token.actor && (hasSceneEnvironments || inEnvironmentRegion)) {
                     inEnvironments.push(token.actor);

--- a/src/scripts/hooks/ready.ts
+++ b/src/scripts/hooks/ready.ts
@@ -136,7 +136,7 @@ export const Ready = {
             const hasSceneEnvironments = !!game.scenes.viewed?.flags.pf2e.environmentTypes?.length;
             for (const token of game.scenes.active?.tokens ?? []) {
                 const inEnvironmentRegion = !!token.regions?.some((r) =>
-                    r.behaviors.some((b) => ["environment", "environmentFeature"].includes(b.type)),
+                    r.behaviors.some((b) => ["environment", "environmentFeature"].includes(b.type) && b.active),
                 );
                 if (token.actor && (hasSceneEnvironments || inEnvironmentRegion)) {
                     inEnvironments.push(token.actor);


### PR DESCRIPTION
Region behaviors (environment and environmentFeature) were always being processed, even when the behavior was not active.

This PR updates the filter searches to only consider region behaviors which are active (`behavior.active`).