### PR TITLE
Update conscious mind Damage Dice overrides to Damage Alteration

### DIFF
--- a/packs/classfeatures/barrows-edge.json
+++ b/packs/classfeatures/barrows-edge.json
@@ -78,7 +78,6 @@
                         "item:melee",
                         {
                             "not": "item:trait:consumable"
-                            
                         },
                         {
                             "or": [

--- a/packs/classfeatures/the-distant-grasp.json
+++ b/packs/classfeatures/the-distant-grasp.json
@@ -11,7 +11,7 @@
         },
         "category": "classfeature",
         "description": {
-            "value": "<p>Motion characterizes the physical-a boulder falls, creatures move, the world turns. You believe the truest form of mind over matter is therefore to move things as well, wielding telekinesis as an arm that can grasp the furthest and finest of objects.</p>\n<p><strong>Granted Spells</strong></p>\n<ul>\n<li>1st: @UUID[Compendium.pf2e.spells-srd.Item.Kinetic Ram]</li>\n<li>2nd: @UUID[Compendium.pf2e.spells-srd.Item.Telekinetic Maneuver]</li>\n<li>3rd: @UUID[Compendium.pf2e.spells-srd.Item.Levitate]</li>\n<li>4th: @UUID[Compendium.pf2e.spells-srd.Item.Fly]</li>\n<li>5th: @UUID[Compendium.pf2e.spells-srd.Item.Telekinetic Haul]</li>\n<li>6th: @UUID[Compendium.pf2e.spells-srd.Item.Poltergeist's Fury]</li>\n<li>7th: @UUID[Compendium.pf2e.spells-srd.Item.Telekinetic Bombardment]</li>\n<li>8th: @UUID[Compendium.pf2e.spells-srd.Item.Falling Sky]</li>\n<li>9th: @UUID[Compendium.pf2e.spells-srd.Item.Implosion]</li>\n</ul>\n<hr />\n<p><strong>Standard Psi Cantrips</strong></p>\n<p>@UUID[Compendium.pf2e.spells-srd.Item.Telekinetic Hand]</p>\n<p>Your mage hand can carry up to 1 Bulk instead of only light Bulk. If the spell is heightened to 3rd level or higher, its maximum Bulk is 2. If the spell is heightened to 7th level or higher, its maximum Bulk is 3. It also gains the following amp.</p>\n<p><strong>Amp</strong> You create a multitude of telekinetic hands that grip onto a creature and move it about. Target a creature of Medium size or smaller with the amped spell instead of an object. You attempt to @UUID[Compendium.pf2e.actionspf2e.Item.Shove] the target in a direction of your choice, rolling a spell attack roll against its Fortitude DC instead of an Athletics check. The creature takes a –10-foot circumstance penalty to its Speeds until the spell ends. Starting the round after you Cast the Spell, the first time each round you Sustain the Spell, you can attempt to Shove the creature again.</p>\n<p><strong>Amp Heightened (4th)</strong> You can attempt to @UUID[Compendium.pf2e.actionspf2e.Item.Disarm] the creature instead of attempting to Shove it. If you knock an item out of the creature's grasp in this way, the mage hand immediately grabs it. Any effect of the mage hand on the creature ends, and the spell now carries the item, just like you had picked it up with an unamped mage hand.</p>\n<p>@UUID[Compendium.pf2e.spells-srd.Item.Telekinetic Projectile]</p>\n<p>Your telekinetic projectiles can fly much further away. Increase the range of telekinetic projectile to 60 feet. It also gains the following amp.</p>\n<p><strong>Amp</strong> You fling objects with even more force, driving your opponents backwards in a hail of objects. On a success, you push the target 5 feet away from you, and on a critical success, you push the target 10 feet away from you in addition to dealing double damage.</p>\n<p><strong>Amp Heightened (+1)</strong> The damage increases by 2d6 instead of by 1d6.</p>\n<hr />\n<p><strong>Unique Psi Cantrips</strong></p>\n<p>surface: @UUID[Compendium.pf2e.spells-srd.Item.Telekinetic Rend]</p>\n<p><strong>Amp</strong> Your thoughts expand in scope and power. The bursts deal @Damage[1d6[bludgeoning]] damage and @Damage[1d6[slashing]] damage, instead of the usual damage. A creature that critically fails its save is also @UUID[Compendium.pf2e.conditionitems.Item.Stunned]{Stunned 1}.</p>\n<p><strong>Amp Heightened (+2)</strong> Both types of damage increase by 1d6 instead of just one. Add a third non-overlapping @Template[burst|distance:5] to the area.</p>\n<p>deeper: @UUID[Compendium.pf2e.spells-srd.Item.Vector Screen]</p>\n<p><em><strong>Amp</strong> Your screen persists for longer, and you can detonate it in an explosive counterattack. The duration of the spell increases to 1 minute. You can Dismiss the spell. If there are any projectiles trapped in the screen, you can cast telekinetic projectile to fire them at one creature as part of Dismissing the spell. Measure the range for the telekinetic projectile from where the vector screen was, instead of from you.</em></p>\n<p>deepest: @UUID[Compendium.pf2e.spells-srd.Item.Dancing Blade]</p>\n<p><strong>Amp</strong> The weapon's attacks increase in strength, and your control is fine enough for advanced technique. The damage dice for the weapon's Strike change from d6s to d10s. When you Cast or Sustain the spell, you can choose from the following options in addition to the standard ones.</p>\n<ul>\n<li><strong>Guard</strong> Rather than attacking, the weapon grants a +2 circumstance bonus to AC against melee attacks to the creature it's following. The bonus lasts until the start of your next turn or until the weapon Changes Partners, whichever comes first.</li>\n<li><strong>Push (attack)</strong> The weapon attempts to @UUID[Compendium.pf2e.bestiary-ability-glossary-srd.Item.Push] its target, using your spell attack roll instead of an Athletics check to determine the results of the Push.</li>\n</ul>"
+            "value": "<p>Motion characterizes the physical-a boulder falls, creatures move, the world turns. You believe the truest form of mind over matter is therefore to move things as well, wielding telekinesis as an arm that can grasp the furthest and finest of objects.</p>\n<p><strong>Granted Spells</strong></p><ul><li>1st: @UUID[Compendium.pf2e.spells-srd.Item.Kinetic Ram]</li><li>2nd: @UUID[Compendium.pf2e.spells-srd.Item.Telekinetic Maneuver]</li><li>3rd: @UUID[Compendium.pf2e.spells-srd.Item.Levitate]</li><li>4th: @UUID[Compendium.pf2e.spells-srd.Item.Fly]</li><li>5th: @UUID[Compendium.pf2e.spells-srd.Item.Telekinetic Haul]</li><li>6th: @UUID[Compendium.pf2e.spells-srd.Item.Poltergeist's Fury]</li><li>7th: @UUID[Compendium.pf2e.spells-srd.Item.Telekinetic Bombardment]</li><li>8th: @UUID[Compendium.pf2e.spells-srd.Item.Falling Sky]</li><li>9th: @UUID[Compendium.pf2e.spells-srd.Item.Implosion]</li></ul><hr /><p><strong>Standard Psi Cantrips</strong></p>\n<p>@UUID[Compendium.pf2e.spells-srd.Item.Telekinetic Hand]</p>\n<p>Your mage hand can carry up to 1 Bulk instead of only light Bulk. If the spell is heightened to 3rd level or higher, its maximum Bulk is 2. If the spell is heightened to 7th level or higher, its maximum Bulk is 3. It also gains the following amp.</p>\n<p><strong>Amp</strong> You create a multitude of telekinetic hands that grip onto a creature and move it about. Target a creature of Medium size or smaller with the amped spell instead of an object. You attempt to @UUID[Compendium.pf2e.actionspf2e.Item.Shove] the target in a direction of your choice, rolling a spell attack roll against its Fortitude DC instead of an Athletics check. The creature takes a –10-foot circumstance penalty to its Speeds until the spell ends. Starting the round after you Cast the Spell, the first time each round you Sustain the Spell, you can attempt to Shove the creature again.</p>\n<p><strong>Amp Heightened (4th)</strong> You can attempt to @UUID[Compendium.pf2e.actionspf2e.Item.Disarm] the creature instead of attempting to Shove it. If you knock an item out of the creature's grasp in this way, the mage hand immediately grabs it. Any effect of the mage hand on the creature ends, and the spell now carries the item, just like you had picked it up with an unamped mage hand.</p>\n<p>@UUID[Compendium.pf2e.spells-srd.Item.Telekinetic Projectile]</p>\n<p>Your telekinetic projectiles can fly much further away. Increase the range of telekinetic projectile to 60 feet. It also gains the following amp.</p>\n<p><strong>Amp</strong> You fling objects with even more force, driving your opponents backwards in a hail of objects. On a success, you push the target 5 feet away from you, and on a critical success, you push the target 10 feet away from you in addition to dealing double damage.</p>\n<p><strong>Amp Heightened (+1)</strong> The damage increases by 2d6 instead of by 1d6.</p><hr /><p><strong>Unique Psi Cantrips</strong></p>\n<p>surface: @UUID[Compendium.pf2e.spells-srd.Item.Telekinetic Rend]</p>\n<p><strong>Amp</strong> Your thoughts expand in scope and power. The bursts deal 1d6 bludgeoning damage and 1d6 slashing damage, instead of the usual damage. A creature that critically fails its save is also @UUID[Compendium.pf2e.conditionitems.Item.Stunned]{Stunned 1}.</p>\n<p><strong>Amp Heightened (+2)</strong> Both types of damage increase by 1d6 instead of just one. Add a third non-overlapping @Template[burst|distance:5] to the area.</p>\n<p>deeper: @UUID[Compendium.pf2e.spells-srd.Item.Vector Screen]</p>\n<p><em><strong>Amp</strong> Your screen persists for longer, and you can detonate it in an explosive counterattack. The duration of the spell increases to 1 minute. You can Dismiss the spell. If there are any projectiles trapped in the screen, you can cast telekinetic projectile to fire them at one creature as part of Dismissing the spell. Measure the range for the telekinetic projectile from where the vector screen was, instead of from you.</em></p>\n<p>deepest: @UUID[Compendium.pf2e.spells-srd.Item.Dancing Blade]</p>\n<p><strong>Amp</strong> The weapon's attacks increase in strength, and your control is fine enough for advanced technique. The damage dice for the weapon's Strike change from d6s to d10s. When you Cast or Sustain the spell, you can choose from the following options in addition to the standard ones.</p><ul><li><strong>Guard</strong> Rather than attacking, the weapon grants a +2 circumstance bonus to AC against melee attacks to the creature it's following. The bonus lasts until the start of your next turn or until the weapon Changes Partners, whichever comes first.</li><li><strong>Push (attack)</strong> The weapon attempts to @UUID[Compendium.pf2e.bestiary-ability-glossary-srd.Item.Push] its target, using your spell attack roll instead of an Athletics check to determine the results of the Push.</li></ul>"
         },
         "level": {
             "value": 1
@@ -191,6 +191,7 @@
             {
                 "diceNumber": "@spell.rank - 1",
                 "dieSize": "d6",
+                "hideIfDisabled": true,
                 "key": "DamageDice",
                 "predicate": [
                     "item:tag:amped",
@@ -206,6 +207,7 @@
                 "damageType": "bludgeoning",
                 "diceNumber": "ceil(@spell.rank/2)",
                 "dieSize": "d6",
+                "hideIfDisabled": true,
                 "key": "DamageDice",
                 "predicate": [
                     "item:tag:amped",
@@ -221,6 +223,7 @@
                 "damageType": "slashing",
                 "diceNumber": "ceil(@spell.rank/2)",
                 "dieSize": "d6",
+                "hideIfDisabled": true,
                 "key": "DamageDice",
                 "predicate": [
                     "item:tag:amped",
@@ -233,18 +236,20 @@
                 "selector": "spell-damage"
             },
             {
-                "key": "DamageDice",
-                "override": {
-                    "dieSize": "d10"
-                },
+                "key": "DamageAlteration",
+                "mode": "upgrade",
                 "predicate": [
+                    "item:slug:dancing-blade",
                     "item:tag:amped",
                     {
                         "not": "alternate-amp"
-                    },
-                    "item:slug:dancing-blade"
+                    }
                 ],
-                "selector": "spell-damage"
+                "property": "dice-faces",
+                "selectors": [
+                    "spell-damage"
+                ],
+                "value": 10
             },
             {
                 "key": "ActiveEffectLike",

--- a/packs/classfeatures/the-oscillating-wave.json
+++ b/packs/classfeatures/the-oscillating-wave.json
@@ -189,12 +189,8 @@
                 "value": 10
             },
             {
-                "hideIfDisabled": true,
-                "key": "DamageDice",
-                "override": {
-                    "diceNumber": "@spell.rank",
-                    "dieSize": "d10"
-                },
+                "key": "DamageAlteration",
+                "mode": "upgrade",
                 "predicate": [
                     "item:slug:ignition",
                     "item:tag:amped",
@@ -205,27 +201,32 @@
                         "not": "item:melee"
                     }
                 ],
-                "selector": "spell-damage"
+                "property": "dice-faces",
+                "selectors": [
+                    "spell-damage"
+                ],
+                "value": 10
             },
             {
-                "hideIfDisabled": true,
-                "key": "DamageDice",
-                "override": {
-                    "diceNumber": "@spell.rank",
-                    "dieSize": "d12"
-                },
+                "key": "DamageAlteration",
+                "mode": "upgrade",
                 "predicate": [
-                    "item:melee",
                     "item:slug:ignition",
                     "item:tag:amped",
+                    "item:melee",
                     {
                         "not": "alternate-amp"
                     }
                 ],
-                "selector": "spell-damage"
+                "property": "dice-faces",
+                "selectors": [
+                    "spell-damage"
+                ],
+                "value": 12
             },
             {
                 "damageCategory": "splash",
+                "hideIfDisabled": true,
                 "key": "FlatModifier",
                 "predicate": [
                     "item:slug:ignition",
@@ -252,12 +253,8 @@
                 "selector": "spell-damage"
             },
             {
-                "hideIfDisabled": true,
-                "key": "DamageDice",
-                "override": {
-                    "diceNumber": "max(6,2*@spell.rank - 4)",
-                    "dieSize": "d6"
-                },
+                "key": "DamageAlteration",
+                "mode": "upgrade",
                 "predicate": [
                     "item:slug:redistribute-potential",
                     "item:tag:amped",
@@ -265,7 +262,27 @@
                         "not": "alternate-amp"
                     }
                 ],
-                "selector": "spell-damage"
+                "property": "dice-number",
+                "selectors": [
+                    "spell-damage"
+                ],
+                "value": "max(6,2*@spell.rank - 4)"
+            },
+            {
+                "key": "DamageAlteration",
+                "mode": "upgrade",
+                "predicate": [
+                    "item:slug:redistribute-potential",
+                    "item:tag:amped",
+                    {
+                        "not": "alternate-amp"
+                    }
+                ],
+                "property": "dice-faces",
+                "selectors": [
+                    "spell-damage"
+                ],
+                "value": 6
             },
             {
                 "alwaysActive": true,
@@ -289,11 +306,8 @@
                 "toggleable": true
             },
             {
-                "hideIfDisabled": true,
-                "key": "DamageDice",
-                "override": {
-                    "damageType": "{item|flags.pf2e.rulesSelections.conservationOfEnergy}"
-                },
+                "key": "DamageAlteration",
+                "mode": "override",
                 "predicate": [
                     {
                         "or": [
@@ -308,9 +322,14 @@
                             "item:slug:ignition",
                             "item:slug:polar-ray"
                         ]
-                    }
+                    },
+                    "dice:slug:base"
                 ],
-                "selector": "spell-damage"
+                "property": "damage-type",
+                "selectors": [
+                    "spell-damage"
+                ],
+                "value": "{item|flags.pf2e.rulesSelections.conservationOfEnergy}"
             },
             {
                 "key": "RollOption",

--- a/packs/classfeatures/the-silent-whisper.json
+++ b/packs/classfeatures/the-silent-whisper.json
@@ -184,21 +184,13 @@
                 "key": "DamageAlteration",
                 "mode": "upgrade",
                 "predicate": [
-                    "item:slug:daze",
-                    "item:tag:amped"
-                ],
-                "property": "dice-faces",
-                "selectors": [
-                    "spell-damage"
-                ],
-                "value": 10
-            },
-            {
-                "key": "DamageAlteration",
-                "mode": "upgrade",
-                "predicate": [
-                    "item:slug:shatter-mind",
-                    "item:tag:amped"
+                    "item:tag:amped",
+                    {
+                        "or": [
+                            "item:slug:daze",
+                            "item:slug:shatter-mind"
+                        ]
+                    }
                 ],
                 "property": "dice-faces",
                 "selectors": [

--- a/packs/classfeatures/the-silent-whisper.json
+++ b/packs/classfeatures/the-silent-whisper.json
@@ -168,27 +168,43 @@
                 ]
             },
             {
-                "key": "DamageDice",
-                "override": {
-                    "diceNumber": "2 * ceil(@spell.rank / 2) - 1",
-                    "dieSize": "d10"
-                },
+                "key": "DamageAlteration",
+                "mode": "upgrade",
                 "predicate": [
                     "item:slug:daze",
                     "item:tag:amped"
                 ],
-                "selector": "spell-damage"
+                "property": "dice-number",
+                "selectors": [
+                    "spell-damage"
+                ],
+                "value": "2 * ceil(@spell.rank / 2) - 1"
             },
             {
-                "key": "DamageDice",
-                "override": {
-                    "dieSize": "d10"
-                },
+                "key": "DamageAlteration",
+                "mode": "upgrade",
+                "predicate": [
+                    "item:slug:daze",
+                    "item:tag:amped"
+                ],
+                "property": "dice-faces",
+                "selectors": [
+                    "spell-damage"
+                ],
+                "value": 10
+            },
+            {
+                "key": "DamageAlteration",
+                "mode": "upgrade",
                 "predicate": [
                     "item:slug:shatter-mind",
                     "item:tag:amped"
                 ],
-                "selector": "spell-damage"
+                "property": "dice-faces",
+                "selectors": [
+                    "spell-damage"
+                ],
+                "value": 10
             },
             {
                 "key": "ActiveEffectLike",

--- a/packs/classfeatures/the-tangible-dream.json
+++ b/packs/classfeatures/the-tangible-dream.json
@@ -175,6 +175,7 @@
             {
                 "diceNumber": "@spell.rank - 1",
                 "dieSize": "d8",
+                "hideIfDisabled": true,
                 "key": "DamageDice",
                 "predicate": [
                     "item:tag:amped",

--- a/packs/classfeatures/the-unbound-step.json
+++ b/packs/classfeatures/the-unbound-step.json
@@ -183,6 +183,7 @@
             {
                 "diceNumber": "@spell.rank - 1",
                 "dieSize": "d4",
+                "hideIfDisabled": true,
                 "key": "DamageDice",
                 "predicate": [
                     "item:tag:amped",


### PR DESCRIPTION
and add `hideIfDisabled` to DamageDice rule elements to clean up the dialog