### PR TITLE
Add Game Hunter (Target) effect

### DIFF
--- a/packs/feat-effects/effect-game-hunter-critical-failure.json
+++ b/packs/feat-effects/effect-game-hunter-critical-failure.json
@@ -1,7 +1,7 @@
 {
-    "_id": "eTosCwuCMf09fYYH",
+    "_id": "lfbDqyKUMssoxUTZ",
     "img": "icons/creatures/eyes/humanoid-single-red-brown.webp",
-    "name": "Effect: Game Hunter (Target)",
+    "name": "Effect: Game Hunter (Critical Failure)",
     "system": {
         "description": {
             "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Game Hunter Dedication]</p>\n<p>Your Speeds are each reduced by 10 feet.</p>"
@@ -9,7 +9,7 @@
         "duration": {
             "expiry": "turn-start",
             "sustained": false,
-            "unit": "rounds",
+            "unit": "minutes",
             "value": 1
         },
         "level": {

--- a/packs/feat-effects/effect-game-hunter-failure.json
+++ b/packs/feat-effects/effect-game-hunter-failure.json
@@ -1,0 +1,42 @@
+{
+    "_id": "eTosCwuCMf09fYYH",
+    "img": "icons/creatures/eyes/humanoid-single-red-brown.webp",
+    "name": "Effect: Game Hunter (Failure)",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Game Hunter Dedication]</p>\n<p>Your Speeds are each reduced by 10 feet.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder #175: Broken Tusk Moon"
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "selector": "all-speeds",
+                "value": -10
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feat-effects/effect-game-hunter-target.json
+++ b/packs/feat-effects/effect-game-hunter-target.json
@@ -4,7 +4,7 @@
     "name": "Effect: Game Hunter (Target)",
     "system": {
         "description": {
-            "value": "<p>Speeds are each reduced by 10 feet</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Game Hunter Dedication]</p>\n<p>Your Speeds are each reduced by 10 feet.</p>"
         },
         "duration": {
             "expiry": "turn-start",

--- a/packs/feat-effects/effect-game-hunter-target.json
+++ b/packs/feat-effects/effect-game-hunter-target.json
@@ -1,0 +1,43 @@
+{
+    "_id": "eTosCwuCMf09fYYH",
+    "img": "icons/creatures/eyes/humanoid-single-red-brown.webp",
+    "name": "Effect: Game Hunter (Target)",
+    "system": {
+        "description": {
+            "value": "<p>Speeds are each reduced by 10 feet</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder #175: Broken Tusk Moon"
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "selector": "all-speeds",
+                "type": "circumstance",
+                "value": -10
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feat-effects/effect-game-hunter-target.json
+++ b/packs/feat-effects/effect-game-hunter-target.json
@@ -24,7 +24,6 @@
             {
                 "key": "FlatModifier",
                 "selector": "all-speeds",
-                "type": "circumstance",
                 "value": -10
             }
         ],

--- a/packs/feats/game-hunter-dedication.json
+++ b/packs/feats/game-hunter-dedication.json
@@ -76,6 +76,13 @@
                             "hunted-prey-game-hunter",
                             "grants-hunt-prey:1"
                         ]
+                    },
+                    {
+                        "or": [
+                            "target:trait:animal",
+                            "target:trait:beast",
+                            "target:trait:dragon"
+                        ]
                     }
                 ],
                 "selector": "attack",

--- a/packs/feats/game-hunter-dedication.json
+++ b/packs/feats/game-hunter-dedication.json
@@ -79,7 +79,7 @@
                     }
                 ],
                 "selector": "attack",
-                "text": "When you succeed at a Strike against your hunted prey while it's off-guard, it must attempt a Fortitude save against your class DC. On a failure, the prey's Speeds are each reduced by 10 feet for 1 round; on a critical failure, the duration of this effect is 1 minute. The prey is then temporarily immune to this effect for 10 minutes."
+                "text": "PF2E.SpecificRule.GameHunterDedication.TargetHuntedPrey.SuccessAttack"
             },
             {
                 "key": "ActiveEffectLike",

--- a/packs/feats/game-hunter-dedication.json
+++ b/packs/feats/game-hunter-dedication.json
@@ -79,7 +79,7 @@
                     }
                 ],
                 "selector": "attack",
-                "text": "PF2E.SpecificRule.GameHunterDedication.TargetHuntedPrey.SuccessAttack"
+                "text": "PF2E.SpecificRule.GameHunterDedication.SuccessAttack"
             },
             {
                 "key": "ActiveEffectLike",

--- a/packs/feats/game-hunter-dedication.json
+++ b/packs/feats/game-hunter-dedication.json
@@ -86,7 +86,8 @@
                     }
                 ],
                 "selector": "attack",
