### PR TITLE
Implement thoughtsense detection mode

### DIFF
--- a/packs/ancestryfeatures/empathic-sense.json
+++ b/packs/ancestryfeatures/empathic-sense.json
@@ -42,6 +42,12 @@
                 "selector": "perception",
                 "type": "circumstance",
                 "value": 2
+            },
+            {
+                "acuity": "imprecise",
+                "key": "Sense",
+                "range": 15,
+                "selector": "thoughtsense"
             }
         ],
         "traits": {

--- a/packs/pathfinder-monster-core/rhu-chalik.json
+++ b/packs/pathfinder-monster-core/rhu-chalik.json
@@ -710,7 +710,7 @@
                 {
                     "acuity": "precise",
                     "range": 60,
-                    "type": "tremorsense"
+                    "type": "thoughtsense"
                 }
             ]
         },

--- a/src/module/canvas/perception/modes.ts
+++ b/src/module/canvas/perception/modes.ts
@@ -152,12 +152,60 @@ class DetectionModeTremorPF2e extends DetectionModeTremor {
     }
 }
 
+class ThoughtsDetectionMode extends DetectionMode {
+    constructor() {
+        super({
+            id: "senseThoughts",
+            label: "PF2E.Actor.Creature.Sense.Type.Thoughtsense",
+            type: DetectionMode.DETECTION_TYPES.OTHER,
+            angle: false,
+        });
+    }
+
+    static override getDetectionFilter(): OutlineOverlayFilter {
+        const filter = (this._detectionFilter ??= OutlineOverlayFilter.create({
+            wave: true,
+            knockout: false,
+            outlineColor: [0, 1, 0, 1],
+        }));
+        filter.thickness = 1;
+        return filter;
+    }
+
+    protected override _canDetect(visionSource: PointVisionSourcePF2e, target: PlaceableObject): boolean {
+        // Not if the target isn't a token
+        if (!(target instanceof TokenPF2e)) return false;
+        const token: TokenPF2e = target;
+        if (!token.actor) return false;
+
+        // Not if the token is GM-hidden
+        if (token.document.hidden) return false;
+
+        // Detection only works on creatures
+        if (!token.actor.isOfType("creature")) return false;
+
+        // Detection cails on mindless creatures
+        if (token.actor.system.traits.value.includes("mindless")) return false;
+
+        // Detection fails if target is immune to mental
+        if (token.actor.attributes.immunities.some((i) => i.type === "mental")) return false;
+
+        return super._canDetect(visionSource, target);
+    }
+}
+
+declare namespace ThoughtsDetectionMode {
+    // eslint-disable-next-line no-var
+    var _detectionFilter: OutlineOverlayFilter | undefined;
+}
+
 function setPerceptionModes(): void {
     CONFIG.Canvas.visionModes.darkvision = darkvision;
     CONFIG.Canvas.detectionModes.basicSight = new VisionDetectionMode();
     CONFIG.Canvas.detectionModes.lightPerception = new LightPerceptionMode();
     CONFIG.Canvas.detectionModes.hearing = new HearingDetectionMode();
     CONFIG.Canvas.detectionModes.feelTremor = new DetectionModeTremorPF2e();
+    CONFIG.Canvas.detectionModes.senseThoughts = new ThoughtsDetectionMode();
 }
 
 export { setPerceptionModes };

--- a/src/module/scene/helpers.ts
+++ b/src/module/scene/helpers.ts
@@ -97,6 +97,11 @@ function computeSightAndDetectionForRBV(token: TokenDocumentPF2e | PrototypeToke
         const range = scene?.flags.pf2e.hearingRange ?? null;
         token.detectionModes.push({ id: "hearing", enabled: true, range });
     }
+
+    const thoughtsense = actor.perception.senses.get("thoughtsense");
+    if (thoughtsense && thoughtsense.acuity !== "vague") {
+        token.detectionModes.push({ id: "senseThoughts", enabled: true, range: thoughtsense.range });
+    }
 }
 
 /** Returns true if this token has the default actor image or the default image for its actor type */


### PR DESCRIPTION
A resubmission of PR #15115 since I screwed up my repository.

Implements the thoughtsense detection mode.

It also updates the "Empathic Sense" ancestry feature for the Kashrishi race to use this new sense out to 15 ft.

The new sense will only detect Actor types of: character, npc, familiar.

It is best tested by giving the PC with "Empathic Sense" the "Deaf" condition (otherwise they can hear it).

This can also be applied to the Cauthooj (in Monster Core) - "The cauthooj senses all non-mindless creatures at the listed range."

Note that Rhu-Chalik (in Monster Core) have this as a precise sense. Cauthooj creature wrongly had tremorsense when it should have thoughtsense. Other creatures in Monster Core already have thoughtsense configured on their Actors.