### PR TITLE
Fix trait toggles on strikes overriden within the same item

### DIFF
--- a/src/module/item/weapon/trait-toggles.ts
+++ b/src/module/item/weapon/trait-toggles.ts
@@ -1,6 +1,5 @@
 import type { ActorPF2e } from "@actor";
 import type { WeaponPF2e } from "@item";
-import type { StrikeRuleElement } from "@module/rules/rule-element/strike.ts";
 import { nextDamageDieSize } from "@system/damage/helpers.ts";
 import type { DamageType } from "@system/damage/types.ts";
 import { objectHasKey, tupleHasValue } from "@util";
@@ -114,10 +113,7 @@ class WeaponTraitToggles {
         } else if (trait === "versatile" && item?.isOfType("shield")) {
             item.update({ "system.traits.integrated.versatile.selected": selected });
         } else if (trait !== "double-barrel") {
-            const rule = item?.rules.find(
-                (r): r is StrikeRuleElement => r.key === "Strike" && !r.ignored && r.slug === weapon.slug,
-            );
-            await rule?.toggleTrait({ trait, selected });
+            weapon.rule?.toggleTrait({ trait, selected });
         }
 
         return true;


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/16982.

I was tempted on leveraging createBatchRuleElementUpdate() to tag every strike with the same slug across every item but I stopped myself. It might create a bit more stability to trait toggle behavior but I doubt it'll be necessary.