### PR TITLE
Internally represent special resources using dromedary

### DIFF
--- a/src/module/actor/creature/document.ts
+++ b/src/module/actor/creature/document.ts
@@ -27,7 +27,7 @@ import { CheckDC } from "@system/degree-of-success.ts";
 import { Predicate } from "@system/predication.ts";
 import { Statistic, StatisticDifficultyClass, type ArmorStatistic } from "@system/statistic/index.ts";
 import { PerceptionStatistic } from "@system/statistic/perception.ts";
-import { ErrorPF2e, localizer, setHasElement } from "@util";
+import { ErrorPF2e, localizer, setHasElement, sluggify } from "@util";
 import { eventToRollParams } from "@util/sheet.ts";
 import * as R from "remeda";
 import {
@@ -623,10 +623,14 @@ abstract class CreaturePF2e<
         });
     }
 
-    /** Updates a resource. Redirects to special resources if needed */
+    /**
+     * Updates a resource. Redirects to special resources if needed.
+     * Accepts resource slugs in both kebab and dromedary, to handle token updates and direct ones.
+     */
     async updateResource(resource: string, value: number): Promise<void> {
         const resources = this.system.resources;
 
+        resource = sluggify(resource, { camel: "dromedary" });
         const special = this.synthetics.resources[resource];
         if (special) {
             await special.update(Math.clamp(value, 0, special.max));

--- a/src/module/actor/creature/sheet.ts
+++ b/src/module/actor/creature/sheet.ts
@@ -8,7 +8,15 @@ import { coerceToSpellGroupId, spellSlotGroupIdToNumber } from "@item/spellcasti
 import { SpellcastingSheetData } from "@item/spellcasting-entry/index.ts";
 import { DropCanvasItemDataPF2e } from "@module/canvas/drop-canvas-data.ts";
 import { OneToTen, ZeroToFour, goesToEleven } from "@module/data.ts";
-import { ErrorPF2e, createHTMLElement, fontAwesomeIcon, htmlClosest, htmlQueryAll, tupleHasValue } from "@util";
+import {
+    ErrorPF2e,
+    createHTMLElement,
+    fontAwesomeIcon,
+    htmlClosest,
+    htmlQueryAll,
+    sluggify,
+    tupleHasValue,
+} from "@util";
 import { eventToRollParams } from "@util/sheet.ts";
 import * as R from "remeda";
 import { ActorSheetPF2e, SheetClickActionHandlers } from "../sheet/base.ts";
@@ -105,7 +113,9 @@ abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends ActorSheet
             const listener = (event: Event) => {
                 const resources = this.actor.system.resources;
                 const resource = htmlClosest(event.target, "[data-resource]")?.dataset.resource;
-                if (!resource || !resources || !(resource in resources)) return;
+                if (!resource || !resources || !(sluggify(resource, { camel: "dromedary" }) in resources)) {
+                    return;
+                }
 
                 const current = resources[resource]?.value ?? 0;
                 const change = event.type === "click" ? 1 : -1;
@@ -123,7 +133,9 @@ abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends ActorSheet
         for (const element of resourceInputs) {
             const resources = this.actor.system.resources;
             const resource = element.dataset.resource;
-            if (!resource || !resources || !(resource in resources)) continue;
+            if (!resource || !resources || !(sluggify(resource, { camel: "dromedary" }) in resources)) {
+                return;
+            }
 
             element.addEventListener("change", () => {
                 this.actor.updateResource(resource, Number(element.value));

--- a/src/module/rules/rule-element/special-resource.ts
+++ b/src/module/rules/rule-element/special-resource.ts
@@ -95,8 +95,9 @@ class SpecialResourceRuleElement extends RuleElementPF2e<SpecialResourceSchema> 
 
         if (this.itemUUID) {
             // For pre creation, we don't really know the true priority. Assume it is the better between this and existing
+            const key = sluggify(this.slug, { camel: "dromedary" });
             const thisMax = Number(this.resolveValue(this.max));
-            this.max = Math.floor(Math.max(thisMax, this.actor.system.resources[this.slug]?.max ?? 0));
+            this.max = Math.floor(Math.max(thisMax, this.actor.system.resources[key]?.max ?? 0));
 
             const uuid = this.resolveInjectedProperties(this.itemUUID);
             const itemExists = this.actor.items.some((i) => i.sourceId === uuid);
@@ -116,15 +117,16 @@ class SpecialResourceRuleElement extends RuleElementPF2e<SpecialResourceSchema> 
 
         // Keep a record of the resource for blacklisting and redirection purposes
         // Also prepare a basic version for active effect like modification
+        const key = sluggify(this.slug, { camel: "dromedary" });
         this.max = Number(this.resolveValue(this.max));
-        if (!(this.slug in this.actor.synthetics.resources)) {
-            this.actor.synthetics.resources[this.slug] = this;
-            this.actor.system.resources[this.slug] = fu.mergeObject(this.actor.system.resources[this.slug] ?? {}, {
+        if (!(key in this.actor.synthetics.resources)) {
+            this.actor.synthetics.resources[key] = this;
+            this.actor.system.resources[key] = fu.mergeObject(this.actor.system.resources[key] ?? {}, {
                 value: 0,
                 max: this.max,
             });
         } else {
-            const existing = this.actor.system.resources[this.slug];
+            const existing = this.actor.system.resources[key];
             if (existing) {
                 this.max = existing.max = Math.floor(Math.max(this.max, existing.max ?? 0));
             }
@@ -135,7 +137,7 @@ class SpecialResourceRuleElement extends RuleElementPF2e<SpecialResourceSchema> 
     override beforePrepareData(): void {
         if (this.ignored) return;
 
-        const existing = this.actor.system.resources[this.slug];
+        const existing = this.actor.system.resources[sluggify(this.slug, { camel: "dromedary" })];
         if (existing) {
             const max = Math.floor(existing.max ?? 0);
             this.max = existing.max = max;


### PR DESCRIPTION
I'm unsure about this and am only trying it out. It trades our current set of problems for a new set of problems.

One annoyance is that a feat that consumes a resource will use kebab case, and then will check using dromedary. So for example, if a feat consumes hero points, the slug will be `hero-points` and it will check `system.resources.heroPoints`.