### PR TITLE
Update 3rd-level rollable tables

### DIFF
--- a/packs/rollable-tables/1st-level-consumables.json
+++ b/packs/rollable-tables/1st-level-consumables.json
@@ -1,8 +1,8 @@
 {
     "_id": "tlX5PLwar8b1tmiQ",
-    "description": "Table of 1st-Level Consumables",
+    "description": "<p>Table of 1st-Level Consumables</p>",
     "displayRoll": true,
-    "formula": "1d246",
+    "formula": "1d330",
     "img": "icons/svg/d20-grey.svg",
     "name": "1st-Level Consumables",
     "ownership": {
@@ -11,7 +11,7 @@
     "replacement": true,
     "results": [
         {
-            "_id": "lFxTQnP90fZKf3Pi",
+            "_id": "cFuhsP5dJeXhMbpc",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "NI7twU2G6UCDmvCO",
             "drawn": false,
@@ -25,7 +25,7 @@
             "weight": 6
         },
         {
-            "_id": "AD6iXxXwvR54mtKk",
+            "_id": "SwJNnQ54Q99zdxRG",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "M1k5QQc1qQLxzyCK",
             "drawn": false,
@@ -39,7 +39,7 @@
             "weight": 6
         },
         {
-            "_id": "0weTT9FVhOQNuwx2",
+            "_id": "aC5fAaMFKvqINcbw",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "yd3kEK21YknZLlcT",
             "drawn": false,
@@ -53,534 +53,730 @@
             "weight": 6
         },
         {
-            "_id": "8eRjamdCmcRyNeJv",
+            "_id": "EsO1qsPUf0CcmbqM",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "AFR01HVd7DcZvkpP",
+            "documentId": "ds0OdA989ZZw9km1",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/bottled-lightning.webp",
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/dread-ampoule.webp",
             "range": [
                 19,
                 24
             ],
-            "text": "Bottled Lightning (Lesser)",
+            "text": "Dread Ampoule (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "WzNJYRFAAMGTlrBY",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "EpxmUtLpCkE8R6KJ",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/frost-vial.webp",
-            "range": [
-                25,
-                30
-            ],
-            "text": "Frost Vial (Lesser)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "c0MFs4hFHxFBYtHL",
+            "_id": "Wl1XIIKyV0ubVvMy",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "T6Appwwl6nUl56Xj",
             "drawn": false,
             "img": "icons/containers/bags/sack-simple-leather-tan.webp",
             "range": [
-                31,
-                36
+                25,
+                30
             ],
-            "text": "Tanglefoot Bag (Lesser)",
+            "text": "Glue Bomb (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "0X1L0UZKv5ITSCZu",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Xnqglykl3Cif8rN9",
-            "drawn": false,
-            "img": "icons/commodities/gems/pearl-rough-turquoise.webp",
-            "range": [
-                37,
-                42
-            ],
-            "text": "Thunderstone (Lesser)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "XQI7NEK3aSdddawh",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "3cWko20JPnjeoofV",
-            "drawn": false,
-            "img": "icons/commodities/materials/feather-blue.webp",
-            "range": [
-                43,
-                48
-            ],
-            "text": "Feather Token (Ladder)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "YcuMCc1qjevdHTDK",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "efFe4EK7ThUrH446",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/other-consumables/holy-water.webp",
-            "range": [
-                49,
-                54
-            ],
-            "text": "Holy Water",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "n5lpwKzBBQEfk9m9",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "ev3F9qlMNlNdCOAI",
-            "drawn": false,
-            "img": "icons/commodities/treasure/token-runed-os-grey.webp",
-            "range": [
-                55,
-                60
-            ],
-            "text": "Runestone",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "9iyp0yLeptIjYutK",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "uplCUQwMwBOBHz0E",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/other-consumables/unholy-water.webp",
-            "range": [
-                61,
-                66
-            ],
-            "text": "Unholy Water",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "RJWPeE88zaQcc3de",
+            "_id": "6DovgTGfme3ZiOBU",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "ktjFOp3U0wQD9t0Z",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/antidote.webp",
             "range": [
-                67,
-                72
+                31,
+                36
             ],
             "text": "Antidote (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "wtRL7scHYl6u1saC",
+            "_id": "7q6UcgxxYbWwGZrH",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "UqinuuCWePTYGhVO",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/antiplague.webp",
             "range": [
-                73,
-                78
+                37,
+                42
             ],
             "text": "Antiplague (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "coPd26lVI1zJOPOj",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "IQK9N2mEOyAj3iWU",
-            "drawn": false,
-            "img": "icons/consumables/potions/bottle-round-flask-fumes-purple.webp",
-            "range": [
-                79,
-                84
-            ],
-            "text": "Bestial Mutagen (Lesser)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "jfeOSgBmONVCWF8A",
+            "_id": "dyc2GQYrqtYy2nkK",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "tyt6rFtv32MZ4DT9",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/cheetahs-elixir.webp",
             "range": [
-                85,
-                90
+                43,
+                48
             ],
             "text": "Cheetah's Elixir (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "pYL9ovjsb7IDe3hW",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "wbr6rkyaVYnDhdgV",
-            "drawn": false,
-            "img": "icons/consumables/potions/potion-vial-corked-purple.webp",
-            "range": [
-                91,
-                96
-            ],
-            "text": "Cognitive Mutagen (Lesser)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "dv7cQYYsQTYQv1cf",
+            "_id": "MBGB4RLImD0VjgsK",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "7Y2yOr4ltpP2tyuL",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/eagle-eyes-elixir.webp",
             "range": [
-                97,
-                102
+                49,
+                54
             ],
             "text": "Eagle Eye Elixir (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "kNTMBGvPI42pyYy9",
+            "_id": "j0eGuYNVuyyjnBqe",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "hDLbR56Id2OtU318",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/elixir-of-life.webp",
             "range": [
-                103,
-                108
+                55,
+                60
             ],
             "text": "Elixir of Life (Minor)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "txFCP4aC30pIREO0",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "xE0EdDrf734l2fQH",
-            "drawn": false,
-            "img": "icons/consumables/potions/bottle-round-corked-green.webp",
-            "range": [
-                109,
-                114
-            ],
-            "text": "Juggernaut Mutagen (Lesser)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "njQ3sTPRy4k45itb",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "uG3xtNrs26scOVgW",
-            "drawn": false,
-            "img": "icons/consumables/potions/potion-jar-capped-teal.webp",
-            "range": [
-                115,
-                120
-            ],
-            "text": "Leaper's Elixir (Lesser)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "ZW1Bp0sab4nnhBPs",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "5MKBwpE401uz4kNN",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/quicksilver-mutagen.webp",
-            "range": [
-                121,
-                126
-            ],
-            "text": "Quicksilver Mutagen (Lesser)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "1qGFeFYGddlH1qCc",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "bOPQDM54W8ZDoULY",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/serene-mutagen.webp",
-            "range": [
-                127,
-                132
-            ],
-            "text": "Serene Mutagen (Lesser)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "NBHo9j3c17FRsEwU",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "YwRAHWW8yUI07sy9",
-            "drawn": false,
-            "img": "icons/consumables/potions/potion-bottle-corked-fancy-blue.webp",
-            "range": [
-                133,
-                138
-            ],
-            "text": "Silvertongue Mutagen (Lesser)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "GZt3ZWcLrFy1VzBf",
+            "_id": "gpLF1CZLYq5fIa5V",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "ukTlC4G83aVQEg7u",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/oils/nectar-of-purification.webp",
             "range": [
-                139,
-                144
+                61,
+                66
             ],
             "text": "Nectar of Purification",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "Ifik32NPS6K2BOJx",
+            "_id": "TsFSDmqdHaHDRjew",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "fTQ5e4utVfgtXV1e",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/oils/oil-of-unlife.webp",
+            "range": [
+                67,
+                72
+            ],
+            "text": "Oil of Unlife (Minor)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "uEpDeYKT0LEWFrMm",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "z9T4c1hXwOotsMCp",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/other-consumables/holy-water.webp",
+            "range": [
+                73,
+                78
+            ],
+            "text": "Holy Water",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "rBzxtzwFTVWSQWLu",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "24hmJWXhSmfVebEE",
+            "drawn": false,
+            "img": "icons/magic/fire/flame-burning-campfire-smoke.webp",
+            "range": [
+                79,
+                84
+            ],
+            "text": "Marvelous Miniature (Campfire)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "kxGf2ZtCeFhK2ff9",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "3cWko20JPnjeoofV",
+            "drawn": false,
+            "img": "icons/sundries/misc/ladder-improvised.webp",
+            "range": [
+                85,
+                90
+            ],
+            "text": "Marvelous Miniature (Ladder)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "w1Q7qFEpX33LfMpt",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "ev3F9qlMNlNdCOAI",
+            "drawn": false,
+            "img": "icons/commodities/treasure/token-runed-os-grey.webp",
+            "range": [
+                91,
+                96
+            ],
+            "text": "Runestone",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "JFzyY3Sb7CeaDeXY",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "EGhUorZhB7nV73Ev",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/other-consumables/unholy-water.webp",
+            "range": [
+                97,
+                102
+            ],
+            "text": "Unholy Water",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "BYeYIEtNN9cUJUU2",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "OIirLySQDLZgT15S",
             "drawn": false,
             "img": "icons/commodities/materials/bowl-powder-teal.webp",
             "range": [
-                145,
-                150
+                103,
+                108
             ],
             "text": "Arsenic",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "7mJP8yFjJTQwqR1N",
+            "_id": "ZDf6QqWXr5HQb568",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "hGw7Q1y2IEXRGAfv",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/potions/gecko-potion.webp",
+            "range": [
+                109,
+                114
+            ],
+            "text": "Gecko Potion",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "xxPk4DV4bmmcaUKw",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "txmX5ghhPS72GKXy",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/giant-centipede-venom.webp",
             "range": [
-                151,
-                156
+                115,
+                120
             ],
             "text": "Giant Centipede Venom",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "9s865cUJGztYpvFi",
+            "_id": "IT2WPD4k9HciGLLe",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "2RuepCemJhrpKKao",
             "drawn": false,
             "img": "icons/consumables/potions/bottle-round-corked-orante-red.webp",
             "range": [
-                157,
-                162
+                121,
+                126
             ],
             "text": "Healing Potion (Minor)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "idP8IDa44rmz8QvR",
+            "_id": "t2CENOxuDVrg0zgq",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "jTfacZ4SRuQd7Avh",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/potions/potion-of-expeditious-retreat.webp",
+            "range": [
+                127,
+                132
+            ],
+            "text": "Potion of Emergency Escape",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "Xw6HJDxil8PBFC6u",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "jlFx4JIBKJuaINpv",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/potions/potion-of-shared-memories.webp",
+            "range": [
+                133,
+                138
+            ],
+            "text": "Potion of Shared Memories",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "dREg060hhZ0gsflp",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "RjuupS9xyXDLgyIr",
             "drawn": false,
             "img": "icons/sundries/scrolls/scroll-symbol-eye-brown.webp",
             "range": [
-                163,
-                168
+                139,
+                144
             ],
-            "text": "Scroll of 1st-level Spell",
+            "text": "Scroll of 1st-rank Spell",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "nZmNbX68qqLlcw3X",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "AFX1V0Go9DqPWBlN",
-            "drawn": false,
-            "img": "icons/tools/instruments/bell-silver.webp",
-            "range": [
-                169,
-                174
-            ],
-            "text": "Alarm Snare",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "8XL4Ufkz4GGDt9Rh",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "kF761P3ibBIFmLm9",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/snares/caltrop-snare.webp",
-            "range": [
-                175,
-                180
-            ],
-            "text": "Caltrop Snare",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "oh2hVlytK77J2xeW",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Km4lSOsyrip5q6iD",
-            "drawn": false,
-            "img": "icons/commodities/wood/kindling-sticks-yellow.webp",
-            "range": [
-                181,
-                186
-            ],
-            "text": "Hampering Snare",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "oXtRBxXlnW1s0YqF",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "oplQpQSTyTvHDDtq",
-            "drawn": false,
-            "img": "icons/consumables/potions/potion-jar-corked-glowing-blue.webp",
-            "range": [
-                187,
-                192
-            ],
-            "text": "Marking Snare",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "nwgLDCGwlXtJGriZ",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "XcD8p1o71tPohZWT",
-            "drawn": false,
-            "img": "icons/commodities/wood/bark-beige.webp",
-            "range": [
-                193,
-                198
-            ],
-            "text": "Signaling Snare",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "pkTwghUiJVzAprcY",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "3V2U720YhW2nyGVx",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/snares/spike-snare.webp",
-            "range": [
-                199,
-                204
-            ],
-            "text": "Spike Snare",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "jj3unclcScG80OUl",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "qoM7Va5GqcLLBzgu",
-            "drawn": false,
-            "img": "icons/commodities/claws/claw-bear-brown.webp",
-            "range": [
-                205,
-                210
-            ],
-            "text": "Owlbear Claw",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "12NXIimK87DZ2E8E",
+            "_id": "mi3XbYqFOn3Xllq2",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "ZCsksGf6NPUKz2Uw",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/talismans/potency-crystal.webp",
             "range": [
-                211,
-                216
+                145,
+                150
             ],
             "text": "Potency Crystal",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "li7ogybaJnC30VWT",
+            "_id": "VMzx9kEXvfOshZML",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "qoM7Va5GqcLLBzgu",
+            "drawn": false,
+            "img": "icons/commodities/claws/claw-bear-brown.webp",
+            "range": [
+                151,
+                156
+            ],
+            "text": "Predator's Claw",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "G1wbxbOkUzrn3GJA",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "clyXfh0aVXgij2Hb",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/talismans/wolf-fang.webp",
             "range": [
-                217,
-                222
+                157,
+                162
             ],
             "text": "Wolf Fang",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "HjbnZiEaEHVEHgAP",
+            "_id": "HIZPsrQEncAN8H1d",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "y4WJY8rCbY6d1MET",
+            "drawn": false,
+            "img": "icons/weapons/wands/wand-carved-fire.webp",
+            "range": [
+                163,
+                168
+            ],
+            "text": "Glow Rod",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "yQqHe6B4OYLGgFxA",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "ylUdMTsfOQGJ3MN3",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/tindertwig.webp",
+            "range": [
+                169,
+                174
+            ],
+            "text": "Matchstick",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "GaR3xmZ92MvjZf28",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "MoBlVd36uD9xVvZC",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/smokestick.webp",
             "range": [
-                223,
-                228
+                175,
+                180
             ],
-            "text": "Smokestick (Lesser)",
+            "text": "Smoke Ball (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "9LxDP58SIODcKXii",
+            "_id": "uDo1SeNTdwPnLOcg",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "xBZCVHAa1SnR8Xul",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/snake-oil.webp",
             "range": [
-                229,
-                234
+                181,
+                186
             ],
             "text": "Snake Oil",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "9eNOLyVOaRPp9dWo",
+            "_id": "u8xFhpL8v5Z4ZsSv",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "y4WJY8rCbY6d1MET",
+            "documentId": "Xnqglykl3Cif8rN9",
             "drawn": false,
-            "img": "icons/weapons/wands/wand-carved-fire.webp",
+            "img": "icons/commodities/gems/pearl-rough-turquoise.webp",
             "range": [
-                235,
-                240
+                187,
+                192
             ],
-            "text": "Sunrod",
+            "text": "Blasting Stone (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "10ttGy8VFFayBaf3",
+            "_id": "T2kdznUbiVEYnFAH",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "ylUdMTsfOQGJ3MN3",
+            "documentId": "j8ajvNqyyQGBpBch",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/tindertwig.webp",
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/blight-bomb.webp",
+            "range": [
+                193,
+                198
+            ],
+            "text": "Blight Bomb (Lesser)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "znwuki0cHI9gyNk6",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "AFR01HVd7DcZvkpP",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/bottled-lightning.webp",
+            "range": [
+                199,
+                204
+            ],
+            "text": "Bottled Lightning (Lesser)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "JkkeCHBheot2zWvF",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "EpxmUtLpCkE8R6KJ",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/frost-vial.webp",
+            "range": [
+                205,
+                210
+            ],
+            "text": "Frost Vial (Lesser)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "GJHnV1vLdbWImInP",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "LNd5u19GqC51ngby",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/ghost-charge.webp",
+            "range": [
+                211,
+                216
+            ],
+            "text": "Ghost Charge (Lesser)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "JjiBnLq3Q1ad2eR8",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "GfegrEtbEs9L6NOg",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/potions/serum-of-sex-shift.webp",
+            "range": [
+                217,
+                222
+            ],
+            "text": "Elixir of Gender Transformation (Lesser)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "HHQ3OKWbw1FCRSQG",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "IQK9N2mEOyAj3iWU",
+            "drawn": false,
+            "img": "icons/consumables/potions/bottle-round-flask-fumes-purple.webp",
+            "range": [
+                223,
+                228
+            ],
+            "text": "Bestial Mutagen (Lesser)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "lm2JtA8D43DhZwLU",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "wbr6rkyaVYnDhdgV",
+            "drawn": false,
+            "img": "icons/consumables/potions/potion-vial-corked-purple.webp",
+            "range": [
+                229,
+                234
+            ],
+            "text": "Cognitive Mutagen (Lesser)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "Koqw293VlmWvRDLK",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "GS4YvQieBS11JNYR",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/drakeheart-mutagen.webp",
+            "range": [
+                235,
+                240
+            ],
+            "text": "Drakeheart Mutagen (Lesser)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "aJBciLj8sL28ImNI",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "xE0EdDrf734l2fQH",
+            "drawn": false,
+            "img": "icons/consumables/potions/bottle-metal-yellow-gray.webp",
             "range": [
                 241,
                 246
             ],
-            "text": "Tindertwig",
+            "text": "Juggernaut Mutagen (Lesser)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "fVmAHWtpleH9ioXX",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "5MKBwpE401uz4kNN",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/quicksilver-mutagen.webp",
+            "range": [
+                247,
+                252
+            ],
+            "text": "Quicksilver Mutagen (Lesser)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "xePtSYWDdq2Lqud3",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "bOPQDM54W8ZDoULY",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/serene-mutagen.webp",
+            "range": [
+                253,
+                258
+            ],
+            "text": "Serene Mutagen (Lesser)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "JLAxZkI6Nw47fUcA",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "YwRAHWW8yUI07sy9",
+            "drawn": false,
+            "img": "icons/consumables/potions/potion-bottle-corked-fancy-blue.webp",
+            "range": [
+                259,
+                264
+            ],
+            "text": "Silvertongue Mutagen (Lesser)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "02w6lKbmtbTq7h4Y",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "EWujUs3YmlBu2jhm",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/oils/shielding-salve.webp",
+            "range": [
+                265,
+                270
+            ],
+            "text": "Shielding Salve",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "oOEc2xckDeOxKIMQ",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
+            "drawn": false,
+            "img": "icons/svg/d20-black.svg",
+            "range": [
+                271,
+                276
+            ],
+            "text": "Potion of Retaliation (Minor)",
+            "type": "text",
+            "weight": 6
+        },
+        {
+            "_id": "jBNmgDifCRB9bbIw",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "3Wb0N7iqmTn6e2Xc",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/potions/ration-tonic.webp",
+            "range": [
+                277,
+                282
+            ],
+            "text": "Ration Tonic",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "qXHOd2ejwxr1gffE",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "AFX1V0Go9DqPWBlN",
+            "drawn": false,
+            "img": "icons/tools/instruments/bell-silver.webp",
+            "range": [
+                283,
+                288
+            ],
+            "text": "Alarm Snare",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "zUO7ozzBTRMTohxe",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "kF761P3ibBIFmLm9",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/snares/caltrop-snare.webp",
+            "range": [
+                289,
+                294
+            ],
+            "text": "Caltrop Snare",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "KbyL8xHcLvue6I1w",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "Km4lSOsyrip5q6iD",
+            "drawn": false,
+            "img": "icons/commodities/wood/kindling-sticks-yellow.webp",
+            "range": [
+                295,
+                300
+            ],
+            "text": "Hampering Snare",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "6I0wOkvait9rKpOe",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "oplQpQSTyTvHDDtq",
+            "drawn": false,
+            "img": "icons/consumables/potions/potion-jar-corked-glowing-blue.webp",
+            "range": [
+                301,
+                306
+            ],
+            "text": "Marking Snare",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "1coDqwqBnHaIxykD",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "XcD8p1o71tPohZWT",
+            "drawn": false,
+            "img": "icons/commodities/wood/bark-beige.webp",
+            "range": [
+                307,
+                312
+            ],
+            "text": "Signaling Snare",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "bGOv4Vc4E8N5ExPT",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "3V2U720YhW2nyGVx",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/snares/spike-snare.webp",
+            "range": [
+                313,
+                318
+            ],
+            "text": "Spike Snare",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "YDRcCCbugdPMdwiS",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "8eTGOQ9P69405jIO",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/forensic-dye.webp",
+            "range": [
+                319,
+                324
+            ],
+            "text": "Forensic Dye",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "LMRmgTiJrQ0oxL2x",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "qnvq3PSTiejQTSi9",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/ghost-ink.webp",
+            "range": [
+                325,
+                330
+            ],
+            "text": "Ghost Ink",
             "type": "pack",
             "weight": 6
         }

--- a/packs/rollable-tables/1st-level-permanent-items.json
+++ b/packs/rollable-tables/1st-level-permanent-items.json
@@ -2,7 +2,7 @@
     "_id": "JyDn13oc0MdLjpyw",
     "description": "<p>Table of 1st-Level Permanent Items</p>",
     "displayRoll": true,
-    "formula": "1d21",
+    "formula": "1d27",
     "img": "icons/svg/d20-grey.svg",
     "name": "1st-Level Permanent Items",
     "ownership": {
@@ -11,60 +11,74 @@
     "replacement": true,
     "results": [
         {
-            "_id": "Q6MCQ3VUAj9b4PnR",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "pRoikbRo5HFW6YUB",
-            "drawn": false,
-            "img": "icons/equipment/chest/breastplate-gorget-steel-white.webp",
-            "range": [
-                1,
-                6
-            ],
-            "text": "Half Plate",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "1q2hXapmXuXfaj4i",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "6AhDKX1dwRwFpQsU",
-            "drawn": false,
-            "img": "icons/equipment/chest/breastplate-layered-leather-studded-black.webp",
-            "range": [
-                7,
-                12
-            ],
-            "text": "Splint Mail",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "DYoDk9CqJNKs6tCj",
+            "_id": "EmzJRAeGxnxlOwyp",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "mRz8Jmk4Q06SsZpC",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/held-items/everburning-torch.webp",
             "range": [
-                13,
-                18
+                1,
+                6
             ],
             "text": "Everlight Crystal",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "4k3k2olirAsJaIsJ",
+            "_id": "58q3tXrsgeDL3VXS",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "Zmz2M2u7mGOCbUf4",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/other/magic-pots/walking-cauldron.webp",
+            "range": [
+                7,
+                12
+            ],
+            "text": "Walking Cauldron",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "Zk6drnpAd6sNuf3a",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "CVTbxCY85nLoHYuw",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/aeon-stone-dull-gray.webp",
             "range": [
-                19,
-                21
+                13,
+                15
             ],
             "text": "Aeon Stone (Consumed)",
             "type": "pack",
             "weight": 3
+        },
+        {
+            "_id": "kJ5IrX1EvCfErzbp",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "yzc8Sll1YMWq8PpR",
+            "drawn": false,
+            "img": "icons/equipment/finger/ring-band-engraved-scrolls-bronze.webp",
+            "range": [
+                16,
+                21
+            ],
+            "text": "Ring of Sigils",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "ejZ2p1mVVItVNOKq",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "ZIQAzOavTXJCcCMD",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/held-items/predictable-silver-piece.webp",
+            "range": [
+                22,
+                27
+            ],
+            "text": "Predictable Silver Piece",
+            "type": "pack",
+            "weight": 6
         }
     ]
 }

--- a/packs/rollable-tables/3rd-level-consumables.json
+++ b/packs/rollable-tables/3rd-level-consumables.json
@@ -1,8 +1,8 @@
 {
     "_id": "mDPLoPYwuPo3o0Wj",
-    "description": "Table of 3rd-Level Consumables",
+    "description": "<p>Table of 3rd-Level Consumables</p>",
     "displayRoll": true,
-    "formula": "1d150",
+    "formula": "1d192",
     "img": "icons/svg/d20-grey.svg",
     "name": "3rd-Level Consumables",
     "ownership": {
@@ -25,339 +25,437 @@
             "weight": 6
         },
         {
-            "_id": "CtCW6OWjZ9LCyV6u",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "RcQ4ZIzRK2xLf4G5",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/ammunition/sleep-arrow.webp",
-            "range": [
-                7,
-                12
-            ],
-            "text": "Sleep Arrow",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "serJqIWHgbmbhDzy",
+            "_id": "MArlPUGX0N1Or4l7",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "NSo0bFX7DGGjqKKl",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/ammunition/spellstrike-ammunition.webp",
             "range": [
-                13,
-                18
+                7,
+                12
             ],
             "text": "Spellstrike Ammunition (Type I)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "iwuBnzg81kfvN9qh",
+            "_id": "072I21YkZAKrwaAU",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "eEnzHpPEbdGgRETM",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/ammunition/vine-arrow.webp",
             "range": [
-                19,
-                24
+                13,
+                18
             ],
             "text": "Vine Arrow",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "wrKtGlVFkGEmsR3E",
+            "_id": "xgHsiPwmRc7x2rV6",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "SgtqZxt26BdjUmEB",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/acid-flask.webp",
             "range": [
-                25,
-                30
+                19,
+                24
             ],
             "text": "Acid Flask (Moderate)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "6fofSWDLAli7D9Vf",
+            "_id": "0nFvNuQ4LlW6y98i",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "gWr4q4HiyGhETA8H",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/alchemists-fire.webp",
             "range": [
-                31,
-                36
+                25,
+                30
             ],
             "text": "Alchemist's Fire (Moderate)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "K6tpDqDyQvis48Iu",
+            "_id": "Qw1vuubRxaw7IFuS",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "97QyNEOAyYLdGaYc",
+            "documentId": "IvFEJqp2MUew65nQ",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/bottled-lightning.webp",
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/dread-ampoule.webp",
             "range": [
-                37,
-                42
+                31,
+                36
             ],
-            "text": "Bottled Lightning (Moderate)",
+            "text": "Dread Ampoule (Moderate)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "J92d4MpwclPadwOc",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "nVvH1ZcM7OwIVIs8",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/frost-vial.webp",
-            "range": [
-                43,
-                48
-            ],
-            "text": "Frost Vial (Moderate)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "3HZHqYqejkaKCSlQ",
+            "_id": "Pk9ZXmhoW5ppr1hf",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "evBPzM1VsuYcoenn",
             "drawn": false,
             "img": "icons/containers/bags/sack-simple-leather-tan.webp",
             "range": [
-                49,
-                54
+                37,
+                42
             ],
-            "text": "Tanglefoot Bag (Moderate)",
+            "text": "Glue Bomb (Moderate)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "tcFhkk6uFUkkQWMk",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "JOaELkzLWTywhn5Z",
-            "drawn": false,
-            "img": "icons/commodities/gems/pearl-rough-turquoise.webp",
-            "range": [
-                55,
-                60
-            ],
-            "text": "Thunderstone (Moderate)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "V7QV2iZcpQW0W4Bl",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "fFq8nsGvSUgzVeND",
-            "drawn": false,
-            "img": "icons/commodities/materials/feather-blue.webp",
-            "range": [
-                61,
-                66
-            ],
-            "text": "Feather Token (Bird)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "VEeUe1e8wg9Ap9a7",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Dn2KQgIeWNijaUzL",
-            "drawn": false,
-            "img": "icons/commodities/materials/feather-blue.webp",
-            "range": [
-                67,
-                72
-            ],
-            "text": "Feather Token (Chest)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "UpLZlf4UpQIHnPZF",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "VISk5uLPVIvNWovB",
-            "drawn": false,
-            "img": "icons/consumables/potions/bottle-round-flask-fumes-purple.webp",
-            "range": [
-                73,
-                78
-            ],
-            "text": "Bestial Mutagen (Moderate)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "vj4JoRI7CsrYl8e0",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "qpzL9UnTi4cDhy6J",
-            "drawn": false,
-            "img": "icons/consumables/potions/potion-vial-corked-purple.webp",
-            "range": [
-                79,
-                84
-            ],
-            "text": "Cognitive Mutagen (Moderate)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "AzSagjT1yaUEXvLF",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "mj9i9GeQTADByNPZ",
-            "drawn": false,
-            "img": "icons/consumables/potions/bottle-round-corked-green.webp",
-            "range": [
-                85,
-                90
-            ],
-            "text": "Juggernaut Mutagen (Moderate)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "aRWR0oDpz3lG7Ye6",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "n52BSbZsnx4Vmt2p",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/quicksilver-mutagen.webp",
-            "range": [
-                91,
-                96
-            ],
-            "text": "Quicksilver Mutagen (Moderate)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "ZIzH7JvfkVjO9W6M",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "XEYveTvLH1lJ4jeI",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/serene-mutagen.webp",
-            "range": [
-                97,
-                102
-            ],
-            "text": "Serene Mutagen (Moderate)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "txw59NSuj5GuarW9",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "lIExlUFBKvBue8hb",
-            "drawn": false,
-            "img": "icons/consumables/potions/potion-bottle-corked-fancy-blue.webp",
-            "range": [
-                103,
-                108
-            ],
-            "text": "Silvertongue Mutagen (Moderate)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "8SZCYCDAopjULZb8",
+            "_id": "kAHYy8XuDJlCb8ZS",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "QN8UIz0nMcnLUWHu",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/oils/oil-of-mending.webp",
             "range": [
-                109,
-                114
+                43,
+                48
             ],
             "text": "Oil of Mending",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "cmwKZov12lzmZ4r3",
+            "_id": "ZKmPhaJKHOSBuMeM",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "aZm1x9tpvBAT8YCd",
+            "documentId": "BSInwFNVBVkfFK0B",
             "drawn": false,
-            "img": "icons/commodities/materials/liquid-purple.webp",
+            "img": "systems/pf2e/icons/equipment/consumables/oils/oil-of-unlife.webp",
             "range": [
-                115,
-                120
+                49,
+                54
             ],
-            "text": "Cytillesh Oil",
+            "text": "Oil of Unlife (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "xsjcKG0Z6oa3E05T",
+            "_id": "iFFctogx3ApStrjK",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "Dn2KQgIeWNijaUzL",
+            "drawn": false,
+            "img": "icons/containers/chest/chest-oak-steel-brown.webp",
+            "range": [
+                55,
+                60
+            ],
+            "text": "Marvelous Miniature (Chest)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "CdgeLpl8yNJXFnED",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "qQqAY59NgGNoy2xr",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/graveroot.webp",
             "range": [
-                121,
-                126
+                61,
+                66
             ],
             "text": "Graveroot",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "13S0UvlDiZlKJ8S9",
+            "_id": "nqj8cAAa9xz0DYfZ",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "e0vSAQfxhHauiAoD",
             "drawn": false,
             "img": "icons/consumables/potions/bottle-round-corked-orante-red.webp",
             "range": [
-                127,
-                132
+                67,
+                72
             ],
             "text": "Healing Potion (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "Anedv6AMhEkiHGj0",
+            "_id": "eufhS8pgSI4XD8RZ",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "WQhnfj1LbrEzvh8z",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/potions/potion-of-water-breathing.webp",
             "range": [
-                133,
-                138
+                73,
+                78
             ],
             "text": "Potion of Water Breathing",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "Fipi7flIfw6EvMea",
+            "_id": "LfRQVcHYqcvhZmgz",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "Y7UD64foDbDMV9sx",
             "drawn": false,
             "img": "icons/sundries/scrolls/scroll-symbol-eye-brown.webp",
             "range": [
-                139,
-                144
+                79,
+                84
             ],
-            "text": "Scroll of 2nd-level Spell",
+            "text": "Scroll of 2nd-rank Spell",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "mJWgsDXgL2Dv3BOw",
+            "_id": "HRziIWLyJVc85Di8",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "X345VfEx9DZwO47G",
+            "drawn": false,
+            "img": "icons/commodities/metal/fragments-steel-ring.webp",
+            "range": [
+                85,
+                90
+            ],
+            "text": "Alloy Orb (Low-Grade)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "AVIUCX55UDCd3sT0",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "0CNSvLpeSM4aIfPJ",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/talismans/feather-step-stone.webp",
             "range": [
-                145,
-                150
+                91,
+                96
             ],
             "text": "Feather Step Stone",
             "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "xc2USLSCpTP9IaRd",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "RcQ4ZIzRK2xLf4G5",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/ammunition/sleep-arrow.webp",
+            "range": [
+                97,
+                102
+            ],
+            "text": "Slumber Arrow",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "Rr34ENl79UaL5YP8",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "JOaELkzLWTywhn5Z",
+            "drawn": false,
+            "img": "icons/commodities/gems/pearl-rough-turquoise.webp",
+            "range": [
+                103,
+                108
+            ],
+            "text": "Blasting Stone (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "EyTg381a7NSxQwmE",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "158vwM1andv8DbRI",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/blight-bomb.webp",
+            "range": [
+                109,
+                114
+            ],
+            "text": "Blight Bomb (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "ZAd7ZGNbSlY8Wuw2",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "97QyNEOAyYLdGaYc",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/bottled-lightning.webp",
+            "range": [
+                115,
+                120
+            ],
+            "text": "Bottled Lightning (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "jADHF9fkO0Q0STL8",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "nVvH1ZcM7OwIVIs8",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/frost-vial.webp",
+            "range": [
+                121,
+                126
+            ],
+            "text": "Frost Vial (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "pT0vImG7DGqPPK1p",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "Wf94e8YNhZdIvWc9",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/ghost-charge.webp",
+            "range": [
+                127,
+                132
+            ],
+            "text": "Ghost Charge (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "qteXWDwcw0Z5gMx2",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "0KXqdhz2MYV0LBm2",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/potions/serum-of-sex-shift.webp",
+            "range": [
+                133,
+                138
+            ],
+            "text": "Elixir of Gender Transformation (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "JnuV4HzIk33c6MQF",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "VISk5uLPVIvNWovB",
+            "drawn": false,
+            "img": "icons/consumables/potions/bottle-round-flask-fumes-purple.webp",
+            "range": [
+                139,
+                144
+            ],
+            "text": "Bestial Mutagen (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "gbF0nwxVjdM3oClA",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "qpzL9UnTi4cDhy6J",
+            "drawn": false,
+            "img": "icons/consumables/potions/potion-vial-corked-purple.webp",
+            "range": [
+                145,
+                150
+            ],
+            "text": "Cognitive Mutagen (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "xR2jnv6uhi5mD45l",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "xY2MogTwH9Fd8UPG",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/drakeheart-mutagen.webp",
+            "range": [
+                151,
+                156
+            ],
+            "text": "Drakeheart Mutagen (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "893TP3dOWfNstY3h",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "mj9i9GeQTADByNPZ",
+            "drawn": false,
+            "img": "icons/consumables/potions/bottle-metal-yellow-gray.webp",
+            "range": [
+                157,
+                162
+            ],
+            "text": "Juggernaut Mutagen (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "zGYyXAelppLTtW1x",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "n52BSbZsnx4Vmt2p",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/quicksilver-mutagen.webp",
+            "range": [
+                163,
+                168
+            ],
+            "text": "Quicksilver Mutagen (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "TK7MGpGo7OtEkdZB",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "XEYveTvLH1lJ4jeI",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/serene-mutagen.webp",
+            "range": [
+                169,
+                174
+            ],
+            "text": "Serene Mutagen (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "BtV5pWwMpz5nTVAU",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "lIExlUFBKvBue8hb",
+            "drawn": false,
+            "img": "icons/consumables/potions/potion-bottle-corked-fancy-blue.webp",
+            "range": [
+                175,
+                180
+            ],
+            "text": "Silvertongue Mutagen (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "86ORdivfqkkXONdn",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "aZm1x9tpvBAT8YCd",
+            "drawn": false,
+            "img": "icons/commodities/materials/liquid-purple.webp",
+            "range": [
+                181,
+                186
+            ],
+            "text": "Cytillesh Oil",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "OAEmZRjyYuuhEQYp",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/potions/potion-of-cold-retalliation.webp",
+            "range": [
+                187,
+                192
+            ],
+            "text": "Potion of Retaliation (Lesser)",
+            "type": "text",
             "weight": 6
         }
     ]

--- a/packs/rollable-tables/3rd-level-permanent-items.json
+++ b/packs/rollable-tables/3rd-level-permanent-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "Ow2zoRUSX0s7JjMo",
-    "description": "Table of 3rd-Level Permanent Items",
+    "description": "<p>Table of 3rd-Level Permanent Items</p>",
     "displayRoll": true,
-    "formula": "1d123",
+    "formula": "1d129",
     "img": "icons/svg/d20-grey.svg",
     "name": "3rd-Level Permanent Items",
     "ownership": {
@@ -53,231 +53,231 @@
             "weight": 6
         },
         {
-            "_id": "2wUqPwwk28SJXbOv",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "kEy7Uc1VisizGgtf",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/runes/armor-property-runes/armor-property-runes.webp",
-            "range": [
-                19,
-                24
-            ],
-            "text": "Shadow",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "bTwikuvoIuXKabFL",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "uQOaRpfkUFVYD0Gx",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/runes/armor-property-runes/armor-property-runes.webp",
-            "range": [
-                25,
-                30
-            ],
-            "text": "Slick",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "KE5WuqxZOMKkfeVK",
+            "_id": "WLXQ7hFaev6CsUXr",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "opfpl1JmKgrfds9P",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/staves/staff-of-fire.webp",
             "range": [
-                31,
-                36
+                19,
+                24
             ],
             "text": "Staff of Fire",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "CUmCEauinNplh5ZA",
+            "_id": "G3yVxCJPvx1XMyju",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "UJWiN0K3jqVjxvKk",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/magic-wands/magic-wand.webp",
             "range": [
-                37,
-                42
+                25,
+                30
             ],
             "text": "Magic Wand (1st-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "niyCneExcTokEG5D",
+            "_id": "aJvasjkn4Veju0EB",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "Kx6FQS5GyVB6jlrW",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/weapons/specific-magic-weapons/fighters-fork.webp",
             "range": [
-                43,
-                48
+                31,
+                36
             ],
             "text": "Fighter's Fork",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "U5iyrCFfxvcv8nBd",
+            "_id": "nKMXVrx9on0RtzLI",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "q6ZvspNDkzJSP6dg",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/weapons/specific-magic-weapons/retribution-axe.webp",
             "range": [
-                49,
-                54
+                37,
+                42
             ],
             "text": "Retribution Axe",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "k06Hg1qDu1oNSiLQ",
+            "_id": "qb7QMuUM8p1NouuZ",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "BKdzb8hu3kZtKH3Z",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/bracelet-of-dashing.webp",
             "range": [
-                55,
-                60
+                43,
+                48
             ],
             "text": "Bracelet of Dashing",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "KAXlei1zEICCrgaJ",
+            "_id": "i5LI4u6c8GfaYcLq",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "eurAnvH8bK0ZctOR",
             "drawn": false,
             "img": "icons/equipment/wrist/bracer-segmented-leather.webp",
             "range": [
-                61,
-                66
+                49,
+                54
             ],
             "text": "Bracers of Missile Deflection",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "I9J6fT8BCKpc9vtC",
+            "_id": "FeUpbVapDdeYiHGY",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "3vxoffA4slKHXtj2",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/channel-protection-amulet.webp",
             "range": [
-                67,
-                69
+                55,
+                57
             ],
             "text": "Channel Protection Amulet",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "P7oC4GEJuR8pVrId",
+            "_id": "7XTPcDJmhJegb2bj",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "LKdgj4UVmOvUwkZu",
+            "drawn": false,
+            "img": "icons/equipment/hand/glove-ringed-leather-yellow.webp",
+            "range": [
+                58,
+                63
+            ],
+            "text": "Charlatan's Gloves",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "jHNiIDILwHG6ZJF0",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "mvMeloQxSiEGIlhL",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/coyote-cloak.webp",
             "range": [
-                70,
-                75
+                64,
+                69
             ],
             "text": "Coyote Cloak",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "cTo0NKKtG0kjBJSd",
+            "_id": "7b06BU1pWSIwGV1K",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "RgNBGpBc9G2yw1C2",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/crafters-eyepiece.webp",
+            "img": "icons/tools/scribal/lens-blue.webp",
             "range": [
-                76,
-                81
+                70,
+                75
             ],
             "text": "Crafter's Eyepiece",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "cVTTKApoz8wZ7pXn",
+            "_id": "4UxX0VIGgyEmJidK",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "Epc1e1Q9M9bcwOR0",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/dancing-scarf.webp",
             "range": [
-                82,
-                87
+                76,
+                81
             ],
             "text": "Dancing Scarf",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "JLwT8DISSWHpWrKr",
+            "_id": "n6CjgJK2XVIPJ68c",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "DwMXEqy7Ws8NYQQh",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/doubling-rings.webp",
             "range": [
-                88,
-                93
+                82,
+                87
             ],
             "text": "Doubling Rings",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "NtaagMSzLpu2aHjU",
+            "_id": "VXsmp86PzxSV889m",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "SswqJqeAWGtX3tTF",
             "drawn": false,
             "img": "icons/equipment/head/hat-belted-simple-grey.webp",
             "range": [
-                94,
-                99
+                88,
+                93
             ],
-            "text": "Hat of the Magi",
+            "text": "Mage's Hat",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "pUUr9C9OZiQdvsgJ",
+            "_id": "dAaIj18F3trnB3Nm",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "zPhqmCvWyHO8i9ws",
             "drawn": false,
             "img": "icons/commodities/biological/eye-purple.webp",
             "range": [
-                100,
-                105
+                94,
+                99
             ],
             "text": "Pendant of the Occult",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "sEKGyq3CgtbpL8YH",
+            "_id": "YDr7JMOOJq8daI7Y",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "MKupH1T018JubYJW",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/persona-mask.webp",
             "range": [
-                106,
-                111
+                100,
+                105
             ],
             "text": "Persona Mask",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "YM85vN0BCmomxJvu",
+            "_id": "JsNzQWA9fYJU9vGU",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "YVtXlsEWb3NIkDyy",
+            "drawn": false,
+            "img": "icons/commodities/treasure/broach-jewel-gold-blue.webp",
+            "range": [
+                106,
+                111
+            ],
+            "text": "Shining Symbol",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "eJp0bYDtwm2FpHLb",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "ZEqAx8jEc6zhX3V1",
             "drawn": false,
@@ -291,7 +291,7 @@
             "weight": 6
         },
         {
-            "_id": "vgCqUe6qZZYaIgGR",
+            "_id": "BAN25rPJJ1s1qwus",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "1r6StS0irdvi5JHY",
             "drawn": false,
@@ -301,6 +301,20 @@
                 123
             ],
             "text": "Ventriloquist's Ring",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "oO1UFo6Fad8CoWz8",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "wJTpzqL8EJ0xVW0y",
+            "drawn": false,
+            "img": "icons/commodities/materials/material-cotton-white.webp",
+            "range": [
+                124,
+                129
+            ],
+            "text": "Twisting Twine (Lesser)",
             "type": "pack",
             "weight": 6
         }


### PR DESCRIPTION
Update 3rd-Level Consumable Items and 3rd-Level Permanent Items tables with remaster changes, consolidating the treasure tables from the GM Core and Player Core 2 books, preserving the item order found in those tables. Weight is based on rarity:

* Common = 6
* Uncommon = 3
* Rare = 1

For items that do not have a corresponding entry in the compendium, create a text entry in the table with the appropriate item name. If possible, set an appropriate icon from the system's icon set.