### PR TITLE
Fix Mark of the Mantis Pregens

### DIFF
--- a/packs/paizo-pregens/kangir.json
+++ b/packs/paizo-pregens/kangir.json
@@ -1204,7 +1204,7 @@
                 "quantity": 1,
                 "rules": [],
                 "runes": {
-                    "potency": 0,
+                    "potency": 1,
                     "property": [],
                     "resilient": 0
                 },

--- a/packs/paizo-pregens/yacob.json
+++ b/packs/paizo-pregens/yacob.json
@@ -2557,7 +2557,7 @@
                     "remaster": false,
                     "title": "Pathfinder Core Rulebook"
                 },
-                "quantity": 1,
+                "quantity": 2,
                 "rules": [],
                 "size": "med",
                 "slug": "rope",

--- a/packs/paizo-pregens/zeah.json
+++ b/packs/paizo-pregens/zeah.json
@@ -3543,7 +3543,7 @@
         {
             "_id": "3VmRd2DOAQeN6G3e",
             "_stats": {
-                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.y4WJY8rCbY6d1MET",
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.y4WJY8rCbY6d1MET"
             },
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/sunrod.webp",
             "name": "Sunrod",

--- a/packs/paizo-pregens/zeah.json
+++ b/packs/paizo-pregens/zeah.json
@@ -3557,7 +3557,7 @@
                 "containerId": "DwBvJXUoIHtZrcwS",
                 "damage": null,
                 "description": {
-                    "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> Interact</p><p>This 1-foot-long, gold-tipped rod glows after it's struck on a hard surface. For the next 6 hours, it sheds bright light in a 20-foot radius (and dim light to the next 40 feet).</p>"
+                    "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> Interact</p>\n<p>This 1-foot-long, gold-tipped rod glows after it's struck on a hard surface. For the next 6 hours, it sheds bright light in a 20-foot radius (and dim light to the next 40 feet).</p>"
                 },
                 "equipped": {
                     "carryType": "worn"

--- a/packs/paizo-pregens/zeah.json
+++ b/packs/paizo-pregens/zeah.json
@@ -3541,6 +3541,73 @@
             "type": "equipment"
         },
         {
+            "_id": "3VmRd2DOAQeN6G3e",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.y4WJY8rCbY6d1MET",
+            },
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/sunrod.webp",
+            "name": "Sunrod",
+            "sort": 0,
+            "system": {
+                "baseItem": null,
+                "bulk": {
+                    "value": 0.1
+                },
+                "category": "other",
+                "containerId": "DwBvJXUoIHtZrcwS",
+                "damage": null,
+                "description": {
+                    "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> Interact</p><p>This 1-foot-long, gold-tipped rod glows after it's struck on a hard surface. For the next 6 hours, it sheds bright light in a 20-foot radius (and dim light to the next 40 feet).</p>"
+                },
+                "equipped": {
+                    "carryType": "worn"
+                },
+                "hardness": 0,
+                "hp": {
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 1
+                },
+                "material": {
+                    "grade": null,
+                    "type": null
+                },
+                "price": {
+                    "value": {
+                        "gp": 3
+                    }
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Core Rulebook"
+                },
+                "quantity": 1,
+                "rules": [],
+                "size": "med",
+                "slug": "sunrod",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "alchemical",
+                        "consumable",
+                        "light"
+                    ]
+                },
+                "usage": {
+                    "value": "held-in-one-hand"
+                },
+                "uses": {
+                    "autoDestroy": true,
+                    "max": 1,
+                    "value": 1
+                }
+            },
+            "type": "consumable"
+        },
+        {
             "_id": "JrE0oAzvLE7ge1nb",
             "_stats": {
                 "compendiumSource": "Compendium.pf2e.equipment-srd.Item.QJb8S927Yj81EgHH"
@@ -5085,10 +5152,10 @@
                 "rank": 0
             },
             "society": {
-                "rank": 0
+                "rank": 2
             },
             "stealth": {
-                "rank": 0
+                "rank": 2
             },
             "survival": {
                 "rank": 1


### PR DESCRIPTION
This is meant to fix some discrepancies between the Foundry pregens and the PDF:
https://paizo.s3.us-west-2.amazonaws.com/PZOPF1004E+Mark+of+the+Mantis+Pregens.pdf

- Kangir's armor is supposed to have a +1
- Yacob has 100 ft of rope, rather than just 50
- Zeah is expert in Society and Stealth (Foundry pregen shows only trained)
- Zeah also has a Sunrod, like Yacob