### PR TITLE
Add support for mythic feat slots

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -138,6 +138,7 @@ interface GamePF2e
                     sections: FeatGroupData[];
                 };
                 languages: LanguageSettings;
+                mythic: "disabled" | "enabled" | "variant-tiers";
             };
             critFumble: {
                 buttons: boolean;
@@ -305,6 +306,7 @@ declare global {
         get(module: "pf2e", setting: "campaignFeats"): boolean;
         get(module: "pf2e", setting: "campaignFeatSections"): FeatGroupData[];
         get(module: "pf2e", setting: "campaignType"): string;
+        get(module: "pf2e", setting: "mythic"): "disabled" | "enabled" | "variant-tiers";
 
         get(module: "pf2e", setting: "activeParty"): string;
         get(module: "pf2e", setting: "activePartyFolderState"): boolean;

--- a/src/module/actor/character/data.ts
+++ b/src/module/actor/character/data.ts
@@ -58,6 +58,8 @@ type CharacterFlags = ActorFlagsPF2e & {
         sheetTabs: CharacterSheetTabVisibility;
         /** Whether the basic unarmed attack is shown on the Actions tab */
         showBasicUnarmed: boolean;
+        /** The limit for each feat group that supports a custom limit. */
+        featLimits: Record<string, number>;
     };
 };
 

--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -252,6 +252,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
             flags.pf2e.sheetTabs ?? {},
         );
         flags.pf2e.showBasicUnarmed ??= true;
+        flags.pf2e.featLimits ??= {};
 
         // Build selections: boosts and skill trainings
         const isGradual = game.pf2e.settings.variants.gab;

--- a/src/module/actor/character/feats/collection.ts
+++ b/src/module/actor/character/feats/collection.ts
@@ -3,7 +3,7 @@ import type { FeatPF2e, ItemPF2e } from "@item";
 import { sluggify } from "@util";
 import * as R from "remeda";
 import { FeatGroup } from "./group.ts";
-import { FeatGroupData } from "./types.ts";
+import { FeatGroupData, FeatSlotData } from "./types.ts";
 
 class CharacterFeats<TActor extends CharacterPF2e> extends Collection<FeatGroup<TActor>> {
     /** Feats belonging no actual group ("bonus feats" in rules text) */
@@ -28,20 +28,17 @@ class CharacterFeats<TActor extends CharacterPF2e> extends Collection<FeatGroup<
             id: "classfeature",
             label: "PF2E.Actor.Character.FeatSlot.ClassFeaturesHeader",
             supported: ["classfeature"],
+            sorted: true,
         });
 
-        // Find every ancestry and versatile heritage the actor counts as, then get all the traits that match them,
-        // falling back to homebrew
-        const ancestryTraitsFilter =
-            actor.system.details.ancestry?.countsAs.flatMap((t) =>
-                t in CONFIG.PF2E.featTraits ? `traits-${t}` : [],
-            ) ?? [];
-
+        const ancestry = actor.system.details.ancestry;
         this.createGroup({
             id: "ancestry",
             label: "PF2E.Actor.Character.FeatSlot.AncestryHeader",
-            featFilter: ancestryTraitsFilter,
             supported: ["ancestry"],
+            filter: {
+                traits: ancestry?.countsAs.flatMap((t) => (t in CONFIG.PF2E.featTraits ? t : [])) ?? [],
+            },
             slots: classFeatSlots?.ancestry ?? [],
         });
 
@@ -51,22 +48,14 @@ class CharacterFeats<TActor extends CharacterPF2e> extends Collection<FeatGroup<
             return slug && slug in CONFIG.PF2E.featTraits ? slug : null;
         })();
 
