### PR TITLE
Implement remaster styled advanced alchemy and Double, Double

### DIFF
--- a/packs/feats/advanced-alchemy.json
+++ b/packs/feats/advanced-alchemy.json
@@ -28,7 +28,18 @@
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [],
+        "rules": [
+            {
+                "craftableItems": [
+                    "item:trait:alchemical"
+                ],
+                "isDailyPrep": true,
+                "key": "CraftingAbility",
+                "label": "PF2E.SpecificRule.AdvancedAlchemy.Label",
+                "maxSlots": 4,
+                "slug": "advanced-alchemy"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/advanced-herbalism.json
+++ b/packs/feats/advanced-herbalism.json
@@ -16,6 +16,7 @@
         "level": {
             "value": 6
         },
+        "maxTakable": 2,
         "prerequisites": {
             "value": [
                 {
@@ -31,7 +32,14 @@
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "system.crafting.entries.advancedAlchemy.maxSlots",
+                "value": "4 + (2 * @item.timesTaken)"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/cauldron.json
+++ b/packs/feats/cauldron.json
@@ -37,15 +37,8 @@
                 "isDailyPrep": true,
                 "key": "CraftingAbility",
                 "label": "PF2E.SpecificRule.Witch.Cauldron.CraftingEntry",
-                "maxSlots": 1,
+                "maxSlots": "ternary(eq(@actor.system.proficiencies.spellcasting.rank,4),3,ternary(eq(@actor.system.proficiencies.spellcasting.rank,3),2,1))",
                 "slug": "cauldron"
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "upgrade",
-                "path": "system.crafting.entries.cauldron.maxSlots",
-                "phase": "beforeDerived",
-                "value": "ternary(eq(@actor.system.proficiencies.spellcasting.rank,4),3,ternary(eq(@actor.system.proficiencies.spellcasting.rank,3),2,1))"
             }
         ],
         "traits": {

--- a/packs/feats/double-double.json
+++ b/packs/feats/double-double.json
@@ -28,7 +28,14 @@
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "system.crafting.entries.cauldron.batchSize",
+                "value": 2
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/herbalist-dedication.json
+++ b/packs/feats/herbalist-dedication.json
@@ -39,9 +39,6 @@
                 "value": 2
             },
             {
-                "batchSizes": {
-                    "default": 1
-                },
                 "craftableItems": [
                     {
                         "or": [
@@ -55,18 +52,11 @@
                         ]
                     }
                 ],
-                "isAlchemical": true,
                 "isDailyPrep": true,
                 "key": "CraftingAbility",
-                "label": "PF2E.SpecificRule.DedicationCraftingEntry.Herbalist",
-                "maxItemLevel": 1,
-                "slug": "herbalist"
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "upgrade",
-                "path": "system.resources.crafting.infusedReagents.max",
-                "value": "@actor.level"
+                "label": "PF2E.SpecificRule.AdvancedAlchemy.Label",
+                "maxSlots": 4,
+                "slug": "advanced-alchemy"
             },
             {
                 "key": "GrantItem",

--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -1066,7 +1066,7 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
             const content = `<p class="hint">${question}</p>`;
             const title = game.i18n.localize("PF2E.CraftingTab.UnprepareFormulaDialogTitle");
             if (event.ctrlKey || (await Dialog.confirm({ title, content }))) {
-                return ability.unprepareFormula(Number(index), uuid);
+                return ability.unprepareFormula(Number(index));
             }
         };
 

--- a/src/module/item/feat/document.ts
+++ b/src/module/item/feat/document.ts
@@ -75,6 +75,14 @@ class FeatPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
         return this.system.maxTakable;
     }
 
+    /** Returns the number of times this feat was taken, limited by maxTakable */
+    get timesTaken(): number {
+        // if performance becomes a concern, we can accumulate in actor flags for O(N)
+        const slug = this.slug ?? sluggify(this.name);
+        const matchingFeats = this.actor?.itemTypes.feat.filter((f) => f.category === this.category && f.slug === slug);
+        return Math.min(matchingFeats?.length ?? 0, this.maxTakable);
+    }
+
     override prepareBaseData(): void {
         super.prepareBaseData();
 

--- a/src/module/rules/rule-element/crafting-ability.ts
+++ b/src/module/rules/rule-element/crafting-ability.ts
@@ -17,17 +17,6 @@ class CraftingAbilityRuleElement extends RuleElementPF2e<CraftingAbilityRuleSche
     }
 
     static override defineSchema(): CraftingAbilityRuleSchema {
-        const quantityField = (): QuantityField =>
-            new fields.NumberField({
-                required: true,
-                nullable: false,
-                positive: true,
-                integer: true,
-                initial: 2,
-                min: 1,
-                max: 99,
-            });
-
         return {
             ...super.defineSchema(),
             slug: new SlugField({ required: true, nullable: false, initial: undefined }),
@@ -36,15 +25,26 @@ class CraftingAbilityRuleElement extends RuleElementPF2e<CraftingAbilityRuleSche
             isPrepared: new fields.BooleanField(),
             batchSizes: new fields.SchemaField(
                 {
-                    default: quantityField(),
+                    default: new fields.NumberField({ required: false, min: 1, max: 99 }),
                     other: new fields.ArrayField(
-                        new fields.SchemaField({ quantity: quantityField(), definition: new PredicateField() }),
+                        new fields.SchemaField({
+                            quantity: new fields.NumberField({
+                                required: true,
+                                nullable: false,
+                                positive: true,
+                                integer: true,
+                                initial: 2,
+                                min: 1,
+                                max: 99,
+                            }),
+                            definition: new PredicateField(),
+                        }),
                     ),
                 },
                 { initial: (d) => ({ default: d.isAlchemical ? 2 : 1, other: [] }) },
             ),
             maxItemLevel: new ResolvableValueField({ required: false, nullable: false }),
-            maxSlots: new fields.NumberField({ required: true, nullable: true, min: 0, integer: true, initial: null }),
+            maxSlots: new ResolvableValueField({ required: false, nullable: false }),
             craftableItems: new PredicateField(),
             prepared: new fields.ArrayField(
                 new fields.SchemaField(
@@ -61,25 +61,45 @@ class CraftingAbilityRuleElement extends RuleElementPF2e<CraftingAbilityRuleSche
         };
     }
 
-    override beforePrepareData(): void {
+    override onApplyActiveEffects(): void {
         if (this.ignored) return;
 
         const slug = this.resolveInjectedProperties(this.slug);
-        this.actor.system.crafting.entries[sluggify(slug, { camel: "dromedary" })] = {
-            slug,
-            label: this.label,
-            isAlchemical: this.isAlchemical,
-            isDailyPrep: this.isDailyPrep,
-            isPrepared: this.isPrepared,
-            batchSizes: this.batchSizes,
-            craftableItems: this.craftableItems,
-            maxItemLevel: Number(this.resolveValue(this.maxItemLevel)) || this.actor.level,
-            maxSlots: this.maxSlots,
-            preparedFormulaData: this.prepared,
-        };
+        const key = sluggify(slug, { camel: "dromedary" });
+        const maxSlots = this.maxSlots !== undefined ? Number(this.resolveValue(this.maxSlots)) : null;
+        const maxItemLevel = Number(this.resolveValue(this.maxItemLevel));
+        const existing = this.actor.system.crafting.entries[key];
+        if (existing) {
+            existing.label = this.label;
+            existing.craftableItems ??= [];
+            if (this.craftableItems) {
+                existing.craftableItems.push({ predicate: this.craftableItems });
+            }
+            existing.batchSize = Math.max(existing.batchSize, this.batchSizes?.default || 1);
+            existing.maxItemLevel = Math.max(maxItemLevel, existing.maxItemLevel);
+            existing.maxSlots =
+                (existing.maxSlots ?? maxSlots) === null ? null : Math.max(existing.maxSlots ?? 0, maxSlots ?? 0);
+            existing.preparedFormulaData ??= this.prepared;
+        } else {
+            this.actor.system.crafting.entries[key] = {
+                slug,
+                label: this.label,
+                isAlchemical: this.isAlchemical,
+                isDailyPrep: this.isDailyPrep,
+                isPrepared: this.isPrepared,
+                batchSize: this.batchSizes.default ?? (this.isAlchemical ? 2 : 1),
+                craftableItems: [
+                    { predicate: this.craftableItems },
+                    ...this.batchSizes.other.map((o) => ({ predicate: o.definition, batchSize: o.quantity })),
+                ],
+                maxItemLevel: maxItemLevel || this.actor.level,
+                maxSlots,
+                preparedFormulaData: this.prepared,
+            };
 
-        // Set a roll option to cue subsequent max-item-level-increasing `ActiveEffectLike`s
-        this.actor.rollOptions.all[`crafting:entry:${slug}`] = true;
+            // Set a roll option to cue subsequent max-item-level-increasing `ActiveEffectLike`s
+            this.actor.rollOptions.all[`crafting:entry:${slug}`] = true;
+        }
     }
 }
 
@@ -98,16 +118,19 @@ type CraftingAbilityRuleSchema = Omit<RuleElementSchema, "slug"> & {
     isDailyPrep: fields.BooleanField<boolean, boolean, false, false, true>;
     isPrepared: fields.BooleanField<boolean, boolean, false, false, true>;
     batchSizes: fields.SchemaField<{
-        default: QuantityField;
-        other: fields.ArrayField<fields.SchemaField<{ quantity: QuantityField; definition: PredicateField }>>;
+        default: fields.NumberField<number, number, false, false, false>;
+        other: fields.ArrayField<
+            fields.SchemaField<{
+                quantity: fields.NumberField<number, number, true, false, true>;
+                definition: PredicateField;
+            }>
+        >;
     }>;
     maxItemLevel: ResolvableValueField<false, false, true>;
-    maxSlots: fields.NumberField<number, number, true, true, true>;
+    maxSlots: ResolvableValueField<false, false, true>;
     craftableItems: PredicateField;
     prepared: fields.ArrayField<fields.SchemaField<PreparedFormulaSchema>>;
 };
-
-type QuantityField = fields.NumberField<number, number, true, false, true>;
 
 type PreparedFormulaSchema = {
     uuid: fields.DocumentUUIDField<ItemUUID, true, false, false>;

--- a/src/module/rules/rule-element/special-resource.ts
+++ b/src/module/rules/rule-element/special-resource.ts
@@ -17,7 +17,7 @@ class SpecialResourceRuleElement extends RuleElementPF2e<SpecialResourceSchema> 
     protected static override validActorTypes: ActorType[] = ["character"];
 
     constructor(source: SpecialResourceSource, options: RuleElementOptions) {
-        super({ priority: 19, ...source }, options);
+        super({ priority: 18, ...source }, options);
         if (this.invalid) return;
 
         this.slug ??= this.item.slug ?? sluggify(this.item.name);

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -209,6 +209,7 @@
                     "Title": "Configure Character"
                 },
                 "Crafting": {
+                    "BatchQuantity": "x{quantity}",
                     "Cost": "Cost",
                     "Daily": {
                         "Complete": {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -1906,6 +1906,9 @@
             "AdoptedAncestry": {
                 "Prompt": "Select a common ancestry."
             },
+            "AdvancedAlchemy": {
+                "Label": "Advanced Alchemy"
+            },
             "AdvancedGeneralTraining": {
                 "Prompt": "Select a 7th-level or lower general feat."
             },

--- a/static/templates/actors/character/tabs/crafting.hbs
+++ b/static/templates/actors/character/tabs/crafting.hbs
@@ -199,6 +199,8 @@
                 <a class="adjust decrease" data-action="decrease-craft-quantity">&ndash;</a>
                 <input type="number" class="formula-number" data-craft-quantity value="{{formula.quantity}}" />
                 <a class="adjust increase" data-action="increase-craft-quantity">+</a>
+            {{else}}
+                {{localize "PF2E.Actor.Character.Crafting.BatchQuantity" quantity=formula.quantity}}
             {{/if}}
         </div>
 


### PR DESCRIPTION
The following occured refactor wise:
1) Crafting Ability now injects initial data during the active effects phase, so that AELike no longer needs to target the beforeDerived phase.
2) Crafting abilities with the same slug merge. The AELikes I added could have more CraftingAbility RE's, but I don't know if we want to incentivize that for abilities without craftable items.
3) Prepared items now support batch sizes. Each prepared item crafts the batch size in the craftable entry, and falls back to the batch size of the entire ability.
4) Items now have a timesTaken getter. The current implementation is inefficient if the getter gets used often. I'll refactor if we start using it a bunch.

This does not update every source of advanced alchemy. I am not touching alchemist class personally until all of this is done.