### PR TITLE
Include Strike REs with battleForm: true to battle forms

### DIFF
--- a/src/module/rules/rule-element/battle-form/rule-element.ts
+++ b/src/module/rules/rule-element/battle-form/rule-element.ts
@@ -424,12 +424,7 @@ class BattleFormRuleElement extends RuleElementPF2e<BattleFormRuleSchema> {
 
         actor.system.actions = actor
             .prepareStrikes({ includeBasicUnarmed: this.ownUnarmed })
-            .filter(
-                (a) =>
-                    (a.slug && a.slug in strikes) ||
-                    a.item.flags.pf2e.battleForm ||
-                    (this.ownUnarmed && a.item.category === "unarmed"),
-            );
+            .filter((a) => a.item.flags.pf2e.battleForm || (this.ownUnarmed && a.item.category === "unarmed"));
         const strikeActions = actor.system.actions.flatMap((s): CharacterStrike[] => [s, ...s.altUsages]);
 
         for (const action of strikeActions) {

--- a/src/module/rules/rule-element/battle-form/rule-element.ts
+++ b/src/module/rules/rule-element/battle-form/rule-element.ts
@@ -424,7 +424,7 @@ class BattleFormRuleElement extends RuleElementPF2e<BattleFormRuleSchema> {
 
         actor.system.actions = actor
             .prepareStrikes({ includeBasicUnarmed: this.ownUnarmed })
-            .filter((a) => (a.slug && a.slug in strikes) || (this.ownUnarmed && a.item.category === "unarmed"));
+            .filter((a) => (a.slug && a.slug in strikes) || a.item.flags.pf2e.battleForm || (this.ownUnarmed && a.item.category === "unarmed"));
         const strikeActions = actor.system.actions.flatMap((s): CharacterStrike[] => [s, ...s.altUsages]);
 
         for (const action of strikeActions) {

--- a/src/module/rules/rule-element/battle-form/rule-element.ts
+++ b/src/module/rules/rule-element/battle-form/rule-element.ts
@@ -424,7 +424,12 @@ class BattleFormRuleElement extends RuleElementPF2e<BattleFormRuleSchema> {
 
         actor.system.actions = actor
             .prepareStrikes({ includeBasicUnarmed: this.ownUnarmed })
-            .filter((a) => (a.slug && a.slug in strikes) || a.item.flags.pf2e.battleForm || (this.ownUnarmed && a.item.category === "unarmed"));
+            .filter(
+                (a) =>
+                    (a.slug && a.slug in strikes) ||
+                    a.item.flags.pf2e.battleForm ||
+                    (this.ownUnarmed && a.item.category === "unarmed"),
+            );
         const strikeActions = actor.system.actions.flatMap((s): CharacterStrike[] => [s, ...s.altUsages]);
 
         for (const action of strikeActions) {


### PR DESCRIPTION
At the moment, the property BattleForm: true in Strike REs has no effect on BattleForm REs. By adding the condition to the filter, individual Strike REs can also be used in BattleForms, instead of the "all or nothing" of ownUnarmed.