### PR TITLE
Update 19th-level rollable tables

### DIFF
--- a/packs/rollable-tables/19th-level-consumables-items.json
+++ b/packs/rollable-tables/19th-level-consumables-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "pH85KVl31VBdENuy",
-    "description": "Table of 19th-Level Consumables Items",
+    "description": "<p>Table of 19th-Level Consumables Items</p>",
     "displayRoll": true,
-    "formula": "1d21",
+    "formula": "1d36",
     "img": "icons/svg/d20-grey.svg",
     "name": "19th-Level Consumables Items",
     "ownership": {
@@ -39,32 +39,60 @@
             "weight": 6
         },
         {
-            "_id": "agFdBRp42DAQhmgE",
+            "_id": "6M5cjcPRZuT0OiMT",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "B9NVsgy2jvd6sJID",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/consumables/oils/oil-of-potency.webp",
+            "range": [
+                13,
+                18
+            ],
+            "text": "Oil of Potency (Major)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "spDrmMzCrZuV4P8j",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "ugxI9kH7osJ3J5qG",
+            "drawn": false,
+            "img": "icons/magic/fire/barrier-shield-explosion-yellow.webp",
+            "range": [
+                19,
+                24
+            ],
+            "text": "Frozen Lava of Barrowsiege",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "AX3Fp9XrtA70dk7o",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "xQS1MSqGQz44FWUh",
             "drawn": false,
             "img": "icons/consumables/potions/potion-flask-corked-tied-necklace-teal.webp",
             "range": [
-                13,
-                18
+                25,
+                30
             ],
             "text": "Black Lotus Extract",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "I9UzhSA9Bbu6a1ke",
+            "_id": "p5QRyPy1h6lpsSyf",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "o1XIHJ4MJyroAHfF",
             "drawn": false,
             "img": "icons/sundries/scrolls/scroll-symbol-eye-brown.webp",
             "range": [
-                19,
-                21
+                31,
+                36
             ],
-            "text": "Scroll of 10th-level Spell",
+            "text": "Scroll of 10th-rank Spell",
             "type": "pack",
-            "weight": 3
+            "weight": 6
         }
     ]
 }

--- a/packs/rollable-tables/19th-level-permanent-items.json
+++ b/packs/rollable-tables/19th-level-permanent-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "gkdB45QC0u1WeiRA",
-    "description": "Table of 19th-Level Permanent Items",
+    "description": "<p>Table of 19th-Level Permanent Items</p>",
     "displayRoll": true,