-        const classFeatFilter = !classTrait
-            ? // A class hasn't been selected: no useful pre-filtering available
-              []
-            : this.actor.level < 2
-              ? // The PC's level is less than 2: only show feats for the class
-                [`traits-${classTrait}`]
-              : this.actor.itemTypes.feat.some((f) => f.traits.has("dedication"))
-                ? // The PC has at least one dedication feat: include all archetype feats
-                  [`traits-${classTrait}`, "traits-archetype"]
-                : // No dedication feat has been selected: include dedication but no other archetype feats
-                  [`traits-${classTrait}`, "traits-dedication"];
+        const hasDedicationFeat = this.actor.itemTypes.feat.some((f) => f.traits.has("dedication"));
         this.createGroup({
             id: "class",
             label: "PF2E.Actor.Character.FeatSlot.ClassHeader",
-            featFilter: classFeatFilter,
             supported: ["class"],
+            filter: {
+                traits: [classTrait, hasDedicationFeat ? "archetype" : "dedication"].filter((t): t is string => !!t),
+            },
             slots: classFeatSlots?.class ?? [],
         });
 
@@ -81,10 +70,12 @@ class CharacterFeats<TActor extends CharacterPF2e> extends Collection<FeatGroup<
                 id: "archetype",
                 label: "PF2E.Actor.Character.FeatSlot.ArchetypeHeader",
                 supported: ["class"],
+                filter: {
+                    traits: [
+                        this.actor.itemTypes.feat.some((f) => f.traits.has("dedication")) ? "archetype" : "dedication",
+                    ],
+                },
                 slots: evenLevels,
-                featFilter: this.actor.itemTypes.feat.some((f) => f.traits.has("dedication"))
-                    ? ["traits-archetype"]
-                    : ["traits-dedication"],
             });
         }
 
@@ -110,14 +101,72 @@ class CharacterFeats<TActor extends CharacterPF2e> extends Collection<FeatGroup<
             slots: classFeatSlots?.general ?? [],
         });
 
+        // Add mythic if enabled
+        const mythicSetting = game.pf2e.settings.campaign.mythic;
+        if (mythicSetting !== "disabled") {
+            this.createGroup({
+                id: "mythic",
+                label: "PF2E.Actor.Character.FeatSlot.MythicHeader",
+                placeholder: "PF2E.Actor.Character.FeatSlot.MythicFeatPlaceholder",
+                customLimit:
+                    mythicSetting === "variant-tiers"
+                        ? {
+                              label: "Tier",
+                              min: 0,
+                              max: 10,
+                          }
+                        : null,
+                filter: {
+                    traits: ["mythic"],
+                },
+                slots: [
+                    {
+                        id: "mythic-calling",
+                        label: "PF2E.Actor.Character.FeatSlot.MythicCallingShort",
+                        placeholder: "PF2E.Actor.Character.FeatSlot.MythicCallingPlaceholder",
+                        filter: {
+                            traits: ["calling"],
+                        },
+                    },
+                    ...[2, 4, 6, 8, 10, 12, 14, 16, 18, 20].map((level, idx): FeatSlotData => {
+                        const tier = mythicSetting === "variant-tiers" ? idx + 1 : null;
+                        const label = String(mythicSetting === "variant-tiers" ? idx + 1 : level);
+                        const base = { id: `mythic-${level}`, level, tier, label };
+                        if (level === 12) {
+                            return {
+                                ...base,
+                                placeholder: "PF2E.Actor.Character.FeatSlot.MythicDestinyPlaceholder",
+                                filter: {
+                                    traits: ["destiny"],
+                                },
+                            };
+                        }
+
+                        return {
+                            ...base,
+                            filter: {
+                                categories: ["class"],
+                                traits: ["mythic"],
+                                omitTraits: ["calling", "destiny"],
+                                conjunction: "and",
+                            },
+                        };
+                    }),
+                ],
+                requiresInitial: true,
+            });
+        }
+
         // Add campaign feats if enabled
         if (game.pf2e.settings.campaign.feats.enabled) {
             this.createGroup({ id: "campaign", label: "PF2E.Actor.Character.FeatSlot.CampaignHeader" });
         }
     }
 
