### PR TITLE
Update 15th-level rollable tables

### DIFF
--- a/packs/rollable-tables/15th-level-consumables-items.json
+++ b/packs/rollable-tables/15th-level-consumables-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "Af7beeFZhtvDAZaM",
-    "description": "Table of 15th-Level Consumables Items",
+    "description": "<p>Table of 15th-Level Consumables Items</p>",
     "displayRoll": true,
-    "formula": "1d63",
+    "formula": "1d69",
     "img": "icons/svg/d20-grey.svg",
     "name": "15th-Level Consumables Items",
     "ownership": {
@@ -11,28 +11,14 @@
     "replacement": true,
     "results": [
         {
-            "_id": "mYq4p5qykRLe1Ok4",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Gfew65lwkzZc3mUV",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/ammunition/disintegration-bolt.webp",
-            "range": [
-                1,
-                3
-            ],
-            "text": "Disintegration Bolt",
-            "type": "pack",
-            "weight": 3
-        },
-        {
             "_id": "QN2b9QvvhEhXYHss",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "WearPqN56FQofpF6",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/ammunition/spellstrike-ammunition.webp",
             "range": [
-                4,
-                9
+                1,
+                6
             ],
             "text": "Spellstrike Ammunition (Type VII)",
             "type": "pack",
@@ -45,8 +31,8 @@
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/ammunition/stone-bullet.webp",
             "range": [
-                10,
-                15
+                7,
+                12
             ],
             "text": "Stone Bullet",
             "type": "pack",
@@ -59,8 +45,8 @@
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/bravos-brew.webp",
             "range": [
-                16,
-                21
+                13,
+                18
             ],
             "text": "Bravo's Brew (Greater)",
             "type": "pack",
@@ -73,8 +59,8 @@
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/elixir-of-life.webp",
             "range": [
-                22,
-                27
+                19,
+                24
             ],
             "text": "Elixir of Life (Major)",
             "type": "pack",
@@ -87,8 +73,8 @@
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/sea-touch-elixir.webp",
             "range": [
-                28,
-                33
+                25,
+                30
             ],
             "text": "Sea Touch Elixir (Greater)",
             "type": "pack",
@@ -101,68 +87,96 @@
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/oils/obfuscation-oil.webp",
             "range": [
-                34,
-                39
+                31,
+                36
             ],
             "text": "Obfuscation Oil",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "HpyqvpBDM6D2jUC6",
+            "_id": "6SWHH86jLsI29CD9",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "6swrLimere2nZtz9",
+            "documentId": "gJboDbIGscCvSlFc",
             "drawn": false,
-            "img": "icons/commodities/materials/glass-orb-marble-green.webp",
+            "img": "icons/magic/fire/barrier-shield-explosion-yellow.webp",
             "range": [
-                40,
-                45
+                37,
+                42
             ],
-            "text": "Dragon Bile",
+            "text": "Frozen Lava of Ka",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "iVRvYJVcwJbGNujk",
+            "_id": "DzyxqRcyNKjwiHB1",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "GMi5tw0cbMx3ZQPg",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/mindfog-mist.webp",
             "range": [
-                46,
-                51
+                43,
+                48
             ],
             "text": "Mindfog Mist",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "n93IZ9OXbT0N8exF",
+            "_id": "nu5pOqFr6c8BrqZK",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "E999hL7XlAlfZhjK",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/potions/potion-of-flying.webp",
             "range": [
-                52,
-                57
+                49,
+                54
             ],
             "text": "Potion of Flying (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "dfzcLplUcufLhROU",
+            "_id": "NygbAM7cNvB1CAQS",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "iPki3yuoucnj7bIt",
             "drawn": false,
             "img": "icons/sundries/scrolls/scroll-symbol-eye-brown.webp",
             "range": [
-                58,
-                63
+                55,
+                60
             ],
-            "text": "Scroll of 8th-level Spell",
+            "text": "Scroll of 8th-rank Spell",
             "type": "pack",
             "weight": 6
+        },
+        {
+            "_id": "96OhBKZ3zIkvOae0",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "9a7nJAErs4dfetFJ",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/potency-crystal.webp",
+            "range": [
+                61,
+                66
+            ],
+            "text": "Potency Crystal (Major)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "w8gzDSYBDW6eOfSh",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "Gfew65lwkzZc3mUV",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/ammunition/disintegration-bolt.webp",
+            "range": [
+                67,
+                69
+            ],
+            "text": "Disintegration Bolt",
+            "type": "pack",
+            "weight": 3
         }
     ]
 }

