### PR TITLE
fix: Do not disable built-in ruler Ctrl+Drag to measure

### DIFF
--- a/src/module/canvas/ruler.ts
+++ b/src/module/canvas/ruler.ts
@@ -6,7 +6,7 @@ import type { TokenPF2e } from "./token/object.ts";
 
 class RulerPF2e<TToken extends TokenPF2e | null = TokenPF2e | null> extends Ruler<TToken, UserPF2e> {
     static override get canMeasure(): boolean {
-        return this.#dragMeasurement ? game.activeTool === "ruler" : super.canMeasure;
+        return super.canMeasure;
     }
 
     /** Whether drag measurement is enabled */


### PR DESCRIPTION
Fix for #15961. 

Examining the history of this method I suspect leaving this check was an oversight after checks for `token` were added elsewhere in the file.