### PR TITLE
Update 7th-level rollable tables

### DIFF
--- a/packs/rollable-tables/7th-level-consumables-items.json
+++ b/packs/rollable-tables/7th-level-consumables-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "E9ZNupg1p4yLpfrd",
-    "description": "Table of 7th-Level Consumables Items",
+    "description": "<p>Table of 7th-Level Consumables Items</p>",
     "displayRoll": true,
-    "formula": "1d75",
+    "formula": "1d93",
     "img": "icons/svg/d20-grey.svg",
     "name": "7th-Level Consumables Items",
     "ownership": {
@@ -25,170 +25,212 @@
             "weight": 6
         },
         {
-            "_id": "QN2b9QvvhEhXYHss",
+            "_id": "fFeFAzY0Td0FRrEB",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "VvljzRwthKMgqUR3",
+            "documentId": "bh3HJkgWC05VSXgs",
             "drawn": false,
-            "img": "icons/commodities/materials/feather-blue.webp",
+            "img": "icons/magic/fire/barrier-shield-explosion-yellow.webp",
             "range": [
                 7,
                 12
             ],
-            "text": "Feather Token (Anchor)",
+            "text": "Frozen Lava of Blackpeak",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "aPbhuQl16Dn83HR8",
+            "_id": "vF1LPiWtPCukIDHb",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "OcBPjVplvy2GbQ8P",
+            "documentId": null,
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/comprehension-elixir.webp",
+            "img": "systems/pf2e/icons/equipment/consumables/potions/green-dragons-breath-potion.webp",
             "range": [
                 13,
                 18
             ],
-            "text": "Comprehension Elixir (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "3EqXFbXhBaS3HemC",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "6eQvHNHf1IC2X5Rx",
-            "drawn": false,
-            "img": "icons/consumables/potions/potion-jar-capped-teal.webp",
-            "range": [
-                19,
-                24
-            ],
-            "text": "Leaper's Elixir (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "lLzSpPUauPOj4sfl",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "aBOPYlfHAcXUmhF7",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/giant-wasp-venom.webp",
-            "range": [
-                25,
-                30
-            ],
-            "text": "Giant Wasp Venom",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "bqsJMu7IB225fTYz",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "76T49dJYfxIrPvQe",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/malyass-root-paste.webp",
-            "range": [
-                31,
-                36
-            ],
-            "text": "Malyass Root Paste",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "xkxbqKf3zQN0HjG2",
-            "documentCollection": "",
-            "documentId": null,
-            "drawn": false,
-            "img": "icons/svg/d20-black.svg",
-            "range": [
-                37,
-                42
-            ],
-            "text": "Dragon's Breath Potion (Young)",
+            "text": "Energy Breath Potion (Lesser)",
             "type": "text",
             "weight": 6
         },
         {
-            "_id": "kQTbzpAKyDIdb9PY",
+            "_id": "IEJDjoKiwKvwiyEr",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "9ignmYCACjfzkxDQ",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/weapons/serum-of-sex-shift.webp",
+            "img": "systems/pf2e/icons/equipment/consumables/potions/serum-of-sex-shift.webp",
             "range": [
-                43,
-                48
+                19,
+                24
             ],
             "text": "Serum of Sex Shift",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "11E6i8082Hr9VbAI",
+            "_id": "2spGL6oHBdQgps5v",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "QSQZJ5BC3DeHv153",
             "drawn": false,
             "img": "icons/sundries/scrolls/scroll-symbol-eye-brown.webp",
             "range": [
-                49,
-                54
+                25,
+                30
             ],
-            "text": "Scroll of 4th-level Spell",
+            "text": "Scroll of 4th-rank Spell",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "61ajGdu6KUgCbRhV",
+            "_id": "WNPjUl7s0vReowTG",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "eEIWjTvZyKsKhYaz",
             "drawn": false,
             "img": "icons/commodities/bones/skull-hollow-worn-white.webp",
             "range": [
-                55,
-                60
+                31,
+                36
             ],
             "text": "Grim Trophy",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "7SGOQT7AOrcdyFAN",
+            "_id": "bXtWcUhY0LpsQC2r",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "YGaO4HyH6jn3P731",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/talismans/murderers-knot.webp",
             "range": [
-                61,
-                66
+                37,
+                42
             ],
             "text": "Murderer's Knot",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "k89jRhkpypFGiAtB",
+            "_id": "1erHF09RBpSMUtqZ",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "4tnPWyApPZP1P1yO",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/talismans/swift-block-cabochon.webp",
             "range": [
-                67,
-                69
+                43,
+                45
             ],
             "text": "Swift Block Cabochon",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "yNMZRnLghOhNPUR4",
+            "_id": "3iprGiNeuUh5PLpo",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "ehss8yPTXxiUdVlJ",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/smokestick.webp",
             "range": [
+                46,
+                51
+            ],
+            "text": "Smoke Ball (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "k5QfiT4afk6BAI66",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "903CuhvVUhE1lmoB",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/ammunition/corrosive-ammunition.webp",
+            "range": [
+                52,
+                57
+            ],
+            "text": "Corrosive Ammunition",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "onjPcvfcbZ6nwklI",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "OcBPjVplvy2GbQ8P",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/comprehension-elixir.webp",
+            "range": [
+                58,
+                63
+            ],
+            "text": "Comprehension Elixir (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "6Hkycf60bdHXodRw",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "XpmPX3ScEOBgAoKd",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/other-consumables/candle-of-revealing.webp",
+            "range": [
+                64,
+                69
+            ],
+            "text": "Candle of Revealing",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "YXAbLgIvt2KyDfA4",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "76T49dJYfxIrPvQe",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/malyass-root-paste.webp",
+            "range": [
                 70,
                 75
             ],
-            "text": "Smokestick (Greater)",
+            "text": "Tangle Root Toxin",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "GeZnMbYaIAPJByDO",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "EkC2W5A5fohoIKSd",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/potions/ration-tonic.webp",
+            "range": [
+                76,
+                81
+            ],
+            "text": "Ration Tonic (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "SJDg9N1KxBKS2K0X",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "7IrQPyMm76nLVoXx",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/soverign-glue.webp",
+            "range": [
+                82,
+                87
+            ],
+            "text": "Everlasting Adhesive",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "Fq2FismwfQuslrcx",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "FgAPV0iLE6R1QMJ5",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/skinitch-salve.webp",
+            "range": [
+                88,
+                93
+            ],
+            "text": "Skinstitch Salve",
             "type": "pack",
             "weight": 6
         }

