### PR TITLE
Update 7th-level rollable tables

### DIFF
--- a/packs/rollable-tables/1st-level-consumables.json
+++ b/packs/rollable-tables/1st-level-consumables.json
@@ -1,8 +1,8 @@
 {
     "_id": "tlX5PLwar8b1tmiQ",
-    "description": "<p>Table of 1st-Level Consumables</p>",
+    "description": "Table of 1st-Level Consumables",
     "displayRoll": true,
-    "formula": "1d330",
+    "formula": "1d246",
     "img": "icons/svg/d20-grey.svg",
     "name": "1st-Level Consumables",
     "ownership": {
@@ -11,7 +11,7 @@
     "replacement": true,
     "results": [
         {
-            "_id": "cFuhsP5dJeXhMbpc",
+            "_id": "lFxTQnP90fZKf3Pi",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "NI7twU2G6UCDmvCO",
             "drawn": false,
@@ -25,7 +25,7 @@
             "weight": 6
         },
         {
-            "_id": "SwJNnQ54Q99zdxRG",
+            "_id": "AD6iXxXwvR54mtKk",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "M1k5QQc1qQLxzyCK",
             "drawn": false,
@@ -39,7 +39,7 @@
             "weight": 6
         },
         {
-            "_id": "aC5fAaMFKvqINcbw",
+            "_id": "0weTT9FVhOQNuwx2",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "yd3kEK21YknZLlcT",
             "drawn": false,
@@ -53,730 +53,534 @@
             "weight": 6
         },
         {
-            "_id": "EsO1qsPUf0CcmbqM",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "ds0OdA989ZZw9km1",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/dread-ampoule.webp",
-            "range": [
-                19,
-                24
-            ],
-            "text": "Dread Ampoule (Lesser)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "Wl1XIIKyV0ubVvMy",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "T6Appwwl6nUl56Xj",
-            "drawn": false,
-            "img": "icons/containers/bags/sack-simple-leather-tan.webp",
-            "range": [
-                25,
-                30
-            ],
-            "text": "Glue Bomb (Lesser)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "6DovgTGfme3ZiOBU",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "ktjFOp3U0wQD9t0Z",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/antidote.webp",
-            "range": [
-                31,
-                36
-            ],
-            "text": "Antidote (Lesser)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "7q6UcgxxYbWwGZrH",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "UqinuuCWePTYGhVO",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/antiplague.webp",
-            "range": [
-                37,
-                42
-            ],
-            "text": "Antiplague (Lesser)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "dyc2GQYrqtYy2nkK",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "tyt6rFtv32MZ4DT9",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/cheetahs-elixir.webp",
-            "range": [
-                43,
-                48
-            ],
-            "text": "Cheetah's Elixir (Lesser)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "MBGB4RLImD0VjgsK",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "7Y2yOr4ltpP2tyuL",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/eagle-eyes-elixir.webp",
-            "range": [
-                49,
-                54
-            ],
-            "text": "Eagle Eye Elixir (Lesser)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "j0eGuYNVuyyjnBqe",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "hDLbR56Id2OtU318",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/elixir-of-life.webp",
-            "range": [
-                55,
-                60
-            ],
-            "text": "Elixir of Life (Minor)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "gpLF1CZLYq5fIa5V",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "ukTlC4G83aVQEg7u",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/oils/nectar-of-purification.webp",
-            "range": [
-                61,
-                66
-            ],
-            "text": "Nectar of Purification",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "TsFSDmqdHaHDRjew",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "fTQ5e4utVfgtXV1e",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/oils/oil-of-unlife.webp",
-            "range": [
-                67,
-                72
-            ],
-            "text": "Oil of Unlife (Minor)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "uEpDeYKT0LEWFrMm",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "z9T4c1hXwOotsMCp",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/other-consumables/holy-water.webp",
-            "range": [
-                73,
-                78
-            ],
-            "text": "Holy Water",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "rBzxtzwFTVWSQWLu",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "24hmJWXhSmfVebEE",
-            "drawn": false,
-            "img": "icons/magic/fire/flame-burning-campfire-smoke.webp",
-            "range": [
-                79,
-                84
-            ],
-            "text": "Marvelous Miniature (Campfire)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "kxGf2ZtCeFhK2ff9",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "3cWko20JPnjeoofV",
-            "drawn": false,
-            "img": "icons/sundries/misc/ladder-improvised.webp",
-            "range": [
-                85,
-                90
-            ],
-            "text": "Marvelous Miniature (Ladder)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "w1Q7qFEpX33LfMpt",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "ev3F9qlMNlNdCOAI",
-            "drawn": false,
-            "img": "icons/commodities/treasure/token-runed-os-grey.webp",
-            "range": [
-                91,
-                96
-            ],
-            "text": "Runestone",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "JFzyY3Sb7CeaDeXY",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "EGhUorZhB7nV73Ev",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/other-consumables/unholy-water.webp",
-            "range": [
-                97,
-                102
-            ],
-            "text": "Unholy Water",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "BYeYIEtNN9cUJUU2",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "OIirLySQDLZgT15S",
-            "drawn": false,
-            "img": "icons/commodities/materials/bowl-powder-teal.webp",
-            "range": [
-                103,
-                108
-            ],
-            "text": "Arsenic",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "ZDf6QqWXr5HQb568",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "hGw7Q1y2IEXRGAfv",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/potions/gecko-potion.webp",
-            "range": [
-                109,
-                114
-            ],
-            "text": "Gecko Potion",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "xxPk4DV4bmmcaUKw",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "txmX5ghhPS72GKXy",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/giant-centipede-venom.webp",
-            "range": [
-                115,
-                120
-            ],
-            "text": "Giant Centipede Venom",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "IT2WPD4k9HciGLLe",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "2RuepCemJhrpKKao",
-            "drawn": false,
-            "img": "icons/consumables/potions/bottle-round-corked-orante-red.webp",
-            "range": [
-                121,
-                126
-            ],
-            "text": "Healing Potion (Minor)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "t2CENOxuDVrg0zgq",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "jTfacZ4SRuQd7Avh",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/potions/potion-of-expeditious-retreat.webp",
-            "range": [
-                127,
-                132
-            ],
-            "text": "Potion of Emergency Escape",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "Xw6HJDxil8PBFC6u",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "jlFx4JIBKJuaINpv",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/potions/potion-of-shared-memories.webp",
-            "range": [
-                133,
-                138
-            ],
-            "text": "Potion of Shared Memories",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "dREg060hhZ0gsflp",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "RjuupS9xyXDLgyIr",
-            "drawn": false,
-            "img": "icons/sundries/scrolls/scroll-symbol-eye-brown.webp",
-            "range": [
-                139,
-                144
-            ],
-            "text": "Scroll of 1st-rank Spell",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "mi3XbYqFOn3Xllq2",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "ZCsksGf6NPUKz2Uw",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/talismans/potency-crystal.webp",
-            "range": [
-                145,
-                150
-            ],
-            "text": "Potency Crystal",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "VMzx9kEXvfOshZML",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "qoM7Va5GqcLLBzgu",
-            "drawn": false,
-            "img": "icons/commodities/claws/claw-bear-brown.webp",
-            "range": [
-                151,
-                156
-            ],
-            "text": "Predator's Claw",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "G1wbxbOkUzrn3GJA",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "clyXfh0aVXgij2Hb",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/talismans/wolf-fang.webp",
-            "range": [
-                157,
-                162
-            ],
-            "text": "Wolf Fang",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "HIZPsrQEncAN8H1d",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "y4WJY8rCbY6d1MET",
-            "drawn": false,
-            "img": "icons/weapons/wands/wand-carved-fire.webp",
-            "range": [
-                163,
-                168
-            ],
-            "text": "Glow Rod",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "yQqHe6B4OYLGgFxA",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "ylUdMTsfOQGJ3MN3",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/tindertwig.webp",
-            "range": [
-                169,
-                174
-            ],
-            "text": "Matchstick",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "GaR3xmZ92MvjZf28",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "MoBlVd36uD9xVvZC",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/smokestick.webp",
-            "range": [
-                175,
-                180
-            ],
-            "text": "Smoke Ball (Lesser)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "uDo1SeNTdwPnLOcg",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "xBZCVHAa1SnR8Xul",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/snake-oil.webp",
-            "range": [
-                181,
-                186
-            ],
-            "text": "Snake Oil",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "u8xFhpL8v5Z4ZsSv",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Xnqglykl3Cif8rN9",
-            "drawn": false,
-            "img": "icons/commodities/gems/pearl-rough-turquoise.webp",
-            "range": [
-                187,
-                192
-            ],
-            "text": "Blasting Stone (Lesser)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "T2kdznUbiVEYnFAH",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "j8ajvNqyyQGBpBch",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/blight-bomb.webp",
-            "range": [
-                193,
-                198
-            ],
-            "text": "Blight Bomb (Lesser)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "znwuki0cHI9gyNk6",
+            "_id": "8eRjamdCmcRyNeJv",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "AFR01HVd7DcZvkpP",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/bottled-lightning.webp",
             "range": [
-                199,
-                204
+                19,
+                24
             ],
             "text": "Bottled Lightning (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "JkkeCHBheot2zWvF",
+            "_id": "WzNJYRFAAMGTlrBY",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "EpxmUtLpCkE8R6KJ",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/frost-vial.webp",
             "range": [
-                205,
-                210
+                25,
+                30
             ],
             "text": "Frost Vial (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "GJHnV1vLdbWImInP",
+            "_id": "c0MFs4hFHxFBYtHL",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "LNd5u19GqC51ngby",
+            "documentId": "T6Appwwl6nUl56Xj",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/ghost-charge.webp",
+            "img": "icons/containers/bags/sack-simple-leather-tan.webp",
             "range": [
-                211,
-                216
+                31,
+                36
             ],
-            "text": "Ghost Charge (Lesser)",
+            "text": "Tanglefoot Bag (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "JjiBnLq3Q1ad2eR8",
+            "_id": "0X1L0UZKv5ITSCZu",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "GfegrEtbEs9L6NOg",
+            "documentId": "Xnqglykl3Cif8rN9",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/potions/serum-of-sex-shift.webp",
+            "img": "icons/commodities/gems/pearl-rough-turquoise.webp",
             "range": [
-                217,
-                222
+                37,
+                42
             ],
-            "text": "Elixir of Gender Transformation (Lesser)",
+            "text": "Thunderstone (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "HHQ3OKWbw1FCRSQG",
+            "_id": "XQI7NEK3aSdddawh",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "3cWko20JPnjeoofV",
+            "drawn": false,
+            "img": "icons/commodities/materials/feather-blue.webp",
+            "range": [
+                43,
+                48
+            ],
+            "text": "Feather Token (Ladder)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "YcuMCc1qjevdHTDK",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "efFe4EK7ThUrH446",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/other-consumables/holy-water.webp",
+            "range": [
+                49,
+                54
+            ],
+            "text": "Holy Water",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "n5lpwKzBBQEfk9m9",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "ev3F9qlMNlNdCOAI",
+            "drawn": false,
+            "img": "icons/commodities/treasure/token-runed-os-grey.webp",
+            "range": [
+                55,
+                60
+            ],
+            "text": "Runestone",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "9iyp0yLeptIjYutK",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "uplCUQwMwBOBHz0E",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/other-consumables/unholy-water.webp",
+            "range": [
+                61,
+                66
+            ],
+            "text": "Unholy Water",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "RJWPeE88zaQcc3de",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "ktjFOp3U0wQD9t0Z",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/antidote.webp",
+            "range": [
+                67,
+                72
+            ],
+            "text": "Antidote (Lesser)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "wtRL7scHYl6u1saC",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "UqinuuCWePTYGhVO",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/antiplague.webp",
+            "range": [
+                73,
+                78
+            ],
+            "text": "Antiplague (Lesser)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "coPd26lVI1zJOPOj",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "IQK9N2mEOyAj3iWU",
             "drawn": false,
             "img": "icons/consumables/potions/bottle-round-flask-fumes-purple.webp",
             "range": [
-                223,
-                228
+                79,
+                84
             ],
             "text": "Bestial Mutagen (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "lm2JtA8D43DhZwLU",
+            "_id": "jfeOSgBmONVCWF8A",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "tyt6rFtv32MZ4DT9",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/cheetahs-elixir.webp",
+            "range": [
+                85,
+                90
+            ],
+            "text": "Cheetah's Elixir (Lesser)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "pYL9ovjsb7IDe3hW",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "wbr6rkyaVYnDhdgV",
             "drawn": false,
             "img": "icons/consumables/potions/potion-vial-corked-purple.webp",
             "range": [
-                229,
-                234
+                91,
+                96
             ],
             "text": "Cognitive Mutagen (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "Koqw293VlmWvRDLK",
+            "_id": "dv7cQYYsQTYQv1cf",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "GS4YvQieBS11JNYR",
+            "documentId": "7Y2yOr4ltpP2tyuL",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/drakeheart-mutagen.webp",
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/eagle-eyes-elixir.webp",
             "range": [
-                235,
-                240
+                97,
+                102
             ],
-            "text": "Drakeheart Mutagen (Lesser)",
+            "text": "Eagle Eye Elixir (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "aJBciLj8sL28ImNI",
+            "_id": "kNTMBGvPI42pyYy9",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "hDLbR56Id2OtU318",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/elixir-of-life.webp",
+            "range": [
+                103,
+                108
+            ],
+            "text": "Elixir of Life (Minor)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "txFCP4aC30pIREO0",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "xE0EdDrf734l2fQH",
             "drawn": false,
-            "img": "icons/consumables/potions/bottle-metal-yellow-gray.webp",
+            "img": "icons/consumables/potions/bottle-round-corked-green.webp",
             "range": [
-                241,
-                246
+                109,
+                114
             ],
             "text": "Juggernaut Mutagen (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "fVmAHWtpleH9ioXX",
+            "_id": "njQ3sTPRy4k45itb",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "uG3xtNrs26scOVgW",
+            "drawn": false,
+            "img": "icons/consumables/potions/potion-jar-capped-teal.webp",
+            "range": [
+                115,
+                120
+            ],
+            "text": "Leaper's Elixir (Lesser)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "ZW1Bp0sab4nnhBPs",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "5MKBwpE401uz4kNN",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/quicksilver-mutagen.webp",
             "range": [
-                247,
-                252
+                121,
+                126
             ],
             "text": "Quicksilver Mutagen (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "xePtSYWDdq2Lqud3",
+            "_id": "1qGFeFYGddlH1qCc",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "bOPQDM54W8ZDoULY",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/serene-mutagen.webp",
             "range": [
-                253,
-                258
+                127,
+                132
             ],
             "text": "Serene Mutagen (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "JLAxZkI6Nw47fUcA",
+            "_id": "NBHo9j3c17FRsEwU",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "YwRAHWW8yUI07sy9",
             "drawn": false,
             "img": "icons/consumables/potions/potion-bottle-corked-fancy-blue.webp",
             "range": [
-                259,
-                264
+                133,
+                138
             ],
             "text": "Silvertongue Mutagen (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "02w6lKbmtbTq7h4Y",
+            "_id": "GZt3ZWcLrFy1VzBf",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "EWujUs3YmlBu2jhm",
+            "documentId": "ukTlC4G83aVQEg7u",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/oils/shielding-salve.webp",
+            "img": "systems/pf2e/icons/equipment/consumables/oils/nectar-of-purification.webp",
             "range": [
-                265,
-                270
+                139,
+                144
             ],
-            "text": "Shielding Salve",
+            "text": "Nectar of Purification",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "oOEc2xckDeOxKIMQ",
+            "_id": "Ifik32NPS6K2BOJx",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": null,
+            "documentId": "OIirLySQDLZgT15S",
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "icons/commodities/materials/bowl-powder-teal.webp",
             "range": [
-                271,
-                276
+                145,
+                150
             ],
-            "text": "Potion of Retaliation (Minor)",
-            "type": "text",
-            "weight": 6
-        },
-        {
-            "_id": "jBNmgDifCRB9bbIw",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "3Wb0N7iqmTn6e2Xc",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/potions/ration-tonic.webp",
-            "range": [
-                277,
-                282
-            ],
-            "text": "Ration Tonic",
+            "text": "Arsenic",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "qXHOd2ejwxr1gffE",
+            "_id": "7mJP8yFjJTQwqR1N",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "txmX5ghhPS72GKXy",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/giant-centipede-venom.webp",
+            "range": [
+                151,
+                156
+            ],
+            "text": "Giant Centipede Venom",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "9s865cUJGztYpvFi",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "2RuepCemJhrpKKao",
+            "drawn": false,
+            "img": "icons/consumables/potions/bottle-round-corked-orante-red.webp",
+            "range": [
+                157,
+                162
+            ],
+            "text": "Healing Potion (Minor)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "idP8IDa44rmz8QvR",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "RjuupS9xyXDLgyIr",
+            "drawn": false,
+            "img": "icons/sundries/scrolls/scroll-symbol-eye-brown.webp",
+            "range": [
+                163,
+                168
+            ],
+            "text": "Scroll of 1st-level Spell",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "nZmNbX68qqLlcw3X",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "AFX1V0Go9DqPWBlN",
             "drawn": false,
             "img": "icons/tools/instruments/bell-silver.webp",
             "range": [
-                283,
-                288
+                169,
+                174
             ],
             "text": "Alarm Snare",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "zUO7ozzBTRMTohxe",
+            "_id": "8XL4Ufkz4GGDt9Rh",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "kF761P3ibBIFmLm9",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/snares/caltrop-snare.webp",
             "range": [
-                289,
-                294
+                175,
+                180
             ],
             "text": "Caltrop Snare",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "KbyL8xHcLvue6I1w",
+            "_id": "oh2hVlytK77J2xeW",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "Km4lSOsyrip5q6iD",
             "drawn": false,
             "img": "icons/commodities/wood/kindling-sticks-yellow.webp",
             "range": [
-                295,
-                300
+                181,
+                186
             ],
             "text": "Hampering Snare",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "6I0wOkvait9rKpOe",
+            "_id": "oXtRBxXlnW1s0YqF",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "oplQpQSTyTvHDDtq",
             "drawn": false,
             "img": "icons/consumables/potions/potion-jar-corked-glowing-blue.webp",
             "range": [
-                301,
-                306
+                187,
+                192
             ],
             "text": "Marking Snare",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "1coDqwqBnHaIxykD",
+            "_id": "nwgLDCGwlXtJGriZ",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "XcD8p1o71tPohZWT",
             "drawn": false,
             "img": "icons/commodities/wood/bark-beige.webp",
             "range": [
-                307,
-                312
+                193,
+                198
             ],
             "text": "Signaling Snare",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "bGOv4Vc4E8N5ExPT",
+            "_id": "pkTwghUiJVzAprcY",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "3V2U720YhW2nyGVx",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/snares/spike-snare.webp",
             "range": [
-                313,
-                318
+                199,
+                204
             ],
             "text": "Spike Snare",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "YDRcCCbugdPMdwiS",
+            "_id": "jj3unclcScG80OUl",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "8eTGOQ9P69405jIO",
+            "documentId": "qoM7Va5GqcLLBzgu",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/forensic-dye.webp",
+            "img": "icons/commodities/claws/claw-bear-brown.webp",
             "range": [
-                319,
-                324
+                205,
+                210
             ],
-            "text": "Forensic Dye",
+            "text": "Owlbear Claw",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "LMRmgTiJrQ0oxL2x",
+            "_id": "12NXIimK87DZ2E8E",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "qnvq3PSTiejQTSi9",
+            "documentId": "ZCsksGf6NPUKz2Uw",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/ghost-ink.webp",
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/potency-crystal.webp",
             "range": [
-                325,
-                330
+                211,
+                216
             ],
-            "text": "Ghost Ink",
+            "text": "Potency Crystal",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "li7ogybaJnC30VWT",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "clyXfh0aVXgij2Hb",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/wolf-fang.webp",
+            "range": [
+                217,
+                222
+            ],
+            "text": "Wolf Fang",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "HjbnZiEaEHVEHgAP",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "MoBlVd36uD9xVvZC",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/smokestick.webp",
+            "range": [
+                223,
+                228
+            ],
+            "text": "Smokestick (Lesser)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "9LxDP58SIODcKXii",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "xBZCVHAa1SnR8Xul",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/snake-oil.webp",
+            "range": [
+                229,
+                234
+            ],
+            "text": "Snake Oil",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "9eNOLyVOaRPp9dWo",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "y4WJY8rCbY6d1MET",
+            "drawn": false,
+            "img": "icons/weapons/wands/wand-carved-fire.webp",
+            "range": [
+                235,
+                240
+            ],
+            "text": "Sunrod",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "10ttGy8VFFayBaf3",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "ylUdMTsfOQGJ3MN3",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/tindertwig.webp",
+            "range": [
+                241,
+                246
+            ],
+            "text": "Tindertwig",
             "type": "pack",
             "weight": 6
         }

--- a/packs/rollable-tables/1st-level-permanent-items.json
+++ b/packs/rollable-tables/1st-level-permanent-items.json
@@ -2,7 +2,7 @@
     "_id": "JyDn13oc0MdLjpyw",
     "description": "<p>Table of 1st-Level Permanent Items</p>",
     "displayRoll": true,
-    "formula": "1d27",
+    "formula": "1d21",
     "img": "icons/svg/d20-grey.svg",
     "name": "1st-Level Permanent Items",
     "ownership": {
@@ -11,74 +11,60 @@
     "replacement": true,
     "results": [
         {
-            "_id": "EmzJRAeGxnxlOwyp",
+            "_id": "Q6MCQ3VUAj9b4PnR",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "pRoikbRo5HFW6YUB",
+            "drawn": false,
+            "img": "icons/equipment/chest/breastplate-gorget-steel-white.webp",
+            "range": [
+                1,
+                6
+            ],
+            "text": "Half Plate",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "1q2hXapmXuXfaj4i",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "6AhDKX1dwRwFpQsU",
+            "drawn": false,
+            "img": "icons/equipment/chest/breastplate-layered-leather-studded-black.webp",
+            "range": [
+                7,
+                12
+            ],
+            "text": "Splint Mail",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "DYoDk9CqJNKs6tCj",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "mRz8Jmk4Q06SsZpC",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/held-items/everburning-torch.webp",
             "range": [
-                1,
-                6
+                13,
+                18
             ],
             "text": "Everlight Crystal",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "58q3tXrsgeDL3VXS",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Zmz2M2u7mGOCbUf4",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/other/magic-pots/walking-cauldron.webp",
-            "range": [
-                7,
-                12
-            ],
-            "text": "Walking Cauldron",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "Zk6drnpAd6sNuf3a",
+            "_id": "4k3k2olirAsJaIsJ",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "CVTbxCY85nLoHYuw",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/aeon-stone-dull-gray.webp",
             "range": [
-                13,
-                15
+                19,
+                21
             ],
             "text": "Aeon Stone (Consumed)",
             "type": "pack",
             "weight": 3
-        },
-        {
-            "_id": "kJ5IrX1EvCfErzbp",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "yzc8Sll1YMWq8PpR",
-            "drawn": false,
-            "img": "icons/equipment/finger/ring-band-engraved-scrolls-bronze.webp",
-            "range": [
-                16,
-                21
-            ],
-            "text": "Ring of Sigils",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "ejZ2p1mVVItVNOKq",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "ZIQAzOavTXJCcCMD",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/held-items/predictable-silver-piece.webp",
-            "range": [
-                22,
-                27
-            ],
-            "text": "Predictable Silver Piece",
-            "type": "pack",
-            "weight": 6
         }
     ]
 }

--- a/packs/rollable-tables/2nd-level-consumables.json
+++ b/packs/rollable-tables/2nd-level-consumables.json
@@ -1,8 +1,8 @@
 {
     "_id": "g30jZWCJEiK1RlIa",
-    "description": "<p>Table of 2nd-Level Consumables</p>",
+    "description": "Table of 2nd-Level Consumables",
     "displayRoll": true,
-    "formula": "1d138",
+    "formula": "1d123",
     "img": "icons/svg/d20-grey.svg",
     "name": "2nd-Level Consumables",
     "ownership": {
@@ -11,338 +11,296 @@
     "replacement": true,
     "results": [
         {
-            "_id": "lc7aACVQBmkrU68m",
+            "_id": "ry32tNrAMQmP8SWu",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "cwurQLvQaqjK70UI",
+            "drawn": false,
+            "img": "icons/commodities/materials/feather-blue.webp",
+            "range": [
+                1,
+                6
+            ],
+            "text": "Feather Token (Holly Bush)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "tD9DOUrhusTOo6ym",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "zM9VX3QwM81DzDUA",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/bravos-brew.webp",
             "range": [
-                1,
-                6
+                7,
+                12
             ],
             "text": "Bravo's Brew (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "Qh3nBGr3L0stQc1e",
+            "_id": "vfRkWUwvvKhVmmVt",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "bQPRKEpnLakJBAAh",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/cats-eye-elixir.webp",
             "range": [
-                7,
-                12
+                13,
+                18
             ],
             "text": "Cat's Eye Elixir",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "UnVA2mUrxNUCvO0Y",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "88pGCHV0uKMskTVO",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/darkvision-elixir.webp",
-            "range": [
-                13,
-                18
-            ],
-            "text": "Darkvision Elixir (Lesser)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "9pAqszqWVddwvNb5",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "j2CHumvbjmlLQX2i",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/oils/oil-of-potency.webp",
-            "range": [
-                19,
-                24
-            ],
-            "text": "Oil of Potency",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "s5kVziRqkODdkz5Q",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "6DmHDtIsGzH1s5JO",
-            "drawn": false,
-            "img": "icons/tools/laboratory/bowl-mixing.webp",
-            "range": [
-                25,
-                30
-            ],
-            "text": "Oil of Weightlessness",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "5Gh5cYpzG0va4PwL",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "ScclzFrjyB0YJlrb",
-            "drawn": false,
-            "img": "icons/consumables/potions/bottle-conical-corked-green.webp",
-            "range": [
-                31,
-                36
-            ],
-            "text": "Black Adder Venom",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "HTbcgU46EURUeIGJ",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "zo0ophqfKunJFxZN",
-            "drawn": false,
-            "img": "icons/commodities/materials/liquid-orange.webp",
-            "range": [
-                37,
-                39
-            ],
-            "text": "Lethargy Poison",
-            "type": "pack",
-            "weight": 3
-        },
-        {
-            "_id": "K0TR1MX5nqvPcUsh",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "nXStoLxPrrP2b6WB",
-            "drawn": false,
-            "img": "icons/equipment/neck/necklace-hook-brown.webp",
-            "range": [
-                40,
-                45
-            ],
-            "text": "Bronze Bull Pendant",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "eL1zq3JJ6cZv1JUP",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "HHELOoN5GVonUiIa",
-            "drawn": false,
-            "img": "icons/commodities/treasure/trinket-wing-white.webp",
-            "range": [
-                46,
-                51
-            ],
-            "text": "Crying Angel Pendant",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "qntUreccNvz1QVTt",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "VPvyyQXjn2HBjnTS",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/talismans/effervescent-ampoule.webp",
-            "range": [
-                52,
-                57
-            ],
-            "text": "Effervescent Ampoule",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "XGfFvBq21RZdcYE8",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "2MgFoNXTccL8Own9",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/talismans/jade-cat.webp",
-            "range": [
-                58,
-                63
-            ],
-            "text": "Jade Cat",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "ZelSO95kKhk18kCA",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "aKbrBW1SnFDxya5J",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/talismans/mesmerizing-opal.webp",
-            "range": [
-                64,
-                69
-            ],
-            "text": "Mesmerizing Opal",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "eHSaj9yY7iaAA04c",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "jdDDqv9LbEYX2wAE",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/talismans/monkey-pin.webp",
-            "range": [
-                70,
-                75
-            ],
-            "text": "Monkey Pin",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "hpmJGvucSklY1WuU",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "0aSdDSjJ5sMzBz1U",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/talismans/onyx-panther.webp",
-            "range": [
-                76,
-                81
-            ],
-            "text": "Onyx Panther",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "yxxgOz1zAqfwg8uD",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "0aSdDSjJ5sMzBz1U",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/talismans/onyx-panther.webp",
-            "range": [
-                82,
-                87
-            ],
-            "text": "Onyx Panther",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "lduH2M9r782znUn5",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "8fbsKEEbZ0CfBMIr",
-            "drawn": false,
-            "img": "icons/consumables/drinks/alcohol-spirits-bottle-blue.webp",
-            "range": [
-                88,
-                93
-            ],
-            "text": "Silver Salve",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "d04MhIz3J2IsS4FZ",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "NSQOijKqomyotXkj",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/ammunition/antler-arrow.webp",
-            "range": [
-                94,
-                99
-            ],
-            "text": "Antler Arrow",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "MBs8CB1IrZHng6TD",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "e2II4yMBFBqVivnk",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/focus-cathartic.webp",
-            "range": [
-                100,
-                105
-            ],
-            "text": "Bottled Catharsis (Minor)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "I8fRC0mXSjvImYfD",
+            "_id": "u5S7bpxsQtmZw1ah",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "3Klm2gPmzOw6ntVb",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/comprehension-elixir.webp",
             "range": [
-                106,
-                111
+                19,
+                24
             ],
             "text": "Comprehension Elixir (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "gTXmm2fj6yLSKOTp",
+            "_id": "BQwlRvlpARru285I",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "yE7PPagK0wsHMA8l",
+            "documentId": "88pGCHV0uKMskTVO",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/sinew-shock-serum.webp",
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/darkvision-elixir.webp",
             "range": [
-                112,
-                117
+                25,
+                30
             ],
-            "text": "Surging Serum (Minor)",
+            "text": "Darkvision Elixir (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "T5qSVFysJIT0Vfze",
+            "_id": "3xDD3sHjTohsIvaL",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "cuomhpenkqGM5lLG",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/infiltrators-elixir.webp",
+            "range": [
+                31,
+                36
+            ],
+            "text": "Infiltrator's Elixir",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "SL183TkVMQkmUDv4",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "FL8QU8TcNauBMMhD",
             "drawn": false,
             "img": "icons/commodities/materials/bowl-liquid-white.webp",
             "range": [
-                118,
-                123
+                37,
+                42
             ],
             "text": "Belladonna",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "6n7glL0NbSAmWliF",
+            "_id": "T2kXzz5x5FFl8qcB",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "craWRj7jI2mLs1Ok",
+            "documentId": "ScclzFrjyB0YJlrb",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/snares/deadweight-snare.webp",
+            "img": "icons/consumables/potions/bottle-conical-corked-green.webp",
             "range": [
-                124,
-                126
+                43,
+                48
             ],
-            "text": "Deadweight Snare",
-            "type": "pack",
-            "weight": 3
-        },
-        {
-            "_id": "p5QL5e6jcrjRtaqA",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "riLNCaVS9zGvt4Nn",
-            "drawn": false,
-            "img": "icons/skills/ranged/cannon-barrel-firing-yellow.webp",
-            "range": [
-                127,
-                132
-            ],
-            "text": "Flare Snare",
+            "text": "Black Adder Venom",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "1ZpSll8c095Jks51",
+            "_id": "QNtUu0hwf189Evrf",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "zo0ophqfKunJFxZN",
+            "drawn": false,
+            "img": "icons/commodities/materials/liquid-orange.webp",
+            "range": [
+                49,
+                51
+            ],
+            "text": "Lethargy Poison",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "pJU1w1RQgdmtxEnT",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "nXStoLxPrrP2b6WB",
+            "drawn": false,
+            "img": "icons/equipment/neck/necklace-hook-brown.webp",
+            "range": [
+                52,
+                57
+            ],
+            "text": "Bronze Bull Pendant",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "klapdf6bAB73uws4",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "HHELOoN5GVonUiIa",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/crying-angel-pendant.webp",
+            "range": [
+                58,
+                63
+            ],
+            "text": "Crying Angel Pendant",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "nuT1akfE0ijxOkDn",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "VPvyyQXjn2HBjnTS",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/effervescent-ampoule.webp",
+            "range": [
+                64,
+                69
+            ],
+            "text": "Effervescent Ampoule",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "zDvdnusRvAVqTeHa",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "Yew9oddFsH0KeDLh",
             "drawn": false,
             "img": "icons/commodities/treasure/dreamcatcher-brown.webp",
             "range": [
-                133,
-                138
+                70,
+                75
             ],
             "text": "Hunter's Bane",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "FuHGz2bpefNLxkjf",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "2MgFoNXTccL8Own9",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/jade-cat.webp",
+            "range": [
+                76,
+                81
+            ],
+            "text": "Jade Cat",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "auXfWiEC0BmCB2mZ",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "aKbrBW1SnFDxya5J",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/mesmerizing-opal.webp",
+            "range": [
+                82,
+                87
+            ],
+            "text": "Mesmerizing Opal",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "Xm7lfo3yQp94m7so",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "jdDDqv9LbEYX2wAE",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/monkey-pin.webp",
+            "range": [
+                88,
+                93
+            ],
+            "text": "Monkey Pin",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "RvapRvAQnCogA41x",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "0aSdDSjJ5sMzBz1U",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/onyx-panther.webp",
+            "range": [
+                94,
+                99
+            ],
+            "text": "Onyx Panther",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "GSPrbuknylF9lRBK",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "j2CHumvbjmlLQX2i",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/oils/oil-of-potency.webp",
+            "range": [
+                100,
+                105
+            ],
+            "text": "Oil of Potency",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "Tl8Jye1UgRHFSr6T",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "6DmHDtIsGzH1s5JO",
+            "drawn": false,
+            "img": "icons/tools/laboratory/bowl-mixing.webp",
+            "range": [
+                106,
+                111
+            ],
+            "text": "Oil of Weightlessness",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "EcjzWnUXW49rqBry",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "qeTWg0TWw9CwMKCO",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/savior-spike.webp",
+            "range": [
+                112,
+                117
+            ],
+            "text": "Savior Spike",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "zCq4yiUgqcecAgCY",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "8fbsKEEbZ0CfBMIr",
+            "drawn": false,
+            "img": "icons/consumables/drinks/alcohol-spirits-bottle-blue.webp",
+            "range": [
+                118,
+                123
+            ],
+            "text": "Silver Salve",
             "type": "pack",
             "weight": 6
         }

--- a/packs/rollable-tables/2nd-level-permanent-items.json
+++ b/packs/rollable-tables/2nd-level-permanent-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "q6hhGYSee35XxKE8",
-    "description": "<p>Table of 2nd-Level Permanent Items</p>",
+    "description": "Table of 2nd-Level Permanent Items",
     "displayRoll": true,
-    "formula": "1d69",
+    "formula": "1d84",
     "img": "icons/svg/d20-grey.svg",
     "name": "2nd-Level Permanent Items",
     "ownership": {
@@ -11,106 +11,106 @@
     "replacement": true,
     "results": [
         {
+            "_id": "13Z9EWcg0MsQhYSz",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "Gq1cZWSKOtJhKd2p",
+            "drawn": false,
+            "img": "icons/equipment/chest/breastplate-layered-steel-green.webp",
+            "range": [
+                1,
+                6
+            ],
+            "text": "Full Plate",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "1ESrHF6Bvt64l0fb",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "BANLXq8FhwqsDu0v",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/held-items/wondrous-figurine-onyx-dog.webp",
+            "range": [
+                7,
+                12
+            ],
+            "text": "Wondrous Figurine (Onyx Dog)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
             "_id": "0UcentA4SnvAdeYa",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "DKWuJb2rSgiotOG7",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/fundamental-weapon-runes/weapon-potency.webp",
             "range": [
-                1,
-                6
+                13,
+                18
             ],
             "text": "Weapon Potency (+1)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "qnI5nkuGsl6Jmjjd",
+            "_id": "CLlpQHOCpeoa9inB",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": null,
+            "documentId": "ckUxr51wJVGRNAD0",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/cold-Iron-buckler.webp",
-            "range": [
-                7,
-                12
-            ],
-            "text": "Cold Iron Buckler (Low-Grade)",
-            "type": "text",
-            "weight": 6
-        },
-        {
-            "_id": "z0tdjRaeXASL4wKn",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": null,
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/cold-Iron-shield.webp",
-            "range": [
-                13,
-                18
-            ],
-            "text": "Cold Iron Shield (Low-Grade)",
-            "type": "text",
-            "weight": 6
-        },
-        {
-            "_id": "JbTOP9JhTvHsBFmL",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": null,
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/silver-buckler.webp",
             "range": [
                 19,
                 24
             ],
-            "text": "Silver Buckler (Low-Grade)",
-            "type": "text",
+            "text": "Cold Iron Buckler (Low-Grade)",
+            "type": "pack",
             "weight": 6
         },
         {
-            "_id": "SoOChaMbrJmNWTs1",
+            "_id": "UJFA5IViCsWIsu15",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": null,
+            "documentId": "5E6l3RheSyl99G3m",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/silver-shield.webp",
+            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/cold-Iron-shield.webp",
             "range": [
                 25,
                 30
             ],
-            "text": "Silver Shield (Low-Grade)",
-            "type": "text",
+            "text": "Cold Iron Shield (Low-Grade)",
+            "type": "pack",
             "weight": 6
         },
         {
-            "_id": "u8nS5wBuSp2s3lwm",
+            "_id": "GwfQLclrSEBfXu3n",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": null,
+            "documentId": "aA9clnIP3deHNNjo",
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/silver-buckler.webp",
             "range": [
                 31,
                 36
             ],
-            "text": "Weapon (+1)",
-            "type": "text",
+            "text": "Silver Buckler (Low-Grade)",
+            "type": "pack",
             "weight": 6
         },
         {
-            "_id": "laOcY47kKt4Ppnym",
+            "_id": "pWUGDsbp9Z1wHnRf",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": null,
+            "documentId": "1xUIdz23mIlYWGPL",
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/silver-shield.webp",
             "range": [
                 37,
                 42
             ],
-            "text": "Cold Iron Weapon (Low-Grade)",
-            "type": "text",
+            "text": "Silver Shield (Low-Grade)",
+            "type": "pack",
             "weight": 6
         },
         {
-            "_id": "0y5jey7BczIbTeJQ",
-            "documentCollection": "pf2e.equipment-srd",
+            "_id": "WNEoZZAhyNxwdPv4",
+            "documentCollection": "",
             "documentId": null,
             "drawn": false,
             "img": "icons/svg/d20-black.svg",
@@ -118,65 +118,107 @@
                 43,
                 48
             ],
-            "text": "Silver Weapon (Low-Grade)",
+            "text": "Weapon (+1)",
             "type": "text",
             "weight": 6
         },
         {
-            "_id": "1XyBjGTgUCNu0Bwc",
-            "documentCollection": "pf2e.equipment-srd",
+            "_id": "QPOhnkaFt7vzO40A",
+            "documentCollection": "",
             "documentId": null,
             "drawn": false,
-            "img": "icons/equipment/hand/gauntlet-simple-leather-brown-gold.webp",
+            "img": "icons/svg/d20-black.svg",
             "range": [
                 49,
                 54
             ],
-            "text": "Handwraps of Mighty Blows (+1)",
+            "text": "Cold iron weapon (low-grade)",
             "type": "text",
             "weight": 6
         },
         {
-            "_id": "FXUNYt42lN8TYElB",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "fvpLYx1Lo42cdleQ",
+            "_id": "FYAlctVCWqu6uA6h",
+            "documentCollection": "",
+            "documentId": null,
             "drawn": false,
-            "img": "icons/equipment/neck/handkerchief-bandana-blue.webp",
+            "img": "icons/svg/d20-black.svg",
             "range": [
                 55,
                 60
             ],
-            "text": "Masquerade Scarf",
+            "text": "Silver weapon (low-grade)",
+            "type": "text",
+            "weight": 6
+        },
+        {
+            "_id": "ryIVsSv5OqeY7ERo",
+            "documentCollection": "",
+            "documentId": null,
+            "drawn": false,
+            "img": "icons/svg/d20-black.svg",
+            "range": [
+                61,
+                66
+            ],
+            "text": "+1 Handwraps of Mighty Blows",
+            "type": "text",
+            "weight": 6
+        },
+        {
+            "_id": "KauQSOfz3WtBhWpd",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "TmQalYKNNRuEdoTh",
+            "drawn": false,
+            "img": "icons/equipment/neck/amulet-round-engraved-gold.webp",
+            "range": [
+                67,
+                69
+            ],
+            "text": "Brooch of Shielding",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "9vx22NLpFZWfL2jo",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "r1hgg2rweqGL1LBl",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/hand-of-the-mage.webp",
+            "range": [
+                70,
+                75
+            ],
+            "text": "Hand of the Mage",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "MlJAJ3Z33wuKQPV8",
+            "_id": "C00C1aH1hV31Y2BQ",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "fvpLYx1Lo42cdleQ",
+            "drawn": false,
+            "img": "icons/equipment/head/hat-belted-grey.webp",
+            "range": [
+                76,
+                81
+            ],
+            "text": "Hat of Disguise",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "6AdAVQweXlduaC9V",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "gbwr57aT9ou8yKWT",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/wayfinder.webp",
             "range": [
-                61,
-                63
+                82,
+                84
             ],
             "text": "Wayfinder",
             "type": "pack",
             "weight": 3
-        },
-        {
-            "_id": "3cVXJkxtztoiRxEs",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "IxuDS3POB6EH8TVN",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/shields/specific-shields/glamorous-buckler.webp",
-            "range": [
-                64,
-                69
-            ],
-            "text": "Glamorous Buckler",
-            "type": "pack",
-            "weight": 6
         }
     ]
 }

--- a/packs/rollable-tables/3rd-level-consumables.json
+++ b/packs/rollable-tables/3rd-level-consumables.json
@@ -1,8 +1,8 @@
 {
     "_id": "mDPLoPYwuPo3o0Wj",
-    "description": "<p>Table of 3rd-Level Consumables</p>",
+    "description": "Table of 3rd-Level Consumables",
     "displayRoll": true,
-    "formula": "1d192",
+    "formula": "1d150",
     "img": "icons/svg/d20-grey.svg",
     "name": "3rd-Level Consumables",
     "ownership": {
@@ -25,437 +25,339 @@
             "weight": 6
         },
         {
-            "_id": "MArlPUGX0N1Or4l7",
+            "_id": "CtCW6OWjZ9LCyV6u",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "RcQ4ZIzRK2xLf4G5",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/ammunition/sleep-arrow.webp",
+            "range": [
+                7,
+                12
+            ],
+            "text": "Sleep Arrow",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "serJqIWHgbmbhDzy",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "NSo0bFX7DGGjqKKl",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/ammunition/spellstrike-ammunition.webp",
             "range": [
-                7,
-                12
+                13,
+                18
             ],
             "text": "Spellstrike Ammunition (Type I)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "072I21YkZAKrwaAU",
+            "_id": "iwuBnzg81kfvN9qh",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "eEnzHpPEbdGgRETM",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/ammunition/vine-arrow.webp",
             "range": [
-                13,
-                18
+                19,
+                24
             ],
             "text": "Vine Arrow",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "xgHsiPwmRc7x2rV6",
+            "_id": "wrKtGlVFkGEmsR3E",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "SgtqZxt26BdjUmEB",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/acid-flask.webp",
             "range": [
-                19,
-                24
+                25,
+                30
             ],
             "text": "Acid Flask (Moderate)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "0nFvNuQ4LlW6y98i",
+            "_id": "6fofSWDLAli7D9Vf",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "gWr4q4HiyGhETA8H",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/alchemists-fire.webp",
             "range": [
-                25,
-                30
+                31,
+                36
             ],
             "text": "Alchemist's Fire (Moderate)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "Qw1vuubRxaw7IFuS",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "IvFEJqp2MUew65nQ",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/dread-ampoule.webp",
-            "range": [
-                31,
-                36
-            ],
-            "text": "Dread Ampoule (Moderate)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "Pk9ZXmhoW5ppr1hf",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "evBPzM1VsuYcoenn",
-            "drawn": false,
-            "img": "icons/containers/bags/sack-simple-leather-tan.webp",
-            "range": [
-                37,
-                42
-            ],
-            "text": "Glue Bomb (Moderate)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "kAHYy8XuDJlCb8ZS",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "QN8UIz0nMcnLUWHu",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/oils/oil-of-mending.webp",
-            "range": [
-                43,
-                48
-            ],
-            "text": "Oil of Mending",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "ZKmPhaJKHOSBuMeM",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "BSInwFNVBVkfFK0B",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/oils/oil-of-unlife.webp",
-            "range": [
-                49,
-                54
-            ],
-            "text": "Oil of Unlife (Lesser)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "iFFctogx3ApStrjK",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Dn2KQgIeWNijaUzL",
-            "drawn": false,
-            "img": "icons/containers/chest/chest-oak-steel-brown.webp",
-            "range": [
-                55,
-                60
-            ],
-            "text": "Marvelous Miniature (Chest)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "CdgeLpl8yNJXFnED",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "qQqAY59NgGNoy2xr",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/graveroot.webp",
-            "range": [
-                61,
-                66
-            ],
-            "text": "Graveroot",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "nqj8cAAa9xz0DYfZ",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "e0vSAQfxhHauiAoD",
-            "drawn": false,
-            "img": "icons/consumables/potions/bottle-round-corked-orante-red.webp",
-            "range": [
-                67,
-                72
-            ],
-            "text": "Healing Potion (Lesser)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "eufhS8pgSI4XD8RZ",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "WQhnfj1LbrEzvh8z",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/potions/potion-of-water-breathing.webp",
-            "range": [
-                73,
-                78
-            ],
-            "text": "Potion of Water Breathing",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "LfRQVcHYqcvhZmgz",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Y7UD64foDbDMV9sx",
-            "drawn": false,
-            "img": "icons/sundries/scrolls/scroll-symbol-eye-brown.webp",
-            "range": [
-                79,
-                84
-            ],
-            "text": "Scroll of 2nd-rank Spell",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "HRziIWLyJVc85Di8",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "X345VfEx9DZwO47G",
-            "drawn": false,
-            "img": "icons/commodities/metal/fragments-steel-ring.webp",
-            "range": [
-                85,
-                90
-            ],
-            "text": "Alloy Orb (Low-Grade)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "AVIUCX55UDCd3sT0",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "0CNSvLpeSM4aIfPJ",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/talismans/feather-step-stone.webp",
-            "range": [
-                91,
-                96
-            ],
-            "text": "Feather Step Stone",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "xc2USLSCpTP9IaRd",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "RcQ4ZIzRK2xLf4G5",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/ammunition/sleep-arrow.webp",
-            "range": [
-                97,
-                102
-            ],
-            "text": "Slumber Arrow",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "Rr34ENl79UaL5YP8",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "JOaELkzLWTywhn5Z",
-            "drawn": false,
-            "img": "icons/commodities/gems/pearl-rough-turquoise.webp",
-            "range": [
-                103,
-                108
-            ],
-            "text": "Blasting Stone (Moderate)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "EyTg381a7NSxQwmE",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "158vwM1andv8DbRI",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/blight-bomb.webp",
-            "range": [
-                109,
-                114
-            ],
-            "text": "Blight Bomb (Moderate)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "ZAd7ZGNbSlY8Wuw2",
+            "_id": "K6tpDqDyQvis48Iu",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "97QyNEOAyYLdGaYc",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/bottled-lightning.webp",
             "range": [
-                115,
-                120
+                37,
+                42
             ],
             "text": "Bottled Lightning (Moderate)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "jADHF9fkO0Q0STL8",
+            "_id": "J92d4MpwclPadwOc",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "nVvH1ZcM7OwIVIs8",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/frost-vial.webp",
             "range": [
-                121,
-                126
+                43,
+                48
             ],
             "text": "Frost Vial (Moderate)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "pT0vImG7DGqPPK1p",
+            "_id": "3HZHqYqejkaKCSlQ",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Wf94e8YNhZdIvWc9",
+            "documentId": "evBPzM1VsuYcoenn",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/ghost-charge.webp",
+            "img": "icons/containers/bags/sack-simple-leather-tan.webp",
             "range": [
-                127,
-                132
+                49,
+                54
             ],
-            "text": "Ghost Charge (Moderate)",
+            "text": "Tanglefoot Bag (Moderate)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "qteXWDwcw0Z5gMx2",
+            "_id": "tcFhkk6uFUkkQWMk",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "0KXqdhz2MYV0LBm2",
+            "documentId": "JOaELkzLWTywhn5Z",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/potions/serum-of-sex-shift.webp",
+            "img": "icons/commodities/gems/pearl-rough-turquoise.webp",
             "range": [
-                133,
-                138
+                55,
+                60
             ],
-            "text": "Elixir of Gender Transformation (Moderate)",
+            "text": "Thunderstone (Moderate)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "JnuV4HzIk33c6MQF",
+            "_id": "V7QV2iZcpQW0W4Bl",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "fFq8nsGvSUgzVeND",
+            "drawn": false,
+            "img": "icons/commodities/materials/feather-blue.webp",
+            "range": [
+                61,
+                66
+            ],
+            "text": "Feather Token (Bird)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "VEeUe1e8wg9Ap9a7",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "Dn2KQgIeWNijaUzL",
+            "drawn": false,
+            "img": "icons/commodities/materials/feather-blue.webp",
+            "range": [
+                67,
+                72
+            ],
+            "text": "Feather Token (Chest)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "UpLZlf4UpQIHnPZF",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "VISk5uLPVIvNWovB",
             "drawn": false,
             "img": "icons/consumables/potions/bottle-round-flask-fumes-purple.webp",
             "range": [
-                139,
-                144
+                73,
+                78
             ],
             "text": "Bestial Mutagen (Moderate)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "gbF0nwxVjdM3oClA",
+            "_id": "vj4JoRI7CsrYl8e0",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "qpzL9UnTi4cDhy6J",
             "drawn": false,
             "img": "icons/consumables/potions/potion-vial-corked-purple.webp",
             "range": [
-                145,
-                150
+                79,
+                84
             ],
             "text": "Cognitive Mutagen (Moderate)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "xR2jnv6uhi5mD45l",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "xY2MogTwH9Fd8UPG",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/drakeheart-mutagen.webp",
-            "range": [
-                151,
-                156
-            ],
-            "text": "Drakeheart Mutagen (Moderate)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "893TP3dOWfNstY3h",
+            "_id": "AzSagjT1yaUEXvLF",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "mj9i9GeQTADByNPZ",
             "drawn": false,
-            "img": "icons/consumables/potions/bottle-metal-yellow-gray.webp",
+            "img": "icons/consumables/potions/bottle-round-corked-green.webp",
             "range": [
-                157,
-                162
+                85,
+                90
             ],
             "text": "Juggernaut Mutagen (Moderate)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "zGYyXAelppLTtW1x",
+            "_id": "aRWR0oDpz3lG7Ye6",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "n52BSbZsnx4Vmt2p",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/quicksilver-mutagen.webp",
             "range": [
-                163,
-                168
+                91,
+                96
             ],
             "text": "Quicksilver Mutagen (Moderate)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "TK7MGpGo7OtEkdZB",
+            "_id": "ZIzH7JvfkVjO9W6M",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "XEYveTvLH1lJ4jeI",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/serene-mutagen.webp",
             "range": [
-                169,
-                174
+                97,
+                102
             ],
             "text": "Serene Mutagen (Moderate)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "BtV5pWwMpz5nTVAU",
+            "_id": "txw59NSuj5GuarW9",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "lIExlUFBKvBue8hb",
             "drawn": false,
             "img": "icons/consumables/potions/potion-bottle-corked-fancy-blue.webp",
             "range": [
-                175,
-                180
+                103,
+                108
             ],
             "text": "Silvertongue Mutagen (Moderate)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "86ORdivfqkkXONdn",
+            "_id": "8SZCYCDAopjULZb8",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "QN8UIz0nMcnLUWHu",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/oils/oil-of-mending.webp",
+            "range": [
+                109,
+                114
+            ],
+            "text": "Oil of Mending",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "cmwKZov12lzmZ4r3",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "aZm1x9tpvBAT8YCd",
             "drawn": false,
             "img": "icons/commodities/materials/liquid-purple.webp",
             "range": [
-                181,
-                186
+                115,
+                120
             ],
             "text": "Cytillesh Oil",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "OAEmZRjyYuuhEQYp",
+            "_id": "xsjcKG0Z6oa3E05T",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": null,
+            "documentId": "qQqAY59NgGNoy2xr",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/potions/potion-of-cold-retalliation.webp",
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/graveroot.webp",
             "range": [
-                187,
-                192
+                121,
+                126
             ],
-            "text": "Potion of Retaliation (Lesser)",
-            "type": "text",
+            "text": "Graveroot",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "13S0UvlDiZlKJ8S9",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "e0vSAQfxhHauiAoD",
+            "drawn": false,
+            "img": "icons/consumables/potions/bottle-round-corked-orante-red.webp",
+            "range": [
+                127,
+                132
+            ],
+            "text": "Healing Potion (Lesser)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "Anedv6AMhEkiHGj0",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "WQhnfj1LbrEzvh8z",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/potions/potion-of-water-breathing.webp",
+            "range": [
+                133,
+                138
+            ],
+            "text": "Potion of Water Breathing",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "Fipi7flIfw6EvMea",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "Y7UD64foDbDMV9sx",
+            "drawn": false,
+            "img": "icons/sundries/scrolls/scroll-symbol-eye-brown.webp",
+            "range": [
+                139,
+                144
+            ],
+            "text": "Scroll of 2nd-level Spell",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "mJWgsDXgL2Dv3BOw",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "0CNSvLpeSM4aIfPJ",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/feather-step-stone.webp",
+            "range": [
+                145,
+                150
+            ],
+            "text": "Feather Step Stone",
+            "type": "pack",
             "weight": 6
         }
     ]

--- a/packs/rollable-tables/3rd-level-permanent-items.json
+++ b/packs/rollable-tables/3rd-level-permanent-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "Ow2zoRUSX0s7JjMo",
-    "description": "<p>Table of 3rd-Level Permanent Items</p>",
+    "description": "Table of 3rd-Level Permanent Items",
     "displayRoll": true,
-    "formula": "1d129",
+    "formula": "1d123",
     "img": "icons/svg/d20-grey.svg",
     "name": "3rd-Level Permanent Items",
     "ownership": {
@@ -53,231 +53,231 @@
             "weight": 6
         },
         {
-            "_id": "WLXQ7hFaev6CsUXr",
+            "_id": "2wUqPwwk28SJXbOv",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "kEy7Uc1VisizGgtf",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/armor-property-runes/armor-property-runes.webp",
+            "range": [
+                19,
+                24
+            ],
+            "text": "Shadow",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "bTwikuvoIuXKabFL",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "uQOaRpfkUFVYD0Gx",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/armor-property-runes/armor-property-runes.webp",
+            "range": [
+                25,
+                30
+            ],
+            "text": "Slick",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "KE5WuqxZOMKkfeVK",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "opfpl1JmKgrfds9P",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/staves/staff-of-fire.webp",
             "range": [
-                19,
-                24
+                31,
+                36
             ],
             "text": "Staff of Fire",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "G3yVxCJPvx1XMyju",
+            "_id": "CUmCEauinNplh5ZA",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "UJWiN0K3jqVjxvKk",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/magic-wands/magic-wand.webp",
             "range": [
-                25,
-                30
+                37,
+                42
             ],
             "text": "Magic Wand (1st-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "aJvasjkn4Veju0EB",
+            "_id": "niyCneExcTokEG5D",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "Kx6FQS5GyVB6jlrW",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/weapons/specific-magic-weapons/fighters-fork.webp",
             "range": [
-                31,
-                36
+                43,
+                48
             ],
             "text": "Fighter's Fork",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "nKMXVrx9on0RtzLI",
+            "_id": "U5iyrCFfxvcv8nBd",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "q6ZvspNDkzJSP6dg",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/weapons/specific-magic-weapons/retribution-axe.webp",
             "range": [
-                37,
-                42
+                49,
+                54
             ],
             "text": "Retribution Axe",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "qb7QMuUM8p1NouuZ",
+            "_id": "k06Hg1qDu1oNSiLQ",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "BKdzb8hu3kZtKH3Z",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/bracelet-of-dashing.webp",
             "range": [
-                43,
-                48
+                55,
+                60
             ],
             "text": "Bracelet of Dashing",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "i5LI4u6c8GfaYcLq",
+            "_id": "KAXlei1zEICCrgaJ",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "eurAnvH8bK0ZctOR",
             "drawn": false,
             "img": "icons/equipment/wrist/bracer-segmented-leather.webp",
             "range": [
-                49,
-                54
+                61,
+                66
             ],
             "text": "Bracers of Missile Deflection",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "FeUpbVapDdeYiHGY",
+            "_id": "I9J6fT8BCKpc9vtC",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "3vxoffA4slKHXtj2",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/channel-protection-amulet.webp",
             "range": [
-                55,
-                57
+                67,
+                69
             ],
             "text": "Channel Protection Amulet",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "7XTPcDJmhJegb2bj",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "LKdgj4UVmOvUwkZu",
-            "drawn": false,
-            "img": "icons/equipment/hand/glove-ringed-leather-yellow.webp",
-            "range": [
-                58,
-                63
-            ],
-            "text": "Charlatan's Gloves",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "jHNiIDILwHG6ZJF0",
+            "_id": "P7oC4GEJuR8pVrId",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "mvMeloQxSiEGIlhL",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/coyote-cloak.webp",
             "range": [
-                64,
-                69
+                70,
+                75
             ],
             "text": "Coyote Cloak",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "7b06BU1pWSIwGV1K",
+            "_id": "cTo0NKKtG0kjBJSd",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "RgNBGpBc9G2yw1C2",
             "drawn": false,
-            "img": "icons/tools/scribal/lens-blue.webp",
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/crafters-eyepiece.webp",
             "range": [
-                70,
-                75
+                76,
+                81
             ],
             "text": "Crafter's Eyepiece",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "4UxX0VIGgyEmJidK",
+            "_id": "cVTTKApoz8wZ7pXn",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "Epc1e1Q9M9bcwOR0",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/dancing-scarf.webp",
             "range": [
-                76,
-                81
+                82,
+                87
             ],
             "text": "Dancing Scarf",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "n6CjgJK2XVIPJ68c",
+            "_id": "JLwT8DISSWHpWrKr",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "DwMXEqy7Ws8NYQQh",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/doubling-rings.webp",
             "range": [
-                82,
-                87
+                88,
+                93
             ],
             "text": "Doubling Rings",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "VXsmp86PzxSV889m",
+            "_id": "NtaagMSzLpu2aHjU",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "SswqJqeAWGtX3tTF",
             "drawn": false,
             "img": "icons/equipment/head/hat-belted-simple-grey.webp",
             "range": [
-                88,
-                93
+                94,
+                99
             ],
-            "text": "Mage's Hat",
+            "text": "Hat of the Magi",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "dAaIj18F3trnB3Nm",
+            "_id": "pUUr9C9OZiQdvsgJ",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "zPhqmCvWyHO8i9ws",
             "drawn": false,
             "img": "icons/commodities/biological/eye-purple.webp",
             "range": [
-                94,
-                99
+                100,
+                105
             ],
             "text": "Pendant of the Occult",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "YDr7JMOOJq8daI7Y",
+            "_id": "sEKGyq3CgtbpL8YH",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "MKupH1T018JubYJW",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/persona-mask.webp",
             "range": [
-                100,
-                105
+                106,
+                111
             ],
             "text": "Persona Mask",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "JsNzQWA9fYJU9vGU",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "YVtXlsEWb3NIkDyy",
-            "drawn": false,
-            "img": "icons/commodities/treasure/broach-jewel-gold-blue.webp",
-            "range": [
-                106,
-                111
-            ],
-            "text": "Shining Symbol",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "eJp0bYDtwm2FpHLb",
+            "_id": "YM85vN0BCmomxJvu",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "ZEqAx8jEc6zhX3V1",
             "drawn": false,
@@ -291,7 +291,7 @@
             "weight": 6
         },
         {
-            "_id": "BAN25rPJJ1s1qwus",
+            "_id": "vgCqUe6qZZYaIgGR",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "1r6StS0irdvi5JHY",
             "drawn": false,
@@ -301,20 +301,6 @@
                 123
             ],
             "text": "Ventriloquist's Ring",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "oO1UFo6Fad8CoWz8",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "wJTpzqL8EJ0xVW0y",
-            "drawn": false,
-            "img": "icons/commodities/materials/material-cotton-white.webp",
-            "range": [
-                124,
-                129
-            ],
-            "text": "Twisting Twine (Lesser)",
             "type": "pack",
             "weight": 6
         }

--- a/packs/rollable-tables/4th-level-consumables-items.json
+++ b/packs/rollable-tables/4th-level-consumables-items.json
@@ -22,368 +22,273 @@
             ],
             "text": "Climbing Bolt",
             "type": "pack",
-            "weight": 6,
-            "flags": {}
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "QN2b9QvvhEhXYHss",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "ilB279mxqXnlaSFj",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/ammunition/viper-arrow.webp",
             "range": [
                 7,
                 12
             ],
-            "drawn": false,
-            "text": "Bomber's Eye Elixir (Lesser)",
-            "documentId": "T4ouD4mVFHA3EHs6",
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/bombers-eye-elixir.webp",
-            "_id": "P9DziNQbhGDwUSYj",
-            "flags": {}
+            "text": "Viper Arrow",
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "k455WZW8SCQLXbsv",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "3Fmbw9wJkqZBV9De",
+            "drawn": false,
+            "img": "icons/commodities/materials/feather-blue.webp",
             "range": [
                 13,
                 18
             ],
-            "drawn": false,
-            "text": "Darkvision Elixir (Moderate)",
-            "documentId": "Y8115p3cmQJBqk5d",
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/darkvision-elixir.webp",
-            "_id": "S3JPIdHfZcnriSrc",
-            "flags": {}
+            "text": "Feather Token (Fan)",
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "oLZsd9xeniDUB97N",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "T4ouD4mVFHA3EHs6",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/bombers-eye-elixir.webp",
             "range": [
                 19,
                 24
             ],
-            "drawn": false,
-            "text": "Mistform Elixir (Lesser)",
-            "documentId": "GyO89RBVjAKFxsFm",
-            "img": "icons/consumables/potions/bottle-conical-corked-blue.webp",
-            "_id": "DTR5QxWuiUdXsjzE",
-            "flags": {}
+            "text": "Bomber's Eye Elixir (Lesser)",
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "zz0eL7k3QNTKNXc3",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "Y8115p3cmQJBqk5d",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/darkvision-elixir.webp",
             "range": [
                 25,
                 30
             ],
-            "drawn": false,
-            "text": "Stone Fist Elixir",
-            "documentId": "YcvSw7Zn3oyqlJaw",
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/stone-fist-elixir.webp",
-            "_id": "BC0Ok7pC20EKBEdN",
-            "flags": {}
+            "text": "Darkvision Elixir (Moderate)",
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "dwXrm0DZwZ0Vtpyl",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "GyO89RBVjAKFxsFm",
+            "drawn": false,
+            "img": "icons/consumables/potions/bottle-conical-corked-blue.webp",
             "range": [
                 31,
                 36
             ],
-            "drawn": false,
-            "text": "Marvelous Miniature (Horse)",
-            "documentId": "TknN7T2RDy9cUtKU",
-            "img": "icons/environment/creatures/horse-tan.webp",
-            "_id": "eR3iOMYCEufD8LpV",
-            "flags": {}
+            "text": "Mistform Elixir (Lesser)",
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "ViMk7CeQzvGeYUrC",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "Ekk7o1gPu8RotixD",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/salamander-elixir.webp",
             "range": [
                 37,
                 42
             ],
-            "drawn": false,
-            "text": "Fearflower Nectar",
-            "documentId": "ALS7pobHFmOnR4yX",
-            "img": "icons/commodities/flowers/lotus-violet.webp",
-            "_id": "Y6zMh7wGkNpDK3vM",
-            "flags": {}
+            "text": "Salamander Elixir (Lesser)",
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "rj2RuyHe7q9qcZ2d",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 3,
+            "documentId": "YcvSw7Zn3oyqlJaw",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/stone-fist-elixir.webp",
             "range": [
                 43,
-                45
+                48
             ],
+            "text": "Stone Fist Elixir",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "o3gZ97kIi4lo11BY",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "n9VrmK9Us0viv20P",
             "drawn": false,
-            "text": "Invisibility Potion",
-            "documentId": "bikFUFRLwfdvX2x2",
             "img": "icons/consumables/potions/bottle-round-ring-teal.webp",
-            "_id": "DrGR0jVfJFbRhMvE",
-            "flags": {}
+            "range": [
+                49,
+                54
+            ],
+            "text": "Winter Wolf Elixir (Lesser)",
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "OtH5vWwuqo4ICMuF",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
-            "range": [
-                46,
-                51
-            ],
-            "drawn": false,
-            "text": "Oak Potion",
             "documentId": "zC7LipQPHRYw2RXx",
-            "img": "systems/pf2e/icons/equipment/consumables/potions/barkskin-potion.webp",
-            "_id": "e9lTnXyHH3Nu5afV",
-            "flags": {}
-        },
-        {
-            "type": "pack",
-            "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
-            "range": [
-                52,
-                57
-            ],
             "drawn": false,
-            "text": "Shrinking Potion",
-            "documentId": "FqbDpztscJfM4XMe",
-            "img": "systems/pf2e/icons/equipment/consumables/potions/shrinking-potion.webp",
-            "_id": "znLnUqKdzAyZGYA3",
-            "flags": {}
+            "img": "systems/pf2e/icons/equipment/consumables/potions/barkskin-potion.webp",
+            "range": [
+                55,
+                60
+            ],
+            "text": "Barkskin Potion",
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "TbqN7piUhgo0OfAf",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "bikFUFRLwfdvX2x2",
+            "drawn": false,
+            "img": "icons/consumables/potions/bottle-round-ring-teal.webp",
             "range": [
-                58,
+                61,
                 63
             ],
-            "drawn": false,
-            "text": "Bloodseeker Beak",
-            "documentId": "k6D64EAjcKMf8NZB",
-            "img": "icons/commodities/claws/claw-insect-brown.webp",
-            "_id": "1cjkjbFKnAmO2KGx",
-            "flags": {}
+            "text": "Invisibility Potion",
+            "type": "pack",
+            "weight": 3
         },
         {
-            "type": "pack",
+            "_id": "l9CD8GKGvhWX8hAA",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "FqbDpztscJfM4XMe",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/potions/shrinking-potion.webp",
             "range": [
                 64,
                 69
             ],
-            "drawn": false,
-            "text": "Dragon Turtle Scale",
-            "documentId": "GnXKCkgZQG0UmuHz",
-            "img": "systems/pf2e/icons/equipment/consumables/talismans/dragon-turtle-scale.webp",
-            "_id": "JaTFdlGNWOxwK6Xz",
-            "flags": {}
+            "text": "Shrinking Potion",
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "t5t1wLQE2o2FC0iI",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "9EZb1hmSKOGrU4Cf",
+            "drawn": false,
+            "img": "icons/environment/traps/trap-jaw-steel.webp",
             "range": [
                 70,
                 75
             ],
-            "drawn": false,
-            "text": "Fear Gem",
-            "documentId": "ZAtwiAPkk1zwCf82",
-            "img": "icons/commodities/gems/gem-rough-oval-purple.webp",
-            "_id": "nvZLkiEuJU1yz0Sp",
-            "flags": {}
+            "text": "Biting Snare",
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "SaGLwztjSNglsrzf",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "0lhh2l4kh3QrwYH9",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/snares/hobbling-snare.webp",
             "range": [
                 76,
-                81
+                78
             ],
-            "drawn": false,
-            "text": "Viper Arrow",
-            "documentId": "ilB279mxqXnlaSFj",
-            "img": "systems/pf2e/icons/equipment/consumables/ammunition/viper-arrow.webp",
-            "_id": "4keNvuWj4zD7L83P",
-            "flags": {}
+            "text": "Hobbling Snare",
+            "type": "pack",
+            "weight": 3
         },
         {
-            "type": "pack",
+            "_id": "vHNOIhldCiAlVI37",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "s9dtRS2SRTqzGdOF",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/snares/stalker-bane-snare.webp",
+            "range": [
+                79,
+                81
+            ],
+            "text": "Stalker Bane Snare",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "wDGaxAN4F6RLlPZV",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "SWqzv0hYCIczICeR",
+            "drawn": false,
+            "img": "icons/commodities/cloth/thread-spindle-white-grey.webp",
             "range": [
                 82,
                 87
             ],
-            "drawn": false,
-            "text": "Crystal Shards (Moderate)",
-            "documentId": "V4wgOWYmHlbSZsVG",
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/crystal-shards.webp",
-            "_id": "1rrWtE8qMdEvXLwV",
-            "flags": {}
+            "text": "Trip Snare",
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "WyvKXDRJxYg9a79P",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "XU8u9F3uoesGDjgM",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/snares/warning-snare.webp",
             "range": [
                 88,
                 93
             ],
-            "drawn": false,
-            "text": "Bottled Catharsis (Lesser)",
-            "documentId": "8KbayiwrUJtvif0a",
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/focus-cathartic.webp",
-            "_id": "u4NmFxoavA5cMmGr",
-            "flags": {}
+            "text": "Warning Snare",
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "YNNBB0NEm00kqxhJ",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "k6D64EAjcKMf8NZB",
+            "drawn": false,
+            "img": "icons/commodities/claws/claw-insect-brown.webp",
             "range": [
                 94,
                 99
             ],
-            "drawn": false,
-            "text": "Cooling Elixir (Lesser)",
-            "documentId": "Ekk7o1gPu8RotixD",
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/salamander-elixir.webp",
-            "_id": "jzTu7G4amSHGZUxa",
-            "flags": {}
+            "text": "Bloodseeker Beak",
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "WsS6m4J1WTXgwz5x",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "GnXKCkgZQG0UmuHz",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/dragon-turtle-scale.webp",
             "range": [
                 100,
                 105
             ],
-            "drawn": false,
-            "text": "Surging Serum (Lesser)",
-            "documentId": "1TWHN8RbimPVXM0U",
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/sinew-shock-serum.webp",
-            "_id": "dURqL0JteziCnBno",
-            "flags": {}
+            "text": "Dragon Turtle Scale",
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "vd0CCfRPIvDD5bR9",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "ZAtwiAPkk1zwCf82",
+            "drawn": false,
+            "img": "icons/commodities/gems/gem-rough-oval-purple.webp",
             "range": [
                 106,
                 111
             ],
-            "drawn": false,
-            "text": "Witchwarg Elixir (Lesser)",
-            "documentId": "n9VrmK9Us0viv20P",
-            "img": "icons/consumables/potions/bottle-round-ring-teal.webp",
-            "_id": "kQTnunLE0S9fmtjU",
-            "flags": {}
-        },
-        {
+            "text": "Fear Gem",
             "type": "pack",
-            "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
-            "range": [
-                112,
-                117
-            ],
-            "drawn": false,
-            "text": "Leadenleg",
-            "documentId": "QJ1fTrX42PoEWpK5",
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/leadenleg.webp",
-            "_id": "ep0uNyFuyGn1znid",
-            "flags": {}
-        },
-        {
-            "type": "pack",
-            "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
-            "range": [
-                118,
-                123
-            ],
-            "drawn": false,
-            "text": "Biting Snare",
-            "documentId": "9EZb1hmSKOGrU4Cf",
-            "img": "icons/environment/traps/trap-jaw-steel.webp",
-            "_id": "Ji88hahtOiyJ87xT",
-            "flags": {}
-        },
-        {
-            "type": "pack",
-            "documentCollection": "pf2e.equipment-srd",
-            "weight": 3,
-            "range": [
-                124,
-                126
-            ],
-            "drawn": false,
-            "text": "Hobbling Snare",
-            "documentId": "0lhh2l4kh3QrwYH9",
-            "img": "icons/magic/nature/root-vine-entangle-foot-green.webp",
-            "_id": "k0S0eznH0ApMmvWi",
-            "flags": {}
-        },
-        {
-            "type": "pack",
-            "documentCollection": "pf2e.equipment-srd",
-            "weight": 3,
-            "range": [
-                127,
-                129
-            ],
-            "drawn": false,
-            "text": "Stalker Bane Snare",
-            "documentId": "s9dtRS2SRTqzGdOF",
-            "img": "systems/pf2e/icons/equipment/snares/stalker-bane-snare.webp",
-            "_id": "13CGauAkkBvfRyb0",
-            "flags": {}
-        },
-        {
-            "type": "pack",
-            "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
-            "range": [
-                130,
-                135
-            ],
-            "drawn": false,
-            "text": "Trip Snare",
-            "documentId": "SWqzv0hYCIczICeR",
-            "img": "icons/commodities/cloth/thread-spindle-white-grey.webp",
-            "_id": "7UxWLNXfbJrmvPn0",
-            "flags": {}
-        },
-        {
-            "type": "pack",
-            "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
-            "range": [
-                136,
-                141
-            ],
-            "drawn": false,
-            "text": "Timeless Salts",
-            "documentId": "Ha6n30Tj3TNru9Dj",
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/timeless-salts.webp",
-            "_id": "v2xbmBtbR33akycD",
-            "flags": {}
+            "weight": 6
         }
     ]
 }

