### PR TITLE
Fix Embed UUID on Thousand League Sandals

### DIFF
--- a/packs/classfeatures/bands-of-imprisonment.json
+++ b/packs/classfeatures/bands-of-imprisonment.json
@@ -127,7 +127,10 @@
                 "mode": "add",
                 "predicate": [
                     "item:tag:physical-ikon:bands-of-imprisonment",
-                    "bands-of-imprisonment-origin:existing"
+                    "bands-of-imprisonment-origin:existing",
+                    {
+                        "not": "item:slug:bands-of-imprisonment"
+                    }
                 ],
                 "property": "description",
                 "value": [

--- a/packs/classfeatures/fetching-bangles.json
+++ b/packs/classfeatures/fetching-bangles.json
@@ -127,7 +127,10 @@
                 "mode": "add",
                 "predicate": [
                     "item:tag:physical-ikon:fetching-bangles",
-                    "fetching-bangles-origin:existing"
+                    "fetching-bangles-origin:existing",
+                    {
+                        "not": "item:slug:fetching-bangles"
+                    }
                 ],
                 "property": "description",
                 "value": [

--- a/packs/classfeatures/horn-of-plenty.json
+++ b/packs/classfeatures/horn-of-plenty.json
@@ -127,7 +127,10 @@
                 "mode": "add",
                 "predicate": [
                     "item:tag:physical-ikon:horn-of-plenty",
-                    "horn-of-plenty-origin:existing"
+                    "horn-of-plenty-origin:existing",
+                    {
+                        "not": "item:slug:horn-of-plenty"
+                    }
                 ],
                 "property": "description",
                 "value": [

--- a/packs/classfeatures/pelt-of-the-beast.json
+++ b/packs/classfeatures/pelt-of-the-beast.json
@@ -134,7 +134,10 @@
                 "mode": "add",
                 "predicate": [
                     "item:tag:physical-ikon:pelt-of-the-beast",
-                    "pelt-of-the-beast-origin:existing"
+                    "pelt-of-the-beast-origin:existing",
+                    {
+                        "not": "item:slug:pelt-of-the-beast"
+                    }
                 ],
                 "property": "description",
                 "value": [

--- a/packs/classfeatures/skybearers-belt.json
+++ b/packs/classfeatures/skybearers-belt.json
@@ -122,7 +122,11 @@
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
-                    "item:tag:physical-ikon:skybearers-belt"
+                    "item:tag:physical-ikon:skybearers-belt",
+                    "skybearers-belt-origin:existing",
+                    {
+                        "not": "item:slug:skybearers-belt"
+                    }
                 ],
                 "property": "description",
                 "value": [

--- a/packs/classfeatures/thousand-league-sandals.json
+++ b/packs/classfeatures/thousand-league-sandals.json
@@ -127,7 +127,7 @@
                 "property": "description",
                 "value": [
                     {
-                        "text": "@Embed[Compendium.pf2e.classfeatures.Item.iecFmUwSrytQNwoE inline]"
+                        "text": "@Embed[Compendium.pf2e.classfeatures.Item.6dtTNqL4SdPFKOrh inline]"
                     }
                 ]
             },

--- a/packs/classfeatures/thousand-league-sandals.json
+++ b/packs/classfeatures/thousand-league-sandals.json
@@ -122,7 +122,11 @@
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
-                    "item:tag:physical-ikon:thousand-league-sandals"
+                    "item:tag:physical-ikon:thousand-league-sandals",
+                    "thousand-league-sandals-origin:existing",
+                    {
+                        "not": "item:slug:thousand-league-sandals"
+                    }
                 ],
                 "property": "description",
                 "value": [

--- a/packs/classfeatures/victors-wreath.json
+++ b/packs/classfeatures/victors-wreath.json
@@ -123,7 +123,11 @@
                 "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
-                    "item:tag:physical-ikon:victors-wreath"
+                    "item:tag:physical-ikon:victors-wreath",
+                    "victors-wreath-origin:existing",
+                    {
+                        "not": "item:slug:victors-wreath"
+                    }
                 ],
                 "property": "description",
                 "value": [


### PR DESCRIPTION
also prevent premade physical worn ikons from having the corresponding class feature redundantly embedded