### PR TITLE
Add damage type as index field for item-filter choice sets

### DIFF
--- a/src/module/rules/rule-element/choice-set/rule-element.ts
+++ b/src/module/rules/rule-element/choice-set/rule-element.ts
@@ -460,6 +460,7 @@ class ChoiceSetRuleElement extends RuleElementPF2e<ChoiceSetSchema> {
                         "system.ancestry",
                         "system.baseItem",
                         "system.category",
+                        "system.damage.damageType",
                         "system.group",
                         "system.level",
                         "system.maxTakable",


### PR DESCRIPTION
This would be useful for exemplar weapon ikons, which let you pick weapons with specific damage types