### PR TITLE
Update 4th-level tables' formatting

### DIFF
--- a/packs/rollable-tables/4th-level-consumables-items.json
+++ b/packs/rollable-tables/4th-level-consumables-items.json
@@ -22,368 +22,343 @@
             ],
             "text": "Climbing Bolt",
             "type": "pack",
-            "weight": 6,
-            "flags": {}
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "P9DziNQbhGDwUSYj",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "T4ouD4mVFHA3EHs6",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/bombers-eye-elixir.webp",
             "range": [
                 7,
                 12
             ],
-            "drawn": false,
             "text": "Bomber's Eye Elixir (Lesser)",
-            "documentId": "T4ouD4mVFHA3EHs6",
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/bombers-eye-elixir.webp",
-            "_id": "P9DziNQbhGDwUSYj",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "S3JPIdHfZcnriSrc",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "Y8115p3cmQJBqk5d",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/darkvision-elixir.webp",
             "range": [
                 13,
                 18
             ],
-            "drawn": false,
             "text": "Darkvision Elixir (Moderate)",
-            "documentId": "Y8115p3cmQJBqk5d",
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/darkvision-elixir.webp",
-            "_id": "S3JPIdHfZcnriSrc",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "DTR5QxWuiUdXsjzE",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "GyO89RBVjAKFxsFm",
+            "drawn": false,
+            "img": "icons/consumables/potions/bottle-conical-corked-blue.webp",
             "range": [
                 19,
                 24
             ],
-            "drawn": false,
             "text": "Mistform Elixir (Lesser)",
-            "documentId": "GyO89RBVjAKFxsFm",
-            "img": "icons/consumables/potions/bottle-conical-corked-blue.webp",
-            "_id": "DTR5QxWuiUdXsjzE",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "BC0Ok7pC20EKBEdN",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "YcvSw7Zn3oyqlJaw",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/stone-fist-elixir.webp",
             "range": [
                 25,
                 30
             ],
-            "drawn": false,
             "text": "Stone Fist Elixir",
-            "documentId": "YcvSw7Zn3oyqlJaw",
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/stone-fist-elixir.webp",
-            "_id": "BC0Ok7pC20EKBEdN",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "eR3iOMYCEufD8LpV",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "TknN7T2RDy9cUtKU",
+            "drawn": false,
+            "img": "icons/environment/creatures/horse-tan.webp",
             "range": [
                 31,
                 36
             ],
-            "drawn": false,
             "text": "Marvelous Miniature (Horse)",
-            "documentId": "TknN7T2RDy9cUtKU",
-            "img": "icons/environment/creatures/horse-tan.webp",
-            "_id": "eR3iOMYCEufD8LpV",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "Y6zMh7wGkNpDK3vM",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "ALS7pobHFmOnR4yX",
+            "drawn": false,
+            "img": "icons/commodities/flowers/lotus-violet.webp",
             "range": [
                 37,
                 42
             ],
-            "drawn": false,
             "text": "Fearflower Nectar",
-            "documentId": "ALS7pobHFmOnR4yX",
-            "img": "icons/commodities/flowers/lotus-violet.webp",
-            "_id": "Y6zMh7wGkNpDK3vM",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "DrGR0jVfJFbRhMvE",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 3,
+            "documentId": "bikFUFRLwfdvX2x2",
+            "drawn": false,
+            "img": "icons/consumables/potions/bottle-round-ring-teal.webp",
             "range": [
                 43,
                 45
             ],
-            "drawn": false,
             "text": "Invisibility Potion",
