### PR TITLE
Fix `DamageContext##findMatchingCheckContext`

### DIFF
--- a/src/module/actor/roll-context/damage.ts
+++ b/src/module/actor/roll-context/damage.ts
@@ -40,7 +40,7 @@ class DamageContext<
             .find((message) => {
                 if (!message.rolls.some((r) => r instanceof CheckRoll)) return false;
                 if (message.actor?.uuid !== actor.uuid) return false;
-                if (target.token !== message.target?.token.object) return false;
+                if (target.token !== message.target?.token) return false;
 
                 const messageItem = message.item;
                 if (!messageItem?.isOfType("melee", "weapon")) return false;
@@ -49,7 +49,7 @@ class DamageContext<
 
                 return !!(
                     paramsItemSlug === messageItemSlug &&
-                    item.uuid === item.uuid &&
+                    item.uuid === messageItem.uuid &&
                     item.isMelee === messageItem.isMelee
                 );
             });

--- a/src/module/actor/roll-context/damage.ts
+++ b/src/module/actor/roll-context/damage.ts
@@ -47,7 +47,7 @@ class DamageContext<
                 const paramsItemSlug = item.slug ?? sluggify(item.name);
                 const messageItemSlug = messageItem.slug ?? sluggify(messageItem.name);
 
-                return !!(
+                return (
                     paramsItemSlug === messageItemSlug &&
                     item.uuid === messageItem.uuid &&
                     item.isMelee === messageItem.isMelee


### PR DESCRIPTION
This was caught by a Biome linter test run.