--- a/packs/rollable-tables/7th-level-permanent-items.json
+++ b/packs/rollable-tables/7th-level-permanent-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "r8F8mI2BZU6nOMQB",
-    "description": "Table of 7th-Level Permanent Items",
+    "description": "<p>Table of 7th-Level Permanent Items</p>",
     "displayRoll": true,
-    "formula": "1d135",
+    "formula": "1d153",
     "img": "icons/svg/d20-grey.svg",
     "name": "7th-Level Permanent Items",
     "ownership": {
@@ -25,7 +25,7 @@
             "weight": 6
         },
         {
-            "_id": "QN2b9QvvhEhXYHss",
+            "_id": "fHDVsWov2bz8OoIY",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "peoheZMxdPHUNo93",
             "drawn": false,
@@ -34,329 +34,371 @@
                 7,
                 12
             ],
-            "text": "Horseshoes of Speed",
+            "text": "Alacritous Horseshoes",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "aPbhuQl16Dn83HR8",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "JBMBaN9dZLytfFLQ",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/held-items/bag-of-holding.webp",
-            "range": [
-                13,
-                18
-            ],
-            "text": "Bag of Holding (Type II)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "3EqXFbXhBaS3HemC",
+            "_id": "JcPUuTgvueG3BlxA",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "7TQw7V1zZKl0a0Xz",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/held-items/bottled-air.webp",
             "range": [
-                19,
-                24
+                13,
+                18
             ],
             "text": "Bottled Air",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "oLZsd9xeniDUB97N",