-    createGroup(data: FeatGroupData): this {
-        return this.set(data.id, new FeatGroup(this.actor, data));
+    createGroup(data: FeatGroupData): FeatGroup {
+        const group = new FeatGroup(this.actor, data);
+        this.set(data.id, group);
+        return group;
     }
 
     /** Inserts a feat into the character. If groupId is empty string, it's a bonus feat. */
@@ -203,13 +252,11 @@ class CharacterFeats<TActor extends CharacterPF2e> extends Collection<FeatGroup<
             if (!group?.assignFeat(feat)) this.bonus.assignFeat(feat);
         }
 
-        this.get("classfeature").feats.sort((a, b) => (a.feat?.level || 0) - (b.feat?.level || 0));
+        // Run all post assignment tasks
+        for (const group of this) {
+            group.postProcess();
+        }
     }
-}
-
-interface CharacterFeats<TActor extends CharacterPF2e> extends Collection<FeatGroup<TActor>> {
-    get(key: "ancestry" | "ancestryfeature" | "class" | "classfeature" | "general" | "skill"): FeatGroup<TActor>;
-    get(key: string): FeatGroup<TActor> | undefined;
 }
 
 function isBoonOrCurse(feat: FeatPF2e) {

--- a/src/module/actor/character/feats/types.ts
+++ b/src/module/actor/character/feats/types.ts
@@ -6,6 +6,7 @@ import type { FeatGroup } from "./group.ts";
 
 /** Any document that is similar enough to a feat/feature to be used as a feat for the purposes of feat groups */
 interface FeatLike<TParent extends ActorPF2e | null = ActorPF2e | null> extends ItemPF2e<TParent> {
+    readonly level: number | null;
     category: string;
     group: FeatGroup<NonNullable<TParent>, this> | null;
     isFeat: boolean;
@@ -19,21 +20,59 @@ interface FeatLike<TParent extends ActorPF2e | null = ActorPF2e | null> extends 
 interface FeatGroupData {
     id: string;
     label: string;
-    featFilter?: string[];
     supported?: FeatOrFeatureCategory[];
-    slots?: (FeatSlotCreationData | string | number)[];
+    filter?: FeatBrowserFilterProps;
+    slots?: (FeatSlotData | number)[];
+    /** If true, all slots are sorted by their level. Only applies if slotless */
+    sorted?: boolean;
+    /** If set to true, all slots except the first will be hidden unless its been assigned to */
+    requiresInitial?: boolean;
+    /** Default placeholder text for empty slots */
+    placeholder?: string;
+    /** If given, this is feat group has a configurable limit independent of level */
+    customLimit?: {
+        label: string;
+        min: number;
+        max: number;
+    } | null;
 }
 
-interface FeatSlot<TItem extends FeatLike | HeritagePF2e = FeatPF2e> {
-    id: string;
+/** Compendium browser filter properties when using the browse features. These do not perform validation */
+interface FeatBrowserFilterProps {
+    categories?: FeatOrFeatureCategory[];
+    traits?: string[];
+    omitTraits?: string[];
+    conjunction?: "or" | "and";
+}
+
+/** Data used to describe a feat slot when creating a new feat group */
+interface FeatSlotData {
+    /**
+     * A globally unique id. In future versions this may become locally unique instead.
+     * If omitted, it is <group id>-<level>.
+     */
+    id?: string;
+    /** Short label for the feat slot, displayeed on the left. By default it is the level */
     label?: Maybe<string>;
+    /** The level of the feat that should go in this slot */
+    level?: Maybe<number>;
+    /**
+     * The limit value the group needs in order to display this feat.
+     * This can be different from level if the group is based on tiers.
+     */
+    tier?: Maybe<number>;
+    /** The text to display when the feat slot is empty */
+    placeholder?: Maybe<string>;
+    /** If given, these filters will be prioritized over the group's filters */
+    filter?: FeatBrowserFilterProps;
+}
+
+/** An active feat slot in a feat group, including any feats that it might be containing */
+interface FeatSlot<TItem extends FeatLike | HeritagePF2e = FeatPF2e> extends FeatSlotData {
+    id: string;
     level: number | null;
     feat?: Maybe<TItem>;
     children: FeatSlot<FeatLike | HeritagePF2e>[];
 }
 
-interface FeatSlotCreationData extends Omit<FeatSlot, "children" | "feat" | "level"> {
-    level?: Maybe<number>;
-}
-
-export type { FeatGroupData, FeatLike, FeatSlot, FeatSlotCreationData };
+export type { FeatBrowserFilterProps, FeatGroupData, FeatLike, FeatSlot, FeatSlotData };

--- a/src/module/actor/party/kingdom/model.ts
+++ b/src/module/actor/party/kingdom/model.ts
@@ -457,7 +457,7 @@ class Kingdom extends DataModel<PartyPF2e, KingdomSchema> implements PartyCampai
                 id: "features",
                 label: "Kingdom Features",
             },
-            { level: this.level },
+            { limit: this.level },
         );
         this.feats = new FeatGroup(
             this.actor,
@@ -465,18 +465,22 @@ class Kingdom extends DataModel<PartyPF2e, KingdomSchema> implements PartyCampai
                 id: "kingdom",
                 label: "Kingdom Feats",
                 slots: [{ id: "government", label: "G" }, ...evenLevels],
-                featFilter: ["traits-kingdom"],
+                filter: {
+                    traits: ["kingdom"],
+                },
             },
-            { level: this.level },
+            { limit: this.level },
         );
         this.bonusFeats = new FeatGroup(
             this.actor,
             {
                 id: "bonus",
                 label: "PF2E.FeatBonusHeader",
-                featFilter: ["traits-kingdom"],
+                filter: {
+                    traits: ["kingdom"],
+                },
             },
-            { level: this.level },
+            { limit: this.level },
         );
 
         // Assign feats and features

