### PR TITLE
Update 14th-level rollable tables

### DIFF
--- a/packs/rollable-tables/14th-level-consumables-items.json
+++ b/packs/rollable-tables/14th-level-consumables-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "Vhuuy0vFJV5tYldR",
-    "description": "Table of 14th-Level Consumables Items",
+    "description": "<p>Table of 14th-Level Consumables Items</p>",
     "displayRoll": true,
-    "formula": "1d48",
+    "formula": "1d60",
     "img": "icons/svg/d20-grey.svg",
     "name": "14th-Level Consumables Items",
     "ownership": {
@@ -67,58 +67,100 @@
             "weight": 6
         },
         {
-            "_id": "3EqXFbXhBaS3HemC",
+            "_id": "IuTwTdEMXprNB4ij",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "ywYt2SyZaV95KcZH",
+            "documentId": "p7kWhbRrUCbMzd7A",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/potions/potion-of-resistance.webp",
+            "img": "icons/consumables/plants/sprout-glowing-roots-green.webp",
             "range": [
                 25,
-                30
+                27
+            ],
+            "text": "Spirit Bulb (Major)",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "iKzY64yAdoMSaUqk",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/potions/potion-of-cold-resistance.webp",
+            "range": [
+                28,
+                33
             ],
             "text": "Potion of Resistance (Greater)",
-            "type": "pack",
+            "type": "text",
             "weight": 6
         },
         {
-            "_id": "oLZsd9xeniDUB97N",
+            "_id": "0NkgMrafnCjulsEp",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "ClKb4YQn8TfPIclE",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/talismans/dazing-coil.webp",
             "range": [
-                31,
-                36
+                34,
+                39
             ],
             "text": "Dazing Coil",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "lLzSpPUauPOj4sfl",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "XvmYNnQ4vg8GREH7",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/talismans/iron-cudgel.webp",
-            "range": [
-                37,
-                42
-            ],
-            "text": "Iron Cudgel",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "HpyqvpBDM6D2jUC6",
+            "_id": "VItRfK1otJI2iddT",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "sjxhPujyv6rJJRWO",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/talismans/vipers-fang.webp",
             "range": [
-                43,
-                48
+                40,
+                45
             ],
             "text": "Viper's Fang",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "WVwiIFcrwe3ztTZW",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "DIQg2Tml1wWjSC1q",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/snares/engulfing-snare.webp",
+            "range": [
+                46,
+                51
+            ],
+            "text": "Engulfing Snare",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "B3WoBEyMRhAIWrPW",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "5koINU0dy5nPL8Cg",
+            "drawn": false,
+            "img": "icons/creatures/abilities/mouth-teeth-rows-white.webp",
+            "range": [
+                52,
+                54
+            ],
+            "text": "Rending Snare",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "8G986jRQaHovnmrj",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "XvmYNnQ4vg8GREH7",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/iron-cudgel.webp",
+            "range": [
+                55,
+                60
+            ],
+            "text": "Iron Cudgel",
             "type": "pack",
             "weight": 6
         }

--- a/packs/rollable-tables/14th-level-permanent-items.json
+++ b/packs/rollable-tables/14th-level-permanent-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "cBpFoBUNSApkvP6L",
-    "description": "Table of 14th-Level Permanent Items",
+    "description": "<p>Table of 14th-Level Permanent Items</p>",
     "displayRoll": true,
