### PR TITLE
Update 13th-level rollable tables

### DIFF
--- a/packs/rollable-tables/13th-level-consumables-items.json
+++ b/packs/rollable-tables/13th-level-consumables-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "awfTQvkm7NrRjRaQ",
-    "description": "Table of 13th-Level Consumables Items",
+    "description": "<p>Table of 13th-Level Consumables Items</p>",
     "displayRoll": true,
-    "formula": "1d42",
+    "formula": "1d51",
     "img": "icons/svg/d20-grey.svg",
     "name": "13th-Level Consumables Items",
     "ownership": {
@@ -53,35 +53,35 @@
             "weight": 6
         },
         {
-            "_id": "aPbhuQl16Dn83HR8",
+            "_id": "1yYNKU8JmLldxwjf",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "YS7LJSvooG7mfwH1",
+            "drawn": false,
+            "img": "icons/magic/fire/barrier-shield-explosion-yellow.webp",
+            "range": [
+                19,
+                24
+            ],
+            "text": "Frozen Lava of Droskar's Crag",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "3omGn6EyNP38q3El",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "87AzvRja9uQOLJCC",
             "drawn": false,
             "img": "icons/tools/laboratory/bowl-powder-purple.webp",
             "range": [
-                19,
-                24
+                25,
+                30
             ],
             "text": "Deathcap Powder",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "oLZsd9xeniDUB97N",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "iRDCa4OVSTGUD3vi",
-            "drawn": false,
-            "img": "icons/consumables/potions/bottle-conical-corked-purple.webp",
-            "range": [
-                25,
-                30
-            ],
-            "text": "Purple Worm Venom",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "zz0eL7k3QNTKNXc3",
+            "_id": "5clBJ5VWyZRDymxs",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "LRSiYsgEz3e0PEwX",
             "drawn": false,
@@ -95,30 +95,58 @@
             "weight": 3
         },
         {
-            "_id": "lLzSpPUauPOj4sfl",
+            "_id": "HUIE6zMei0kftd8V",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "1YROvQsCdq8WFWRj",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/potions/time-shield-potion.webp",
+            "range": [
+                34,
+                39
+            ],
+            "text": "Time Shield Potion",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "I6taOsMr3zahGcAK",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "fomEZZ4MxVVK3uVu",
             "drawn": false,
             "img": "icons/sundries/scrolls/scroll-symbol-eye-brown.webp",
             "range": [
-                34,
-                39
+                40,
+                45
             ],
-            "text": "Scroll of 7th-level Spell",
+            "text": "Scroll of 7th-rank Spell",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "HpyqvpBDM6D2jUC6",
+            "_id": "c1yxGarL0MnVz78E",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "JSmdTDUEGwHVbV7g",
             "drawn": false,
             "img": "icons/environment/traps/grate-steel.webp",
             "range": [
-                40,
-                42
+                46,
+                48
             ],
             "text": "Mending Lattice",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "yvfeqLxGq6FvxsEY",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "vp3Yr59O9dO9MDlb",
+            "drawn": false,
+            "img": "icons/sundries/lights/candle-lit-angelic.webp",
+            "range": [
+                49,
+                51
+            ],
+            "text": "Taper of Sanctification",
             "type": "pack",
             "weight": 3
         }

--- a/packs/rollable-tables/13th-level-permanent-items.json
+++ b/packs/rollable-tables/13th-level-permanent-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "eo7kjM8xv6KD5h5q",
-    "description": "Table of 13th-Level Permanent Items",
+    "description": "<p>Table of 13th-Level Permanent Items</p>",
     "displayRoll": true,
