### PR TITLE
Automate Energized Spark's inline damage alteration

### DIFF
--- a/packs/feats/energized-spark.json
+++ b/packs/feats/energized-spark.json
@@ -140,6 +140,248 @@
                 "flag": "energizedSpark",
                 "key": "ChoiceSet",
                 "rollOption": "energized-spark"
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Exemplar.EnergizedSpark.Label",
+                "option": "energized-spark-trait",
+                "suboptions": [
+                    {
+                        "label": "PF2E.TraitAir",
+                        "predicate": [
+                            "energized-spark:air"
+                        ],
+                        "value": "air"
+                    },
+                    {
+                        "label": "PF2E.TraitCold",
+                        "predicate": [
+                            "energized-spark:cold"
+                        ],
+                        "value": "cold"
+                    },
+                    {
+                        "label": "PF2E.TraitEarth",
+                        "predicate": [
+                            "energized-spark:earth"
+                        ],
+                        "value": "earth"
+                    },
+                    {
+                        "label": "PF2E.TraitElectricity",
+                        "predicate": [
+                            "energized-spark:electricity"
+                        ],
+                        "value": "electricity"
+                    },
+                    {
+                        "label": "PF2E.TraitFire",
+                        "predicate": [
+                            "energized-spark:fire"
+                        ],
+                        "value": "fire"
+                    },
+                    {
+                        "label": "PF2E.TraitMetal",
+                        "predicate": [
+                            "energized-spark:metal"
+                        ],
+                        "value": "metal"
+                    },
+                    {
+                        "label": "PF2E.TraitPoison",
+                        "predicate": [
+                            "energized-spark:poison"
+                        ],
+                        "value": "poison"
+                    },
+                    {
+                        "label": "PF2E.TraitSonic",
+                        "predicate": [
+                            "energized-spark:sonic"
+                        ],
+                        "value": "sonic"
+                    },
+                    {
+                        "label": "PF2E.TraitVitality",
+                        "predicate": [
+                            "energized-spark:vitality"
+                        ],
+                        "value": "vitality"
+                    },
+                    {
+                        "label": "PF2E.TraitVoid",
+                        "predicate": [
+                            "energized-spark:void"
+                        ],
+                        "value": "void"
+                    },
+                    {
+                        "label": "PF2E.TraitWater",
+                        "predicate": [
+                            "energized-spark:water"
+                        ],
+                        "value": "water"
+                    },
+                    {
+                        "label": "PF2E.TraitWood",
+                        "predicate": [
+                            "energized-spark:wood"
+                        ],
+                        "value": "wood"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "key": "DamageAlteration",
+                "mode": "override",
+                "predicate": [
+                    "damage:type:spirit",
+                    "item:trait:exemplar",
+                    {
+                        "or": [
+                            "energized-spark-trait:air",
+                            "energized-spark-trait:metal"
+                        ]
+                    }
+                ],
+                "property": "damage-type",
+                "selectors": [
+                    "inline-damage"
+                ],
+                "value": "slashing"
+            },
+            {
+                "key": "DamageAlteration",
+                "mode": "override",
+                "predicate": [
+                    "damage:type:spirit",
+                    "item:trait:exemplar",
+                    "energized-spark-trait:cold"
+                ],
+                "property": "damage-type",
+                "selectors": [
+                    "inline-damage"
+                ],
+                "value": "cold"
+            },
+            {
+                "key": "DamageAlteration",
+                "mode": "override",
+                "predicate": [
+                    "damage:type:spirit",
+                    "item:trait:exemplar",
+                    {
+                        "or": [
+                            "energized-spark-trait:earth",
+                            "energized-spark-trait:water"
+                        ]
+                    }
+                ],
+                "property": "damage-type",
+                "selectors": [
+                    "inline-damage"
+                ],
+                "value": "bludgeoning"
+            },
+            {
+                "key": "DamageAlteration",
+                "mode": "override",
+                "predicate": [
+                    "damage:type:spirit",
+                    "item:trait:exemplar",
+                    "energized-spark-trait:electricity"
+                ],
+                "property": "damage-type",
+                "selectors": [
+                    "inline-damage"
+                ],
+                "value": "electricity"
+            },
+            {
+                "key": "DamageAlteration",
+                "mode": "override",
+                "predicate": [
+                    "damage:type:spirit",
+                    "item:trait:exemplar",
+                    "energized-spark-trait:fire"
+                ],
+                "property": "damage-type",
+                "selectors": [
+                    "inline-damage"
+                ],
+                "value": "fire"
+            },
+            {
+                "key": "DamageAlteration",
+                "mode": "override",
+                "predicate": [
+                    "damage:type:spirit",
+                    "item:trait:exemplar",
+                    "energized-spark-trait:poison"
+                ],
+                "property": "damage-type",
+                "selectors": [
+                    "inline-damage"
+                ],
+                "value": "poison"
+            },
+            {
+                "key": "DamageAlteration",
+                "mode": "override",
+                "predicate": [
+                    "damage:type:spirit",
+                    "item:trait:exemplar",
+                    "energized-spark-trait:sonic"
+                ],
+                "property": "damage-type",
+                "selectors": [
+                    "inline-damage"
+                ],
+                "value": "sonic"
+            },
+            {
+                "key": "DamageAlteration",
+                "mode": "override",
+                "predicate": [
+                    "damage:type:spirit",
+                    "item:trait:exemplar",
+                    "energized-spark-trait:vitality"
+                ],
+                "property": "damage-type",
+                "selectors": [
+                    "inline-damage"
+                ],
+                "value": "vitality"
+            },
+            {
+                "key": "DamageAlteration",
+                "mode": "override",
+                "predicate": [
+                    "damage:type:spirit",
+                    "item:trait:exemplar",
+                    "energized-spark-trait:void"
+                ],
+                "property": "damage-type",
+                "selectors": [
+                    "inline-damage"
+                ],
+                "value": "void"
+            },
+            {
+                "key": "DamageAlteration",
+                "mode": "override",
+                "predicate": [
+                    "damage:type:spirit",
+                    "item:trait:exemplar",
+                    "energized-spark-trait:wood"
+                ],
+                "property": "damage-type",
+                "selectors": [
+                    "inline-damage"
+                ],
+                "value": "piercing"
             }
         ],
         "traits": {

--- a/packs/feats/energized-spark.json
+++ b/packs/feats/energized-spark.json
@@ -144,14 +144,19 @@
             {
                 "key": "RollOption",
                 "label": "PF2E.SpecificRule.Exemplar.EnergizedSpark.Label",
-                "option": "energized-spark-trait",
+                "option": "energized-spark-damage",
                 "suboptions": [
                     {
-                        "label": "PF2E.TraitAir",
+                        "label": "PF2E.TraitBludgeoning",
                         "predicate": [
-                            "energized-spark:air"
+                            {
+                                "or": [
+                                    "energized-spark:earth",
+                                    "energized-spark:water"
+                                ]
+                            }
                         ],
-                        "value": "air"
+                        "value": "bludgeoning"
                     },
                     {
                         "label": "PF2E.TraitCold",
@@ -159,13 +164,6 @@
                             "energized-spark:cold"
                         ],
                         "value": "cold"
-                    },
-                    {
-                        "label": "PF2E.TraitEarth",
-                        "predicate": [
-                            "energized-spark:earth"
-                        ],
-                        "value": "earth"
                     },
                     {
                         "label": "PF2E.TraitElectricity",
@@ -182,11 +180,11 @@
                         "value": "fire"
                     },
                     {
-                        "label": "PF2E.TraitMetal",
+                        "label": "PF2E.TraitPiercing",
                         "predicate": [
-                            "energized-spark:metal"
+                            "energized-spark:wood"
                         ],
-                        "value": "metal"
+                        "value": "piercing"
                     },
                     {
                         "label": "PF2E.TraitPoison",
@@ -194,6 +192,18 @@
                             "energized-spark:poison"
                         ],
                         "value": "poison"
+                    },
+                    {
+                        "label": "PF2E.TraitSlashing",
+                        "predicate": [
+                            {
+                                "or": [
+                                    "energized-spark:air",
+                                    "energized-spark:metal"
+                                ]
+                            }
+                        ],
+                        "value": "slashing"
                     },
                     {
                         "label": "PF2E.TraitSonic",
@@ -215,20 +225,6 @@
                             "energized-spark:void"
                         ],
                         "value": "void"
-                    },
-                    {
-                        "label": "PF2E.TraitWater",
-                        "predicate": [
-                            "energized-spark:water"
-                        ],
-                        "value": "water"
-                    },
-                    {
-                        "label": "PF2E.TraitWood",
-                        "predicate": [
-                            "energized-spark:wood"
-                        ],
-                        "value": "wood"
                     }
                 ],
                 "toggleable": true
