### PR TITLE
Update 4th-level rollable tables

### DIFF
--- a/packs/rollable-tables/4th-level-consumables-items.json
+++ b/packs/rollable-tables/4th-level-consumables-items.json
@@ -22,273 +22,368 @@
             ],
             "text": "Climbing Bolt",
             "type": "pack",
-            "weight": 6
+            "weight": 6,
+            "flags": {}
         },
         {
-            "_id": "QN2b9QvvhEhXYHss",
+            "type": "pack",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "ilB279mxqXnlaSFj",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/ammunition/viper-arrow.webp",
+            "weight": 6,
             "range": [
                 7,
                 12
             ],
-            "text": "Viper Arrow",
-            "type": "pack",
-            "weight": 6
+            "drawn": false,
+            "text": "Bomber's Eye Elixir (Lesser)",
+            "documentId": "T4ouD4mVFHA3EHs6",
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/bombers-eye-elixir.webp",
+            "_id": "P9DziNQbhGDwUSYj",
+            "flags": {}
         },
         {
-            "_id": "k455WZW8SCQLXbsv",
+            "type": "pack",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "3Fmbw9wJkqZBV9De",
-            "drawn": false,
-            "img": "icons/commodities/materials/feather-blue.webp",
+            "weight": 6,
             "range": [
                 13,
                 18
             ],
-            "text": "Feather Token (Fan)",
-            "type": "pack",
-            "weight": 6
+            "drawn": false,
+            "text": "Darkvision Elixir (Moderate)",
+            "documentId": "Y8115p3cmQJBqk5d",
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/darkvision-elixir.webp",
+            "_id": "S3JPIdHfZcnriSrc",
+            "flags": {}
         },
         {
-            "_id": "oLZsd9xeniDUB97N",
+            "type": "pack",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "T4ouD4mVFHA3EHs6",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/bombers-eye-elixir.webp",
+            "weight": 6,
             "range": [
                 19,
                 24
             ],
-            "text": "Bomber's Eye Elixir (Lesser)",
-            "type": "pack",
-            "weight": 6
+            "drawn": false,
+            "text": "Mistform Elixir (Lesser)",
+            "documentId": "GyO89RBVjAKFxsFm",
+            "img": "icons/consumables/potions/bottle-conical-corked-blue.webp",
+            "_id": "DTR5QxWuiUdXsjzE",
+            "flags": {}
         },
         {
-            "_id": "zz0eL7k3QNTKNXc3",
+            "type": "pack",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Y8115p3cmQJBqk5d",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/darkvision-elixir.webp",
+            "weight": 6,
             "range": [
                 25,
                 30
             ],
-            "text": "Darkvision Elixir (Moderate)",
-            "type": "pack",
-            "weight": 6
+            "drawn": false,
+            "text": "Stone Fist Elixir",
+            "documentId": "YcvSw7Zn3oyqlJaw",
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/stone-fist-elixir.webp",
+            "_id": "BC0Ok7pC20EKBEdN",
+            "flags": {}
         },
         {
-            "_id": "dwXrm0DZwZ0Vtpyl",
+            "type": "pack",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "GyO89RBVjAKFxsFm",
-            "drawn": false,
-            "img": "icons/consumables/potions/bottle-conical-corked-blue.webp",
+            "weight": 6,
             "range": [
                 31,
                 36
             ],
-            "text": "Mistform Elixir (Lesser)",
-            "type": "pack",
-            "weight": 6
+            "drawn": false,
+            "text": "Marvelous Miniature (Horse)",
+            "documentId": "TknN7T2RDy9cUtKU",
+            "img": "icons/environment/creatures/horse-tan.webp",
+            "_id": "eR3iOMYCEufD8LpV",
+            "flags": {}
         },
         {
-            "_id": "ViMk7CeQzvGeYUrC",
+            "type": "pack",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Ekk7o1gPu8RotixD",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/salamander-elixir.webp",
+            "weight": 6,
             "range": [
                 37,
                 42
             ],
-            "text": "Salamander Elixir (Lesser)",
-            "type": "pack",
-            "weight": 6
+            "drawn": false,
+            "text": "Fearflower Nectar",
+            "documentId": "ALS7pobHFmOnR4yX",
+            "img": "icons/commodities/flowers/lotus-violet.webp",
+            "_id": "Y6zMh7wGkNpDK3vM",
+            "flags": {}
         },
         {
-            "_id": "rj2RuyHe7q9qcZ2d",
+            "type": "pack",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "YcvSw7Zn3oyqlJaw",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/stone-fist-elixir.webp",
+            "weight": 3,
             "range": [
                 43,
-                48
+                45
             ],
-            "text": "Stone Fist Elixir",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "o3gZ97kIi4lo11BY",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "n9VrmK9Us0viv20P",
             "drawn": false,
-            "img": "icons/consumables/potions/bottle-round-ring-teal.webp",
-            "range": [
-                49,
-                54
-            ],
-            "text": "Winter Wolf Elixir (Lesser)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "OtH5vWwuqo4ICMuF",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "zC7LipQPHRYw2RXx",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/potions/barkskin-potion.webp",
-            "range": [
-                55,
-                60
-            ],
-            "text": "Barkskin Potion",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "TbqN7piUhgo0OfAf",
-            "documentCollection": "pf2e.equipment-srd",
+            "text": "Invisibility Potion",
             "documentId": "bikFUFRLwfdvX2x2",
-            "drawn": false,
             "img": "icons/consumables/potions/bottle-round-ring-teal.webp",
+            "_id": "DrGR0jVfJFbRhMvE",
+            "flags": {}
+        },
+        {
+            "type": "pack",
+            "documentCollection": "pf2e.equipment-srd",
+            "weight": 6,
             "range": [
-                61,
+                46,
+                51
+            ],
+            "drawn": false,
+            "text": "Oak Potion",
+            "documentId": "zC7LipQPHRYw2RXx",
+            "img": "systems/pf2e/icons/equipment/consumables/potions/barkskin-potion.webp",
+            "_id": "e9lTnXyHH3Nu5afV",
+            "flags": {}
+        },
+        {
+            "type": "pack",
+            "documentCollection": "pf2e.equipment-srd",
+            "weight": 6,
+            "range": [
+                52,
+                57
+            ],
+            "drawn": false,
+            "text": "Shrinking Potion",
+            "documentId": "FqbDpztscJfM4XMe",
+            "img": "systems/pf2e/icons/equipment/consumables/potions/shrinking-potion.webp",
+            "_id": "znLnUqKdzAyZGYA3",
+            "flags": {}
+        },
+        {
+            "type": "pack",
+            "documentCollection": "pf2e.equipment-srd",
+            "weight": 6,
+            "range": [
+                58,
                 63
             ],
-            "text": "Invisibility Potion",
-            "type": "pack",
-            "weight": 3
+            "drawn": false,
+            "text": "Bloodseeker Beak",
+            "documentId": "k6D64EAjcKMf8NZB",
+            "img": "icons/commodities/claws/claw-insect-brown.webp",
+            "_id": "1cjkjbFKnAmO2KGx",
+            "flags": {}
         },
         {
-            "_id": "l9CD8GKGvhWX8hAA",
+            "type": "pack",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "FqbDpztscJfM4XMe",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/potions/shrinking-potion.webp",
+            "weight": 6,
             "range": [
                 64,
                 69
             ],
-            "text": "Shrinking Potion",
-            "type": "pack",
-            "weight": 6
+            "drawn": false,
+            "text": "Dragon Turtle Scale",
+            "documentId": "GnXKCkgZQG0UmuHz",
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/dragon-turtle-scale.webp",
+            "_id": "JaTFdlGNWOxwK6Xz",
+            "flags": {}
         },
         {
-            "_id": "t5t1wLQE2o2FC0iI",
+            "type": "pack",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "9EZb1hmSKOGrU4Cf",
-            "drawn": false,
-            "img": "icons/environment/traps/trap-jaw-steel.webp",
+            "weight": 6,
             "range": [
                 70,
                 75
             ],
-            "text": "Biting Snare",
-            "type": "pack",
-            "weight": 6
+            "drawn": false,
+            "text": "Fear Gem",
+            "documentId": "ZAtwiAPkk1zwCf82",
+            "img": "icons/commodities/gems/gem-rough-oval-purple.webp",
+            "_id": "nvZLkiEuJU1yz0Sp",
+            "flags": {}
         },
         {
-            "_id": "SaGLwztjSNglsrzf",
+            "type": "pack",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "0lhh2l4kh3QrwYH9",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/snares/hobbling-snare.webp",
+            "weight": 6,
             "range": [
                 76,
-                78
-            ],
-            "text": "Hobbling Snare",
-            "type": "pack",
-            "weight": 3
-        },
-        {
-            "_id": "vHNOIhldCiAlVI37",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "s9dtRS2SRTqzGdOF",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/snares/stalker-bane-snare.webp",
-            "range": [
-                79,
                 81
             ],
-            "text": "Stalker Bane Snare",
-            "type": "pack",
-            "weight": 3
+            "drawn": false,
+            "text": "Viper Arrow",
+            "documentId": "ilB279mxqXnlaSFj",
+            "img": "systems/pf2e/icons/equipment/consumables/ammunition/viper-arrow.webp",
+            "_id": "4keNvuWj4zD7L83P",
+            "flags": {}
         },
         {
-            "_id": "wDGaxAN4F6RLlPZV",
+            "type": "pack",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "SWqzv0hYCIczICeR",
-            "drawn": false,
-            "img": "icons/commodities/cloth/thread-spindle-white-grey.webp",
+            "weight": 6,
             "range": [
                 82,
                 87
             ],
-            "text": "Trip Snare",
-            "type": "pack",
-            "weight": 6
+            "drawn": false,
+            "text": "Crystal Shards (Moderate)",
+            "documentId": "V4wgOWYmHlbSZsVG",
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/crystal-shards.webp",
+            "_id": "1rrWtE8qMdEvXLwV",
+            "flags": {}
         },
         {
-            "_id": "WyvKXDRJxYg9a79P",
+            "type": "pack",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "XU8u9F3uoesGDjgM",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/snares/warning-snare.webp",
+            "weight": 6,
             "range": [
                 88,
                 93
             ],
-            "text": "Warning Snare",
-            "type": "pack",
-            "weight": 6
+            "drawn": false,
+            "text": "Bottled Catharsis (Lesser)",
+            "documentId": "8KbayiwrUJtvif0a",
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/focus-cathartic.webp",
+            "_id": "u4NmFxoavA5cMmGr",
+            "flags": {}
         },
         {
-            "_id": "YNNBB0NEm00kqxhJ",
+            "type": "pack",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "k6D64EAjcKMf8NZB",
-            "drawn": false,
-            "img": "icons/commodities/claws/claw-insect-brown.webp",
+            "weight": 6,
             "range": [
                 94,
                 99
             ],
-            "text": "Bloodseeker Beak",
-            "type": "pack",
-            "weight": 6
+            "drawn": false,
+            "text": "Cooling Elixir (Lesser)",
+            "documentId": "Ekk7o1gPu8RotixD",
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/salamander-elixir.webp",
+            "_id": "jzTu7G4amSHGZUxa",
+            "flags": {}
         },
         {
-            "_id": "WsS6m4J1WTXgwz5x",
+            "type": "pack",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "GnXKCkgZQG0UmuHz",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/talismans/dragon-turtle-scale.webp",
+            "weight": 6,
             "range": [
                 100,
                 105
             ],
-            "text": "Dragon Turtle Scale",
-            "type": "pack",
-            "weight": 6
+            "drawn": false,
+            "text": "Surging Serum (Lesser)",
+            "documentId": "1TWHN8RbimPVXM0U",
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/sinew-shock-serum.webp",
+            "_id": "dURqL0JteziCnBno",
+            "flags": {}
         },
         {
-            "_id": "vd0CCfRPIvDD5bR9",
+            "type": "pack",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "ZAtwiAPkk1zwCf82",
-            "drawn": false,
-            "img": "icons/commodities/gems/gem-rough-oval-purple.webp",
+            "weight": 6,
             "range": [
                 106,
                 111
             ],
-            "text": "Fear Gem",
+            "drawn": false,
+            "text": "Witchwarg Elixir (Lesser)",
+            "documentId": "n9VrmK9Us0viv20P",
+            "img": "icons/consumables/potions/bottle-round-ring-teal.webp",
+            "_id": "kQTnunLE0S9fmtjU",
+            "flags": {}
+        },
+        {
             "type": "pack",
-            "weight": 6
+            "documentCollection": "pf2e.equipment-srd",
+            "weight": 6,
+            "range": [
+                112,
+                117
+            ],
+            "drawn": false,
+            "text": "Leadenleg",
+            "documentId": "QJ1fTrX42PoEWpK5",
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/leadenleg.webp",
+            "_id": "ep0uNyFuyGn1znid",
+            "flags": {}
+        },
+        {
+            "type": "pack",
+            "documentCollection": "pf2e.equipment-srd",
+            "weight": 6,
+            "range": [
+                118,
+                123
+            ],
+            "drawn": false,
+            "text": "Biting Snare",
+            "documentId": "9EZb1hmSKOGrU4Cf",
+            "img": "icons/environment/traps/trap-jaw-steel.webp",
+            "_id": "Ji88hahtOiyJ87xT",
+            "flags": {}
+        },
+        {
+            "type": "pack",
+            "documentCollection": "pf2e.equipment-srd",
+            "weight": 3,
+            "range": [
+                124,
+                126
+            ],
+            "drawn": false,
+            "text": "Hobbling Snare",
+            "documentId": "0lhh2l4kh3QrwYH9",
+            "img": "icons/magic/nature/root-vine-entangle-foot-green.webp",
+            "_id": "k0S0eznH0ApMmvWi",
+            "flags": {}
+        },
+        {
+            "type": "pack",
+            "documentCollection": "pf2e.equipment-srd",
+            "weight": 3,
+            "range": [
+                127,
+                129
+            ],
+            "drawn": false,
+            "text": "Stalker Bane Snare",
+            "documentId": "s9dtRS2SRTqzGdOF",
+            "img": "systems/pf2e/icons/equipment/snares/stalker-bane-snare.webp",
+            "_id": "13CGauAkkBvfRyb0",
+            "flags": {}
+        },
+        {
+            "type": "pack",
+            "documentCollection": "pf2e.equipment-srd",
+            "weight": 6,
+            "range": [
+                130,
+                135
+            ],
+            "drawn": false,
+            "text": "Trip Snare",
+            "documentId": "SWqzv0hYCIczICeR",
+            "img": "icons/commodities/cloth/thread-spindle-white-grey.webp",
+            "_id": "7UxWLNXfbJrmvPn0",
+            "flags": {}
+        },
+        {
+            "type": "pack",
+            "documentCollection": "pf2e.equipment-srd",
+            "weight": 6,
+            "range": [
+                136,
+                141
+            ],
+            "drawn": false,
+            "text": "Timeless Salts",
+            "documentId": "Ha6n30Tj3TNru9Dj",
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/timeless-salts.webp",
+            "_id": "v2xbmBtbR33akycD",
+            "flags": {}
         }
     ]
 }

