### PR TITLE
Update Typescript to version 5.6.3 with minimal code changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
                 "tinymce": "6.8.4",
                 "tsconfig-paths": "^4.2.0",
                 "tsx": "^4.19.1",
-                "typescript": "^5.3.3",
+                "typescript": "^5.6.3",
                 "typescript-eslint": "^8.10.0",
                 "vite": "^5.4.9",
                 "vite-plugin-checker": "^0.8.0",
@@ -8590,9 +8590,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-            "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+            "version": "5.6.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+            "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
         "tinymce": "6.8.4",
         "tsconfig-paths": "^4.2.0",
         "tsx": "^4.19.1",
-        "typescript": "^5.3.3",
+        "typescript": "^5.6.3",
         "typescript-eslint": "^8.10.0",
         "vite": "^5.4.9",
         "vite-plugin-checker": "^0.8.0",

--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -106,7 +106,7 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
     declare armorClass: StatisticDifficultyClass<ArmorStatistic> | null;
 
     /** A separate collection of owned spellcasting entries for convenience */
-    declare spellcasting: ActorSpellcasting<this> | null;
+    declare spellcasting: ActorSpellcasting<ActorPF2e<TParent>> | null;
 
     /** Rule elements drawn from owned items */
     declare rules: RuleElementPF2e[];

--- a/src/module/actor/creature/document.ts
+++ b/src/module/actor/creature/document.ts
@@ -46,7 +46,7 @@ abstract class CreaturePF2e<
     TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | null,
 > extends ActorPF2e<TParent> {
     /** A separate collection of owned spellcasting entries for convenience */
-    declare spellcasting: ActorSpellcasting<this>;
+    declare spellcasting: ActorSpellcasting<CreaturePF2e<TParent>>;
 
     declare parties: Set<PartyPF2e>;
     /** A creature always has an AC */
@@ -260,9 +260,12 @@ abstract class CreaturePF2e<
             const spell = consumable.embeddedSpell;
             if (!spell?.id) continue;
             const ability = this.spellcasting
-                .filter((e): e is SpellcastingEntry<this> => !!e.statistic && e.canCast(spell, { origin: consumable }))
+                .filter(
+                    (e): e is SpellcastingEntry<CreaturePF2e<TParent>> =>
+                        !!e.statistic && e.canCast(spell, { origin: consumable }),
+                )
                 .reduce(
-                    (best: SpellcastingEntry<this> | null, e) =>
+                    (best: SpellcastingEntry<CreaturePF2e<TParent>> | null, e) =>
                         best === null ? e : e.statistic.dc.value > best.statistic.dc.value ? e : best,
                     null,
                 );

--- a/src/module/actor/creature/sheet.ts
+++ b/src/module/actor/creature/sheet.ts
@@ -15,6 +15,7 @@ import { ActorSheetPF2e, SheetClickActionHandlers } from "../sheet/base.ts";
 import { CreatureConfig } from "./config.ts";
 import { Language } from "./index.ts";
 import { SpellPreparationSheet } from "./spell-preparation-sheet.ts";
+import { SpellCollection } from "@item/spellcasting-entry/collection.ts";
 
 /**
  * Base class for NPC and character sheets
@@ -361,7 +362,9 @@ abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends ActorSheet
         if (item.isOfType("spell")) {
             if (!(dropItemEl && dropContainerEl)) return [];
             const entryId = dropContainerEl.dataset.containerId;
-            const collection = this.actor.spellcasting.collections.get(entryId, { strict: true });
+            const collection = this.actor.spellcasting.collections.get<SpellCollection<TActor>>(entryId, {
+                strict: true,
+            });
             const groupId = coerceToSpellGroupId(dropItemEl.dataset.groupId);
             const slotId = Number(dropItemEl.dataset.slotId);
 

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -61,6 +61,7 @@ import { IdentifyItemPopup } from "./popups/identify-popup.ts";
 import { ItemTransferDialog } from "./popups/item-transfer-dialog.ts";
 import { IWREditor } from "./popups/iwr-editor.ts";
 import { RemoveCoinsPopup } from "./popups/remove-coins-popup.ts";
+import { SpellCollection } from "@item/spellcasting-entry/collection.ts";
 
 /**
  * Extend the basic ActorSheet class to do all the PF2e things!
@@ -515,7 +516,8 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
                 const itemEl = htmlClosest(anchor, "[data-item-id]");
                 const collectionId = itemEl?.dataset.entryId;
                 const collection: Collection<ItemPF2e<TActor>> = collectionId
-                    ? (actor.spellcasting?.collections.get(collectionId, { strict: true }) ?? actor.items)
+                    ? (actor.spellcasting?.collections.get<SpellCollection<TActor>>(collectionId, { strict: true }) ??
+                      actor.items)
                     : actor.items;
 
                 const itemId = itemEl?.dataset.itemId;

--- a/src/module/item/helpers.ts
+++ b/src/module/item/helpers.ts
@@ -2,6 +2,7 @@ import type { ActorPF2e } from "@actor";
 import type { EnrichmentOptionsPF2e } from "@system/text-editor.ts";
 import { createHTMLElement, setHasElement } from "@util";
 import * as R from "remeda";
+import type { Converter } from "showdown";
 import type { ItemSourcePF2e, ItemType, RawItemChatData } from "./base/data/index.ts";
 import { ItemDescriptionData } from "./base/data/system.ts";
 import type { ItemPF2e } from "./base/document.ts";
@@ -47,7 +48,7 @@ class ItemChatData {
     htmlOptions: EnrichmentOptionsPF2e;
 
     /** A showdown markdown converter */
-    static #mdConverter: showdown.Converter | null = null;
+    static #mdConverter: Converter | null = null;
 
     constructor({ item, data, htmlOptions = {} }: ItemChatDataConstructorOptions) {
         this.item = item;


### PR DESCRIPTION
It looks like `ActorSpellcasting` is fully responsible for the previous "type instantiation is excessively deep" errors. Changing that to not reference `this` and the necessary follow up changes clears up all other errors.
The only caveat is that the `TActor` generic has to be manually passed to  `ActorSpellcasting#collections#get` to correctly resolve the return type.
I haven't managed to solve that another way yet.
