### PR TITLE
Update 3rd-level rollable tables

### DIFF
--- a/packs/rollable-tables/3rd-level-consumables.json
+++ b/packs/rollable-tables/3rd-level-consumables.json
@@ -1,8 +1,8 @@
 {
     "_id": "mDPLoPYwuPo3o0Wj",
-    "description": "Table of 3rd-Level Consumables",
+    "description": "<p>Table of 3rd-Level Consumables</p>",
     "displayRoll": true,
-    "formula": "1d150",
+    "formula": "1d192",
     "img": "icons/svg/d20-grey.svg",
     "name": "3rd-Level Consumables",
     "ownership": {
@@ -25,339 +25,437 @@
             "weight": 6
         },
         {
-            "_id": "CtCW6OWjZ9LCyV6u",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "RcQ4ZIzRK2xLf4G5",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/ammunition/sleep-arrow.webp",
-            "range": [
-                7,
-                12
-            ],
-            "text": "Sleep Arrow",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "serJqIWHgbmbhDzy",
+            "_id": "MArlPUGX0N1Or4l7",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "NSo0bFX7DGGjqKKl",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/ammunition/spellstrike-ammunition.webp",
             "range": [
-                13,
-                18
+                7,
+                12
             ],
             "text": "Spellstrike Ammunition (Type I)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "iwuBnzg81kfvN9qh",
+            "_id": "072I21YkZAKrwaAU",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "eEnzHpPEbdGgRETM",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/ammunition/vine-arrow.webp",
             "range": [
-                19,
-                24
+                13,
+                18
             ],
             "text": "Vine Arrow",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "wrKtGlVFkGEmsR3E",
+            "_id": "xgHsiPwmRc7x2rV6",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "SgtqZxt26BdjUmEB",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/acid-flask.webp",
             "range": [
-                25,
-                30
+                19,
+                24
             ],
             "text": "Acid Flask (Moderate)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "6fofSWDLAli7D9Vf",
+            "_id": "0nFvNuQ4LlW6y98i",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "gWr4q4HiyGhETA8H",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/alchemists-fire.webp",
             "range": [
-                31,
-                36
+                25,
+                30
             ],
             "text": "Alchemist's Fire (Moderate)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "K6tpDqDyQvis48Iu",
+            "_id": "Qw1vuubRxaw7IFuS",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "97QyNEOAyYLdGaYc",
+            "documentId": "IvFEJqp2MUew65nQ",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/bottled-lightning.webp",
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/dread-ampoule.webp",
             "range": [
-                37,
-                42
+                31,
+                36
             ],
-            "text": "Bottled Lightning (Moderate)",
+            "text": "Dread Ampoule (Moderate)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "J92d4MpwclPadwOc",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "nVvH1ZcM7OwIVIs8",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/frost-vial.webp",
-            "range": [
-                43,
-                48
-            ],
-            "text": "Frost Vial (Moderate)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "3HZHqYqejkaKCSlQ",
+            "_id": "Pk9ZXmhoW5ppr1hf",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "evBPzM1VsuYcoenn",
             "drawn": false,
             "img": "icons/containers/bags/sack-simple-leather-tan.webp",
             "range": [
-                49,
-                54
+                37,
+                42
             ],
-            "text": "Tanglefoot Bag (Moderate)",
+            "text": "Glue Bomb (Moderate)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "tcFhkk6uFUkkQWMk",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "JOaELkzLWTywhn5Z",
-            "drawn": false,
-            "img": "icons/commodities/gems/pearl-rough-turquoise.webp",
-            "range": [
-                55,
-                60
-            ],
-            "text": "Thunderstone (Moderate)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "V7QV2iZcpQW0W4Bl",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "fFq8nsGvSUgzVeND",
-            "drawn": false,
-            "img": "icons/commodities/materials/feather-blue.webp",
-            "range": [
-                61,
-                66
-            ],
-            "text": "Feather Token (Bird)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "VEeUe1e8wg9Ap9a7",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Dn2KQgIeWNijaUzL",
-            "drawn": false,
-            "img": "icons/commodities/materials/feather-blue.webp",
-            "range": [
-                67,
-                72
-            ],
-            "text": "Feather Token (Chest)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "UpLZlf4UpQIHnPZF",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "VISk5uLPVIvNWovB",
-            "drawn": false,
-            "img": "icons/consumables/potions/bottle-round-flask-fumes-purple.webp",
-            "range": [
-                73,
-                78
-            ],
-            "text": "Bestial Mutagen (Moderate)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "vj4JoRI7CsrYl8e0",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "qpzL9UnTi4cDhy6J",
-            "drawn": false,
-            "img": "icons/consumables/potions/potion-vial-corked-purple.webp",
-            "range": [
-                79,
-                84
-            ],
-            "text": "Cognitive Mutagen (Moderate)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "AzSagjT1yaUEXvLF",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "mj9i9GeQTADByNPZ",
-            "drawn": false,
-            "img": "icons/consumables/potions/bottle-round-corked-green.webp",
-            "range": [
-                85,
-                90
-            ],
-            "text": "Juggernaut Mutagen (Moderate)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "aRWR0oDpz3lG7Ye6",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "n52BSbZsnx4Vmt2p",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/quicksilver-mutagen.webp",
-            "range": [
-                91,
-                96
-            ],
-            "text": "Quicksilver Mutagen (Moderate)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "ZIzH7JvfkVjO9W6M",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "XEYveTvLH1lJ4jeI",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/serene-mutagen.webp",
-            "range": [
-                97,
-                102
-            ],
-            "text": "Serene Mutagen (Moderate)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "txw59NSuj5GuarW9",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "lIExlUFBKvBue8hb",
-            "drawn": false,
-            "img": "icons/consumables/potions/potion-bottle-corked-fancy-blue.webp",
-            "range": [
-                103,
-                108
-            ],
-            "text": "Silvertongue Mutagen (Moderate)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "8SZCYCDAopjULZb8",
+            "_id": "kAHYy8XuDJlCb8ZS",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "QN8UIz0nMcnLUWHu",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/oils/oil-of-mending.webp",
             "range": [
-                109,
-                114
+                43,
+                48
             ],
             "text": "Oil of Mending",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "cmwKZov12lzmZ4r3",
+            "_id": "ZKmPhaJKHOSBuMeM",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "aZm1x9tpvBAT8YCd",
+            "documentId": "BSInwFNVBVkfFK0B",
             "drawn": false,
-            "img": "icons/commodities/materials/liquid-purple.webp",
+            "img": "systems/pf2e/icons/equipment/consumables/oils/oil-of-unlife.webp",
             "range": [
-                115,
-                120
+                49,
+                54
             ],
-            "text": "Cytillesh Oil",
+            "text": "Oil of Unlife (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "xsjcKG0Z6oa3E05T",
+            "_id": "iFFctogx3ApStrjK",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "Dn2KQgIeWNijaUzL",
+            "drawn": false,
+            "img": "icons/containers/chest/chest-oak-steel-brown.webp",
+            "range": [
+                55,
+                60
+            ],
+            "text": "Marvelous Miniature (Chest)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "CdgeLpl8yNJXFnED",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "qQqAY59NgGNoy2xr",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/graveroot.webp",
             "range": [
-                121,
-                126
+                61,
+                66
             ],
             "text": "Graveroot",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "13S0UvlDiZlKJ8S9",
+            "_id": "nqj8cAAa9xz0DYfZ",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "e0vSAQfxhHauiAoD",
             "drawn": false,
             "img": "icons/consumables/potions/bottle-round-corked-orante-red.webp",
             "range": [
-                127,
-                132
+                67,
+                72
             ],
             "text": "Healing Potion (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "Anedv6AMhEkiHGj0",
+            "_id": "eufhS8pgSI4XD8RZ",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "WQhnfj1LbrEzvh8z",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/potions/potion-of-water-breathing.webp",
             "range": [
-                133,
-                138
+                73,
+                78
             ],
             "text": "Potion of Water Breathing",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "Fipi7flIfw6EvMea",
+            "_id": "LfRQVcHYqcvhZmgz",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "Y7UD64foDbDMV9sx",
             "drawn": false,
             "img": "icons/sundries/scrolls/scroll-symbol-eye-brown.webp",
             "range": [
-                139,
-                144
+                79,
+                84
             ],
-            "text": "Scroll of 2nd-level Spell",
+            "text": "Scroll of 2nd-rank Spell",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "mJWgsDXgL2Dv3BOw",
+            "_id": "HRziIWLyJVc85Di8",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "X345VfEx9DZwO47G",
+            "drawn": false,
+            "img": "icons/commodities/metal/fragments-steel-ring.webp",
+            "range": [
+                85,
+                90
+            ],
+            "text": "Alloy Orb (Low-Grade)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "AVIUCX55UDCd3sT0",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "0CNSvLpeSM4aIfPJ",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/talismans/feather-step-stone.webp",
             "range": [
-                145,
-                150
+                91,
+                96
             ],
             "text": "Feather Step Stone",
             "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "xc2USLSCpTP9IaRd",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "RcQ4ZIzRK2xLf4G5",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/ammunition/sleep-arrow.webp",
+            "range": [
+                97,
+                102
+            ],
+            "text": "Slumber Arrow",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "Rr34ENl79UaL5YP8",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "JOaELkzLWTywhn5Z",
+            "drawn": false,
+            "img": "icons/commodities/gems/pearl-rough-turquoise.webp",
+            "range": [
+                103,
+                108
+            ],
+            "text": "Blasting Stone (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "EyTg381a7NSxQwmE",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "158vwM1andv8DbRI",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/blight-bomb.webp",
+            "range": [
+                109,
+                114
+            ],
+            "text": "Blight Bomb (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "ZAd7ZGNbSlY8Wuw2",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "97QyNEOAyYLdGaYc",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/bottled-lightning.webp",
+            "range": [
+                115,
+                120
+            ],
+            "text": "Bottled Lightning (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "jADHF9fkO0Q0STL8",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "nVvH1ZcM7OwIVIs8",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/frost-vial.webp",
+            "range": [
+                121,
+                126
+            ],
+            "text": "Frost Vial (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "pT0vImG7DGqPPK1p",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "Wf94e8YNhZdIvWc9",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/ghost-charge.webp",
+            "range": [
+                127,
+                132
+            ],
+            "text": "Ghost Charge (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "qteXWDwcw0Z5gMx2",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "0KXqdhz2MYV0LBm2",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/potions/serum-of-sex-shift.webp",
+            "range": [
+                133,
+                138
+            ],
+            "text": "Elixir of Gender Transformation (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "JnuV4HzIk33c6MQF",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "VISk5uLPVIvNWovB",
+            "drawn": false,
+            "img": "icons/consumables/potions/bottle-round-flask-fumes-purple.webp",
+            "range": [
+                139,
+                144
+            ],
+            "text": "Bestial Mutagen (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "gbF0nwxVjdM3oClA",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "qpzL9UnTi4cDhy6J",
+            "drawn": false,
+            "img": "icons/consumables/potions/potion-vial-corked-purple.webp",
+            "range": [
+                145,
+                150
+            ],
+            "text": "Cognitive Mutagen (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "xR2jnv6uhi5mD45l",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "xY2MogTwH9Fd8UPG",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/drakeheart-mutagen.webp",
+            "range": [
+                151,
+                156
+            ],
+            "text": "Drakeheart Mutagen (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "893TP3dOWfNstY3h",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "mj9i9GeQTADByNPZ",
+            "drawn": false,
+            "img": "icons/consumables/potions/bottle-metal-yellow-gray.webp",
+            "range": [
+                157,
+                162
+            ],
+            "text": "Juggernaut Mutagen (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "zGYyXAelppLTtW1x",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "n52BSbZsnx4Vmt2p",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/quicksilver-mutagen.webp",
+            "range": [
+                163,
+                168
+            ],
+            "text": "Quicksilver Mutagen (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "TK7MGpGo7OtEkdZB",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "XEYveTvLH1lJ4jeI",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/serene-mutagen.webp",
+            "range": [
+                169,
+                174
+            ],
+            "text": "Serene Mutagen (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "BtV5pWwMpz5nTVAU",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "lIExlUFBKvBue8hb",
+            "drawn": false,
+            "img": "icons/consumables/potions/potion-bottle-corked-fancy-blue.webp",
+            "range": [
+                175,
+                180
+            ],
+            "text": "Silvertongue Mutagen (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "86ORdivfqkkXONdn",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "aZm1x9tpvBAT8YCd",
+            "drawn": false,
+            "img": "icons/commodities/materials/liquid-purple.webp",
+            "range": [
+                181,
+                186
+            ],
+            "text": "Cytillesh Oil",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "OAEmZRjyYuuhEQYp",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/potions/potion-of-cold-retalliation.webp",
+            "range": [
+                187,
+                192
+            ],
+            "text": "Potion of Retaliation (Lesser)",
+            "type": "text",
             "weight": 6
         }
     ]

