### PR TITLE
Update 18th-level rollable tables

### DIFF
--- a/packs/rollable-tables/18th-level-consumables.json
+++ b/packs/rollable-tables/18th-level-consumables.json
@@ -1,8 +1,8 @@
 {
     "_id": "PSs31Xj5RfszMbAe",
-    "description": "Table of 18th-Level Consumables Items",
+    "description": "<p>Table of 18th-Level Consumables Items</p>",
     "displayRoll": true,
-    "formula": "1d18",
+    "formula": "1d57",
     "img": "icons/svg/d20-grey.svg",
     "name": "18th-Level Consumables",
     "ownership": {
@@ -11,21 +11,21 @@
     "replacement": true,
     "results": [
         {
-            "_id": "JUhkDL3C0e5g0N8w",
+            "_id": "ERAfkhWp5o6ZA0BC",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "RkI3jKKrCozvEvfr",
+            "documentId": "obER4cKi8UbGhSg7",
             "drawn": false,
-            "img": "icons/consumables/potions/potion-flask-corked-labeled-pink.webp",
+            "img": "systems/pf2e/icons/equipment/consumables/oils/oil-of-unlife.webp",
             "range": [
                 1,
                 6
             ],
-            "text": "King's Sleep",
+            "text": "Oil of Unlife (Major)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "yHmHb5vJkmqmywHU",
+            "_id": "erYUCrEfx73FOHcp",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "p3ppzFSsZXFRe3H8",
             "drawn": false,
@@ -39,7 +39,7 @@
             "weight": 6
         },
         {
-            "_id": "IyJWyGEjEFTlgBWX",
+            "_id": "jC6cvkl6Du7CIkaY",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "UblsH5cGyUdXypek",
             "drawn": false,
@@ -49,6 +49,104 @@
                 18
             ],
             "text": "Potion of Undetectability",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "RrByibG44q00z6ux",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "ECjche2BfpWHZ3vU",
+            "drawn": false,
+            "img": "icons/commodities/metal/fragments-steel-ring.webp",
+            "range": [
+                19,
+                21
+            ],
+            "text": "Alloy Orb (Exquisite High-Grade)",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "ZrZrRAZmeMZLW66l",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "V2knI4GpdJYLupjg",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/crystal-shards.webp",
+            "range": [
+                22,
+                27
+            ],
+            "text": "Crystal Shards (Major)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "dfypFImh3WoOLAOR",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "Pnw4A7fhUhTS85Te",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/focus-cathartic.webp",
+            "range": [
+                28,
+                33
+            ],
+            "text": "Bottled Catharsis (Major)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "BJODqnzF99AuK5CW",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "YIgIF1845n5UBFnE",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/sinew-shock-serum.webp",
+            "range": [
+                34,
+                39
+            ],
+            "text": "Surging Serum (Major)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "gviSz5f6DbxO5Ju4",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "RkI3jKKrCozvEvfr",
+            "drawn": false,
+            "img": "icons/consumables/potions/potion-flask-corked-labeled-pink.webp",
+            "range": [
+                40,
+                45
+            ],
+            "text": "King's Sleep",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "87xPbrMbTERta9Gl",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/potions/potion-of-cold-retalliation.webp",
+            "range": [
+                46,
+                51
+            ],
+            "text": "Potion of Retaliation (Major)",
+            "type": "text",
+            "weight": 6
+        },
+        {
+            "_id": "JYXuLktqUhR8akCO",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "jdkMRl7zxOVGUuGI",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-tools/universal-solvent.webp",
+            "range": [
+                52,
+                57
+            ],
+            "text": "Absolute Solvent (Greater)",
             "type": "pack",
             "weight": 6
         }

--- a/packs/rollable-tables/18th-level-permanent-items.json
+++ b/packs/rollable-tables/18th-level-permanent-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "6FmhLLYH94xhucIs",
-    "description": "Table of 18th-Level Permanent Items",
+    "description": "<p>Table of 18th-Level Permanent Items</p>",
     "displayRoll": true,
-    "formula": "1d101",
+    "formula": "1d149",
     "img": "icons/svg/d20-grey.svg",
     "name": "18th-Level Permanent Items",
     "ownership": {
@@ -15,7 +15,7 @@
             "documentCollection": "",
             "documentId": null,
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "systems/pf2e/icons/equipment/armor/scale-mail.webp",
             "range": [
                 1,
                 6
@@ -25,28 +25,14 @@
             "weight": 6
         },
         {
-            "_id": "gJB3UcpgtlC07O4k",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "XKON66YXYLXlGPPg",
-            "drawn": false,
-            "img": "icons/equipment/chest/breastplate-gorget-steel-purple.webp",
-            "range": [
-                7,
-                12
-            ],
-            "text": "Breastplate of Command (Greater)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
             "_id": "C6ippWC7SsXOvPgH",
             "documentCollection": "",
             "documentId": null,
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "systems/pf2e/icons/equipment/armor/breastplate.webp",
             "range": [
-                13,
-                18
+                7,
+                12
             ],
             "text": "Cold Iron Armor (High-Grade)",
             "type": "text",
@@ -57,10 +43,10 @@
             "documentCollection": "",
             "documentId": null,
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "systems/pf2e/icons/equipment/armor/breastplate.webp",
             "range": [
-                19,
-                24
+                13,
+                18
             ],
             "text": "Silver Armor (High-Grade)",
             "type": "text",
@@ -73,8 +59,8 @@
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/held-items/maestros-instrument.webp",
             "range": [
-                25,
-                30
+                19,
+                24
             ],
             "text": "Maestro's Instrument (Greater)",
             "type": "pack",
@@ -87,8 +73,8 @@
             "drawn": false,
             "img": "icons/containers/bags/pouch-leather-silver-white.webp",
             "range": [
-                31,
-                36
+                25,
+                30
             ],
             "text": "Marvelous Medicines (Greater)",
             "type": "pack",
@@ -101,8 +87,8 @@
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/held-items/possibility-tome.webp",
             "range": [
-                37,
-                42
+                31,
+                36
             ],
             "text": "Possibility Tome",
             "type": "pack",
@@ -115,8 +101,8 @@
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/held-items/thurible-of-revelation.webp",
             "range": [
-                43,
-                48
+                37,
+                42
             ],
             "text": "Thurible of Revelation (Greater)",
             "type": "pack",
@@ -129,15 +115,29 @@
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/fundamental-armor-runes/armor-potency.webp",
             "range": [
-                49,
-                54
+                43,
+                48
             ],
             "text": "Armor Potency (+3)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "UpaKSgXrKvWSjMPJ",
+            "_id": "56T7eflwa5sNv3Kk",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "n8MonEa4ZBdvEovc",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/weapon-property-runes/weapon-property-runes.webp",
+            "range": [
+                49,
+                54
+            ],
+            "text": "Brilliant (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "4ZahKFCfqj0RRGnq",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "ujWnpVMkbTljMGN9",
             "drawn": false,
@@ -151,7 +151,7 @@
             "weight": 6
         },
         {
-            "_id": "zrymm07q77o0qDVi",
+            "_id": "DWoJdSL3iQKDz9Dh",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "SUbYk6B1iPoGyyjh",
             "drawn": false,
@@ -165,7 +165,7 @@
             "weight": 1
         },
         {
-            "_id": "kZuXo7VtlKcxFJSj",
+            "_id": "MRcIkpq4YIWjFuqJ",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "La9qYc5NHsg423Jb",
             "drawn": false,
@@ -179,100 +179,226 @@
             "weight": 3
         },
         {
-            "_id": "8HlZU8WjXzpPjaT0",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "LnXYSaLxWMyAT3Ef",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-slaying.webp",
-            "range": [
-                65,
-                70
-            ],
-            "text": "Wand of Slaying (8th-Rank Spell)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "IuaIq8uMe5efm2ZD",
+            "_id": "AxdtTGmes632KVx2",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "20nQTcGzpUv8jJ6R",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-widening.webp",
             "range": [
-                71,
-                76
+                65,
+                70
             ],
             "text": "Wand of Widening (8th-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "DQXpEC3gEUXHrVDu",
-            "documentCollection": "",
+            "_id": "IrJG9FbHryJyRAs7",
+            "documentCollection": "pf2e.equipment-srd",
             "documentId": null,
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "systems/pf2e/icons/equipment/weapons/shortsword.webp",
             "range": [
-                77,
-                77
+                71,
+                71
             ],
-            "text": "Orichalcum Weapon, High-Grade",
+            "text": "Orichalcum Weapon (High-Grade)",
             "type": "text",
             "weight": 1
         },
         {
-            "_id": "ypwrqQs15lWnt7Kf",
+            "_id": "owGfoVxCabOLbQlk",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "i9mxfSIBTTOwsSlx",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/weapons/specific-magic-weapons/storm-flash.webp",
             "range": [
-                78,
-                83
+                72,
+                77
             ],
             "text": "Storm Flash (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "aqx18CDCK998paCE",
+            "_id": "4TxaeFaJyjNCLPsq",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "rXXNw6dwVn96giDi",
+            "documentId": "39wTBxfaHkAHwXhw",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/goggles-of-night.webp",
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/aluum-charm.webp",
             "range": [
-                84,
-                89
+                78,
+                80
             ],
-            "text": "Obsidian Goggles (Major)",
+            "text": "Countering Charm (Major)",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "RUh2yhWsz0D7jsNa",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "4v850xbHgUdlvamn",
+            "drawn": false,
+            "img": "icons/equipment/finger/ring-crown-gold-pink.webp",
+            "range": [
+                81,
+                86
+            ],
+            "text": "Crown of Witchcraft (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "spRTcttinnFogKjC",
+            "_id": "QtZpUfs3ShKsxInI",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "V9iVPhIk980GT6A2",
             "drawn": false,
             "img": "icons/equipment/waist/belt-leather-studded-gold.webp",
             "range": [
-                90,
-                95
+                87,
+                92
             ],
             "text": "Inexplicable Apparatus",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "8dlmyudY7oQ3nj3v",
+            "_id": "WIEb3T5u1PROoA6N",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "IdI7rfCk7WjGbJHN",
+            "drawn": false,
+            "img": "icons/equipment/back/mantle-collared-green.webp",
+            "range": [
+                93,
+                98
+            ],
+            "text": "Living Mantle (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "UbTg7A4Xc2SDUTsS",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "rXXNw6dwVn96giDi",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/goggles-of-night.webp",
+            "range": [
+                99,
+                104
+            ],
+            "text": "Obsidian Goggles (Major)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "mNqnqXh7bMrHsDgy",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "C7FeT7eVuwRnLhJy",
+            "drawn": false,
+            "img": "icons/commodities/treasure/broach-eye-silver-teal.webp",
+            "range": [
+                105,
+                107
+            ],
+            "text": "Symbol of Conflict (Major)",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "q65YDWbuOFuZ1kyl",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "XKON66YXYLXlGPPg",
+            "drawn": false,
+            "img": "icons/equipment/chest/breastplate-gorget-steel-purple.webp",
+            "range": [
+                108,
+                113
+            ],
+            "text": "Warleader's Bulwark (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "a8xT7QYTVLN2bTjP",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "U28jkj5ZDl2drtEH",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-crackling-lightning.webp",
+            "range": [
+                114,
+                119
+            ],
+            "text": "Wand of Crackling Lightning (8th-Rank Spell)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "1WF1xYtdhBOK5qPu",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "LnXYSaLxWMyAT3Ef",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-slaying.webp",
+            "range": [
+                120,
+                125
+            ],
+            "text": "Wand of Slaughter (8th-Rank Spell)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "wfvrV6qqTLMCt7a1",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "q2kE0mEUAEL3gQv0",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-the-snowfields.webp",
+            "range": [
+                126,
+                131
+            ],
+            "text": "Wand of the Snowfields (7th-Rank Spell)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "Ax7n9MKcYsaaQtCE",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "FKf6eELtbFhbK69W",
+            "drawn": false,
+            "img": "icons/equipment/head/helm-barbute-rounded-gold.webp",
+            "range": [
+                132,
+                137
+            ],
+            "text": "Helm Of Zeal (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "3SMLaDGYLWgKuxkV",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "2FlazfdJE2XPRba8",
+            "drawn": false,
+            "img": "icons/equipment/head/hood-purple-mask.webp",
+            "range": [
+                138,
+                143
+            ],
+            "text": "Prognostic Veil (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "7CchMzGHQtfeei3Y",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "Wkm2VYPsfGjWBtQe",
             "drawn": false,
             "img": "icons/equipment/finger/ring-band-engraved-scrolls-bronze.webp",
             "range": [
-                96,
-                101
+                144,
+                149
             ],
-            "text": "Ring of Manical Devices (Greater)",
+            "text": "Ring of Maniacal Devices (Greater)",
             "type": "pack",
             "weight": 6
         }


### PR DESCRIPTION
Update 18th-Level Consumable Items and 18th-Level Permanent Items tables with remaster changes, consolidating the treasure tables from the GM Core and Player Core 2 books, preserving the item order found in those tables. Weight is based on rarity:

    Common = 6
    Uncommon = 3
    Rare = 1

For items that do not have a corresponding entry in the compendium, create a text entry in the table with the appropriate item name. If possible, set an appropriate icon from the system's icon set.