### PR TITLE
Replace some NPCs Reactive Strike action with the one from the Bestiary Ability Glossary

### DIFF
--- a/packs/howl-of-the-wild-bestiary/mocking-chorus.json
+++ b/packs/howl-of-the-wild-bestiary/mocking-chorus.json
@@ -344,9 +344,9 @@
             "type": "action"
         },
         {
-            "_id": "S89CqP7ZKbThtFmc",
+            "_id": "N9bWptF3zp8Wq4Uf",
             "_stats": {
-                "compendiumSource": "Compendium.pf2e.actionspf2e.Item.KAVf7AmRnbCAHrkT"
+                "compendiumSource": "Compendium.pf2e.bestiary-ability-glossary-srd.Item.W7SbTykXrNwxDzJc"
             },
             "img": "systems/pf2e/icons/actions/Reaction.webp",
             "name": "Reactive Strike",
@@ -360,12 +360,12 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> A creature within your reach uses a manipulate action or a move action, makes a ranged attack, or leaves a square during a move action it's using.</p>\n<hr />\n<p>You lash out at a foe that leaves an opening. Make a melee Strike against the triggering creature. If your attack is a critical hit and the trigger was a manipulate action, you disrupt that action. This Strike doesn't count toward your multiple attack penalty, and your multiple attack penalty doesn't apply to this Strike.</p>"
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.ReactiveStrike]</p>"
                 },
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Pathfinder Monster Core"
                 },
                 "rules": [],
                 "slug": "reactive-strike",

--- a/packs/howl-of-the-wild-bestiary/prismhydra.json
+++ b/packs/howl-of-the-wild-bestiary/prismhydra.json
@@ -339,9 +339,9 @@
             "type": "action"
         },
         {
-            "_id": "pgvtTMt0WtdPRchX",
+            "_id": "FGdCWpMGifRh1eVg",
             "_stats": {
-                "compendiumSource": "Compendium.pf2e.actionspf2e.Item.KAVf7AmRnbCAHrkT"
+                "compendiumSource": "Compendium.pf2e.bestiary-ability-glossary-srd.Item.W7SbTykXrNwxDzJc"
             },
             "img": "systems/pf2e/icons/actions/Reaction.webp",
             "name": "Reactive Strike",
@@ -355,12 +355,12 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> A creature within your reach uses a manipulate action or a move action, makes a ranged attack, or leaves a square during a move action it's using.</p>\n<hr />\n<p>You lash out at a foe that leaves an opening. Make a melee Strike against the triggering creature. If your attack is a critical hit and the trigger was a manipulate action, you disrupt that action. This Strike doesn't count toward your multiple attack penalty, and your multiple attack penalty doesn't apply to this Strike.</p>"
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.ReactiveStrike]</p>"
                 },
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Pathfinder Monster Core"
                 },
                 "rules": [],
                 "slug": "reactive-strike",

--- a/packs/howl-of-the-wild-bestiary/sunscale-serpent.json
+++ b/packs/howl-of-the-wild-bestiary/sunscale-serpent.json
@@ -229,9 +229,9 @@
             "type": "action"
         },
         {
-            "_id": "GMu9RZCvNZG7CW4h",
+            "_id": "aiMjaYRHJ2xpQP4Y",
             "_stats": {
-                "compendiumSource": "Compendium.pf2e.actionspf2e.Item.KAVf7AmRnbCAHrkT"
+                "compendiumSource": "Compendium.pf2e.bestiary-ability-glossary-srd.Item.W7SbTykXrNwxDzJc"
             },
             "img": "systems/pf2e/icons/actions/Reaction.webp",
             "name": "Reactive Strike (Tail Only)",
@@ -245,12 +245,12 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> A creature within your reach uses a manipulate action or a move action, makes a ranged attack, or leaves a square during a move action it's using.</p>\n<hr />\n<p>You lash out at a foe that leaves an opening. Make a melee Strike against the triggering creature. If your attack is a critical hit and the trigger was a manipulate action, you disrupt that action. This Strike doesn't count toward your multiple attack penalty, and your multiple attack penalty doesn't apply to this Strike.</p>"
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.ReactiveStrike]</p>"
                 },
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Pathfinder Monster Core"
                 },
                 "rules": [],
                 "slug": "reactive-strike",

