### PR TITLE
Update 12th-level rollable tables

### DIFF
--- a/packs/rollable-tables/12th-level-consumables-items.json
+++ b/packs/rollable-tables/12th-level-consumables-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "5HHqLskEnfjxpkCO",
-    "description": "Table of 12th-Level Consumables Items",
+    "description": "<p>Table of 12th-Level Consumables Items</p>",
     "displayRoll": true,
-    "formula": "1d90",
+    "formula": "1d156",
     "img": "icons/svg/d20-grey.svg",
     "name": "12th-Level Consumables Items",
     "ownership": {
@@ -25,63 +25,63 @@
             "weight": 6
         },
         {
-            "_id": "QN2b9QvvhEhXYHss",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "EEJiqzU89Ofk7dr6",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/salamander-elixir.webp",
-            "range": [
-                7,
-                12
-            ],
-            "text": "Salamander Elixir (Moderate)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "k455WZW8SCQLXbsv",
+            "_id": "lJMuDbMoiWIAwiaS",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "2hc1EEcb3pfr7Hac",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/sea-touch-elixir.webp",
             "range": [
-                13,
-                18
+                7,
+                12
             ],
             "text": "Sea Touch Elixir (Moderate)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "3EqXFbXhBaS3HemC",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "2prxM8Q0F4sdSwPx",
-            "drawn": false,
-            "img": "icons/consumables/potions/bottle-round-ring-teal.webp",
-            "range": [
-                19,
-                24
-            ],
-            "text": "Winter Wolf Elixir (Moderate)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "oLZsd9xeniDUB97N",
+            "_id": "3FX8Tzwv5UMoTKvn",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "KVrmsNbro6mJ9wuT",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/oils/oil-of-animation.webp",
             "range": [
-                25,
-                27
+                13,
+                15
             ],
             "text": "Oil of Animation",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "zz0eL7k3QNTKNXc3",
+            "_id": "x3T90aaGWupGopYU",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "PLuJEzJWaWamW0Fc",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/oils/oil-of-potency.webp",
+            "range": [
+                16,
+                21
+            ],
+            "text": "Oil of Potency (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "ww6gEOmF3GBlPLut",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "RhOx5wenvlljzOku",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/oils/oil-of-unlife.webp",
+            "range": [
+                22,
+                27
+            ],
+            "text": "Oil of Unlife (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "s24EkAdI3JFmpUat",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "ybu2BMu2oWj74wl8",
             "drawn": false,
@@ -95,142 +95,310 @@
             "weight": 6
         },
         {
-            "_id": "HpyqvpBDM6D2jUC6",
+            "_id": "cir7vmjw4EirRcQu",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "w492F18MtpqNu2X7",
+            "drawn": false,
+            "img": "icons/consumables/plants/sprout-glowing-roots-green.webp",
+            "range": [
+                34,
+                36
+            ],
+            "text": "Spirit Bulb (Greater)",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "haIM8jjAI03EO1my",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "z7eOUqVwyht6tj11",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/slumber-wine.webp",
             "range": [
-                34,
-                39
+                37,
+                42
             ],
             "text": "Slumber Wine",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "bqsJMu7IB225fTYz",
-            "documentCollection": "",
+            "_id": "2lt3KAx6HzXe9TJS",
+            "documentCollection": "pf2e.equipment-srd",
             "documentId": null,
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "systems/pf2e/icons/equipment/consumables/potions/green-dragons-breath-potion.webp",
             "range": [
-                40,
-                45
+                43,
+                48
             ],
-            "text": "Dragon's Breath Potion (Adult)",
+            "text": "Energy Breath Potion (Moderate)",
             "type": "text",
             "weight": 6
         },
         {
-            "_id": "xkxbqKf3zQN0HjG2",
+            "_id": "bhU7rCYRe9uggNP0",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "TSrbwHW8zm0mhkwb",
             "drawn": false,
             "img": "icons/consumables/potions/bottle-round-corked-orante-red.webp",
             "range": [
-                46,
-                51
+                49,
+                54
             ],
             "text": "Healing Potion (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "kQTbzpAKyDIdb9PY",
+            "_id": "rzS0K6NV8nuvWTiK",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "drxEWZl8mqMOZ23E",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/potions/potion-of-tongues.webp",
             "range": [
-                52,
-                54
+                55,
+                57
             ],
-            "text": "Potion of Tongues",
+            "text": "Potion of Truespeech",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "11E6i8082Hr9VbAI",
+            "_id": "lfUrF1Z2Cnv3snOb",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "9Kk6P7idLGRhZJ2q",
+            "documentId": "tTrJnXJYt15arH6G",
             "drawn": false,
-            "img": "icons/consumables/plants/thorned-stem-vine-green.webp",
+            "img": "icons/commodities/metal/fragments-steel-ring.webp",
             "range": [
-                55,
+                58,
                 60
             ],
-            "text": "Bleeding Spines Snare",
+            "text": "Alloy Orb (Exquisite Standard-Grade)",
             "type": "pack",
-            "weight": 6
+            "weight": 3
         },
         {
-            "_id": "6kQzn5rLnCNXBS9Q",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "mWXaROc9ytjdGVVP",
-            "drawn": false,
-            "img": "icons/weapons/daggers/dagger-ritual-simple-green.webp",
-            "range": [
-                61,
-                66
-            ],
-            "text": "Scything Blade Snare",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "VGGQXPWdzG59Nm30",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "a2XaerM1KkPyLIPM",
-            "drawn": false,
-            "img": "icons/weapons/hammers/hammer-mallet-wood-banded.webp",
-            "range": [
-                67,
-                72
-            ],
-            "text": "Stunning Snare",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "nTEs6YU02ad96T98",
+            "_id": "k5Zw3gXC3scKyNm9",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "cxOf1V1kN9tnj1g9",
             "drawn": false,
             "img": "icons/commodities/biological/eye-lizard-orange.webp",
             "range": [
-                73,
-                78
+                61,
+                66
             ],
             "text": "Eye of Apprehension",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "lPrbQ84yWjWIgUxi",
+            "_id": "2RgwDCgGzKoQ3gvx",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "FrbvejTNfS5fep9f",
             "drawn": false,
             "img": "icons/commodities/cloth/yarn-skein-white-red.webp",
             "range": [
-                79,
-                84
+                67,
+                72
             ],
             "text": "Fade Band",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "2lOvcOhgIjutlg6N",
+            "_id": "oFoGEqYIRl3W2Z3v",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "ivaL0xt33k6QNwQK",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/crystal-shards.webp",
+            "range": [
+                73,
+                78
+            ],
+            "text": "Crystal Shards (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "qhUHNPuMP9FduKce",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "vMs9n8oXlZttcJkX",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/focus-cathartic.webp",
+            "range": [
+                79,
+                84
+            ],
+            "text": "Bottled Catharsis (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "X3VU6THzy2TaevUv",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "EEJiqzU89Ofk7dr6",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/salamander-elixir.webp",
+            "range": [
+                85,
+                90
+            ],
+            "text": "Cooling Elixir (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "ocq5HXNmLcSLzUFp",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "62HxCEDwhlZaeR0Q",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/sinew-shock-serum.webp",
+            "range": [
+                91,
+                96
+            ],
+            "text": "Surging Serum (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "2IVNhlz0vI8gmJhf",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "2prxM8Q0F4sdSwPx",
+            "drawn": false,
+            "img": "icons/consumables/potions/bottle-round-ring-teal.webp",
+            "range": [
+                97,
+                102
+            ],
+            "text": "Witchwarg Elixir (Moderate)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "jhdRmufmgjfDcY23",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "4RKfLoqVluZGWzLc",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/other-consumables/incense-of-distilled-death.webp",
+            "range": [
+                103,
+                108
+            ],
+            "text": "Incense of Distilled Death",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "0lFx2ik59sHh7LwT",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "iRDCa4OVSTGUD3vi",
+            "drawn": false,
+            "img": "icons/consumables/potions/bottle-conical-corked-purple.webp",
+            "range": [
+                109,
+                114
+            ],
+            "text": "Cave Worm Venom",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "FZo1uervoVClcAC4",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/potions/potion-of-cold-retalliation.webp",
+            "range": [
+                115,
+                120
+            ],
+            "text": "Potion of Retaliation (Greater)",
+            "type": "text",
+            "weight": 6
+        },
+        {
+            "_id": "LpYJrzO74TtwnGsY",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "9Kk6P7idLGRhZJ2q",
+            "drawn": false,
+            "img": "icons/consumables/plants/thorned-stem-vine-green.webp",
+            "range": [
+                121,
+                126
+            ],
+            "text": "Bleeding Spines Snare",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "cnuU3SDhi73Qa3pd",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "mWXaROc9ytjdGVVP",
+            "drawn": false,
+            "img": "icons/weapons/daggers/dagger-ritual-simple-green.webp",
+            "range": [
+                127,
+                132
+            ],
+            "text": "Scything Blade Snare",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "UveUn4XCSHreaOGZ",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "a2XaerM1KkPyLIPM",
+            "drawn": false,
+            "img": "icons/weapons/hammers/hammer-mallet-wood-banded.webp",
+            "range": [
+                133,
+                138
+            ],
+            "text": "Stunning Snare",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "K7pOfymXB0VyTUJL",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "Do8vjuUBOslgPtyw",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/balisse-feather.webp",
+            "range": [
+                139,
+                144
+            ],
+            "text": "Balisse Feather",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "ZK7zK2KASsb7v6LF",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "KrtZmC3qfZIGXu76",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/talismans/iron-equalizer.webp",
             "range": [
-                85,
-                90
+                145,
+                150
             ],
             "text": "Iron Equalizer",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "k2VFk8UmoMRm5bOL",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "jdkMRl7zxOVGUuGI",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/universal-solvent.webp",
+            "range": [
+                151,
+                156
+            ],
+            "text": "Absolute Solvent (Greater)",
             "type": "pack",
             "weight": 6
         }