--- a/packs/rollable-tables/4th-level-permanent-items.json
+++ b/packs/rollable-tables/4th-level-permanent-items.json
@@ -11,200 +11,259 @@
     "replacement": true,
     "results": [
         {
-            "_id": "QN2b9QvvhEhXYHss",
+            "type": "pack",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "jaEEvuQ32GjAa8jy",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/held-items/bag-of-holding.webp",
+            "weight": 6,
             "range": [
                 1,
                 6
             ],
-            "text": "Bag of Holding (Type I)",
-            "type": "pack",
-            "weight": 6
+            "drawn": false,
+            "text": "Spacious Pouch (Type I)",
+            "documentId": "jaEEvuQ32GjAa8jy",
+            "img": "systems/pf2e/icons/equipment/held-items/bag-of-holding.webp",
+            "_id": "SRACM7psSWbt7MUy",
+            "flags": {}
         },
         {
-            "_id": "aPbhuQl16Dn83HR8",
+            "type": "pack",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "JQdwHECogcTzdd8R",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
+            "weight": 6,
             "range": [
                 7,
                 12
             ],
+            "drawn": false,
             "text": "Ghost Touch",
-            "type": "pack",
-            "weight": 6
+            "documentId": "JQdwHECogcTzdd8R",
+            "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
+            "_id": "vepEjDl8jOX86vNe",
+            "flags": {}
         },
         {
-            "_id": "3EqXFbXhBaS3HemC",
+            "type": "pack",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "DxCuJKynlnMQZHgp",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/runes/fundamental-weapon-runes/striking.webp",
+            "weight": 6,
             "range": [
                 13,
                 18
             ],
-            "text": "Striking",
-            "type": "pack",
-            "weight": 6
+            "drawn": false,
+            "text": "Reinforcing Rune (Minor)",
+            "documentId": "x9SNVpAAnXKJeoqp",
+            "img": "icons/commodities/treasure/token-runed-os-grey.webp",
+            "_id": "7GVKVhPHE1tRqofk",
+            "flags": {}
         },
         {
-            "_id": "oLZsd9xeniDUB97N",
+            "type": "pack",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "f9ygr5Cjrmop8LWV",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/shields/specific-shields/sturdy-shield.webp",
+            "weight": 6,
             "range": [
                 19,
                 24
             ],
-            "text": "Sturdy Shield (Minor)",
-            "type": "pack",
-            "weight": 6
+            "drawn": false,
+            "text": "Striking",
+            "documentId": "DxCuJKynlnMQZHgp",
+            "img": "systems/pf2e/icons/equipment/runes/fundamental-weapon-runes/striking.webp",
+            "_id": "Q5GdUSJPaUQunMLC",
+            "flags": {}
         },
         {
-            "_id": "zz0eL7k3QNTKNXc3",
+            "type": "pack",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "WcuknnE3xYfSdbhm",
-            "drawn": false,
-            "img": "icons/weapons/staves/staff-ornate-bird.webp",
+            "weight": 6,
             "range": [
                 25,
                 30
             ],
-            "text": "Animal Staff",
-            "type": "pack",
-            "weight": 6
+            "drawn": false,
+            "text": "Sturdy Shield (Minor)",
+            "documentId": "f9ygr5Cjrmop8LWV",
+            "img": "systems/pf2e/icons/equipment/shields/specific-shields/sturdy-shield.webp",
+            "_id": "FaCinm93O2jFlr6V",
+            "flags": {}
         },
         {
-            "_id": "lLzSpPUauPOj4sfl",
+            "type": "pack",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "xwiZBOjispKVZzGA",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/staves/mentalist-staff.webp",
+            "weight": 6,
             "range": [
                 31,
                 36
             ],
-            "text": "Mentalist's Staff",
-            "type": "pack",
-            "weight": 6
+            "drawn": false,
+            "text": "Animal Staff",
+            "documentId": "WcuknnE3xYfSdbhm",
+            "img": "icons/weapons/staves/staff-ornate-bird.webp",
+            "_id": "CqAVPdu3PE9R0AVY",
+            "flags": {}
         },
         {
-            "_id": "HpyqvpBDM6D2jUC6",
+            "type": "pack",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "3OkOKxCee9WruGU5",
-            "drawn": false,
-            "img": "icons/weapons/staves/staff-ornate-gold-jeweled.webp",
+            "weight": 6,
             "range": [
                 37,
                 42
             ],
-            "text": "Staff of Healing",
-            "type": "pack",
-            "weight": 6
+            "drawn": false,
+            "text": "Mentalist's Staff",
+            "documentId": "xwiZBOjispKVZzGA",
+            "img": "systems/pf2e/icons/equipment/staves/mentalist-staff.webp",
+            "_id": "AHr6259HQlrLJpiq",
+            "flags": {}
         },
         {
-            "_id": "kQTbzpAKyDIdb9PY",
+            "type": "pack",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Zw3BKaJYxxxzNZ0f",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-widening.webp",
+            "weight": 6,
             "range": [
                 43,
                 48
             ],
-            "text": "Wand of Widening (1st-Rank Spell)",
-            "type": "pack",
-            "weight": 6
+            "drawn": false,
+            "text": "Staff of Healing",
+            "documentId": "3OkOKxCee9WruGU5",
+            "img": "icons/weapons/staves/staff-ornate-gold-jeweled.webp",
+            "_id": "dWPzhR7OlQPGUF4H",
+            "flags": {}
         },
         {
-            "_id": "11E6i8082Hr9VbAI",
-            "documentCollection": "",
-            "documentId": null,
-            "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "type": "pack",
+            "documentCollection": "pf2e.equipment-srd",
+            "weight": 6,
             "range": [
                 49,
                 54
             ],
-            "text": "Weapon (+1 Striking)",
-            "type": "text",
-            "weight": 6
+            "drawn": false,
+            "text": "Wand of Widening (1st-Rank Spell)",
+            "documentId": "Zw3BKaJYxxxzNZ0f",
+            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-widening.webp",
+            "_id": "tlsLBZ3bm0MD7b9I",
+            "flags": {}
         },
         {
-            "_id": "dwXrm0DZwZ0Vtpyl",
+            "type": "text",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "7JVgLiNTAs4clEW8",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/alchemist-goggles.webp",
+            "weight": 6,
             "range": [
                 55,
                 60
             ],
-            "text": "Alchemist Goggles",
-            "type": "pack",
-            "weight": 6
+            "drawn": false,
+            "_id": "ws11Q7zMLmdJi0QE",
+            "text": "Striking Weapon (+1)",
+            "img": "systems/pf2e/icons/equipment/weapons/shortsword.webp",
+            "documentId": null,
+            "flags": {}
         },
         {
-            "_id": "TbqN7piUhgo0OfAf",
-            "documentCollection": "",
-            "documentId": "oC4ZMEdBJ3ia4ALm",
-            "drawn": false,
-            "img": "icons/equipment/back/mantle-collared-blue.webp",
+            "type": "text",
+            "documentCollection": "pf2e.equipment-srd",
+            "weight": 6,
             "range": [
                 61,
                 66
             ],
-            "text": "+1 striking Handwraps of Mighty Blows",
-            "type": "text",
-            "weight": 6
+            "drawn": false,
+            "_id": "PYXHf2kEFfDwhPiP",
+            "text": "Striking Handwraps of Mighty Blows (+1)",
+            "img": "icons/equipment/hand/gauntlet-simple-leather-brown-gold.webp",
+            "documentId": null,
+            "flags": {}
         },
         {
-            "_id": "l9CD8GKGvhWX8hAA",
+            "type": "pack",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "2gYZiUw9yjtb0yJY",
-            "drawn": false,
-            "img": "icons/equipment/head/mask-horned-brown.webp",
+            "weight": 6,
             "range": [
                 67,
                 72
             ],
+            "drawn": false,
             "text": "Demon Mask",
-            "type": "pack",
-            "weight": 6
+            "documentId": "2gYZiUw9yjtb0yJY",
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/demon-mask.webp",
+            "_id": "XU0XOMqExbnQXxEp",
+            "flags": {}
         },
         {
-            "_id": "t5t1wLQE2o2FC0iI",
+            "type": "pack",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "o1zKhvYUUc1hE2AE",
-            "drawn": false,
-            "img": "icons/equipment/hand/glove-simple-cloth-white.webp",
+            "weight": 6,
             "range": [
                 73,
                 78
             ],
+            "drawn": false,
             "text": "Healer's Gloves",
-            "type": "pack",
-            "weight": 6
+            "documentId": "o1zKhvYUUc1hE2AE",
+            "img": "icons/equipment/hand/glove-simple-cloth-white.webp",
+            "_id": "roFmJTv0LJz24H24",
+            "flags": {}
         },
         {
-            "_id": "vHNOIhldCiAlVI37",
+            "type": "pack",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "g2oaOGSpttfH1q6W",
-            "drawn": false,
-            "img": "icons/equipment/waist/belt-leather-brown.webp",
+            "weight": 6,
             "range": [
                 79,
                 84
             ],
+            "drawn": false,
             "text": "Lifting Belt",
+            "documentId": "g2oaOGSpttfH1q6W",
+            "img": "icons/equipment/waist/belt-leather-brown.webp",
+            "_id": "4Z4p2caLt6tpbLZM",
+            "flags": {}
+        },
+        {
             "type": "pack",
-            "weight": 6
+            "documentCollection": "pf2e.equipment-srd",
+            "weight": 6,
+            "range": [
+                85,
+                90
+            ],
+            "drawn": false,
+            "text": "Sleeves of Storage",
+            "documentId": "1pglC9PQx6yOgcKL",
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/sleeves-of-storage.webp",
+            "_id": "AujXBLZGBU2e4ekK",
+            "flags": {}
+        },
+        {
+            "type": "pack",
+            "documentCollection": "pf2e.equipment-srd",
+            "weight": 3,
+            "range": [
+                91,
+                93
+            ],
+            "drawn": false,
+            "text": "Symbol of Conflict",
+            "documentId": "BHjJpNILf85M2LJE",
+            "img": "icons/commodities/treasure/broach-eye-silver-teal.webp",
+            "_id": "pZj5ByKYQIL7yzQw",
+            "flags": {}
+        },
+        {
+            "type": "pack",
+            "documentCollection": "pf2e.equipment-srd",
+            "weight": 6,
+            "range": [
+                94,
+                99
+            ],
+            "drawn": false,
+            "text": "Alchemist Goggles",
+            "documentId": "7JVgLiNTAs4clEW8",
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/alchemist-goggles.webp",
+            "_id": "TKvSCbirYVz9rdA4",
+            "flags": {}
         }
     ]
 }


### PR DESCRIPTION
Update 4th-Level Consumable Items and 4th-Level Permanent Items tables with remaster changes, consolidating the treasure tables from the GM Core and Player Core 2 books, preserving the item order found in those tables. Weight is based on rarity:

* Common = 6
* Uncommon = 3
* Rare = 1

For items that do not have a corresponding entry in the compendium, create a text entry in the table with the appropriate item name. If possible, set an appropriate icon from the system's icon set.