### PR TITLE
Use toggle to tag unarmed attack as a weapon ikon

### DIFF
--- a/packs/classfeatures/gleaming-blade.json
+++ b/packs/classfeatures/gleaming-blade.json
@@ -58,22 +58,6 @@
                 "adjustName": false,
                 "choices": [
                     {
-                        "label": "PF2E.SpecificRule.Exemplar.Ikon.Physical.Grant",
-                        "value": "granted"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Exemplar.Ikon.Physical.Existing",
-                        "value": "existing"
-                    }
-                ],
-                "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.Exemplar.Ikon.Physical.Prompt",
-                "rollOption": "gleaming-blade-origin"
-            },
-            {
-                "adjustName": false,
-                "choices": [
-                    {
                         "label": "PF2E.WeaponTypeUnarmed",
                         "value": "unarmed"
                     },
@@ -83,11 +67,43 @@
                     }
                 ],
                 "key": "ChoiceSet",
-                "predicate": [
-                    "gleaming-blade-origin:existing"
-                ],
                 "prompt": "PF2E.SpecificRule.Exemplar.Ikon.Physical.UnarmedOrWeapon",
-                "rollOption": "gleaming-blade-origin:existing"
+                "rollOption": "gleaming-blade"
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Exemplar.Ikon.UnarmedIkonToggle",
+                "mergeable": true,
+                "option": "unarmed-ikon",
+                "predicate": [
+                    "gleaming-blade:unarmed"
+                ],
+                "suboptions": [
+                    {
+                        "label": "{item|name}",
+                        "value": "gleaming-blade"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "adjustName": false,
+                "choices": [
+                    {
+                        "label": "PF2E.SpecificRule.Exemplar.Ikon.Physical.Grant",
+                        "value": "granted"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Exemplar.Ikon.Physical.Existing",
+                        "value": "existing"
+                    }
+                ],
+                "key": "ChoiceSet",
+                "predicate": [
+                    "gleaming-blade:weapon"
+                ],
+                "prompt": "PF2E.SpecificRule.Exemplar.Ikon.Physical.Prompt",
+                "rollOption": "gleaming-blade-origin"
             },
             {
                 "adjustName": false,
@@ -108,26 +124,12 @@
                         "weapon"
                     ]
                 },
