### PR TITLE
Make mythic variant rule hint more descriptive

### DIFF
--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3573,18 +3573,18 @@
                 "Hint": "Enable and configure variant rules like Proficiency Without Level or the Stamina system.",
                 "Label": "Toggle Variant Rules",
                 "Mythic": {
-                    "Hint": "Enables the assignment of mythic callings, feats, and destinies.",
+                    "Hint": "Enables the assignment of mythic callings, feats, and destinies. Alternate Mythic Progression, published in Alternate Mythic Rules, sets characters to advance independently of gaining level.",
                     "Name": "Mythic Rules",
                     "Choices": {
                         "disabled": "Disabled",
                         "enabled": "Enabled",
-                        "variant-tiers": "Variant (Mythic Tiers)"
+                        "variant-tiers": "Alternate Mythic Progression"
                     }
                 },
                 "Name": "Variant Rules",
                 "Proficiency": {
                     "Hint": "Play with the proficiency without level variant from GM Core pg 85.",
-                    "ModifiersHint": "Set the modifier value for each proficiency rank.",
+                    "ModifiersHint": "Set the modifier value for each proficiency rank (proficiency without level only).",
                     "Name": "Proficiency without Level"
                 },
                 "Stamina": {


### PR DESCRIPTION
This attempts to resolve make alternate mythic progression easier to understand, and also hopefully proficiency without level's modifier adjustments.

![image](https://github.com/user-attachments/assets/1b00dfb5-ad93-4c47-9427-c24d336fad9b)
