### PR TITLE
provide a workaround for the Change Shape bug and a little RE cleanup

### DIFF
--- a/packs/ancestries/kitsune.json
+++ b/packs/ancestries/kitsune.json
@@ -95,15 +95,20 @@
                 "label": "PF2E.NPCAbility.ChangeShape.Label",
                 "mergeable": true,
                 "option": "change-shape",
-                "predicate": [
-                    {
-                        "not": "non-tailless-form"
-                    }
-                ],
                 "suboptions": [
                     {
                         "label": "PF2E.NPCAbility.ChangeShape.Form.Tailless",
+                        "predicate": [
+                            "kitsune:shapes:tailless"
+                        ],
                         "value": "tailless"
+                    },
+                    {
+                        "label": "PF2E.NPCAbility.ChangeShape.Form.Fox",
+                        "predicate": [
+                            "kitsune:shapes:fox"
+                        ],
+                        "value": "fox"
                     }
                 ],
                 "toggleable": true

--- a/packs/feats/myriad-forms.json
+++ b/packs/feats/myriad-forms.json
@@ -26,22 +26,14 @@
         },
         "rules": [
             {
-                "alwaysActive": true,
                 "key": "RollOption",
-                "label": "PF2E.NPCAbility.ChangeShape.Label",
-                "mergeable": true,
-                "option": "change-shape",
-                "suboptions": [
-                    {
-                        "label": "PF2E.NPCAbility.ChangeShape.Form.Fox",
-                        "value": "fox"
-                    },
-                    {
-                        "label": "PF2E.NPCAbility.ChangeShape.Form.Tailless",
-                        "value": "tailless"
-                    }
-                ],
-                "toggleable": true
+                "option": "kitsune:shapes:tailless",
+                "priority": 49
+            },
+            {
+                "key": "RollOption",
+                "option": "kitsune:shapes:fox",
+                "priority": 49
             }
         ],
         "traits": {

--- a/packs/heritages/kitsune/celestial-envoy-kitsune.json
+++ b/packs/heritages/kitsune/celestial-envoy-kitsune.json
@@ -21,6 +21,11 @@
             {
                 "key": "GrantItem",
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Invoke Celestial Privilege"
+            },
+            {
+                "key": "RollOption",
+                "option": "kitsune:shapes:tailless",
+                "priority": 49
             }
         ],
         "traits": {

--- a/packs/heritages/kitsune/dark-fields-kitsune.json
+++ b/packs/heritages/kitsune/dark-fields-kitsune.json
@@ -24,22 +24,8 @@
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Invigorating Fear"
             },
             {
-                "alwaysActive": true,
                 "key": "RollOption",
-                "label": "PF2E.NPCAbility.ChangeShape.Label",
-                "mergeable": true,
-                "option": "change-shape",
-                "suboptions": [
-                    {
-                        "label": "PF2E.NPCAbility.ChangeShape.Form.Fox",
-                        "value": "fox"
-                    }
-                ],
-                "toggleable": true
-            },
-            {
-                "key": "RollOption",
-                "option": "non-tailless-form",
+                "option": "kitsune:shapes:fox",
                 "priority": 49
             }
         ],

--- a/packs/heritages/kitsune/earthly-wilds-kitsune.json
+++ b/packs/heritages/kitsune/earthly-wilds-kitsune.json
@@ -54,7 +54,7 @@
             },
             {
                 "key": "RollOption",
-                "option": "non-tailless-form",
+                "option": "kitsune:shapes:fox",
                 "priority": 49
             }
         ],

--- a/packs/heritages/kitsune/empty-sky-kitsune.json
+++ b/packs/heritages/kitsune/empty-sky-kitsune.json
@@ -21,6 +21,11 @@
             {
                 "key": "GrantItem",
                 "uuid": "Compendium.pf2e.feats-srd.Item.Kitsune Spell Familiarity"
+            },
+            {
+                "key": "RollOption",
+                "option": "kitsune:shapes:tailless",
+                "priority": 49
             }
         ],
         "traits": {

--- a/packs/heritages/kitsune/frozen-wind-kitsune.json
+++ b/packs/heritages/kitsune/frozen-wind-kitsune.json
@@ -22,6 +22,11 @@
                 "key": "Resistance",
                 "type": "cold",
                 "value": "max(1,floor(@actor.level/2))"
+            },
+            {
+                "key": "RollOption",
+                "option": "kitsune:shapes:tailless",
+                "priority": 49
             }
         ],
         "traits": {

--- a/packs/heritages/kitsune/palace-echoes-kitsune.json
+++ b/packs/heritages/kitsune/palace-echoes-kitsune.json
@@ -21,6 +21,11 @@
             {
                 "key": "GrantItem",
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Nudging Whisper"
+            },
+            {
+                "key": "RollOption",
+                "option": "kitsune:shapes:tailless",
+                "priority": 49
             }
         ],
         "traits": {


### PR DESCRIPTION
Partially addresses #17015

It's just a little unification for the Kitsune Change Shape REs. The Roll Option with both Suboptions is now part of the Ancestry while Heritages an Ancestry Feats enable these suboptions.

This also avoids the bug in #17015, as there are no more duplicate Suboptions.