### PR TITLE
Update 17th-level rollable tables

### DIFF
--- a/packs/rollable-tables/17th-level-consumables-items.json
+++ b/packs/rollable-tables/17th-level-consumables-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "YyQkwd1PksU1Lno4",
-    "description": "Table of 17th-Level Consumables Items",
+    "description": "<p>Table of 17th-Level Consumables Items</p>",
     "displayRoll": true,
-    "formula": "1d102",
+    "formula": "1d132",
     "img": "icons/svg/d20-grey.svg",
     "name": "17th-Level Consumables Items",
     "ownership": {
@@ -53,198 +53,268 @@
             "weight": 6
         },
         {
-            "_id": "aPbhuQl16Dn83HR8",
+            "_id": "3pjgz5ntFYRWT91T",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "rpbbfkexLhtadBDV",
+            "documentId": "MCHYtxP8E7njLC3s",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/bottled-lightning.webp",
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/dread-ampoule.webp",
             "range": [
                 19,
                 24
             ],
-            "text": "Bottled Lightning (Major)",
+            "text": "Dread Ampoule (Major)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "3EqXFbXhBaS3HemC",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "4DJQID8GIlxQ7b9C",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/frost-vial.webp",
-            "range": [
-                25,
-                30
-            ],
-            "text": "Frost Vial (Major)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "zz0eL7k3QNTKNXc3",
+            "_id": "K8ZbgmPz7sd36RfT",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "BxJNWWvpxacDIsdt",
             "drawn": false,
             "img": "icons/containers/bags/sack-simple-leather-tan.webp",
             "range": [
+                25,
+                30
+            ],
+            "text": "Glue Bomb (Major)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "b7q4a5qCotNK268i",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "lvsQe0qLzhnWYqa0",
+            "drawn": false,
+            "img": "icons/magic/fire/barrier-shield-explosion-yellow.webp",
+            "range": [
                 31,
                 36
             ],
-            "text": "Tanglefoot Bag (Major)",
+            "text": "Frozen Lava of Sakalayo",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "lLzSpPUauPOj4sfl",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "IuGydh0En8LbfnWo",
-            "drawn": false,
-            "img": "icons/commodities/gems/pearl-rough-turquoise.webp",
-            "range": [
-                37,
-                42
-            ],
-            "text": "Thunderstone (Major)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "HpyqvpBDM6D2jUC6",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "nS75vsM3x5jxlUqn",
-            "drawn": false,
-            "img": "icons/consumables/potions/bottle-round-flask-fumes-purple.webp",
-            "range": [
-                43,
-                48
-            ],
-            "text": "Bestial Mutagen (Major)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "iVRvYJVcwJbGNujk",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "VBK9i74dry8yf8f0",
-            "drawn": false,
-            "img": "icons/consumables/potions/potion-vial-corked-purple.webp",
-            "range": [
-                49,
-                54
-            ],
-            "text": "Cognitive Mutagen (Major)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "dfzcLplUcufLhROU",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "1kNp6yOS0aZPBPzZ",
-            "drawn": false,
-            "img": "icons/consumables/potions/bottle-round-corked-green.webp",
-            "range": [
-                55,
-                60
-            ],
-            "text": "Juggernaut Mutagen (Major)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "lOjMYhGKB6F7sxCJ",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "4GXzTN6iSDGfYEAi",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/quicksilver-mutagen.webp",
-            "range": [
-                61,
-                66
-            ],
-            "text": "Quicksilver Mutagen (Major)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "cNiXfxE2P5RtTXho",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "ccrdVliTNBh2mNZf",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/serene-mutagen.webp",
-            "range": [
-                67,
-                72
-            ],
-            "text": "Serene Mutagen (Major)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "DgXAZtsXNLNOBZef",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "uD5vRYVOXNJ53sEE",
-            "drawn": false,
-            "img": "icons/consumables/potions/potion-bottle-corked-fancy-blue.webp",
-            "range": [
-                73,
-                78
-            ],
-            "text": "Silvertongue Mutagen (Major)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "AFCYNssCdBzJJVoj",
+            "_id": "DbQB4uyQuSA31siP",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "MP7updiiSct04vno",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/hemlock.webp",
             "range": [
-                79,
-                84
+                37,
+                42
             ],
             "text": "Hemlock",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "L0pHQgrfUEM4EvtT",
-            "documentCollection": "",
+            "_id": "oSws9xfamTmNoygk",
+            "documentCollection": "pf2e.equipment-srd",
             "documentId": null,
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "systems/pf2e/icons/equipment/consumables/potions/green-dragons-breath-potion.webp",
             "range": [
-                85,
-                90
+                43,
+                48
             ],
-            "text": "Dragon's Breath Potion, Wyrm",
+            "text": "Energy Breath Potion (Greater)",
             "type": "text",
             "weight": 6
         },
         {
-            "_id": "EQ4wSNuLtSMzgDxo",
+            "_id": "ClRvaHzj6CVpAKGC",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "cFHomF3tty8Wi1e5",
             "drawn": false,
             "img": "icons/sundries/scrolls/scroll-symbol-eye-brown.webp",
             "range": [
-                91,
-                96
+                49,
+                54
             ],
-            "text": "Scroll of 9th-level Spell",
+            "text": "Scroll of 9th-rank Spell",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "ab0fuZuEzGYeHk0f",
+            "_id": "8QKpmna1p5xrvdt2",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "mGIJCGFkBQLkzhTg",
             "drawn": false,
             "img": "icons/commodities/stone/paver-cobble-white.webp",
             "range": [
+                55,
+                60
+            ],
+            "text": "Dispelling Sliver",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "fNSQp0IlYDKlBwZA",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "IuGydh0En8LbfnWo",
+            "drawn": false,
+            "img": "icons/commodities/gems/pearl-rough-turquoise.webp",
+            "range": [
+                61,
+                66
+            ],
+            "text": "Blasting Stone (Major)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "1IALZvAWBe1S5iNz",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "sJjuv1991SZ7DWWD",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/blight-bomb.webp",
+            "range": [
+                67,
+                72
+            ],
+            "text": "Blight Bomb (Major)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "ZyfeMthAq4YgdsjV",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "rpbbfkexLhtadBDV",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/bottled-lightning.webp",
+            "range": [
+                73,
+                78
+            ],
+            "text": "Bottled Lightning (Major)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "GXR39wGMifblNk4W",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "4DJQID8GIlxQ7b9C",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/frost-vial.webp",
+            "range": [
+                79,
+                84
+            ],
+            "text": "Frost Vial (Major)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "HlYtNd9YC3Xma6aD",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "i7bJcib5TUJKOd4Z",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/ghost-charge.webp",
+            "range": [
+                85,
+                90
+            ],
+            "text": "Ghost Charge (Major)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "I8JOxqZaAwcbM3tu",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "nS75vsM3x5jxlUqn",
+            "drawn": false,
+            "img": "icons/consumables/potions/bottle-round-flask-fumes-purple.webp",
+            "range": [
+                91,
+                96
+            ],
+            "text": "Bestial Mutagen (Major)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "7CpzPnoXuHfXhj1b",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "VBK9i74dry8yf8f0",
+            "drawn": false,
+            "img": "icons/consumables/potions/potion-vial-corked-purple.webp",
+            "range": [
                 97,
                 102
             ],
-            "text": "Dispelling Sliver",
+            "text": "Cognitive Mutagen (Major)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "CAamimQ9OHHxUcin",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "M4ZOHOlne43ArjOC",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/drakeheart-mutagen.webp",
+            "range": [
+                103,
+                108
+            ],
+            "text": "Drakeheart Mutagen (Major)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "oHRqsdeQhPZD9s8j",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "1kNp6yOS0aZPBPzZ",
+            "drawn": false,
+            "img": "icons/consumables/potions/bottle-metal-yellow-gray.webp",
+            "range": [
+                109,
+                114
+            ],
+            "text": "Juggernaut Mutagen (Major)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "HredApICg5LUKDk2",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "4GXzTN6iSDGfYEAi",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/quicksilver-mutagen.webp",
+            "range": [
+                115,
+                120
+            ],
+            "text": "Quicksilver Mutagen (Major)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "XO0c6j11uqjl7sAu",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "ccrdVliTNBh2mNZf",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/serene-mutagen.webp",
+            "range": [
+                121,
+                126
+            ],
+            "text": "Serene Mutagen (Major)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "3qbKS5MHfUZJgdYe",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "uD5vRYVOXNJ53sEE",
+            "drawn": false,
+            "img": "icons/consumables/potions/potion-bottle-corked-fancy-blue.webp",
+            "range": [
+                127,
+                132
+            ],
+            "text": "Silvertongue Mutagen (Major)",
             "type": "pack",
             "weight": 6
         }