--- a/src/module/item/class/document.ts
+++ b/src/module/item/class/document.ts
@@ -1,6 +1,6 @@
 import type { ActorPF2e, CharacterPF2e } from "@actor";
 import { ClassDCData } from "@actor/character/data.ts";
-import type { FeatSlotCreationData } from "@actor/character/feats/index.ts";
+import type { FeatSlotData } from "@actor/character/feats/index.ts";
 import { SaveType } from "@actor/types.ts";
 import { SAVE_TYPES } from "@actor/values.ts";
 import { ABCItemPF2e, FeatPF2e } from "@item";
@@ -34,7 +34,7 @@ class ClassPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends ABC
         return this.system.savingThrows;
     }
 
-    get grantedFeatSlots(): Record<"ancestry" | "class" | "skill" | "general", (number | FeatSlotCreationData)[]> {
+    get grantedFeatSlots(): Record<"ancestry" | "class" | "skill" | "general", (number | FeatSlotData)[]> {
         const system = this.system;
 
         return {

--- a/src/module/system/settings/menu.ts
+++ b/src/module/system/settings/menu.ts
@@ -157,7 +157,7 @@ interface SettingsMenuOptions extends FormApplicationOptions {
 
 function settingsToSheetData(
     settings: Record<string, PartialSettingsData>,
-    cache: Record<string, unknown>,
+    cache: Record<string, unknown> = {},
 ): Record<string, SettingsTemplateData> {
     return Object.entries(settings).reduce((result: Record<string, SettingsTemplateData>, [key, setting]) => {
         const lookupKey = `${setting.prefix ?? ""}${key}`;

--- a/src/scripts/set-game-pf2e.ts
+++ b/src/scripts/set-game-pf2e.ts
@@ -114,6 +114,7 @@ export const SetGamePF2e = {
                     sections: game.settings.get("pf2e", "campaignFeatSections"),
                 },
                 languages: game.settings.get("pf2e", "homebrew.languageRarities"),
+                mythic: game.settings.get("pf2e", "mythic"),
             },
             critFumble: {
                 buttons: game.settings.get("pf2e", "critFumbleButtons"),

--- a/src/styles/actor/character/_feats.scss
+++ b/src/styles/actor/character/_feats.scss
@@ -1,6 +1,16 @@
 &.feats {
     .feat-section {
         padding-bottom: 1em;
+        header .limit {
+            input {
+                background: rgba(0, 0, 0, 0.05);
+                display: inline;
+                color: inherit;
+                font: inherit;
+                height: 1em;
+                width: 2.2ch;
+            }
+        }
     }
 
     ol.feats-list {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -230,6 +230,11 @@
                     "ClassFeaturesHeader": "Class Features",
                     "DivineIntercessions": "Divine Intercessions",
                     "GeneralHeader": "General Feats",
+                    "MythicCallingPlaceholder": "Mythic Calling",
+                    "MythicCallingShort": "C",
+                    "MythicDestinyPlaceholder": "Mythic Destiny",
+                    "MythicHeader": "Mythic",
+                    "MythicFeatPlaceholder": "Mythic Feat",
                     "SkillHeader": "Skill Feats"
                 },
                 "HandsOccupied": "Hands Occupied",
@@ -3567,6 +3572,15 @@
                 },
                 "Hint": "Enable and configure variant rules like Proficiency Without Level or the Stamina system.",
                 "Label": "Toggle Variant Rules",
+                "Mythic": {
+                    "Hint": "Enables the assignment of mythic callings, feats, and destinies.",
+                    "Name": "Mythic Rules",
+                    "Choices": {
+                        "disabled": "Disabled",
+                        "enabled": "Enabled",
+                        "variant-tiers": "Variant (Mythic Tiers)"
+                    }
+                },
                 "Name": "Variant Rules",
                 "Proficiency": {
                     "Hint": "Play with the proficiency without level variant from GM Core pg 85.",

--- a/static/templates/actors/character/partials/feat-slot.hbs
+++ b/static/templates/actors/character/partials/feat-slot.hbs
@@ -62,13 +62,12 @@
     <li class="slot" data-slot-id="{{slot.id}}">
         <div class="item-name">
             <div class="feat-slot-title">{{slot.label}}</div>
-            <div class="item-placeholder">{{coalesce slot.restriction.hint (localize "PF2E.EmptySlot")}}</div>
+            <div class="item-placeholder">{{localize slot.placeholder}}</div>
         </div>
         <div class="item-controls">
             {{#if @root.editable}}
                 <a
                     data-action="browse-feats"
-                    data-filter="{{featFilter}},conjunction-or"
                     data-level="{{slot.level}}"
                 ><i class="fa-solid fa-fw fa-search"></i></a>
             {{/if}}

--- a/static/templates/actors/character/tabs/feats.hbs
+++ b/static/templates/actors/character/tabs/feats.hbs
@@ -3,6 +3,11 @@
         <section class="feat-section major" data-group-id="{{section.id}}">
             <header>
                 {{localize section.label}}
+                {{#with section.customLimit}}
+                    <span class="limit">
+                        ({{label}} <input type="number" name="{{concat "flags.pf2e.featLimits." section.id}}" value="{{section.limit}}" min="{{min}}" max="{{max}}" step="1"/>)
+                    </span>
+                {{/with}}
                 <div class="controls">
                     {{#if (eq section.id "bonus")}}
                         <button type="button" data-action="create-feat">
@@ -13,7 +18,6 @@
                         type="button"
                         data-action="browse-feats"
                         data-type="feat"
-                        data-filter="{{section.featFilter}},conjunction-or"
                     >
                         <i class="fa-solid fa-fw fa-search"></i>{{localize "PF2E.BrowseLabel"}}
                     </button>

--- a/static/templates/system/settings/variant-rules.hbs
+++ b/static/templates/system/settings/variant-rules.hbs
@@ -1,40 +1,26 @@
 <form class="flexcol" autocomplete="off">
-    <div class="form-group">
-        <label>{{localize gradualBoostsVariant.setting.name}}</label>
-        <div class="form-fields">
-            <input name="gradualBoostsVariant" type="checkbox" {{checked gradualBoostsVariant.value}} />
-        </div>
-        <p class="hint">{{localize gradualBoostsVariant.setting.hint}}</p>
-    </div>
-
-    <div class="form-group">
-        <label>{{localize staminaVariant.setting.name}}</label>
-        <div class="form-fields">
-            <input name="staminaVariant" type="checkbox" {{checked staminaVariant.value}} />
-        </div>
-        <p class="hint">{{localize staminaVariant.setting.hint}}</p>
-    </div>
-
-    <div class="form-group">
-        <label>{{localize freeArchetypeVariant.setting.name}}</label>
-        <div class="form-fields">
-            <input name="freeArchetypeVariant" type="checkbox" {{checked freeArchetypeVariant.value}} />
-        </div>
-        <p class="hint">{{localize freeArchetypeVariant.setting.hint}}</p>
-    </div>
+    {{> systems/pf2e/templates/system/settings/basic-setting.hbs setting=gradualBoostsVariant}}
+    {{> systems/pf2e/templates/system/settings/basic-setting.hbs setting=staminaVariant}}
+    {{> systems/pf2e/templates/system/settings/basic-setting.hbs setting=freeArchetypeVariant}}
 
     <div class="form-group abp">
-        <label>{{localize automaticBonusVariant.setting.name}}</label>
+        <label>{{localize automaticBonusVariant.name}}</label>
         <div class="form-fields">
             <select name="automaticBonusVariant">
-                {{selectOptions automaticBonusVariant.setting.choices selected=automaticBonusVariant.value localize=true}}
+                {{selectOptions
+                    automaticBonusVariant.choices
+                    selected=automaticBonusVariant.value
+                    localize=true
+                }}
             </select>
         </div>
-        <p class="hint">{{localize automaticBonusVariant.setting.hint}}</p>
+        <p class="hint">{{localize automaticBonusVariant.hint}}</p>
     </div>
 
+    {{> systems/pf2e/templates/system/settings/basic-setting.hbs setting=mythic}}
+
     <div class="form-group">
-        <label>{{localize proficiencyVariant.setting.name}}</label>
+        <label>{{localize proficiencyVariant.name}}</label>
         <div class="form-fields">
             <input type="checkbox" name="proficiencyVariant" {{checked proficiencyVariant.value}} />
         </div>
@@ -45,7 +31,11 @@
         <div class="modifier">
             <label>{{localize "PF2E.ProficiencyLevel0"}}</label>
             <div class="form-fields">
-                <input type="number" name="proficiencyUntrainedModifier" value="{{proficiencyUntrainedModifier.value}}" />
+                <input
+                    type="number"
+                    name="proficiencyUntrainedModifier"
+                    value="{{proficiencyUntrainedModifier.value}}"
+                />
             </div>
         </div>
         <div class="modifier">
@@ -69,7 +59,11 @@
         <div class="modifier">
             <label>{{localize "PF2E.ProficiencyLevel4"}}</label>
             <div class="form-fields">
-                <input type="number" name="proficiencyLegendaryModifier" value="{{proficiencyLegendaryModifier.value}}" />
+                <input
+                    type="number"
+                    name="proficiencyLegendaryModifier"
+                    value="{{proficiencyLegendaryModifier.value}}"
+                />
             </div>
         </div>
         <p class="hint">{{localize "PF2E.SETTINGS.Variant.Proficiency.ModifiersHint"}}</p>
@@ -79,10 +73,12 @@
 
     <footer class="sheet-footer">
         <button type="submit">
-            <i class="fa-regular fa-save"></i> {{localize "SETTINGS.Save"}}
+            <i class="fa-regular fa-save"></i>
+            {{localize "SETTINGS.Save"}}
         </button>
         <button type="reset">
-            <i class="fa-solid fa-undo"></i> {{localize "PF2E.SETTINGS.ResetChanges"}}
+            <i class="fa-solid fa-undo"></i>
+            {{localize "PF2E.SETTINGS.ResetChanges"}}
         </button>
     </footer>
 </form>


### PR DESCRIPTION
This includes the variant introduced in a separate pdf. I put them in homebrew settings under campaign, but I'm almost tempted to put it under variant rules instead. Not sure.

This PR introduces the ability for a group to have a separate configurable limit in the feat header. So far the only other official use I can think of where it'd be handy is strength of thousands.