### PR TITLE
Add resource consumption support to daily prep crafting

### DIFF
--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -1896,7 +1896,7 @@ interface CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocument
     readonly _source: CharacterSource;
     system: CharacterSystemData;
 
-    getResource(resource: "hero-points" | "mythic-points" | "focus" | "investiture"): ResourceData;
+    getResource(resource: "hero-points" | "mythic-points" | "focus" | "investiture" | "infused-reagents"): ResourceData;
     getResource(resource: string): ResourceData | null;
 }
 

--- a/src/module/actor/creature/document.ts
+++ b/src/module/actor/creature/document.ts
@@ -634,6 +634,17 @@ abstract class CreaturePF2e<
     getResource(resource: string): ResourceData | null {
         const slug = sluggify(resource);
         const key = sluggify(resource, { camel: "dromedary" });
+
+        // Temporary compatibility hack until the big migration
+        if (slug === "infused-reagents" && this.isOfType("character")) {
+            const data = this.system.resources.crafting.infusedReagents;
+            return {
+                ...data,
+                slug,
+                label: "PF2E.CraftingTab.Alchemical.InfusedReagents",
+            };
+        }
+
         const data = this.system.resources[key];
         if (!data) return null;
 
@@ -651,6 +662,13 @@ abstract class CreaturePF2e<
         const slug = sluggify(resource);
         const key = sluggify(resource, { camel: "dromedary" });
         if (key === "investiture") return;
+
+        // Temporary compatibility hack until the big migration
+        if (slug === "infused-reagents" && this.isOfType("character")) {
+            value = Math.clamp(value, 0, this.system.resources.crafting.infusedReagents.max);
+            await this.update({ [`system.resources.crafting.infusedReagents.value`]: value });
+            return;
+        }
 
         const resources = this.system.resources;
         const special = this.synthetics.resources[key];

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -219,6 +219,7 @@
                         },
                         "Perform": "Perform Daily Crafting"
                     },
+                    "MissingResource": "Insufficient resources to complete crafting.",
                     "RemainingSlots": "Empty Slot ({remaining} remaining)"
                 },
                 "CreateFeat": "Create Feat",
@@ -1128,8 +1129,7 @@
                 "FormulaExpended": "Prepared formula has already been crafted.",
                 "ItemMissingTraits": "Item is not compatible with crafting entry item requirements.",
                 "MaxItemLevel": "Item level exceeds maximum item level {level}.",
-                "MaxSlots": "Crafting entry's allowed slots are full.",
-                "MissingReagents": "Insufficient infused reagents to complete crafting."
+                "MaxSlots": "Crafting entry's allowed slots are full."
             },
             "CraftQuantityTitle": "Quantity",
             "ExpendFormula": "Expend Formula",

--- a/static/templates/actors/character/tabs/crafting.hbs
+++ b/static/templates/actors/character/tabs/crafting.hbs
@@ -20,27 +20,7 @@
             <li class="crafting-entry item-container" data-container-type="craftingEntryGroup">
                 <div class="action-header">{{localize "PF2E.CraftingTab.Alchemical.AdvancedAlchemy"}}</div>
                 <ol class="directory-list item-list formula-list">
-                    <li class="formula-level-header formula-header infused-reagents">
-                        <div class="level-name reagent-cost">
-                            <h3>{{localize "PF2E.CraftingTab.Alchemical.TotalCost"}}:</h3>
-                            <div class="formula-number">{{crafting.abilities.alchemical.totalReagentCost}}</div>
-                        </div>
-
-                        <div class="level-name reagent-resource">
-                            <h3>{{localize "PF2E.CraftingTab.Alchemical.InfusedReagents"}}:</h3>
-                            <input
-                                class="formula-number"
-                                type="number"
-                                name="system.resources.crafting.infusedReagents.value"
-                                value="{{crafting.abilities.alchemical.infusedReagents.value}}"
-                                placeholder="0"
-                            />
-                            <h3>/</h3>
-                            <div class="formula-number">
-                                {{crafting.abilities.alchemical.infusedReagents.max}}
-                            </div>
-                        </div>
-                    </li>
+                    {{> resourceRow resource=crafting.abilities.alchemical.resource resourceCost=crafting.abilities.alchemical.resourceCost}}
                     {{#each crafting.abilities.alchemical.entries as |ability|}}
                         <li class="crafting-entry item-container alchemical-entry" data-container-type="craftingEntry" data-ability="{{ability.slug}}">
                             <div class="action-header alchemical-title">{{ability.label}}</div>
@@ -49,7 +29,7 @@
                                 <li class="formula-level-header formula-header">
                                     <div class="level-name reagent-cost">
                                         <h3>{{localize "PF2E.CraftingTab.Alchemical.ReagentCost"}}:</h3>
-                                        <span class="formula-number">{{ability.reagentCost}}</span>
+                                        <span class="formula-number">{{ability.resourceCost}}</span>
                                     </div>
 
                                     <div class="level-name aa-level">
@@ -79,12 +59,19 @@
                     <span class="level">{{localize "PF2E.LevelN" level=ability.maxItemLevel}}</span>
                 </div>
                 <ol class="directory-list item-list formula-list">
+                    {{#if ability.resource}}
+                        {{> resourceRow resource=ability.resource resourceCost=ability.resourceCost}}
+                    {{/if}}
                     {{#each ability.prepared as |formula|}}
                         {{> preparedFormula ability=ability formula=formula}}
                     {{/each}}
                     {{#if remainingSlots}}
                         <li class="formula-item empty">
                             {{localize "PF2E.Actor.Character.Crafting.RemainingSlots" remaining=remainingSlots}}
+                        </li>
+                    {{else if (and ability.resource (not ability.prepared.length))}}
+                        <li class="formula-header empty">
+                            <h4>{{localize "PF2E.FormulaListEmpty"}}</h4>
                         </li>
                     {{/if}}
                 </ol>
@@ -175,6 +162,31 @@
     </ol>
 </div>
 
+{{#*inline "resourceRow"}}
+    <li class="formula-level-header formula-header infused-reagents">
+        <div class="level-name reagent-cost">
+            <h3>{{localize "PF2E.CraftingTab.Alchemical.TotalCost"}}:</h3>
+            <div class="formula-number">{{resourceCost}}</div>
+        </div>
+
+        <div class="level-name reagent-resource">
+            <h3>{{localize resource.label}}:</h3>
+            <input
+                class="formula-number"
+                type="number"
+                data-action="adjust-resource"
+                data-resource="{{resource.slug}}"
+                value="{{resource.value}}"
+                placeholder="0"
+            />
+            <h3>/</h3>
+            <div class="formula-number">
+                {{resource.max}}
+            </div>
+        </div>
+    </li>
+{{/inline}}
+
 {{#*inline "preparedFormula"}}
     <li
         class="item formula-item"
@@ -195,7 +207,7 @@
         <div class="dc"></div>
         <div class="cost"></div>
         <div class="quantity">
-            {{#if ability.isAlchemical}}
+            {{#if ability.resource}}
                 <a class="adjust decrease" data-action="decrease-craft-quantity">&ndash;</a>
                 <input type="number" class="formula-number" data-craft-quantity value="{{formula.quantity}}" />
                 <a class="adjust increase" data-action="increase-craft-quantity">+</a>


### PR DESCRIPTION
There is some temporary hackery for rerouting the infused reagents resource. We can kill that later once the data is migrated.