--- a/packs/rollable-tables/4th-level-permanent-items.json
+++ b/packs/rollable-tables/4th-level-permanent-items.json
@@ -11,259 +11,200 @@
     "replacement": true,
     "results": [
         {
-            "type": "pack",
+            "_id": "QN2b9QvvhEhXYHss",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "jaEEvuQ32GjAa8jy",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/held-items/bag-of-holding.webp",
             "range": [
                 1,
                 6
             ],
-            "drawn": false,
-            "text": "Spacious Pouch (Type I)",
-            "documentId": "jaEEvuQ32GjAa8jy",
-            "img": "systems/pf2e/icons/equipment/held-items/bag-of-holding.webp",
-            "_id": "SRACM7psSWbt7MUy",
-            "flags": {}
+            "text": "Bag of Holding (Type I)",
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "aPbhuQl16Dn83HR8",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "JQdwHECogcTzdd8R",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
             "range": [
                 7,
                 12
             ],
-            "drawn": false,
             "text": "Ghost Touch",
-            "documentId": "JQdwHECogcTzdd8R",
-            "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
-            "_id": "vepEjDl8jOX86vNe",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "3EqXFbXhBaS3HemC",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "DxCuJKynlnMQZHgp",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/fundamental-weapon-runes/striking.webp",
             "range": [
                 13,
                 18
             ],
-            "drawn": false,
-            "text": "Reinforcing Rune (Minor)",
-            "documentId": "x9SNVpAAnXKJeoqp",
-            "img": "icons/commodities/treasure/token-runed-os-grey.webp",
-            "_id": "7GVKVhPHE1tRqofk",
-            "flags": {}
+            "text": "Striking",
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "oLZsd9xeniDUB97N",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "f9ygr5Cjrmop8LWV",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/shields/specific-shields/sturdy-shield.webp",
             "range": [
                 19,
                 24
             ],
-            "drawn": false,
-            "text": "Striking",
-            "documentId": "DxCuJKynlnMQZHgp",
-            "img": "systems/pf2e/icons/equipment/runes/fundamental-weapon-runes/striking.webp",
-            "_id": "Q5GdUSJPaUQunMLC",
-            "flags": {}
+            "text": "Sturdy Shield (Minor)",
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "zz0eL7k3QNTKNXc3",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "WcuknnE3xYfSdbhm",
+            "drawn": false,
+            "img": "icons/weapons/staves/staff-ornate-bird.webp",
             "range": [
                 25,
                 30
             ],
-            "drawn": false,
-            "text": "Sturdy Shield (Minor)",
-            "documentId": "f9ygr5Cjrmop8LWV",
-            "img": "systems/pf2e/icons/equipment/shields/specific-shields/sturdy-shield.webp",
-            "_id": "FaCinm93O2jFlr6V",
-            "flags": {}
+            "text": "Animal Staff",
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "lLzSpPUauPOj4sfl",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "xwiZBOjispKVZzGA",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/staves/mentalist-staff.webp",
             "range": [
                 31,
                 36
             ],
-            "drawn": false,
-            "text": "Animal Staff",
-            "documentId": "WcuknnE3xYfSdbhm",
-            "img": "icons/weapons/staves/staff-ornate-bird.webp",
-            "_id": "CqAVPdu3PE9R0AVY",
-            "flags": {}
+            "text": "Mentalist's Staff",
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "HpyqvpBDM6D2jUC6",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "3OkOKxCee9WruGU5",
+            "drawn": false,
+            "img": "icons/weapons/staves/staff-ornate-gold-jeweled.webp",
             "range": [
                 37,
                 42
             ],
-            "drawn": false,
-            "text": "Mentalist's Staff",
-            "documentId": "xwiZBOjispKVZzGA",
-            "img": "systems/pf2e/icons/equipment/staves/mentalist-staff.webp",
-            "_id": "AHr6259HQlrLJpiq",
-            "flags": {}
+            "text": "Staff of Healing",
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "kQTbzpAKyDIdb9PY",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "Zw3BKaJYxxxzNZ0f",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-widening.webp",
             "range": [
                 43,
                 48
             ],
-            "drawn": false,
-            "text": "Staff of Healing",
-            "documentId": "3OkOKxCee9WruGU5",
-            "img": "icons/weapons/staves/staff-ornate-gold-jeweled.webp",
-            "_id": "dWPzhR7OlQPGUF4H",
-            "flags": {}
+            "text": "Wand of Widening (1st-Rank Spell)",
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
-            "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "_id": "11E6i8082Hr9VbAI",
+            "documentCollection": "",
+            "documentId": null,
+            "drawn": false,
+            "img": "icons/svg/d20-black.svg",
             "range": [
                 49,
                 54
             ],
-            "drawn": false,
-            "text": "Wand of Widening (1st-Rank Spell)",
-            "documentId": "Zw3BKaJYxxxzNZ0f",
-            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-widening.webp",
-            "_id": "tlsLBZ3bm0MD7b9I",
-            "flags": {}
+            "text": "Weapon (+1 Striking)",
+            "type": "text",
+            "weight": 6
         },
         {
-            "type": "text",
+            "_id": "dwXrm0DZwZ0Vtpyl",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "7JVgLiNTAs4clEW8",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/alchemist-goggles.webp",
             "range": [
                 55,
                 60
             ],
-            "drawn": false,
-            "_id": "ws11Q7zMLmdJi0QE",
-            "text": "Striking Weapon (+1)",
-            "img": "systems/pf2e/icons/equipment/weapons/shortsword.webp",
-            "documentId": null,
-            "flags": {}
+            "text": "Alchemist Goggles",
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "text",
-            "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "_id": "TbqN7piUhgo0OfAf",
+            "documentCollection": "",
+            "documentId": "oC4ZMEdBJ3ia4ALm",
+            "drawn": false,
+            "img": "icons/equipment/back/mantle-collared-blue.webp",
             "range": [
                 61,
                 66
             ],
-            "drawn": false,
-            "_id": "PYXHf2kEFfDwhPiP",
-            "text": "Striking Handwraps of Mighty Blows (+1)",
-            "img": "icons/equipment/hand/gauntlet-simple-leather-brown-gold.webp",
-            "documentId": null,
-            "flags": {}
+            "text": "+1 striking Handwraps of Mighty Blows",
+            "type": "text",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "l9CD8GKGvhWX8hAA",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "2gYZiUw9yjtb0yJY",
+            "drawn": false,
+            "img": "icons/equipment/head/mask-horned-brown.webp",
             "range": [
                 67,
                 72
             ],
-            "drawn": false,
             "text": "Demon Mask",
-            "documentId": "2gYZiUw9yjtb0yJY",
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/demon-mask.webp",
-            "_id": "XU0XOMqExbnQXxEp",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "t5t1wLQE2o2FC0iI",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "o1zKhvYUUc1hE2AE",
+            "drawn": false,
+            "img": "icons/equipment/hand/glove-simple-cloth-white.webp",
             "range": [
                 73,
                 78
             ],
-            "drawn": false,
             "text": "Healer's Gloves",
-            "documentId": "o1zKhvYUUc1hE2AE",
-            "img": "icons/equipment/hand/glove-simple-cloth-white.webp",
-            "_id": "roFmJTv0LJz24H24",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "vHNOIhldCiAlVI37",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "g2oaOGSpttfH1q6W",
+            "drawn": false,
+            "img": "icons/equipment/waist/belt-leather-brown.webp",
             "range": [
                 79,
                 84
             ],
-            "drawn": false,
             "text": "Lifting Belt",
-            "documentId": "g2oaOGSpttfH1q6W",
-            "img": "icons/equipment/waist/belt-leather-brown.webp",
-            "_id": "4Z4p2caLt6tpbLZM",
-            "flags": {}
-        },
-        {
             "type": "pack",
-            "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
-            "range": [
-                85,
-                90
-            ],
-            "drawn": false,
-            "text": "Sleeves of Storage",
-            "documentId": "1pglC9PQx6yOgcKL",
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/sleeves-of-storage.webp",
-            "_id": "AujXBLZGBU2e4ekK",
-            "flags": {}
-        },
-        {
-            "type": "pack",
-            "documentCollection": "pf2e.equipment-srd",
-            "weight": 3,
-            "range": [
-                91,
-                93
-            ],
-            "drawn": false,
-            "text": "Symbol of Conflict",
-            "documentId": "BHjJpNILf85M2LJE",
-            "img": "icons/commodities/treasure/broach-eye-silver-teal.webp",
-            "_id": "pZj5ByKYQIL7yzQw",
-            "flags": {}
-        },
-        {
-            "type": "pack",
-            "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
-            "range": [
-                94,
-                99
-            ],
-            "drawn": false,
-            "text": "Alchemist Goggles",
-            "documentId": "7JVgLiNTAs4clEW8",
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/alchemist-goggles.webp",
-            "_id": "TKvSCbirYVz9rdA4",
-            "flags": {}
+            "weight": 6
         }
     ]
 }