--- a/packs/howl-of-the-wild-bestiary/tyrafdir.json
+++ b/packs/howl-of-the-wild-bestiary/tyrafdir.json
@@ -296,9 +296,9 @@
             "type": "action"
         },
         {
-            "_id": "ZZEKgpUjMC3LM8Vh",
+            "_id": "If6YOqwfIky1CKHO",
             "_stats": {
-                "compendiumSource": "Compendium.pf2e.actionspf2e.Item.KAVf7AmRnbCAHrkT"
+                "compendiumSource": "Compendium.pf2e.bestiary-ability-glossary-srd.Item.W7SbTykXrNwxDzJc"
             },
             "img": "systems/pf2e/icons/actions/Reaction.webp",
             "name": "Reactive Strike",
@@ -312,12 +312,12 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> A creature within your reach uses a manipulate action or a move action, makes a ranged attack, or leaves a square during a move action it's using.</p>\n<hr />\n<p>You lash out at a foe that leaves an opening. Make a melee Strike against the triggering creature. If your attack is a critical hit and the trigger was a manipulate action, you disrupt that action. This Strike doesn't count toward your multiple attack penalty, and your multiple attack penalty doesn't apply to this Strike.</p>"
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.ReactiveStrike]</p>"
                 },
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Pathfinder Monster Core"
                 },
                 "rules": [],
                 "slug": "reactive-strike",

--- a/packs/howl-of-the-wild-bestiary/wereshark.json
+++ b/packs/howl-of-the-wild-bestiary/wereshark.json
@@ -353,9 +353,9 @@
             "type": "action"
         },
         {
-            "_id": "nHVX37TzVoUKuuD8",
+            "_id": "okSfSYHIUyG1GZeC",
             "_stats": {
-                "compendiumSource": "Compendium.pf2e.actionspf2e.Item.KAVf7AmRnbCAHrkT"
+                "compendiumSource": "Compendium.pf2e.bestiary-ability-glossary-srd.Item.W7SbTykXrNwxDzJc"
             },
             "img": "systems/pf2e/icons/actions/Reaction.webp",
             "name": "Reactive Strike",
@@ -369,12 +369,12 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> A creature within your reach uses a manipulate action or a move action, makes a ranged attack, or leaves a square during a move action it's using.</p>\n<hr />\n<p>You lash out at a foe that leaves an opening. Make a melee Strike against the triggering creature. If your attack is a critical hit and the trigger was a manipulate action, you disrupt that action. This Strike doesn't count toward your multiple attack penalty, and your multiple attack penalty doesn't apply to this Strike.</p>"
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.ReactiveStrike]</p>"
                 },
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Pathfinder Monster Core"
                 },
                 "rules": [],
                 "slug": "reactive-strike",

--- a/packs/quest-for-the-frozen-flame-bestiary/desiak.json
+++ b/packs/quest-for-the-frozen-flame-bestiary/desiak.json
@@ -334,9 +334,9 @@
             "type": "melee"
         },
         {
-            "_id": "uP8cy0HAno7CGoRL",
+            "_id": "pmcWL2CccDASnpnL",
             "_stats": {
-                "compendiumSource": "Compendium.pf2e.actionspf2e.Item.KAVf7AmRnbCAHrkT"
+                "compendiumSource": "Compendium.pf2e.bestiary-ability-glossary-srd.Item.hFtNbo1LKYCoDy2O"
             },
             "img": "systems/pf2e/icons/actions/Reaction.webp",
             "name": "Attack of Opportunity",
@@ -350,7 +350,7 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> A creature within your reach uses a manipulate action or a move action, makes a ranged attack, or leaves a square during a move action it's using.</p>\n<hr />\n<p>You lash out at a foe that leaves an opening. Make a melee Strike against the triggering creature. If your attack is a critical hit and the trigger was a manipulate action, you disrupt that action. This Strike doesn't count toward your multiple attack penalty, and your multiple attack penalty doesn't apply to this Strike.</p>"
+                    "value": "<p>@Localize[PF2E.NPC.Abilities.Glossary.AttackOfOpportunity]</p>"
                 },
                 "publication": {
                     "license": "OGL",


### PR DESCRIPTION
Some NPCs had Reactive Strike/AoO abilities that used the descriptions of PC's RS/AoO.
Replaced them with the ability from Bestiary Glossary.