### PR TITLE
Fix svelte applications not being responsive to application triggered rerenders

### DIFF
--- a/src/module/system/svelte/mixin.svelte.ts
+++ b/src/module/system/svelte/mixin.svelte.ts
@@ -42,10 +42,10 @@ function SvelteApplicationMixin<
             content: HTMLElement,
             options: ApplicationRenderOptions,
         ): void {
-            if (options.isFirstRender) {
-                this.#mount = svelte.mount(this.root, { target: content, props: result });
-            }
             Object.assign(this.$state, result.state);
+            if (options.isFirstRender) {
+                this.#mount = svelte.mount(this.root, { target: content, props: { ...result, state: this.$state } });
+            }
         }
 
         protected override _onClose(options: ApplicationRenderOptions): void {


### PR DESCRIPTION
$state was never passed to svelte with mounted, and thus updates to it never reflected in the application itself. Existing applications don't need this, but future ones will.

This is part of the quick alchemy PR, but since compendium browser seems to rely on this I pushed it up early.