--- a/packs/rollable-tables/5th-level-consumables-items.json
+++ b/packs/rollable-tables/5th-level-consumables-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "zRyuNslbOzN9oW5u",
-    "description": "Table of 5th-Level Consumables Items",
+    "description": "<p>Table of 5th-Level Consumables Items</p>",
     "displayRoll": true,
-    "formula": "1d78",
+    "formula": "1d105",
     "img": "icons/svg/d20-grey.svg",
     "name": "5th-Level Consumables Items",
     "ownership": {
@@ -81,21 +81,21 @@
             "weight": 6
         },
         {
-            "_id": "HpyqvpBDM6D2jUC6",
+            "_id": "Rrs8qHoXPcKakCTn",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "MobYbxEL4KgxVi63",
+            "documentId": "5lpBiEqrxiyj48JB",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/oils/salve-of-slipperiness.webp",
+            "img": "icons/magic/fire/barrier-shield-explosion-yellow.webp",
             "range": [
                 31,
                 36
             ],
-            "text": "Salve of Slipperiness",
+            "text": "Frozen Lava",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "xkxbqKf3zQN0HjG2",
+            "_id": "CXnx9g4ixYgYuGgN",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "5RGNjhDxZ0yMhTds",
             "drawn": false,
@@ -104,12 +104,12 @@
                 37,
                 42
             ],