--- a/packs/rollable-tables/15th-level-permanent-items.json
+++ b/packs/rollable-tables/15th-level-permanent-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "X2QkgnYrda4mV5v3",
-    "description": "Table of 15th-Level Permanent Items",
+    "description": "<p>Table of 15th-Level Permanent Items</p>",
     "displayRoll": true,
-    "formula": "1d87",
+    "formula": "1d105",
     "img": "icons/svg/d20-grey.svg",
     "name": "15th-Level Permanent Items",
     "ownership": {
@@ -11,49 +11,35 @@
     "replacement": true,
     "results": [
         {
-            "_id": "mYq4p5qykRLe1Ok4",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "gp5kgCySEOuntQPF",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/armor/specific-magic-armor/plate-armor-of-the-deep.webp",
-            "range": [
-                1,
-                3
-            ],
-            "text": "Plate Armor of the Deep",
-            "type": "pack",
-            "weight": 3
-        },
-        {
             "_id": "QN2b9QvvhEhXYHss",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "VDMYyVQUWJAjVyru",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/held-items/crystal-ball-selenite.webp",
             "range": [
-                4,
-                6
+                1,
+                3
             ],
             "text": "Crystal Ball (Selenite)",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "aPbhuQl16Dn83HR8",
+            "_id": "tY25nyR43Qsv5X4h",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "RnpzfRWsOW6zmAgN",
+            "documentId": "X9ZEqWNgHPQO1SCc",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/held-items/wondrous-figurine-obsidian-steed.webp",
+            "img": "icons/magic/earth/explosion-lava-orange.webp",
             "range": [
-                7,
+                4,
                 9
             ],
-            "text": "Wondrous Figurine (Obsidian Steed)",
+            "text": "Eternal Eruption of Ka",
             "type": "pack",
-            "weight": 3
+            "weight": 6
         },
         {
-            "_id": "oLZsd9xeniDUB97N",
+            "_id": "x7YcQk1nzhmI5erd",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "o02lg3k1RBoFXVFV",
             "drawn": false,
@@ -67,186 +53,228 @@
             "weight": 3
         },
         {
-            "_id": "zz0eL7k3QNTKNXc3",
+            "_id": "q1xiJNlsgDEzUpGg",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "vQUIUAFOTOWj3ohh",
+            "documentId": "hebf5k3cd7LO6luX",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
             "range": [
                 13,
                 18
             ],
-            "text": "Corrosive (Greater)",
+            "text": "Astral (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "lLzSpPUauPOj4sfl",
+            "_id": "F0oGKYOwenW33oPe",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "RSZwUlCzUX7Nb4UA",
+            "documentId": "vQUIUAFOTOWj3ohh",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
             "range": [
                 19,
                 24
             ],
-            "text": "Flaming (Greater)",
+            "text": "Corrosive (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "HpyqvpBDM6D2jUC6",
+            "_id": "NfHNE6lqr6fKMCLN",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Sexud7FdxIrg50vU",
+            "documentId": "HGsA5gXtaAA65n9e",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
             "range": [
                 25,
                 30
             ],
-            "text": "Frost (Greater)",
+            "text": "Decaying (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "bqsJMu7IB225fTYz",
+            "_id": "WbF0KEl8ifSBwcG2",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "TEa1oKZbwsOvC6TZ",
+            "documentId": "RSZwUlCzUX7Nb4UA",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
             "range": [
                 31,
                 36
             ],
-            "text": "Shock (Greater)",
+            "text": "Flaming (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "xkxbqKf3zQN0HjG2",
+            "_id": "WdPXRr8lSrCq4qDb",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Lb7F2BR9X9TF1vjX",
+            "documentId": "Sexud7FdxIrg50vU",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
             "range": [
                 37,
                 42
             ],
+            "text": "Frost (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "s2rcNN81mAQLC4vI",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "TEa1oKZbwsOvC6TZ",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
+            "range": [
+                43,
+                48
+            ],
+            "text": "Shock (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "0AwWVoJ3T1LXWJfj",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "Lb7F2BR9X9TF1vjX",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
+            "range": [
+                49,
+                54
+            ],
             "text": "Thundering (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "kQTbzpAKyDIdb9PY",
+            "_id": "Wh7vECo1qGhBEJPH",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "kCjvkkuI3JP4TQ0t",
+            "documentId": null,
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/cold-Iron-buckler.webp",
-            "range": [
-                43,
-                48
-            ],
-            "text": "Cold Iron Buckler (High-Grade)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "11E6i8082Hr9VbAI",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "nRmGErgTLZYf6WMD",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/cold-Iron-shield.webp",
-            "range": [
-                49,
-                54
-            ],
-            "text": "Cold Iron Shield (High-Grade)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "dwXrm0DZwZ0Vtpyl",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "LboYDYZ0IbDWuWMl",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/silver-buckler.webp",
             "range": [
                 55,
                 60
             ],
-            "text": "Silver Buckler (High-Grade)",
-            "type": "pack",
+            "text": "Cold Iron Buckler (High-Grade)",
+            "type": "text",
             "weight": 6
         },
         {
-            "_id": "ViMk7CeQzvGeYUrC",
+            "_id": "a7Hio2h8DBxyOxtW",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "pRzafUKQviDSMRJp",
+            "documentId": null,
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/silver-shield.webp",
+            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/cold-Iron-shield.webp",
             "range": [
                 61,
                 66
             ],
-            "text": "Silver Shield (High-Grade)",
-            "type": "pack",
+            "text": "Cold Iron Shield (High-Grade)",
+            "type": "text",
             "weight": 6
         },
         {
-            "_id": "rj2RuyHe7q9qcZ2d",
+            "_id": "8OznDFr9BOMq5Wa2",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/silver-buckler.webp",
+            "range": [
+                67,
+                72
+            ],
+            "text": "Silver Buckler (High-Grade)",
+            "type": "text",
+            "weight": 6
+        },
+        {
+            "_id": "0XYx2mFHoq1jVNvR",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/silver-shield.webp",
+            "range": [
+                73,
+                78
+            ],
+            "text": "Silver Shield (High-Grade)",
+            "type": "text",
+            "weight": 6
+        },
+        {
+            "_id": "bDCNLD8uieg27jbk",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "nmXPj9zuMRQBNT60",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/magic-wands/magic-wand.webp",
             "range": [
-                67,
-                72
+                79,
+                84
             ],
             "text": "Magic Wand (7th-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "o3gZ97kIi4lo11BY",
+            "_id": "sz8DxD7RYFZUaNQe",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "35rLqxDWgiDIkL8e",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-continuation.webp",
             "range": [
-                73,
-                78
+                85,
+                90
             ],
             "text": "Wand of Continuation (6th-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "TbqN7piUhgo0OfAf",
+            "_id": "3tBbYBoFBhnDqkL8",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "ZZcIhgiKuptXRGyK",
+            "documentId": "rrWSGLJVxXAMeP07",
             "drawn": false,
-            "img": "icons/equipment/neck/collar-rounded-carved-wood-spiral.webp",
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/aluum-charm.webp",
             "range": [
-                79,
-                84
+                91,
+                93
             ],
-            "text": "Necklace of Fireballs VI",
+            "text": "Countering Charm (Greater)",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "LF6hEKPt87Q70SOg",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "3pKIEBtZBVmSmVPl",
+            "drawn": false,
+            "img": "icons/equipment/back/mantle-collared-brown.webp",
+            "range": [
+                94,
+                99
+            ],
+            "text": "Earthglide Cloak",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "t5t1wLQE2o2FC0iI",
+            "_id": "xPCOnyZmGiqZpTsm",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Wkh5rQx3IqInEKdT",
+            "documentId": "VtzChvlCG2TQRrgu",
             "drawn": false,
-            "img": "icons/equipment/chest/robe-layered-white.webp",
+            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-overflowing-life.webp",
             "range": [
-                85,
-                87
+                100,
+                105
             ],
-            "text": "Robe of the Archmagi",
+            "text": "Wand of Overflowing Life (6th-Rank Spell)",
             "type": "pack",
-            "weight": 3
+            "weight": 6
         }
     ]
 }


### PR DESCRIPTION
Update 15th-Level Consumable Items and 15th-Level Permanent Items tables with remaster changes, consolidating the treasure tables from the GM Core and Player Core 2 books, preserving the item order found in those tables. Weight is based on rarity:

    Common = 6
    Uncommon = 3
    Rare = 1

For items that do not have a corresponding entry in the compendium, create a text entry in the table with the appropriate item name. If possible, set an appropriate icon from the system's icon set.