-    "formula": "1d108",
+    "formula": "1d126",
     "img": "icons/svg/d20-grey.svg",
     "name": "13th-Level Permanent Items",
     "ownership": {
@@ -11,296 +11,338 @@
     "replacement": true,
     "results": [
         {
-            "_id": "mYq4p5qykRLe1Ok4",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "2uHcTZ40oZ62R9gy",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/armor/specific-magic-armor/celestial-armor.webp",
-            "range": [
-                1,
-                6
-            ],
-            "text": "Celestial Armor",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "QN2b9QvvhEhXYHss",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "hYBZK1kaGPeR85CH",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/armor/specific-magic-armor/demon-armor.webp",
-            "range": [
-                7,
-                12
-            ],
-            "text": "Demon Armor",
-            "type": "pack",
-            "weight": 6
-        },
-        {
             "_id": "k455WZW8SCQLXbsv",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "peAvz7u35GEfTXxp",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/armor/precious-metal-armor/elven-chain.webp",
             "range": [
-                13,
-                15
+                1,
+                3
             ],
             "text": "Elven Chain (Standard-Grade)",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "aPbhuQl16Dn83HR8",
+            "_id": "27VngXK2LL8RYcti",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "AdJgj7vVvNGvPIEj",
+            "documentId": "khzffn47ZUG0tHhl",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/armor/specific-magic-armor/mail-of-luck.webp",
+            "img": "icons/magic/earth/explosion-lava-orange.webp",
             "range": [
-                16,
-                21
+                4,
+                9
             ],
-            "text": "Mail of Luck",
+            "text": "Eternal Eruption of Droskar's Crag",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "oLZsd9xeniDUB97N",
+            "_id": "QHvZNxsIpXSpQrpU",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "1IeT2jIpBxxUo1uD",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/held-items/slates-of-distant-letters.webp",
+            "range": [
+                10,
+                15
+            ],
+            "text": "Slates of Distant Letters",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "t0bg8hDUnycoIGpa",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "34DA4rFy7bduRAld",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/held-items/bag-of-holding.webp",
             "range": [
-                22,
-                27
+                16,
+                21
             ],
-            "text": "Bag of Holding (Type IV)",
+            "text": "Spacious Pouch (Type IV)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "zz0eL7k3QNTKNXc3",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "TXPQfQriNJqMYcfp",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/held-items/wondrous-figurine-marble-elephant.webp",
-            "range": [
-                28,
-                33
-            ],
-            "text": "Wondrous Figurine (Marble Elephant)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "HpyqvpBDM6D2jUC6",
+            "_id": "xnUPfcEgqcDxUdyh",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "DCPsilr8wbPXxTUv",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
             "range": [
-                34,
-                36
+                22,
+                24
             ],
-            "text": "Dancing",
+            "text": "Animated",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "bqsJMu7IB225fTYz",
+            "_id": "GJmsXtzmArtM0oww",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "WHwprq9Xym2DOr2x",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
+            "range": [
+                25,
+                30
+            ],
+            "text": "Extending (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "QqeHLE53RPaVb4CS",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "hg3IogR8ue2IWwgS",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
             "range": [
-                37,
-                39
+                31,
+                33
             ],
             "text": "Keen",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "kQTbzpAKyDIdb9PY",
+            "_id": "bYAKMXA0kIWMIeNw",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "payq4TwkN2BRF6fs",
+            "documentId": "vT1LG3uNuCCnZhPq",
+            "drawn": false,
+            "img": "icons/commodities/treasure/token-runed-os-grey.webp",
+            "range": [
+                34,
+                39
+            ],
+            "text": "Reinforcing Rune (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "EvekS6VGyS8k3gwE",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "QNaCujl2faKRyLD1",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
             "range": [
                 40,
                 42
             ],
-            "text": "Spell-Storing",
+            "text": "Shockwave",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "11E6i8082Hr9VbAI",
+            "_id": "SG2WnO3t8KQkbOG0",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "payq4TwkN2BRF6fs",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
+            "range": [
+                43,
+                45
+            ],
+            "text": "Spell Reservoir",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "2lpPrlCjop5rsJPy",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "ds7j3D8IIyxWd2XI",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/armor-property-runes/armor-property-runes.webp",
+            "range": [
+                46,
+                51
+            ],
+            "text": "Winged",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "Ghi2wTV9oWNHalRT",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "rrnWORxT2Ch4pUFb",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/shields/specific-shields/sturdy-shield.webp",
             "range": [
-                43,
-                48
+                52,
+                57
             ],
             "text": "Sturdy Shield (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "vQq7Hy7Dx1a8GCHZ",
+            "_id": "YtuHmCM8ZESJmMHv",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "kiXh4SUWKr166ZeM",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/magic-wands/magic-wand.webp",
             "range": [
-                49,
-                54
+                58,
+                63
             ],
             "text": "Magic Wand (6th-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "dwXrm0DZwZ0Vtpyl",
+            "_id": "i1hZ4X57OEerxoEO",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "tDEi3zLVpxwA74qz",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-continuation.webp",
             "range": [
-                55,
-                60
+                64,
+                69
             ],
             "text": "Wand of Continuation (5th-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "ViMk7CeQzvGeYUrC",
+            "_id": "fPYN3oNg2jsnqU8F",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "y6if8e8OB3RUywF8",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-manifold-missiles.webp",
             "range": [
-                61,
-                66
+                70,
+                75
             ],
-            "text": "Wand of Manifold Missiles (5th-Rank Spell)",
+            "text": "Wand of Shardstorm (5th-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "o3gZ97kIi4lo11BY",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "XK4DM8wOtcuOsji6",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/weapons/specific-magic-weapons/dwarven-thrower.webp",
-            "range": [
-                67,
-                72
-            ],
-            "text": "Dwarven Thrower",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "OtH5vWwuqo4ICMuF",
+            "_id": "w29Gl1dK3am1EMRY",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "G3a60Ug3YNCMyMVR",
             "drawn": false,
             "img": "icons/weapons/swords/sword-guard-red.webp",
             "range": [
-                73,
-                78
-            ],
-            "text": "Flame Tongue",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "TbqN7piUhgo0OfAf",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "B4R0LK8bgw0Vjtf0",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/aeon-stone-pale-lavender-ellipsoid.webp",
-            "range": [
-                79,
+                76,
                 81
             ],
-            "text": "Aeon Stone (Pale Lavender Ellipsoid)",
-            "type": "pack",
-            "weight": 3
-        },
-        {
-            "_id": "l9CD8GKGvhWX8hAA",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Ck5k13uTNqibLFJk",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/boots-of-speed.webp",
-            "range": [
-                82,
-                87
-            ],
-            "text": "Boots of Speed",
+            "text": "Searing Blade",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "t5t1wLQE2o2FC0iI",
+            "_id": "DkYda2GzDYfdPPY4",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "lKMSAlp0ZoFUK4FV",
             "drawn": false,
             "img": "icons/commodities/biological/eye-blue.webp",
             "range": [
-                88,
-                93
+                82,
+                87
             ],
             "text": "Eye of Fortune",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "SaGLwztjSNglsrzf",
+            "_id": "7VnQe4R9cT8neLS7",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "9cK0QVSjNd8tQtiQ",
+            "documentId": "vBgElXswf6xBx4k9",
             "drawn": false,
-            "img": "icons/containers/bags/pouch-simple-leather-tan.webp",
+            "img": "icons/equipment/feet/boots-armored-steel-purple.webp",
             "range": [
-                94,
-                96
+                88,
+                93
             ],
-            "text": "Knapsack of Halflingkind (Greater)",
-            "type": "pack",
-            "weight": 3
-        },
-        {
-            "_id": "vHNOIhldCiAlVI37",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "hDO0vRS8r9K2Zw87",
-            "drawn": false,
-            "img": "icons/equipment/neck/collar-rounded-carved-wood-spiral.webp",
-            "range": [
-                97,
-                102
-            ],
-            "text": "Necklace of Fireballs V",
+            "text": "Hellfire Boots",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "ND9f91U4mIQQpsxt",
+            "_id": "nX5WmWs8gWI1dnrs",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "oSltacqbeotmzLNJ",
+            "documentId": "Ck5k13uTNqibLFJk",
             "drawn": false,
-            "img": "icons/equipment/finger/ring-crown-dragon-green.webp",
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/boots-of-speed.webp",
+            "range": [
+                94,
+                99
+            ],
+            "text": "Propulsive Boots",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "0OlFPmet1v9jsCFd",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "V1XhLQPWjdQz759K",
+            "drawn": false,
+            "img": "icons/equipment/waist/belt-buckle-ring-leather-red.webp",
+            "range": [
+                100,
+                102
+            ],
+            "text": "Retrieval Belt (Major)",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "S6fEgzDQthgWDZ1t",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "2uHcTZ40oZ62R9gy",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/armor/specific-magic-armor/celestial-armor.webp",
             "range": [
                 103,
                 108
             ],
-            "text": "Ring of the Ram (Greater)",
+            "text": "Holy Chain",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "rPeojMtFrap3lHuA",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "hYBZK1kaGPeR85CH",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/armor/specific-magic-armor/demon-armor.webp",
+            "range": [
+                109,
+                114
+            ],
+            "text": "Unholy Plate",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "KLG4C9NlyBJeQzGS",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "nzQKwdUxzmmwWtzT",
+            "drawn": false,
+            "img": "icons/equipment/shield/heater-wooden-antlers-blue.webp",
+            "range": [
+                115,
+                120
+            ],
+            "text": "Medusa's Scream",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "PTvggJJi2tuNqGkq",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "aj2eTtEAgLu4f14b",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-overflowing-life.webp",
+            "range": [
+                121,
+                126
+            ],
+            "text": "Wand of Overflowing Life (5th-Rank Spell)",
             "type": "pack",
             "weight": 6
         }


### PR DESCRIPTION
Update 13th-Level Consumable Items and 13th-Level Permanent Items tables with remaster changes, consolidating the treasure tables from the GM Core and Player Core 2 books, preserving the item order found in those tables. Weight is based on rarity:

    Common = 6
    Uncommon = 3
    Rare = 1

For items that do not have a corresponding entry in the compendium, create a text entry in the table with the appropriate item name. If possible, set an appropriate icon from the system's icon set.