### PR TITLE
Exclude `node_modules` directory in tsconfig watch options

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -78,6 +78,7 @@
         "fallbackPolling": "dynamicpriority",
         "excludeDirectories": [
             "dist",
+            "node_modules",
             "packs",
             "static"
         ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,7 @@
         "resolveJsonModule": true,
         "useDefineForClassFields": true,
         "noErrorTruncation": true,
+        "disableSizeLimit": true,
         "paths": {
             "@actor": [
                 "src/module/actor/index.ts"


### PR DESCRIPTION
I did some tests with a script from [here](https://unix.stackexchange.com/questions/15509/whos-consuming-my-inotify-resources/502812#502812) to monitor the amount of watched files.

`tsc --watch` before exclusion of  `node_modules`:
<img width="661" alt="tsc-watch-count-1" src="https://github.com/user-attachments/assets/be8a4555-0a8d-49bd-ae0c-a62571d7f2cb">

`tsc --watch` after exclusion of  `node_modules`:
<img width="660" alt="tsc-watch-count-no-node_modules" src="https://github.com/user-attachments/assets/fa76f39c-9348-4f05-a8e5-6b74ab5adceb">

