### PR TITLE
Make Energized Spark's suboptions mergeable

### DIFF
--- a/packs/feats/energized-spark.json
+++ b/packs/feats/energized-spark.json
@@ -144,6 +144,7 @@
             {
                 "key": "RollOption",
                 "label": "PF2E.SpecificRule.Exemplar.EnergizedSpark.Label",
+                "mergeable": true,
                 "option": "energized-spark-damage",
                 "suboptions": [
                     {


### PR DESCRIPTION
Forgot this, which made the inactive roll options throw warnings