### PR TITLE
Update 2nd-level rollable tables

### DIFF
--- a/packs/equipment/cold-iron-buckler-high-grade.json
+++ b/packs/equipment/cold-iron-buckler-high-grade.json
@@ -1,0 +1,54 @@
+{
+    "_id": "lit8IyoUHuybenvU",
+    "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/cold-Iron-buckler.webp",
+    "name": "Cold Iron Buckler (High-Grade)",
+    "system": {
+        "acBonus": 1,
+        "baseItem": "buckler",
+        "bulk": {
+            "value": 0.1
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p>Cold iron shields don't typically have an additional effect, though when used for a shield bash, they are cold iron weapons.</p>\n<p>The shield has Hardness 8, HP 32, and BT 16.</p>\n<p><strong>Craft Requirements</strong> cold iron worth at least 2,500 gp</p>"
+        },
+        "hardness": 8,
+        "hp": {
+            "max": 32,
+            "value": 32
+        },
+        "level": {
+            "value": 15
+        },
+        "material": {
+            "grade": "high",
+            "type": "cold-iron"
+        },
+        "price": {
+            "value": {
+                "gp": 5000
+            }
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Core Rulebook"
+        },
+        "quantity": 1,
+        "rules": [],
+        "runes": {
+            "potency": 0,
+            "property": [],
+            "reinforcing": 0,
+            "resilient": 0
+        },
+        "size": "med",
+        "speedPenalty": 0,
+        "traits": {
+            "integrated": null,
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "type": "shield"
+}

--- a/packs/equipment/cold-iron-buckler-low-grade.json
+++ b/packs/equipment/cold-iron-buckler-low-grade.json
@@ -1,0 +1,54 @@
+{
+    "_id": "JBRjwH8gJeXtxSYF",
+    "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/cold-Iron-buckler.webp",
+    "name": "Cold Iron Buckler (Low-Grade)",
+    "system": {
+        "acBonus": 1,
+        "baseItem": "buckler",
+        "bulk": {
+            "value": 0.1
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p>Cold iron shields don't typically have an additional effect, though when used for a shield bash, they are cold iron weapons.</p>\n<p>The shield has Hardness 3, HP 12, and BT 6.</p>\n<p><strong>Craft Requirements</strong> cold iron worth at least 15 sp</p>"
+        },
+        "hardness": 3,
+        "hp": {
+            "max": 12,
+            "value": 12
+        },
+        "level": {
+            "value": 2
+        },
+        "material": {
+            "grade": "low",
+            "type": "cold-iron"
+        },
+        "price": {
+            "value": {
+                "gp": 30
+            }
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Core Rulebook"
+        },
+        "quantity": 1,
+        "rules": [],
+        "runes": {
+            "potency": 0,
+            "property": [],
+            "reinforcing": 0,
+            "resilient": 0
+        },
+        "size": "med",
+        "speedPenalty": 0,
+        "traits": {
+            "integrated": null,
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "type": "shield"
+}

--- a/packs/equipment/cold-iron-buckler-standard-grade.json
+++ b/packs/equipment/cold-iron-buckler-standard-grade.json
@@ -1,0 +1,54 @@
+{
+    "_id": "NbophhQ0WLmRD5nu",
+    "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/cold-Iron-buckler.webp",
+    "name": "Cold Iron Buckler (Standard-Grade)",
+    "system": {
+        "acBonus": 1,
+        "baseItem": "buckler",
+        "bulk": {
+            "value": 0.1
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p>Cold iron shields don't typically have an additional effect, though when used for a shield bash, they are cold iron weapons.</p>\n<p>The shield has Hardness 5, HP 20, and BT 10.</p>\n<p><strong>Craft Requirements</strong> cold iron worth at least 375 sp</p>"
+        },
+        "hardness": 5,
+        "hp": {
+            "max": 20,
+            "value": 20
+        },
+        "level": {
+            "value": 7
+        },
+        "material": {
+            "grade": "standard",
+            "type": "cold-iron"
+        },
+        "price": {
+            "value": {
+                "gp": 300
+            }
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Core Rulebook"
+        },
+        "quantity": 1,
+        "rules": [],
+        "runes": {
+            "potency": 0,
+            "property": [],
+            "reinforcing": 0,
+            "resilient": 0
+        },
+        "size": "med",
+        "speedPenalty": 0,
+        "traits": {
+            "integrated": null,
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "type": "shield"
+}

--- a/packs/equipment/cold-iron-shield-high-grade.json
+++ b/packs/equipment/cold-iron-shield-high-grade.json
@@ -1,0 +1,54 @@
+{
+    "_id": "kEtwA282PdfawLzM",
+    "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/cold-Iron-shield.webp",
+    "name": "Cold Iron Shield (High-Grade)",
+    "system": {
+        "acBonus": 2,
+        "baseItem": null,
+        "bulk": {
+            "value": 1
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p>Cold iron shields don't typically have an additional effect, though when used for a shield bash, they are cold iron weapons.</p>\n<p>The shield has Hardness 10, HP 40, and BT 20.</p>\n<hr />\n<p><strong>Craft Requirements</strong> cold iron worth at least 2,750 gp</p>"
+        },
+        "hardness": 10,
+        "hp": {
+            "max": 40,
+            "value": 40
+        },
+        "level": {
+            "value": 15
+        },
+        "material": {
+            "grade": "high",
+            "type": "cold-iron"
+        },
+        "price": {
+            "value": {
+                "gp": 5500
+            }
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Core Rulebook"
+        },
+        "quantity": 1,
+        "rules": [],
+        "runes": {
+            "potency": 0,
+            "property": [],
+            "reinforcing": 0,
+            "resilient": 0
+        },
+        "size": "med",
+        "speedPenalty": 0,
+        "traits": {
+            "integrated": null,
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "type": "shield"
+}

--- a/packs/equipment/cold-iron-shield-low-grade.json
+++ b/packs/equipment/cold-iron-shield-low-grade.json
@@ -1,0 +1,54 @@
+{
+    "_id": "WzZovtHSVjFJw9PI",
+    "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/cold-Iron-shield.webp",
+    "name": "Cold Iron Shield (Low-Grade)",
+    "system": {
+        "acBonus": 2,
+        "baseItem": null,
+        "bulk": {
+            "value": 1
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p>Cold iron shields don't typically have an additional effect, though when used for a shield bash, they are cold iron weapons.</p>\n<p>The shield has Hardness 5, HP 20, and BT 10.</p>\n<p><strong>Craft Requirements</strong> cold iron worth at least 17 sp</p>"
+        },
+        "hardness": 5,
+        "hp": {
+            "max": 20,
+            "value": 20
+        },
+        "level": {
+            "value": 2
+        },
+        "material": {
+            "grade": "low",
+            "type": "cold-iron"
+        },
+        "price": {
+            "value": {
+                "gp": 34
+            }
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Core Rulebook"
+        },
+        "quantity": 1,
+        "rules": [],
+        "runes": {
+            "potency": 0,
+            "property": [],
+            "reinforcing": 0,
+            "resilient": 0
+        },
+        "size": "med",
+        "speedPenalty": 0,
+        "traits": {
+            "integrated": null,
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "type": "shield"
+}

--- a/packs/equipment/cold-iron-shield-standard-grade.json
+++ b/packs/equipment/cold-iron-shield-standard-grade.json
@@ -1,0 +1,54 @@
+{
+    "_id": "8mm0M9Fh2sTA1PzK",
+    "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/cold-Iron-shield.webp",
+    "name": "Cold Iron Shield (Standard-Grade)",
+    "system": {
+        "acBonus": 2,
+        "baseItem": null,
+        "bulk": {
+            "value": 1
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p>Cold iron shields don't typically have an additional effect, though when used for a shield bash, they are cold iron weapons.</p>\n<p>The shield has Hardness 7, HP 28, and BT 14.</p>\n<p><strong>Craft Requirements</strong> cold iron worth at least 425 sp</p>"
+        },
+        "hardness": 7,
+        "hp": {
+            "max": 28,
+            "value": 28
+        },
+        "level": {
+            "value": 7
+        },
+        "material": {
+            "grade": "standard",
+            "type": "cold-iron"
+        },
+        "price": {
+            "value": {
+                "gp": 340
+            }
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Core Rulebook"
+        },
+        "quantity": 1,
+        "rules": [],
+        "runes": {
+            "potency": 0,
+            "property": [],
+            "reinforcing": 0,
+            "resilient": 0
+        },
+        "size": "med",
+        "speedPenalty": 0,
+        "traits": {
+            "integrated": null,
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "type": "shield"
+}

--- a/packs/equipment/glamorous-buckler.json
+++ b/packs/equipment/glamorous-buckler.json
@@ -48,7 +48,7 @@
             }
         ],
         "runes": {
-            "reinforcing": null
+            "reinforcing": 0
         },
         "size": "med",
         "specific": {

--- a/packs/equipment/silver-buckler-high-grade.json
+++ b/packs/equipment/silver-buckler-high-grade.json
@@ -1,0 +1,54 @@
+{
+    "_id": "pCTw0Lo9VPHzmrPb",
+    "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/silver-buckler.webp",
+    "name": "Silver Buckler (High-Grade)",
+    "system": {
+        "acBonus": 1,
+        "baseItem": "buckler",
+        "bulk": {
+            "value": 0.1
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p>Silver shields don't typically have an additional effect, though when used for a shield bash, they are silver weapons.</p>\n<hr />\n<p>The shield has Hardness 6, HP 24, and BT 12.</p>\n<p><strong>Craft Requirements</strong> silver worth at least 2,500 gp</p>"
+        },
+        "hardness": 6,
+        "hp": {
+            "max": 24,
+            "value": 24
+        },
+        "level": {
+            "value": 15
+        },
+        "material": {
+            "grade": "high",
+            "type": "silver"
+        },
+        "price": {
+            "value": {
+                "gp": 5000
+            }
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Core Rulebook"
+        },
+        "quantity": 1,
+        "rules": [],
+        "runes": {
+            "potency": 0,
+            "property": [],
+            "reinforcing": 0,
+            "resilient": 0
+        },
+        "size": "med",
+        "speedPenalty": 0,
+        "traits": {
+            "integrated": null,
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "type": "shield"
+}

--- a/packs/equipment/silver-buckler-low-grade.json
+++ b/packs/equipment/silver-buckler-low-grade.json
@@ -1,0 +1,54 @@
+{
+    "_id": "qYGtQGYj1SfBuvYT",
+    "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/silver-buckler.webp",
+    "name": "Silver Buckler (Low-Grade)",
+    "system": {
+        "acBonus": 1,
+        "baseItem": "buckler",
+        "bulk": {
+            "value": 0.1
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p>Silver shields don't typically have an additional effect, though when used for a shield bash, they are silver weapons.</p>\n<hr />\n<p>The shield has Hardness 1, HP 4, and BT 2.</p>\n<p><strong>Craft Requirements</strong> silver worth at least 15 sp</p>"
+        },
+        "hardness": 1,
+        "hp": {
+            "max": 4,
+            "value": 4
+        },
+        "level": {
+            "value": 2
+        },
+        "material": {
+            "grade": "low",
+            "type": "silver"
+        },
+        "price": {
+            "value": {
+                "gp": 30
+            }
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Core Rulebook"
+        },
+        "quantity": 1,
+        "rules": [],
+        "runes": {
+            "potency": 0,
+            "property": [],
+            "reinforcing": 0,
+            "resilient": 0
+        },
+        "size": "med",
+        "speedPenalty": 0,
+        "traits": {
+            "integrated": null,
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "type": "shield"
+}

--- a/packs/equipment/silver-buckler-standard-grade.json
+++ b/packs/equipment/silver-buckler-standard-grade.json
@@ -1,0 +1,54 @@
+{
+    "_id": "9pwPK79TXCoJsc3k",
+    "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/silver-buckler.webp",
+    "name": "Silver Buckler (Standard-Grade)",
+    "system": {
+        "acBonus": 1,
+        "baseItem": "buckler",
+        "bulk": {
+            "value": 0.1
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p>Silver shields don't typically have an additional effect, though when used for a shield bash, they are silver weapons.</p>\n<hr />\n<p>The shield has Hardness 3, HP 12, BT 6.</p>\n<p><strong>Craft Requirements</strong> silver worth at least 375 sp</p>"
+        },
+        "hardness": 3,
+        "hp": {
+            "max": 12,
+            "value": 12
+        },
+        "level": {
+            "value": 7
+        },
+        "material": {
+            "grade": "standard",
+            "type": "silver"
+        },
+        "price": {
+            "value": {
+                "gp": 300
+            }
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Core Rulebook"
+        },
+        "quantity": 1,
+        "rules": [],
+        "runes": {
+            "potency": 0,
+            "property": [],
+            "reinforcing": 0,
+            "resilient": 0
+        },
+        "size": "med",
+        "speedPenalty": 0,
+        "traits": {
+            "integrated": null,
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "type": "shield"
+}

--- a/packs/equipment/silver-shield-high-grade.json
+++ b/packs/equipment/silver-shield-high-grade.json
@@ -1,0 +1,54 @@
+{
+    "_id": "ZcKzK2T7E251qrk3",
+    "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/silver-shield.webp",
+    "name": "Silver Shield (High-Grade)",
+    "system": {
+        "acBonus": 2,
+        "baseItem": null,
+        "bulk": {
+            "value": 1
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p>Silver shields don't typically have an additional effect, though when used for a shield bash, they are silver weapons.</p>\n<hr />\n<p>The shield has Hardness 8 HP 32, and BT 16.</p>\n<p><strong>Craft Requirements</strong> silver worth at least 2,750 gp</p>"
+        },
+        "hardness": 8,
+        "hp": {
+            "max": 32,
+            "value": 32
+        },
+        "level": {
+            "value": 15
+        },
+        "material": {
+            "grade": "high",
+            "type": "silver"
+        },
+        "price": {
+            "value": {
+                "gp": 5500
+            }
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Core Rulebook"
+        },
+        "quantity": 1,
+        "rules": [],
+        "runes": {
+            "potency": 0,
+            "property": [],
+            "reinforcing": 0,
+            "resilient": 0
+        },
+        "size": "med",
+        "speedPenalty": 0,
+        "traits": {
+            "integrated": null,
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "type": "shield"
+}

--- a/packs/equipment/silver-shield-low-grade.json
+++ b/packs/equipment/silver-shield-low-grade.json
@@ -1,0 +1,54 @@
+{
+    "_id": "csT3nokH8Unxal1D",
+    "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/silver-shield.webp",
+    "name": "Silver Shield (Low-Grade)",
+    "system": {
+        "acBonus": 2,
+        "baseItem": null,
+        "bulk": {
+            "value": 1
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p>Silver shields don't typically have an additional effect, though when used for a shield bash, they are silver weapons.</p>\n<hr />\n<p>The shield has Hardness 3, HP 12, and BT 6.</p>\n<p><strong>Craft Requirements</strong> silver worth at least 17 sp</p>"
+        },
+        "hardness": 3,
+        "hp": {
+            "max": 12,
+            "value": 12
+        },
+        "level": {
+            "value": 2
+        },
+        "material": {
+            "grade": "low",
+            "type": "silver"
+        },
+        "price": {
+            "value": {
+                "gp": 34
+            }
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Core Rulebook"
+        },
+        "quantity": 1,
+        "rules": [],
+        "runes": {
+            "potency": 0,
+            "property": [],
+            "reinforcing": 0,
+            "resilient": 0
+        },
+        "size": "med",
+        "speedPenalty": 0,
+        "traits": {
+            "integrated": null,
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "type": "shield"
+}

--- a/packs/equipment/silver-shield-standard-grade.json
+++ b/packs/equipment/silver-shield-standard-grade.json
@@ -1,0 +1,54 @@
+{
+    "_id": "B7F7z9LQAKMBeZvY",
+    "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/silver-shield.webp",
+    "name": "Silver Shield (Standard-Grade)",
+    "system": {
+        "acBonus": 2,
+        "baseItem": null,
+        "bulk": {
+            "value": 1
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p>Silver shields don't typically have an additional effect, though when used for a shield bash, they are silver weapons.</p>\n<hr />\n<p>The shield has Hardness 5, HP 20, and BT 10.</p>\n<p><strong>Craft Requirements</strong> silver worth at least 425 sp</p>"
+        },
+        "hardness": 5,
+        "hp": {
+            "max": 20,
+            "value": 20
+        },
+        "level": {
+            "value": 7
+        },
+        "material": {
+            "grade": "standard",
+            "type": "silver"
+        },
+        "price": {
+            "value": {
+                "gp": 340
+            }
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Core Rulebook"
+        },
+        "quantity": 1,
+        "rules": [],
+        "runes": {
+            "potency": 0,
+            "property": [],
+            "reinforcing": 0,
+            "resilient": 0
+        },
+        "size": "med",
+        "speedPenalty": 0,
+        "traits": {
+            "integrated": null,
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "type": "shield"
+}

--- a/packs/rollable-tables/2nd-level-consumables.json
+++ b/packs/rollable-tables/2nd-level-consumables.json
@@ -1,8 +1,8 @@
 {
     "_id": "g30jZWCJEiK1RlIa",
-    "description": "Table of 2nd-Level Consumables",
+    "description": "<p>Table of 2nd-Level Consumables</p>",
     "displayRoll": true,
-    "formula": "1d123",
+    "formula": "1d138",
     "img": "icons/svg/d20-grey.svg",
     "name": "2nd-Level Consumables",
     "ownership": {
@@ -11,296 +11,338 @@
     "replacement": true,
     "results": [
         {
-            "_id": "ry32tNrAMQmP8SWu",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "cwurQLvQaqjK70UI",
-            "drawn": false,
-            "img": "icons/commodities/materials/feather-blue.webp",
-            "range": [
-                1,
-                6
-            ],
-            "text": "Feather Token (Holly Bush)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "tD9DOUrhusTOo6ym",
+            "_id": "QzQEScjJZlIv7FIZ",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "zM9VX3QwM81DzDUA",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/bravos-brew.webp",
             "range": [
-                7,
-                12
+                1,
+                6
             ],
             "text": "Bravo's Brew (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "vfRkWUwvvKhVmmVt",
+            "_id": "1F0uS1u48itGfNnO",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "bQPRKEpnLakJBAAh",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/cats-eye-elixir.webp",
             "range": [
-                13,
-                18
+                7,
+                12
             ],
             "text": "Cat's Eye Elixir",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "u5S7bpxsQtmZw1ah",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "3Klm2gPmzOw6ntVb",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/comprehension-elixir.webp",
-            "range": [
-                19,
-                24
-            ],
-            "text": "Comprehension Elixir (Lesser)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "BQwlRvlpARru285I",
+            "_id": "RzzmnuTvowvxZO0B",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "88pGCHV0uKMskTVO",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/darkvision-elixir.webp",
             "range": [
-                25,
-                30
+                13,
+                18
             ],
             "text": "Darkvision Elixir (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "3xDD3sHjTohsIvaL",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "cuomhpenkqGM5lLG",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/infiltrators-elixir.webp",
-            "range": [
-                31,
-                36
-            ],
-            "text": "Infiltrator's Elixir",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "SL183TkVMQkmUDv4",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "FL8QU8TcNauBMMhD",
-            "drawn": false,
-            "img": "icons/commodities/materials/bowl-liquid-white.webp",
-            "range": [
-                37,
-                42
-            ],
-            "text": "Belladonna",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "T2kXzz5x5FFl8qcB",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "ScclzFrjyB0YJlrb",
-            "drawn": false,
-            "img": "icons/consumables/potions/bottle-conical-corked-green.webp",
-            "range": [
-                43,
-                48
-            ],
-            "text": "Black Adder Venom",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "QNtUu0hwf189Evrf",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "zo0ophqfKunJFxZN",
-            "drawn": false,
-            "img": "icons/commodities/materials/liquid-orange.webp",
-            "range": [
-                49,
-                51
-            ],
-            "text": "Lethargy Poison",
-            "type": "pack",
-            "weight": 3
-        },
-        {
-            "_id": "pJU1w1RQgdmtxEnT",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "nXStoLxPrrP2b6WB",
-            "drawn": false,
-            "img": "icons/equipment/neck/necklace-hook-brown.webp",
-            "range": [
-                52,
-                57
-            ],
-            "text": "Bronze Bull Pendant",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "klapdf6bAB73uws4",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "HHELOoN5GVonUiIa",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/talismans/crying-angel-pendant.webp",
-            "range": [
-                58,
-                63
-            ],
-            "text": "Crying Angel Pendant",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "nuT1akfE0ijxOkDn",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "VPvyyQXjn2HBjnTS",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/talismans/effervescent-ampoule.webp",
-            "range": [
-                64,
-                69
-            ],
-            "text": "Effervescent Ampoule",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "zDvdnusRvAVqTeHa",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Yew9oddFsH0KeDLh",
-            "drawn": false,
-            "img": "icons/commodities/treasure/dreamcatcher-brown.webp",
-            "range": [
-                70,
-                75
-            ],
-            "text": "Hunter's Bane",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "FuHGz2bpefNLxkjf",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "2MgFoNXTccL8Own9",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/talismans/jade-cat.webp",
-            "range": [
-                76,
-                81
-            ],
-            "text": "Jade Cat",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "auXfWiEC0BmCB2mZ",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "aKbrBW1SnFDxya5J",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/talismans/mesmerizing-opal.webp",
-            "range": [
-                82,
-                87
-            ],
-            "text": "Mesmerizing Opal",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "Xm7lfo3yQp94m7so",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "jdDDqv9LbEYX2wAE",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/talismans/monkey-pin.webp",
-            "range": [
-                88,
-                93
-            ],
-            "text": "Monkey Pin",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "RvapRvAQnCogA41x",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "0aSdDSjJ5sMzBz1U",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/talismans/onyx-panther.webp",
-            "range": [
-                94,
-                99
-            ],
-            "text": "Onyx Panther",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "GSPrbuknylF9lRBK",
+            "_id": "DRCu65SqnqZbmwTX",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "j2CHumvbjmlLQX2i",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/oils/oil-of-potency.webp",
             "range": [
-                100,
-                105
+                19,
+                24
             ],
             "text": "Oil of Potency",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "Tl8Jye1UgRHFSr6T",
+            "_id": "x7ovT6CbrB3o09BT",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "6DmHDtIsGzH1s5JO",
             "drawn": false,
             "img": "icons/tools/laboratory/bowl-mixing.webp",
             "range": [
-                106,
-                111
+                25,
+                30
             ],
             "text": "Oil of Weightlessness",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "EcjzWnUXW49rqBry",
+            "_id": "hqywJY3NgLhzfvGa",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "ScclzFrjyB0YJlrb",
+            "drawn": false,
+            "img": "icons/consumables/potions/bottle-conical-corked-green.webp",
+            "range": [
+                31,
+                36
+            ],
+            "text": "Black Adder Venom",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "FQglPLGVYctnn3NG",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "zo0ophqfKunJFxZN",
+            "drawn": false,
+            "img": "icons/commodities/materials/liquid-orange.webp",
+            "range": [
+                37,
+                39
+            ],
+            "text": "Lethargy Poison",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "lDIkUxsnri2tGd5i",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "nXStoLxPrrP2b6WB",
+            "drawn": false,
+            "img": "icons/equipment/neck/necklace-hook-brown.webp",
+            "range": [
+                40,
+                45
+            ],
+            "text": "Bronze Bull Pendant",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "WWcGQZtxvzY98dKC",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "HHELOoN5GVonUiIa",
+            "drawn": false,
+            "img": "icons/commodities/treasure/trinket-wing-white.webp",
+            "range": [
+                46,
+                51
+            ],
+            "text": "Crying Angel Pendant",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "knpbPiBuOts2VkGT",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "VPvyyQXjn2HBjnTS",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/effervescent-ampoule.webp",
+            "range": [
+                52,
+                57
+            ],
+            "text": "Effervescent Ampoule",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "mkrlfImqSd192xpN",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "2MgFoNXTccL8Own9",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/jade-cat.webp",
+            "range": [
+                58,
+                63
+            ],
+            "text": "Jade Cat",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "AptH1ypXLIPO8atn",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "aKbrBW1SnFDxya5J",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/mesmerizing-opal.webp",
+            "range": [
+                64,
+                69
+            ],
+            "text": "Mesmerizing Opal",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "04ChkD9rneXRSmGC",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "jdDDqv9LbEYX2wAE",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/monkey-pin.webp",
+            "range": [
+                70,
+                75
+            ],
+            "text": "Monkey Pin",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "nc2nthc3wmCznm7r",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "0aSdDSjJ5sMzBz1U",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/onyx-panther.webp",
+            "range": [
+                76,
+                81
+            ],
+            "text": "Onyx Panther",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "Wpn3tZ1nbPs001px",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "qeTWg0TWw9CwMKCO",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/talismans/savior-spike.webp",
             "range": [
-                112,
-                117
+                82,
+                87
             ],
             "text": "Savior Spike",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "zCq4yiUgqcecAgCY",
+            "_id": "yCta7aJZ9QJA8Mss",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "8fbsKEEbZ0CfBMIr",
             "drawn": false,
             "img": "icons/consumables/drinks/alcohol-spirits-bottle-blue.webp",
             "range": [
+                88,
+                93
+            ],
+            "text": "Silver Salve",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "FzquFwOWSINlFYKS",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "NSQOijKqomyotXkj",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/ammunition/antler-arrow.webp",
+            "range": [
+                94,
+                99
+            ],
+            "text": "Antler Arrow",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "hzzu8lWAkR8A3ln2",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "e2II4yMBFBqVivnk",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/focus-cathartic.webp",
+            "range": [
+                100,
+                105
+            ],
+            "text": "Bottled Catharsis (Minor)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "gI3R9wuwAopPRE9C",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "3Klm2gPmzOw6ntVb",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/comprehension-elixir.webp",
+            "range": [
+                106,
+                111
+            ],
+            "text": "Comprehension Elixir (Lesser)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "LqTtd8Hb9Aesblex",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "yE7PPagK0wsHMA8l",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/sinew-shock-serum.webp",
+            "range": [
+                112,
+                117
+            ],
+            "text": "Surging Serum (Minor)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "KIk8kst6ztw0qo63",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "FL8QU8TcNauBMMhD",
+            "drawn": false,
+            "img": "icons/commodities/materials/bowl-liquid-white.webp",
+            "range": [
                 118,
                 123
             ],
-            "text": "Silver Salve",
+            "text": "Belladonna",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "CYCeUN0XnVNMZvtR",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "craWRj7jI2mLs1Ok",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/snares/deadweight-snare.webp",
+            "range": [
+                124,
+                126
+            ],
+            "text": "Deadweight Snare",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "m0SrhjWKScmGmopx",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "riLNCaVS9zGvt4Nn",
+            "drawn": false,
+            "img": "icons/skills/ranged/cannon-barrel-firing-yellow.webp",
+            "range": [
+                127,
+                132
+            ],
+            "text": "Flare Snare",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "zGer5xkNU9yT73TU",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "Yew9oddFsH0KeDLh",
+            "drawn": false,
+            "img": "icons/commodities/treasure/dreamcatcher-brown.webp",
+            "range": [
+                133,
+                138
+            ],
+            "text": "Hunter's Bane",
             "type": "pack",
             "weight": 6
         }

--- a/packs/rollable-tables/2nd-level-permanent-items.json
+++ b/packs/rollable-tables/2nd-level-permanent-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "q6hhGYSee35XxKE8",
-    "description": "Table of 2nd-Level Permanent Items",
+    "description": "<p>Table of 2nd-Level Permanent Items</p>",
     "displayRoll": true,
-    "formula": "1d84",
+    "formula": "1d69",
     "img": "icons/svg/d20-grey.svg",
     "name": "2nd-Level Permanent Items",
     "ownership": {
@@ -11,106 +11,106 @@
     "replacement": true,
     "results": [
         {
-            "_id": "13Z9EWcg0MsQhYSz",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Gq1cZWSKOtJhKd2p",
-            "drawn": false,
-            "img": "icons/equipment/chest/breastplate-layered-steel-green.webp",
-            "range": [
-                1,
-                6
-            ],
-            "text": "Full Plate",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "1ESrHF6Bvt64l0fb",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "BANLXq8FhwqsDu0v",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/held-items/wondrous-figurine-onyx-dog.webp",
-            "range": [
-                7,
-                12
-            ],
-            "text": "Wondrous Figurine (Onyx Dog)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "0UcentA4SnvAdeYa",
+            "_id": "wkgIIuIjEnAIsewu",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "DKWuJb2rSgiotOG7",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/fundamental-weapon-runes/weapon-potency.webp",
             "range": [
-                13,
-                18
+                1,
+                6
             ],
             "text": "Weapon Potency (+1)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "CLlpQHOCpeoa9inB",
+            "_id": "gzaOS3IuX4v6AEAq",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "ckUxr51wJVGRNAD0",
+            "documentId": "JBRjwH8gJeXtxSYF",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/cold-Iron-buckler.webp",
             "range": [
-                19,
-                24
+                7,
+                12
             ],
             "text": "Cold Iron Buckler (Low-Grade)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "UJFA5IViCsWIsu15",
+            "_id": "lycoyTxIqfiwCJri",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "5E6l3RheSyl99G3m",
+            "documentId": "WzZovtHSVjFJw9PI",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/cold-Iron-shield.webp",
             "range": [
-                25,
-                30
+                13,
+                18
             ],
             "text": "Cold Iron Shield (Low-Grade)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "GwfQLclrSEBfXu3n",
+            "_id": "yvNCauUKnfq8Y08d",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "aA9clnIP3deHNNjo",
+            "documentId": "qYGtQGYj1SfBuvYT",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/silver-buckler.webp",
             "range": [
-                31,
-                36
+                19,
+                24
             ],
             "text": "Silver Buckler (Low-Grade)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "pWUGDsbp9Z1wHnRf",
+            "_id": "P17v6yUF7oD5VoNY",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "1xUIdz23mIlYWGPL",
+            "documentId": "csT3nokH8Unxal1D",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/silver-shield.webp",
             "range": [
-                37,
-                42
+                25,
+                30
             ],
             "text": "Silver Shield (Low-Grade)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "WNEoZZAhyNxwdPv4",
-            "documentCollection": "",
+            "_id": "65Xqzr2hrXLFbhIE",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
+            "drawn": false,
+            "img": "icons/svg/d20-black.svg",
+            "range": [
+                31,
+                36
+            ],
+            "text": "Weapon (+1)",
+            "type": "text",
+            "weight": 6
+        },
+        {
+            "_id": "tA4zLpBYkjXJ5JLg",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
+            "drawn": false,
+            "img": "icons/svg/d20-black.svg",
+            "range": [
+                37,
+                42
+            ],
+            "text": "Cold Iron Weapon (Low-Grade)",
+            "type": "text",
+            "weight": 6
+        },
+        {
+            "_id": "szMyP7nORa1T2Dl7",
+            "documentCollection": "pf2e.equipment-srd",
             "documentId": null,
             "drawn": false,
             "img": "icons/svg/d20-black.svg",
@@ -118,107 +118,65 @@
                 43,
                 48
             ],
-            "text": "Weapon (+1)",
+            "text": "Silver Weapon (Low-Grade)",
             "type": "text",
             "weight": 6
         },
         {
-            "_id": "QPOhnkaFt7vzO40A",
-            "documentCollection": "",
-            "documentId": null,
+            "_id": "w0l4jWJMPaSJPKdx",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "FNDq4NFSN0g2HKWO",
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "icons/equipment/hand/gauntlet-simple-leather-brown-gold.webp",
             "range": [
                 49,
                 54
             ],
-            "text": "Cold iron weapon (low-grade)",
-            "type": "text",
+            "text": "Handwraps of Mighty Blows",
+            "type": "pack",
             "weight": 6
         },
         {
-            "_id": "FYAlctVCWqu6uA6h",
-            "documentCollection": "",
-            "documentId": null,
+            "_id": "fsWllAa607jcTJhP",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "fvpLYx1Lo42cdleQ",
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "icons/equipment/neck/handkerchief-bandana-blue.webp",
             "range": [
                 55,
                 60
             ],
-            "text": "Silver weapon (low-grade)",
-            "type": "text",
-            "weight": 6
-        },
-        {
-            "_id": "ryIVsSv5OqeY7ERo",
-            "documentCollection": "",
-            "documentId": null,
-            "drawn": false,
-            "img": "icons/svg/d20-black.svg",
-            "range": [
-                61,
-                66
-            ],
-            "text": "+1 Handwraps of Mighty Blows",
-            "type": "text",
-            "weight": 6
-        },
-        {
-            "_id": "KauQSOfz3WtBhWpd",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "TmQalYKNNRuEdoTh",
-            "drawn": false,
-            "img": "icons/equipment/neck/amulet-round-engraved-gold.webp",
-            "range": [
-                67,
-                69
-            ],
-            "text": "Brooch of Shielding",
-            "type": "pack",
-            "weight": 3
-        },
-        {
-            "_id": "9vx22NLpFZWfL2jo",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "r1hgg2rweqGL1LBl",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/hand-of-the-mage.webp",
-            "range": [
-                70,
-                75
-            ],
-            "text": "Hand of the Mage",
+            "text": "Masquerade Scarf",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "C00C1aH1hV31Y2BQ",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "fvpLYx1Lo42cdleQ",
-            "drawn": false,
-            "img": "icons/equipment/head/hat-belted-grey.webp",
-            "range": [
-                76,
-                81
-            ],
-            "text": "Hat of Disguise",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "6AdAVQweXlduaC9V",
+            "_id": "KwzP857WsAKXHVZL",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "gbwr57aT9ou8yKWT",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/wayfinder.webp",
             "range": [
-                82,
-                84
+                61,
+                63
             ],
             "text": "Wayfinder",
             "type": "pack",
             "weight": 3
+        },
+        {
+            "_id": "yknWC0Wgc2pzDo1P",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "IxuDS3POB6EH8TVN",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/shields/specific-shields/glamorous-buckler.webp",
+            "range": [
+                64,
+                69
+            ],
+            "text": "Glamorous Buckler",
+            "type": "pack",
+            "weight": 6
         }
     ]
 }


### PR DESCRIPTION
Update 2nd-Level Consumable Items and 2nd-Level Permanent Items tables with remaster changes, consolidating the treasure tables from the GM Core and Player Core 2 books, preserving the item order found in those tables. Weight is based on rarity:

* Common = 6
* Uncommon = 3
* Rare = 1