### PR TITLE
Add ability to simulate potency runes on Strike rule elements

### DIFF
--- a/src/module/rules/rule-element/strike.ts
+++ b/src/module/rules/rule-element/strike.ts
@@ -23,6 +23,7 @@ import type {
 } from "types/foundry/common/data/fields.d.ts";
 import { RuleElementOptions, RuleElementPF2e } from "./base.ts";
 import { ModelPropsFromRESchema, ResolvableValueField, RuleElementSchema, RuleElementSource } from "./data.ts";
+import { ZeroToFour } from "@module/data.ts";
 
 /**
  * Create an ephemeral strike on an actor
@@ -135,6 +136,14 @@ class StrikeRuleElement extends RuleElementPF2e<StrikeSchema> {
                     data.fist ? StrikeRuleElement.#defaultFistIcon : "systems/pf2e/icons/default-icons/melee.svg",
             }),
             attackModifier: new fields.NumberField({ integer: true, positive: true, nullable: true, initial: null }),
+            attackItemBonus: new fields.NumberField({
+                integer: true,
+                positive: true,
+                nullable: true,
+                initial: null,
+                min: 0,
+                max: 4,
+            }),
             replaceAll: new fields.BooleanField({ required: false, nullable: false, initial: undefined }),
             replaceBasicUnarmed: new fields.BooleanField({ required: false, nullable: false, initial: undefined }),
             battleForm: new fields.BooleanField({ required: false, nullable: false, initial: undefined }),
@@ -279,7 +288,11 @@ class StrikeRuleElement extends RuleElementPF2e<StrikeSchema> {
                     },
                 },
                 options: { value: this.options },
-                runes: this.category === "unarmed" ? (unarmedRunes ?? {}) : {},
+                runes: this.attackItemBonus
+                    ? { potency: this.attackItemBonus as ZeroToFour }
+                    : this.category === "unarmed"
+                      ? (unarmedRunes ?? {})
+                      : {},
                 usage: { value: "held-in-one-hand" },
                 equipped: {
                     carryType: "held",
@@ -352,6 +365,10 @@ type StrikeSchema = RuleElementSchema & {
      * Also causes the damage to not be recalculated when converting the resulting weapon to an NPC attack
      */
     attackModifier: NumberField<number, number, false, true, true>;
+    /**
+     * An attack bonus, meant to be used in place of potency runes for abilities that grant such bonuses
+     */
+    attackItemBonus: NumberField<number, number, false, true, true>;
     range: SchemaField<
         {
             increment: NumberField<number, number, false, true, true>;


### PR DESCRIPTION
This might make it easier to set up a Strike rule element on something like Spirit's Wrath, which gives a flat Item bonus to the granted Strike

https://2e.aonprd.com/Feats.aspx?ID=5858

![image](https://github.com/user-attachments/assets/43dd8339-ee24-42fb-a493-d550727f8f66)