-    "formula": "1d120",
+    "formula": "1d138",
     "img": "icons/svg/d20-grey.svg",
     "name": "14th-Level Permanent Items",
     "ownership": {
@@ -15,7 +15,7 @@
             "documentCollection": "",
             "documentId": null,
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "systems/pf2e/icons/equipment/armor/scale-mail.webp",
             "range": [
                 1,
                 6
@@ -25,296 +25,338 @@
             "weight": 6
         },
         {
-            "_id": "aPbhuQl16Dn83HR8",
+            "_id": "EH2myMHbVyA9TYFt",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "h9sZfo6UmHIOU5wb",
+            "drawn": false,
+            "img": "icons/equipment/chest/breastplate-layered-leather-studded-black.webp",
+            "range": [
+                7,
+                12
+            ],
+            "text": "Life-Saver Mail",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "hOwl38FeECg5jCyH",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "t0pzdb54KD2JQcEa",
             "drawn": false,
             "img": "icons/sundries/misc/horseshoe-iron.webp",
             "range": [
-                7,
-                12
+                13,
+                18
             ],
-            "text": "Horseshoes of Speed (Greater)",
+            "text": "Alacritous Horseshoes (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "3EqXFbXhBaS3HemC",
+            "_id": "ZRCnORAdb9dl9HEE",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "RM3SR1omNZfppZGl",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/held-items/crystal-ball-clear-quartz.webp",
             "range": [
-                13,
-                15
+                19,
+                21
             ],
             "text": "Crystal Ball (Clear Quartz)",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "oLZsd9xeniDUB97N",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "HZDkF6MlNQ6yYobD",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/held-items/primeval-mistletoe.webp",
-            "range": [
-                16,
-                21
-            ],
-            "text": "Primeval Mistletoe (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "zz0eL7k3QNTKNXc3",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "gEenEoxLjL5z28rG",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/held-items/rod-of-negation.webp",
-            "range": [
-                22,
-                27
-            ],
-            "text": "Rod of Negation",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "lLzSpPUauPOj4sfl",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "oVrVzML63VFvVfKk",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
-            "range": [
-                28,
-                30
-            ],
-            "text": "Disrupting (Greater)",
-            "type": "pack",
-            "weight": 3
-        },
-        {
-            "_id": "HpyqvpBDM6D2jUC6",
+            "_id": "oXTohw0EcH1Lz0DC",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "fCdcyCkGlmp0c34A",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/fundamental-armor-runes/armor-potency.webp",
             "range": [
-                31,
-                36
+                22,
+                27
             ],
             "text": "Resilient (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "bqsJMu7IB225fTYz",
+            "_id": "qHbzl1c86qnT0Stw",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "ZSt2PxZVik7UHGG3",
+            "documentId": "oVrVzML63VFvVfKk",
             "drawn": false,
-            "img": "icons/weapons/staves/staff-simple-spiral.webp",
+            "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
             "range": [
-                37,
-                42
+                28,
+                33
             ],
-            "text": "Staff of Abjuration (Major)",
+            "text": "Vitalizing (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "xkxbqKf3zQN0HjG2",
+            "_id": "q8TNFASSDux7JPLm",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "7aLpTxRVmoNQTqvJ",
+            "documentId": "smrNvKVL976JNEab",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/staves/staff-of-conjuration.webp",
+            "img": "icons/weapons/staves/staff-orb-feather.webp",
+            "range": [
+                34,
+                39
+            ],
+            "text": "Fluid Form Staff (Major)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "gMpkl2Cv34oi7x4E",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "ndF4yxyM5ci1DcrO",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/staves/staff-of-enchantment.webp",
+            "range": [
+                40,
+                42
+            ],
+            "text": "Staff of Control (Major)",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "fswfPDe1HmCdV16t",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "9UfuJHNdyBBNfCsO",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/staves/staff-of-evocation.webp",
             "range": [
                 43,
                 48
             ],
-            "text": "Staff of Conjuration (Major)",
+            "text": "Staff of Elemental Power (Major)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "kQTbzpAKyDIdb9PY",
+            "_id": "zPRWCcsgNwVMGEUn",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "lOeShVkqV98KlvTI",
+            "documentId": "7RBY90RmMtZjvnGW",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/staves/staff-of-divination.webp",
+            "img": "systems/pf2e/icons/equipment/staves/staff-of-illusion.webp",
             "range": [
                 49,
                 54
             ],
-            "text": "Staff of Divination (Major)",
+            "text": "Staff of Phantasms (Major)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "11E6i8082Hr9VbAI",
+            "_id": "x1TbOL0cK5XbyvL5",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "MeUgw1hsSEcWP97G",
+            "documentId": "TLLZIFIPbhW8kjyL",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/staves/staff-of-enchantment.webp",
+            "img": "icons/weapons/staves/staff-engraved-wood.webp",
             "range": [
                 55,
                 60
             ],
-            "text": "Staff of Enchantment (Major)",
+            "text": "Staff of Protection (Major)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "vQq7Hy7Dx1a8GCHZ",
+            "_id": "pCEhWPN2UPwqZsQO",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "kNvo4FNaiQRnZfO7",
+            "documentId": "027hHaJojFz1qJBG",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/staves/staff-of-evocation.webp",
+            "img": "systems/pf2e/icons/equipment/staves/staff-of-conjuration.webp",
             "range": [
                 61,
                 66
             ],
-            "text": "Staff of Evocation (Major)",
+            "text": "Staff of Summoning (Major)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "dwXrm0DZwZ0Vtpyl",
+            "_id": "ngGZxMgK4Jg8RndL",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "gG4IUEzqD253s7nx",
+            "documentId": "E30OrRp0StKLQwbQ",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/staves/staff-of-illusion.webp",
+            "img": "icons/weapons/staves/staff-skull-feathers-brown.webp",
             "range": [
                 67,
                 72
             ],
-            "text": "Staff of Illusion (Major)",
+            "text": "Staff of the Dead (Major)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "ViMk7CeQzvGeYUrC",
+            "_id": "oXFzgueayodUdKu1",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "IIV5L4y8zLH17mAK",
+            "documentId": "APjEozp9ibSFV7zM",
             "drawn": false,
-            "img": "icons/weapons/staves/staff-skull-feathers-brown.webp",
+            "img": "icons/weapons/staves/staff-ornate-eye.webp",
             "range": [
                 73,
-                78
+                75
             ],
-            "text": "Staff of Necromancy (Major)",
+            "text": "Staff of the Unblinking Eye (Major)",
             "type": "pack",
-            "weight": 6
+            "weight": 3
         },
         {
-            "_id": "rj2RuyHe7q9qcZ2d",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "GlyiVrIokFpFFRu2",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/staves/staff-of-transmutation.webp",
-            "range": [
-                79,
-                84
-            ],
-            "text": "Staff of Transmutation (Major)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "o3gZ97kIi4lo11BY",
+            "_id": "vZfdoeHsW3UCcPyV",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "JDQ4jqp6O8SurQGe",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-widening.webp",
             "range": [
-                85,
-                90
+                76,
+                81
             ],
             "text": "Wand of Widening (6th-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "TbqN7piUhgo0OfAf",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "OIs6WPuCRh2UJTOe",
-            "drawn": false,
-            "img": "icons/weapons/swords/greatsword-guard-gold-worn.webp",
-            "range": [
-                91,
-                93
-            ],
-            "text": "Holy Avenger",
-            "type": "pack",
-            "weight": 3
-        },
-        {
-            "_id": "l9CD8GKGvhWX8hAA",
+            "_id": "wth333kNJGimbHY2",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "Za5Mnae009cDCwuN",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/weapons/specific-magic-weapons/storm-flash.webp",
             "range": [
-                94,
-                99
+                82,
+                87
             ],
             "text": "Storm Flash",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "t5t1wLQE2o2FC0iI",
+            "_id": "1lf5WiZq6cGalaE0",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "8mhSUxEvNuXDP8Ki",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/bracers-of-armor.webp",
+            "range": [
+                88,
+                93
+            ],
+            "text": "Bands of Force (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "6mdIhYWj5lwRwz5q",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "31knfVD7lEd8BPrQ",
             "drawn": false,
             "img": "icons/equipment/feet/boots-leather-engraved-brown.webp",
             "range": [
-                100,
-                105
+                94,
+                99
             ],
             "text": "Boots of Bounding (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "SaGLwztjSNglsrzf",
+            "_id": "vIfsdo05U4hcTLV1",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "8mhSUxEvNuXDP8Ki",
+            "documentId": "zyAzx6fLsPurRFQO",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/bracers-of-armor.webp",
+            "img": "icons/equipment/neck/amulet-round-engraved-spiral-gold.webp",
+            "range": [
+                100,
+                105
+            ],
+            "text": "Charm of Resistance (Major)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "TNsWCtdpRTjCgpOr",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "HZDkF6MlNQ6yYobD",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/held-items/primeval-mistletoe.webp",
             "range": [
                 106,
                 111
             ],
-            "text": "Bracers of Armor II",
+            "text": "Primeval Mistletoe (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "wDGaxAN4F6RLlPZV",
+            "_id": "uUEnYd2PJ0vwXF9L",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "zyAzx6fLsPurRFQO",
+            "documentId": "U8vVCE2ePjyca666",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/ring-of-energy-resistance.webp",
+            "img": "icons/weapons/staves/staff-ornate-eye.webp",
             "range": [
                 112,
                 117
             ],
-            "text": "Ring of Energy Resistance (Major)",
+            "text": "Staff of Providence (Major)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "S0kG1NmHVtkY2ZNf",
+            "_id": "vZpRloBZxqlWpRZG",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "8jPsriZqWY1hAgob",
+            "documentId": "RDoxgjEFsherGA5x",
             "drawn": false,
-            "img": "icons/equipment/finger/ring-band-engraved-silver.webp",
+            "img": "icons/weapons/staves/staff-simple-wrapped.webp",
             "range": [
                 118,
-                120
+                123
             ],
-            "text": "Ring of Wizardry (Type IV)",
+            "text": "Staff of the Tempest (Major)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "yKcAKyNCkd24VRMQ",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/wands/magic-wands/magic-wand.webp",
+            "range": [
+                124,
+                129
+            ],
+            "text": "Wand of Crackling Lightning (6th-Rank Spell)",
+            "type": "text",
+            "weight": 6
+        },
+        {
+            "_id": "PLZOGOlGS1YUXBgr",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "ut83Grf73Z8ZTaV1",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-the-snowfields.webp",
+            "range": [
+                130,
+                135
+            ],
+            "text": "Wand of the Snowfields (5th-Rank Spell)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "C9qzZsPrMcWgeB37",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "OIs6WPuCRh2UJTOe",
+            "drawn": false,
+            "img": "icons/weapons/swords/greatsword-guard-gold-worn.webp",
+            "range": [
+                136,
+                138
+            ],
+            "text": "Chalice of Justice",
             "type": "pack",
             "weight": 3
         }


### PR DESCRIPTION
Update 14th-Level Consumable Items and 14th-Level Permanent Items tables with remaster changes, consolidating the treasure tables from the GM Core and Player Core 2 books, preserving the item order found in those tables. Weight is based on rarity:

    Common = 6
    Uncommon = 3
    Rare = 1

For items that do not have a corresponding entry in the compendium, create a text entry in the table with the appropriate item name. If possible, set an appropriate icon from the system's icon set.