### PR TITLE
Update 11th-level rollable tables

### DIFF
--- a/packs/rollable-tables/11th-level-consumables-items.json
+++ b/packs/rollable-tables/11th-level-consumables-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "Ca7vD8PZtMPqVuHu",
-    "description": "Table of 11th-Level Consumables Items",
+    "description": "<p>Table of 11th-Level Consumables Items</p>",
     "displayRoll": true,
-    "formula": "1d105",
+    "formula": "1d144",
     "img": "icons/svg/d20-grey.svg",
     "name": "11th-Level Consumables Items",
     "ownership": {
@@ -53,214 +53,312 @@
             "weight": 6
         },
         {
-            "_id": "aPbhuQl16Dn83HR8",
+            "_id": "v0bTFq1jcvwtGV0k",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "r2iTRbt1zpkAqHj2",
+            "documentId": "kpJmjm843vaMZjIu",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/bottled-lightning.webp",
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/dread-ampoule.webp",
             "range": [
                 19,
                 24
             ],
-            "text": "Bottled Lightning (Greater)",
+            "text": "Dread Ampoule (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "3EqXFbXhBaS3HemC",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "intVPcEzbE9o4NQd",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/frost-vial.webp",
-            "range": [
-                25,
-                30
-            ],
-            "text": "Frost Vial (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "zz0eL7k3QNTKNXc3",
+            "_id": "6rMeSvg0aNWzfhjV",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "5Qkz4RVJr2Kx3RL6",
             "drawn": false,
             "img": "icons/containers/bags/sack-simple-leather-tan.webp",
             "range": [
-                31,
-                36
+                25,
+                30
             ],
-            "text": "Tanglefoot Bag (Greater)",
+            "text": "Glue Bomb (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "lLzSpPUauPOj4sfl",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "dsMkvuLgpOOGLWDy",
-            "drawn": false,
-            "img": "icons/commodities/gems/pearl-rough-turquoise.webp",
-            "range": [
-                37,
-                42
-            ],
-            "text": "Thunderstone (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "HpyqvpBDM6D2jUC6",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "gDheph8YteBtnyKp",
-            "drawn": false,
-            "img": "icons/consumables/potions/bottle-round-flask-fumes-purple.webp",
-            "range": [
-                43,
-                48
-            ],
-            "text": "Bestial Mutagen (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "bqsJMu7IB225fTYz",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "ZGojRKG1yYiVWemR",
-            "drawn": false,
-            "img": "icons/consumables/potions/potion-vial-corked-purple.webp",
-            "range": [
-                49,
-                54
-            ],
-            "text": "Cognitive Mutagen (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "kQTbzpAKyDIdb9PY",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "TMtQnY6yvIRCpK9v",
-            "drawn": false,
-            "img": "icons/consumables/potions/bottle-round-corked-green.webp",
-            "range": [
-                55,
-                60
-            ],
-            "text": "Juggernaut Mutagen (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "11E6i8082Hr9VbAI",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "eQDTsetadI8u8Kc0",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/quicksilver-mutagen.webp",
-            "range": [
-                61,
-                66
-            ],
-            "text": "Quicksilver Mutagen (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "6kQzn5rLnCNXBS9Q",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Yej7lnnDYDZybGqo",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/serene-mutagen.webp",
-            "range": [
-                67,
-                72
-            ],
-            "text": "Serene Mutagen (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "VGGQXPWdzG59Nm30",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "uggpIk6vguWFXVli",
-            "drawn": false,
-            "img": "icons/consumables/potions/potion-bottle-corked-fancy-blue.webp",
-            "range": [
-                73,
-                78
-            ],
-            "text": "Silvertongue Mutagen (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "nTEs6YU02ad96T98",
+            "_id": "LY8P7UhykoFQAOKV",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "1DHjXJEdJ7GlGSzg",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/oils/oil-of-keen-edges.webp",
             "range": [
-                79,
-                81
+                31,
+                33
             ],
             "text": "Oil of Keen Edges",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "lPrbQ84yWjWIgUxi",
+            "_id": "QumC9Hmab8jLFaxZ",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "IZRfgOYlZ3HRBkYX",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/oils/oil-of-repulsion.webp",
             "range": [
-                82,
-                87
+                34,
+                39
             ],
             "text": "Oil of Repulsion",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "2lOvcOhgIjutlg6N",
+            "_id": "rwDzq4FYERZXM2it",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "X1KGaXLDUxNJ1XXB",
+            "drawn": false,
+            "img": "icons/magic/fire/barrier-shield-explosion-yellow.webp",
+            "range": [
+                40,
+                45
+            ],
+            "text": "Frozen Lava of Mhar Massif",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "3hhP8PvTvcOGg2lZ",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "Cc4SokzVBoBCkHId",
             "drawn": false,
             "img": "icons/commodities/stone/geode-raw-teal.webp",
             "range": [
-                88,
-                93
+                46,
+                51
             ],
             "text": "Blightburn Resin",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "UgTNCT92Sg8Bz3LO",
+            "_id": "lXhQ5JeMioytLBkz",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "OMJgFmy3jut79Iaj",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/potions/potion-of-swimming.webp",
             "range": [
-                94,
-                99
+                52,
+                57
             ],
             "text": "Potion of Swimming (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "K9q0NL8Xd4NGji43",
+            "_id": "grvmGy33sm8IIDUi",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "4sGIy77COooxhQuC",
             "drawn": false,
             "img": "icons/sundries/scrolls/scroll-symbol-eye-brown.webp",
             "range": [
+                58,
+                63
+            ],
+            "text": "Scroll of 6th-rank Spell",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "s9sCYDIBHQKaZJwQ",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "lbr6acClmnMmB7QZ",
+            "drawn": false,
+            "img": "icons/commodities/bones/skull-hollow-worn-white.webp",
+            "range": [
+                64,
+                69
+            ],
+            "text": "Grim Trophy (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "5vjpBwQYwxZMOcA3",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "dsMkvuLgpOOGLWDy",
+            "drawn": false,
+            "img": "icons/commodities/gems/pearl-rough-turquoise.webp",
+            "range": [
+                70,
+                75
+            ],
+            "text": "Blasting Stone (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "wGEUGC8CkKkoKfkO",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "LhMXIGelSrFPYild",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/blight-bomb.webp",
+            "range": [
+                76,
+                81
+            ],
+            "text": "Blight Bomb (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "YBSohXVZbxyrq68v",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "r2iTRbt1zpkAqHj2",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/bottled-lightning.webp",
+            "range": [
+                82,
+                87
+            ],
+            "text": "Bottled Lightning (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "AyG6zvcuApVtOyue",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "intVPcEzbE9o4NQd",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/frost-vial.webp",
+            "range": [
+                88,
+                93
+            ],
+            "text": "Frost Vial (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "u0yZvoxl4YCa0Kaz",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "28osNZINXLWzqzUL",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/ghost-charge.webp",
+            "range": [
+                94,
+                99
+            ],
+            "text": "Ghost Charge (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "gykFsnOrGhSUkILf",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "gDheph8YteBtnyKp",
+            "drawn": false,
+            "img": "icons/consumables/potions/bottle-round-flask-fumes-purple.webp",
+            "range": [
                 100,
                 105
             ],
-            "text": "Scroll of 6th-level Spell",
+            "text": "Bestial Mutagen (Greater)",
             "type": "pack",
             "weight": 6
+        },
+        {
+            "_id": "ndCw8VDyidPK0qIN",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "ZGojRKG1yYiVWemR",
+            "drawn": false,
+            "img": "icons/consumables/potions/potion-vial-corked-purple.webp",
+            "range": [
+                106,
+                111
+            ],
+            "text": "Cognitive Mutagen (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "X51yXvVj23NI8ebc",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "WuzLBK78DgIt8SsN",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/drakeheart-mutagen.webp",
+            "range": [
+                112,
+                117
+            ],
+            "text": "Drakeheart Mutagen (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "pipOVFZlbGb3sn0S",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "TMtQnY6yvIRCpK9v",
+            "drawn": false,
+            "img": "icons/consumables/potions/bottle-metal-yellow-gray.webp",
+            "range": [
+                118,
+                123
+            ],
+            "text": "Juggernaut Mutagen (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "CbQjlNgKbZPtDhUo",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "eQDTsetadI8u8Kc0",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/quicksilver-mutagen.webp",
+            "range": [
+                124,
+                129
+            ],
+            "text": "Quicksilver Mutagen (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "kH8yqiaUhCZPsjxe",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "Yej7lnnDYDZybGqo",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/serene-mutagen.webp",
+            "range": [
+                130,
+                135
+            ],
+            "text": "Serene Mutagen (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "XEk4ewnVTo1GlBDP",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "uggpIk6vguWFXVli",
+            "drawn": false,
+            "img": "icons/consumables/potions/potion-bottle-corked-fancy-blue.webp",
+            "range": [
+                136,
+                141
+            ],
+            "text": "Silvertongue Mutagen (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "XbLA1XSzMv9b2Bed",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "ThX0ntpTqonGqguT",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/potions/potion-of-disguise.webp",
+            "range": [
+                142,
+                144
+            ],
+            "text": "Potion of Disguise (Greater)",
+            "type": "pack",
+            "weight": 3
         }
     ]
 }

