### PR TITLE
fix "double vs" resistance requiring all entries to be true

### DIFF
--- a/src/module/actor/data/iwr.ts
+++ b/src/module/actor/data/iwr.ts
@@ -369,7 +369,7 @@ class Resistance extends IWR<ResistanceType> implements ResistanceSource {
     /** Get the doubled value of this resistance if present and applicable to a given instance of damage */
     getDoubledValue(damageDescription: Set<string>): number {
         if (this.doubleVs.length === 0) return this.value;
-        const predicate = new Predicate({or: this.doubleVs.flatMap((d) => this.describe(d))});
+        const predicate = new Predicate({ or: this.doubleVs.flatMap((d) => this.describe(d)) });
         return predicate.test(damageDescription) ? this.value * 2 : this.value;
     }
 }

--- a/src/module/actor/data/iwr.ts
+++ b/src/module/actor/data/iwr.ts
@@ -369,7 +369,7 @@ class Resistance extends IWR<ResistanceType> implements ResistanceSource {
     /** Get the doubled value of this resistance if present and applicable to a given instance of damage */
     getDoubledValue(damageDescription: Set<string>): number {
         if (this.doubleVs.length === 0) return this.value;
-        const predicate = new Predicate(this.doubleVs.flatMap((d) => this.describe(d)));
+        const predicate = new Predicate({or: this.doubleVs.flatMap((d) => this.describe(d))});
         return predicate.test(damageDescription) ? this.value * 2 : this.value;
     }
 }

--- a/src/module/actor/data/iwr.ts
+++ b/src/module/actor/data/iwr.ts
@@ -82,8 +82,6 @@ abstract class IWR<TType extends IWRType> {
                 return ["check:outcome:critical-success"];
             case "custom":
                 return this.definition ?? [];
-            case "damage-from-spells":
-                return ["damage", "item:type:spell", "impulse"];
             case "disease":
                 return ["item:trait:disease"];
             case "emotion":
@@ -159,9 +157,9 @@ abstract class IWR<TType extends IWRType> {
                 const component = iwrType === "splash-damage" ? "splash" : "precision";
                 return [`damage:component:${component}`];
             }
-            case "spells": {
-                return ["damage", { or: ["item:type:spell", "item:from-spell", "impulse"] }];
-            }
+            case "spells":
+            case "damage-from-spells":
+                return ["damage", { or: ["item:type:spell", "item:from-spell", "item:trait:impulse"] }];
             case "unarmed-attacks":
                 return ["item:category:unarmed"];
             case "unholy":

--- a/src/module/actor/data/iwr.ts
+++ b/src/module/actor/data/iwr.ts
@@ -369,7 +369,15 @@ class Resistance extends IWR<ResistanceType> implements ResistanceSource {
     /** Get the doubled value of this resistance if present and applicable to a given instance of damage */
     getDoubledValue(damageDescription: Set<string>): number {
         if (this.doubleVs.length === 0) return this.value;
-        const predicate = new Predicate({ or: this.doubleVs.flatMap((d) => this.describe(d)) });
+        const predicate =
+            this.doubleVs.length === 1
+                ? new Predicate(this.describe(this.doubleVs[0]))
+                : new Predicate({
+                      or: this.doubleVs.map((doubleVs) => {
+                          const description = this.describe(doubleVs);
+                          return description.length === 1 ? description[0] : { and: description };
+                      }),
+                  });
         return predicate.test(damageDescription) ? this.value * 2 : this.value;
     }
 }


### PR DESCRIPTION
Double Vs check was being treated as an "and" instead of an "or". Change the predicate test into "or".