### PR TITLE
Update 10th-level rollable tables

### DIFF
--- a/packs/rollable-tables/10th-level-consumables-items.json
+++ b/packs/rollable-tables/10th-level-consumables-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "AIBvZzHidUXxZfEF",
-    "description": "Table of 10th-Level Consumables Items",
+    "description": "<p>Table of 10th-Level Consumables Items</p>",
     "displayRoll": true,
-    "formula": "1d72",
+    "formula": "1d78",
     "img": "icons/svg/d20-grey.svg",
     "name": "10th-Level Consumables Items",
     "ownership": {
@@ -11,170 +11,198 @@
     "replacement": true,
     "results": [
         {
-            "_id": "mYq4p5qykRLe1Ok4",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "TgZdamADHuaKyriW",
-            "drawn": false,
-            "img": "icons/commodities/gems/gem-rough-round-blue.webp",
-            "range": [
-                1,
-                6
-            ],
-            "text": "Elemental Gem",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "QN2b9QvvhEhXYHss",
+            "_id": "jyhJwR67lpDdKiDD",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "XWkeL34yJK6t5qUE",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/antidote.webp",
             "range": [
-                7,
-                12
+                1,
+                6
             ],
             "text": "Antidote (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "k455WZW8SCQLXbsv",
+            "_id": "U72FCIknlWmuuDVY",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "ORDaAzMZLrf6Hn8A",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/antiplague.webp",
             "range": [
-                13,
-                18
+                7,
+                12
             ],
             "text": "Antiplague (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "aPbhuQl16Dn83HR8",
+            "_id": "7EFd3PvIjHb3Ox5N",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "oCuwJ9IUDAuzsUwa",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/bravos-brew.webp",
             "range": [
-                19,
-                24
+                13,
+                18
             ],
             "text": "Bravo's Brew (Moderate)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "3EqXFbXhBaS3HemC",
+            "_id": "5x9lfRYKMN2YPSyv",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "xWCdsGSwLLTeX6tQ",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/eagle-eyes-elixir.webp",
             "range": [
-                25,
-                30
+                19,
+                24
             ],
             "text": "Eagle Eye Elixir (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "oLZsd9xeniDUB97N",
+            "_id": "pHSpGfznLxy68SY3",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "04giYigfDL5geu5f",
             "drawn": false,
             "img": "icons/consumables/potions/bottle-conical-corked-blue.webp",
             "range": [
-                31,
-                36
+                25,
+                30
             ],
             "text": "Mistform Elixir (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "zz0eL7k3QNTKNXc3",
+            "_id": "ezWgkbYgnCBecaSg",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Wjkw0lEUOhypYvzo",
+            "documentId": "AeL8qd4hqaNN5MxP",
             "drawn": false,
-            "img": "icons/consumables/potions/bottle-bulb-empty-glass.webp",
+            "img": "icons/consumables/plants/sprout-glowing-roots-green.webp",
             "range": [
-                37,
-                42
+                31,
+                33
             ],
-            "text": "Shadow Essence",
+            "text": "Spirit Bulb",
             "type": "pack",
-            "weight": 6
+            "weight": 3
         },
         {
-            "_id": "lLzSpPUauPOj4sfl",
+            "_id": "7fI1juiV8DSee1pz",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "NRoA1HpA3ElPGBEQ",
             "drawn": false,
             "img": "icons/consumables/drinks/wine-amphora-clay-blue.webp",
             "range": [
-                43,
-                48
+                34,
+                39
             ],
             "text": "Wolfsbane",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "HpyqvpBDM6D2jUC6",
+            "_id": "8grstfxII17gHd1A",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "dzfmP3WsA15puenS",
+            "documentId": null,
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/potions/potion-of-resistance.webp",
+            "img": "systems/pf2e/icons/equipment/consumables/potions/potion-of-cold-resistance.webp",
             "range": [
-                49,
-                54
+                40,
+                45
             ],
             "text": "Potion of Resistance (Moderate)",
-            "type": "pack",
+            "type": "text",
             "weight": 6
         },
         {
-            "_id": "bqsJMu7IB225fTYz",
+            "_id": "HT0fturYFcvaIPTH",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "ewzJzyJ4Vo9lZKvp",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/talismans/iron-medallion.webp",
             "range": [
-                55,
-                60
+                46,
+                51
             ],
             "text": "Iron Medallion",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "kQTbzpAKyDIdb9PY",
+            "_id": "XeEYRL3D5ia9iSlQ",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "UnDjPxFOs6bldlcM",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/talismans/mummified-bat.webp",
             "range": [
-                61,
-                66
+                52,
+                57
             ],
             "text": "Mummified Bat",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "11E6i8082Hr9VbAI",
+            "_id": "Qrk7zDrTR6IsVNOF",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "dBevXop3G2P3PGjp",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/talismans/vanishing-coin.webp",
             "range": [
-                67,
-                72
+                58,
+                63
             ],
             "text": "Vanishing Coin",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "fOVCBMxAUSmiXjqm",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "Wjkw0lEUOhypYvzo",
+            "drawn": false,
+            "img": "icons/consumables/potions/bottle-bulb-empty-glass.webp",
+            "range": [
+                64,
+                69
+            ],
+            "text": "Nethershade",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "dXbJ8TXlUkqZQKgQ",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "Ap2Styg25sZMx3wn",
+            "drawn": false,
+            "img": "icons/commodities/stone/ore-pile-orange.webp",
+            "range": [
+                70,
+                72
+            ],
+            "text": "Mudrock Snare",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "nVE6Afp640l4fTIj",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "j9G3tnrKQ1N1dLzN",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/snares/snagging-hook-snare.webp",
+            "range": [
+                73,
+                78
+            ],
+            "text": "Snagging Hook Snare",
             "type": "pack",
             "weight": 6
         }

--- a/packs/rollable-tables/10th-level-permanent-items.json
+++ b/packs/rollable-tables/10th-level-permanent-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "W0qudblot2Z9Vu86",
-    "description": "Table of 10th-Level Permanent Items",
+    "description": "<p>Table of 10th-Level Permanent Items</p>",
     "displayRoll": true,
-    "formula": "1d198",
+    "formula": "1d261",
     "img": "icons/svg/d20-grey.svg",
     "name": "10th-Level Permanent Items",
     "ownership": {
@@ -11,35 +11,35 @@
     "replacement": true,
     "results": [
         {
-            "_id": "mYq4p5qykRLe1Ok4",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "RUEAV5LMUGFHcXcW",
-            "drawn": false,
-            "img": "icons/equipment/chest/breastplate-gorget-steel-purple.webp",
-            "range": [
-                1,
-                6
-            ],
-            "text": "Breastplate of Command",
-            "type": "pack",
-            "weight": 6
-        },
-        {
             "_id": "QN2b9QvvhEhXYHss",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "8HxM35X8DDt2gw9d",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/armor/specific-magic-armor/electric-eelskin.webp",
             "range": [
-                7,
-                12
+                1,
+                6
             ],
             "text": "Electric Eelskin",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "k455WZW8SCQLXbsv",
+            "_id": "ciGdruxBAmd692cf",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "7jGnVnqFt2gFtU1g",
+            "drawn": false,
+            "img": "icons/equipment/chest/breastplate-layered-leather-blue.webp",
+            "range": [
+                7,
+                12
+            ],
+            "text": "Tideplate",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "oudJeH6hPuEB5bcN",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "eoI3M6FXtcPWeg7i",
             "drawn": false,
@@ -53,49 +53,49 @@
             "weight": 6
         },
         {
-            "_id": "oLZsd9xeniDUB97N",
+            "_id": "aFIfCLc2FSkgZdcC",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "9Y86NM6nt2WtYBOy",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/structures/explorers-yurt.webp",
+            "range": [
+                19,
+                24
+            ],
+            "text": "Explorer's Yurt",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "TA1RJqjKJ7st9zkQ",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "3mprh9aZ670HfNhT",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/held-items/maestros-instrument.webp",
             "range": [
-                19,
-                24
+                25,
+                30
             ],
             "text": "Maestro's Instrument (Moderate)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "zz0eL7k3QNTKNXc3",
+            "_id": "Oxjwf2R7EjJugIno",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "QEPx1fCf74xdpXBH",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/held-items/thurible-of-revelation.webp",
             "range": [
-                25,
-                30
+                31,
+                36
             ],
             "text": "Thurible of Revelation (Moderate)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "lLzSpPUauPOj4sfl",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "RTxne78VqPqTz2VN",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/held-items/wondrous-figurine-golden-lion.webp",
-            "range": [
-                31,
-                36
-            ],
-            "text": "Wondrous Figurine (Golden Lions)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "HpyqvpBDM6D2jUC6",
+            "_id": "acEumOv11DbWXZi0",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "pOoEiuEuITm4I2Il",
             "drawn": false,
@@ -109,7 +109,7 @@
             "weight": 6
         },
         {
-            "_id": "bqsJMu7IB225fTYz",
+            "_id": "Z6B5YbMt9578ex4w",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "bxz885LMjLCkpDq3",
             "drawn": false,
@@ -123,394 +123,548 @@
             "weight": 6
         },
         {
-            "_id": "kQTbzpAKyDIdb9PY",
+            "_id": "78DjSZEVAAHluzkV",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "bvROhtzAez0KP7Vt",
+            "drawn": false,
+            "img": "icons/commodities/treasure/token-runed-os-grey.webp",
+            "range": [
+                49,
+                54
+            ],
+            "text": "Reinforcing Rune (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "7M2HRXJ8PrgOchIt",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "NoTUhKkiTY5BQU5T",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/shields/specific-shields/forge-warden.webp",
             "range": [
-                49,
-                51
+                55,
+                57
             ],
             "text": "Forge Warden",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "11E6i8082Hr9VbAI",
+            "_id": "Ukf4aagqZ6DIR6e1",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "pNQJ9PTOEHxEZCgp",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/shields/specific-shields/sturdy-shield.webp",
             "range": [
-                52,
-                57
+                58,
+                63
             ],
             "text": "Sturdy Shield (Moderate)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "vQq7Hy7Dx1a8GCHZ",
+            "_id": "xxiagrX3dhPsLgTK",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "HRNQ1j2OM54Qakhp",
+            "documentId": "bQynfb23iexSu8zU",
             "drawn": false,
-            "img": "icons/weapons/staves/staff-simple-spiral.webp",
-            "range": [
-                58,
-                63
-            ],
-            "text": "Staff of Protection (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "dwXrm0DZwZ0Vtpyl",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "xQf98bdGgE7UiBe4",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/staves/staff-of-conjuration.webp",
+            "img": "icons/weapons/staves/staff-orb-feather.webp",
             "range": [
                 64,
                 69
-            ],
-            "text": "Staff of Summoning (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "ViMk7CeQzvGeYUrC",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "E63MaprijBuUK9Om",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/staves/staff-of-divination.webp",
-            "range": [
-                70,
-                75
-            ],
-            "text": "Staff of the Unblinking Eye (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "rj2RuyHe7q9qcZ2d",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "ExExv8dJVcCj4rL0",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/staves/staff-of-enchantment.webp",
-            "range": [
-                76,
-                81
-            ],
-            "text": "Staff of Control (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "o3gZ97kIi4lo11BY",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "RCQ4DzDh34ZBiTxI",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/staves/staff-of-evocation.webp",
-            "range": [
-                82,
-                87
-            ],
-            "text": "Staff of Elemental Power (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "OtH5vWwuqo4ICMuF",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "6u14xOkKhnB9lVy0",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/staves/staff-of-illusion.webp",
-            "range": [
-                88,
-                93
-            ],
-            "text": "Staff of Phantasms (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "TbqN7piUhgo0OfAf",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Ab5EjJyoRSec5YrW",
-            "drawn": false,
-            "img": "icons/weapons/staves/staff-skull-feathers-brown.webp",
-            "range": [
-                94,
-                99
-            ],
-            "text": "Staff of the Dead (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "l9CD8GKGvhWX8hAA",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "YxLC2Np7cEBnZzGX",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/staves/staff-of-transmutation.webp",
-            "range": [
-                100,
-                105
             ],
             "text": "Fluid Form Staff (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "t5t1wLQE2o2FC0iI",
+            "_id": "Vx1WAKaF4qykmyI8",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "9Y86NM6nt2WtYBOy",
+            "documentId": "d5dnhOf5RHFFnsiB",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/structures/explorers-yurt.webp",
+            "img": "systems/pf2e/icons/equipment/staves/staff-of-enchantment.webp",
             "range": [
-                106,
-                111
+                70,
+                75
             ],
-            "text": "Explorer's Yurt",
+            "text": "Staff of Control (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "SaGLwztjSNglsrzf",
+            "_id": "jFLF0aEoRJ4EOGjS",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "nvSZioRW4J1sMtO7",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/staves/staff-of-evocation.webp",
+            "range": [
+                76,
+                81
+            ],
+            "text": "Staff of Elemental Power (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "K9dZso61oYAVCvZ2",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "Svq02kCaFadVPOSq",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/staves/staff-of-illusion.webp",
+            "range": [
+                82,
+                87
+            ],
+            "text": "Staff of Phantasms (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "g6UiUyT6aJrFwBq9",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "XE8AxkahYPVzeLCW",
+            "drawn": false,
+            "img": "icons/weapons/staves/staff-engraved-wood.webp",
+            "range": [
+                88,
+                93
+            ],
+            "text": "Staff of Protection (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "rrJCuFu7rOlzBqNU",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "GeAz02cQMU4X9nYp",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/staves/staff-of-conjuration.webp",
+            "range": [
+                94,
+                99
+            ],
+            "text": "Staff of Summoning (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "kBKOSJJOthXUTf0h",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "Ab5EjJyoRSec5YrW",
+            "drawn": false,
+            "img": "icons/weapons/staves/staff-skull-feathers-brown.webp",
+            "range": [
+                100,
+                105
+            ],
+            "text": "Staff of the Dead (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "881hg9ckAmdGzlia",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "jUL4ZdztH8VODBuv",
+            "drawn": false,
+            "img": "icons/weapons/staves/staff-ornate-eye.webp",
+            "range": [
+                106,
+                108
+            ],
+            "text": "Staff of the Unblinking Eye (Greater)",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "cXQCxtF4sQ6gvLnJ",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "zYRzgETeR1Hs1ti1",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-widening.webp",
             "range": [
-                112,
-                117
+                109,
+                114
             ],
             "text": "Wand of Widening (4th-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "vHNOIhldCiAlVI37",
-            "documentCollection": "",
+            "_id": "G6QovZFdg6g38tvN",
+            "documentCollection": "pf2e.equipment-srd",
             "documentId": null,
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "systems/pf2e/icons/equipment/weapons/shortsword.webp",
             "range": [
-                118,
-                123
+                115,
+                120
             ],
-            "text": "Magic Weapon (+2 Striking)",
+            "text": "Striking Weapon (+2)",
             "type": "text",
             "weight": 6
         },
         {
-            "_id": "wDGaxAN4F6RLlPZV",
-            "documentCollection": "",
+            "_id": "PzAMwmwHTMf10pQQ",
+            "documentCollection": "pf2e.equipment-srd",
             "documentId": null,
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "systems/pf2e/icons/equipment/weapons/shortsword.webp",
             "range": [
-                124,
-                129
+                121,
+                126
             ],
             "text": "Cold Iron Weapon (Standard-Grade)",
             "type": "text",
             "weight": 6
         },
         {
-            "_id": "S0kG1NmHVtkY2ZNf",
-            "documentCollection": "",
+            "_id": "wWUp1qvdIJxBLhep",
+            "documentCollection": "pf2e.equipment-srd",
             "documentId": null,
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "systems/pf2e/icons/equipment/weapons/shortsword.webp",
             "range": [
-                130,
-                135
+                127,
+                132
             ],
             "text": "Silver Weapon (Standard-Grade)",
             "type": "text",
             "weight": 6
         },
         {
-            "_id": "ND9f91U4mIQQpsxt",
-            "documentCollection": "",
+            "_id": "cNuhT4AiHOdOV64F",
+            "documentCollection": "pf2e.equipment-srd",
             "documentId": null,
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "icons/equipment/hand/gauntlet-simple-leather-brown-gold.webp",
             "range": [
-                136,
-                141
+                133,
+                138
             ],
-            "text": "+2 striking Handwraps of Mighty Blows",
+            "text": "Striking Handwraps of Mighty Blows (+2)",
             "type": "text",
             "weight": 6
         },
         {
-            "_id": "51ULgg4Z2gGAZbMm",
+            "_id": "Z9nv6izcPtN4I0ei",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "D8VKhm7rSBozJkMN",
+            "drawn": false,
+            "img": "icons/equipment/chest/robe-collared-blue.webp",
+            "range": [
+                139,
+                144
+            ],
+            "text": "Accolade Robe",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "fUpdqbv3ZKaRcD5L",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "uiJAR3jQbQHhiP3Q",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/cape-of-the-mountebank.webp",
             "range": [
-                142,
-                144
+                145,
+                147
             ],
             "text": "Charlatan's Cape",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "WGS4NVKgvBlbRbTe",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "br4eClrcGeLTL6Ba",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/choker-of-elocution.webp",
-            "range": [
-                145,
-                150
-            ],
-            "text": "Choker of Elocution (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "7Z6tn2kUuYj3hLx2",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "6jRXUXzYKIpm2uNp",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/clandestine-cloak.webp",
-            "range": [
-                151,
-                153
-            ],
-            "text": "Clandestine Cloak (Greater)",
-            "type": "pack",
-            "weight": 3
-        },
-        {
-            "_id": "STcQUllJfx9jubmn",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "dipcMOtBFxtmsjkS",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/cloak-of-the-bat.webp",
-            "range": [
-                154,
-                159
-            ],
-            "text": "Cloak of the Bat",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "9V0wkAcLvloWJuB2",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "mmdnWrQsh7vDspLK",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/daredevil-boots.webp",
-            "range": [
-                160,
-                165
-            ],
-            "text": "Daredevil Boots",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "1I1aKyDFUhl3sgcR",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "shKPtYN0YUOe07K2",
-            "drawn": false,
-            "img": "icons/equipment/head/mask-horned-brown.webp",
-            "range": [
-                166,
-                171
-            ],
-            "text": "Demon Mask (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "UvP7whKlzWpyF6YX",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "hvlEFx25ogf1K1C2",
-            "drawn": false,
-            "img": "icons/equipment/back/mantle-collared-green.webp",
-            "range": [
-                172,
-                177
-            ],
-            "text": "Living Mantle",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "PNVHDBdtL0VUAY66",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "cBKrXbxM02MlycpV",
-            "drawn": false,
-            "img": "icons/equipment/finger/ring-cabochon-silver-gold-green.webp",
-            "range": [
-                178,
-                180
-            ],
-            "text": "Ring of Counterspells",
-            "type": "pack",
-            "weight": 3
-        },
-        {
-            "_id": "LStiXIuZbUODq3Sv",
+            "_id": "MBRWXABrKJ6CPIdR",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "X3Nfa7bByYFrg1lU",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/ring-of-energy-resistance.webp",
+            "img": "icons/equipment/neck/amulet-round-engraved-spiral-gold.webp",
             "range": [
-                181,
-                186
+                148,
+                153
             ],
             "text": "Charm of Resistance (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "Zz0g5cgA1H086yPC",
+            "_id": "MrY2fq5aNm2PqjkL",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "br4eClrcGeLTL6Ba",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/choker-of-elocution.webp",
+            "range": [
+                154,
+                159
+            ],
+            "text": "Choker of Elocution (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "ninWfWwGfOy7w3i2",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "6jRXUXzYKIpm2uNp",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/clandestine-cloak.webp",
+            "range": [
+                160,
+                162
+            ],
+            "text": "Clandestine Cloak (Greater)",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "JkR1RZAMyd9YRedy",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "4v8FIJSPaJUbccLz",
+            "drawn": false,
+            "img": "icons/equipment/finger/ring-crown-gold-pink.webp",
+            "range": [
+                163,
+                168
+            ],
+            "text": "Crown of Witchcraft",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "qzCUiWHBlPFP8RmW",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "mmdnWrQsh7vDspLK",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/daredevil-boots.webp",
+            "range": [
+                169,
+                174
+            ],
+            "text": "Daredevil Boots",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "DOtIN50dWN91TvRP",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "shKPtYN0YUOe07K2",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/demon-mask.webp",
+            "range": [
+                175,
+                180
+            ],
+            "text": "Demon Mask (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "cMWGMvMtBkAnUlrN",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "IM9W5fovv44ZKDRQ",
+            "drawn": false,
+            "img": "icons/equipment/neck/choker-rounded-gold-green.webp",
+            "range": [
+                181,
+                186
+            ],
+            "text": "Entertainer's Cincture",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "ek9burQBg1GBJBJv",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "hvlEFx25ogf1K1C2",
+            "drawn": false,
+            "img": "icons/equipment/back/mantle-collared-green.webp",
+            "range": [
+                187,
+                192
+            ],
+            "text": "Living Mantle",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "TeURcsi5zD1vp63j",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "OTeONq4r10Xm6gSy",
             "drawn": false,
             "img": "icons/equipment/finger/ring-band-engraved-scrolls-silver.webp",
             "range": [
-                187,
-                189
+                193,
+                195
             ],
             "text": "Ring of Lies",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "RMjFs8UpifF2ce9E",
+            "_id": "c5hpg9ZsflwhJvA5",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "2tSDgHfSkkaX4CA4",
+            "documentId": "1T1TJB929nC7wBtC",
             "drawn": false,
-            "img": "icons/equipment/finger/ring-band-engraved-silver.webp",
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/shadow-signet.webp",
             "range": [
-                190,
-                192
+                196,
+                201
             ],
-            "text": "Ring of Wizardry (Type II)",
+            "text": "Shadow Signet",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "faSGBSJSHLbN1A8V",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "Wtm4JdxeTLQi3zQI",
+            "drawn": false,
+            "img": "icons/commodities/treasure/broach-eye-silver-teal.webp",
+            "range": [
+                202,
+                204
+            ],
+            "text": "Symbol of Conflict (Greater)",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "ae2DsfA6PVx9MojG",
+            "_id": "eEC4apvPqTlttK9H",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "aKoMqPDmVzPI7Q20",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/winged-boots.webp",
             "range": [
-                193,
-                198
+                205,
+                210
             ],
             "text": "Winged Sandals",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "9v8CIPH9aduJeDbX",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "RUEAV5LMUGFHcXcW",
+            "drawn": false,
+            "img": "icons/equipment/chest/breastplate-gorget-steel-purple.webp",
+            "range": [
+                211,
+                216
+            ],
+            "text": "Warleader's Bulwark",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "ASA2rQI0Lnog6KaE",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "T1L6XbgMqJLDv2Pi",
+            "drawn": false,
+            "img": "icons/weapons/staves/staff-ornate-eye.webp",
+            "range": [
+                217,
+                222
+            ],
+            "text": "Staff of Providence (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "AcLAETcNIQzMgcE0",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "8Ia2jOo23XoArpJm",
+            "drawn": false,
+            "img": "icons/weapons/staves/staff-simple-wrapped.webp",
+            "range": [
+                223,
+                228
+            ],
+            "text": "Staff of the Tempest (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "dkJ0Cn4gTboOwuXt",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/wands/magic-wands/magic-wand.webp",
+            "range": [
+                229,
+                234
+            ],
+            "text": "Wand of Crackling Lighting 4th-Rank",
+            "type": "text",
+            "weight": 6
+        },
+        {
+            "_id": "VAUzL6OL2gaoMpDN",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "9ftc8XfloerPcJnI",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-hopeless-night.webp",
+            "range": [
+                235,
+                240
+            ],
+            "text": "Wand of Hopeless Night (4th-Rank Spell)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "mXnjYmaWFmAPEP0Y",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "64mxKuxc9k98FkUi",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/fire-jump-ring.webp",
+            "range": [
+                241,
+                243
+            ],
+            "text": "Fire-Jump Ring",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "TJVa9XMnkRtQz8GM",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "7wuDdrF6HKPXyxqj",
+            "drawn": false,
+            "img": "icons/equipment/head/hood-purple-mask.webp",
+            "range": [
+                244,
+                249
+            ],
+            "text": "Prognostic Veil",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "lyaawPbciwLeP0VL",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "xyTF5YznEskKIXpp",
+            "drawn": false,
+            "img": "icons/equipment/neck/pendant-faceted-red.webp",
+            "range": [
+                250,
+                255
+            ],
+            "text": "Sanguine Pendant",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "bLCXzSc33Ru4q5As",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "Rr7dAVnfpnnQPAWh",
+            "drawn": false,
+            "img": "icons/equipment/waist/sash-cloth-green-white.webp",
+            "range": [
+                256,
+                261
+            ],
+            "text": "Sash of Prowess",
             "type": "pack",
             "weight": 6
         }


### PR DESCRIPTION
Update 10th-Level Consumable Items and 10th-Level Permanent Items tables with remaster changes, consolidating the treasure tables from the GM Core and Player Core 2 books, preserving the item order found in those tables. Weight is based on rarity:

- Common = 6
- Uncommon = 3
- Rare = 1

For items that do not have a corresponding entry in the compendium, create a text entry in the table with the appropriate item name. If possible, set an appropriate icon from the system's icon set.