+            "_id": "7UVnOMJAVOKIN2Ku",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "aBVrNIPoPGOYxm80",
+            "documentId": "zP7Eo57IYMUKxwPO",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/held-items/decanter-of-endless-water.webp",
+            "img": "icons/magic/earth/explosion-lava-orange.webp",
+            "range": [
+                19,
+                24
+            ],
+            "text": "Eternal Eruption of Blackpeak",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "s8mmFw5fODAuPKHO",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "JBMBaN9dZLytfFLQ",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/held-items/bag-of-holding.webp",
             "range": [
                 25,
                 30
             ],
-            "text": "Decanter of Endless Water",
+            "text": "Spacious Pouch (Type II)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "lLzSpPUauPOj4sfl",
+            "_id": "1URd1EqYZ66HuHE9",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "RjJw7iHantxqeJu1",
+            "documentId": "o65PFCSOyMje6fwi",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/held-items/wondrous-figurine-jade-serpent.webp",
+            "img": "icons/commodities/treasure/token-runed-os-grey.webp",
             "range": [
                 31,
                 36
             ],
-            "text": "Wondrous Figurine (Jade Serpent)",
+            "text": "Reinforcing Rune (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "bqsJMu7IB225fTYz",
+            "_id": "Vyz4XUBbC99X3uSV",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "Z5FvYWLEpWVo3PUF",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/armor-property-runes/armor-property-runes.webp",
+            "range": [
+                37,
+                42
+            ],
+            "text": "Size-Changing",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "QO5Gq7bEaEvgTFNR",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "fo6Yhq5mbQXsnZs0",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
             "range": [
-                37,
-                42
+                43,
+                48
             ],
             "text": "Wounding",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "xkxbqKf3zQN0HjG2",
+            "_id": "5tBCxKoBvOWy8FCh",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "PsyfqGIzDbr1mX6d",
+            "documentId": null,
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/cold-Iron-buckler.webp",
-            "range": [
-                43,
-                48
-            ],
-            "text": "Cold Iron Buckler (Standard-Grade)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "kQTbzpAKyDIdb9PY",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "p1uYtIUYXXoNdVKg",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/cold-Iron-shield.webp",
             "range": [
                 49,
                 54
             ],
