### PR TITLE
Fix immunities of Animated Armor

### DIFF
--- a/packs/pathfinder-monster-core/animated-armor.json
+++ b/packs/pathfinder-monster-core/animated-armor.json
@@ -211,7 +211,56 @@
                 "temp": 0,
                 "value": 20
             },
-            "immunities": [],
+            "immunities": [
+                {
+                    "type": "bleed"
+                },
+                {
+                    "type": "death effects"
+                },
+                {
+                    "type": "disease"
+                },
+                {
+                    "type": "doomed"
+                },
+                {
+                    "type": "drained"
+                },
+                {
+                    "type": "fatigued"
+                },
+                {
+                    "type": "healing"
+                },
+                {
+                    "type": "mental"
+                },
+                {
+                    "type": "nonlethal attacks"
+                },
+                {
+                    "type": "paralyzed"
+                },
+                {
+                    "type": "poison"
+                },
+                {
+                    "type": "sickened"
+                },
+                {
+                    "type": "spirit"
+                },
+                {
+                    "type": "unconscious"
+                },
+                {
+                    "type": "vitality"
+                },
+                {
+                    "type": "void"
+                }
+            ],
             "speed": {
                 "otherSpeeds": [],
                 "value": 20


### PR DESCRIPTION
"Animated Armor" does not have any immunities listed in it's "Monster Core" JSON file.
I added the immunities according to the "Monster Core".