### PR TITLE
Update Awaken Entropy spell variants

### DIFF
--- a/packs/spells/awaken-entropy.json
+++ b/packs/spells/awaken-entropy.json
@@ -47,15 +47,22 @@
             "value": 6
         },
         "overlays": {
-            "8dn7dtgsd1tbcl3l": {
-                "_id": "8dn7dtgsd1tbcl3l",
-                "name": "Awaken Entropy (Immune to Void)",
+            "JctMbZoy1N1BvIH5": {
                 "overlayType": "override",
                 "sort": 1,
+                "system": {}
+            },
+            "XxDiv22oJDXssXI2": {
+                "name": "Awaken Entropy (Immune to Void)",
+                "overlayType": "override",
+                "sort": 2,
                 "system": {
                     "damage": {
                         "ub9o9w3b7bmmuy9r": {
                             "category": null,
+                            "kinds": [
+                                "damage"
+                            ],
                             "type": "force"
                         }
                     }

--- a/packs/spells/awaken-entropy.json
+++ b/packs/spells/awaken-entropy.json
@@ -30,7 +30,7 @@
             }
         },
         "description": {
-            "value": "<p>All things age, all things die, and at the end of days even the universe will grow quiet and still. You awaken the cosmic principle of entropy, accelerating time in an area-flesh falters, plants shrivel, and even stone begins to crumble. Any creature that enters or begins its turn in the area must succeed at a basic Fortitude save or take @Damage[8d6[void]] damage, or @Damage[8d6[force]] damage if the creature normally doesn't take void damage, such as if the creature is a construct or undead. Even beings such as fiends with unlimited lifespans can be worn away by entropy. The first time you Sustain the Spell on each subsequent turn, the entropic zone grows stronger in addition to having its duration increased. The radius of the burst increases by 10 feet (to a maximum of 40 feet), and the size of the damage dice increases by one step (from d6 to d8, then to d10, and finally to d12).</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The damage increases by [[/r 1d6]]{1d6}.</p>"
+            "value": "<p>All things age, all things die, and at the end of days even the universe will grow quiet and still. You awaken the cosmic principle of entropy, accelerating time in an area-flesh falters, plants shrivel, and even stone begins to crumble. Any creature that enters or begins its turn in the area must succeed at a basic Fortitude save or take 8d6 void damage, or 8d6 force damage if the creature normally doesn't take void damage, such as if the creature is a construct or undead. Even beings such as fiends with unlimited lifespans can be worn away by entropy. The first time you Sustain the Spell on each subsequent turn, the entropic zone grows stronger in addition to having its duration increased. The radius of the burst increases by 10 feet (to a maximum of 40 feet), and the size of the damage dice increases by one step (from d6 to d8, then to d10, and finally to d12).</p><hr /><p><strong>Heightened (+1)</strong> The damage increases by 1d6.</p>"
         },
         "duration": {
             "sustained": true,
@@ -50,7 +50,13 @@
             "JctMbZoy1N1BvIH5": {
                 "overlayType": "override",
                 "sort": 1,
-                "system": {}
+                "system": {
+                    "damage": {
+                        "ub9o9w3b7bmmuy9r": {
+                            "category": null
+                        }
+                    }
+                }
             },
             "XxDiv22oJDXssXI2": {
                 "name": "Awaken Entropy (Immune to Void)",


### PR DESCRIPTION
Added a vanilla variant for the void damage in addition to the force damage variant.

Closes #17441