### PR TITLE
Fix regressions and other issues in daily crafting

### DIFF
--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -212,11 +212,7 @@
                     "BatchQuantity": "x{quantity}",
                     "Cost": "Cost",
                     "Daily": {
-                        "Complete": {
-                            "OneConsumed": "Daily crafting complete: one reagent was consumed.",
-                            "NConsumed": "Daily crafting complete: {quantity} reagents were consumed.",
-                            "ZeroConsumed": "Daily crafting complete."
-                        },
+                        "Complete": "Daily crafting complete.",
                         "Perform": "Perform Daily Crafting"
                     },
                     "MissingResource": "Insufficient resources to complete crafting.",


### PR DESCRIPTION
Fixes special resource items being deleted by daily crafting, brings back the message complete notification, and does not craft items that are set to expended.

These are either irrelevant or too inconsequential for the changelog