@@ -239,149 +235,13 @@
                 "predicate": [
                     "damage:type:spirit",
                     "item:trait:exemplar",
-                    {
-                        "or": [
-                            "energized-spark-trait:air",
-                            "energized-spark-trait:metal"
-                        ]
-                    }
+                    "energized-spark-damage"
                 ],
                 "property": "damage-type",
                 "selectors": [
                     "inline-damage"
                 ],
-                "value": "slashing"
-            },
-            {
-                "key": "DamageAlteration",
-                "mode": "override",
-                "predicate": [
-                    "damage:type:spirit",
-                    "item:trait:exemplar",
-                    "energized-spark-trait:cold"
-                ],
-                "property": "damage-type",
-                "selectors": [
-                    "inline-damage"
-                ],
-                "value": "cold"
-            },
-            {
-                "key": "DamageAlteration",
-                "mode": "override",
-                "predicate": [
-                    "damage:type:spirit",
-                    "item:trait:exemplar",
-                    {
-                        "or": [
-                            "energized-spark-trait:earth",
-                            "energized-spark-trait:water"
-                        ]
-                    }
-                ],
-                "property": "damage-type",
-                "selectors": [
-                    "inline-damage"
-                ],
-                "value": "bludgeoning"
-            },
-            {
-                "key": "DamageAlteration",
-                "mode": "override",
-                "predicate": [
-                    "damage:type:spirit",
-                    "item:trait:exemplar",
-                    "energized-spark-trait:electricity"
-                ],
-                "property": "damage-type",
-                "selectors": [
-                    "inline-damage"
-                ],
-                "value": "electricity"
-            },
-            {
-                "key": "DamageAlteration",
-                "mode": "override",
-                "predicate": [
-                    "damage:type:spirit",
-                    "item:trait:exemplar",
-                    "energized-spark-trait:fire"
-                ],
-                "property": "damage-type",
-                "selectors": [
-                    "inline-damage"
-                ],
-                "value": "fire"
-            },
-            {
-                "key": "DamageAlteration",
-                "mode": "override",
-                "predicate": [
-                    "damage:type:spirit",
-                    "item:trait:exemplar",
-                    "energized-spark-trait:poison"
-                ],
-                "property": "damage-type",
-                "selectors": [
-                    "inline-damage"
-                ],
-                "value": "poison"
-            },
-            {
-                "key": "DamageAlteration",
-                "mode": "override",
-                "predicate": [
-                    "damage:type:spirit",
-                    "item:trait:exemplar",
-                    "energized-spark-trait:sonic"
-                ],
-                "property": "damage-type",
-                "selectors": [
-                    "inline-damage"
-                ],
-                "value": "sonic"
-            },
-            {
-                "key": "DamageAlteration",
-                "mode": "override",
-                "predicate": [
-                    "damage:type:spirit",
-                    "item:trait:exemplar",
-                    "energized-spark-trait:vitality"
-                ],
-                "property": "damage-type",
-                "selectors": [
-                    "inline-damage"
-                ],
-                "value": "vitality"
-            },
-            {
-                "key": "DamageAlteration",
-                "mode": "override",
-                "predicate": [
-                    "damage:type:spirit",
-                    "item:trait:exemplar",
-                    "energized-spark-trait:void"
-                ],
-                "property": "damage-type",
-                "selectors": [
-                    "inline-damage"
-                ],
-                "value": "void"
-            },
-            {
-                "key": "DamageAlteration",
-                "mode": "override",
-                "predicate": [
-                    "damage:type:spirit",
-                    "item:trait:exemplar",
-                    "energized-spark-trait:wood"
-                ],
-                "property": "damage-type",
-                "selectors": [
-                    "inline-damage"
-                ],
-                "value": "piercing"
+                "value": "{item|flags.pf2e.rulesSelections.energizedSparkDamage}"
             }
         ],
         "traits": {


### PR DESCRIPTION
Made the suboptions based on the damage instead of traits since I don't think we can automate adding the traits right now, due to not having context on whether a feat is "damaging". Plus, it means we only need one Damage Alteration.

Weapon dice and modifiers pending system enhancements.