-            "text": "Hunting Spider Venom",
+            "text": "Spider Venom",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "kQTbzpAKyDIdb9PY",
+            "_id": "ZzDsQOSKWDMA91GN",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "rzEQvcWfhR3T4FNd",
             "drawn": false,
@@ -123,7 +123,7 @@
             "weight": 6
         },
         {
-            "_id": "11E6i8082Hr9VbAI",
+            "_id": "UT9bJq4HVcWhLZca",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "ZmefGBXGJF3CFDbn",
             "drawn": false,
@@ -132,12 +132,12 @@
                 49,
                 54
             ],
-            "text": "Scroll of 3nd-level Spell",
+            "text": "Scroll of 3rd-rank Spell",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "dwXrm0DZwZ0Vtpyl",
+            "_id": "Yo626hW89KvUrHSh",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "3uhaf2YL9hmix3pe",
             "drawn": false,
@@ -151,7 +151,7 @@
             "weight": 6
         },
         {
-            "_id": "ViMk7CeQzvGeYUrC",
+            "_id": "ZWY5IRctsSyPNSqY",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "Tj4uaNw2lgevxGl7",
             "drawn": false,
@@ -165,7 +165,7 @@
             "weight": 6
         },
         {
-            "_id": "rj2RuyHe7q9qcZ2d",
+            "_id": "ZTigufocRwaBXVGl",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "1v1OK06JxdXn6MP4",
             "drawn": false,
@@ -179,7 +179,7 @@
             "weight": 6
         },
         {
-            "_id": "o3gZ97kIi4lo11BY",
+            "_id": "3vfwQG41FZlX1E5R",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "zrZ1FaaqW6VIajj7",
             "drawn": false,
@@ -189,6 +189,76 @@
                 78
             ],
             "text": "Tiger Menuki",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "VzOnWjcm42gyiYeT",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "Xnmx6SJ6OkJOfYxF",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/ammunition/freezing-ammunition.webp",