--- a/packs/rollable-tables/12th-level-permanent-items.json
+++ b/packs/rollable-tables/12th-level-permanent-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "uzkmxRIn4CtzfP47",
-    "description": "Table of 12th-Level Permanent Items",
+    "description": "<p>Table of 12th-Level Permanent Items</p>",
     "displayRoll": true,
-    "formula": "1d126",
+    "formula": "1d145",
     "img": "icons/svg/d20-grey.svg",
     "name": "12th-Level Permanent Items",
     "ownership": {
@@ -13,9 +13,9 @@
         {
             "_id": "mYq4p5qykRLe1Ok4",
             "documentCollection": "",
-            "documentId": "1erd18HS57aCyC6r",
+            "documentId": null,
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/held-items/broom-of-flying.webp",
+            "img": "systems/pf2e/icons/equipment/armor/breastplate.webp",
             "range": [
                 1,
                 3
@@ -29,308 +29,378 @@
             "documentCollection": "",
             "documentId": null,
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "systems/pf2e/icons/equipment/armor/breastplate.webp",
             "range": [
                 4,
                 6
-            ],
-            "text": "Duskwood Armor, Standard-Grade",
-            "type": "text",
-            "weight": 3
-        },
-        {
-            "_id": "aPbhuQl16Dn83HR8",
-            "documentCollection": "",
-            "documentId": "aZ8HzjZCOJCV7ZWh",
-            "drawn": false,
-            "img": "icons/containers/bags/pouch-leather-silver-white.webp",
-            "range": [
-                10,
-                12
             ],
             "text": "Dawnsilver Armor, Standard-Grade",
             "type": "text",
             "weight": 3
         },
         {
-            "_id": "3EqXFbXhBaS3HemC",
+            "_id": "XAQlR4bSihWi4T68",
+            "documentCollection": "",
+            "documentId": null,
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/armor/chainshirt.webp",
+            "range": [
+                7,
+                9
+            ],
+            "text": "Duskwood Armor (Standard-Grade)",
+            "type": "text",
+            "weight": 3
+        },
+        {
+            "_id": "rG3QEK474sxp1KCd",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "EBuQjgVZaQpjQUjc",
+            "drawn": false,
+            "img": "icons/equipment/chest/breastplate-layered-gold.webp",
+            "range": [
+                10,
+                15
+            ],
+            "text": "Lion's Armor",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "Z96u4JUracJJVXdY",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "1erd18HS57aCyC6r",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/held-items/broom-of-flying.webp",
             "range": [
-                13,
-                18
+                16,
+                21
             ],
-            "text": "Broom of Flying",
+            "text": "Flying Broomstick",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "oLZsd9xeniDUB97N",
+            "_id": "JYKFmPwG5fBkb4FQ",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "aZ8HzjZCOJCV7ZWh",
             "drawn": false,
             "img": "icons/containers/bags/pouch-leather-silver-white.webp",
             "range": [
-                19,
-                24
+                22,
+                27
             ],
             "text": "Marvelous Medicines",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "zz0eL7k3QNTKNXc3",
+            "_id": "8bulQWRf9XjZ4oTz",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "LbdnZFlyLFdAE617",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
+            "range": [
+                28,
+                33
+            ],
+            "text": "Brilliant",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "fqohuZNRPZ9RyeKo",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "9CAWAKkZE7dr4FlJ",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/armor-property-runes/armor-property-runes.webp",
             "range": [
-                25,
-                30
+                34,
+                39
             ],
             "text": "Energy-Resistant (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "lLzSpPUauPOj4sfl",
+            "_id": "rKNx30jLNu4mgiao",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "uz3JCjRvkE44jxMd",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
+            "range": [
+                40,
+                45
+            ],
+            "text": "Fearsome (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "T38LeoChOLPi5jfj",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "8buhFcGwuaJRrp0y",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/armor-property-runes/armor-property-runes.webp",
             "range": [
-                31,
-                36
+                46,
+                51
             ],
             "text": "Fortification",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "HpyqvpBDM6D2jUC6",
+            "_id": "8PHQYY6SQ5hXnBSq",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "KCQRFvUgbyclvOGi",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/fundamental-weapon-runes/striking.webp",
             "range": [
-                37,
-                42
+                52,
+                57
             ],
             "text": "Striking (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "bqsJMu7IB225fTYz",
+            "_id": "MhbyYNGEYflFKm2B",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "Oo7IpJQDSTmzUyzG",
             "drawn": false,
             "img": "icons/weapons/staves/staff-ornate-bird.webp",
             "range": [
-                43,
-                48
+                58,
+                63
             ],
             "text": "Animal Staff (Major)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "xkxbqKf3zQN0HjG2",
+            "_id": "nLHp6zQLJZUCl5OZ",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "DTIBj6Yhy73G5P6j",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/staves/mentalist-staff.webp",
             "range": [
-                49,
-                54
+                64,
+                69
             ],
             "text": "Mentalist's Staff (Major)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "kQTbzpAKyDIdb9PY",
+            "_id": "yWpAoO7SkYsch6Kb",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "0mCj6HZcwFzVxVyM",
+            "drawn": false,
+            "img": "icons/weapons/staves/staff-ornate-blue.webp",
+            "range": [
+                70,
+                70
+            ],
+            "text": "Staff of Arcane Might",
+            "type": "pack",
+            "weight": 1
+        },
+        {
+            "_id": "jT19FSPdts4DP4ds",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "qx4Cq99vng6GhzEh",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/staves/staff-of-fire.webp",
             "range": [
-                55,
-                60
+                71,
+                76
             ],
             "text": "Staff of Fire (Major)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "11E6i8082Hr9VbAI",
+            "_id": "rsrQo6HCGjhLrBCS",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "FTVap8IjoKgCexH7",
             "drawn": false,
             "img": "icons/weapons/staves/staff-ornate-gold-jeweled.webp",
             "range": [
-                61,
-                66
+                77,
+                82
             ],
             "text": "Staff of Healing (Major)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "vQq7Hy7Dx1a8GCHZ",
+            "_id": "KF5WlrzgD6nwUmAW",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "ylRk8NvpK2kA8bjw",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/staves/verdant-staff.webp",
+            "img": "icons/weapons/staves/staff-nature-spiral.webp",
             "range": [
-                67,
-                72
+                83,
+                88
             ],
             "text": "Verdant Staff (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "dwXrm0DZwZ0Vtpyl",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "zToq18jKonWIp48U",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-smoldering-fireballs.webp",
-            "range": [
-                73,
-                78
-            ],
-            "text": "Wand of Smoldering Fireballs (5th-Rank Spell)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "ViMk7CeQzvGeYUrC",
+            "_id": "bUiSgFGU6jWdkMt4",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "TGxZ3acyWjjTvfU9",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-widening.webp",
             "range": [
-                79,
-                84
+                89,
+                94
             ],
             "text": "Wand of Widening (5th-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "rj2RuyHe7q9qcZ2d",
-            "documentCollection": "",
+            "_id": "G6NLKr5GklQEbxh6",
+            "documentCollection": "pf2e.equipment-srd",
             "documentId": null,
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "systems/pf2e/icons/equipment/weapons/shortsword.webp",
             "range": [
-                85,
-                90
+                95,
+                100
             ],
-            "text": "Magic Weapon (+2 Greater Striking)",
+            "text": "Magic Weapon (+1 striking)",
             "type": "text",
             "weight": 6
         },
         {
-            "_id": "o3gZ97kIi4lo11BY",
-            "documentCollection": "",
+            "_id": "LRqfXvaDgqs2P7AM",
+            "documentCollection": "pf2e.equipment-srd",
             "documentId": null,
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "icons/equipment/hand/gauntlet-simple-leather-brown-gold.webp",
             "range": [
-                91,
-                96
+                101,
+                106
             ],
-            "text": "+2 greater striking Handwraps of Mighty Blows",
+            "text": "Handwraps of Mighty Blows (+2 greater striking)",
             "type": "text",
             "weight": 6
         },
         {
-            "_id": "OtH5vWwuqo4ICMuF",
+            "_id": "egrEh9YK0PiZ4I0z",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "lJ3BzUZkGTOCWleL",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/aeon-stone-pink-rhomboid.webp",
-            "range": [
-                97,
-                99
-            ],
-            "text": "Aeon Stone (Pink Rhomboid)",
-            "type": "pack",
-            "weight": 3
-        },
-        {
-            "_id": "l9CD8GKGvhWX8hAA",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "DwLaGtbBdCh2NFbT",
-            "drawn": false,
-            "img": "icons/equipment/back/cloak-brown-accent-brown-layered-collared-fur.webp",
-            "range": [
-                100,
-                105
-            ],
-            "text": "Berserker's Cloak",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "t5t1wLQE2o2FC0iI",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "ZelCRLDI6M5IfjAI",
+            "documentId": "I0XiBnHFCXi64XiD",
             "drawn": false,
             "img": "icons/equipment/back/cloak-collared-feathers-green.webp",
             "range": [
-                106,
-                111
+                107,
+                112
             ],
-            "text": "Cloak of Elvenkind (Greater)",
+            "text": "Cloak of Illusions (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "SaGLwztjSNglsrzf",
+            "_id": "a9YE2HJMT5ihbKPf",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "GpuzMoZYehYvZ50E",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/ring-of-climbing.webp",
             "range": [
-                112,
-                117
+                113,
+                118
             ],
             "text": "Ring of Climbing",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "EkwMh4K3qpHW7heM",
+            "_id": "kqaJGsxE1MNyTRdk",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "fFx6SEyZlHZtcLGX",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/ring-of-swimming.webp",
             "range": [
-                118,
-                123
+                119,
+                124
             ],
             "text": "Ring of Swimming",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "WGS4NVKgvBlbRbTe",
+            "_id": "n2ff0N2dTOWamrub",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "otCgznS0L14Z46rf",
+            "documentId": null,
             "drawn": false,
-            "img": "icons/equipment/finger/ring-band-engraved-silver.webp",
+            "img": "systems/pf2e/icons/equipment/armor/leather-armor.webp",
             "range": [
-                124,
-                126
+                125,
+                127
             ],
-            "text": "Ring of Wizardry (Type III)",
+            "text": "Dragonhide Armor (Standard-Grade)",
+            "type": "text",
+            "weight": 3
+        },
+        {
+            "_id": "MMeofJLjfvqYyXFE",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "KxSyomQx7rpwqemP",
+            "drawn": false,
+            "img": "icons/weapons/staves/staff-crescent-green.webp",
+            "range": [
+                128,
+                130
+            ],
+            "text": "Staff of Impossible Visions (Greater)",
             "type": "pack",
             "weight": 3
+        },
+        {
+            "_id": "4dbhxrvfY0OzOFs3",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "zToq18jKonWIp48U",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-smoldering-fireballs.webp",
+            "range": [
+                131,
+                136
+            ],
+            "text": "Wand of Smoldering Fireballs (5th-Rank Spell)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "cAJRtpkKdljiV6fa",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "3oexArva2aEm69WV",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/weapons/specific-magic-weapons/four-ways-dogslicer.webp",
+            "range": [
+                137,
+                139
+            ],
+            "text": "Four-Ways Dogslicer",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "isqJcBUMt3G4Du0v",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "DwLaGtbBdCh2NFbT",
+            "drawn": false,
+            "img": "icons/equipment/back/cloak-brown-accent-brown-layered-collared-fur.webp",
+            "range": [
+                140,
+                145
+            ],
+            "text": "Berserker's Cloak",
+            "type": "pack",
+            "weight": 6
         }
     ]
 }


### PR DESCRIPTION
Update 12th-Level Consumable Items and 12th-Level Permanent Items tables with remaster changes, consolidating the treasure tables from the GM Core and Player Core 2 books, preserving the item order found in those tables. Weight is based on rarity:

    Common = 6
    Uncommon = 3
    Rare = 1

For items that do not have a corresponding entry in the compendium, create a text entry in the table with the appropriate item name. If possible, set an appropriate icon from the system's icon set.