### PR TITLE
Improve aura rendering for tokens with multiple auras

### DIFF
--- a/src/module/canvas/token/aura/renderer.ts
+++ b/src/module/canvas/token/aura/renderer.ts
@@ -4,7 +4,7 @@ import { TokenAuraData } from "@scene/token-document/aura/index.ts";
 import { isVideoFilePath } from "@util";
 import type { EffectAreaSquare } from "../../effect-area-square.ts";
 import type { TokenPF2e } from "../index.ts";
-import { getAreaSquares } from "./util.ts";
+import { getAreaSquares, getAuraRestrictionType } from "./util.ts";
 
 /** Visual rendering of auras emanated by a token's actor */
 class AuraRenderer extends PIXI.Graphics implements TokenAuraData {
@@ -32,6 +32,12 @@ class AuraRenderer extends PIXI.Graphics implements TokenAuraData {
 
     textureContainer: PIXI.Graphics | null = null;
 
+    /** An optional set of predefined polygons used to test square inclusion */
+    polygons?: ClockwiseSweepPolygon[];
+
+    /** The wall restriction type used for this aura */
+    restrictionType: Exclude<WallRestrictionType, "light">;
+
     constructor(params: AuraRendererParams) {
         super();
 
@@ -42,6 +48,7 @@ class AuraRenderer extends PIXI.Graphics implements TokenAuraData {
         this.radiusPixels =
             0.5 * this.token.mechanicalBounds.width + (this.radius / canvas.dimensions.distance) * canvas.grid.size;
         this.traits = params.traits;
+        this.restrictionType = getAuraRestrictionType(this);
         this.addChild(this.border);
     }
 

--- a/src/module/canvas/token/object.ts
+++ b/src/module/canvas/token/object.ts
@@ -637,7 +637,7 @@ class TokenPF2e<TDocument extends TokenDocumentPF2e = TokenDocumentPF2e> extends
     ): void {
         super._onUpdate(changed, operation, userId);
 
-        if (changed.width) {
+        if (changed.width || changed.flags?.pf2e?.linkToActorSize !== undefined) {
             if (this.animation) {
                 this.animation.then(() => {
                     this.auras.reset();


### PR DESCRIPTION
As a bonus rerendering the same aura is now always cached even for single aura tokens.

Aura highlights are now always drawn from largest to smallest to ensure larger auras not painting over a smaller aura's squares. That could be reversed from small to large with skipping alredy highlighted squares but I'm not sure that the minor performance gain would warrant that.

I think I've got all reset cases covered expect when the scene changes the polygons of tokens in the old scene are not reset. They are reset when the scene changes back however, so it might not be necessary to do that.