### PR TITLE
Fix Fracture Mountain's immanence damage adjustment

### DIFF
--- a/packs/actions/fracture-mountains.json
+++ b/packs/actions/fracture-mountains.json
@@ -26,14 +26,14 @@
             },
             {
                 "key": "AdjustModifier",
-                "mode": "override",
+                "mode": "multiply",
                 "predicate": [
                     "fracture-mountains"
                 ],
                 "relabel": "{item|name}",
                 "selector": "strike-damage",
                 "slug": "titans-breaker-immanence",
-                "value": 4
+                "value": 2
             },
             {
                 "damageType": "spirit",


### PR DESCRIPTION
The action makes the modifier go from its original 2 per weapon damage die to 4 per weapon damage die