### PR TITLE
Adjust Armor Proficiency Choice Set to not be ignored

### DIFF
--- a/packs/feats/armor-proficiency.json
+++ b/packs/feats/armor-proficiency.json
@@ -48,7 +48,6 @@
                     {
                         "label": "PF2E.Actor.Character.Proficiency.Defense.HeavyShort",
                         "predicate": [
-                            "defense:heavy:rank:0",
                             {
                                 "nor": [
                                     "defense:light:rank:0",

--- a/packs/feats/champion-dedication.json
+++ b/packs/feats/champion-dedication.json
@@ -55,7 +55,6 @@
                     {
                         "label": "PF2E.Actor.Character.Proficiency.Defense.HeavyShort",
                         "predicate": [
-                            "defense:heavy:rank:0",
                             {
                                 "nor": [
                                     "defense:light:rank:0",
@@ -67,8 +66,7 @@
                     }
                 ],
                 "flag": "armor",
-                "key": "ChoiceSet",
-                "selection": "heavy"
+                "key": "ChoiceSet"
             },
             {
                 "adjustName": false,


### PR DESCRIPTION
Closes #17285
No need to check if Heavy Armor is untrained, as there is no higher tier of armor than itself to accidentally grant. This way the Choice Set isn't skipped if a character is already trained in Heavy Armor, which can happen in cases where the feat is automatically granted as seen in the linked issue.

Also did the same for Champion Dedication and fixed heavy armor being pre-selected for it.