### PR TITLE
Update 16th-level rollable tables

### DIFF
--- a/packs/rollable-tables/16th-level-consumables-items.json
+++ b/packs/rollable-tables/16th-level-consumables-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "aomFSKgGl52z7tdX",
-    "description": "Table of 16th-Level Consumables Items",
+    "description": "<p>Table of 16th-Level Consumables Items</p>",
     "displayRoll": true,
-    "formula": "1d60",
+    "formula": "1d78",
     "img": "icons/svg/d20-grey.svg",
     "name": "16th-Level Consumables Items",
     "ownership": {
@@ -25,128 +25,184 @@
             "weight": 6
         },
         {
-            "_id": "QN2b9QvvhEhXYHss",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "XMuLrJYL6fxv4YNA",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/salamander-elixir.webp",
-            "range": [
-                7,
-                12
-            ],
-            "text": "Salamander Elixir (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "k455WZW8SCQLXbsv",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "aDn5blt2iiYJpzbe",
-            "drawn": false,
-            "img": "icons/consumables/potions/bottle-round-ring-teal.webp",
-            "range": [
-                13,
-                18
-            ],
-            "text": "Winter Wolf Elixir (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "aPbhuQl16Dn83HR8",
+            "_id": "RhMMkUEM2ZHPjHub",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "9nhvZ7VnDQHuyBdf",
             "drawn": false,
             "img": "icons/tools/laboratory/mortar-powder-green.webp",
             "range": [
-                19,
-                24
+                7,
+                12
             ],
             "text": "Brimstone Fumes",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "oLZsd9xeniDUB97N",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "X6vNtRjyHIuN7vqj",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/nightmare-vapor.webp",
-            "range": [
-                25,
-                30
-            ],
-            "text": "Nightmare Vapor",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "lLzSpPUauPOj4sfl",
+            "_id": "pyr2VtgKceCBGueK",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "CoMwPsQ8mPj5Evti",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/weapons/truesight-potion.webp",
+            "img": "systems/pf2e/icons/equipment/consumables/potions/truesight-potion.webp",
             "range": [
-                31,
-                36
+                13,
+                18
             ],
             "text": "Truesight Potion",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "HpyqvpBDM6D2jUC6",
+            "_id": "TlldR5zAmAJmyVfz",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "s0DffbZbYlav3mu1",
+            "drawn": false,
+            "img": "icons/commodities/metal/fragments-steel-ring.webp",
+            "range": [
+                19,
+                24
+            ],
+            "text": "Alloy Orb (High-Grade)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "1HqDgeyzFU4dgF74",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "dmQAN56aMro0gecx",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/ghost-dust.webp",
+            "range": [
+                25,
+                30
+            ],
+            "text": "Ghost Dust",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "XfZt0NUuVgQx23II",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "XMuLrJYL6fxv4YNA",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/salamander-elixir.webp",
+            "range": [
+                31,
+                36
+            ],
+            "text": "Cooling Elixir (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "o9SZUcyDhASqPmCL",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "aDn5blt2iiYJpzbe",
+            "drawn": false,
+            "img": "icons/consumables/potions/bottle-round-ring-teal.webp",
+            "range": [
+                37,
+                42
+            ],
+            "text": "Witchwarg Elixir (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "qEkGehl1hwCyqOWV",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "EP8f2NL28vPlmX7k",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/oils/oil-of-object-animation.webp",
+            "range": [
+                43,
+                45
+            ],
+            "text": "Oil of Dynamism (Greater)",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "UbDH7OtN077SfQkC",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "yPFHTY1GH3rdWwds",
+            "drawn": false,
+            "img": "icons/containers/bags/coinpouch-leather-grey.webp",
+            "range": [
+                46,
+                48
+            ],
+            "text": "Dust of Corpse Animation (Greater)",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "vQChpy6BOD8BbyiU",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "9hdT05ywPVyh9vQX",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/cerulean-scourge.webp",
+            "range": [
+                49,
+                54
+            ],
+            "text": "Cerulean Scourge",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "9vWsgTXQhl0rUazd",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "Odl2SyKw8Zg6ckKb",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/snares/hail-of-arrows-snare.webp",
             "range": [
-                37,
-                42
+                55,
+                60
             ],
             "text": "Hail of Arrows Snare",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "iVRvYJVcwJbGNujk",
+            "_id": "kWHlhqqW8UO3687G",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "tnCKwIsRsKj3FtG6",
             "drawn": false,
             "img": "icons/weapons/polearms/javelin.webp",
             "range": [
-                43,
-                48
+                61,
+                66
             ],
             "text": "Omnidirectional Spear Snare",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "n93IZ9OXbT0N8exF",
+            "_id": "a4NIm4AlC9hi44gz",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "K2Exm6VVe9XXCdZe",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/balisse-feather.webp",
+            "range": [
+                67,
+                72
+            ],
+            "text": "Balisse Feather (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "WLRY4fw2lISUj8pr",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "4Pmo9gc81JAOzdke",
             "drawn": false,
             "img": "icons/commodities/treasure/token-runed-mem-red.webp",
             "range": [
-                49,
-                54
+                73,
+                78
             ],
             "text": "Flame Navette",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "dfzcLplUcufLhROU",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "dmQAN56aMro0gecx",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/consumables/talismans/ghost-dust.webp",
-            "range": [
-                55,
-                60
-            ],
-            "text": "Ghost Dust",
             "type": "pack",
             "weight": 6
         }