-                "flag": "existingIkonWeapon",
+                "flag": "existingIkon",
                 "key": "ChoiceSet",
                 "predicate": [
-                    "gleaming-blade-origin:existing:weapon"
-                ]
-            },
-            {
-                "adjustName": false,
-                "choices": {
-                    "predicate": [
-                        "item:damage:type:slashing",
-                        "item:melee"
-                    ],
-                    "unarmedAttacks": true
-                },
-                "flag": "existingIkonUnarmed",
-                "key": "ChoiceSet",
-                "predicate": [
-                    "gleaming-blade-origin:existing:unarmed"
-                ]
+                    "gleaming-blade-origin:existing"
+                ],
+                "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
             {
                 "adjustName": false,
@@ -153,7 +155,8 @@
                 "key": "ChoiceSet",
                 "predicate": [
                     "gleaming-blade-origin:granted"
-                ]
+                ],
+                "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
             {
                 "key": "GrantItem",
@@ -171,13 +174,15 @@
                         "or": [
                             {
                                 "and": [
+                                    "gleaming-blade:unarmed",
+                                    "unarmed-ikon:gleaming-blade",
+                                    "item:category:unarmed"
+                                ]
+                            },
+                            {
+                                "and": [
                                     "gleaming-blade-origin:existing",
-                                    {
-                                        "or": [
-                                            "item:slug:{item|flags.pf2e.rulesSelections.existingIkonUnarmed}",
-                                            "item:id:{item|flags.pf2e.rulesSelections.existingIkonWeapon}"
-                                        ]
-                                    }
+                                    "item:id:{item|flags.pf2e.rulesSelections.existingIkon}"
                                 ]
                             },
                             {
@@ -201,13 +206,15 @@
                         "or": [
                             {
                                 "and": [
+                                    "gleaming-blade:unarmed",
+                                    "unarmed-ikon:gleaming-blade",
+                                    "item:category:unarmed"
+                                ]
+                            },
+                            {
+                                "and": [
                                     "gleaming-blade-origin:existing",
-                                    {
-                                        "or": [
-                                            "item:slug:{item|flags.pf2e.rulesSelections.existingIkonUnarmed}",
-                                            "item:id:{item|flags.pf2e.rulesSelections.existingIkonWeapon}"
-                                        ]
-                                    }
+                                    "item:id:{item|flags.pf2e.rulesSelections.existingIkon}"
                                 ]
                             },
                             {

--- a/packs/classfeatures/hands-of-the-wildling.json
+++ b/packs/classfeatures/hands-of-the-wildling.json
@@ -123,7 +123,8 @@
                 "key": "ChoiceSet",
                 "predicate": [
                     "hands-of-the-wildling-origin:existing"
-                ]
+                ],
+                "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
             {
                 "adjustName": false,
@@ -144,7 +145,8 @@
                 "key": "ChoiceSet",
                 "predicate": [
                     "hands-of-the-wildling-origin:granted"
-                ]
+                ],
+                "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
             {
                 "key": "GrantItem",

--- a/packs/classfeatures/hands-of-the-wildling.json
+++ b/packs/classfeatures/hands-of-the-wildling.json
@@ -58,22 +58,6 @@
                 "adjustName": false,
                 "choices": [
                     {
-                        "label": "PF2E.SpecificRule.Exemplar.Ikon.Physical.Grant",
-                        "value": "granted"
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.Exemplar.Ikon.Physical.Existing",
-                        "value": "existing"
-                    }
-                ],
-                "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.Exemplar.Ikon.Physical.Prompt",
-                "rollOption": "hands-of-the-wildling-origin"
-            },
-            {
-                "adjustName": false,
-                "choices": [
-                    {
                         "label": "PF2E.WeaponTypeUnarmed",
                         "value": "unarmed"
                     },
@@ -83,11 +67,43 @@
                     }
                 ],
                 "key": "ChoiceSet",
-                "predicate": [
-                    "hands-of-the-wildling-origin:existing"
-                ],
                 "prompt": "PF2E.SpecificRule.Exemplar.Ikon.Physical.UnarmedOrWeapon",
-                "rollOption": "hands-of-the-wildling-origin:existing"
+                "rollOption": "hands-of-the-wildling"
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Exemplar.Ikon.UnarmedIkonToggle",
+                "mergeable": true,
+                "option": "unarmed-ikon",
+                "predicate": [
+                    "hands-of-the-wildling:unarmed"
+                ],
+                "suboptions": [
+                    {
+                        "label": "{item|name}",
+                        "value": "hands-of-the-wildling"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "adjustName": false,
+                "choices": [
+                    {
+                        "label": "PF2E.SpecificRule.Exemplar.Ikon.Physical.Grant",
+                        "value": "granted"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Exemplar.Ikon.Physical.Existing",
+                        "value": "existing"
+                    }
+                ],
+                "key": "ChoiceSet",
+                "predicate": [
+                    "hands-of-the-wildling:weapon"
+                ],
+                "prompt": "PF2E.SpecificRule.Exemplar.Ikon.Physical.Prompt",
+                "rollOption": "hands-of-the-wildling-origin"
             },
             {
                 "adjustName": false,
@@ -103,24 +119,10 @@
                         "weapon"
                     ]
                 },
-                "flag": "existingIkonWeapon",
+                "flag": "existingIkon",
                 "key": "ChoiceSet",
                 "predicate": [
-                    "hands-of-the-wildling-origin:existing:weapon"
-                ]
-            },
-            {
-                "adjustName": false,
-                "choices": {
-                    "predicate": [
-                        "item:melee"
-                    ],
-                    "unarmedAttacks": true
-                },
-                "flag": "existingIkonUnarmed",
-                "key": "ChoiceSet",
-                "predicate": [
-                    "hands-of-the-wildling-origin:existing:unarmed"
+                    "hands-of-the-wildling-origin:existing"
                 ]
             },
             {
@@ -160,18 +162,20 @@
                         "or": [
                             {
                                 "and": [
-                                    "hands-of-the-wildling-origin:existing",
-                                    {
-                                        "or": [
-                                            "item:slug:{item|flags.pf2e.rulesSelections.existingIkonUnarmed}",
-                                            "item:id:{item|flags.pf2e.rulesSelections.existingIkonWeapon}"
-                                        ]
-                                    }
+                                    "hands-of-the-wildling:unarmed",
+                                    "unarmed-ikon:hands-of-the-wildling",
+                                    "item:category:unarmed"
                                 ]
                             },
                             {
                                 "and": [
-                                    "hands-of-the-wildling:granted",
+                                    "hands-of-the-wildling-origin:existing",
+                                    "item:id:{item|flags.pf2e.rulesSelections.existingIkon}"
+                                ]
+                            },
+                            {
+                                "and": [
+                                    "hands-of-the-wildling-origin:granted",
                                     "item:granter:slug:hands-of-the-wildling"
                                 ]
                             }
@@ -190,18 +194,20 @@
                         "or": [
                             {
                                 "and": [
-                                    "hands-of-the-wildling-origin:existing",
-                                    {
-                                        "or": [
-                                            "item:slug:{item|flags.pf2e.rulesSelections.existingIkonUnarmed}",
-                                            "item:id:{item|flags.pf2e.rulesSelections.existingIkonWeapon}"
-                                        ]
-                                    }
+                                    "hands-of-the-wildling:unarmed",
+                                    "unarmed-ikon:hands-of-the-wildling",
+                                    "item:category:unarmed"
                                 ]
                             },
                             {
                                 "and": [
-                                    "hands-of-the-wildling:granted",
+                                    "hands-of-the-wildling-origin:existing",
+                                    "item:id:{item|flags.pf2e.rulesSelections.existingIkon}"
+                                ]
+                            },
+                            {
+                                "and": [
+                                    "hands-of-the-wildling-origin:granted",
                                     "item:granter:slug:hands-of-the-wildling"
                                 ]
                             }

--- a/packs/classfeatures/titans-breaker.json
+++ b/packs/classfeatures/titans-breaker.json
@@ -58,6 +58,38 @@
                 "adjustName": false,
                 "choices": [
                     {
+                        "label": "PF2E.WeaponTypeUnarmed",
+                        "value": "unarmed"
+                    },
+                    {
+                        "label": "TYPES.Item.weapon",
+                        "value": "weapon"
+                    }
+                ],
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Exemplar.Ikon.Physical.UnarmedOrWeapon",
+                "rollOption": "titans-breaker"
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Exemplar.Ikon.UnarmedIkonToggle",
+                "mergeable": true,
+                "option": "unarmed-ikon",
+                "predicate": [
+                    "titans-breaker:unarmed"
+                ],
+                "suboptions": [
+                    {
+                        "label": "{item|name}",
+                        "value": "titans-breaker"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "adjustName": false,
+                "choices": [
+                    {
                         "label": "PF2E.SpecificRule.Exemplar.Ikon.Physical.Grant",
                         "value": "granted"
                     },
@@ -67,6 +99,9 @@
                     }
                 ],
                 "key": "ChoiceSet",
+                "predicate": [
+                    "titans-breaker:weapon"
+                ],
                 "prompt": "PF2E.SpecificRule.Exemplar.Ikon.Physical.Prompt",
                 "rollOption": "titans-breaker-origin"
             },
@@ -107,25 +142,6 @@
             },
             {
                 "adjustName": false,
-                "choices": [
-                    {
-                        "label": "PF2E.WeaponTypeUnarmed",
-                        "value": "unarmed"
-                    },
-                    {
-                        "label": "TYPES.Item.weapon",
-                        "value": "weapon"
-                    }
-                ],
-                "key": "ChoiceSet",
-                "predicate": [
-                    "titans-breaker-origin:existing"
-                ],
-                "prompt": "PF2E.SpecificRule.Exemplar.Ikon.Physical.UnarmedOrWeapon",
-                "rollOption": "titans-breaker-origin:existing"
-            },
-            {
-                "adjustName": false,
                 "choices": {
                     "ownedItems": true,
                     "predicate": [
@@ -145,25 +161,10 @@
                         "weapon"
                     ]
                 },
-                "flag": "existingIkonWeapon",
+                "flag": "existingIkon",
                 "key": "ChoiceSet",
                 "predicate": [
-                    "titans-breaker-origin:existing:weapon"
-                ]
-            },
-            {
-                "adjustName": false,
-                "choices": {
-                    "predicate": [
-                        "item:damage:type:bludgeoning",
-                        "item:melee"
-                    ],
-                    "unarmedAttacks": true
-                },
-                "flag": "existingIkonUnarmed",
-                "key": "ChoiceSet",
-                "predicate": [
-                    "titans-breaker-origin:existing:unarmed"
+                    "titans-breaker-origin:existing"
                 ]
             },
             {
@@ -175,13 +176,15 @@
                         "or": [
                             {
                                 "and": [
+                                    "titans-breaker:unarmed",
+                                    "unarmed-ikon:titans-breaker",
+                                    "item:category:unarmed"
+                                ]
+                            },
+                            {
+                                "and": [
                                     "titans-breaker-origin:existing",
-                                    {
-                                        "or": [
-                                            "item:slug:{item|flags.pf2e.rulesSelections.existingIkonUnarmed}",
-                                            "item:id:{item|flags.pf2e.rulesSelections.existingIkonWeapon}"
-                                        ]
-                                    }
+                                    "item:id:{item|flags.pf2e.rulesSelections.existingIkon}"
                                 ]
                             },
                             {
@@ -205,13 +208,15 @@
                         "or": [
                             {
                                 "and": [
+                                    "titans-breaker:unarmed",
+                                    "unarmed-ikon:titans-breaker",
+                                    "item:category:unarmed"
+                                ]
+                            },
+                            {
+                                "and": [
                                     "titans-breaker-origin:existing",
-                                    {
-                                        "or": [
-                                            "item:slug:{item|flags.pf2e.rulesSelections.existingIkonUnarmed}",
-                                            "item:id:{item|flags.pf2e.rulesSelections.existingIkonWeapon}"
-                                        ]
-                                    }
+                                    "item:id:{item|flags.pf2e.rulesSelections.existingIkon}"
                                 ]
                             },
                             {

--- a/packs/classfeatures/titans-breaker.json
+++ b/packs/classfeatures/titans-breaker.json
@@ -131,7 +131,8 @@
                 "key": "ChoiceSet",
                 "predicate": [
                     "titans-breaker-origin:granted"
-                ]
+                ],
+                "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
             {
                 "key": "GrantItem",
@@ -165,7 +166,8 @@
                 "key": "ChoiceSet",
                 "predicate": [
                     "titans-breaker-origin:existing"
-                ]
+                ],
+                "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
             {
                 "itemType": "weapon",

--- a/packs/feats/vow-of-mortal-defiance.json
+++ b/packs/feats/vow-of-mortal-defiance.json
@@ -31,7 +31,8 @@
         "rules": [
             {
                 "key": "RollOption",
-                "option": "vow-of-mortal-defiance"
+                "option": "vow-of-mortal-defiance",
+                "toggleable": true
             },
             {
                 "damageType": "spirit",

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -3315,6 +3315,7 @@
                     "TitansBreaker": {
                        "Label": "Titan's Breaker"
                     },
+                    "UnarmedIkonToggle": "Attack with unarmed ikon",
                     "UnfailingBow": {
                        "Label": "Unfailing Bow"
                     },


### PR DESCRIPTION
Instead of having the user choose a specific unarmed Strike, they can use the toggle to say they're using whatever unarmed attack qualifies as an ikon.

Also closes #17100 while I'm at it