+            "range": [
+                79,
+                84
+            ],
+            "text": "Freezing Ammunition",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "Yadc8fCrbWLcMo3k",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "o9k5L682AlZfhpRu",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/oils/oil-of-revelation.webp",
+            "range": [
+                85,
+                90
+            ],
+            "text": "Oil of Revelation",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "uXErqCHvoJXkK5eM",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "MobYbxEL4KgxVi63",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/oils/salve-of-slipperiness.webp",
+            "range": [
+                91,
+                96
+            ],
+            "text": "Tricky Liniment",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "ZsKXOLZ6KgEDFdI0",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "QNub2kTE7LpdMPII",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/potions/potion-of-disguise.webp",
+            "range": [
+                97,
+                99
+            ],
+            "text": "Potion of Disguise (Lesser)",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "JlycqoDvvOrZixtH",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "mR9RD9S08jIX1IPm",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/universal-solvent.webp",
+            "range": [
+                100,
+                105
+            ],
+            "text": "Absolute Solvent (Moderate)",
             "type": "pack",
             "weight": 6
         }

--- a/packs/rollable-tables/5th-level-permanent-items.json
+++ b/packs/rollable-tables/5th-level-permanent-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "k5bG37570BbflxR2",
-    "description": "Table of 5th-Level Permanent Items",
+    "description": "<p>Table of 5th-Level Permanent Items</p>",
     "displayRoll": true,