--- a/packs/rollable-tables/16th-level-permanent-items.json
+++ b/packs/rollable-tables/16th-level-permanent-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "J7XfeVrfUj72IkRY",
-    "description": "Table of 16th-Level Permanent Items",
+    "description": "<p>Table of 16th-Level Permanent Items</p>",
     "displayRoll": true,
-    "formula": "1d119",
+    "formula": "1d125",
     "img": "icons/svg/d20-grey.svg",
     "name": "16th-Level Permanent Items",
     "ownership": {
@@ -11,28 +11,14 @@
     "replacement": true,
     "results": [
         {
-            "_id": "mYq4p5qykRLe1Ok4",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "3xsQ1AA4dyMHLxpw",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/armor/specific-magic-armor/dragonplate.webp",
-            "range": [
-                1,
-                3
-            ],
-            "text": "Dragonplate",
-            "type": "pack",
-            "weight": 3
-        },
-        {
             "_id": "QN2b9QvvhEhXYHss",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "S0IshWO7Vx29PKaq",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/held-items/crystal-ball-moonstone.webp",
             "range": [
-                4,
-                6
+                1,
+                3
             ],
             "text": "Crystal Ball (Moonstone)",
             "type": "pack",
@@ -45,362 +31,404 @@
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/fundamental-weapon-runes/weapon-potency.webp",
             "range": [
-                7,
-                12
+                4,
+                9
             ],
             "text": "Weapon Potency (+3)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "3EqXFbXhBaS3HemC",
+            "_id": "ErQAnCfjM1myq3DW",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "KnZL0xPWDzQx9vWQ",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
+            "range": [
+                10,
+                10
+            ],
+            "text": "Quickstrike",
+            "type": "pack",
+            "weight": 1
+        },
+        {
+            "_id": "SNRw2amo9a9V1VCp",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "1Nhc0C2gdJvIM7Mv",
+            "drawn": false,
+            "img": "icons/commodities/treasure/token-runed-os-grey.webp",
+            "range": [
+                11,
+                16
+            ],
+            "text": "Reinforcing Rune (Major)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "gf7IvA6RX6tBy9IP",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "9imz3VgBXCg13RfT",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/armor-property-runes/armor-property-runes.webp",
             "range": [
-                13,
-                18
+                17,
+                22
             ],
             "text": "Slick (Major)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "oLZsd9xeniDUB97N",
+            "_id": "vCuzOYCakW2jYfWL",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "KnZL0xPWDzQx9vWQ",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
-            "range": [
-                19,
-                19
-            ],
-            "text": "Speed",
-            "type": "pack",
-            "weight": 1
-        },
-        {
-            "_id": "zz0eL7k3QNTKNXc3",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "AbYyx61j1K4F27tC",
+            "documentId": null,
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/adamantite-buckler.webp",
-            "range": [
-                20,
-                22
-            ],
-            "text": "Adamantine Buckler (High-Grade)",
-            "type": "pack",
-            "weight": 3
-        },
-        {
-            "_id": "lLzSpPUauPOj4sfl",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "rA1hULhhqOP2u4Ze",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/adamantite-shield.webp",
             "range": [
                 23,
                 25
             ],
-            "text": "Adamantine Shield (High-Grade)",
-            "type": "pack",
+            "text": "Adamantine Buckler (High-Grade)",
+            "type": "text",
             "weight": 3
         },
         {
-            "_id": "HpyqvpBDM6D2jUC6",
+            "_id": "MOGcB4tFiWnqnjTB",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "sRHR4cEo8WnowjU3",
+            "documentId": null,
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/darkwood-buckler.webp",
+            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/adamantite-shield.webp",
             "range": [
                 26,
                 28
             ],
-            "text": "Duskwood Buckler (High-Grade)",
-            "type": "pack",
+            "text": "Adamantine Shield (High-Grade)",
+            "type": "text",
             "weight": 3
         },
         {
-            "_id": "bqsJMu7IB225fTYz",
+            "_id": "QJge9C87jWXwTqxx",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "V4kbHwiODxwJOJga",
+            "documentId": null,
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/darkwood-shield.webp",
+            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/mithral-buckler.webp",
             "range": [
                 29,
                 31
             ],
-            "text": "Duskwood Shield (High-Grade)",
-            "type": "pack",
+            "text": "Dawnsilver Buckler (High-Grade)",
+            "type": "text",
             "weight": 3
         },
         {
-            "_id": "xkxbqKf3zQN0HjG2",
+            "_id": "5SC049RWqPZCEb0b",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "8gcuJ2Ev3euFyXnS",
+            "documentId": null,
             "drawn": false,
-            "img": "icons/equipment/shield/oval-wooden-boss-bronze.webp",
+            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/mithral-shield.webp",
             "range": [
                 32,
                 34
             ],
-            "text": "Duskwood Tower Shield (High-Grade)",
-            "type": "pack",
+            "text": "Dawnsilver Shield (High-Grade)",
+            "type": "text",
             "weight": 3
         },
         {
-            "_id": "11E6i8082Hr9VbAI",
+            "_id": "KukTyATcUCIgDwE1",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "R1I1MEKwDYtCfZr3",
+            "documentId": null,
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/dragonhide-buckler.webp",
+            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/darkwood-buckler.webp",
             "range": [
                 35,
                 37
             ],
-            "text": "Dragonhide Buckler (High-Grade)",
-            "type": "pack",
+            "text": "Duskwood Buckler (High-Grade)",
+            "type": "text",
             "weight": 3
         },
         {
-            "_id": "vQq7Hy7Dx1a8GCHZ",
+            "_id": "f9D1HL9zEaN7UFbS",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "LVixPROPOwIfHgEK",
+            "documentId": null,
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/dragonhide-shield.webp",
+            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/darkwood-shield.webp",
             "range": [
                 38,
                 40
             ],
-            "text": "Dragonhide Shield (High-Grade)",
-            "type": "pack",
+            "text": "Duskwood Shield (High-Grade)",
+            "type": "text",
             "weight": 3
         },
         {
-            "_id": "dwXrm0DZwZ0Vtpyl",
+            "_id": "cYMwgBndcsiUdBWO",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/darkwood-tower-shield.webp",
+            "range": [
+                41,
+                43
+            ],
+            "text": "Duskwood Tower Shield (High-Grade)",
+            "type": "text",
+            "weight": 3
+        },
+        {
+            "_id": "09rH95pMX5yv2imP",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "uAs0hUUgROrndceD",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/shields/specific-shields/floating-shield.webp",
             "range": [
-                41,
+                44,
                 46
             ],
             "text": "Floating Shield (Greater)",
             "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "ViMk7CeQzvGeYUrC",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "ZZrCiVcoKinA5wyu",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/mithral-buckler.webp",
-            "range": [
-                47,
-                49
-            ],
-            "text": "Dawnsilver Buckler (High-Grade)",
-            "type": "pack",
             "weight": 3
         },
         {
-            "_id": "rj2RuyHe7q9qcZ2d",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "5dBSn9brsT9NISoR",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/mithral-shield.webp",
-            "range": [
-                50,
-                52
-            ],
-            "text": "Dawnsilver Shield (High-Grade)",
-            "type": "pack",
-            "weight": 3
-        },
-        {
-            "_id": "o3gZ97kIi4lo11BY",
+            "_id": "kXL56LrtVzve5vnA",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "BWQzaHbGVqlBuMww",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/shields/specific-shields/sturdy-shield.webp",
             "range": [
-                53,
-                58
+                47,
+                52
             ],
             "text": "Sturdy Shield (Major)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "OtH5vWwuqo4ICMuF",
+            "_id": "7c2OxWu0aYI6xlbb",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "L7FuscHIuzQ7FjnB",
+            "drawn": false,
+            "img": "icons/weapons/staves/staff-ornate-blue.webp",
+            "range": [
+                53,
+                53
+            ],
+            "text": "Staff of Arcane Might (Greater)",
+            "type": "pack",
+            "weight": 1
+        },
+        {
+            "_id": "KpcO84KW5GbzV14f",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "WbcQqXrUytXkCMK3",
             "drawn": false,
             "img": "icons/weapons/staves/staff-ornate-gold-jeweled.webp",
             "range": [
-                59,
-                64
+                54,
+                59
             ],
             "text": "Staff of Healing (True)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "TbqN7piUhgo0OfAf",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "6m9niDjhA6tBfp5x",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/staves/staff-of-power.webp",
-            "range": [
-                65,
-                65
-            ],
-            "text": "Staff of Power",
-            "type": "pack",
-            "weight": 1
-        },
-        {
-            "_id": "l9CD8GKGvhWX8hAA",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "EXXqJp8rU6HR5Ufg",
-            "drawn": false,
-            "img": "icons/commodities/stone/masonry-block-cube-white.webp",
-            "range": [
-                66,
-                68
-            ],
-            "text": "Instant Fortress",
-            "type": "pack",
-            "weight": 3
-        },
-        {
-            "_id": "t5t1wLQE2o2FC0iI",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "CjfBdn0fOIarWzBc",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-slaying.webp",
-            "range": [
-                69,
-                74
-            ],
-            "text": "Wand of Slaying (7th-Rank Spell)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "h0V7NslKyo33CZ8S",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "YR8IAV94fPo0kfBz",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-smoldering-fireballs.webp",
-            "range": [
-                75,
-                80
-            ],
-            "text": "Wand of Smoldering Fireballs (7th-Rank Spell)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "ijektyI06wFyI74K",
+            "_id": "wduLku2rYtrAiZ5g",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "kNfdGNIGzF0fW7aq",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-widening.webp",
             "range": [
-                81,
-                86
+                60,
+                65
             ],
             "text": "Wand of Widening (7th-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "ptNK0YuKNbGPVoft",
-            "documentCollection": "",
-            "documentId": "87IvbaQnkUOBgdD0",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/weapons/specific-magic-weapons/frost-brand.webp",
-            "range": [
-                87,
-                92
-            ],
-            "text": "+3 greater striking weapon",
-            "type": "text",
-            "weight": 6
-        },
-        {
-            "_id": "Y5y28wkaN1jjSkAn",
-            "documentCollection": "",
+            "_id": "shsNW4GWyqdUH6kv",
+            "documentCollection": "pf2e.equipment-srd",
             "documentId": null,
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "systems/pf2e/icons/equipment/weapons/shortsword.webp",
             "range": [
-                93,
-                98
+                66,
+                71
             ],
-            "text": "Cold Iron Weapon (High-Grade)",
+            "text": "PFS Standard Magic Weapon (+3 greater striking)",
             "type": "text",
             "weight": 6
         },
         {
-            "_id": "Q7Ve3BbkAHrs0xMr",
+            "_id": "Xn8lbAyrzA81tueY",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "87IvbaQnkUOBgdD0",
+            "documentId": "NARrXbTyQ2X6hA7e",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/weapons/specific-magic-weapons/frost-brand.webp",
+            "img": "icons/magic/water/projectile-arrow-ice-gray-blue.webp",
             "range": [
-                99,
-                104
+                72,
+                77
             ],
-            "text": "Frost Brand",
+            "text": "Icicle",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "V4OLETYmWxh1173i",
-            "documentCollection": "",
-            "documentId": "MO8J2IcBhiTnm9D8",
+            "_id": "zzvOhjNSYEcFOSro",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/aeon-stone-orange-prism.webp",
+            "img": "systems/pf2e/icons/equipment/weapons/shortsword.webp",
             "range": [
-                105,
-                110
+                78,
+                83
             ],
             "text": "Silver Weapon (High-Grade)",
             "type": "text",
             "weight": 6
         },
         {
-            "_id": "tzBqLHuSP3M9RvFR",
-            "documentCollection": "",
-            "documentId": "sRHR4cEo8WnowjU3",
+            "_id": "n5zDdFGdfjsLYXX1",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/darkwood-buckler.webp",
+            "img": "icons/equipment/hand/gauntlet-simple-leather-brown-gold.webp",
             "range": [
-                111,
-                116
+                84,
+                89
             ],
-            "text": "+3 greater striking Handwraps of Mighty Blows",
+            "text": "Handwraps of Mighty Blows (+3 greater striking)",
             "type": "text",
             "weight": 6
         },
         {
-            "_id": "HTKMHSq72RqTtwHx",
+            "_id": "snd5rdXixGN0YJ1a",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "MO8J2IcBhiTnm9D8",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/aeon-stone-orange-prism.webp",
             "range": [
-                117,
-                119
+                90,
+                92
             ],
             "text": "Aeon Stone (Amplifying)",
             "type": "pack",
             "weight": 3
+        },
+        {
+            "_id": "Tav6IxAFToZDfwN2",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "r8i96DqaLYfWDW1T",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/aeon-stone-pearly-white-spindle.webp",
+            "range": [
+                93,
+                95
+            ],
+            "text": "Aeon Stone (Peering)",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "IIympAUOn1NOEvqz",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "3xsQ1AA4dyMHLxpw",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/armor/specific-magic-armor/dragonplate.webp",
+            "range": [
+                96,
+                98
+            ],
+            "text": "Dragonplate",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "Zvf9LDDHW7eDT1nz",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/dragonhide-buckler.webp",
+            "range": [
+                99,
+                101
+            ],
+            "text": "Dragonhide Buckler (High-Grade)",
+            "type": "text",
+            "weight": 3
+        },
+        {
+            "_id": "1M5zQjvdRmPxnqWn",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/dragonhide-shield.webp",
+            "range": [
+                102,
+                104
+            ],
+            "text": "Dragonhide Shield (High-Grade)",
+            "type": "text",
+            "weight": 3
+        },
+        {
+            "_id": "NaGBBxvHeDphCE7I",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "TyW1XOWYMM2xHGaI",
+            "drawn": false,
+            "img": "icons/equipment/shield/heater-wooden-antlers-blue.webp",
+            "range": [
+                105,
+                110
+            ],
+            "text": "Medusa's Scream (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "QQjShkfaqjxi27Zt",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "oT4pyqLKpJVXDb46",
+            "drawn": false,
+            "img": "icons/weapons/staves/staff-crescent-green.webp",
+            "range": [
+                111,
+                113
+            ],
+            "text": "Staff of Impossible Visions (Major)",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "Xcm9hIIhrToB6Mym",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "CjfBdn0fOIarWzBc",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-slaying.webp",
+            "range": [
+                114,
+                119
+            ],
+            "text": "Wand of Slaughter (7th-Rank Spell)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "QPluqB8EzBYSVd3J",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "YR8IAV94fPo0kfBz",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-smoldering-fireballs.webp",
+            "range": [
+                120,
+                125
+            ],
+            "text": "Wand of Smoldering Fireballs (7th-Rank Spell)",
+            "type": "pack",
+            "weight": 6
         }
     ]
 }


### PR DESCRIPTION
Update 16th-Level Consumable Items and 16th-Level Permanent Items tables with remaster changes, consolidating the treasure tables from the GM Core and Player Core 2 books, preserving the item order found in those tables. Weight is based on rarity:

    Common = 6
    Uncommon = 3
    Rare = 1

For items that do not have a corresponding entry in the compendium, create a text entry in the table with the appropriate item name. If possible, set an appropriate icon from the system's icon set.