### PR TITLE
Update Animist focus pool based on feats and features

### DIFF
--- a/packs/classfeatures/crafter-in-the-vault.json
+++ b/packs/classfeatures/crafter-in-the-vault.json
@@ -24,7 +24,14 @@
             "remaster": true,
             "title": "Pathfinder War of Immortals"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.animist.numberOfApparitions",
+                "value": 1
+            }
+        ],
         "traits": {
             "otherTags": [
                 "animist-apparition"

--- a/packs/classfeatures/custodian-of-groves-and-gardens.json
+++ b/packs/classfeatures/custodian-of-groves-and-gardens.json
@@ -24,7 +24,14 @@
             "remaster": true,
             "title": "Pathfinder War of Immortals"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.animist.numberOfApparitions",
+                "value": 1
+            }
+        ],
         "traits": {
             "otherTags": [
                 "animist-apparition"

--- a/packs/classfeatures/echo-of-lost-moments.json
+++ b/packs/classfeatures/echo-of-lost-moments.json
@@ -24,7 +24,14 @@
             "remaster": true,
             "title": "Pathfinder War of Immortals"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.animist.numberOfApparitions",
+                "value": 1
+            }
+        ],
         "traits": {
             "otherTags": [
                 "animist-apparition"

--- a/packs/classfeatures/fourth-apparition.json
+++ b/packs/classfeatures/fourth-apparition.json
@@ -24,7 +24,14 @@
             "remaster": true,
             "title": "Pathfinder War of Immortals"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "system.resources.focus.max",
+                "value": 1
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/classfeatures/impostor-in-hidden-places.json
+++ b/packs/classfeatures/impostor-in-hidden-places.json
@@ -24,7 +24,14 @@
             "remaster": true,
             "title": "Pathfinder War of Immortals"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.animist.numberOfApparitions",
+                "value": 1
+            }
+        ],
         "traits": {
             "otherTags": [
                 "animist-apparition"

--- a/packs/classfeatures/lurker-in-devouring-dark.json
+++ b/packs/classfeatures/lurker-in-devouring-dark.json
@@ -24,7 +24,14 @@
             "remaster": true,
             "title": "Pathfinder War of Immortals"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.animist.numberOfApparitions",
+                "value": 1
+            }
+        ],
         "traits": {
             "otherTags": [
                 "animist-apparition"

--- a/packs/classfeatures/medium.json
+++ b/packs/classfeatures/medium.json
@@ -28,6 +28,20 @@
             {
                 "key": "GrantItem",
                 "uuid": "Compendium.pf2e.feats-srd.Item.Relinquish Control"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "system.resources.focus.max",
+                "predicate": [
+                    {
+                        "gte": [
+                            "self:level",
+                            9
+                        ]
+                    }
+                ],
+                "value": "@actor.flags.pf2e.animist.numberOfApparitions"
             }
         ],
         "traits": {

--- a/packs/classfeatures/monarch-of-the-fey-courts.json
+++ b/packs/classfeatures/monarch-of-the-fey-courts.json
@@ -24,7 +24,14 @@
             "remaster": true,
             "title": "Pathfinder War of Immortals"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.animist.numberOfApparitions",
+                "value": 1
+            }
+        ],
         "traits": {
             "otherTags": [
                 "animist-apparition"

--- a/packs/classfeatures/reveler-in-lost-glee.json
+++ b/packs/classfeatures/reveler-in-lost-glee.json
@@ -24,7 +24,14 @@
             "remaster": true,
             "title": "Pathfinder War of Immortals"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.animist.numberOfApparitions",
+                "value": 1
+            }
+        ],
         "traits": {
             "otherTags": [
                 "animist-apparition"

--- a/packs/classfeatures/stalker-in-darkened-boughs.json
+++ b/packs/classfeatures/stalker-in-darkened-boughs.json
@@ -24,7 +24,14 @@
             "remaster": true,
             "title": "Pathfinder War of Immortals"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.animist.numberOfApparitions",
+                "value": 1
+            }
+        ],
         "traits": {
             "otherTags": [
                 "animist-apparition"

--- a/packs/classfeatures/steward-of-stone-and-fire.json
+++ b/packs/classfeatures/steward-of-stone-and-fire.json
@@ -24,7 +24,14 @@
             "remaster": true,
             "title": "Pathfinder War of Immortals"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.animist.numberOfApparitions",
+                "value": 1
+            }
+        ],
         "traits": {
             "otherTags": [
                 "animist-apparition"

--- a/packs/classfeatures/third-apparition.json
+++ b/packs/classfeatures/third-apparition.json
@@ -24,7 +24,14 @@
             "remaster": true,
             "title": "Pathfinder War of Immortals"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "system.resources.focus.max",
+                "value": 1
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/classfeatures/vanguard-of-roaring-waters.json
+++ b/packs/classfeatures/vanguard-of-roaring-waters.json
@@ -24,7 +24,14 @@
             "remaster": true,
             "title": "Pathfinder War of Immortals"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.animist.numberOfApparitions",
+                "value": 1
+            }
+        ],
         "traits": {
             "otherTags": [
                 "animist-apparition"

--- a/packs/classfeatures/witness-to-ancient-battles.json
+++ b/packs/classfeatures/witness-to-ancient-battles.json
@@ -24,7 +24,14 @@
             "remaster": true,
             "title": "Pathfinder War of Immortals"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.animist.numberOfApparitions",
+                "value": 1
+            }
+        ],
         "traits": {
             "otherTags": [
                 "animist-apparition"

--- a/packs/feats/circle-of-spirits.json
+++ b/packs/feats/circle-of-spirits.json
@@ -28,7 +28,14 @@
             "remaster": true,
             "title": "Pathfinder War of Immortals"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "system.resources.focus.max",
+                "value": "@actor.flags.pf2e.animist.numberOfApparitions"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [


### PR DESCRIPTION
Circle of Spirits and Dual Invocation (medium level 9) upgrade the focus pool to the number of attuned apparitions.
Third and Fourth apparitions increase the focus pool by 1.