-            "text": "Cold Iron Shield (Standard-Grade)",
-            "type": "pack",
+            "text": "Cold Iron Buckler (Standard-Grade)",
+            "type": "text",
             "weight": 6
         },
         {
-            "_id": "vQq7Hy7Dx1a8GCHZ",
+            "_id": "vmgndvjErJl4KGjr",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "8DNpWWeL7X9MDG0i",
+            "documentId": null,
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/silver-buckler.webp",
+            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/cold-Iron-shield.webp",
             "range": [
                 55,
                 60
             ],
-            "text": "Silver Buckler (Standard-Grade)",
-            "type": "pack",
+            "text": "Cold Iron Shield (Standard-Grade)",
+            "type": "text",
             "weight": 6
         },
         {
-            "_id": "dwXrm0DZwZ0Vtpyl",
+            "_id": "6U7RxYpfBESBrbOR",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "KVj9RP2qvpsHHGqE",
+            "documentId": null,
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/silver-shield.webp",
+            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/silver-buckler.webp",
             "range": [
                 61,
                 66
             ],
-            "text": "Silver Shield (Standard-Grade)",
-            "type": "pack",
+            "text": "Silver Buckler (Standard-Grade)",
+            "type": "text",
             "weight": 6
         },
         {
-            "_id": "ViMk7CeQzvGeYUrC",
+            "_id": "ymYabv3L4B5aOs8h",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/silver-shield.webp",
+            "range": [
+                67,
+                72
+            ],
+            "text": "Silver Shield (Standard-Grade)",
+            "type": "text",
+            "weight": 6
+        },
+        {
+            "_id": "9uUWNq4jQT2veSkW",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "WDh4fb9N86mNLfDV",
             "drawn": false,
             "img": "icons/equipment/shield/kite-decorative-steel-claws.webp",
             "range": [
-                67,
-                72
+                73,
+                78
             ],
             "text": "Spined Shield",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "rj2RuyHe7q9qcZ2d",
+            "_id": "Yz0MWOETG0T98Dp4",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "nDZX25OwoN0Imrq6",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/shields/specific-shields/sturdy-shield.webp",
             "range": [
-                73,
-                78
+                79,
+                84
             ],
             "text": "Sturdy Shield (Lesser)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "o3gZ97kIi4lo11BY",
+            "_id": "2km9KcOYf2ueGRKQ",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "wrDmWkGxmwzYtfiA",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/magic-wands/magic-wand.webp",
             "range": [
-                79,
-                84
+                85,
+                90
             ],
             "text": "Magic Wand (3rd-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "OtH5vWwuqo4ICMuF",
+            "_id": "aMXzm0fJ5TfNpORh",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "5V9bgqgQY1CHLd40",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-continuation.webp",
             "range": [
-                85,
-                90
+                91,
+                96
             ],
             "text": "Wand of Continuation (2nd-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "TbqN7piUhgo0OfAf",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "M2CPAgSAoEL4oawq",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/aeon-stone-clear-spindle.webp",
-            "range": [
-                91,
-                93
-            ],
-            "text": "Aeon Stone (Clear Spindle)",
-            "type": "pack",
-            "weight": 3
-        },
-        {
-            "_id": "l9CD8GKGvhWX8hAA",
+            "_id": "MRd0vrJTcb8Ol7va",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "kSaUlWgYMywIRV3C",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/aeon-stone-tourmaline-sphere.webp",
             "range": [
-                94,
-                96
+                97,
+                99
             ],
-            "text": "Aeon Stone (Tourmaline Sphere)",
+            "text": "Aeon Stone (Delaying)",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "t5t1wLQE2o2FC0iI",
+            "_id": "DndICdwdeH6R4dR6",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "M2CPAgSAoEL4oawq",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/aeon-stone-clear-spindle.webp",
+            "range": [
+                100,
+                102
+            ],
+            "text": "Aeon Stone (Nourishing)",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "jnJZfVXgTQ5CVsv0",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "3obTVPkQ5mGwXJat",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/aeon-stone-lavender-and-green-ellipsoid.webp",
+            "range": [
+                103,
+                105
+            ],
+            "text": "Aeon Stone (Smoothing)",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "3OmOC7rCTtWjN2RA",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "ecqz1iUGtyQEkZwy",
             "drawn": false,
             "img": "icons/equipment/feet/boots-leather-engraved-brown.webp",
             "range": [
-                97,
-                102
+                106,
+                111
             ],
             "text": "Boots of Bounding",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "SaGLwztjSNglsrzf",
+            "_id": "EpSrShR3VAp4nd9E",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "MNBnZn0b80Q7yHJM",
+            "documentId": "fVOObByW6XHADQ2J",
             "drawn": false,
-            "img": "icons/equipment/back/cloak-collared-feathers-green.webp",
-            "range": [
-                103,
-                108
-            ],
-            "text": "Cloak of Elvenkind",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "S0kG1NmHVtkY2ZNf",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "ngz7dYysC1NkBBRK",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/cursed-items/gloves-of-carelessness.webp",
-            "range": [
-                109,
-                111
-            ],
-            "text": "Gloves of Storing",
-            "type": "pack",
-            "weight": 3
-        },
-        {
-            "_id": "ND9f91U4mIQQpsxt",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "WPSp5MLb0VOfmUqH",
-            "drawn": false,
-            "img": "icons/equipment/head/hat-belted-grey.webp",
+            "img": "icons/equipment/hand/gauntlet-clawed-steel.webp",
             "range": [
                 112,
                 117
             ],
-            "text": "Hat of Disguise (Greater)",
+            "text": "Clawed Bracers",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "EkwMh4K3qpHW7heM",
+            "_id": "O7XYfHQCQRyRYH6Z",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Zun8aKbODnBFeut6",
+            "documentId": "0HvjITehMdaFYUkb",
             "drawn": false,
-            "img": "icons/equipment/neck/collar-rounded-carved-wood-spiral.webp",
+            "img": "icons/equipment/back/cloak-collared-feathers-green.webp",
             "range": [
                 118,
                 123
             ],
-            "text": "Necklace of Fireballs II",
+            "text": "Cloak of Illusions",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "51ULgg4Z2gGAZbMm",
+            "_id": "69jUC4fWyCOFCvxa",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "WPSp5MLb0VOfmUqH",
+            "drawn": false,
+            "img": "icons/equipment/neck/handkerchief-bandana-blue.webp",
+            "range": [
+                124,
+                129
+            ],
+            "text": "Masquerade Scarf (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "nhHW687pn4XEdYOA",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "ngz7dYysC1NkBBRK",
+            "drawn": false,
+            "img": "icons/equipment/waist/belt-buckle-ring-leather-red.webp",
+            "range": [
+                130,
+                132
+            ],
+            "text": "Retrieval Belt",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "xp7EaAVPJFQujbBy",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "14rbefsoClgClRQ8",
             "drawn": false,
             "img": "icons/equipment/finger/ring-band-engraved-teal.webp",
             "range": [
-                124,
-                126
+                133,
+                135
             ],
             "text": "Ring of Sustenance",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "WGS4NVKgvBlbRbTe",
+            "_id": "MGsLkU1Lkp8wHJfY",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "faKyy6ETkDgrUnvf",
+            "documentId": "ULHYQIoVL2gKN7TM",
             "drawn": false,
-            "img": "icons/equipment/finger/ring-band-engraved-silver.webp",
+            "img": "icons/commodities/materials/material-cotton-white.webp",
             "range": [
-                127,
-                129
+                136,
+                141
             ],
-            "text": "Ring of Wizardry (Type I)",
+            "text": "Twisting Twine (Greater)",
             "type": "pack",
-            "weight": 3
+            "weight": 6
         },
         {
-            "_id": "7Z6tn2kUuYj3hLx2",
+            "_id": "J0VFRR3C0FP4p7YA",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "skBa6D1uxb0b2USn",
+            "documentId": "tf69NMnUoUAYrWtj",
             "drawn": false,
-            "img": "icons/equipment/feet/boots-collared-leather-white.webp",
+            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-the-snowfields.webp",
             "range": [
-                130,
-                135
+                142,
+                147
             ],
-            "text": "Slippers of Spider Climbing",
+            "text": "Wand of the Spider (2nd-Rank Spell)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "MurMM7jxf5Wkp1wi",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "v6LpzpIA0BmKvEtK",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/weapons/specific-magic-weapons/spellguard-blade.webp",
+            "range": [
+                148,
+                153
+            ],
+            "text": "Spellguard Blade",
             "type": "pack",
             "weight": 6
         }


### PR DESCRIPTION
Update 7th-Level Consumable Items and 7th-Level Permanent Items tables with remaster changes, consolidating the treasure tables from the GM Core and Player Core 2 books, preserving the item order found in those tables. Weight is based on rarity:

- Common = 6
- Uncommon = 3
- Rare = 1

For items that do not have a corresponding entry in the compendium, create a text entry in the table with the appropriate item name. If possible, set an appropriate icon from the system's icon set.