--- a/packs/rollable-tables/11th-level-permanent-items.json
+++ b/packs/rollable-tables/11th-level-permanent-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "ood552HB1onSdJFS",
-    "description": "Table of 11th-Level Permanent Items",
+    "description": "<p>Table of 11th-Level Permanent Items</p>",
     "displayRoll": true,
-    "formula": "1d148",
+    "formula": "1d165",
     "img": "icons/svg/d20-grey.svg",
     "name": "11th-Level Permanent Items",
     "ownership": {
@@ -13,7 +13,7 @@
         {
             "_id": "mYq4p5qykRLe1Ok4",
             "documentCollection": "",
-            "documentId": "eoQRjG2RjppnbYGL",
+            "documentId": null,
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/artifacts/eye-of-the-wise.webp",
             "range": [
@@ -27,9 +27,9 @@
         {
             "_id": "QN2b9QvvhEhXYHss",
             "documentCollection": "",
-            "documentId": "EIBmADRICTyYzxik",
+            "documentId": null,
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/cursed-items/bag-of-devouring.webp",
+            "img": "systems/pf2e/icons/equipment/armor/breastplate.webp",
             "range": [
                 7,
                 12
@@ -41,9 +41,9 @@
         {
             "_id": "k455WZW8SCQLXbsv",
             "documentCollection": "",
-            "documentId": "JBMBaN9dZLytfFLQ",
+            "documentId": null,
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/held-items/bag-of-holding.webp",
+            "img": "systems/pf2e/icons/equipment/armor/breastplate.webp",
             "range": [
                 13,
                 18
@@ -53,350 +53,378 @@
             "weight": 6
         },
         {
-            "_id": "aPbhuQl16Dn83HR8",
+            "_id": "gPdqoWdpR9cVtgRx",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "jkb2WNby4mjcYqq9",
+            "documentId": "YguYZuHT6k1jVBvy",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/held-items/bag-of-holding.webp",
+            "img": "icons/magic/earth/explosion-lava-orange.webp",
             "range": [
                 19,
                 24
             ],
-            "text": "Bag of Holding (Type III)",
+            "text": "Eternal Eruption of Mhar Massif",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "3EqXFbXhBaS3HemC",
+            "_id": "XrpvCyILgxm4XBmi",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "OHs7L8CJMdp2UV0P",
+            "documentId": "xdPU7qrl5hIvaArY",
             "drawn": false,
-            "img": "icons/equipment/neck/necklace-runed-white-red.webp",
+            "img": "icons/commodities/treasure/horn-spiral-pink.webp",
             "range": [
                 25,
-                27
+                30
             ],
-            "text": "Holy Prayer Beads (Greater)",
+            "text": "Horn of Exorcism",
             "type": "pack",
-            "weight": 3
+            "weight": 6
         },
         {
-            "_id": "lLzSpPUauPOj4sfl",
+            "_id": "4WueoyeSPxdxmr65",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "AFE073UYI0mkWuUs",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/held-items/skeleton-key.webp",
             "range": [
-                28,
-                33
+                31,
+                36
             ],
             "text": "Skeleton Key (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "HpyqvpBDM6D2jUC6",
+            "_id": "nVfZeUZWBd0VJYQ6",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "jkb2WNby4mjcYqq9",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/held-items/bag-of-holding.webp",
+            "range": [
+                37,
+                42
+            ],
+            "text": "Spacious Pouch (Type III)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "bCTFosBrue8lbQLJ",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "4Hb8tvvWFtykbZhG",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/fundamental-armor-runes/armor-potency.webp",
             "range": [
-                34,
-                39
+                43,
+                48
             ],
             "text": "Armor Potency (+2)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "bqsJMu7IB225fTYz",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "65YL6nk1jIzCWutt",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
-            "range": [
-                40,
-                45
-            ],
-            "text": "Anarchic",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "xkxbqKf3zQN0HjG2",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "6xu6dPIaUZ7edKEB",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
-            "range": [
-                46,
-                51
-            ],
-            "text": "Axiomatic",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "kQTbzpAKyDIdb9PY",
+            "_id": "Uxy6FpBgltVS9ctz",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "DH0kB9Wbr5pDeunX",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
             "range": [
-                52,
-                57
+                49,
+                54
             ],
             "text": "Holy",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "11E6i8082Hr9VbAI",
+            "_id": "Md69l7WC4JgqC0XU",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "fumxKes1z2hLN2U7",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/armor-property-runes/armor-property-runes.webp",
+            "range": [
+                55,
+                60
+            ],
+            "text": "Ready (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "tO6Xg54WCfxspfIO",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "gmMrJREf4JSHd2dZ",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
             "range": [
-                58,
-                63
+                61,
+                66
             ],
             "text": "Unholy",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "vQq7Hy7Dx1a8GCHZ",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "9ZGkQo739t9utj37",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/shields/specific-shields/arrow-catching-shield.webp",
-            "range": [
-                64,
-                69
-            ],
-            "text": "Arrow-Catching Shield",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "dwXrm0DZwZ0Vtpyl",
+            "_id": "lruzObO0jdCpA4SG",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "ydNocKN6afzIyVh6",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/shields/specific-shields/floating-shield.webp",
             "range": [
-                70,
-                72
+                67,
+                69
             ],
             "text": "Floating Shield",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "ViMk7CeQzvGeYUrC",
+            "_id": "4DFIkmV9bIQokVd2",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "kHLvz8icxAW9EAIj",
+            "drawn": false,
+            "img": "icons/equipment/shield/heater-stone-orange.webp",
+            "range": [
+                70,
+                75
+            ],
+            "text": "Lodestone Shield",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "hI2ZOFXgDhi6Vv97",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "5BF7zMnrPYzyigCs",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/magic-wands/magic-wand.webp",
             "range": [
-                73,
-                78
+                76,
+                81
             ],
             "text": "Magic Wand (5th-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "rj2RuyHe7q9qcZ2d",
+            "_id": "iVmhWPBaxncvSEvy",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "bCsdAkffuk29ssUg",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-continuation.webp",
             "range": [
-                79,
-                84
+                82,
+                87
             ],
             "text": "Wand of Continuation (4th-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "o3gZ97kIi4lo11BY",
-            "documentCollection": "",
-            "documentId": "bheWnrBqMphBRUmn",
+            "_id": "Z3wgvAAF6SpPFbsT",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
             "drawn": false,
-            "img": "icons/weapons/bows/longbow-gold-pink.webp",
-            "range": [
-                85,
-                87
-            ],
-            "text": "Adamantine Weapon, Standard Grade",
-            "type": "text",
-            "weight": 3
-        },
-        {
-            "_id": "OtH5vWwuqo4ICMuF",
-            "documentCollection": "",
-            "documentId": "tE2IarA29mYsgrxj",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/weapons/specific-magic-weapons/spore-sap.webp",
+            "img": "systems/pf2e/icons/equipment/weapons/greatsword.webp",
             "range": [
                 88,
                 90
             ],
-            "text": "Duskwood Weapon, Standard Grade",
+            "text": "Adamantine Weapon (Standard-Grade)",
             "type": "text",
             "weight": 3
         },
         {
-            "_id": "TbqN7piUhgo0OfAf",
-            "documentCollection": "",
-            "documentId": "ud3pqCquYA5UecaS",
+            "_id": "zjFNu8gzAfPFJUv6",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
             "drawn": false,
-            "img": "icons/weapons/polearms/spear-simple-engraved.webp",
+            "img": "systems/pf2e/icons/equipment/weapons/greatsword.webp",
             "range": [
                 91,
                 93
             ],
-            "text": "Dawnsilver Weapon, Standard Grade",
+            "text": "Dawnsilver Weapon (Standard-Grade)",
             "type": "text",
             "weight": 3
         },
         {
-            "_id": "l9CD8GKGvhWX8hAA",
+            "_id": "oZy4Q5zhxbvqCS0p",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "bheWnrBqMphBRUmn",
-            "drawn": false,
-            "img": "icons/weapons/bows/longbow-gold-pink.webp",
-            "range": [
-                94,
-                99
-            ],
-            "text": "Oathbow",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "t5t1wLQE2o2FC0iI",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "8XZqdeZStFAM4XnH",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/alchemist-goggles.webp",
-            "range": [
-                100,
-                105
-            ],
-            "text": "Alchemist Goggles (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "51ULgg4Z2gGAZbMm",
-            "documentCollection": "",
             "documentId": null,
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "systems/pf2e/icons/equipment/weapons/greatsword.webp",
             "range": [
-                106,
-                106
+                94,
+                96
             ],
-            "text": "Dawnsilver Weapon (Standard-Grade)",
+            "text": "Duskwood Weapon (Standard-Grade)",
             "type": "text",
-            "weight": 1
+            "weight": 3
         },
         {
-            "_id": "WGS4NVKgvBlbRbTe",
+            "_id": "b0c7ksuCGId589N2",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "62vH66XLehPiRwwo",
+            "documentId": "4DnjM0PNivT2dlf9",
             "drawn": false,
-            "img": "icons/equipment/chest/robe-layered-red.webp",
+            "img": "systems/pf2e/icons/equipment/weapons/specific-magic-weapons/hunters-bow.webp",
             "range": [
-                107,
-                112
+                97,
+                102
             ],
-            "text": "Cassock of Devotion",
+            "text": "Hunter's Anthem",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "7Z6tn2kUuYj3hLx2",
+            "_id": "JUpGCzPmjvLfI3RY",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "dvHvLFTbjnsE0xoN",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/aluum-charm.webp",
+            "range": [
+                103,
+                105
+            ],
+            "text": "Countering Charm",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "j9ERpaEnurUguPaf",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "JSYtBZ7XblyAEFoV",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/crafters-eyepiece.webp",
+            "img": "icons/tools/scribal/lens-blue.webp",
             "range": [
-                113,
-                118
+                106,
+                111
             ],
             "text": "Crafter's Eyepiece (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "STcQUllJfx9jubmn",
+            "_id": "z5dHSfj126QA77sj",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "as84dZ5Hliru148n",
+            "drawn": false,
+            "img": "icons/equipment/back/mantle-collared-green.webp",
+            "range": [
+                112,
+                117
+            ],
+            "text": "Devoted Vestments",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "Fb7q0yOczTCy2TaX",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "gRQXLqUuP4GWfDWI",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/doubling-rings.webp",
             "range": [
-                119,
-                124
+                118,
+                123
             ],
             "text": "Doubling Rings (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "9V0wkAcLvloWJuB2",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Tej30MsQo8Ek9aA6",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/goggles-of-night.webp",
-            "range": [
-                125,
-                130
-            ],
-            "text": "Obsidian Goggles (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "1I1aKyDFUhl3sgcR",
+            "_id": "mkru2AdGgguNg8MG",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "WYg2dZ8UK1N3rpgs",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/gorget-of-the-primal-roar.webp",
             "range": [
-                131,
-                136
+                124,
+                129
             ],
             "text": "Gorget of the Primal Roar",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "UvP7whKlzWpyF6YX",
+            "_id": "KofrOeQsCUnpiGOQ",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Dr9b08JhDThUenF9",
+            "documentId": "Tej30MsQo8Ek9aA6",
             "drawn": false,
-            "img": "icons/equipment/neck/collar-rounded-carved-wood-spiral.webp",
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/goggles-of-night.webp",
             "range": [
-                137,
-                142
+                130,
+                135
             ],
-            "text": "Necklace of Fireballs IV",
+            "text": "Obsidian Goggles (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "4C60NntnlXweLDuB",
+            "_id": "wEZYLGdPWfcOGzxh",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "85GqeSGXjSQwLy07",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-overflowing-life.webp",
+            "range": [
+                136,
+                141
+            ],
+            "text": "Wand of Overflowing Life (4th-Rank Spell)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "j2JDzhi33JVlhE9X",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "9YtYO8u5UOg4q64Y",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-the-snowfields.webp",
+            "range": [
+                142,
+                147
+            ],
+            "text": "Wand of the Spider (4th-Rank Spell)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "hDsmlIui9uor9hUW",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "8XZqdeZStFAM4XnH",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/alchemist-goggles.webp",
+            "range": [
+                148,
+                153
+            ],
+            "text": "Alchemist Goggles (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "rFA39q1iQy5Ed6zi",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "h2gpUvHN3hTRS7jv",
+            "drawn": false,
+            "img": "icons/equipment/head/helm-barbute-rounded-gold.webp",
+            "range": [
+                154,
+                159
+            ],
+            "text": "Helm Of Zeal",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "fnUtO3HcaHmpGJVO",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "nLvP7U50hLqz26Uy",
             "drawn": false,
             "img": "icons/equipment/finger/ring-band-engraved-scrolls-bronze.webp",
             "range": [
-                143,
-                148
+                160,
+                165
             ],
             "text": "Ring of Maniacal Devices",
             "type": "pack",


### PR DESCRIPTION
Update 11th-Level Consumable Items and 11th-Level Permanent Items tables with remaster changes, consolidating the treasure tables from the GM Core and Player Core 2 books, preserving the item order found in those tables. Weight is based on rarity:

    Common = 6
    Uncommon = 3
    Rare = 1

For items that do not have a corresponding entry in the compendium, create a text entry in the table with the appropriate item name. If possible, set an appropriate icon from the system's icon set.