### PR TITLE
Add redundant registration of action-glyph font

### DIFF
--- a/src/styles/_fonts.scss
+++ b/src/styles/_fonts.scss
@@ -27,4 +27,9 @@
     --journal-serif: "Vollkorn", var(--serif);
     --fa6: "Font Awesome 6 Pro", sans-serif;
     --fad6: "Font Awesome 6 Duotone", sans-serif;
+
+    @font-face {
+        font-family: "Pathfinder2eActions";
+        src: url("/fonts/pathfinder-2e-actions.woff2") format("woff2");
+    }
 }


### PR DESCRIPTION
Throwing darts at the Firefox bug