-    "formula": "1d73",
+    "formula": "1d99",
     "img": "icons/svg/d20-grey.svg",
     "name": "19th-Level Permanent Items",
     "ownership": {
@@ -15,7 +15,7 @@
             "documentCollection": "",
             "documentId": null,
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "systems/pf2e/icons/equipment/armor/breastplate.webp",
             "range": [
                 1,
                 3
@@ -25,212 +25,254 @@
             "weight": 3
         },
         {
-            "_id": "lHyWiON0vciepWpd",
-            "documentCollection": "",
-            "documentId": null,
-            "drawn": false,
-            "img": "icons/svg/d20-black.svg",
-            "range": [
-                4,
-                6
-            ],
-            "text": "Duskwood Armor, High-Grade",
-            "type": "text",
-            "weight": 3
-        },
-        {
             "_id": "qxzQgU4OuEyT8GNx",
             "documentCollection": "",
             "documentId": null,
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "systems/pf2e/icons/equipment/armor/breastplate.webp",
             "range": [
-                10,
-                12
+                4,
+                6
             ],
             "text": "Dawnsilver Armor, High Grade",
             "type": "text",
             "weight": 3
         },
         {
-            "_id": "fvoXiNzvY6KsLdcR",
+            "_id": "KB3Kd0IrTgohqh6j",
+            "documentCollection": "",
+            "documentId": null,
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/armor/chainshirt.webp",
+            "range": [
+                7,
+                9
+            ],
+            "text": "Duskwood Armor, High-Grade",
+            "type": "text",
+            "weight": 3
+        },
+        {
+            "_id": "Ktk7SzYjrzilxDKz",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "dmEmxoEVzOeEkscr",
+            "drawn": false,
+            "img": "icons/equipment/chest/breastplate-layered-gold.webp",
+            "range": [
+                10,
+                15
+            ],
+            "text": "Lion's Armor (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "xdHL43ECxeAfRiRS",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "WKdI4LbwgcNHhMdp",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/held-items/crystal-ball-obsidian.webp",
             "range": [
-                13,
-                15
+                16,
+                18
             ],
             "text": "Crystal Ball (Obsidian)",
             "type": "pack",
             "weight": 3
         },
         {
-            "_id": "PUtEP2B8WFVzvMS0",
+            "_id": "vnrl8Z7sAdWwE1B9",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "ZxsPHkzzn6QwfPEz",
+            "drawn": false,
+            "img": "icons/magic/earth/explosion-lava-orange.webp",
+            "range": [
+                19,
+                24
+            ],
+            "text": "Eternal Eruption of Barrowsiege",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "kThMH6BhMzHRygTo",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "0iPTcAgtbtMj6Lwn",
+            "drawn": false,
+            "img": "icons/commodities/treasure/token-runed-os-grey.webp",
+            "range": [
+                25,
+                30
+            ],
+            "text": "Reinforcing Rune (Supreme)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "RYcIeluPlXT2c7Z9",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "woxl2FrrgAcJDu0t",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/fundamental-weapon-runes/striking.webp",
             "range": [
-                16,
-                21
+                31,
+                36
             ],
             "text": "Striking (Major)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "dLNZ5k0DdnGSn6n9",
+            "_id": "FBvtZZKVa735E1D3",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "Ztb4xv4UGZbF32TE",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/runes/armor-property-runes/armor-property-runes.webp",
+            "range": [
+                37,
+                42
+            ],
+            "text": "Winged (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "B3gKfn8Dl2xhhXW1",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "7Z8XXGiUiyyisKOD",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/shields/specific-shields/sturdy-shield.webp",
             "range": [
-                22,
-                27
+                43,
+                48
             ],
             "text": "Sturdy Shield (Supreme)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "SKFga5QL7ZxKwAP7",
+            "_id": "xXw7gEq9dgklHhRh",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "Fgv722039TVM5JTc",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/magic-wands/magic-wand.webp",
             "range": [
-                28,
-                33
+                49,
+                54
             ],
             "text": "Magic Wand (9th-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "236RC2vAYxTJBTrV",
+            "_id": "rj4w9R59xGnnrvCi",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "KMqHzKfpPq5H8GOo",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-continuation.webp",
             "range": [
-                34,
-                39
+                55,
+                60
             ],
             "text": "Wand of Continuation (8th-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "KB7hXBtubEEcpJL2",
-            "documentCollection": "",
+            "_id": "yG4GwoYUoL5E0QnP",
+            "documentCollection": "pf2e.equipment-srd",
             "documentId": null,
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "systems/pf2e/icons/equipment/weapons/shortsword.webp",
             "range": [
-                40,
-                45
+                61,
+                66
             ],
-            "text": "+3 major striking weapon",
+            "text": "Magic Weapon (+3 major striking)",
             "type": "text",
             "weight": 6
         },
         {
-            "_id": "9N4lgILguVKOWwcY",
+            "_id": "gSOnTA94nEXi4kwm",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "C3vAFRWoeGbMQTAH",
-            "drawn": false,
-            "img": "icons/weapons/swords/sword-guard-engraved.webp",
-            "range": [
-                46,
-                46
-            ],
-            "text": "Luck Blade (Wishing)",
-            "type": "pack",
-            "weight": 1
-        },
-        {
-            "_id": "5Zg0JRCzTszoJgvK",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "WCWdJmR5tYO7Aulb",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/weapons/specific-magic-weapons/mattock-of-the-titans.webp",
-            "range": [
-                47,
-                49
-            ],
-            "text": "Mattock of the Titans",
-            "type": "pack",
-            "weight": 3
-        },
-        {
-            "_id": "FQaObQK9vKZnhd2h",
-            "documentCollection": "",
             "documentId": null,
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "icons/equipment/hand/gauntlet-simple-leather-brown-gold.webp",
             "range": [
-                50,
-                55
+                67,
+                72
             ],
-            "text": "+3 major striking Handwraps of Mighty Blows",
+            "text": "Handwraps of Mighty Blows (+3 major striking)",
             "type": "text",
             "weight": 6
         },
         {
-            "_id": "Dpb0pw94Yh4NqM0i",
+            "_id": "JWWalovxHM2J3zBM",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "5sMAAIymln2yIl4q",
+            "documentId": "7MTjAlCVVLsNFo7w",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/aeon-stone-lavender-and-green-ellipsoid.webp",
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/third-eye.webp",
             "range": [
-                56,
-                58
+                73,
+                78
             ],
-            "text": "Aeon Stone (Lavender and Green Ellipsoid)",
+            "text": "Third Eye",
             "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "oPPErpJO9yse3BLY",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/armor/leather-armor.webp",
+            "range": [
+                79,
+                81
+            ],
+            "text": "Dragonhide Armor (High-Grade)",
+            "type": "text",
             "weight": 3
         },
         {
-            "_id": "Jh3L4Ekk9LmKEDmp",
+            "_id": "JbVPNttf5toC1dAu",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "xZFbFeJckiQS7smT",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-overflowing-life.webp",
+            "range": [
+                82,
+                87
+            ],
+            "text": "Wand of Overflowing Life (8th-Rank Spell)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "1NZLTBIznFih3XXU",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "OGKI8NS8Er3qumJS",
             "drawn": false,
             "img": "icons/equipment/back/cloak-brown-accent-brown-layered-collared-fur.webp",
             "range": [
-                59,
-                64
+                88,
+                93
             ],
             "text": "Berserker's Cloak (Greater)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "pCbqR8YdQ2808w29",
+            "_id": "iDUBatJNZO1otE86",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "7ynjS9llFg7tPMoj",
+            "documentId": "b2shhButUcNimET9",
             "drawn": false,
-            "img": "icons/equipment/chest/robe-layered-white.webp",
+            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/mask-of-the-banshee.webp",
             "range": [
-                65,
-                67
+                94,
+                99
             ],
-            "text": "Robe of the Archmagi (Greater)",
-            "type": "pack",
-            "weight": 3
-        },
-        {
-            "_id": "scjG7V8r7BWxtB2a",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "7MTjAlCVVLsNFo7w",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/third-eye.webp",
-            "range": [
-                68,
-                73
-            ],
-            "text": "Third Eye",
+            "text": "Guise of the Smirking Devil (Greater)",
             "type": "pack",
             "weight": 6
         }


### PR DESCRIPTION
Update 19th-Level Consumable Items and 19th-Level Permanent Items tables with remaster changes, consolidating the treasure tables from the GM Core and Player Core 2 books, preserving the item order found in those tables. Weight is based on rarity:

    Common = 6
    Uncommon = 3
    Rare = 1

For items that do not have a corresponding entry in the compendium, create a text entry in the table with the appropriate item name. If possible, set an appropriate icon from the system's icon set.