-            "documentId": "bikFUFRLwfdvX2x2",
-            "img": "icons/consumables/potions/bottle-round-ring-teal.webp",
-            "_id": "DrGR0jVfJFbRhMvE",
-            "flags": {}
+            "type": "pack",
+            "weight": 3
         },
         {
-            "type": "pack",
+            "_id": "e9lTnXyHH3Nu5afV",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "zC7LipQPHRYw2RXx",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/potions/barkskin-potion.webp",
             "range": [
                 46,
                 51
             ],
-            "drawn": false,
             "text": "Oak Potion",
-            "documentId": "zC7LipQPHRYw2RXx",
-            "img": "systems/pf2e/icons/equipment/consumables/potions/barkskin-potion.webp",
-            "_id": "e9lTnXyHH3Nu5afV",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "znLnUqKdzAyZGYA3",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "FqbDpztscJfM4XMe",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/potions/shrinking-potion.webp",
             "range": [
                 52,
                 57
             ],
-            "drawn": false,
             "text": "Shrinking Potion",
-            "documentId": "FqbDpztscJfM4XMe",
-            "img": "systems/pf2e/icons/equipment/consumables/potions/shrinking-potion.webp",
-            "_id": "znLnUqKdzAyZGYA3",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "1cjkjbFKnAmO2KGx",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "k6D64EAjcKMf8NZB",
+            "drawn": false,
+            "img": "icons/commodities/claws/claw-insect-brown.webp",
             "range": [
                 58,
                 63
             ],
-            "drawn": false,
             "text": "Bloodseeker Beak",
-            "documentId": "k6D64EAjcKMf8NZB",
-            "img": "icons/commodities/claws/claw-insect-brown.webp",
-            "_id": "1cjkjbFKnAmO2KGx",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "JaTFdlGNWOxwK6Xz",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "GnXKCkgZQG0UmuHz",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/dragon-turtle-scale.webp",
             "range": [
                 64,
                 69
             ],
-            "drawn": false,
             "text": "Dragon Turtle Scale",
-            "documentId": "GnXKCkgZQG0UmuHz",
-            "img": "systems/pf2e/icons/equipment/consumables/talismans/dragon-turtle-scale.webp",
-            "_id": "JaTFdlGNWOxwK6Xz",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "nvZLkiEuJU1yz0Sp",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "ZAtwiAPkk1zwCf82",
+            "drawn": false,
+            "img": "icons/commodities/gems/gem-rough-oval-purple.webp",
             "range": [
                 70,
                 75
             ],
-            "drawn": false,
             "text": "Fear Gem",
-            "documentId": "ZAtwiAPkk1zwCf82",
-            "img": "icons/commodities/gems/gem-rough-oval-purple.webp",
-            "_id": "nvZLkiEuJU1yz0Sp",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "4keNvuWj4zD7L83P",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "ilB279mxqXnlaSFj",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/ammunition/viper-arrow.webp",
             "range": [
                 76,
                 81
             ],
-            "drawn": false,
             "text": "Viper Arrow",
-            "documentId": "ilB279mxqXnlaSFj",
-            "img": "systems/pf2e/icons/equipment/consumables/ammunition/viper-arrow.webp",
-            "_id": "4keNvuWj4zD7L83P",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "1rrWtE8qMdEvXLwV",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "V4wgOWYmHlbSZsVG",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/crystal-shards.webp",
             "range": [
                 82,
                 87
             ],
-            "drawn": false,
             "text": "Crystal Shards (Moderate)",
-            "documentId": "V4wgOWYmHlbSZsVG",
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/crystal-shards.webp",
-            "_id": "1rrWtE8qMdEvXLwV",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "u4NmFxoavA5cMmGr",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "8KbayiwrUJtvif0a",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/focus-cathartic.webp",
             "range": [
                 88,
                 93
             ],
-            "drawn": false,
             "text": "Bottled Catharsis (Lesser)",
-            "documentId": "8KbayiwrUJtvif0a",
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/focus-cathartic.webp",
-            "_id": "u4NmFxoavA5cMmGr",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "jzTu7G4amSHGZUxa",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "Ekk7o1gPu8RotixD",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/salamander-elixir.webp",
             "range": [
                 94,
                 99
             ],
-            "drawn": false,
             "text": "Cooling Elixir (Lesser)",
-            "documentId": "Ekk7o1gPu8RotixD",
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/salamander-elixir.webp",
-            "_id": "jzTu7G4amSHGZUxa",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "dURqL0JteziCnBno",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "1TWHN8RbimPVXM0U",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/sinew-shock-serum.webp",
             "range": [
                 100,
                 105
             ],
-            "drawn": false,
             "text": "Surging Serum (Lesser)",
-            "documentId": "1TWHN8RbimPVXM0U",
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/sinew-shock-serum.webp",
-            "_id": "dURqL0JteziCnBno",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "kQTnunLE0S9fmtjU",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "n9VrmK9Us0viv20P",
+            "drawn": false,
+            "img": "icons/consumables/potions/bottle-round-ring-teal.webp",
             "range": [
                 106,
                 111
             ],
-            "drawn": false,
             "text": "Witchwarg Elixir (Lesser)",
-            "documentId": "n9VrmK9Us0viv20P",
-            "img": "icons/consumables/potions/bottle-round-ring-teal.webp",
-            "_id": "kQTnunLE0S9fmtjU",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "ep0uNyFuyGn1znid",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "QJ1fTrX42PoEWpK5",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/leadenleg.webp",
             "range": [
                 112,
                 117
             ],
-            "drawn": false,
             "text": "Leadenleg",
-            "documentId": "QJ1fTrX42PoEWpK5",
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/leadenleg.webp",
-            "_id": "ep0uNyFuyGn1znid",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "Ji88hahtOiyJ87xT",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "9EZb1hmSKOGrU4Cf",
+            "drawn": false,
+            "img": "icons/environment/traps/trap-jaw-steel.webp",
             "range": [
                 118,
                 123
             ],
-            "drawn": false,
             "text": "Biting Snare",
-            "documentId": "9EZb1hmSKOGrU4Cf",
-            "img": "icons/environment/traps/trap-jaw-steel.webp",
-            "_id": "Ji88hahtOiyJ87xT",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "k0S0eznH0ApMmvWi",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 3,
+            "documentId": "0lhh2l4kh3QrwYH9",
+            "drawn": false,
+            "img": "icons/magic/nature/root-vine-entangle-foot-green.webp",
             "range": [
                 124,
                 126
             ],
-            "drawn": false,
             "text": "Hobbling Snare",
-            "documentId": "0lhh2l4kh3QrwYH9",
-            "img": "icons/magic/nature/root-vine-entangle-foot-green.webp",
-            "_id": "k0S0eznH0ApMmvWi",
-            "flags": {}
+            "type": "pack",
+            "weight": 3
         },
         {
-            "type": "pack",
+            "_id": "13CGauAkkBvfRyb0",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 3,
+            "documentId": "s9dtRS2SRTqzGdOF",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/snares/stalker-bane-snare.webp",
             "range": [
                 127,
                 129
             ],
-            "drawn": false,
             "text": "Stalker Bane Snare",
-            "documentId": "s9dtRS2SRTqzGdOF",
-            "img": "systems/pf2e/icons/equipment/snares/stalker-bane-snare.webp",
-            "_id": "13CGauAkkBvfRyb0",
-            "flags": {}
+            "type": "pack",
+            "weight": 3
         },
         {
-            "type": "pack",
+            "_id": "7UxWLNXfbJrmvPn0",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "SWqzv0hYCIczICeR",
+            "drawn": false,
+            "img": "icons/commodities/cloth/thread-spindle-white-grey.webp",
             "range": [
                 130,
                 135
             ],
-            "drawn": false,
             "text": "Trip Snare",
-            "documentId": "SWqzv0hYCIczICeR",
-            "img": "icons/commodities/cloth/thread-spindle-white-grey.webp",
-            "_id": "7UxWLNXfbJrmvPn0",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "v2xbmBtbR33akycD",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "Ha6n30Tj3TNru9Dj",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/timeless-salts.webp",
             "range": [
                 136,
                 141
             ],
-            "drawn": false,
             "text": "Timeless Salts",
-            "documentId": "Ha6n30Tj3TNru9Dj",
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/timeless-salts.webp",
-            "_id": "v2xbmBtbR33akycD",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         }
     ]
 }