-                "text": "PF2E.SpecificRule.GameHunterDedication.SuccessAttack"
+                "text": "PF2E.SpecificRule.GameHunterDedication.SuccessAttack",
+                "title": "{item|name}"
             },
             {
                 "key": "ActiveEffectLike",

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -3529,7 +3529,7 @@
             },
             "GameHunterDedication": {
                 "TargetHuntedPrey": "Target is your Hunted Prey (Animal, Beast, or Dragon Only)",
-                "SuccessAttack": "When you succeed at a Strike against your hunted prey while it's off-guard, it must attempt a Fortitude save against your class DC. On a failure, the prey's Speeds are each reduced by 10 feet for 1 round; on a critical failure, the duration of this effect is 1 minute. The prey is then temporarily immune to this effect for 10 minutes.<hr>@UUID[Compendium.pf2e.feat-effects.Item.eTosCwuCMf09fYYH]<hr>@UUID[Compendium.pf2e.feat-effects.Item.lfbDqyKUMssoxUTZ]"
+                "SuccessAttack": "When you succeed at a Strike against your hunted prey while it's off-guard, it must attempt a @Check[fortitude|against:class] save against your class DC. On a failure, the prey's Speeds are each reduced by 10 feet for 1 round; on a critical failure, the duration of this effect is 1 minute. The prey is then temporarily immune to this effect for 10 minutes.<hr>@UUID[Compendium.pf2e.feat-effects.Item.eTosCwuCMf09fYYH]<hr>@UUID[Compendium.pf2e.feat-effects.Item.lfbDqyKUMssoxUTZ]"
             },
             "Ganzi": {
                 "Irrepressible": {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -3528,7 +3528,8 @@
                 "Note": "Whenever someone benefitting from this bonus critically succeeds at a saving throw against an enemy's mental effect, its revelry increases, granting it a +1 status bonus to attack rolls and damage rolls for 1 round. @UUID[Compendium.pf2e.spell-effects.Item.ldl1aU5ovTQMUHJ2]{Spell Effect: Frenzied Revelry (Critical)}"
             },
             "GameHunterDedication": {
-                "TargetHuntedPrey": "Target is your Hunted Prey (Animal, Beast, or Dragon Only)"
+                "TargetHuntedPrey": "Target is your Hunted Prey (Animal, Beast, or Dragon Only)",
+                "SuccessAttack": "When you succeed at a Strike against your hunted prey while it's off-guard, it must attempt a Fortitude save against your class DC. On a failure, the prey's Speeds are each reduced by 10 feet for 1 round; on a critical failure, the duration of this effect is 1 minute. The prey is then temporarily immune to this effect for 10 minutes.<hr>@UUID[Compendium.pf2e.feat-effects.Item.eTosCwuCMf09fYYH]<hr>@UUID[Compendium.pf2e.feat-effects.Item.lfbDqyKUMssoxUTZ]"
             },
             "Ganzi": {
                 "Irrepressible": {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -3529,7 +3529,7 @@
             },
             "GameHunterDedication": {
                 "TargetHuntedPrey": "Target is your Hunted Prey (Animal, Beast, or Dragon Only)",
-                "SuccessAttack": "When you succeed at a Strike against your hunted prey while it's off-guard, it must attempt a @Check[fortitude|against:class] save against your class DC. On a failure, the prey's Speeds are each reduced by 10 feet for 1 round; on a critical failure, the duration of this effect is 1 minute. The prey is then temporarily immune to this effect for 10 minutes.<hr>@UUID[Compendium.pf2e.feat-effects.Item.eTosCwuCMf09fYYH]<hr>@UUID[Compendium.pf2e.feat-effects.Item.lfbDqyKUMssoxUTZ]"
+                "SuccessAttack": "When you succeed at a Strike against your hunted prey while it's off-guard, it must attempt a @Check[fortitude|against:class] save against your class DC. On a failure, the prey's Speeds are each reduced by 10 feet for 1 round; on a critical failure, the duration of this effect is 1 minute. The prey is then temporarily immune to this effect for 10 minutes. @UUID[Compendium.pf2e.feat-effects.Item.eTosCwuCMf09fYYH]{Effect: Game Hunter (Failure)} @UUID[Compendium.pf2e.feat-effects.Item.lfbDqyKUMssoxUTZ]{Effect: Game Hunter (Critical Failure)}"
             },
             "Ganzi": {
                 "Irrepressible": {


### PR DESCRIPTION
```When you succeed at a Strike against your hunted prey while it's Off-Guard, it must attempt a Fortitude save against your class DC. On a failure, the prey's Speeds are each reduced by 10 feet for 1 round; on a critical failure, the duration of this effect is 1 minute. The prey is then temporarily immune to this effect for 10 minutes.```

<img width="311" alt="image" src="https://github.com/user-attachments/assets/76bd3db7-de15-46fc-ad4b-c443b98868e3">
