### PR TITLE
Predicate Unleash Psyche's bonus on `psi-cantrip` tag

### DIFF
--- a/packs/feat-effects/effect-unleash-psyche.json
+++ b/packs/feat-effects/effect-unleash-psyche.json
@@ -27,20 +27,11 @@
                     "unleash-psyche-damage",
                     "item:duration:0",
                     "damaging-effect",
+                    "spellcasting:tradition:occult",
                     {
                         "or": [
-                            {
-                                "and": [
-                                    "item:trait:cantrip",
-                                    "item:trait:psychic"
-                                ]
-                            },
-                            {
-                                "and": [
-                                    "spellcasting:category:spontaneous",
-                                    "spellcasting:tradition:occult"
-                                ]
-                            }
+                            "item:tag:psi-cantrip",
+                            "spellcasting:category:spontaneous"
                         ]
                     }
                 ],


### PR DESCRIPTION
Rather than cantrips with the psychic trait, which missed non-psychic-exclusive cantrips like Telekinetic Projectile
Closes #17203