### PR TITLE
Update 9th-level rollable tables

### DIFF
--- a/packs/rollable-tables/9th-level-consumables-items.json
+++ b/packs/rollable-tables/9th-level-consumables-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "XAJFTpuo8qrcW30P",
-    "description": "Table of 9th-Level Consumables Items",
+    "description": "<p>Table of 9th-Level Consumables Items</p>",
     "displayRoll": true,
-    "formula": "1d72",
+    "formula": "1d78",
     "img": "icons/svg/d20-grey.svg",
     "name": "9th-Level Consumables Items",
     "ownership": {
@@ -39,49 +39,49 @@
             "weight": 6
         },
         {
-            "_id": "k455WZW8SCQLXbsv",
+            "_id": "oaRxxh7mtl5tHjbD",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "RpvH9EDquO0jS3Jz",
+            "documentId": "t4X6GDybqLmt7UkN",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/ammunition/storm-arrow.webp",
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/cheetahs-elixir.webp",
             "range": [
                 13,
                 18
             ],
-            "text": "Storm Arrow",
+            "text": "Cheetah's Elixir (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "aPbhuQl16Dn83HR8",
+            "_id": "RtrQYxkUzaeoAiDL",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "9XSOAzq3xp9g6qkF",
+            "documentId": "c21stU5rhN4F2fZl",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/other-consumables/dust-of-disappearance.webp",
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/elixir-of-life.webp",
             "range": [
                 19,
                 24
             ],
-            "text": "Dust of Disappearance",
+            "text": "Elixir of Life (Moderate)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "3EqXFbXhBaS3HemC",
+            "_id": "xYV9bJgcf3NylTfM",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "XAuWVlZYGgCguzwz",
+            "documentId": "QGgTedo2uMi6e9PR",
             "drawn": false,
-            "img": "icons/commodities/materials/feather-blue.webp",
+            "img": "icons/magic/fire/barrier-shield-explosion-yellow.webp",
             "range": [
                 25,
                 30
             ],
-            "text": "Feather Token (Whip)",
+            "text": "Frozen Lava of Pale Mountain",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "oLZsd9xeniDUB97N",
+            "_id": "ce61xlGU7GafZXP8",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "wDhqRxuXPQfyD0eX",
             "drawn": false,
@@ -90,91 +90,105 @@
                 31,
                 36
             ],
-            "text": "Javelin of Lightning",
+            "text": "Trident of Lightning",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "zz0eL7k3QNTKNXc3",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "t4X6GDybqLmt7UkN",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/cheetahs-elixir.webp",
-            "range": [
-                37,
-                42
-            ],
-            "text": "Cheetah's Elixir (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "lLzSpPUauPOj4sfl",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "c21stU5rhN4F2fZl",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/elixir-of-life.webp",
-            "range": [
-                43,
-                48
-            ],
-            "text": "Elixir of Life (Moderate)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "bqsJMu7IB225fTYz",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "3uqUIZZuEyAMORUi",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/oils/aligned-oil.webp",
-            "range": [
-                49,
-                54
-            ],
-            "text": "Aligned Oil",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "xkxbqKf3zQN0HjG2",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "ca2lzxfJxvuLDrKu",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/lich-dust.webp",
-            "range": [
-                55,
-                60
-            ],
-            "text": "Lich Dust",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "kQTbzpAKyDIdb9PY",
+            "_id": "tbdXVobIhP7Szx2R",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "oOXvk18K4izaJzG7",
             "drawn": false,
             "img": "icons/commodities/materials/slime-purple.webp",
             "range": [
-                61,
-                66
+                37,
+                42
             ],
             "text": "Spider Root",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "11E6i8082Hr9VbAI",
+            "_id": "XakW6lxuPilbUCOG",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "tjLvRWklAylFhBHQ",
             "drawn": false,
             "img": "icons/sundries/scrolls/scroll-symbol-eye-brown.webp",
             "range": [
+                43,
+                48
+            ],
+            "text": "Scroll of 5th-rank Spell",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "ThPLecZfRqQ1d7EF",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "vL6AtFbcxbipGvtf",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/basilisk-eye.webp",
+            "range": [
+                49,
+                54
+            ],
+            "text": "Basilisk Eye",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "UhHjDSM5Ix4yVOFn",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "VeqgYabyGPd7kuSg",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/emerald-grasshopper.webp",
+            "range": [
+                55,
+                60
+            ],
+            "text": "Emerald Grasshopper (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "kh4iomLruS6SImYk",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "aSRUX4WGfalK4A5J",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/potency-crystal.webp",
+            "range": [
+                61,
+                66
+            ],
+            "text": "Potency Crystal (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "QfSIHz1AXk0JSjt8",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "RpvH9EDquO0jS3Jz",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/ammunition/storm-arrow.webp",
+            "range": [
                 67,
                 72
             ],
