### PR TITLE
Update 6th-level rollable tables

### DIFF
--- a/packs/rollable-tables/6th-level-consumables-items.json
+++ b/packs/rollable-tables/6th-level-consumables-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "A68C9O0vtWbFXbfS",
-    "description": "Table of 6th-Level Consumables Items",
+    "description": "<p>Table of 6th-Level Consumables Items</p>",
     "displayRoll": true,
-    "formula": "1d75",
+    "formula": "1d99",
     "img": "icons/svg/d20-grey.svg",
     "name": "6th-Level Consumables Items",
     "ownership": {
@@ -11,42 +11,14 @@
     "replacement": true,
     "results": [
         {
-            "_id": "mYq4p5qykRLe1Ok4",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "8iGmSwTTUdj6gqN5",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/other-consumables/dust-of-apperance.webp",
-            "range": [
-                1,
-                6
-            ],
-            "text": "Dust of Appearance",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "QN2b9QvvhEhXYHss",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "4owFeOy4zxy8rv7W",
-            "drawn": false,
-            "img": "icons/commodities/materials/feather-blue.webp",
-            "range": [
-                7,
-                12
-            ],
-            "text": "Feather Token (Tree)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
             "_id": "k455WZW8SCQLXbsv",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "AJ1dC7EtTIfBey0M",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/antidote.webp",
             "range": [
-                13,
-                18
+                1,
+                6
             ],
             "text": "Antidote (Moderate)",
             "type": "pack",
@@ -59,8 +31,8 @@
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/antiplague.webp",
             "range": [
-                19,
-                24
+                7,
+                12
             ],
             "text": "Antiplague (Moderate)",
             "type": "pack",
@@ -73,122 +45,206 @@
             "drawn": false,
             "img": "icons/consumables/potions/bottle-conical-corked-blue.webp",
             "range": [
-                25,
-                30
+                13,
+                18
             ],
             "text": "Mistform Elixir (Moderate)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "zz0eL7k3QNTKNXc3",
+            "_id": "y977Zj9sp6RCGTyf",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "YHev1WJ2tOiTBg9o",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/oils/oil-of-unlife.webp",
+            "range": [
+                19,
+                24
+            ],
+            "text": "Oil of Unlife (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "uGipXme0dXd6db1O",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "Ru4xaA4kjdZ4IFS5",
             "drawn": false,
             "img": "icons/tools/laboratory/bowl-mixing.webp",
             "range": [
-                31,
-                36
+                25,
+                30
             ],
             "text": "Oil of Weightlessness (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "lLzSpPUauPOj4sfl",
+            "_id": "CseEtJ2CvUFC1PIG",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "ZEKmCg8K2hUHbmnT",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/oils/salve-of-antiparalysis.webp",
             "range": [
-                37,
-                42
+                31,
+                36
             ],
             "text": "Salve of Antiparalysis",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "HpyqvpBDM6D2jUC6",
+            "_id": "HndMKLINkYf4gBNZ",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "QGXNqpP5KvSldoZz",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/giant-scorpion-venom.webp",
+            "img": "icons/consumables/potions/bottle-ornate-bat-teal.webp",
             "range": [
-                43,
-                48
+                37,
+                42
             ],
             "text": "Giant Scorpion Venom",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "bqsJMu7IB225fTYz",
+            "_id": "PEG3Y4QCGKzTFVjm",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "G7haQ5gDt30ftJLC",
             "drawn": false,
             "img": "icons/consumables/potions/bottle-round-corked-orante-red.webp",
             "range": [
-                49,
-                54
+                43,
+                48
             ],
             "text": "Healing Potion (Moderate)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "xkxbqKf3zQN0HjG2",
+            "_id": "Bg6sjAczrRQvalH8",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "V2TUEoiDwJ125qzN",
+            "documentId": null,
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/potions/potion-of-resistance.webp",
+            "img": "systems/pf2e/icons/equipment/consumables/potions/potion-of-cold-resistance.webp",
             "range": [
-                55,
-                60
+                49,
+                54
             ],
             "text": "Potion of Resistance (Lesser)",
-            "type": "pack",
+            "type": "text",
             "weight": 6
         },
         {
-            "_id": "kQTbzpAKyDIdb9PY",
+            "_id": "mpr6MJfXsldFsF0W",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "Eb4dEuV22QVlMumS",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/potions/potion-of-swimming.webp",
             "range": [
-                61,
-                66
+                55,
+                60
             ],
-            "text": "Potion of Swimming (Moderate)",
+            "text": "Potion of Swimming",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "11E6i8082Hr9VbAI",
+            "_id": "WIJywXumOMSLrFkT",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "HAEz4sSa6OH6C7Cs",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/weapons/truth-potion.webp",
+            "img": "systems/pf2e/icons/equipment/consumables/potions/truth-potion.webp",
             "range": [
-                67,
-                69
+                61,
+                63
             ],
             "text": "Truth Potion",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "61ajGdu6KUgCbRhV",
+            "_id": "5nDbgrqvtXyAZbAK",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "StsE5POM7OSE36Ia",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/talismans/iron-cube.webp",
             "range": [
+                64,
+                69
+            ],
+            "text": "Iron Cube",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "8iEj0vohIgG04HNl",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "ROdjFw7wby982qf5",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/ammunition/terrifying-ammunition.webp",
+            "range": [
                 70,
                 75
             ],
-            "text": "Iron Cube",
+            "text": "Terrifying Ammunition",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "9SZticWLOnbfXD8W",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "rDM6rxWVzKtFQOKg",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/potions/serum-of-sex-shift.webp",
+            "range": [
+                76,
+                81
+            ],
+            "text": "Elixir of Gender Transformation (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "yWyjYnCC5KZRQrkG",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
+            "drawn": false,
+            "img": "icons/svg/d20-black.svg",
+            "range": [
+                82,
+                87
+            ],
+            "text": "Potion of Retaliation (Moderate)",
+            "type": "text",
+            "weight": 6
+        },
+        {
+            "_id": "Ye0EaIvlAkXgcxHI",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "axU0I9xIm4xm2VPH",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/snares/bomb-snare.webp",
+            "range": [
+                88,
+                93
+            ],
+            "text": "Bomb Snare",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "hybwkXsxWYKBI3Jt",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "MbPboT76BBKVGepB",
+            "drawn": false,
+            "img": "icons/commodities/materials/slime-thick-green.webp",
+            "range": [
+                94,
+                99
+            ],
+            "text": "Nauseating Snare",
             "type": "pack",
             "weight": 6
         }

--- a/packs/rollable-tables/6th-level-permanent-items.json
+++ b/packs/rollable-tables/6th-level-permanent-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "9xol7FdCfaU585WR",
-    "description": "Table of 6th-Level Permanent Items",
+    "description": "<p>Table of 6th-Level Permanent Items</p>",
     "displayRoll": true,
-    "formula": "1d135",
+    "formula": "1d156",
     "img": "icons/svg/d20-grey.svg",
     "name": "6th-Level Permanent Items",
     "ownership": {
@@ -11,352 +11,408 @@
     "replacement": true,
     "results": [
         {
-            "_id": "mYq4p5qykRLe1Ok4",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "hRwnNTMj7wa8S4Ji",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/armor/specific-magic-armor/ghoul-hide.webp",
-            "range": [
-                1,
-                3
-            ],
-            "text": "Ghoul Hide",
-            "type": "pack",
-            "weight": 3
-        },
-        {
-            "_id": "QN2b9QvvhEhXYHss",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "3sGpEBXsZwjGnoES",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/held-items/chime-of-opening.webp",
-            "range": [
-                4,
-                6
-            ],
-            "text": "Chime of Opening",
-            "type": "pack",
-            "weight": 3
-        },
-        {
-            "_id": "k455WZW8SCQLXbsv",
+            "_id": "7Rcpk1JnR3jacT6Y",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "hcGvN03ieNWlSQYa",
             "drawn": false,
             "img": "icons/commodities/bones/horn-curved-worn-brown.webp",
             "range": [
-                7,
-                12
+                1,
+                6
             ],
-            "text": "Horn of Fog",
+            "text": "Cloud Pouch",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "3EqXFbXhBaS3HemC",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "J5MqY1P3JWrezcQX",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/held-items/primeval-mistletoe.webp",
-            "range": [
-                13,
-                18
-            ],
-            "text": "Primeval Mistletoe",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "oLZsd9xeniDUB97N",
+            "_id": "LSRGMrp2NenKJggD",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "nNtakXnSrcXWndBV",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/held-items/travelers-any-tool.webp",
             "range": [
-                19,
-                24
+                7,
+                12
             ],
             "text": "Traveler's Any-Tool",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "zz0eL7k3QNTKNXc3",
+            "_id": "pDN7c62acos7VhF5",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "QNPwzwKervKpk6YO",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/armor-property-runes/armor-property-runes.webp",
+            "range": [
+                13,
+                18
+            ],
+            "text": "Ready",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "QLR1mfyiW6Prk7VP",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "roeYtwlIe65BPMJ1",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
             "range": [
-                25,
-                30
+                19,
+                24
             ],
             "text": "Shifting",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "lLzSpPUauPOj4sfl",
+            "_id": "vRY5hhU73ZuAhX4X",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "eMDt5vCQztp7cC6B",
             "drawn": false,
             "img": "icons/equipment/shield/kite-steel-boss-gold.webp",
             "range": [
-                31,
-                36
+                25,
+                30
             ],
             "text": "Lion's Shield",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "HpyqvpBDM6D2jUC6",
+            "_id": "TOoEEtHlouThULSt",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "OqDAx4HJ39ojVtvg",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/shields/specific-shields/spellguard-shield.webp",
             "range": [
-                37,
-                42
+                31,
+                36
             ],
             "text": "Spellguard Shield",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "bqsJMu7IB225fTYz",
+            "_id": "9P9BIxqwYhfCxXTO",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "EYRrABqjUYPrhrZr",
+            "documentId": "B71BgdfFApkYmAjc",
             "drawn": false,
-            "img": "icons/weapons/staves/staff-simple-spiral.webp",
+            "img": "icons/weapons/staves/staff-orb-feather.webp",
+            "range": [
+                37,
+                42
+            ],
+            "text": "Fluid Form Staff",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "YBOT9RWK4K3Ehh72",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "wUFQ8cqkwn2xTCma",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/staves/staff-of-enchantment.webp",
             "range": [
                 43,
                 48
             ],
-            "text": "Staff of Abjuration",
+            "text": "Staff of Control",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "xkxbqKf3zQN0HjG2",
+            "_id": "Zr8S7nPiA7ND1bWw",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "6IJZamE4JkERQumf",
+            "documentId": "0Vw44XmzVS4knsa8",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/staves/staff-of-conjuration.webp",
+            "img": "systems/pf2e/icons/equipment/staves/staff-of-evocation.webp",
             "range": [
                 49,
                 54
             ],
-            "text": "Staff of Conjuration",
+            "text": "Staff of Elemental Power",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "kQTbzpAKyDIdb9PY",
+            "_id": "QU96DZjjequnzq04",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "ObmYN6I64Pjj7yEA",
+            "documentId": "HVgolLqbXUeRHXVN",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/staves/staff-of-divination.webp",
+            "img": "systems/pf2e/icons/equipment/staves/staff-of-illusion.webp",
             "range": [
                 55,
                 60
             ],
-            "text": "Staff of Divination",
+            "text": "Staff of Phantasms",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "11E6i8082Hr9VbAI",
+            "_id": "YYDeiJ3kQvSuHBFB",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "eaYNVLnTX9VejnaA",
+            "documentId": "4O00N0HoPz5ywNyz",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/staves/staff-of-enchantment.webp",
+            "img": "icons/weapons/staves/staff-engraved-wood.webp",
             "range": [
                 61,
                 66
             ],
-            "text": "Staff of Enchantment",
+            "text": "Staff of Protection",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "vQq7Hy7Dx1a8GCHZ",
+            "_id": "H0OITxeA3J1Fnx1X",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "96VBd7CV8NQyv3lP",
+            "documentId": "v0IrX97Pf96jPvxP",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/staves/staff-of-evocation.webp",
+            "img": "systems/pf2e/icons/equipment/staves/staff-of-conjuration.webp",
             "range": [
                 67,
                 72
             ],
-            "text": "Staff of Evocation",
+            "text": "Staff of Summoning",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "dwXrm0DZwZ0Vtpyl",
+            "_id": "BwvkgqvHve7OXJxv",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Q2QHZdBaoOLkE1lX",
+            "documentId": "1uWytZ76MwVQYIO9",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/staves/staff-of-illusion.webp",
+            "img": "icons/weapons/staves/staff-skull-feathers-brown.webp",
             "range": [
                 73,
                 78
             ],
-            "text": "Staff of Illusion",
+            "text": "Staff of the Dead",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "ViMk7CeQzvGeYUrC",
+            "_id": "fq6GZkujm3T1dXiL",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "c40Zn2TCRr3inIBA",
+            "documentId": "uhsVSBF4f3D5oym0",
             "drawn": false,
-            "img": "icons/weapons/staves/staff-skull-feathers-brown.webp",
+            "img": "icons/weapons/staves/staff-ornate-eye.webp",
             "range": [
                 79,
-                84
+                81
             ],
-            "text": "Staff of Necromancy",
+            "text": "Staff of the Unblinking Eye",
             "type": "pack",
-            "weight": 6
+            "weight": 3
         },
         {
-            "_id": "rj2RuyHe7q9qcZ2d",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "p1pysEaGypaNxTEL",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/staves/staff-of-transmutation.webp",
-            "range": [
-                85,
-                90
-            ],
-            "text": "Staff of Transmutation",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "o3gZ97kIi4lo11BY",
+            "_id": "KzSsJeAmKV9bUNWs",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "sQFQlglhORQsxBKS",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/staves/verdant-staff.webp",
+            "img": "icons/weapons/staves/staff-nature-spiral.webp",
             "range": [
-                91,
-                96
+                82,
+                87
             ],
             "text": "Verdant Staff",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "OtH5vWwuqo4ICMuF",
+            "_id": "agivIGn9NuuD8650",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "qmWlvoIlJRJ6pAeG",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-widening.webp",
             "range": [
-                97,
-                102
+                88,
+                93
             ],
             "text": "Wand of Widening (2nd-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "l9CD8GKGvhWX8hAA",
+            "_id": "sxJJa10ACfGQK2DB",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "tNue4PqJe85ZEE5v",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/weapons/specific-magic-weapons/bloodletting-kukri.webp",
             "range": [
-                103,
-                105
+                94,
+                96
             ],
             "text": "Bloodletting Kukri",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "t5t1wLQE2o2FC0iI",
+            "_id": "WSdLtrutUAszSLmi",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "pjUACbrAXNIy9O7S",
+            "documentId": null,
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/weapons/specific-magic-weapons/twining-staff.webp",
+            "img": "systems/pf2e/icons/equipment/staves/staff-of-enchantment.webp",
             "range": [
-                106,
-                111
+                97,
+                102
             ],
-            "text": "Twining Staff",
-            "type": "pack",
+            "text": "Twinning Staff",
+            "type": "text",
             "weight": 6
         },
         {
-            "_id": "SaGLwztjSNglsrzf",
+            "_id": "n8zzaLuj9KkGCL9E",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "odSvUKzphdwvDqgE",
+            "documentId": "BYr1DRYmiRsyr4po",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/aeon-stone-gold-nodule.webp",
+            "img": "systems/pf2e/icons/equipment/treasure/gems/moderate-semiprecious-stones/chrysoprase.webp",
             "range": [
-                112,
-                114
+                103,
+                105
             ],
-            "text": "Aeon Stone (Gold Nodule)",
+            "text": "Aeon Stone (Sprouting)",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "S0kG1NmHVtkY2ZNf",
+            "_id": "gEInK56HNFJjff1p",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "EkZVXMdtqTTgahiJ",
+            "drawn": false,
+            "img": "icons/equipment/neck/amulet-round-engraved-spiral-gold.webp",
+            "range": [
+                106,
+                111
+            ],
+            "text": "Charm of Resistance",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "j8vbdPkA7LIdBvhq",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "TacKaUs8cIddqiCU",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/choker-of-elocution.webp",
             "range": [
-                115,
-                120
+                112,
+                117
             ],
             "text": "Choker of Elocution",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "ND9f91U4mIQQpsxt",
+            "_id": "EC76uTrf0AL0DLSB",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "hmmDa6LCS22dZT7P",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/clandestine-cloak.webp",
             "range": [
-                121,
-                123
+                118,
+                120
             ],
             "text": "Clandestine Cloak",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "WGS4NVKgvBlbRbTe",
+            "_id": "5U1kBceeX5058dMn",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "EkZVXMdtqTTgahiJ",
+            "documentId": "J5MqY1P3JWrezcQX",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/ring-of-energy-resistance.webp",
+            "img": "systems/pf2e/icons/equipment/held-items/primeval-mistletoe.webp",
             "range": [
-                124,
-                129
+                121,
+                126
             ],
-            "text": "Ring of Energy Resistance",
+            "text": "Primeval Mistletoe",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "7Z6tn2kUuYj3hLx2",
+            "_id": "LfwFboFTSMWhVwlb",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "s97FDCHi2UcfzKGn",
+            "documentId": "Ld6K4snDzKbNXy2g",
             "drawn": false,
-            "img": "icons/equipment/finger/ring-crown-dragon-green.webp",
+            "img": "icons/equipment/finger/ring-band-engraved-scrolls-bronze.webp",
             "range": [
-                130,
+                127,
+                132
+            ],
+            "text": "Ring of Sigils (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "62TvZHikUZgpCIZy",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "hRwnNTMj7wa8S4Ji",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/armor/specific-magic-armor/ghoul-hide.webp",
+            "range": [
+                133,
                 135
             ],
-            "text": "Ring of the Ram",
+            "text": "Ghoul Hide",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "q5XH2RdN5KwvmaVx",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "WA5eoFFuAsyx7A2t",
+            "drawn": false,
+            "img": "icons/weapons/staves/staff-crescent-green.webp",
+            "range": [
+                136,
+                138
+            ],
+            "text": "Staff of Impossible Visions",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "2jDRRvthedzhFxyG",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "XeTmuhuNnhGf7c4t",
+            "drawn": false,
+            "img": "icons/weapons/staves/staff-ornate-eye.webp",
+            "range": [
+                139,
+                144
+            ],
+            "text": "Staff of Providence",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "NaGEulqB95OEeh1C",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "0S8lZFSEP7ZlLFqA",
+            "drawn": false,
+            "img": "icons/weapons/staves/staff-simple-wrapped.webp",
+            "range": [
+                145,
+                150
+            ],
+            "text": "Staff of the Tempest",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "0pkddwK4yFXhicAy",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "ZJ3ahspZOXL4CK4J",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-hopeless-night.webp",
+            "range": [
+                151,
+                156
+            ],
+            "text": "Wand of Hopeless Night (2nd-Rank Spell)",
             "type": "pack",
             "weight": 6
         }


### PR DESCRIPTION
Update 6th-Level Consumable Items and 6th-Level Permanent Items tables with remaster changes, consolidating the treasure tables from the GM Core and Player Core 2 books, preserving the item order found in those tables. Weight is based on rarity:

* Common = 6
* Uncommon = 3
* Rare = 1

For items that do not have a corresponding entry in the compendium, create a text entry in the table with the appropriate item name. If possible, set an appropriate icon from the system's icon set.