### PR TITLE
Localize Quick Climb and Quick Swim notes and update the latter's value

### DIFF
--- a/packs/feats/quick-climb.json
+++ b/packs/feats/quick-climb.json
@@ -39,11 +39,15 @@
             },
             {
                 "key": "Note",
+                "outcome": [
+                    "success",
+                    "criticalSuccess"
+                ],
                 "predicate": [
                     "action:climb"
                 ],
                 "selector": "athletics",
-                "text": "You move 5 more feet on a success, and 10 more feet on a critical success.",
+                "text": "PF2E.SpecificRule.Feat.QuickClimb.Note",
                 "title": "{item|name}"
             }
         ],

--- a/packs/feats/quick-swim.json
+++ b/packs/feats/quick-swim.json
@@ -31,25 +31,23 @@
         "rules": [
             {
                 "key": "BaseSpeed",
+                "predicate": [
+                    "skill:athletics:rank:4"
+                ],
                 "selector": "swim",
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 4,
-                            "start": 4,
-                            "value": "@actor.attributes.speed.total"
-                        }
-                    ],
-                    "field": "actor|system.skills.athletics.rank"
-                }
+                "value": "@actor.attributes.speed.total"
             },
             {
                 "key": "Note",
+                "outcome": [
+                    "success",
+                    "criticalSuccess"
+                ],
                 "predicate": [
                     "action:swim"
                 ],
                 "selector": "athletics",
-                "text": "You swim 5 more feet on a success, and 10 more feet on a critical success.",
+                "text": "PF2E.SpecificRule.Feat.QuickSwim.Note",
                 "title": "{item|name}"
             }
         ],

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -3437,6 +3437,12 @@
                 "PeerBeyond": {
                     "Note": "You can roll a Spirit Lore or Haunt Lore check for initiative if you know that an incorporeal undead or a haunt is present."
                 },
+                "QuickClimb": {
+                    "Note": "You move 5 more feet on a success and 10 more feet on a critical success, up to your Speed."
+                },
+                "QuickSwim": {
+                    "Note": "You Swim 5 feet farther on a success and 10 feet farther on a critical success, to a maximum of your Speed."
+                },
                 "RiskySurgery": {
                     "Note": "When you Treat Wounds, you can deal @Damage[1d8[slashing]] damage to your patient just before applying the effects of the Treat Wounds. If you do, gain a +2 circumstance bonus to your Medicine check to Treat Wounds, and if you roll a success, you get a critical success instead."
                 },


### PR DESCRIPTION
Using brackets for the value made it so the armor penalties applied as if the character didn't meet the strength requirement. Perhaps the bracket resolving before that is taken into account? Either way, predicating the BaseSpeed rule element instead resolves the issue and is the better way to do it.
Closes #17199