--- a/packs/rollable-tables/4th-level-permanent-items.json
+++ b/packs/rollable-tables/4th-level-permanent-items.json
@@ -11,259 +11,242 @@
     "replacement": true,
     "results": [
         {
-            "type": "pack",
+            "_id": "SRACM7psSWbt7MUy",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "jaEEvuQ32GjAa8jy",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/held-items/bag-of-holding.webp",
             "range": [
                 1,
                 6
             ],
-            "drawn": false,
             "text": "Spacious Pouch (Type I)",
-            "documentId": "jaEEvuQ32GjAa8jy",
-            "img": "systems/pf2e/icons/equipment/held-items/bag-of-holding.webp",
-            "_id": "SRACM7psSWbt7MUy",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "vepEjDl8jOX86vNe",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "JQdwHECogcTzdd8R",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
             "range": [
                 7,
                 12
             ],
-            "drawn": false,
             "text": "Ghost Touch",
-            "documentId": "JQdwHECogcTzdd8R",
-            "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
-            "_id": "vepEjDl8jOX86vNe",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "7GVKVhPHE1tRqofk",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "x9SNVpAAnXKJeoqp",
+            "drawn": false,
+            "img": "icons/commodities/treasure/token-runed-os-grey.webp",
             "range": [
                 13,
                 18
             ],
-            "drawn": false,
             "text": "Reinforcing Rune (Minor)",
-            "documentId": "x9SNVpAAnXKJeoqp",
-            "img": "icons/commodities/treasure/token-runed-os-grey.webp",
-            "_id": "7GVKVhPHE1tRqofk",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "Q5GdUSJPaUQunMLC",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "DxCuJKynlnMQZHgp",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/fundamental-weapon-runes/striking.webp",
             "range": [
                 19,
                 24
             ],
-            "drawn": false,
             "text": "Striking",
-            "documentId": "DxCuJKynlnMQZHgp",
-            "img": "systems/pf2e/icons/equipment/runes/fundamental-weapon-runes/striking.webp",
-            "_id": "Q5GdUSJPaUQunMLC",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "FaCinm93O2jFlr6V",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "f9ygr5Cjrmop8LWV",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/shields/specific-shields/sturdy-shield.webp",
             "range": [
                 25,
                 30
             ],
-            "drawn": false,
             "text": "Sturdy Shield (Minor)",
-            "documentId": "f9ygr5Cjrmop8LWV",
-            "img": "systems/pf2e/icons/equipment/shields/specific-shields/sturdy-shield.webp",
-            "_id": "FaCinm93O2jFlr6V",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "CqAVPdu3PE9R0AVY",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "WcuknnE3xYfSdbhm",
+            "drawn": false,
+            "img": "icons/weapons/staves/staff-ornate-bird.webp",
             "range": [
                 31,
                 36
             ],
-            "drawn": false,
             "text": "Animal Staff",
-            "documentId": "WcuknnE3xYfSdbhm",
-            "img": "icons/weapons/staves/staff-ornate-bird.webp",
-            "_id": "CqAVPdu3PE9R0AVY",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "AHr6259HQlrLJpiq",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "xwiZBOjispKVZzGA",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/staves/mentalist-staff.webp",
             "range": [
                 37,
                 42
             ],
-            "drawn": false,
             "text": "Mentalist's Staff",
-            "documentId": "xwiZBOjispKVZzGA",
-            "img": "systems/pf2e/icons/equipment/staves/mentalist-staff.webp",
-            "_id": "AHr6259HQlrLJpiq",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "dWPzhR7OlQPGUF4H",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "3OkOKxCee9WruGU5",
+            "drawn": false,
+            "img": "icons/weapons/staves/staff-ornate-gold-jeweled.webp",
             "range": [
                 43,
                 48
             ],
-            "drawn": false,
             "text": "Staff of Healing",
-            "documentId": "3OkOKxCee9WruGU5",
-            "img": "icons/weapons/staves/staff-ornate-gold-jeweled.webp",
-            "_id": "dWPzhR7OlQPGUF4H",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "tlsLBZ3bm0MD7b9I",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "Zw3BKaJYxxxzNZ0f",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-widening.webp",
             "range": [
                 49,
                 54
             ],
-            "drawn": false,
             "text": "Wand of Widening (1st-Rank Spell)",
-            "documentId": "Zw3BKaJYxxxzNZ0f",
-            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-widening.webp",
-            "_id": "tlsLBZ3bm0MD7b9I",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "text",
+            "_id": "ws11Q7zMLmdJi0QE",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": null,
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/weapons/shortsword.webp",
             "range": [
                 55,
                 60
             ],
-            "drawn": false,
-            "_id": "ws11Q7zMLmdJi0QE",
             "text": "Striking Weapon (+1)",
-            "img": "systems/pf2e/icons/equipment/weapons/shortsword.webp",
-            "documentId": null,
-            "flags": {}
+            "type": "text",
+            "weight": 6
         },
         {
-            "type": "text",
+            "_id": "PYXHf2kEFfDwhPiP",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": null,
+            "drawn": false,
+            "img": "icons/equipment/hand/gauntlet-simple-leather-brown-gold.webp",
             "range": [
                 61,
                 66
             ],
-            "drawn": false,
-            "_id": "PYXHf2kEFfDwhPiP",
             "text": "Striking Handwraps of Mighty Blows (+1)",
-            "img": "icons/equipment/hand/gauntlet-simple-leather-brown-gold.webp",
-            "documentId": null,
-            "flags": {}
+            "type": "text",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "XU0XOMqExbnQXxEp",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "2gYZiUw9yjtb0yJY",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/demon-mask.webp",
             "range": [
                 67,
                 72
             ],
-            "drawn": false,
             "text": "Demon Mask",
-            "documentId": "2gYZiUw9yjtb0yJY",
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/demon-mask.webp",
-            "_id": "XU0XOMqExbnQXxEp",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "roFmJTv0LJz24H24",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "o1zKhvYUUc1hE2AE",
+            "drawn": false,
+            "img": "icons/equipment/hand/glove-simple-cloth-white.webp",
             "range": [
                 73,
                 78
             ],
-            "drawn": false,
             "text": "Healer's Gloves",
-            "documentId": "o1zKhvYUUc1hE2AE",
-            "img": "icons/equipment/hand/glove-simple-cloth-white.webp",
-            "_id": "roFmJTv0LJz24H24",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "4Z4p2caLt6tpbLZM",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "g2oaOGSpttfH1q6W",
+            "drawn": false,
+            "img": "icons/equipment/waist/belt-leather-brown.webp",
             "range": [
                 79,
                 84
             ],
-            "drawn": false,
             "text": "Lifting Belt",
-            "documentId": "g2oaOGSpttfH1q6W",
-            "img": "icons/equipment/waist/belt-leather-brown.webp",
-            "_id": "4Z4p2caLt6tpbLZM",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "AujXBLZGBU2e4ekK",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "1pglC9PQx6yOgcKL",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/sleeves-of-storage.webp",
             "range": [
                 85,
                 90
             ],
-            "drawn": false,
             "text": "Sleeves of Storage",
-            "documentId": "1pglC9PQx6yOgcKL",
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/sleeves-of-storage.webp",
-            "_id": "AujXBLZGBU2e4ekK",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         },
         {
-            "type": "pack",
+            "_id": "pZj5ByKYQIL7yzQw",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 3,
+            "documentId": "BHjJpNILf85M2LJE",
+            "drawn": false,
+            "img": "icons/commodities/treasure/broach-eye-silver-teal.webp",
             "range": [
                 91,
                 93
             ],
-            "drawn": false,
             "text": "Symbol of Conflict",
-            "documentId": "BHjJpNILf85M2LJE",
-            "img": "icons/commodities/treasure/broach-eye-silver-teal.webp",
-            "_id": "pZj5ByKYQIL7yzQw",
-            "flags": {}
+            "type": "pack",
+            "weight": 3
         },
         {
-            "type": "pack",
+            "_id": "TKvSCbirYVz9rdA4",
             "documentCollection": "pf2e.equipment-srd",
-            "weight": 6,
+            "documentId": "7JVgLiNTAs4clEW8",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/alchemist-goggles.webp",
             "range": [
                 94,
                 99
             ],
-            "drawn": false,
             "text": "Alchemist Goggles",
-            "documentId": "7JVgLiNTAs4clEW8",
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/alchemist-goggles.webp",
-            "_id": "TKvSCbirYVz9rdA4",
-            "flags": {}
+            "type": "pack",
+            "weight": 6
         }
     ]
 }


### PR DESCRIPTION
After running npm run extractPacks rollable-tables the 4th-level tables are modified despite not having been edited. Prior to running the command, each entry in the table has an empty flags key and the keys are in a different order. The items themselves are the same before and after tunning the command.