--- a/packs/rollable-tables/17th-level-permanent-items.json
+++ b/packs/rollable-tables/17th-level-permanent-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "0jlGmwn6YGqsfG1q",
-    "description": "Table of 17th-Level Permanent Items",
+    "description": "<p>Table of 17th-Level Permanent Items</p>",
     "displayRoll": true,
-    "formula": "1d36",
+    "formula": "1d165",
     "img": "icons/svg/d20-grey.svg",
     "name": "17th-Level Permanent Items",
     "ownership": {
@@ -11,438 +11,466 @@
     "replacement": true,
     "results": [
         {
-            "_id": "mYq4p5qykRLe1Ok4",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "9IwSktj0Xj7A2Ruh",
-            "drawn": false,
-            "img": "icons/equipment/neck/collar-rounded-gold-blue.webp",
-            "range": [
-                1,
-                1
-            ],
-            "text": "Anklets of Alacrity",
-            "type": "pack",
-            "weight": 1
-        },
-        {
-            "_id": "QN2b9QvvhEhXYHss",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "7utuH8VJjKEzKtNw",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/apex-items/belt-of-giant-strength.webp",
-            "range": [
-                2,
-                2
-            ],
-            "text": "Belt of Giant Strength",
-            "type": "pack",
-            "weight": 1
-        },
-        {
-            "_id": "k455WZW8SCQLXbsv",
+            "_id": "ym4yu8G8JjvkyolF",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "K2rMmiBlzcysNuj6",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/apex-items/belt-of-regeneration.webp",
             "range": [
-                3,
-                3
+                1,
+                6
             ],
-            "text": "Belt of Regeneration",
+            "text": "Belt of Long Life",
             "type": "pack",
-            "weight": 1
+            "weight": 6
         },
         {
-            "_id": "aPbhuQl16Dn83HR8",
+            "_id": "wGGifecdqAuMsSMy",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "0yeM77XLNrB0a0LF",
+            "documentId": "WOiCJSS2MicKCMVs",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/apex-items/circlet-of-persuasion.webp",
+            "img": "icons/equipment/wrist/bracer-segmented-leather.webp",
             "range": [
-                4,
-                4
+                7,
+                12
             ],
-            "text": "Circlet of Persuasion",
+            "text": "Bracers of Strength",
             "type": "pack",
-            "weight": 1
+            "weight": 6
         },
         {
-            "_id": "3EqXFbXhBaS3HemC",
+            "_id": "SOUNJEubhyc7xYE9",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "C3SwBSW8XzzBPDVT",
+            "drawn": false,
+            "img": "icons/equipment/back/mantle-collared-blue.webp",
+            "range": [
+                13,
+                18
+            ],
+            "text": "Cloak of Swiftness",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "4hRVczdLzPvBzQ6t",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "1FKDq4Gfev5GObDT",
             "drawn": false,
             "img": "icons/equipment/finger/ring-band-thin-silver-teal.webp",
             "range": [
-                5,
-                5
+                19,
+                24
             ],
-            "text": "Diadem of Intellect",
+            "text": "Crown of Intellect",
             "type": "pack",
-            "weight": 1
+            "weight": 6
         },
         {
-            "_id": "oLZsd9xeniDUB97N",
+            "_id": "80VEKNReXw5gRLsi",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "hjfoSyfsGSTLpPMr",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/apex-items/headband-of-inspired-wisdom.webp",
             "range": [
-                6,
-                6
+                25,
+                30
             ],
-            "text": "Headband of Inspired Wisdom",
+            "text": "Headwrap of Wisdom",
             "type": "pack",
-            "weight": 1
+            "weight": 6
         },
         {
-            "_id": "zz0eL7k3QNTKNXc3",
+            "_id": "DFlSIGNvTHUqEuam",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "AMOs47C4WiVY5IW3",
+            "drawn": false,
+            "img": "icons/equipment/neck/necklace-jeweled-silver-blue.webp",
+            "range": [
+                31,
+                36
+            ],
+            "text": "Necklace of Allure",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "L7xByb0nJayanRsL",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "aLA7pikfeNIAAGLw",
             "drawn": false,
             "img": "icons/equipment/chest/breastplate-banded-steel.webp",
             "range": [
-                7,
-                7
+                37,
+                39
             ],
             "text": "Impenetrable Scale",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "lLzSpPUauPOj4sfl",
+            "_id": "eJdkKJkZ0iV6rMET",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "ByRyBRjNBcK5rwQ9",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/held-items/crystal-ball-peridot.webp",
             "range": [
-                8,
-                8
+                40,
+                42
             ],
             "text": "Crystal Ball (Peridot)",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "bqsJMu7IB225fTYz",
+            "_id": "kj3WbPMkao19WQro",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "q70WXJO1rswduHuT",
+            "documentId": "fhOnKVwftnOwayBp",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/runes/armor-property-runes/armor-property-runes.webp",
+            "img": "icons/magic/earth/explosion-lava-orange.webp",
             "range": [
-                10,
-                10
+                43,
+                48
             ],
-            "text": "Ethereal",
+            "text": "Eternal Eruption of Sakalayo",
             "type": "pack",
-            "weight": 3
+            "weight": 6
         },
         {
-            "_id": "xkxbqKf3zQN0HjG2",
+            "_id": "GmctGkBejac8V4c0",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "2FjdEflsVldnuebM",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/armor-property-runes/armor-property-runes.webp",
             "range": [
-                11,
-                11
+                49,
+                54
             ],
             "text": "Shadow (Major)",
             "type": "pack",
-            "weight": 1
+            "weight": 6
         },
         {
-            "_id": "kQTbzpAKyDIdb9PY",
+            "_id": "w9aI81BWww2hmC8V",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "6xaxxKfvXED6LfIY",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
             "range": [
-                12,
-                12
+                55,
+                55
             ],
             "text": "Vorpal",
             "type": "pack",
             "weight": 1
         },
         {
-            "_id": "11E6i8082Hr9VbAI",
+            "_id": "krGdjQzVCJV4L8dL",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "PeS3J9r4ss7gNytK",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/orichalcum-shield.webp",
-            "range": [
-                13,
-                13
-            ],
-            "text": "Orichalcum Shield (High-Grade)",
-            "type": "pack",
-            "weight": 1
-        },
-        {
-            "_id": "vQq7Hy7Dx1a8GCHZ",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "OKo8ub6D11ztZc2V",
+            "documentId": null,
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/orichalcum-buckler.webp",
             "range": [
-                14,
-                14
+                56,
+                56
             ],
             "text": "Orichalcum Buckler (High-Grade)",
-            "type": "pack",
+            "type": "text",
             "weight": 1
         },
         {
-            "_id": "dwXrm0DZwZ0Vtpyl",
+            "_id": "5jH4YZ61q3ZXR8Up",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/shields/precious-material-shields/orichalcum-shield.webp",
+            "range": [
+                57,
+                57
+            ],
+            "text": "Orichalcum Shield (High-Grade)",
+            "type": "text",
+            "weight": 1
+        },
+        {
+            "_id": "ei0B9bj5o4dfjutO",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "Qs8RgNH6thRPv2jt",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/magic-wands/magic-wand.webp",
             "range": [
-                15,
-                15
+                58,
+                63
             ],
             "text": "Magic Wand (8th-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "ViMk7CeQzvGeYUrC",
+            "_id": "6sI9KTT76wMGLd5I",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "H1XGrl6Z0bzXN2oi",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-continuation.webp",
             "range": [
-                16,
-                16
+                64,
+                69
             ],
             "text": "Wand of Continuation (7th-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "rj2RuyHe7q9qcZ2d",
+            "_id": "4h7EA9VpYQjzOrnO",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "WeX7rAO2kAyP0QnG",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-manifold-missiles.webp",
             "range": [
-                17,
-                17
+                70,
+                75
             ],
-            "text": "Wand of Manifold Missiles (7th-Rank Spell)",
+            "text": "Wand of Shardstorm (7th-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "o3gZ97kIi4lo11BY",
-            "documentCollection": "",
+            "_id": "SWTpYQqnH8N5Rc27",
+            "documentCollection": "pf2e.equipment-srd",
             "documentId": null,
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "systems/pf2e/icons/equipment/weapons/greatsword.webp",
             "range": [
-                18,
-                18
+                76,
+                78
             ],
             "text": "Adamantine Weapon (High-Grade)",
             "type": "text",
             "weight": 3
         },
         {
-            "_id": "OtH5vWwuqo4ICMuF",
-            "documentCollection": "",
+            "_id": "U6qWRAv8ho1VOAxD",
+            "documentCollection": "pf2e.equipment-srd",
             "documentId": null,
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "systems/pf2e/icons/equipment/weapons/greatsword.webp",
             "range": [
-                19,
-                19
-            ],
-            "text": "Duskwood Weapon (High-Grade)",
-            "type": "text",
-            "weight": 3
-        },
-        {
-            "_id": "TbqN7piUhgo0OfAf",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "pvxRcuBexbFawjCg",
-            "drawn": false,
-            "img": "icons/weapons/swords/sword-guard-red.webp",
-            "range": [
-                20,
-                20
-            ],
-            "text": "Flame Tongue (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "l9CD8GKGvhWX8hAA",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "pIYlenaADKnxdp11",
-            "drawn": false,
-            "img": "icons/weapons/swords/sword-guard-engraved.webp",
-            "range": [
-                21,
-                21
-            ],
-            "text": "Luck Blade",
-            "type": "pack",
-            "weight": 1
-        },
-        {
-            "_id": "t5t1wLQE2o2FC0iI",
-            "documentCollection": "",
-            "documentId": null,
-            "drawn": false,
-            "img": "icons/svg/d20-black.svg",
-            "range": [
-                22,
-                22
+                79,
+                81
             ],
             "text": "Dawnsilver Weapon (High-Grade)",
             "type": "text",
             "weight": 3
         },
         {
-            "_id": "ijektyI06wFyI74K",
+            "_id": "8VykN166sn0jGWUv",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "bnmfBLXOBd3ah6GK",
+            "documentId": null,
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/alchemist-goggles.webp",
+            "img": "systems/pf2e/icons/equipment/weapons/greatsword.webp",
             "range": [
-                24,
-                24
+                82,
+                84
             ],
-            "text": "Alchemist Goggles (Major)",
+            "text": "Duskwood Weapon (High-Grade)",
+            "type": "text",
+            "weight": 3
+        },
+        {
+            "_id": "r98ZFKTBhfj95PVV",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "pvxRcuBexbFawjCg",
+            "drawn": false,
+            "img": "icons/weapons/swords/sword-guard-red.webp",
+            "range": [
+                85,
+                90
+            ],
+            "text": "Searing Blade (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "ptNK0YuKNbGPVoft",
+            "_id": "q5iVaLDpXHXCPoM3",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "ZdAZ1ALZ28QOeCN7",
+            "drawn": false,
+            "img": "icons/equipment/chest/robe-collared-blue.webp",
+            "range": [
+                91,
+                96
+            ],
+            "text": "Accolade Robe (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "Refccn218PWSt6qK",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "FNccUmKsyXKmfe5c",
             "drawn": false,
             "img": "icons/equipment/wrist/bracer-studded-leather-steel.webp",
             "range": [
-                25,
-                25
+                97,
+                102
             ],
             "text": "Armbands of Athleticism (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "Q7Ve3BbkAHrs0xMr",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "ifAp8wHKBZltgHG0",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/cloak-of-the-bat.webp",
-            "range": [
-                27,
-                27
-            ],
-            "text": "Cloak of the Bat (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "V4OLETYmWxh1173i",
+            "_id": "XsZaGyoWMXul2Rw9",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "kjFFmqci69k2zMXF",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/daredevil-boots.webp",
             "range": [
-                28,
-                28
+                103,
+                108
             ],
             "text": "Daredevil Boots (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "tzBqLHuSP3M9RvFR",
+            "_id": "SIID2LyLE3WKICgQ",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "pDw2wi0znVb8Dysg",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/dread-blindfold.webp",
             "range": [
-                29,
-                29
+                109,
+                114
             ],
             "text": "Dread Blindfold",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "HTKMHSq72RqTtwHx",
+            "_id": "jintxS1zU5mnLgvL",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "DrjFwJhp66GfH5Wi",
+            "drawn": false,
+            "img": "icons/equipment/neck/choker-rounded-gold-green.webp",
+            "range": [
+                115,
+                120
+            ],
+            "text": "Entertainer's Cincture (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "9efvy46Lt0iYAIYL",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "AynKTlER5ZbfF62f",
+            "drawn": false,
+            "img": "icons/containers/bags/pouch-leather-green.webp",
+            "range": [
+                121,
+                126
+            ],
+            "text": "Humbug Pocket (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "dbq5v0mRAjWCVsCm",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "b9YHyjOL4sg7tjI4",
             "drawn": false,
             "img": "icons/equipment/finger/ring-faceted-ornate-silver-red.webp",
             "range": [
-                30,
-                30
+                127,
+                132
             ],
             "text": "Messenger's Ring (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "RmELaGtnx5jnCttJ",
+            "_id": "kZbWumUFlP59Eh0A",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "mOY0STwY5hx4UPCN",
+            "documentId": "etnis6HOeGZEbScD",
             "drawn": false,
-            "img": "icons/equipment/neck/collar-rounded-carved-wood-spiral.webp",
+            "img": "icons/commodities/treasure/broach-jewel-gold-blue.webp",
             "range": [
-                31,
-                31
+                133,
+                138
             ],
-            "text": "Necklace of Fireballs VII",
+            "text": "Shining Symbol (Major)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "cUiaoi4qfU7SkB7r",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "hrG2w4IfF1QZhSzw",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/phylactery-of-faithfulness.webp",
-            "range": [
-                32,
-                32
-            ],
-            "text": "Phylactery of Faithfulness (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "ZTXWhifc6MYf96Ya",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "KFfM3Y8SbhdxpbQI",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/robe-of-eyes.webp",
-            "range": [
-                34,
-                34
-            ],
-            "text": "Robe of Eyes",
-            "type": "pack",
-            "weight": 3
-        },
-        {
-            "_id": "NO1x4QDskWaHpo55",
+            "_id": "l2yQnEp2GyXkEmyr",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "LRSIRUERqBAJ1HGT",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/voyagers-pack.webp",
             "range": [
-                36,
-                36
+                139,
+                141
             ],
             "text": "Voyager's Pack",
             "type": "pack",
             "weight": 3
+        },
+        {
+            "_id": "zkWL3YmsSVsmkeU9",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "grRxpX1iE3zOJA1q",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-overflowing-life.webp",
+            "range": [
+                142,
+                147
+            ],
+            "text": "Wand of Overflowing Life (7th-Rank Spell)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "3x2LLKKDSDjasjJv",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "bnmfBLXOBd3ah6GK",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/alchemist-goggles.webp",
+            "range": [
+                148,
+                153
+            ],
+            "text": "Alchemist Goggles (Major)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "EPht3z9Tqmb2iybo",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "6fnjxb9sjrKm0N2r",
+            "drawn": false,
+            "img": "icons/equipment/neck/pendant-faceted-red.webp",
+            "range": [
+                154,
+                159
+            ],
+            "text": "Sanguine Pendant (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "TEyQokhJtDXJnZbe",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "uj09q6x8wPAZcMs9",
+            "drawn": false,
+            "img": "icons/equipment/waist/sash-cloth-green-white.webp",
+            "range": [
+                160,
+                165
+            ],
+            "text": "Sash of Prowess (Greater)",
+            "type": "pack",
+            "weight": 6
         }
     ]
 }


### PR DESCRIPTION
Update 17th-Level Consumable Items and 17th-Level Permanent Items tables with remaster changes, consolidating the treasure tables from the GM Core and Player Core 2 books, preserving the item order found in those tables. Weight is based on rarity:

    Common = 6
    Uncommon = 3
    Rare = 1

For items that do not have a corresponding entry in the compendium, create a text entry in the table with the appropriate item name. If possible, set an appropriate icon from the system's icon set.