### PR TITLE
Fix /act enricher regex to prevent catastrophic backtracking

### DIFF
--- a/src/scripts/hooks/init.ts
+++ b/src/scripts/hooks/init.ts
@@ -143,7 +143,7 @@ export const Init = {
             });
 
             CONFIG.TextEditor.enrichers.push({
-                pattern: /\[\[\/(act) (?<slug>[-a-z]+)(\s+)?(?<options>[^\]]+)*]](?:{(?<label>[^}]+)})?/g,
+                pattern: /\[\[\/(act)\s+(?<slug>[-a-z]+)\s*(?<options>[^\]]+)?\]\](?:{(?<label>[^}]+)})?/g,
                 enricher: (match, options) => game.pf2e.TextEditor.enrichString(match, options),
             });
 

--- a/src/scripts/hooks/init.ts
+++ b/src/scripts/hooks/init.ts
@@ -143,7 +143,7 @@ export const Init = {
             });
 
             CONFIG.TextEditor.enrichers.push({
-                pattern: /\[\[\/(act)\s+(?<slug>[-a-z]+)\s*(?<options>[^\]]+)?\]\](?:{(?<label>[^}]+)})?/g,
+                pattern: /\[\[\/(act)\s+(?<slug>[-a-z]+)(?:\s+(?<options>[^\]]+))?\]\](?:{(?<label>[^}]+)})?/g,
                 enricher: (match, options) => game.pf2e.TextEditor.enrichString(match, options),
             });
 


### PR DESCRIPTION
Should resolve https://github.com/foundryvtt/pf2e/issues/17111
Also requires whitespace between slug and options.
Can add a check for a trailing whitespace after the slug, but I don't think it's necessary.