### PR TITLE
Improve aura rendering performance

### DIFF
--- a/src/module/canvas/token/aura/util.ts
+++ b/src/module/canvas/token/aura/util.ts
@@ -61,6 +61,14 @@ export function getAreaSquares(data: GetAreaSquaresParams): EffectAreaSquare[] {
         return new PointSource({ object: tokenObject });
     })();
 
+    const tokenCenterPolygons = tokenCenters.map((c) =>
+        CONFIG.Canvas.polygonBackends[collisionType].create(c, {
+            type: collisionType,
+            source: pointSource,
+            boundaryShape: [data.bounds],
+        }),
+    );
+
     return emptyVector
         .reduce(
             (squares: EffectAreaSquare[][]) => {
@@ -76,14 +84,7 @@ export function getAreaSquares(data: GetAreaSquaresParams): EffectAreaSquare[] {
         .flat()
         .filter((s) => measureDistanceCuboid(tokenBounds, s) <= data.radius)
         .map((square) => {
-            square.active = tokenCenters.some(
-                (c) =>
-                    !CONFIG.Canvas.polygonBackends[collisionType].testCollision(c, square.center, {
-                        type: collisionType,
-                        mode: "any",
-                        source: pointSource,
-                    }),
-            );
+            square.active = tokenCenterPolygons.some((c) => c.contains(square.center.x, square.center.y));
             return square;
         });
 }


### PR DESCRIPTION
Instead of testing each aura square against each source point of the aura, compute the full clockwise sweep polygons for the collisionType to reduce edge intersection tests in core foundry methods. 
Rendering the full polygon is a little wasteful for very small aura shapes, but greatly improves performance for large auras.
In my testing on a scene with 1099 wall segments, only auras with a radius of 15ft or smaller were faster to render with the current method. I'd argue though that these aura sizes could already be rendered "fast enough".  

As for performance numbers, on my system the aura drawing times improved in the following ways in the above mentioned test scene:
90ft: 195ms -> 21ms
60ft: 78ms -> 16ms
30ft: 18ms -> 12ms
15ft: 6ms -> 12ms

I know the system does not specifically cater to each and every module, but the popular "levels" modules makes modifications to the line of sight checking code that introduces additional overhead to each `testCollisoin` check that has no impact on the result of the aura drawing, but on the performance. With `levels` activated (even though the scene does not make use of it and wall-height being disabled), the time it takes to calculate the 90ft aura increases to 830ms, while staying flat at 21ms with the new implementation.