### PR TITLE
fix issue with Diplomat's Badge bonus being hidden while having Effect

### DIFF
--- a/packs/equipment-effects/effect-diplomats-badge.json
+++ b/packs/equipment-effects/effect-diplomats-badge.json
@@ -22,6 +22,7 @@
         },
         "rules": [
             {
+                "label": "Diplomat's Bearing",
                 "key": "FlatModifier",
                 "predicate": [
                     "group"

--- a/packs/equipment-effects/effect-diplomats-badge.json
+++ b/packs/equipment-effects/effect-diplomats-badge.json
@@ -22,7 +22,7 @@
         },
         "rules": [
             {
-                "label": "Diplomat's Bearing",
+                "slug": "diplomats-bearing",
                 "key": "FlatModifier",
                 "predicate": [
                     "group"

--- a/packs/equipment-effects/effect-diplomats-badge.json
+++ b/packs/equipment-effects/effect-diplomats-badge.json
@@ -22,12 +22,12 @@
         },
         "rules": [
             {
-                "slug": "diplomats-bearing",
                 "key": "FlatModifier",
                 "predicate": [
                     "group"
                 ],
                 "selector": "diplomacy",
+                "slug": "diplomats-bearing",
                 "type": "item",
                 "value": 2
             }


### PR DESCRIPTION
Unconditional +1 from the item was being hidden by the conditional +2 from the activated effect due to duplicate slug. Giving effect unique label based on the activation action name so +1 can still apply.