### PR TITLE
Add level override support to special resource

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -567,7 +567,7 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
 
             // Restore special resources
             for (const resource of Object.values(this.synthetics.resources)) {
-                const updates = await resource.update(resource.max, { save: false });
+                const updates = await resource.update(resource.max, { save: false, checkLevel: true });
                 commitData.itemCreates.push(...updates.itemCreates);
                 commitData.itemUpdates.push(...updates.itemUpdates);
                 if (updates.itemCreates.length || updates.itemUpdates.length) {


### PR DESCRIPTION
The level overrides are applied when first creating the item and when resting for the night