### PR TITLE
Update 20-level rollable tables

### DIFF
--- a/packs/rollable-tables/20th-level-consumable-items.json
+++ b/packs/rollable-tables/20th-level-consumable-items.json
@@ -1,6 +1,6 @@
 {
     "_id": "nusyoQjLs0ZxifRd",
-    "description": "Table of 20th-Level Consumables Items",
+    "description": "<p>Table of 20th-Level Consumables Items</p>",
     "displayRoll": true,
     "formula": "1d25",
     "img": "icons/svg/d20-grey.svg",
@@ -11,28 +11,14 @@
     "replacement": true,
     "results": [
         {
-            "_id": "GvtGRGlE8zHSu2aj",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "UHrLqWCnFEUspSQj",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/elixir-of-rejuvenation.webp",
-            "range": [
-                1,
-                3
-            ],
-            "text": "Elixir of Rejuvenation",
-            "type": "pack",
-            "weight": 3
-        },
-        {
             "_id": "hDeiVDQYZMWyWqqY",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "737LQfIaLXBPEzc3",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/consumables/oils/antimagic-oil.webp",
             "range": [
-                4,
-                4
+                1,
+                1
             ],
             "text": "Antimagic Oil",
             "type": "pack",
@@ -45,15 +31,29 @@
             "drawn": false,
             "img": "icons/consumables/drinks/wine-amphora-clay-gray.webp",
             "range": [
-                5,
-                10
+                2,
+                7
             ],
             "text": "Tears of Death",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "HEQWxVwkZlaRttlq",
+            "_id": "UBw3aOH9xuzEHV4Z",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "UHrLqWCnFEUspSQj",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/elixir-of-rejuvenation.webp",
+            "range": [
+                8,
+                10
+            ],
+            "text": "Elixir of Rejuvenation",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "Rs25gZLEbjRusM4d",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "qvfO0jFIvIM8hReG",
             "drawn": false,
@@ -67,7 +67,7 @@
             "weight": 6
         },
         {
-            "_id": "FgVurBQfzjblrN2c",
+            "_id": "g8UNoLnKMIZZc2SW",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "xqCz2vStMNJujfpp",
             "drawn": false,
@@ -81,7 +81,7 @@
             "weight": 6
         },
         {
-            "_id": "MEtCarvtTcn9UNJn",
+            "_id": "SBOzshBkA9RDCSHw",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "Fv97oB3iEIFAyzTu",
             "drawn": false,

--- a/packs/rollable-tables/20th-level-permanent-items.json
+++ b/packs/rollable-tables/20th-level-permanent-items.json
@@ -1,8 +1,8 @@
 {
     "_id": "NOkobOGi0nqsboHI",
-    "description": "Table of 20th-Level Permanent Items",
+    "description": "<p>Table of 20th-Level Permanent Items</p>",
     "displayRoll": true,
-    "formula": "1d44",
+    "formula": "1d59",
     "img": "icons/svg/d20-grey.svg",
     "name": "20th-Level Permanent Items",
     "ownership": {
@@ -15,12 +15,12 @@
             "documentCollection": "",
             "documentId": null,
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "systems/pf2e/icons/equipment/armor/scale-mail.webp",
             "range": [
                 1,
                 6
             ],
-            "text": "+3 major resilient Armor",
+            "text": "Magic Armor (+3 Greater Resilient)",
             "type": "text",
             "weight": 6
         },
@@ -39,144 +39,186 @@
             "weight": 3
         },
         {
-            "_id": "z4BMPsRKIjkv5nFV",
-            "documentCollection": "",
-            "documentId": null,
+            "_id": "32TWjhFW4ouWwD8v",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "oRBcuFdQDRCn1pwo",
             "drawn": false,
-            "img": "icons/svg/d20-black.svg",
+            "img": "icons/equipment/chest/breastplate-layered-leather-studded-black.webp",
             "range": [
                 10,
-                10
+                15
+            ],
+            "text": "Life-Saver Mail (Greater)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "IbXWbT6hEaI9KOkz",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": null,
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/armor/ceramic-plate.webp",
+            "range": [
+                16,
+                16
             ],
             "text": "Orichalcum Armor (High-Grade)",
             "type": "text",
             "weight": 1
         },
         {
-            "_id": "iYf3xiuu1PJYrEfV",
+            "_id": "hai6fzvgv0XZkh75",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "WKcvvaZ0LxwYreb7",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/runes/fundamental-armor-runes/armor-potency.webp",
             "range": [
-                11,
-                16
+                17,
+                22
             ],
             "text": "Resilient (Major)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "Ta6KiuexBRSqdASJ",
+            "_id": "hhZlZ4nRxFbbtNf9",
             "documentCollection": "pf2e.equipment-srd",
-            "documentId": "nI9shR1EG3P09I8r",
+            "documentId": "w2AxS7q8bjh77pp2",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/staves/staff-of-the-magi.webp",
+            "img": "icons/weapons/staves/staff-ornate-blue.webp",
             "range": [
-                17,
-                17
+                23,
+                23
             ],
-            "text": "Staff of the Magi",
+            "text": "Staff of Arcane Might (Major)",
             "type": "pack",
             "weight": 1
         },
         {
-            "_id": "6UgkskpmQmziHdAh",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "mMZWdoHvP2yYJzrR",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-slaying.webp",
-            "range": [
-                18,
-                23
-            ],
-            "text": "Wand of Slaying (9th-Rank Spell)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "3rf5LFAdIZ1EYl7q",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "tBwMPimZ6A93XpHf",
-            "drawn": false,
-            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-smoldering-fireballs.webp",
-            "range": [
-                24,
-                29
-            ],
-            "text": "Wand of Smoldering Fireballs (9th-Rank Spell)",
-            "type": "pack",
-            "weight": 6
-        },
-        {
-            "_id": "QCgX2cEDaVItV1xO",
+            "_id": "K4IHmSBWsw8PwL6h",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "t5978mZ6CqfUDCP6",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-widening.webp",
             "range": [
-                30,
-                35
+                24,
+                29
             ],
             "text": "Wand of Widening (9th-Rank Spell)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "tjWwsoo48SNItXrR",
+            "_id": "EUkvfYeDtH49PSTt",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "ANvbi1zKF1So8bON",
             "drawn": false,
             "img": "icons/weapons/hammers/hammer-drilling-spiked.webp",
             "range": [
-                36,
-                36
+                30,
+                30
             ],
             "text": "Sky Hammer",
             "type": "pack",
             "weight": 1
         },
         {
-            "_id": "4ELJmIx2epqXwUdn",
+            "_id": "W0tGl4ZcHYq8lOJq",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "rqJzQawe3CbXiWnG",
             "drawn": false,
             "img": "systems/pf2e/icons/equipment/worn-items/other-worn-items/bracers-of-armor.webp",
             "range": [
-                37,
-                42
+                31,
+                36
             ],
-            "text": "Bracers of Armor III",
+            "text": "Bands of Force (Major)",
             "type": "pack",
             "weight": 6
         },
         {
-            "_id": "0JhebUbi2fejagKA",
-            "documentCollection": "pf2e.equipment-srd",
-            "documentId": "Ivqd84dkWA8DW8YJ",
-            "drawn": false,
-            "img": "icons/equipment/finger/ring-winged-gold-blue.webp",
-            "range": [
-                43,
-                43
-            ],
-            "text": "Ring of Spell Turning",
-            "type": "pack",
-            "weight": 1
-        },
-        {
-            "_id": "G9VmMvjTaacfwl2w",
+            "_id": "pMMt3Y05FkFENQzY",
             "documentCollection": "pf2e.equipment-srd",
             "documentId": "sKyJDfHdKacfbNOG",
             "drawn": false,
             "img": "icons/equipment/neck/amulet-carved-stone-purple.webp",
             "range": [
-                44,
-                44
+                37,
+                37
             ],
             "text": "Whisper of the First Lie",
             "type": "pack",
             "weight": 1
+        },
+        {
+            "_id": "E0e2fcgZYnxRNLoY",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "W8Vh7KTl3Ux7VYVU",
+            "drawn": false,
+            "img": "icons/commodities/cloth/cloth-bolt-embroidered-pink.webp",
+            "range": [
+                38,
+                38
+            ],
+            "text": "Cloth of Nullification",
+            "type": "pack",
+            "weight": 1
+        },
+        {
+            "_id": "wLYfYlcSf1MDyYGE",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "1glQQ63AeQOfQNvc",
+            "drawn": false,
+            "img": "icons/weapons/staves/staff-crescent-green.webp",
+            "range": [
+                39,
+                41
+            ],
+            "text": "Staff of Impossible Visions (True)",
+            "type": "pack",
+            "weight": 3
+        },
+        {
+            "_id": "Olx9HqnqDDsI311E",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "pIagOwW8EFBaKW3k",
+            "drawn": false,
+            "img": "icons/weapons/staves/staff-ornate-eye.webp",
+            "range": [
+                42,
+                47
+            ],
+            "text": "Staff of Providence (True)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "1GOnkDsJIgjOzwrZ",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "mMZWdoHvP2yYJzrR",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-slaying.webp",
+            "range": [
+                48,
+                53
+            ],
+            "text": "Wand of Slaughter (9th-Rank Spell)",
+            "type": "pack",
+            "weight": 6
+        },
+        {
+            "_id": "plFQe8Otg2EwLUDe",
+            "documentCollection": "pf2e.equipment-srd",
+            "documentId": "tBwMPimZ6A93XpHf",
+            "drawn": false,
+            "img": "systems/pf2e/icons/equipment/wands/specialty-wands/wand-of-smoldering-fireballs.webp",
+            "range": [
+                54,
+                59
+            ],
+            "text": "Wand of Smoldering Fireballs (9th-Rank Spell)",
+            "type": "pack",
+            "weight": 6
         }
     ]
 }


### PR DESCRIPTION
Update 20-Level Consumable Items and 20-Level Permanent Items tables with remaster changes, consolidating the treasure tables from the GM Core and Player Core 2 books, preserving the item order found in those tables. Weight is based on rarity:

    Common = 6
    Uncommon = 3
    Rare = 1

For items that do not have a corresponding entry in the compendium, create a text entry in the table with the appropriate item name. If possible, set an appropriate icon from the system's icon set.