### PR TITLE
Fix reroll using a hero point erroneously displaying for a mythic character

### DIFF
--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -365,9 +365,12 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
         };
         system.proficiencies.spellcasting ??= { rank: 0 };
 
-        // Resources
+        // Resources (Mythic points replace hero points if the character is mythic)
         const { resources } = this.system;
-        resources.heroPoints.max = 3;
+        const isMythic =
+            game.pf2e.settings.campaign.mythic !== "disabled" &&
+            this.itemTypes.feat.some((f) => f.category === "calling");
+        resources.heroPoints.max = isMythic ? 0 : 3;
         resources.investiture = { value: 0, max: 10 };
         resources.focus = {
             value: resources.focus?.value || 0,
@@ -376,9 +379,6 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
         };
         resources.crafting = fu.mergeObject({ infusedReagents: { value: 0, max: 0 } }, resources.crafting ?? {});
         resources.crafting.infusedReagents.max = 0;
-        const isMythic =
-            game.pf2e.settings.campaign.mythic !== "disabled" &&
-            this.itemTypes.feat.some((f) => f.system.traits.value.includes("calling"));
         resources.mythicPoints = { value: resources.mythicPoints?.value ?? 0, max: isMythic ? 3 : 0 };
 
         // Size

--- a/src/module/actor/character/feats/collection.ts
+++ b/src/module/actor/character/feats/collection.ts
@@ -125,7 +125,7 @@ class CharacterFeats<TActor extends CharacterPF2e> extends Collection<FeatGroup<
                         label: "PF2E.Actor.Character.FeatSlot.MythicCallingShort",
                         placeholder: "PF2E.Actor.Character.FeatSlot.MythicCallingPlaceholder",
                         filter: {
-                            traits: ["calling"],
+                            categories: ["calling"],
                         },
                     },
                     ...[2, 4, 6, 8, 10, 12, 14, 16, 18, 20].map((level, idx): FeatSlotData => {


### PR DESCRIPTION
The rerolll prompt checks if you have hero points before showing the option. This removes hero points from the pc. Even if the value is still in the data, the clamp will set it to zero during data preparation.