### PR TITLE
Improve display of /act in chat for secret rolls

### DIFF
--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -466,7 +466,7 @@ class TextEditorPF2e extends TextEditor {
                 element.appendChild(document.createTextNode(" "));
 
                 const details = document.createElement("span");
-                if (dc && showDC && Number.isNumeric(dc)) {
+                if (dc && showDC && Number.isNumeric(dc) && statistic) {
                     // (<span data-visibility="...">DC #</span> Statistic)
                     details.appendChild(document.createTextNode("("));
                     const span = document.createElement("span");
@@ -477,6 +477,10 @@ class TextEditorPF2e extends TextEditor {
                         ? ` ${ActionMacroHelpers.getSimpleCheckLabel(statistic) || statistic})`
                         : ")";
                     details.appendChild(document.createTextNode(suffix));
+                } else if (dc && showDC && Number.isNumeric(dc)) {
+                    // (<span data-visibility="...">DC #</span> Statistic)
+                    details.dataset["visibility"] = visibility;
+                    details.innerText = `(${game.i18n.format("PF2E.InlineAction.Check.DC", { dc })})`;
                 } else if (dc && showDC) {
                     // (Statistic vs Defense DC)
                     const defense = game.i18n.localize(`PF2E.Check.DC.Specific.${dc}`);

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -479,18 +479,17 @@ class TextEditorPF2e extends TextEditor {
                         details.innerText = `(${text})`;
                     } else if (statistic) {
                         // (<span data-visibility="...">DC #</span> Statistic)
-                        details.appendChild(document.createTextNode("("));
-                        const span = document.createElement("span");
-                        span.dataset["visibility"] = visibility;
-                        span.innerText = game.i18n.format("PF2E.InlineAction.Check.DC", { dc });
-                        details.appendChild(span);
-                        const suffix = statistic
+                        const span = createHTMLElement("span", {
+                            dataset: { visibility },
+                            children: [game.i18n.format("PF2E.InlineAction.Check.DC", { dc })],
+                        });
+                        const end = statistic
                             ? ` ${ActionMacroHelpers.getSimpleCheckLabel(statistic) || statistic})`
                             : ")";
-                        details.appendChild(document.createTextNode(suffix));
+                        details.append("(", span, end);
                     } else {
-                        // (<span data-visibility="...">DC #</span> Statistic)
-                        details.dataset["visibility"] = visibility;
+                        // <span data-visibility="...">(DC #)</span>
+                        details.dataset.visibility = visibility;
                         details.innerText = `(${game.i18n.format("PF2E.InlineAction.Check.DC", { dc })})`;
                     }
                 } else {

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -466,32 +466,34 @@ class TextEditorPF2e extends TextEditor {
                 element.appendChild(document.createTextNode(" "));
 
                 const details = document.createElement("span");
-                if (dc && showDC && Number.isNumeric(dc) && statistic) {
-                    // (<span data-visibility="...">DC #</span> Statistic)
-                    details.appendChild(document.createTextNode("("));
-                    const span = document.createElement("span");
-                    span.dataset["visibility"] = visibility;
-                    span.innerText = game.i18n.format("PF2E.InlineAction.Check.DC", { dc });
-                    details.appendChild(span);
-                    const suffix = statistic
-                        ? ` ${ActionMacroHelpers.getSimpleCheckLabel(statistic) || statistic})`
-                        : ")";
-                    details.appendChild(document.createTextNode(suffix));
-                } else if (dc && showDC && Number.isNumeric(dc)) {
-                    // (<span data-visibility="...">DC #</span> Statistic)
-                    details.dataset["visibility"] = visibility;
-                    details.innerText = `(${game.i18n.format("PF2E.InlineAction.Check.DC", { dc })})`;
-                } else if (dc && showDC) {
-                    // (Statistic vs Defense DC)
-                    const defense = game.i18n.localize(`PF2E.Check.DC.Specific.${dc}`);
-                    const text = statistic
-                        ? game.i18n.format("PF2E.InlineAction.Check.StatisticVsDefense", {
-                              defense,
-                              statistic: ActionMacroHelpers.getSimpleCheckLabel(statistic) || statistic,
-                          })
-                        : game.i18n.format("PF2E.InlineAction.Check.VsDefense", { defense });
-                    details.innerText = `(${text})`;
-                } else if (statistic) {
+                if (dc && showDC) {
+                    if (!Number.isNumeric(dc)) {
+                        // (Statistic vs Defense DC)
+                        const defense = game.i18n.localize(`PF2E.Check.DC.Specific.${dc}`);
+                        const text = statistic
+                            ? game.i18n.format("PF2E.InlineAction.Check.StatisticVsDefense", {
+                                  defense,
+                                  statistic: ActionMacroHelpers.getSimpleCheckLabel(statistic) || statistic,
+                              })
+                            : game.i18n.format("PF2E.InlineAction.Check.VsDefense", { defense });
+                        details.innerText = `(${text})`;
+                    } else if (statistic) {
+                        // (<span data-visibility="...">DC #</span> Statistic)
+                        details.appendChild(document.createTextNode("("));
+                        const span = document.createElement("span");
+                        span.dataset["visibility"] = visibility;
+                        span.innerText = game.i18n.format("PF2E.InlineAction.Check.DC", { dc });
+                        details.appendChild(span);
+                        const suffix = statistic
+                            ? ` ${ActionMacroHelpers.getSimpleCheckLabel(statistic) || statistic})`
+                            : ")";
+                        details.appendChild(document.createTextNode(suffix));
+                    } else {
+                        // (<span data-visibility="...">DC #</span> Statistic)
+                        details.dataset["visibility"] = visibility;
+                        details.innerText = `(${game.i18n.format("PF2E.InlineAction.Check.DC", { dc })})`;
+                    }
+                } else {
                     // (Statistic)
                     const text = ActionMacroHelpers.getSimpleCheckLabel(statistic) || statistic;
                     details.innerText = `(${text})`;

--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -91,7 +91,7 @@ export class InlineRollLinks {
     static #makeRepostHtml(target: HTMLElement, defaultVisibility: string): string {
         const flavor = game.i18n.localize(target.dataset.pf2RepostFlavor ?? "");
         const showDC = target.dataset.pf2ShowDc ?? defaultVisibility;
-        return `<span data-visibility="${showDC}">${flavor}</span> ${target.outerHTML}`.trim();
+        return (flavor ? `<span data-visibility="${showDC}">${flavor}</span> ` : '') + `${target.outerHTML}`.trim();
     }
 
     static #onClickInlineAction(event: MouseEvent, link: HTMLAnchorElement | HTMLSpanElement): void {

--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -91,7 +91,7 @@ export class InlineRollLinks {
     static #makeRepostHtml(target: HTMLElement, defaultVisibility: string): string {
         const flavor = game.i18n.localize(target.dataset.pf2RepostFlavor ?? "");
         const showDC = target.dataset.pf2ShowDc ?? defaultVisibility;
-        return (flavor ? `<span data-visibility="${showDC}">${flavor}</span> ` : '') + `${target.outerHTML}`.trim();
+        return (flavor ? `<span data-visibility="${showDC}">${flavor}</span> ` : "") + `${target.outerHTML}`.trim();
     }
 
     static #onClickInlineAction(event: MouseEvent, link: HTMLAnchorElement | HTMLSpanElement): void {


### PR DESCRIPTION
When a `/act` with a secret roll is made, the display would include a space (or dot) before the action link, and would display "()" at the end of the string to players.