-            "text": "Scroll of 5th-level Spell",
+            "text": "Storm Arrow",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "WSTqTb7HkfTpSEeX",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "ca2lzxfJxvuLDrKu",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/lich-dust.webp",
+            "range": [
+                73,
+                78
+            ],
+            "text": "Enervating Powder",
             "type": "pack",
             "weight": 6
         }

--- a/packs/rollable-tables/9th-level-permanent-items.json
+++ b/packs/rollable-tables/9th-level-permanent-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "AJOYeeeF3E8UC7KF",
-    "description": "Table of 9th-Level Permanent Items",
+    "description": "<p>Table of 9th-Level Permanent Items</p>",
     "displayRoll": true,
-    "formula": "1d162",
+    "formula": "1d198",
     "img": "icons/svg/d20-grey.svg",
     "name": "9th-Level Permanent Items",
     "ownership": {
@@ -11,189 +11,189 @@
     "replacement": true,
     "results": [
         {
-            "_id": "mYq4p5qykRLe1Ok4",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "C4XKMcHZoGzrAZBl",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/armor/specific-magic-armor/rhino-hide.webp",
-            "range": [
-                1,
-                6
-            ],
-            "text": "Rhino Hide",
-            "type": "pack",
-            "weight": 6
-        },
-        {
             "_id": "k455WZW8SCQLXbsv",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "cO7ANYLkcmfCn9c9",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/companion-items/collar-of-empathy.webp",
             "range": [
-                7,
-                12
+                1,
+                6
             ],
             "text": "Collar of Empathy",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "lLzSpPUauPOj4sfl",
+            "_id": "opvwOuQyV4LotdaO",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "WAMDYE9tt3W8obzr",
+            "documentId": "FB8EAFOz2hS6Jbic",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/held-items/horn-of-blasting.webp",
+            "img": "icons/magic/earth/explosion-lava-orange.webp",
+            "range": [
+                7,
+                12
+            ],
+            "text": "Eternal Eruption of Pale Mountain",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "N8O0tYmTrnQhy3Pw",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "bJORQsO9E1JCJh6i",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
             "range": [
                 13,
                 18
             ],
-            "text": "Horn of Blasting",
+            "text": "Extending",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "HpyqvpBDM6D2jUC6",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "14LrP7bx8Q1jimHO",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/held-items/immovable-rod.webp",
-            "range": [
-                19,
-                24
-            ],
-            "text": "Immovable Rod",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "kQTbzpAKyDIdb9PY",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "KLWjINVkWwJlOZEX",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/held-items/tritons-conch.webp",
-            "range": [
-                25,
-                30
-            ],
-            "text": "Triton's Conch",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "11E6i8082Hr9VbAI",
+            "_id": "PBY7PI08A2qn4e0A",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "qUnDHEXteUQGE8yp",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
             "range": [
-                31,
-                36
+                19,
+                24
             ],
             "text": "Grievous",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "vQq7Hy7Dx1a8GCHZ",
+            "_id": "JX6t91kYSnMpw6KZ",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "bSm0Hki8N2L50OZw",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/armor-property-runes/armor-property-runes.webp",
             "range": [
-                37,
-                42
+                25,
+                30
             ],
             "text": "Shadow (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "dwXrm0DZwZ0Vtpyl",
+            "_id": "JYSsnFSHoaQNxumt",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "Q8BscHUFiM1a86PO",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/shields/specific-shields/dragonslayers-shield.webp",
             "range": [
-                43,
-                45
+                31,
+                33
             ],
             "text": "Dragonslayer's Shield",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "ViMk7CeQzvGeYUrC",
+            "_id": "nVeRkvi7ub1H5HuW",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "DIzZr0K20eCbNzQo",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/shields/specific-shields/force-shield.webp",
             "range": [
-                46,
-                48
+                34,
+                36
             ],
             "text": "Force Shield",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "o3gZ97kIi4lo11BY",
+            "_id": "LaTDSERBGN6DMHOm",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "Sn7v9SsbEDMUIwrO",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/magic-wands/magic-wand.webp",
             "range": [
-                49,
-                54
+                37,
+                42
             ],
             "text": "Magic Wand (4th-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "OtH5vWwuqo4ICMuF",
+            "_id": "AS7aUDh9Ku7HNz5z",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "R88HWv9rw1VNMRer",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-continuation.webp",
             "range": [
-                55,
-                60
+                43,
+                48
             ],
             "text": "Wand of Continuation (3rd-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "TbqN7piUhgo0OfAf",
+            "_id": "Dzdv2ndDfAYGdNos",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "3Lexs7KnhbV0HgFh",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-manifold-missiles.webp",
             "range": [
-                61,
-                66
+                49,
+                54
             ],
-            "text": "Wand of Manifold Missiles (3rd-Rank Spell)",
+            "text": "Wand of Shardstorm (3rd-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "t5t1wLQE2o2FC0iI",
+            "_id": "xLvvpoamFZNNmBFY",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "yHtlXoXKPis7eTR0",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/weapons/mace.webp",
+            "range": [
+                55,
+                60
+            ],
+            "text": "Chaplain's Cudgel",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "hCe1xZuUqYWOFeTL",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "w5ZX1R3dPvuLcuRx",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/weapons/specific-magic-weapons/gloom-blade.webp",
             "range": [
-                67,
-                72
+                61,
+                66
             ],
             "text": "Gloom Blade",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "vHNOIhldCiAlVI37",
+            "_id": "m6segpV87oZdV5L8",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "rRAx62TLPTZSiaLD",
+            "drawn": false,
+            "img": "icons/equipment/feet/boots-collared-green.webp",
+            "range": [
+                67,
+                72
+            ],
+            "text": "Arboreal Boots (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "zi5zDZUVg2b9UM6V",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "wI4Tj8bNwpZHequC",
             "drawn": false,
@@ -207,147 +207,133 @@
             "weight": 6
         },
         {
-            "_id": "wDGaxAN4F6RLlPZV",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "YCjVrQnHfOtpmjYW",
-            "drawn": false,
-            "img": "icons/equipment/waist/belt-buckle-round-steel-purple.webp",
-            "range": [
-                79,
-                81
-            ],
-            "text": "Belt of the Five Kings",
-            "type": "pack",
-            "weight": 3
-        },
-        {
-            "_id": "S0kG1NmHVtkY2ZNf",
+            "_id": "V9yrcU708k9yyBav",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "P5nasaE0JgvkZyZp",
             "drawn": false,
             "img": "icons/equipment/wrist/bracer-segmented-leather.webp",
             "range": [
-                82,
-                87
+                79,
+                84
             ],
             "text": "Bracers of Missile Deflection (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "EkwMh4K3qpHW7heM",
+            "_id": "AsC0cuGutgMd9rSX",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "t8RXms7xq8atF9W7",
+            "drawn": false,
+            "img": "icons/equipment/hand/glove-ringed-leather-yellow.webp",
+            "range": [
+                85,
+                90
+            ],
+            "text": "Charlatan's Gloves (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "lCQIK9q3JKcLIsUc",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "sls3pfkhgCbW723f",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/coyote-cloak.webp",
             "range": [
-                88,
-                93
+                91,
+                96
             ],
             "text": "Coyote Cloak (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "51ULgg4Z2gGAZbMm",
+            "_id": "q34zOzb0os9LISEj",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "QJ1PhbtbLzwhRlY0",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/dancing-scarf.webp",
             "range": [
-                94,
-                99
+                97,
+                102
             ],
             "text": "Dancing Scarf (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "WGS4NVKgvBlbRbTe",
+            "_id": "AlhZ6094TmydDO5t",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "dLTN4FU3qBoDZ5CJ",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/eyes-of-the-eagle.webp",
             "range": [
-                100,
-                105
+                103,
+                108
             ],
-            "text": "Eyes of the Eagle",
+            "text": "Eyes of the Cat",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "7Z6tn2kUuYj3hLx2",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Hd1AfC08ytBg67Ey",
-            "drawn": false,
-            "img": "icons/equipment/head/hat-belted-simple-grey.webp",
-            "range": [
-                106,
-                111
-            ],
-            "text": "Hat of the Magi (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "STcQUllJfx9jubmn",
+            "_id": "GF0g28rsDoYyBIIS",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "0GOHTXBxs6H6ARBz",
             "drawn": false,
             "img": "icons/equipment/hand/glove-simple-cloth-white.webp",
             "range": [
-                112,
-                117
+                109,
+                114
             ],
             "text": "Healer's Gloves (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "1I1aKyDFUhl3sgcR",
+            "_id": "ajBQAA4r1EAAy1Wr",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "rdF2RKgFK0vOlaeV",
+            "documentId": "FXdESP5mmP01tL2v",
             "drawn": false,
-            "img": "icons/containers/bags/pouch-simple-leather-tan.webp",
+            "img": "icons/containers/bags/pouch-leather-green.webp",
             "range": [
-                118,
+                115,
                 120
             ],
-            "text": "Knapsack of Halflingkind",
+            "text": "Humbug Pocket",
             "type": "pack",
-            "weight": 3
+            "weight": 6
         },
         {
-            "_id": "UvP7whKlzWpyF6YX",
+            "_id": "pNyPdeA1S5EAQyO7",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "Hd1AfC08ytBg67Ey",
+            "drawn": false,
+            "img": "icons/equipment/head/hat-belted-simple-grey.webp",
+            "range": [
+                121,
+                126
+            ],
+            "text": "Mage's Hat (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "AuzNQp6jhbKnXRSz",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "HAtj6AGCIZHpD7Nl",
             "drawn": false,
             "img": "icons/equipment/finger/ring-faceted-ornate-silver-red.webp",
             "range": [
-                121,
-                126
+                127,
+                132
             ],
             "text": "Messenger's Ring",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "4C60NntnlXweLDuB",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "IufO3dNPhC1c2ZcL",
-            "drawn": false,
-            "img": "icons/equipment/neck/collar-rounded-carved-wood-spiral.webp",
-            "range": [
-                127,
-                132
-            ],
-            "text": "Necklace of Fireballs III",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "x0pg8SppDMv5G1FN",
+            "_id": "bmwFw7X0UuvhxwCg",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "1bvH8zFQvDYky9tr",
             "drawn": false,
@@ -361,7 +347,7 @@
             "weight": 6
         },
         {
-            "_id": "PNVHDBdtL0VUAY66",
+            "_id": "my8NzYYuq1wtEVY5",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "0PPQl3TEr1yNhhN6",
             "drawn": false,
@@ -375,44 +361,142 @@
             "weight": 6
         },
         {
-            "_id": "LStiXIuZbUODq3Sv",
+            "_id": "x6Wbe27Mc4MP8j8J",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "pPl2b7fqfB6dyQwf",
+            "documentId": "8jNsUCsNe6PyenNZ",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/phylactery-of-faithfulness.webp",
+            "img": "icons/equipment/waist/belt-buckle-ring-leather-red.webp",
             "range": [
                 145,
-                150
+                147
             ],
-            "text": "Phylactery of Faithfulness",
+            "text": "Retrieval Belt (Greater)",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "W9Y3KmZviqtxiE6Q",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "M7c4uXraP05HYNXs",
+            "drawn": false,
+            "img": "icons/commodities/treasure/broach-jewel-gold-blue.webp",
+            "range": [
+                148,
+                153
+            ],
+            "text": "Shining Symbol (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "Zz0g5cgA1H086yPC",
+            "_id": "YjGEXTsUPMofHhUf",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "3hv6NVC2rVu4QCNt",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/sleeves-of-storage.webp",
+            "range": [
+                154,
+                159
+            ],
+            "text": "Sleeves of Storage (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "dSkWZBcd9jM36EpL",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "OYeYYJ4i66VtGY3O",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/trackers-goggles.webp",
             "range": [
-                151,
-                156
+                160,
+                165
             ],
             "text": "Tracker's Goggles (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "RMjFs8UpifF2ce9E",
+            "_id": "31nu7uxiNDm587IY",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "dolBtAdB5lpQpQpp",
             "drawn": false,
             "img": "icons/equipment/finger/ring-band-engraved-lines-bronze.webp",
             "range": [
-                157,
-                162
+                166,
+                171
             ],
             "text": "Ventriloquist's Ring (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "zKkT5AYW0KtGYB2U",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "C4XKMcHZoGzrAZBl",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/armor/specific-magic-armor/rhino-hide.webp",
+            "range": [
+                172,
+                177
+            ],
+            "text": "Onslaught Hide",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "SU3ZqxGPTcKkM0N6",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "kZKK4Va3e7n3p3tv",
+            "drawn": false,
+            "img": "icons/containers/chest/chest-elm-steel-brown.webp",
+            "range": [
+                178,
+                180
+            ],
+            "text": "Earthsight Box",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "uzvYZpNjqpXzXRMK",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "3G2No6QaU1wSPTh6",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/held-items/urn-of-ashes.webp",
+            "range": [
+                181,
+                186
+            ],
+            "text": "Urn of Ashes",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "GO1KRdMlUcFhkiBg",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "qQpcBE7ngv7TIAW3",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-overflowing-life.webp",
+            "range": [
+                187,
+                192
+            ],
+            "text": "Wand of Overflowing Life (3rd-Rank Spell)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "TI2TZT1wo233kMfM",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "tr2eOlJMmBKBZtI9",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/mask-of-the-banshee.webp",
+            "range": [
+                193,
+                198
+            ],
+            "text": "Guise of the Smirking Devil",
             "type": "pack",
             "weight": 6
         }


### PR DESCRIPTION
Update 9th-Level Consumable Items and 9th-Level Permanent Items tables with remaster changes, consolidating the treasure tables from the GM Core and Player Core 2 books, preserving the item order found in those tables. Weight is based on rarity:

- Common = 6
- Uncommon = 3
- Rare = 1

For items that do not have a corresponding entry in the compendium, create a text entry in the table with the appropriate item name. If possible, set an appropriate icon from the system's icon set.