--- a/packs/rollable-tables/3rd-level-permanent-items.json
+++ b/packs/rollable-tables/3rd-level-permanent-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "Ow2zoRUSX0s7JjMo",
-    "description": "Table of 3rd-Level Permanent Items",
+    "description": "<p>Table of 3rd-Level Permanent Items</p>",
     "displayRoll": true,
-    "formula": "1d123",
+    "formula": "1d129",
     "img": "icons/svg/d20-grey.svg",
     "name": "3rd-Level Permanent Items",
     "ownership": {
@@ -53,231 +53,231 @@
             "weight": 6
         },
         {
-            "_id": "2wUqPwwk28SJXbOv",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "kEy7Uc1VisizGgtf",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/runes/armor-property-runes/armor-property-runes.webp",
-            "range": [
-                19,
-                24
-            ],
-            "text": "Shadow",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "bTwikuvoIuXKabFL",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "uQOaRpfkUFVYD0Gx",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/runes/armor-property-runes/armor-property-runes.webp",
-            "range": [
-                25,
-                30
-            ],
-            "text": "Slick",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "KE5WuqxZOMKkfeVK",
+            "_id": "WLXQ7hFaev6CsUXr",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "opfpl1JmKgrfds9P",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/staves/staff-of-fire.webp",
             "range": [
-                31,
-                36
+                19,
+                24
             ],
             "text": "Staff of Fire",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "CUmCEauinNplh5ZA",
+            "_id": "G3yVxCJPvx1XMyju",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "UJWiN0K3jqVjxvKk",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/magic-wands/magic-wand.webp",
             "range": [
-                37,
-                42
+                25,
+                30
             ],
             "text": "Magic Wand (1st-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "niyCneExcTokEG5D",
+            "_id": "aJvasjkn4Veju0EB",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "Kx6FQS5GyVB6jlrW",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/weapons/specific-magic-weapons/fighters-fork.webp",
             "range": [
-                43,
-                48
+                31,
+                36
             ],
             "text": "Fighter's Fork",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "U5iyrCFfxvcv8nBd",
+            "_id": "nKMXVrx9on0RtzLI",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "q6ZvspNDkzJSP6dg",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/weapons/specific-magic-weapons/retribution-axe.webp",
             "range": [
-                49,
-                54
+                37,
+                42
             ],
             "text": "Retribution Axe",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "k06Hg1qDu1oNSiLQ",
+            "_id": "qb7QMuUM8p1NouuZ",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "BKdzb8hu3kZtKH3Z",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/bracelet-of-dashing.webp",
             "range": [
-                55,
-                60
+                43,
+                48
             ],
             "text": "Bracelet of Dashing",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "KAXlei1zEICCrgaJ",
+            "_id": "i5LI4u6c8GfaYcLq",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "eurAnvH8bK0ZctOR",
             "drawn": false,
             "img": "icons/equipment/wrist/bracer-segmented-leather.webp",
             "range": [
-                61,
-                66
+                49,
+                54
             ],
             "text": "Bracers of Missile Deflection",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "I9J6fT8BCKpc9vtC",
+            "_id": "FeUpbVapDdeYiHGY",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "3vxoffA4slKHXtj2",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/channel-protection-amulet.webp",
             "range": [
-                67,
-                69
+                55,
+                57
             ],
             "text": "Channel Protection Amulet",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "P7oC4GEJuR8pVrId",
+            "_id": "7XTPcDJmhJegb2bj",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "LKdgj4UVmOvUwkZu",
+            "drawn": false,
+            "img": "icons/equipment/hand/glove-ringed-leather-yellow.webp",
+            "range": [
+                58,
+                63
+            ],
+            "text": "Charlatan's Gloves",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "jHNiIDILwHG6ZJF0",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "mvMeloQxSiEGIlhL",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/coyote-cloak.webp",
             "range": [
-                70,
-                75
+                64,
+                69
             ],
             "text": "Coyote Cloak",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "cTo0NKKtG0kjBJSd",
+            "_id": "7b06BU1pWSIwGV1K",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "RgNBGpBc9G2yw1C2",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/crafters-eyepiece.webp",
+            "img": "icons/tools/scribal/lens-blue.webp",
             "range": [
-                76,
-                81
+                70,
+                75
             ],
             "text": "Crafter's Eyepiece",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "cVTTKApoz8wZ7pXn",
+            "_id": "4UxX0VIGgyEmJidK",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "Epc1e1Q9M9bcwOR0",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/dancing-scarf.webp",
             "range": [
-                82,
-                87
+                76,
+                81
             ],
             "text": "Dancing Scarf",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "JLwT8DISSWHpWrKr",
+            "_id": "n6CjgJK2XVIPJ68c",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "DwMXEqy7Ws8NYQQh",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/doubling-rings.webp",
             "range": [
-                88,
-                93
+                82,
+                87
             ],
             "text": "Doubling Rings",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "NtaagMSzLpu2aHjU",
+            "_id": "VXsmp86PzxSV889m",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "SswqJqeAWGtX3tTF",
             "drawn": false,
             "img": "icons/equipment/head/hat-belted-simple-grey.webp",
             "range": [
-                94,
-                99
+                88,
+                93
             ],
-            "text": "Hat of the Magi",
+            "text": "Mage's Hat",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "pUUr9C9OZiQdvsgJ",
+            "_id": "dAaIj18F3trnB3Nm",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "zPhqmCvWyHO8i9ws",
             "drawn": false,
             "img": "icons/commodities/biological/eye-purple.webp",
             "range": [
-                100,
-                105
+                94,
+                99
             ],
             "text": "Pendant of the Occult",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "sEKGyq3CgtbpL8YH",
+            "_id": "YDr7JMOOJq8daI7Y",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "MKupH1T018JubYJW",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/persona-mask.webp",
             "range": [
-                106,
-                111
+                100,
+                105
             ],
             "text": "Persona Mask",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "YM85vN0BCmomxJvu",
+            "_id": "JsNzQWA9fYJU9vGU",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "YVtXlsEWb3NIkDyy",
+            "drawn": false,
+            "img": "icons/commodities/treasure/broach-jewel-gold-blue.webp",
+            "range": [
+                106,
+                111
+            ],
+            "text": "Shining Symbol",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "eJp0bYDtwm2FpHLb",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "ZEqAx8jEc6zhX3V1",
             "drawn": false,
@@ -291,7 +291,7 @@
             "weight": 6
         },
         {
-            "_id": "vgCqUe6qZZYaIgGR",
+            "_id": "BAN25rPJJ1s1qwus",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "1r6StS0irdvi5JHY",
             "drawn": false,
@@ -301,6 +301,20 @@
                 123
             ],
             "text": "Ventriloquist's Ring",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "oO1UFo6Fad8CoWz8",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "wJTpzqL8EJ0xVW0y",
+            "drawn": false,
+            "img": "icons/commodities/materials/material-cotton-white.webp",
+            "range": [
+                124,
+                129
+            ],
+            "text": "Twisting Twine (Lesser)",
             "type": "pack",
             "weight": 6
         }


### PR DESCRIPTION
Update 3rd-Level Consumable Items and 3rd-Level Permanent Items tables with remaster changes, consolidating the treasure tables from the GM Core and Player Core 2 books, preserving the item order found in those tables. Weight is based on rarity:

* Common = 6
* Uncommon = 3
* Rare = 1

For items that do not have a corresponding entry in the compendium, create a text entry in the table with the appropriate item name. If possible, set an appropriate icon from the system's icon set.