### PR TITLE
Refactor Sneak Attack to be tag-based and add missing Avenger features

### DIFF
--- a/packs/actions/mark-for-death.json
+++ b/packs/actions/mark-for-death.json
@@ -102,20 +102,7 @@
                     "marked-for-death",
                     "feature:sneak-attack",
                     "target:condition:off-guard",
-                    {
-                        "or": [
-                            "item:trait:agile",
-                            "item:trait:finesse",
-                            {
-                                "and": [
-                                    "item:ranged",
-                                    {
-                                        "not": "item:thrown-melee"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
+                    "item:tag:sneak-attack"
                 ],
                 "selector": "strike-damage",
                 "slug": "mark-for-death-damage",

--- a/packs/classfeatures/avenger.json
+++ b/packs/classfeatures/avenger.json
@@ -115,7 +115,6 @@
             "keyOptions": [
                 "str"
             ],
-            "proficiencies": {},
             "suppressedFeatures": [
                 "Compendium.pf2e.classfeatures.Item.w6rMqmGzhUahdnA7"
             ]

--- a/packs/classfeatures/avenger.json
+++ b/packs/classfeatures/avenger.json
@@ -38,6 +38,10 @@
                 "value": 1
             },
             {
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.actionspf2e.Item.Hunt Prey"
+            },
+            {
                 "choices": {
                     "filter": [
                         {
@@ -88,18 +92,6 @@
                 "value": "@actor.system.proficiencies.defenses.light.rank"
             },
             {
-                "category": "precision",
-                "diceNumber": "@actor.flags.pf2e.sneakAttackDamage.number",
-                "dieSize": "d{actor|flags.pf2e.sneakAttackDamage.faces}",
-                "key": "DamageDice",
-                "label": "PF2E.SpecificRule.SneakAttack",
-                "predicate": [
-                    "target:condition:off-guard",
-                    "item:deity-favored"
-                ],
-                "selector": "strike-damage"
-            },
-            {
                 "key": "CriticalSpecialization",
                 "predicate": [
                     "item:deity-favored",
@@ -107,8 +99,14 @@
                 ]
             },
             {
-                "key": "GrantItem",
-                "uuid": "Compendium.pf2e.actionspf2e.Item.Hunt Prey"
+                "itemType": "weapon",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:deity-favored"
+                ],
+                "property": "other-tags",
+                "value": "sneak-attack"
             }
         ],
         "subfeatures": {

--- a/packs/classfeatures/avenger.json
+++ b/packs/classfeatures/avenger.json
@@ -79,34 +79,43 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "flags.pf2e.favoredWeaponRank",
-                "predicate": [
-                    "item:slug:avenger"
-                ],
-                "value": 1
-            },
-            {
-                "key": "GrantItem",
-                "uuid": "Compendium.pf2e.actionspf2e.Item.Hunt Prey"
+                "value": "@actor.system.proficiencies.attacks.simple.rank"
             },
             {
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.proficiencies.defenses.medium.rank",
+                "value": "@actor.system.proficiencies.defenses.light.rank"
+            },
+            {
+                "category": "precision",
+                "diceNumber": "@actor.flags.pf2e.sneakAttackDamage.number",
+                "dieSize": "d{actor|flags.pf2e.sneakAttackDamage.faces}",
+                "key": "DamageDice",
+                "label": "PF2E.SpecificRule.SneakAttack",
                 "predicate": [
-                    {
-                        "gte": [
-                            "self:level",
-                            13
-                        ]
-                    }
+                    "target:condition:off-guard",
+                    "item:deity-favored"
                 ],
-                "value": "ternary(gte(@actor.system.proficiencies.defenses.light.rank,2),2,1)"
+                "selector": "strike-damage"
+            },
+            {
+                "key": "CriticalSpecialization",
+                "predicate": [
+                    "item:deity-favored",
+                    "target:condition:off-guard"
+                ]
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.actionspf2e.Item.Hunt Prey"
             }
         ],
         "subfeatures": {
             "keyOptions": [
                 "str"
             ],
+            "proficiencies": {},
             "suppressedFeatures": [
                 "Compendium.pf2e.classfeatures.Item.w6rMqmGzhUahdnA7"
             ]

--- a/packs/classfeatures/ruffian.json
+++ b/packs/classfeatures/ruffian.json
@@ -26,13 +26,10 @@
         },
         "rules": [
             {
-                "category": "precision",
-                "diceNumber": "@actor.flags.pf2e.sneakAttackDamage.number",
-                "dieSize": "d{actor|flags.pf2e.sneakAttackDamage.faces}",
-                "key": "DamageDice",
-                "label": "PF2E.SpecificRule.SneakAttack",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
+                "mode": "add",
                 "predicate": [
-                    "target:condition:off-guard",
                     {
                         "or": [
                             {
@@ -63,23 +60,10 @@
                                 ]
                             }
                         ]
-                    },
-                    {
-                        "nor": [
-                            {
-                                "and": [
-                                    "item:ranged",
-                                    {
-                                        "not": "item:thrown-melee"
-                                    }
-                                ]
-                            },
-                            "item:trait:agile",
-                            "item:trait:finesse"
-                        ]
                     }
                 ],
-                "selector": "strike-damage"
+                "property": "other-tags",
+                "value": "sneak-attack"
             },
             {
                 "key": "ActiveEffectLike",

--- a/packs/classfeatures/sneak-attack.json
+++ b/packs/classfeatures/sneak-attack.json
@@ -51,12 +51,10 @@
                 "toggleable": "totm"
             },
             {
-                "category": "precision",
-                "diceNumber": "@actor.flags.pf2e.sneakAttackDamage.number",
-                "dieSize": "d{actor|flags.pf2e.sneakAttackDamage.faces}",
-                "key": "DamageDice",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
+                "mode": "add",
                 "predicate": [
-                    "target:condition:off-guard",
                     {
                         "or": [
                             "item:trait:agile",
@@ -71,6 +69,18 @@
                             }
                         ]
                     }
+                ],
+                "property": "other-tags",
+                "value": "sneak-attack"
+            },
+            {
+                "category": "precision",
+                "diceNumber": "@actor.flags.pf2e.sneakAttackDamage.number",
+                "dieSize": "d{actor|flags.pf2e.sneakAttackDamage.faces}",
+                "key": "DamageDice",
+                "predicate": [
+                    "item:tag:sneak-attack",
+                    "target:condition:off-guard"
                 ],
                 "selector": "strike-damage"
             }

--- a/packs/feats/shadow-sneak-attack.json
+++ b/packs/feats/shadow-sneak-attack.json
@@ -30,30 +30,21 @@
         },
         "rules": [
             {
-                "category": "precision",
-                "diceNumber": 1,
-                "dieSize": "d6",
-                "key": "DamageDice",
-                "predicate": [
-                    "target:condition:off-guard",
-                    {
-                        "or": [
-                            "item:trait:agile",
-                            "item:trait:finesse",
-                            {
-                                "and": [
-                                    "item:ranged",
-                                    {
-                                        "not": "item:thrown-melee"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                ],
-                "selector": "strike-damage"
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.sneakAttackDamage.number",
+                "priority": 49,
+                "value": 1
             },
             {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.sneakAttackDamage.faces",
+                "priority": 49,
+                "value": 6
+            },
+            {
+                "allowDuplicate": false,
                 "key": "GrantItem",
                 "uuid": "Compendium.pf2e.classfeatures.Item.Sneak Attack"
             },

--- a/packs/feats/sly-striker.json
+++ b/packs/feats/sly-striker.json
@@ -31,67 +31,11 @@
         "rules": [
             {
                 "category": "precision",
+                "diceNumber": "ternary(gte(@actor.level,14),ternary(gte(@actor.flags.pf2e.sneakAttackDamage.number,3),2,1),1)",
                 "dieSize": "d6",
                 "key": "DamageDice",
                 "predicate": [
-                    "class:rogue",
-                    {
-                        "or": [
-                            "item:trait:agile",
-                            "item:trait:finesse",
-                            {
-                                "and": [
-                                    "item:ranged",
-                                    {
-                                        "not": "item:thrown-melee"
-                                    }
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "not": "target:condition:off-guard"
-                    }
-                ],
-                "selector": "strike-damage",
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 13,
-                            "value": {
-                                "diceNumber": 1
-                            }
-                        },
-                        {
-                            "start": 14,
-                            "value": {
-                                "diceNumber": 2
-                            }
-                        }
-                    ]
-                }
-            },
-            {
-                "category": "precision",
-                "diceNumber": 1,
-                "dieSize": "d6",
-                "key": "DamageDice",
-                "predicate": [
-                    "feat:rogue-dedication",
-                    {
-                        "or": [
-                            "item:trait:agile",
-                            "item:trait:finesse",
-                            {
-                                "and": [
-                                    "item:ranged",
-                                    {
-                                        "not": "item:thrown-melee"
-                                    }
-                                ]
-                            }
-                        ]
-                    },
+                    "item:tag:sneak-attack",
                     {
                         "not": "target:condition:off-guard"
                     }


### PR DESCRIPTION
Sneak Attack now gives its default weapons the `sneak-attack` tag and predicates its damage on that tag. Avenger and Ruffian tag their own weapons, thus qualifying them for Sneak Attack. Switched to tag-based predicate on Sly Striker as well.

Closes #17160