### PR TITLE
Fix Assurance grant of Farmhand background

### DIFF
--- a/packs/backgrounds/farmhand.json
+++ b/packs/backgrounds/farmhand.json
@@ -24,20 +24,21 @@
         "description": {
             "value": "<p>With a strong back and an understanding of seasonal cycles, you tilled the land and tended crops. Your farm could have been razed by invaders, you could have lost the family tying you to the land, or you might have simply tired of the drudgery, but at some point, you became an adventurer.</p>\n<p>Choose two attribute boosts. One must be to <strong>Constitution</strong> or <strong>Wisdom</strong>, and one is a free attribute boost.</p>\n<p>You're trained in the Athletics skill and the Farming Lore skill. You gain the @UUID[Compendium.pf2e.feats-srd.Item.Assurance] skill feat with Athletics.</p>"
         },
-        "items": {
-            "00b8b": {
-                "img": "icons/sundries/books/book-red-exclamation.webp",
-                "level": 1,
-                "name": "Assurance",
-                "uuid": "Compendium.pf2e.feats-srd.Item.Assurance"
-            }
-        },
+        "items": {},
         "publication": {
             "license": "ORC",
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "GrantItem",
+                "preselectChoices": {
+                    "assurance": "athletics"
+                },
+                "uuid": "Compendium.pf2e.feats-srd.Item.Assurance"
+            }
+        ],
         "trainedSkills": {
             "lore": [
                 "Farming Lore"

--- a/packs/spell-effects/spell-effect-enlarge.json
+++ b/packs/spell-effects/spell-effect-enlarge.json
@@ -86,10 +86,7 @@
             },
             {
                 "key": "FlatModifier",
-                "predicate": [
-                    "item:melee"
-                ],
-                "selector": "strike-damage",
+                "selector": "melee-strike-damage",
                 "type": "status",
                 "value": "{item|flags.pf2e.rulesSelections.enlarge.damage}"
             }


### PR DESCRIPTION
Also clean up the Enlarge spell effect
Closes #17212