### PR TITLE
fix issue with PFS boons not displaying on character sheet

### DIFF
--- a/static/templates/actors/character/tabs/pfs.hbs
+++ b/static/templates/actors/character/tabs/pfs.hbs
@@ -37,7 +37,7 @@
     </header>
 
     <ol class="actions-list directory-list">
-        {{#each actor.pfsBoons as |feat|}}
+        {{#each document.pfsBoons as |feat|}}
             <li class="item feat-item" data-item-id="{{feat.id}}">
                 <div class="item-name">
                     <a class="item-image framed" data-action="item-to-chat">


### PR DESCRIPTION
Change template file to look at `document.pfsBoons` instead of `actor.pfsBoons`, matching the way divine intercessions are accessed shows the boons