### PR TITLE
Update 2nd-level rollable tables

### DIFF
--- a/packs/rollable-tables/2nd-level-consumables.json
+++ b/packs/rollable-tables/2nd-level-consumables.json
@@ -1,8 +1,8 @@
 {
     "_id": "g30jZWCJEiK1RlIa",
-    "description": "Table of 2nd-Level Consumables",
+    "description": "<p>Table of 2nd-Level Consumables</p>",
     "displayRoll": true,
-    "formula": "1d123",
+    "formula": "1d138",
     "img": "icons/svg/d20-grey.svg",
     "name": "2nd-Level Consumables",
     "ownership": {
@@ -11,296 +11,338 @@
     "replacement": true,
     "results": [
         {
-            "_id": "ry32tNrAMQmP8SWu",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "cwurQLvQaqjK70UI",
-            "drawn": false,
-            "img": "icons/commodities/materials/feather-blue.webp",
-            "range": [
-                1,
-                6
-            ],
-            "text": "Feather Token (Holly Bush)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "tD9DOUrhusTOo6ym",
+            "_id": "lc7aACVQBmkrU68m",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "zM9VX3QwM81DzDUA",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/bravos-brew.webp",
             "range": [
-                7,
-                12
+                1,
+                6
             ],
             "text": "Bravo's Brew (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "vfRkWUwvvKhVmmVt",
+            "_id": "Qh3nBGr3L0stQc1e",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "bQPRKEpnLakJBAAh",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/cats-eye-elixir.webp",
             "range": [
-                13,
-                18
+                7,
+                12
             ],
             "text": "Cat's Eye Elixir",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "u5S7bpxsQtmZw1ah",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "3Klm2gPmzOw6ntVb",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/comprehension-elixir.webp",
-            "range": [
-                19,
-                24
-            ],
-            "text": "Comprehension Elixir (Lesser)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "BQwlRvlpARru285I",
+            "_id": "UnVA2mUrxNUCvO0Y",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "88pGCHV0uKMskTVO",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/darkvision-elixir.webp",
             "range": [
-                25,
-                30
+                13,
+                18
             ],
             "text": "Darkvision Elixir (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "3xDD3sHjTohsIvaL",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "cuomhpenkqGM5lLG",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/infiltrators-elixir.webp",
-            "range": [
-                31,
-                36
-            ],
-            "text": "Infiltrator's Elixir",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "SL183TkVMQkmUDv4",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "FL8QU8TcNauBMMhD",
-            "drawn": false,
-            "img": "icons/commodities/materials/bowl-liquid-white.webp",
-            "range": [
-                37,
-                42
-            ],
-            "text": "Belladonna",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "T2kXzz5x5FFl8qcB",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "ScclzFrjyB0YJlrb",
-            "drawn": false,
-            "img": "icons/consumables/potions/bottle-conical-corked-green.webp",
-            "range": [
-                43,
-                48
-            ],
-            "text": "Black Adder Venom",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "QNtUu0hwf189Evrf",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "zo0ophqfKunJFxZN",
-            "drawn": false,
-            "img": "icons/commodities/materials/liquid-orange.webp",
-            "range": [
-                49,
-                51
-            ],
-            "text": "Lethargy Poison",
-            "type": "pack",
-            "weight": 3
-        },
-        {
-            "_id": "pJU1w1RQgdmtxEnT",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "nXStoLxPrrP2b6WB",
-            "drawn": false,
-            "img": "icons/equipment/neck/necklace-hook-brown.webp",
-            "range": [
-                52,
-                57
-            ],
-            "text": "Bronze Bull Pendant",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "klapdf6bAB73uws4",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "HHELOoN5GVonUiIa",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/talismans/crying-angel-pendant.webp",
-            "range": [
-                58,
-                63
-            ],
-            "text": "Crying Angel Pendant",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "nuT1akfE0ijxOkDn",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "VPvyyQXjn2HBjnTS",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/talismans/effervescent-ampoule.webp",
-            "range": [
-                64,
-                69
-            ],
-            "text": "Effervescent Ampoule",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "zDvdnusRvAVqTeHa",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Yew9oddFsH0KeDLh",
-            "drawn": false,
-            "img": "icons/commodities/treasure/dreamcatcher-brown.webp",
-            "range": [
-                70,
-                75
-            ],
-            "text": "Hunter's Bane",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "FuHGz2bpefNLxkjf",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "2MgFoNXTccL8Own9",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/talismans/jade-cat.webp",
-            "range": [
-                76,
-                81
-            ],
-            "text": "Jade Cat",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "auXfWiEC0BmCB2mZ",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "aKbrBW1SnFDxya5J",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/talismans/mesmerizing-opal.webp",
-            "range": [
-                82,
-                87
-            ],
-            "text": "Mesmerizing Opal",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "Xm7lfo3yQp94m7so",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "jdDDqv9LbEYX2wAE",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/talismans/monkey-pin.webp",
-            "range": [
-                88,
-                93
-            ],
-            "text": "Monkey Pin",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "RvapRvAQnCogA41x",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "0aSdDSjJ5sMzBz1U",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/talismans/onyx-panther.webp",
-            "range": [
-                94,
-                99
-            ],
-            "text": "Onyx Panther",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "GSPrbuknylF9lRBK",
+            "_id": "9pAqszqWVddwvNb5",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "j2CHumvbjmlLQX2i",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/oils/oil-of-potency.webp",
             "range": [
-                100,
-                105
+                19,
+                24
             ],
             "text": "Oil of Potency",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "Tl8Jye1UgRHFSr6T",
+            "_id": "s5kVziRqkODdkz5Q",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "6DmHDtIsGzH1s5JO",
             "drawn": false,
             "img": "icons/tools/laboratory/bowl-mixing.webp",
             "range": [
-                106,
-                111
+                25,
+                30
             ],
             "text": "Oil of Weightlessness",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "EcjzWnUXW49rqBry",
+            "_id": "5Gh5cYpzG0va4PwL",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "qeTWg0TWw9CwMKCO",
+            "documentId": "ScclzFrjyB0YJlrb",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/talismans/savior-spike.webp",
+            "img": "icons/consumables/potions/bottle-conical-corked-green.webp",
             "range": [
-                112,
-                117
+                31,
+                36
             ],
-            "text": "Savior Spike",
+            "text": "Black Adder Venom",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "zCq4yiUgqcecAgCY",
+            "_id": "HTbcgU46EURUeIGJ",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "zo0ophqfKunJFxZN",
+            "drawn": false,
+            "img": "icons/commodities/materials/liquid-orange.webp",
+            "range": [
+                37,
+                39
+            ],
+            "text": "Lethargy Poison",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "K0TR1MX5nqvPcUsh",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "nXStoLxPrrP2b6WB",
+            "drawn": false,
+            "img": "icons/equipment/neck/necklace-hook-brown.webp",
+            "range": [
+                40,
+                45
+            ],
+            "text": "Bronze Bull Pendant",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "eL1zq3JJ6cZv1JUP",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "HHELOoN5GVonUiIa",
+            "drawn": false,
+            "img": "icons/commodities/treasure/trinket-wing-white.webp",
+            "range": [
+                46,
+                51
+            ],
+            "text": "Crying Angel Pendant",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "qntUreccNvz1QVTt",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "VPvyyQXjn2HBjnTS",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/effervescent-ampoule.webp",
+            "range": [
+                52,
+                57
+            ],
+            "text": "Effervescent Ampoule",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "XGfFvBq21RZdcYE8",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "2MgFoNXTccL8Own9",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/jade-cat.webp",
+            "range": [
+                58,
+                63
+            ],
+            "text": "Jade Cat",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "ZelSO95kKhk18kCA",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "aKbrBW1SnFDxya5J",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/mesmerizing-opal.webp",
+            "range": [
+                64,
+                69
+            ],
+            "text": "Mesmerizing Opal",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "eHSaj9yY7iaAA04c",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "jdDDqv9LbEYX2wAE",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/monkey-pin.webp",
+            "range": [
+                70,
+                75
+            ],
+            "text": "Monkey Pin",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "hpmJGvucSklY1WuU",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "0aSdDSjJ5sMzBz1U",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/onyx-panther.webp",
+            "range": [
+                76,
+                81
+            ],
+            "text": "Onyx Panther",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "yxxgOz1zAqfwg8uD",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "0aSdDSjJ5sMzBz1U",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/onyx-panther.webp",
+            "range": [
+                82,
+                87
+            ],
+            "text": "Onyx Panther",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "lduH2M9r782znUn5",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "8fbsKEEbZ0CfBMIr",
             "drawn": false,
             "img": "icons/consumables/drinks/alcohol-spirits-bottle-blue.webp",
             "range": [
+                88,
+                93
+            ],
+            "text": "Silver Salve",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "d04MhIz3J2IsS4FZ",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "NSQOijKqomyotXkj",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/ammunition/antler-arrow.webp",
+            "range": [
+                94,
+                99
+            ],
+            "text": "Antler Arrow",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "MBs8CB1IrZHng6TD",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "e2II4yMBFBqVivnk",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/focus-cathartic.webp",
+            "range": [
+                100,
+                105
+            ],
+            "text": "Bottled Catharsis (Minor)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "I8fRC0mXSjvImYfD",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "3Klm2gPmzOw6ntVb",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/comprehension-elixir.webp",
+            "range": [
+                106,
+                111
+            ],
+            "text": "Comprehension Elixir (Lesser)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "gTXmm2fj6yLSKOTp",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "yE7PPagK0wsHMA8l",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/sinew-shock-serum.webp",
+            "range": [
+                112,
+                117
+            ],
+            "text": "Surging Serum (Minor)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "T5qSVFysJIT0Vfze",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "FL8QU8TcNauBMMhD",
+            "drawn": false,
+            "img": "icons/commodities/materials/bowl-liquid-white.webp",
+            "range": [
                 118,
                 123
             ],
-            "text": "Silver Salve",
+            "text": "Belladonna",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "6n7glL0NbSAmWliF",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "craWRj7jI2mLs1Ok",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/snares/deadweight-snare.webp",
+            "range": [
+                124,
+                126
+            ],
+            "text": "Deadweight Snare",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "p5QL5e6jcrjRtaqA",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "riLNCaVS9zGvt4Nn",
+            "drawn": false,
+            "img": "icons/skills/ranged/cannon-barrel-firing-yellow.webp",
+            "range": [
+                127,
+                132
+            ],
+            "text": "Flare Snare",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "1ZpSll8c095Jks51",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "Yew9oddFsH0KeDLh",
+            "drawn": false,
+            "img": "icons/commodities/treasure/dreamcatcher-brown.webp",
+            "range": [
+                133,
+                138
+            ],
+            "text": "Hunter's Bane",
             "type": "pack",
             "weight": 6
         }

--- a/packs/rollable-tables/2nd-level-permanent-items.json
+++ b/packs/rollable-tables/2nd-level-permanent-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "q6hhGYSee35XxKE8",
-    "description": "Table of 2nd-Level Permanent Items",
+    "description": "<p>Table of 2nd-Level Permanent Items</p>",
     "displayRoll": true,
-    "formula": "1d84",
+    "formula": "1d69",
     "img": "icons/svg/d20-grey.svg",
     "name": "2nd-Level Permanent Items",
     "ownership": {
@@ -11,106 +11,106 @@
     "replacement": true,
     "results": [
         {
-            "_id": "13Z9EWcg0MsQhYSz",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Gq1cZWSKOtJhKd2p",
-            "drawn": false,
-            "img": "icons/equipment/chest/breastplate-layered-steel-green.webp",
-            "range": [
-                1,
-                6
-            ],
-            "text": "Full Plate",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "1ESrHF6Bvt64l0fb",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "BANLXq8FhwqsDu0v",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/held-items/wondrous-figurine-onyx-dog.webp",
-            "range": [
-                7,
-                12
-            ],
-            "text": "Wondrous Figurine (Onyx Dog)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
             "_id": "0UcentA4SnvAdeYa",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "DKWuJb2rSgiotOG7",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/fundamental-weapon-runes/weapon-potency.webp",
             "range": [
-                13,
-                18
+                1,
+                6
             ],
             "text": "Weapon Potency (+1)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "CLlpQHOCpeoa9inB",
+            "_id": "qnI5nkuGsl6Jmjjd",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "ckUxr51wJVGRNAD0",
+            "documentId": null,
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/cold-Iron-buckler.webp",
+            "range": [
+                7,
+                12
+            ],
+            "text": "Cold Iron Buckler (Low-Grade)",
+            "type": "text",
+            "weight": 6
+        },
+        {
+            "_id": "z0tdjRaeXASL4wKn",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/cold-Iron-shield.webp",
+            "range": [
+                13,
+                18
+            ],
+            "text": "Cold Iron Shield (Low-Grade)",
+            "type": "text",
+            "weight": 6
+        },
+        {
+            "_id": "JbTOP9JhTvHsBFmL",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/silver-buckler.webp",
             "range": [
                 19,
                 24
             ],
-            "text": "Cold Iron Buckler (Low-Grade)",
-            "type": "pack",
+            "text": "Silver Buckler (Low-Grade)",
+            "type": "text",
             "weight": 6
         },
         {
-            "_id": "UJFA5IViCsWIsu15",
+            "_id": "SoOChaMbrJmNWTs1",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "5E6l3RheSyl99G3m",
+            "documentId": null,
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/cold-Iron-shield.webp",
+            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/silver-shield.webp",
             "range": [
                 25,
                 30
             ],
-            "text": "Cold Iron Shield (Low-Grade)",
-            "type": "pack",
+            "text": "Silver Shield (Low-Grade)",
+            "type": "text",
             "weight": 6
         },
         {
-            "_id": "GwfQLclrSEBfXu3n",
+            "_id": "u8nS5wBuSp2s3lwm",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "aA9clnIP3deHNNjo",
+            "documentId": null,
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/silver-buckler.webp",
+            "img": "icons/svg/d20-black.svg",
             "range": [
                 31,
                 36
             ],
-            "text": "Silver Buckler (Low-Grade)",
-            "type": "pack",
+            "text": "Weapon (+1)",
+            "type": "text",
             "weight": 6
         },
         {
-            "_id": "pWUGDsbp9Z1wHnRf",
+            "_id": "laOcY47kKt4Ppnym",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "1xUIdz23mIlYWGPL",
+            "documentId": null,
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/silver-shield.webp",
+            "img": "icons/svg/d20-black.svg",
             "range": [
                 37,
                 42
             ],
-            "text": "Silver Shield (Low-Grade)",
-            "type": "pack",
+            "text": "Cold Iron Weapon (Low-Grade)",
+            "type": "text",
             "weight": 6
         },
         {
-            "_id": "WNEoZZAhyNxwdPv4",
-            "documentCollection": "",
+            "_id": "0y5jey7BczIbTeJQ",
+            "documentCollection": "pf2e.equipment-srd",
             "documentId": null,
             "drawn": false,
             "img": "icons/svg/d20-black.svg",
@@ -118,107 +118,65 @@
                 43,
                 48
             ],
-            "text": "Weapon (+1)",
+            "text": "Silver Weapon (Low-Grade)",
             "type": "text",
             "weight": 6
         },
         {
-            "_id": "QPOhnkaFt7vzO40A",
-            "documentCollection": "",
+            "_id": "1XyBjGTgUCNu0Bwc",
+            "documentCollection": "pf2e.equipment-srd",
             "documentId": null,
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "icons/equipment/hand/gauntlet-simple-leather-brown-gold.webp",
             "range": [
                 49,
                 54
             ],
-            "text": "Cold iron weapon (low-grade)",
+            "text": "Handwraps of Mighty Blows (+1)",
             "type": "text",
             "weight": 6
         },
         {
-            "_id": "FYAlctVCWqu6uA6h",
-            "documentCollection": "",
-            "documentId": null,
+            "_id": "FXUNYt42lN8TYElB",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "fvpLYx1Lo42cdleQ",
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "icons/equipment/neck/handkerchief-bandana-blue.webp",
             "range": [
                 55,
                 60
             ],
-            "text": "Silver weapon (low-grade)",
-            "type": "text",
-            "weight": 6
-        },
-        {
-            "_id": "ryIVsSv5OqeY7ERo",
-            "documentCollection": "",
-            "documentId": null,
-            "drawn": false,
-            "img": "icons/svg/d20-black.svg",
-            "range": [
-                61,
-                66
-            ],
-            "text": "+1 Handwraps of Mighty Blows",
-            "type": "text",
-            "weight": 6
-        },
-        {
-            "_id": "KauQSOfz3WtBhWpd",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "TmQalYKNNRuEdoTh",
-            "drawn": false,
-            "img": "icons/equipment/neck/amulet-round-engraved-gold.webp",
-            "range": [
-                67,
-                69
-            ],
-            "text": "Brooch of Shielding",
-            "type": "pack",
-            "weight": 3
-        },
-        {
-            "_id": "9vx22NLpFZWfL2jo",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "r1hgg2rweqGL1LBl",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/hand-of-the-mage.webp",
-            "range": [
-                70,
-                75
-            ],
-            "text": "Hand of the Mage",
+            "text": "Masquerade Scarf",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "C00C1aH1hV31Y2BQ",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "fvpLYx1Lo42cdleQ",
-            "drawn": false,
-            "img": "icons/equipment/head/hat-belted-grey.webp",
-            "range": [
-                76,
-                81
-            ],
-            "text": "Hat of Disguise",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "6AdAVQweXlduaC9V",
+            "_id": "MlJAJ3Z33wuKQPV8",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "gbwr57aT9ou8yKWT",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/wayfinder.webp",
             "range": [
-                82,
-                84
+                61,
+                63
             ],
             "text": "Wayfinder",
             "type": "pack",
             "weight": 3
+        },
+        {
+            "_id": "3cVXJkxtztoiRxEs",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "IxuDS3POB6EH8TVN",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/shields/specific-shields/glamorous-buckler.webp",
+            "range": [
+                64,
+                69
+            ],
+            "text": "Glamorous Buckler",
+            "type": "pack",
+            "weight": 6
         }
     ]
 }


### PR DESCRIPTION
Update 2nd-Level Consumable Items and 2nd-Level Permanent Items tables with remaster changes, consolidating the treasure tables from the GM Core and Player Core 2 books, preserving the item order found in those tables. Weight is based on rarity:

* Common = 6
* Uncommon = 3
* Rare = 1

For items that do not have a corresponding entry in the compendium, create a text entry in the table with the appropriate item name. If possible, set an appropriate icon from the system's icon set.