-    "formula": "1d105",
+    "formula": "1d144",
     "img": "icons/svg/d20-grey.svg",
     "name": "5th-Level Permanent Items",
     "ownership": {
@@ -15,7 +15,7 @@
             "documentCollection": "",
             "documentId": null,
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "systems/pf2e/icons/equipment/armor/scale-mail.webp",
             "range": [
                 1,
                 6
@@ -29,7 +29,7 @@
             "documentCollection": "",
             "documentId": null,
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "systems/pf2e/icons/equipment/armor/breastplate.webp",
             "range": [
                 7,
                 12
@@ -43,7 +43,7 @@
             "documentCollection": "",
             "documentId": null,
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "systems/pf2e/icons/equipment/armor/breastplate.webp",
             "range": [
                 13,
                 18
@@ -53,212 +53,310 @@
             "weight": 6
         },
         {
-            "_id": "aPbhuQl16Dn83HR8",
+            "_id": "H23xnoZDtd9XEjr4",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "KrmSuQIyu6OEi5ew",
+            "documentId": "aJEXZJYjzoMHc5Pm",
             "drawn": false,
-            "img": "icons/equipment/neck/necklace-runed-white-red.webp",
+            "img": "icons/magic/earth/explosion-lava-orange.webp",
             "range": [
                 19,
-                21
+                24
             ],
-            "text": "Holy Prayer Beads",
-            "type": "pack",
-            "weight": 3
-        },
-        {
-            "_id": "3EqXFbXhBaS3HemC",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "fprUZviW8khm2BLo",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/held-items/skeleton-key.webp",
-            "range": [
-                22,
-                27
-            ],
-            "text": "Skeleton Key",
+            "text": "Eternal Eruption",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "lLzSpPUauPOj4sfl",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Ro3g2JpJXrKXVyEr",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/runes/fundamental-armor-runes/armor-potency.webp",
-            "range": [
-                28,
-                33
-            ],
-            "text": "Armor Potency (+1)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "HpyqvpBDM6D2jUC6",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "iTxqImupNnm8gvoe",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/runes/armor-property-runes/armor-property-runes.webp",
-            "range": [
-                34,
-                39
-            ],
-            "text": "Glamered",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "bqsJMu7IB225fTYz",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "LwQb7ryTC8FlOXgX",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
-            "range": [
-                40,
-                45
-            ],
-            "text": "Disrupting",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "xkxbqKf3zQN0HjG2",
+            "_id": "lMCzXDM2R34rR52m",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "BNelZMBHKlPAWl9Z",
             "drawn": false,
             "img": "icons/environment/settlement/palast.webp",
             "range": [
-                46,
-                51
+                25,
+                30
             ],
             "text": "Pocket Stage",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "kQTbzpAKyDIdb9PY",
+            "_id": "brZi9pWwD3Zi8gwS",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "fprUZviW8khm2BLo",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/held-items/skeleton-key.webp",
+            "range": [
+                31,
+                36
+            ],
+            "text": "Skeleton Key",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "jKyU9GIANsOrz7FE",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "Ro3g2JpJXrKXVyEr",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/fundamental-armor-runes/armor-potency.webp",
+            "range": [
+                37,
+                42
+            ],
+            "text": "Armor Potency (+1)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "mCCqN1RuWVcuJJl0",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "P6v2AtJw7AUwaDzf",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
+            "range": [
+                43,
+                48
+            ],
+            "text": "Fearsome",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "G3DO21lXUdbg8x1f",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "iTxqImupNnm8gvoe",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/armor-property-runes/armor-property-runes.webp",
+            "range": [
+                49,
+                54
+            ],
+            "text": "Raiment",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "6LI1ZZTI4EbeElQ5",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "kEy7Uc1VisizGgtf",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/armor-property-runes/armor-property-runes.webp",
+            "range": [
+                55,
+                60
+            ],
+            "text": "Shadow",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "mGpAbfy7TesRlWcQ",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "uQOaRpfkUFVYD0Gx",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/armor-property-runes/armor-property-runes.webp",
+            "range": [
+                61,
+                66
+            ],
+            "text": "Slick",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "Sb75nEgYTfTWteAL",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "LwQb7ryTC8FlOXgX",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
+            "range": [
+                67,
+                72
+            ],
+            "text": "Vitalizing",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "IkLx4N0E8cfF4mbw",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "vJZ49cgi8szuQXAD",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/magic-wands/magic-wand.webp",
             "range": [
-                52,
-                57
+                73,
+                78
             ],
             "text": "Magic Wand (2nd-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "11E6i8082Hr9VbAI",
+            "_id": "inTe84JhacwTnDbC",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "a60NH7OztaEaGlU8",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-continuation.webp",
             "range": [
-                58,
-                63
+                79,
+                84
             ],
             "text": "Wand of Continuation (1st-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "vQq7Hy7Dx1a8GCHZ",
+            "_id": "smxVnyBoMeOxbOwt",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "KPWN5tGGkvZR7K3K",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-manifold-missiles.webp",
             "range": [
-                64,
-                69
+                85,
+                90
             ],
-            "text": "Wand of Manifold Missiles (1st-Rank Spell)",
+            "text": "Wand of Shardstorm (1st-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "dwXrm0DZwZ0Vtpyl",
+            "_id": "PItIkLUlBbWN1StV",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "2KNAip9W6IoBrfIU",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/weapons/specific-magic-weapons/caterwaul-sling.webp",
+            "img": "systems/pf2e/icons/equipment/weapons/sling.webp",
             "range": [
-                70,
-                75
+                91,
+                96
             ],
             "text": "Caterwaul Sling",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "ViMk7CeQzvGeYUrC",
+            "_id": "a6rXacafU2711JI2",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "ZvIEJCY60fHqzl6r",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/weapons/specific-magic-weapons/dagger-of-venom.webp",
             "range": [
-                76,
-                81
+                97,
+                102
             ],
-            "text": "Dagger of Venom",
+            "text": "Serpent Dagger",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "o3gZ97kIi4lo11BY",
+            "_id": "rKlYjBbJd7mtjXUh",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "T00Xa9aDwHxd60Zh",
+            "documentId": "xwX93cp1GiTwgtBj",
             "drawn": false,
-            "img": "icons/equipment/feet/boots-leather-green.webp",
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/aeon-stone-gold-nodule.webp",
             "range": [
-                82,
-                87
+                103,
+                105
             ],
-            "text": "Boots of Elvenkind",
+            "text": "Aeon Stone (Preserving)",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "g2fTWOVYpPwRYwiB",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "amJW9azNUSJLmWGP",
+            "drawn": false,
+            "img": "icons/equipment/feet/boots-collared-green.webp",
+            "range": [
+                106,
+                111
+            ],
+            "text": "Arboreal Boots",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "l9CD8GKGvhWX8hAA",
+            "_id": "VxCr0rTUrZGKO2KO",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "JJZgRx6naNJmDa81",
             "drawn": false,
             "img": "icons/commodities/treasure/token-gold-cross.webp",
             "range": [
-                88,
-                93
+                112,
+                117
             ],
             "text": "Diplomat's Badge",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "t5t1wLQE2o2FC0iI",
+            "_id": "j7elRASlljLPDJ3w",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "K7VHhUamFz3kTnm5",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/goggles-of-night.webp",
             "range": [
-                94,
-                99
+                118,
+                123
             ],
             "text": "Obsidian Goggles",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "vHNOIhldCiAlVI37",
+            "_id": "H4625mLPUoeOV56D",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "6cV9Kpwc7aiuhqbH",
+            "documentId": "YfRwH0wIEmuNDL7I",
             "drawn": false,
-            "img": "icons/equipment/neck/collar-rounded-carved-wood-spiral.webp",
+            "img": "icons/equipment/chest/breastplate-layered-leather-studded-black.webp",
             "range": [
-                100,
-                105
+                124,
+                126
             ],
-            "text": "Necklace of Fireballs I",
+            "text": "Mariner's Splint",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "B3cCyohmGELsBcWx",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "5QbocabfxRZjb3qn",
+            "drawn": false,
+            "img": "icons/commodities/materials/material-cotton-white.webp",
+            "range": [
+                127,
+                132
+            ],
+            "text": "Twisting Twine (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "v4hEvLA04CETShcm",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "slQRh4FVDzP8h1wj",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/shields/specific-shields/exploding-shield.webp",
+            "range": [
+                133,
+                138
+            ],
+            "text": "Exploding Shield",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "TPp1qV32w2nFKa2Z",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "AYdpUABAZeZnSA7s",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/weapons/sword-cane.webp",
+            "range": [
+                139,
+                144
+            ],
+            "text": "Infiltrator's Accessory",
             "type": "pack",
             "weight": 6
         }

--- a/packs/rollable-tables/7th-level-consumables-items.json
+++ b/packs/rollable-tables/7th-level-consumables-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "E9ZNupg1p4yLpfrd",
-    "description": "Table of 7th-Level Consumables Items",
+    "description": "<p>Table of 7th-Level Consumables Items</p>",
     "displayRoll": true,
-    "formula": "1d75",
+    "formula": "1d93",
     "img": "icons/svg/d20-grey.svg",
     "name": "7th-Level Consumables Items",
     "ownership": {
@@ -25,170 +25,212 @@
             "weight": 6
         },
         {
-            "_id": "QN2b9QvvhEhXYHss",
+            "_id": "fFeFAzY0Td0FRrEB",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "VvljzRwthKMgqUR3",
+            "documentId": "bh3HJkgWC05VSXgs",
             "drawn": false,
-            "img": "icons/commodities/materials/feather-blue.webp",
+            "img": "icons/magic/fire/barrier-shield-explosion-yellow.webp",
             "range": [
                 7,
                 12
             ],
-            "text": "Feather Token (Anchor)",
+            "text": "Frozen Lava of Blackpeak",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "aPbhuQl16Dn83HR8",
+            "_id": "vF1LPiWtPCukIDHb",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "OcBPjVplvy2GbQ8P",
+            "documentId": null,
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/comprehension-elixir.webp",
+            "img": "systems/pf2e/icons/equipment/consumables/potions/green-dragons-breath-potion.webp",
             "range": [
                 13,
                 18
             ],
-            "text": "Comprehension Elixir (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "3EqXFbXhBaS3HemC",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "6eQvHNHf1IC2X5Rx",
-            "drawn": false,
-            "img": "icons/consumables/potions/potion-jar-capped-teal.webp",
-            "range": [
-                19,
-                24
-            ],
-            "text": "Leaper's Elixir (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "lLzSpPUauPOj4sfl",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "aBOPYlfHAcXUmhF7",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/giant-wasp-venom.webp",
-            "range": [
-                25,
-                30
-            ],
-            "text": "Giant Wasp Venom",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "bqsJMu7IB225fTYz",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "76T49dJYfxIrPvQe",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/malyass-root-paste.webp",
-            "range": [
-                31,
-                36
-            ],
-            "text": "Malyass Root Paste",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "xkxbqKf3zQN0HjG2",
-            "documentCollection": "",
-            "documentId": null,
-            "drawn": false,
-            "img": "icons/svg/d20-black.svg",
-            "range": [
-                37,
-                42
-            ],
-            "text": "Dragon's Breath Potion (Young)",
+            "text": "Energy Breath Potion (Lesser)",
             "type": "text",
             "weight": 6
         },
         {
-            "_id": "kQTbzpAKyDIdb9PY",
+            "_id": "IEJDjoKiwKvwiyEr",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "9ignmYCACjfzkxDQ",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/weapons/serum-of-sex-shift.webp",
+            "img": "systems/pf2e/icons/equipment/consumables/potions/serum-of-sex-shift.webp",
             "range": [
-                43,
-                48
+                19,
+                24
             ],
             "text": "Serum of Sex Shift",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "11E6i8082Hr9VbAI",
+            "_id": "2spGL6oHBdQgps5v",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "QSQZJ5BC3DeHv153",
             "drawn": false,
             "img": "icons/sundries/scrolls/scroll-symbol-eye-brown.webp",
             "range": [
-                49,
-                54
+                25,
+                30
             ],
-            "text": "Scroll of 4th-level Spell",
+            "text": "Scroll of 4th-rank Spell",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "61ajGdu6KUgCbRhV",
+            "_id": "WNPjUl7s0vReowTG",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "eEIWjTvZyKsKhYaz",
             "drawn": false,
             "img": "icons/commodities/bones/skull-hollow-worn-white.webp",
             "range": [
-                55,
-                60
+                31,
+                36
             ],
             "text": "Grim Trophy",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "7SGOQT7AOrcdyFAN",
+            "_id": "bXtWcUhY0LpsQC2r",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "YGaO4HyH6jn3P731",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/talismans/murderers-knot.webp",
             "range": [
-                61,
-                66
+                37,
+                42
             ],
             "text": "Murderer's Knot",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "k89jRhkpypFGiAtB",
+            "_id": "1erHF09RBpSMUtqZ",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "4tnPWyApPZP1P1yO",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/talismans/swift-block-cabochon.webp",
             "range": [
-                67,
-                69
+                43,
+                45
             ],
             "text": "Swift Block Cabochon",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "yNMZRnLghOhNPUR4",
+            "_id": "3iprGiNeuUh5PLpo",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "ehss8yPTXxiUdVlJ",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/smokestick.webp",
             "range": [
+                46,
+                51
+            ],
+            "text": "Smoke Ball (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "k5QfiT4afk6BAI66",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "903CuhvVUhE1lmoB",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/ammunition/corrosive-ammunition.webp",
+            "range": [
+                52,
+                57
+            ],
+            "text": "Corrosive Ammunition",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "onjPcvfcbZ6nwklI",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "OcBPjVplvy2GbQ8P",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/comprehension-elixir.webp",
+            "range": [
+                58,
+                63
+            ],
+            "text": "Comprehension Elixir (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "6Hkycf60bdHXodRw",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "XpmPX3ScEOBgAoKd",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/other-consumables/candle-of-revealing.webp",
+            "range": [
+                64,
+                69
+            ],
+            "text": "Candle of Revealing",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "YXAbLgIvt2KyDfA4",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "76T49dJYfxIrPvQe",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/malyass-root-paste.webp",
+            "range": [
                 70,
                 75
             ],
-            "text": "Smokestick (Greater)",
+            "text": "Tangle Root Toxin",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "GeZnMbYaIAPJByDO",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "EkC2W5A5fohoIKSd",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/potions/ration-tonic.webp",
+            "range": [
+                76,
+                81
+            ],
+            "text": "Ration Tonic (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "SJDg9N1KxBKS2K0X",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "7IrQPyMm76nLVoXx",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/soverign-glue.webp",
+            "range": [
+                82,
+                87
+            ],
+            "text": "Everlasting Adhesive",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "Fq2FismwfQuslrcx",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "FgAPV0iLE6R1QMJ5",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/skinitch-salve.webp",
+            "range": [
+                88,
+                93
+            ],
+            "text": "Skinstitch Salve",
             "type": "pack",
             "weight": 6
         }

--- a/packs/rollable-tables/7th-level-permanent-items.json
+++ b/packs/rollable-tables/7th-level-permanent-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "r8F8mI2BZU6nOMQB",
-    "description": "Table of 7th-Level Permanent Items",
+    "description": "<p>Table of 7th-Level Permanent Items</p>",
     "displayRoll": true,
-    "formula": "1d135",
+    "formula": "1d153",
     "img": "icons/svg/d20-grey.svg",
     "name": "7th-Level Permanent Items",
     "ownership": {
@@ -25,7 +25,7 @@
             "weight": 6
         },
         {
-            "_id": "QN2b9QvvhEhXYHss",
+            "_id": "fHDVsWov2bz8OoIY",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "peoheZMxdPHUNo93",
             "drawn": false,
@@ -34,329 +34,371 @@
                 7,
                 12
             ],
-            "text": "Horseshoes of Speed",
+            "text": "Alacritous Horseshoes",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "aPbhuQl16Dn83HR8",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "JBMBaN9dZLytfFLQ",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/held-items/bag-of-holding.webp",
-            "range": [
-                13,
-                18
-            ],
-            "text": "Bag of Holding (Type II)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "3EqXFbXhBaS3HemC",
+            "_id": "JcPUuTgvueG3BlxA",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "7TQw7V1zZKl0a0Xz",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/held-items/bottled-air.webp",
             "range": [
-                19,
-                24
+                13,
+                18
             ],
             "text": "Bottled Air",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "oLZsd9xeniDUB97N",
+            "_id": "7UVnOMJAVOKIN2Ku",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "aBVrNIPoPGOYxm80",
+            "documentId": "zP7Eo57IYMUKxwPO",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/held-items/decanter-of-endless-water.webp",
+            "img": "icons/magic/earth/explosion-lava-orange.webp",
+            "range": [
+                19,
+                24
+            ],
+            "text": "Eternal Eruption of Blackpeak",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "s8mmFw5fODAuPKHO",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "JBMBaN9dZLytfFLQ",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/held-items/bag-of-holding.webp",
             "range": [
                 25,
                 30
             ],
-            "text": "Decanter of Endless Water",
+            "text": "Spacious Pouch (Type II)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "lLzSpPUauPOj4sfl",
+            "_id": "1URd1EqYZ66HuHE9",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "RjJw7iHantxqeJu1",
+            "documentId": "o65PFCSOyMje6fwi",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/held-items/wondrous-figurine-jade-serpent.webp",
+            "img": "icons/commodities/treasure/token-runed-os-grey.webp",
             "range": [
                 31,
                 36
             ],
-            "text": "Wondrous Figurine (Jade Serpent)",
+            "text": "Reinforcing Rune (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "bqsJMu7IB225fTYz",
+            "_id": "Vyz4XUBbC99X3uSV",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "Z5FvYWLEpWVo3PUF",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/armor-property-runes/armor-property-runes.webp",
+            "range": [
+                37,
+                42
+            ],
+            "text": "Size-Changing",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "QO5Gq7bEaEvgTFNR",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "fo6Yhq5mbQXsnZs0",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
             "range": [
-                37,
-                42
+                43,
+                48
             ],
             "text": "Wounding",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "xkxbqKf3zQN0HjG2",
+            "_id": "5tBCxKoBvOWy8FCh",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "PsyfqGIzDbr1mX6d",
+            "documentId": null,
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/cold-Iron-buckler.webp",
-            "range": [
-                43,
-                48
-            ],
-            "text": "Cold Iron Buckler (Standard-Grade)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "kQTbzpAKyDIdb9PY",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "p1uYtIUYXXoNdVKg",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/cold-Iron-shield.webp",
             "range": [
                 49,
                 54
             ],
-            "text": "Cold Iron Shield (Standard-Grade)",
-            "type": "pack",
+            "text": "Cold Iron Buckler (Standard-Grade)",
+            "type": "text",
             "weight": 6
         },
         {
-            "_id": "vQq7Hy7Dx1a8GCHZ",
+            "_id": "vmgndvjErJl4KGjr",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "8DNpWWeL7X9MDG0i",
+            "documentId": null,
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/silver-buckler.webp",
+            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/cold-Iron-shield.webp",
             "range": [
                 55,
                 60
             ],
-            "text": "Silver Buckler (Standard-Grade)",
-            "type": "pack",
+            "text": "Cold Iron Shield (Standard-Grade)",
+            "type": "text",
             "weight": 6
         },
         {
-            "_id": "dwXrm0DZwZ0Vtpyl",
+            "_id": "6U7RxYpfBESBrbOR",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "KVj9RP2qvpsHHGqE",
+            "documentId": null,
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/silver-shield.webp",
+            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/silver-buckler.webp",
             "range": [
                 61,
                 66
             ],
-            "text": "Silver Shield (Standard-Grade)",
-            "type": "pack",
+            "text": "Silver Buckler (Standard-Grade)",
+            "type": "text",
             "weight": 6
         },
         {
-            "_id": "ViMk7CeQzvGeYUrC",
+            "_id": "ymYabv3L4B5aOs8h",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/silver-shield.webp",
+            "range": [
+                67,
+                72
+            ],
+            "text": "Silver Shield (Standard-Grade)",
+            "type": "text",
+            "weight": 6
+        },
+        {
+            "_id": "9uUWNq4jQT2veSkW",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "WDh4fb9N86mNLfDV",
             "drawn": false,
             "img": "icons/equipment/shield/kite-decorative-steel-claws.webp",
             "range": [
-                67,
-                72
+                73,
+                78
             ],
             "text": "Spined Shield",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "rj2RuyHe7q9qcZ2d",
+            "_id": "Yz0MWOETG0T98Dp4",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "nDZX25OwoN0Imrq6",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/shields/specific-shields/sturdy-shield.webp",
             "range": [
-                73,
-                78
+                79,
+                84
             ],
             "text": "Sturdy Shield (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "o3gZ97kIi4lo11BY",
+            "_id": "2km9KcOYf2ueGRKQ",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "wrDmWkGxmwzYtfiA",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/magic-wands/magic-wand.webp",
             "range": [
-                79,
-                84
+                85,
+                90
             ],
             "text": "Magic Wand (3rd-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "OtH5vWwuqo4ICMuF",
+            "_id": "aMXzm0fJ5TfNpORh",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "5V9bgqgQY1CHLd40",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-continuation.webp",
             "range": [
-                85,
-                90
+                91,
+                96
             ],
             "text": "Wand of Continuation (2nd-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "TbqN7piUhgo0OfAf",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "M2CPAgSAoEL4oawq",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/aeon-stone-clear-spindle.webp",
-            "range": [
-                91,
-                93
-            ],
-            "text": "Aeon Stone (Clear Spindle)",
-            "type": "pack",
-            "weight": 3
-        },
-        {
-            "_id": "l9CD8GKGvhWX8hAA",
+            "_id": "MRd0vrJTcb8Ol7va",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "kSaUlWgYMywIRV3C",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/aeon-stone-tourmaline-sphere.webp",
             "range": [
-                94,
-                96
+                97,
+                99
             ],
-            "text": "Aeon Stone (Tourmaline Sphere)",
+            "text": "Aeon Stone (Delaying)",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "t5t1wLQE2o2FC0iI",
+            "_id": "DndICdwdeH6R4dR6",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "M2CPAgSAoEL4oawq",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/aeon-stone-clear-spindle.webp",
+            "range": [
+                100,
+                102
+            ],
+            "text": "Aeon Stone (Nourishing)",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "jnJZfVXgTQ5CVsv0",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "3obTVPkQ5mGwXJat",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/aeon-stone-lavender-and-green-ellipsoid.webp",
+            "range": [
+                103,
+                105
+            ],
+            "text": "Aeon Stone (Smoothing)",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "3OmOC7rCTtWjN2RA",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "ecqz1iUGtyQEkZwy",
             "drawn": false,
             "img": "icons/equipment/feet/boots-leather-engraved-brown.webp",
             "range": [
-                97,
-                102
+                106,
+                111
             ],
             "text": "Boots of Bounding",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "SaGLwztjSNglsrzf",
+            "_id": "EpSrShR3VAp4nd9E",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "MNBnZn0b80Q7yHJM",
+            "documentId": "fVOObByW6XHADQ2J",
             "drawn": false,
-            "img": "icons/equipment/back/cloak-collared-feathers-green.webp",
-            "range": [
-                103,
-                108
-            ],
-            "text": "Cloak of Elvenkind",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "S0kG1NmHVtkY2ZNf",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "ngz7dYysC1NkBBRK",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/cursed-items/gloves-of-carelessness.webp",
-            "range": [
-                109,
-                111
-            ],
-            "text": "Gloves of Storing",
-            "type": "pack",
-            "weight": 3
-        },
-        {
-            "_id": "ND9f91U4mIQQpsxt",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "WPSp5MLb0VOfmUqH",
-            "drawn": false,
-            "img": "icons/equipment/head/hat-belted-grey.webp",
+            "img": "icons/equipment/hand/gauntlet-clawed-steel.webp",
             "range": [
                 112,
                 117
             ],
-            "text": "Hat of Disguise (Greater)",
+            "text": "Clawed Bracers",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "EkwMh4K3qpHW7heM",
+            "_id": "O7XYfHQCQRyRYH6Z",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Zun8aKbODnBFeut6",
+            "documentId": "0HvjITehMdaFYUkb",
             "drawn": false,
-            "img": "icons/equipment/neck/collar-rounded-carved-wood-spiral.webp",
+            "img": "icons/equipment/back/cloak-collared-feathers-green.webp",
             "range": [
                 118,
                 123
             ],
-            "text": "Necklace of Fireballs II",
+            "text": "Cloak of Illusions",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "51ULgg4Z2gGAZbMm",
+            "_id": "69jUC4fWyCOFCvxa",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "WPSp5MLb0VOfmUqH",
+            "drawn": false,
+            "img": "icons/equipment/neck/handkerchief-bandana-blue.webp",
+            "range": [
+                124,
+                129
+            ],
+            "text": "Masquerade Scarf (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "nhHW687pn4XEdYOA",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "ngz7dYysC1NkBBRK",
+            "drawn": false,
+            "img": "icons/equipment/waist/belt-buckle-ring-leather-red.webp",
+            "range": [
+                130,
+                132
+            ],
+            "text": "Retrieval Belt",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "xp7EaAVPJFQujbBy",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "14rbefsoClgClRQ8",
             "drawn": false,
             "img": "icons/equipment/finger/ring-band-engraved-teal.webp",
             "range": [
-                124,
-                126
+                133,
+                135
             ],
             "text": "Ring of Sustenance",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "WGS4NVKgvBlbRbTe",
+            "_id": "MGsLkU1Lkp8wHJfY",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "faKyy6ETkDgrUnvf",
+            "documentId": "ULHYQIoVL2gKN7TM",
             "drawn": false,
-            "img": "icons/equipment/finger/ring-band-engraved-silver.webp",
+            "img": "icons/commodities/materials/material-cotton-white.webp",
             "range": [
-                127,
-                129
+                136,
+                141
             ],
-            "text": "Ring of Wizardry (Type I)",
+            "text": "Twisting Twine (Greater)",
             "type": "pack",
-            "weight": 3
+            "weight": 6
         },
         {
-            "_id": "7Z6tn2kUuYj3hLx2",
+            "_id": "J0VFRR3C0FP4p7YA",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "skBa6D1uxb0b2USn",
+            "documentId": "tf69NMnUoUAYrWtj",
             "drawn": false,
-            "img": "icons/equipment/feet/boots-collared-leather-white.webp",
+            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-the-snowfields.webp",
             "range": [
-                130,
-                135
+                142,
+                147
             ],
-            "text": "Slippers of Spider Climbing",
+            "text": "Wand of the Spider (2nd-Rank Spell)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "MurMM7jxf5Wkp1wi",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "v6LpzpIA0BmKvEtK",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/weapons/specific-magic-weapons/spellguard-blade.webp",
+            "range": [
+                148,
+                153
+            ],
+            "text": "Spellguard Blade",
             "type": "pack",
             "weight": 6
         }


### PR DESCRIPTION
Update 7th-Level Consumable Items and 7th-Level Permanent Items tables with remaster changes, consolidating the treasure tables from the GM Core and Player Core 2 books, preserving the item order found in those tables. Weight is based on rarity:

- Common = 6
- Uncommon = 3
- Rare = 1

For items that do not have a corresponding entry in the compendium, create a text entry in the table with the appropriate item name. If possible, set an appropriate icon from the system's icon set.