### PR TITLE
Fix rollItemMacro to allow feat and action hotbar macros to function again

### DIFF
--- a/src/scripts/macros/hotbar.ts
+++ b/src/scripts/macros/hotbar.ts
@@ -22,7 +22,7 @@ export async function rollItemMacro(itemId: string, event: Event | null = null):
         return null;
     }
 
-    if (item.isOfType("action", "feat")) {
+    if (item.isOfType("action", "feat") && (item.system.selfEffect || item.system.frequency)) {
         return createUseActionMessage(item);
     }
 


### PR DESCRIPTION
Resolves this issue present since the frequency tracking update.
![image](https://github.com/user-attachments/assets/868c9071-dbc2-4625-b744-d3728fa0bfc5)

Currently in release and master, only Self Effect and Frequency-defined hotbar macros of feats and actions will function.

To replicate the problem, drag any non-SelfEffect or Frequency-bearing feat or action to the macro hotbar and click on it, view the error in the console.