### PR TITLE
Update 8th-level rollable tables

### DIFF
--- a/packs/rollable-tables/8th-level-consumables-items.json
+++ b/packs/rollable-tables/8th-level-consumables-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "UmJGUUgN9TQtFQDI",
-    "description": "Table of 8th-Level Consumables Items",
+    "description": "<p>Table of 8th-Level Consumables Items</p>",
     "displayRoll": true,
-    "formula": "1d72",
+    "formula": "1d105",
     "img": "icons/svg/d20-grey.svg",
     "name": "8th-Level Consumables Items",
     "ownership": {
@@ -11,182 +11,280 @@
     "replacement": true,
     "results": [
         {
-            "_id": "mYq4p5qykRLe1Ok4",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "61mFRFnaCLHDtvdv",
-            "drawn": false,
-            "img": "icons/sundries/lights/candle-unlit-yellow.webp",
-            "range": [
-                1,
-                3
-            ],
-            "text": "Candle of Truth",
-            "type": "pack",
-            "weight": 3
-        },
-        {
-            "_id": "k455WZW8SCQLXbsv",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "WzsKbMMewXbf1nws",
-            "drawn": false,
-            "img": "icons/commodities/materials/feather-blue.webp",
-            "range": [
-                4,
-                9
-            ],
-            "text": "Feather Token (Swan Boat)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "3EqXFbXhBaS3HemC",
+            "_id": "wqKdV2zq2UmajPOr",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "bz8Y8bVUe7QfBk9g",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/darkvision-elixir.webp",
             "range": [
-                10,
-                15
+                1,
+                6
             ],
             "text": "Darkvision Elixir (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "oLZsd9xeniDUB97N",
+            "_id": "khogK7sWIXGJ8a94",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "KdeeRCrtsDCJLfgc",
+            "documentId": "61mFRFnaCLHDtvdv",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/nettleweed-residue.webp",
+            "img": "icons/sundries/lights/candle-unlit-yellow.webp",
             "range": [
-                16,
-                21
+                7,
+                9
             ],
-            "text": "Nettleweed Residue",
+            "text": "Candle of Truth",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "3yGZ96viFsE1McUp",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "WzsKbMMewXbf1nws",
+            "drawn": false,
+            "img": "icons/tools/nautical/steering-wheel.webp",
+            "range": [
+                10,
+                15
+            ],
+            "text": "Marvelous Miniature (Boat)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "zz0eL7k3QNTKNXc3",
+            "_id": "xW6FcVstpSnHPfDT",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "WL4O32qFifxnMj0H",
             "drawn": false,
             "img": "icons/commodities/materials/liquid-blue.webp",
             "range": [
-                22,
-                27
+                16,
+                21
             ],
             "text": "Wyvern Poison",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "lLzSpPUauPOj4sfl",
+            "_id": "eQ1gSV7agqyIT2hH",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "KlJSw919hpN6V9oK",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/potions/potion-of-flying.webp",
             "range": [
-                28,
-                33
+                22,
+                27
             ],
             "text": "Potion of Flying (Standard)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "HpyqvpBDM6D2jUC6",
+            "_id": "ruXTdjX0G3ugF5tL",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "kORpovlPYicysr2g",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/potions/potion-of-quickness.webp",
             "range": [
-                34,
-                39
+                28,
+                33
             ],
             "text": "Potion of Quickness",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "bqsJMu7IB225fTYz",
+            "_id": "jNklOhy4if8oCBMp",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "5xsfj30uXMKINxnk",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/weapons/shrinking-potion-greater.webp",
+            "img": "systems/pf2e/icons/equipment/consumables/potions/shrinking-potion-greater.webp",
             "range": [
-                40,
-                45
+                34,
+                39
             ],
             "text": "Shrinking Potion (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "kQTbzpAKyDIdb9PY",
+            "_id": "RRcgyDANr3e3xOFi",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "axU0I9xIm4xm2VPH",
+            "documentId": "OOli8iQmLZoMOoG0",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/snares/bomb-snare.webp",
+            "img": "icons/commodities/metal/fragments-steel-ring.webp",
+            "range": [
+                40,
+                45
+            ],
+            "text": "Alloy Orb (Standard-Grade)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "KBzJUujKYXpTSC2a",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "oTRUHPASPD4USU4o",
+            "drawn": false,
+            "img": "icons/commodities/claws/claw-insect-brown.webp",
             "range": [
                 46,
                 51
             ],
-            "text": "Bomb Snare",
+            "text": "Bloodseeker Beak (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "11E6i8082Hr9VbAI",
+            "_id": "YgWyHsVn9KA72xlq",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "TFnr9Gq7VXPJu0GQ",
+            "documentId": "4MfrhRlz4VeYtYVn",
             "drawn": false,
-            "img": "icons/magic/nature/root-vine-entangle-foot-green.webp",
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/dragon-turtle-scale.webp",
             "range": [
                 52,
-                54
+                57
             ],
-            "text": "Grasping Snare",
-            "type": "pack",
-            "weight": 3
-        },
-        {
-            "_id": "61ajGdu6KUgCbRhV",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "6KdYdFovFBivwI8M",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/snares/striking-snare.webp",
-            "range": [
-                55,
-                60
-            ],
-            "text": "Striking Snare",
+            "text": "Dragon Turtle Scale (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "eKm3g1vLvoZDKctH",
+            "_id": "UilOoVeaUxqeKCgT",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "u6g7AClRFEAj4lf4",
             "drawn": false,
             "img": "icons/equipment/neck/necklace-simple-teeth.webp",
             "range": [
-                61,
-                66
+                58,
+                63
             ],
             "text": "Gallows Tooth",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "1ULLBfpXeyX73K7j",
+            "_id": "NSWRcEDzJZ1P4XJE",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "XfcSVHwMA60JxUXJ",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/focus-cathartic.webp",
+            "range": [
+                64,
+                69
+            ],
+            "text": "Bottled Catharsis (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "DVW8ymEZcWs1KqMs",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "tslVf3qtQE7V1YvG",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/sinew-shock-serum.webp",
+            "range": [
+                70,
+                75
+            ],
+            "text": "Surging Serum (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "PRIbPqlllXQjP0uH",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "C0kSU5KWMzLngvTa",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/oils/oil-of-object-animation.webp",
+            "range": [
+                76,
+                78
+            ],
+            "text": "Oil of Dynamism",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "IU5TXCVkezQ6z3s2",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "2koNKqbQV05myfuL",
+            "drawn": false,
+            "img": "icons/containers/bags/coinpouch-leather-grey.webp",
+            "range": [
+                79,
+                81
+            ],
+            "text": "Dust of Corpse Animation",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "9ITvnEZkY4rJTEQB",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "KdeeRCrtsDCJLfgc",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/nettleweed-residue.webp",
+            "range": [
+                82,
+                87
+            ],
+            "text": "Nettleweed Residue",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "MnYWxeKtF6e3dqjG",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "25Rr05SIfTj0GA31",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/potions/potion-of-disguise.webp",
+            "range": [
+                88,
+                90
+            ],
+            "text": "Potion of Disguise (Moderate)",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "pbRaHPvHib9I5r0S",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "TFnr9Gq7VXPJu0GQ",
+            "drawn": false,
+            "img": "icons/magic/nature/root-vine-entangle-foot-green.webp",
+            "range": [
+                91,
+                93
+            ],
+            "text": "Grasping Snare",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "MqaaAfBkUaifdCJS",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "6KdYdFovFBivwI8M",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/snares/striking-snare.webp",
+            "range": [
+                94,
+                99
+            ],
+            "text": "Striking Snare",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "aVAxkzNWofYTc1rN",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "cKqZe5imzxqSnzwD",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/talismans/jade-bauble.webp",
             "range": [
-                67,
-                72
+                100,
+                105
             ],
             "text": "Jade Bauble",
             "type": "pack",

--- a/packs/rollable-tables/8th-level-permanent-items.json
+++ b/packs/rollable-tables/8th-level-permanent-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "QoEkRoteKJwHHVRd",
-    "description": "Table of 8th-Level Permanent Items",
+    "description": "<p>Table of 8th-Level Permanent Items</p>",
     "displayRoll": true,
-    "formula": "1d169",
+    "formula": "1d172",
     "img": "icons/svg/d20-grey.svg",
     "name": "8th-Level Permanent Items",
     "ownership": {
@@ -15,7 +15,7 @@
             "documentCollection": "",
             "documentId": null,
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "systems/pf2e/icons/equipment/armor/scale-mail.webp",
             "range": [
                 1,
                 6
@@ -39,382 +39,466 @@
             "weight": 6
         },
         {
-            "_id": "k455WZW8SCQLXbsv",
+            "_id": "IyyeXt2AjsAaSdG2",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "6wVWwpL9pYr3yQtt",
+            "documentId": "bL7HnxNYGq6nTpgp",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/held-items/rod-of-wonder.webp",
+            "img": "systems/pf2e/icons/equipment/consumables/other-consumables/chimera-thread.webp",
             "range": [
                 13,
                 13
             ],
-            "text": "Rod of Wonder",
+            "text": "Madcap Top",
             "type": "pack",
             "weight": 1
         },
         {
-            "_id": "3EqXFbXhBaS3HemC",
+            "_id": "pTcUjDwSiTZNBA7v",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Wm0X7Pfd1bfocPSv",
+            "documentId": "6llILJtsTPgtYXgx",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
             "range": [
                 14,
                 19
             ],
+            "text": "Astral",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "Us7p1HZxTxxac02S",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "Wm0X7Pfd1bfocPSv",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
+            "range": [
+                20,
+                25
+            ],
             "text": "Corrosive",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "oLZsd9xeniDUB97N",
+            "_id": "9WtMTydl6fX8yB9z",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Lw3B9DpnyrpXD9Di",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/runes/armor-property-runes/armor-property-runes.webp",
-            "range": [
-                20,
-                25
-            ],
-            "text": "Energy-Resistant",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "zz0eL7k3QNTKNXc3",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "XszNvxnymWYRaoTp",
+            "documentId": "fyiW23MFe8p06KL5",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
             "range": [
                 26,
                 31
             ],
+            "text": "Decaying",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "LR10q8mlAnVkOWBg",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "Lw3B9DpnyrpXD9Di",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/armor-property-runes/armor-property-runes.webp",
+            "range": [
+                32,
+                37
+            ],
+            "text": "Energy-Resistant",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "fSz41BeHZz54C776",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "XszNvxnymWYRaoTp",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
+            "range": [
+                38,
+                43
+            ],
             "text": "Flaming",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "lLzSpPUauPOj4sfl",
+            "_id": "KpTnsPY8CdqgV2d6",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "M5M1WJ5KzbYfRGsY",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
             "range": [
-                32,
-                37
+                44,
+                49
             ],
             "text": "Frost",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "HpyqvpBDM6D2jUC6",
+            "_id": "kZsd8JITWvp4cGLn",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "VDudQ4x2ozosAbTb",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/armor-property-runes/armor-property-runes.webp",
             "range": [
-                38,
-                43
+                50,
+                55
             ],
             "text": "Invisibility",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "bqsJMu7IB225fTYz",
+            "_id": "8vvalFVNguyIuI8y",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "eSjQgsl3pYkirOwk",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/fundamental-armor-runes/armor-potency.webp",
             "range": [
-                44,
-                49
+                56,
+                61
             ],
             "text": "Resilient",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "xkxbqKf3zQN0HjG2",
+            "_id": "VOa7W52LvFhRtNNZ",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "NVst7e69agGG9Qwd",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
-            "range": [
-                50,
-                55
-            ],
-            "text": "Shock",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "kQTbzpAKyDIdb9PY",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "LiJMupjynmkM5Mld",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/runes/armor-property-runes/armor-property-runes.webp",
-            "range": [
-                56,
-                61
-            ],
-            "text": "Slick (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "11E6i8082Hr9VbAI",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "dTxbaa7HSiJbIuNN",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
             "range": [
                 62,
                 67
             ],
+            "text": "Shock",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "AHC2BIbIAUdNpW61",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "LiJMupjynmkM5Mld",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/armor-property-runes/armor-property-runes.webp",
+            "range": [
+                68,
+                73
+            ],
+            "text": "Slick (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "rCF4iyAsuqKvQm0L",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "dTxbaa7HSiJbIuNN",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
+            "range": [
+                74,
+                79
+            ],
             "text": "Thundering",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "vQq7Hy7Dx1a8GCHZ",
+            "_id": "CcFSvU9Mmrip8E5J",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "4aVkppixLHPg940o",
+            "documentId": null,
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/adamantite-buckler.webp",
             "range": [
-                68,
-                73
+                80,
+                82
             ],
             "text": "Adamantine Buckler (Standard-Grade)",
-            "type": "pack",
-            "weight": 6
+            "type": "text",
+            "weight": 3
         },
         {
-            "_id": "dwXrm0DZwZ0Vtpyl",
+            "_id": "my2jSejW9KRoI7Gc",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "2gMlhHlkQp3DuWw5",
+            "documentId": null,
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/adamantite-shield.webp",
             "range": [
-                74,
-                79
-            ],
-            "text": "Adamantine Shield (Standard-Grade)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "ViMk7CeQzvGeYUrC",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "BUHV5rev5HVgCrUB",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/darkwood-buckler.webp",
-            "range": [
-                80,
+                83,
                 85
             ],
-            "text": "Duskwood Buckler (Standard-Grade)",
-            "type": "pack",
-            "weight": 6
+            "text": "Adamantine Shield (Standard-Grade)",
+            "type": "text",
+            "weight": 3
         },
         {
-            "_id": "rj2RuyHe7q9qcZ2d",
+            "_id": "fjz0JhTBhS4V7jnO",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "UdvSJPCtBr2Y1e22",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/darkwood-shield.webp",
-            "range": [
-                86,
-                91
-            ],
-            "text": "Duskwood Shield (Standard-Grade)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "o3gZ97kIi4lo11BY",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Snu8yjMrUi3ockyA",
-            "drawn": false,
-            "img": "icons/equipment/shield/oval-wooden-boss-bronze.webp",
-            "range": [
-                92,
-                97
-            ],
-            "text": "Duskwood Tower Shield (Standard-Grade)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "OtH5vWwuqo4ICMuF",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "vfzzrp0tKXznWnhY",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/dragonhide-buckler.webp",
-            "range": [
-                98,
-                103
-            ],
-            "text": "Dragonhide Buckler (Standard-Grade)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "TbqN7piUhgo0OfAf",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "daX1jX7XYo3mWZmP",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/dragonhide-shield.webp",
-            "range": [
-                104,
-                109
-            ],
-            "text": "Dragonhide Shield (Standard-Grade)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "l9CD8GKGvhWX8hAA",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "CF9BCVE0ppxMmULb",
+            "documentId": null,
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/mithral-buckler.webp",
             "range": [
-                110,
-                115
+                86,
+                88
             ],
             "text": "Dawnsilver Buckler (Standard-Grade)",
-            "type": "pack",
-            "weight": 6
+            "type": "text",
+            "weight": 3
         },
         {
-            "_id": "t5t1wLQE2o2FC0iI",
+            "_id": "lTkXdbFj2PwcsDMJ",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "ETHbpwjh8aLGrXi0",
+            "documentId": null,
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/mithral-shield.webp",
             "range": [
-                116,
-                121
+                89,
+                91
             ],
             "text": "Dawnsilver Shield (Standard-Grade)",
-            "type": "pack",
-            "weight": 6
+            "type": "text",
+            "weight": 3
         },
         {
-            "_id": "SaGLwztjSNglsrzf",
+            "_id": "UFBIj5HsXCcW4T5b",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/darkwood-buckler.webp",
+            "range": [
+                92,
+                94
+            ],
+            "text": "Duskwood Buckler (Standard-Grade)",
+            "type": "text",
+            "weight": 3
+        },
+        {
+            "_id": "iWxpEl1j1O4tW7rG",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/darkwood-shield.webp",
+            "range": [
+                95,
+                97
+            ],
+            "text": "Duskwood Shield (Standard-Grade)",
+            "type": "text",
+            "weight": 3
+        },
+        {
+            "_id": "4Xt7xoXfcdxwmLxI",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/darkwood-tower-shield.webp",
+            "range": [
+                98,
+                100
+            ],
+            "text": "Duskwood Tower Shield (Standard-Grade)",
+            "type": "text",
+            "weight": 3
+        },
+        {
+            "_id": "88PbPRLzF3jexqKA",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "bT9azgpc96DNbitA",
             "drawn": false,
             "img": "icons/weapons/staves/staff-ornate-bird.webp",
             "range": [
-                122,
-                127
+                101,
+                106
             ],
             "text": "Animal Staff (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "vHNOIhldCiAlVI37",
+            "_id": "YQEHxez6Nyd7aTZi",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "0RCC0fOg1Lp7f79I",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/staves/mentalist-staff.webp",
             "range": [
-                128,
-                133
+                107,
+                112
             ],
             "text": "Mentalist's Staff (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "wDGaxAN4F6RLlPZV",
+            "_id": "9LmM2xouxtkxkfHA",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "KcjaeMgrsBGgwUWL",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/staves/staff-of-fire.webp",
             "range": [
-                134,
-                139
+                113,
+                118
             ],
             "text": "Staff of Fire (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "S0kG1NmHVtkY2ZNf",
+            "_id": "6mqXrBYamIjOqpqW",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "XSwEE8wjHr6UXzpw",
             "drawn": false,
             "img": "icons/weapons/staves/staff-ornate-gold-jeweled.webp",
             "range": [
-                140,
-                145
+                119,
+                124
             ],
             "text": "Staff of Healing (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "ND9f91U4mIQQpsxt",
+            "_id": "2py838f3KDq5OdNP",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "8No84rsBOCVCkXJK",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/staves/staff-of-illumination.webp",
             "range": [
-                146,
-                151
+                125,
+                130
             ],
             "text": "Staff of Illumination",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "EkwMh4K3qpHW7heM",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "c2Oa9UbhjwAsZaPp",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-smoldering-fireballs.webp",
-            "range": [
-                152,
-                157
-            ],
-            "text": "Wand of Smoldering Fireballs (3rd-Rank Spell)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "51ULgg4Z2gGAZbMm",
+            "_id": "MZ0T375xyBuwROAz",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "TJaumkbZy11sIAgR",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-widening.webp",
             "range": [
-                158,
-                163
+                131,
+                136
             ],
             "text": "Wand of Widening (3rd-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "WGS4NVKgvBlbRbTe",
+            "_id": "t48YOTDOvY0nUjtm",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "rAkxflw4pNrPAq4p",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/aeon-stone-pale-orange-rhomboid.webp",
+            "range": [
+                137,
+                139
+            ],
+            "text": "Aeon Stone (Envisioning)",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "xfLTJPadn4bh4OHl",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "02q8s6sSicMkhs1l",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/bracers-of-armor.webp",
             "range": [
+                140,
+                145
+            ],
+            "text": "Bands of Force",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "tq0K1E9hWCwmr8hd",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "nZE16PtiyY7DWlzd",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/lovers-gloves.webp",
+            "range": [
+                146,
+                151
+            ],
+            "text": "Lover's Gloves",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "68mYV0QqhyVWIHMv",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/dragonhide-buckler.webp",
+            "range": [
+                152,
+                154
+            ],
+            "text": "Dragonhide Buckler (Standard-Grade)",
+            "type": "text",
+            "weight": 3
+        },
+        {
+            "_id": "Pe4abHNZQ8yDLQNJ",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/dragonhide-shield.webp",
+            "range": [
+                155,
+                157
+            ],
+            "text": "Dragonhide Shield (Standard-Grade)",
+            "type": "text",
+            "weight": 3
+        },
+        {
+            "_id": "QunwVXXk5nz3odNt",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/wands/magic-wands/magic-wand.webp",
+            "range": [
+                158,
+                163
+            ],
+            "text": "Wand of Crackling Lighting 3rd",
+            "type": "text",
+            "weight": 6
+        },
+        {
+            "_id": "UJAihWTVhJumDORk",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "c2Oa9UbhjwAsZaPp",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-smoldering-fireballs.webp",
+            "range": [
                 164,
                 169
             ],
-            "text": "Bracers of Armor I",
+            "text": "Wand of Smoldering Fireballs (3rd-Rank Spell)",
             "type": "pack",
             "weight": 6
+        },
+        {
+            "_id": "8N9kATt1KpQghZ2u",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "2UX3tlC5vKeQjG7t",
+            "drawn": false,
+            "img": "icons/weapons/crossbows/crossbow-ornamental-black.webp",
+            "range": [
+                170,
+                172
+            ],
+            "text": "Spiritsight Crossbow",
+            "type": "pack",
+            "weight": 3
         }
     ]
 }


### PR DESCRIPTION
Update 8th-Level Consumable Items and 8th-Level Permanent Items tables with remaster changes, consolidating the treasure tables from the GM Core and Player Core 2 books, preserving the item order found in those tables. Weight is based on rarity:

- Common = 6
- Uncommon = 3
- Rare = 1

For items that do not have a corresponding entry in the compendium, create a text entry in the table with the appropriate item name. If possible, set an appropriate icon from the system's icon set.