### PR TITLE
Preserve token ring on extraction and fix Nahoa and Samo tokens

### DIFF
--- a/build/lib/extractor.ts
+++ b/build/lib/extractor.ts
@@ -467,12 +467,17 @@ class PackExtractor {
                                 img: ImageFilePath;
                                 prototypeToken: DeepPartial<foundry.data.PrototypeTokenSource>;
                             } = docSource;
+                            const ringSetting = docSource.prototypeToken.ring;
                             withToken.prototypeToken = { name: docSource.prototypeToken.name };
                             // Iconics have special tokens
                             if (withToken.img?.includes("iconics")) {
                                 withToken.prototypeToken.texture = {
                                     src: withToken.img.replace("Full", "") as ImageFilePath,
                                 };
+                            }
+                            // If using dynamic ring, preserve enabled status and subject texture
+                            if (ringSetting?.enabled) {
+                                withToken.prototypeToken.ring = R.pick(ringSetting, ["enabled", "subject"]);
                             }
                         }
 

--- a/packs/iconics/nahoa-level-1.json
+++ b/packs/iconics/nahoa-level-1.json
@@ -3230,6 +3230,13 @@
     "name": "Nahoa (Level 1)",
     "prototypeToken": {
         "name": "Nahoa",
+        "ring": {
+            "enabled": true,
+            "subject": {
+                "scale": 1,
+                "texture": "systems/pf2e/icons/iconics/Nahoa.webp"
+            }
+        },
         "texture": {
             "src": "systems/pf2e/icons/iconics/Nahoa.webp"
         }

--- a/packs/iconics/nahoa-level-3.json
+++ b/packs/iconics/nahoa-level-3.json
@@ -3700,6 +3700,13 @@
     "name": "Nahoa (Level 3)",
     "prototypeToken": {
         "name": "Nahoa",
+        "ring": {
+            "enabled": true,
+            "subject": {
+                "scale": 1,
+                "texture": "systems/pf2e/icons/iconics/Nahoa.webp"
+            }
+        },
         "texture": {
             "src": "systems/pf2e/icons/iconics/Nahoa.webp"
         }

--- a/packs/iconics/nahoa-level-5.json
+++ b/packs/iconics/nahoa-level-5.json
@@ -4076,6 +4076,13 @@
     "name": "Nahoa (Level 5)",
     "prototypeToken": {
         "name": "Nahoa",
+        "ring": {
+            "enabled": true,
+            "subject": {
+                "scale": 1,
+                "texture": "systems/pf2e/icons/iconics/Nahoa.webp"
+            }
+        },
         "texture": {
             "src": "systems/pf2e/icons/iconics/Nahoa.webp"
         }

--- a/packs/iconics/samo-level-1.json
+++ b/packs/iconics/samo-level-1.json
@@ -2799,6 +2799,13 @@
     "name": "Samo (Level 1)",
     "prototypeToken": {
         "name": "Samo",
+        "ring": {
+            "enabled": true,
+            "subject": {
+                "scale": 1,
+                "texture": "systems/pf2e/icons/iconics/Samo.webp"
+            }
+        },
         "texture": {
             "src": "systems/pf2e/icons/iconics/Samo.webp"
         }

--- a/packs/iconics/samo-level-3.json
+++ b/packs/iconics/samo-level-3.json
@@ -4068,6 +4068,13 @@
     "name": "Samo (Level 3)",
     "prototypeToken": {
         "name": "Samo",
+        "ring": {
+            "enabled": true,
+            "subject": {
+                "scale": 1,
+                "texture": "systems/pf2e/icons/iconics/Samo.webp"
+            }
+        },
         "texture": {
             "src": "systems/pf2e/icons/iconics/Samo.webp"
         }

--- a/packs/iconics/samo-level-5.json
+++ b/packs/iconics/samo-level-5.json
@@ -4843,6 +4843,13 @@
     "name": "Samo (Level 5)",
     "prototypeToken": {
         "name": "Samo",
+        "ring": {
+            "enabled": true,
+            "subject": {
+                "scale": 1,
+                "texture": "systems/pf2e/icons/iconics/Samo.webp"
+            }
+        },
         "texture": {
             "src": "systems/pf2e/icons/iconics/Samo.webp"
         }


### PR DESCRIPTION
We might need @SpartanCPA to make fallback tokens but they shouldn't look weird on the canvas anymore.