### PR TITLE
fix memory leaks due to retained tagify, sortable or tooltipster instances

### DIFF
--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -79,6 +79,12 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
     /** Non-persisted tweaks to formula data */
     #formulaQuantities: Record<string, number> = {};
 
+    /** PC Sheet Tab manager instance. Must be destroyed to avoid memory leaks  */
+    #tabManager: PCSheetTabManager | null = null;
+
+    /** Elements with registered $.tooltipster instances. Have to be cleaned up to avoid memory leaks */
+    #tooltipsterElements: JQuery[] = [];
+
     static override get defaultOptions(): ActorSheetOptions {
         const options = super.defaultOptions;
         options.classes = [...options.classes, "character"];
@@ -685,16 +691,18 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
             const side = hoverEl.dataset.tooltipSide
                 ?.split(",")
                 ?.filter((t): t is (typeof allSides)[number] => tupleHasValue(allSides, t)) ?? ["right", "bottom"];
-            $(hoverEl).tooltipster({
-                trigger: "click",
-                arrow: false,
-                contentAsHTML: true,
-                debug: BUILD_MODE === "development",
-                interactive: true,
-                side,
-                theme: "crb-hover",
-                minWidth: 120,
-            });
+            this.#tooltipsterElements.push(
+                $(hoverEl).tooltipster({
+                    trigger: "click",
+                    arrow: false,
+                    contentAsHTML: true,
+                    debug: BUILD_MODE === "development",
+                    interactive: true,
+                    side,
+                    theme: "crb-hover",
+                    minWidth: 120,
+                }),
+            );
         }
 
         // SPELLCASTING
@@ -762,6 +770,14 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
         }
     }
 
+    protected override _resetListeners(): void {
+        super._resetListeners();
+        this.#tabManager?.destroy();
+        this.#tabManager = null;
+        this.#tooltipsterElements.forEach((element) => element.tooltipster("destroy"));
+        this.#tooltipsterElements = [];
+    }
+
     /** Activate listeners of main sheet navigation section */
     #activateNavListeners(html: HTMLElement): void {
         const sheetNavigation = htmlQuery(html, "nav.sheet-navigation");
@@ -774,7 +790,9 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
 
         navTitleArea.innerText = game.i18n.localize(activeTab.dataset.tooltip ?? "");
         const manageTabsAnchor = htmlQuery<HTMLAnchorElement>(sheetNavigation, ":scope > a[data-action=manage-tabs]");
-        if (manageTabsAnchor) PCSheetTabManager.initialize(this.actor, manageTabsAnchor);
+        if (manageTabsAnchor) {
+            this.#tabManager = PCSheetTabManager.initialize(this.actor, manageTabsAnchor);
+        }
 
         sheetNavigation.addEventListener("click", (event) => {
             const anchor = htmlClosest(event.target, "a[data-tab]");

--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -685,7 +685,7 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
             const side = hoverEl.dataset.tooltipSide
                 ?.split(",")
                 ?.filter((t): t is (typeof allSides)[number] => tupleHasValue(allSides, t)) ?? ["right", "bottom"];
-            this.tooltipsterElements.push(
+            this.ensureTooltipsterCleanup(
                 $(hoverEl).tooltipster({
                     trigger: "click",
                     arrow: false,
@@ -777,7 +777,7 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
         navTitleArea.innerText = game.i18n.localize(activeTab.dataset.tooltip ?? "");
         const manageTabsAnchor = htmlQuery<HTMLAnchorElement>(sheetNavigation, ":scope > a[data-action=manage-tabs]");
         if (manageTabsAnchor) {
-            this.destroyables.push(PCSheetTabManager.initialize(this.actor, manageTabsAnchor));
+            this.ensureDestroyableCleanup(PCSheetTabManager.initialize(this.actor, manageTabsAnchor));
         }
 
         sheetNavigation.addEventListener("click", (event) => {

--- a/src/module/actor/character/tab-manager.ts
+++ b/src/module/actor/character/tab-manager.ts
@@ -86,7 +86,7 @@ export class PCSheetTabManager {
         }
     }
 
-    async destroy(): Promise<void> {
+    destroy(): void {
         this.#tooltipsterElement?.tooltipster("destroy");
     }
 }

--- a/src/module/actor/character/tab-manager.ts
+++ b/src/module/actor/character/tab-manager.ts
@@ -1,12 +1,13 @@
 import type { CharacterPF2e } from "./document.ts";
 
 export class PCSheetTabManager {
+    #tooltipsterElement: JQuery | null = null;
     constructor(
         public actor: CharacterPF2e,
         public link: HTMLAnchorElement,
     ) {
         renderTemplate("systems/pf2e/templates/actors/character/manage-tabs.hbs").then((template) => {
-            $(this.link).tooltipster({
+            this.#tooltipsterElement = $(this.link).tooltipster({
                 content: template,
                 contentAsHTML: true,
                 delay: 250,
@@ -22,8 +23,8 @@ export class PCSheetTabManager {
         });
     }
 
-    static initialize(actor: CharacterPF2e, link: HTMLAnchorElement): void {
-        new this(actor, link);
+    static initialize(actor: CharacterPF2e, link: HTMLAnchorElement): PCSheetTabManager {
+        return new this(actor, link);
     }
 
     /** Set each checkbox to be checked according to its corresponding tab visibility */
@@ -83,5 +84,9 @@ export class PCSheetTabManager {
                 tab.classList.add("hidden");
             }
         }
+    }
+
+    async destroy(): Promise<void> {
+        this.#tooltipsterElement?.tooltipster("destroy");
     }
 }

--- a/src/module/actor/hazard/sheet.ts
+++ b/src/module/actor/hazard/sheet.ts
@@ -5,12 +5,8 @@ import { HTMLTagifyTagsElement } from "@system/html-elements/tagify-tags.ts";
 import { htmlClosest, htmlQuery, tagify, traitSlugToObject } from "@util";
 import type { HazardPF2e } from "./document.ts";
 import { HazardActionSheetData, HazardSaveSheetData, HazardSheetData } from "./types.ts";
-import type Tagify from "@yaireo/tagify";
 
 export class HazardSheetPF2e extends ActorSheetPF2e<HazardPF2e> {
-    /** Active tagify instances. Have to be cleaned up to avoid memory leaks */
-    #tagifyInstances: Tagify<Record<"id" | "value", string>>[] = [];
-
     static override get defaultOptions(): ActorSheetOptions {
         const options = super.defaultOptions;
         return {
@@ -136,18 +132,12 @@ export class HazardSheetPF2e extends ActorSheetPF2e<HazardPF2e> {
         const traitsEl = htmlQuery<HTMLTagifyTagsElement>(html, 'tagify-tags[name="system.traits.value"]');
         if (traitsEl) {
             const tags = tagify(traitsEl, { whitelist: CONFIG.PF2E.hazardTraits });
-            this.#tagifyInstances.push(tags);
+            this.destroyables.push(tags);
             const traitsPrepend = html.querySelector<HTMLTemplateElement>(".traits-extra");
             if (traitsPrepend) {
                 tags.DOM.scope.prepend(traitsPrepend.content);
             }
         }
-    }
-
-    protected override _resetListeners(): void {
-        super._resetListeners();
-        this.#tagifyInstances.forEach((tagified) => tagified.destroy());
-        this.#tagifyInstances = [];
     }
 
     protected override activateClickListener(html: HTMLElement): SheetClickActionHandlers {

--- a/src/module/actor/hazard/sheet.ts
+++ b/src/module/actor/hazard/sheet.ts
@@ -5,8 +5,12 @@ import { HTMLTagifyTagsElement } from "@system/html-elements/tagify-tags.ts";
 import { htmlClosest, htmlQuery, tagify, traitSlugToObject } from "@util";
 import type { HazardPF2e } from "./document.ts";
 import { HazardActionSheetData, HazardSaveSheetData, HazardSheetData } from "./types.ts";
+import type Tagify from "@yaireo/tagify";
 
 export class HazardSheetPF2e extends ActorSheetPF2e<HazardPF2e> {
+    /** Active tagify instances. Have to be cleaned up to avoid memory leaks */
+    #tagifyInstances: Tagify<Record<"id" | "value", string>>[] = [];
+
     static override get defaultOptions(): ActorSheetOptions {
         const options = super.defaultOptions;
         return {
@@ -132,11 +136,18 @@ export class HazardSheetPF2e extends ActorSheetPF2e<HazardPF2e> {
         const traitsEl = htmlQuery<HTMLTagifyTagsElement>(html, 'tagify-tags[name="system.traits.value"]');
         if (traitsEl) {
             const tags = tagify(traitsEl, { whitelist: CONFIG.PF2E.hazardTraits });
+            this.#tagifyInstances.push(tags);
             const traitsPrepend = html.querySelector<HTMLTemplateElement>(".traits-extra");
             if (traitsPrepend) {
                 tags.DOM.scope.prepend(traitsPrepend.content);
             }
         }
+    }
+
+    protected override _resetListeners(): void {
+        super._resetListeners();
+        this.#tagifyInstances.forEach((tagified) => tagified.destroy());
+        this.#tagifyInstances = [];
     }
 
     protected override activateClickListener(html: HTMLElement): SheetClickActionHandlers {

--- a/src/module/actor/hazard/sheet.ts
+++ b/src/module/actor/hazard/sheet.ts
@@ -132,7 +132,7 @@ export class HazardSheetPF2e extends ActorSheetPF2e<HazardPF2e> {
         const traitsEl = htmlQuery<HTMLTagifyTagsElement>(html, 'tagify-tags[name="system.traits.value"]');
         if (traitsEl) {
             const tags = tagify(traitsEl, { whitelist: CONFIG.PF2E.hazardTraits });
-            this.destroyables.push(tags);
+            this.ensureDestroyableCleanup(tags);
             const traitsPrepend = html.querySelector<HTMLTemplateElement>(".traits-extra");
             if (traitsPrepend) {
                 tags.DOM.scope.prepend(traitsPrepend.content);

--- a/src/module/actor/npc/sheet.ts
+++ b/src/module/actor/npc/sheet.ts
@@ -109,8 +109,7 @@ abstract class AbstractNPCSheet extends CreatureSheetPF2e<NPCPF2e> {
 
         // Tagify the traits selection
         const traitsEl = htmlQuery<HTMLTagifyTagsElement>(html, 'tagify-tags[name="system.traits.value"]');
-        const tags = tagify(traitsEl, { whitelist: CONFIG.PF2E.creatureTraits });
-        if (tags) this.destroyables.push(tags);
+        this.ensureDestroyableCleanup(tagify(traitsEl, { whitelist: CONFIG.PF2E.creatureTraits }));
     }
 
     protected override activateClickListener(html: HTMLElement): SheetClickActionHandlers {

--- a/src/module/actor/npc/sheet.ts
+++ b/src/module/actor/npc/sheet.ts
@@ -37,9 +37,6 @@ import {
 abstract class AbstractNPCSheet extends CreatureSheetPF2e<NPCPF2e> {
     protected readonly actorConfigClass = NPCConfig;
 
-    /** Active tagify instances. Have to be cleaned up to avoid memory leaks */
-    #tagifyInstances: (Tagify<Record<"id" | "value", string>> | null)[] = [];
-
     static override get defaultOptions(): ActorSheetOptions {
         const options = super.defaultOptions;
         options.classes.push("pf2e", "npc");
@@ -112,13 +109,8 @@ abstract class AbstractNPCSheet extends CreatureSheetPF2e<NPCPF2e> {
 
         // Tagify the traits selection
         const traitsEl = htmlQuery<HTMLTagifyTagsElement>(html, 'tagify-tags[name="system.traits.value"]');
-        this.#tagifyInstances.push(tagify(traitsEl, { whitelist: CONFIG.PF2E.creatureTraits }));
-    }
-
-    protected override _resetListeners(): void {
-        super._resetListeners();
-        this.#tagifyInstances.forEach((tagifyInstance) => tagifyInstance?.destroy());
-        this.#tagifyInstances = [];
+        const tags = tagify(traitsEl, { whitelist: CONFIG.PF2E.creatureTraits });
+        if (tags) this.destroyables.push(tags);
     }
 
     protected override activateClickListener(html: HTMLElement): SheetClickActionHandlers {

--- a/src/module/actor/npc/sheet.ts
+++ b/src/module/actor/npc/sheet.ts
@@ -37,6 +37,9 @@ import {
 abstract class AbstractNPCSheet extends CreatureSheetPF2e<NPCPF2e> {
     protected readonly actorConfigClass = NPCConfig;
 
+    /** Active tagify instances. Have to be cleaned up to avoid memory leaks */
+    #tagifyInstances: (Tagify<Record<"id" | "value", string>> | null)[] = [];
+
     static override get defaultOptions(): ActorSheetOptions {
         const options = super.defaultOptions;
         options.classes.push("pf2e", "npc");
@@ -109,7 +112,13 @@ abstract class AbstractNPCSheet extends CreatureSheetPF2e<NPCPF2e> {
 
         // Tagify the traits selection
         const traitsEl = htmlQuery<HTMLTagifyTagsElement>(html, 'tagify-tags[name="system.traits.value"]');
-        tagify(traitsEl, { whitelist: CONFIG.PF2E.creatureTraits });
+        this.#tagifyInstances.push(tagify(traitsEl, { whitelist: CONFIG.PF2E.creatureTraits }));
+    }
+
+    protected override _resetListeners(): void {
+        super._resetListeners();
+        this.#tagifyInstances.forEach((tagifyInstance) => tagifyInstance?.destroy());
+        this.#tagifyInstances = [];
     }
 
     protected override activateClickListener(html: HTMLElement): SheetClickActionHandlers {

--- a/src/module/actor/party/kingdom/sheet.ts
+++ b/src/module/actor/party/kingdom/sheet.ts
@@ -67,12 +67,6 @@ class KingdomSheetPF2e extends ActorSheetPF2e<PartyPF2e> {
 
     #editingSettlements: Record<string, boolean> = {};
 
-    /** Elements with registered $.tooltipster instances. Have to be cleaned up to avoid memory leaks */
-    #tooltipsterElements: JQuery[] = [];
-
-    /** Active sortable instances. Have to be cleaned up to avoid memory leaks */
-    #sortables: Sortable[] = [];
-
     constructor(actor: PartyPF2e, options?: Partial<ActorSheetOptions>) {
         super(actor, options);
     }
@@ -340,7 +334,7 @@ class KingdomSheetPF2e extends ActorSheetPF2e<PartyPF2e> {
             if (vacantEl) {
                 const lines = vacantEl.title.split(/;\s*/).map((l) => createHTMLElement("li", { children: [l] }));
                 const content = createHTMLElement("ul", { children: lines });
-                this.#tooltipsterElements.push(
+                this.tooltipsterElements.push(
                     $(vacantEl).tooltipster({
                         content,
                         contentAsHTML: true,
@@ -383,10 +377,10 @@ class KingdomSheetPF2e extends ActorSheetPF2e<PartyPF2e> {
             this.filterActions(filterButton.dataset.slug ?? null);
         });
 
-        const tooltipContentEl = $html.find("[data-tooltip-content]");
-        if (tooltipContentEl[0])
-            this.#tooltipsterElements.push(
-                tooltipContentEl.tooltipster({
+        const $tooltipContent = $html.find("[data-tooltip-content]");
+        if ($tooltipContent.length > 0)
+            this.tooltipsterElements.push(
+                $tooltipContent.tooltipster({
                     trigger: "click",
                     arrow: false,
                     contentAsHTML: true,
@@ -507,16 +501,8 @@ class KingdomSheetPF2e extends ActorSheetPF2e<PartyPF2e> {
                     this.kingdom.update(updates);
                 },
             });
-            this.#sortables.push(sortable);
+            this.destroyables.push(sortable);
         }
-    }
-
-    protected override _resetListeners(): void {
-        super._resetListeners();
-        this.#tooltipsterElements.forEach((element) => element.tooltipster("destroy"));
-        this.#tooltipsterElements = [];
-        this.#sortables.forEach((sortable) => sortable.destroy());
-        this.#sortables = [];
     }
 
     protected override activateClickListener(html: HTMLElement): SheetClickActionHandlers {

--- a/src/module/actor/party/sheet.ts
+++ b/src/module/actor/party/sheet.ts
@@ -359,7 +359,7 @@ class PartySheetPF2e extends ActorSheetPF2e<PartyPF2e> {
             const titleLabel = game.i18n.localize("PF2E.Actor.Party.MembersLabel");
             const title = createHTMLElement("strong", { children: [titleLabel] });
             const content = createHTMLElement("span", { children: [title, members] });
-            this.tooltipsterElements.push($(languageTag).tooltipster({ content }));
+            this.ensureTooltipsterCleanup($(languageTag).tooltipster({ content }));
         }
 
         // Mouseover summary skill tooltips to show all actor modifiers
@@ -376,7 +376,7 @@ class PartySheetPF2e extends ActorSheetPF2e<PartyPF2e> {
             });
 
             const content = createHTMLElement("div", { children: labels });
-            this.tooltipsterElements.push($(skillTag).tooltipster({ content }));
+            this.ensureTooltipsterCleanup($(skillTag).tooltipster({ content }));
         }
 
         // Mouseover tooltip for exploration activities
@@ -390,7 +390,7 @@ class PartySheetPF2e extends ActorSheetPF2e<PartyPF2e> {
                     classes: ["item-summary"],
                     innerHTML: await TextEditor.enrichHTML(document.description, { rollData }),
                 });
-                this.tooltipsterElements.push(
+                this.ensureTooltipsterCleanup(
                     $(activityElem).tooltipster({
                         contentAsHTML: true,
                         content,
@@ -483,7 +483,7 @@ class PartySheetPF2e extends ActorSheetPF2e<PartyPF2e> {
     }
 
     override render(force?: boolean, options?: PartySheetRenderOptions): this {
-        this._resetListeners();
+        this.resetListeners();
         if (options?.actors) {
             this.getData().then(async (data) => {
                 this._saveScrollPositions(this.element);

--- a/src/module/actor/party/sheet.ts
+++ b/src/module/actor/party/sheet.ts
@@ -26,9 +26,6 @@ interface PartySheetRenderOptions extends ActorSheetRenderOptionsPF2e {
 class PartySheetPF2e extends ActorSheetPF2e<PartyPF2e> {
     currentSummaryView = "languages";
 
-    /** Elements with registered $.tooltipster instances. Have to be cleaned up to avoid memory leaks */
-    #tooltipsterElements: JQuery[] = [];
-
     static override get defaultOptions(): ActorSheetOptions {
         const options = super.defaultOptions;
 
@@ -362,7 +359,7 @@ class PartySheetPF2e extends ActorSheetPF2e<PartyPF2e> {
             const titleLabel = game.i18n.localize("PF2E.Actor.Party.MembersLabel");
             const title = createHTMLElement("strong", { children: [titleLabel] });
             const content = createHTMLElement("span", { children: [title, members] });
-            this.#tooltipsterElements.push($(languageTag).tooltipster({ content }));
+            this.tooltipsterElements.push($(languageTag).tooltipster({ content }));
         }
 
         // Mouseover summary skill tooltips to show all actor modifiers
@@ -379,7 +376,7 @@ class PartySheetPF2e extends ActorSheetPF2e<PartyPF2e> {
             });
 
             const content = createHTMLElement("div", { children: labels });
-            this.#tooltipsterElements.push($(skillTag).tooltipster({ content }));
+            this.tooltipsterElements.push($(skillTag).tooltipster({ content }));
         }
 
         // Mouseover tooltip for exploration activities
@@ -393,7 +390,7 @@ class PartySheetPF2e extends ActorSheetPF2e<PartyPF2e> {
                     classes: ["item-summary"],
                     innerHTML: await TextEditor.enrichHTML(document.description, { rollData }),
                 });
-                this.#tooltipsterElements.push(
+                this.tooltipsterElements.push(
                     $(activityElem).tooltipster({
                         contentAsHTML: true,
                         content,
@@ -422,12 +419,6 @@ class PartySheetPF2e extends ActorSheetPF2e<PartyPF2e> {
         htmlQuery(html, "[data-action=prompt]")?.addEventListener("click", () => {
             game.pf2e.gm.checkPrompt({ actors: this.actor.members });
         });
-    }
-
-    protected override _resetListeners(): void {
-        super._resetListeners();
-        this.#tooltipsterElements.forEach((element) => element.tooltipster("destroy"));
-        this.#tooltipsterElements = [];
     }
 
     /** Overriden to prevent inclusion of campaign-only item types. Those should get added to their own sheet */

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -1314,13 +1314,17 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
     }
 
     /**
-     * Overridden _replaceHtml to reset event listeners.
-     * It would be nicer to have the `this.resetListeners()` call in
-     * activateListeners, but tooltipster hase to be cleaned up and that library
-     * throws errors when trying to clean up elements that have been
-     * `$(element).remove` from the dom. Sadly, even when it is removed, some references
-     * are still beeing retained, leaking memory. This is why the base call to
-     * `resetListeners` is just before the old html is being replaced with the new.
+     * Overridden _replaceHTML to reset event listeners.
+     * It would be nicer to have the resetListeners call in activateListeners,
+     * but tooltipster instances have to be cleaned up before the registered html
+     * elements are removed from the dom, as the library throws errors when trying
+     * to call the destroy method otherwise. Even though the library throws errors
+     * when trying to destroy an instance that has been detached from the main
+     * document, some references are still registered internally which leads to the
+     * whole detached element tree (the whole actor sheet) being retained in memory
+     * indefinitely.
+     * This is why `resetListeners` has to be called just before the old html is
+     * replaced.
      */
     protected override _replaceHTML(
         element: JQuery,

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -95,8 +95,11 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
     /** Implementation used to handle the toggling and rendering of item summaries */
     itemRenderer: ItemSummaryRenderer<TActor, ActorSheetPF2e<TActor>> = new ItemSummaryRenderer(this);
 
-    /** Active sortable instances. Have to be cleaned up to avoid memory leaks */
-    #sortables: Sortable[] = [];
+    /** Active destroyable resources. Have to be cleaned up to avoid memory leaks */
+    protected destroyables: { destroy(): void }[] = [];
+
+    /** Elements with registered $.tooltipster instances. Have to be cleaned up to avoid memory leaks */
+    protected tooltipsterElements: JQuery[] = [];
 
     /** Is this sheet one in which the actor is not owned by the user, but the user can still take and deposit items? */
     get isLootSheet(): boolean {
@@ -284,7 +287,7 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
         })();
         this.#activateInventoryDragDrop(inventoryPanel);
 
-        // // Everything below here is only needed if the sheet is editable
+        // Everything below here is only needed if the sheet is editable
         if (!this.options.editable) return;
 
         // Handlers for number inputs of properties subject to modification by AE-like rules elements
@@ -466,8 +469,10 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
     }
 
     protected _resetListeners(): void {
-        this.#sortables.forEach((sortable) => sortable.destroy());
-        this.#sortables = [];
+        this.destroyables.forEach((sortable) => sortable.destroy());
+        this.destroyables = [];
+        this.tooltipsterElements.forEach((element) => element.tooltipster("destroy"));
+        this.tooltipsterElements = [];
     }
 
     /** Sheet-wide click listeners for elements selectable as `a[data-action]` */
@@ -701,7 +706,7 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
                 onEnd: (event) => this.#onDropInventoryItem(event),
             };
 
-            this.#sortables.push(new Sortable(list, options));
+            this.destroyables.push(new Sortable(list, options));
         }
     }
 

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -714,7 +714,7 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
                 onEnd: (event) => this.#onDropInventoryItem(event),
             };
 
-            this.#destroyables.push(new Sortable(list, options));
+            this.ensureDestroyableCleanup(new Sortable(list, options));
         }
     }
 

--- a/src/module/actor/sheet/popups/iwr-editor.ts
+++ b/src/module/actor/sheet/popups/iwr-editor.ts
@@ -9,6 +9,9 @@ class IWREditor<TActor extends ActorPF2e> extends DocumentSheet<TActor, IWREdito
 
     types: Record<string, string>;
 
+    /** Active tagify instances. Have to be cleaned up to avoid memory leaks */
+    #tagifyInstances: Tagify<Record<"id" | "value", string>>[] = [];
+
     constructor(actor: TActor, options: IWREditorConstructorOptions) {
         super(actor, options);
 
@@ -145,10 +148,11 @@ class IWREditor<TActor extends ActorPF2e> extends DocumentSheet<TActor, IWREdito
     }
 
     override activateListeners($html: JQuery): void {
+        this._resetListeners();
         const html = $html[0];
 
         for (const input of htmlQueryAll<HTMLInputElement>(html, "input[type=text]")) {
-            tagify(input, { whitelist: this.types, maxTags: 6 });
+            this.#tagifyInstances.push(tagify(input, { whitelist: this.types, maxTags: 6 }));
         }
 
         htmlQuery(html, "a[data-action=add]")?.addEventListener("click", (event) => {
@@ -177,6 +181,16 @@ class IWREditor<TActor extends ActorPF2e> extends DocumentSheet<TActor, IWREdito
                 this.#updateIWR();
             });
         }
+    }
+
+    _resetListeners(): void {
+        this.#tagifyInstances.forEach((tagified) => tagified.destroy());
+        this.#tagifyInstances = [];
+    }
+
+    override async close(options?: { force?: boolean | undefined }): Promise<void> {
+        this._resetListeners();
+        return super.close(options);
     }
 }
 

--- a/src/module/actor/sheet/popups/iwr-editor.ts
+++ b/src/module/actor/sheet/popups/iwr-editor.ts
@@ -148,7 +148,7 @@ class IWREditor<TActor extends ActorPF2e> extends DocumentSheet<TActor, IWREdito
     }
 
     override activateListeners($html: JQuery): void {
-        this._resetListeners();
+        this.#resetListeners();
         const html = $html[0];
 
         for (const input of htmlQueryAll<HTMLInputElement>(html, "input[type=text]")) {
@@ -183,13 +183,13 @@ class IWREditor<TActor extends ActorPF2e> extends DocumentSheet<TActor, IWREdito
         }
     }
 
-    _resetListeners(): void {
+    #resetListeners(): void {
         this.#tagifyInstances.forEach((tagified) => tagified.destroy());
         this.#tagifyInstances = [];
     }
 
     override async close(options?: { force?: boolean | undefined }): Promise<void> {
-        this._resetListeners();
+        this.#resetListeners();
         return super.close(options);
     }
 }

--- a/src/module/apps/compendium-browser/index.ts
+++ b/src/module/apps/compendium-browser/index.ts
@@ -44,6 +44,12 @@ class CompendiumBrowser extends Application {
     navigationTab: Tabs;
     tabs: BrowserTabs;
 
+    /** Active tagify instances. Have to be cleaned up to avoid memory leaks */
+    #tagifyInstances: Tagify<{
+        label: string;
+        value: string;
+    }>[] = [];
+
     packLoader = new PackLoader();
     declare activeTab: TabName;
 
@@ -100,6 +106,7 @@ class CompendiumBrowser extends Application {
         for (const tab of Object.values(this.tabs)) {
             tab.filterData.search.text = "";
         }
+        this._resetListeners();
         await super.close(options);
     }
 
@@ -311,6 +318,7 @@ class CompendiumBrowser extends Application {
 
     override activateListeners($html: JQuery): void {
         super.activateListeners($html);
+        this._resetListeners();
         const html = $html[0];
         const activeTabName = this.activeTab;
 
@@ -610,6 +618,7 @@ class CompendiumBrowser extends Application {
                             }
                         },
                     });
+                    this.#tagifyInstances.push(tagify);
 
                     tagify.on("click", (event) => {
                         const target = event.detail.event.target as HTMLElement;
@@ -731,6 +740,11 @@ class CompendiumBrowser extends Application {
 
         // Initial result list render
         this.#renderResultList({ list });
+    }
+
+    _resetListeners(): void {
+        this.#tagifyInstances.forEach((tagified) => tagified.destroy());
+        this.#tagifyInstances = [];
     }
 
     async #resetInitializedTabs(): Promise<void> {

--- a/src/module/apps/compendium-browser/index.ts
+++ b/src/module/apps/compendium-browser/index.ts
@@ -106,7 +106,7 @@ class CompendiumBrowser extends Application {
         for (const tab of Object.values(this.tabs)) {
             tab.filterData.search.text = "";
         }
-        this._resetListeners();
+        this.resetListeners();
         await super.close(options);
     }
 
@@ -318,7 +318,7 @@ class CompendiumBrowser extends Application {
 
     override activateListeners($html: JQuery): void {
         super.activateListeners($html);
-        this._resetListeners();
+        this.resetListeners();
         const html = $html[0];
         const activeTabName = this.activeTab;
 
@@ -742,7 +742,7 @@ class CompendiumBrowser extends Application {
         this.#renderResultList({ list });
     }
 
-    _resetListeners(): void {
+    resetListeners(): void {
         this.#tagifyInstances.forEach((tagified) => tagified.destroy());
         this.#tagifyInstances = [];
     }

--- a/src/module/apps/pick-a-thing-prompt.ts
+++ b/src/module/apps/pick-a-thing-prompt.ts
@@ -85,6 +85,7 @@ abstract class PickAThingPrompt<TItem extends ItemPF2e, TThing extends string | 
         const select = htmlQuery<HTMLInputElement>(html, "input[data-tagify-select]");
         if (!select) return;
 
+        this.selectMenu?.destroy();
         this.selectMenu = new Tagify(select, {
             enforceWhitelist: true,
             keepInvalidTags: false,
@@ -109,6 +110,8 @@ abstract class PickAThingPrompt<TItem extends ItemPF2e, TThing extends string | 
         for (const element of htmlQueryAll(this.element[0], "button, select")) {
             element.style.pointerEvents = "none";
         }
+        this.selectMenu?.destroy();
+        this.selectMenu = undefined;
         this.#resolve?.(this.selection);
 
         return super.close(options);

--- a/src/module/apps/sidebar/chat-log.ts
+++ b/src/module/apps/sidebar/chat-log.ts
@@ -12,6 +12,9 @@ import { fontAwesomeIcon, htmlClosest, htmlQuery, objectHasKey } from "@util";
 import type { ChatMessageSource } from "types/foundry/common/documents/chat-message.d.ts";
 
 class ChatLogPF2e extends ChatLog<ChatMessagePF2e> {
+    /** Elements with registered $.tooltipster instances. Have to be cleaned up to avoid memory leaks */
+    #tooltipsterElements: JQuery[] = [];
+
     /* -------------------------------------------- */
     /*  Event Listeners and Handlers                */
     /* -------------------------------------------- */
@@ -209,91 +212,93 @@ class ChatLogPF2e extends ChatLog<ChatMessagePF2e> {
 
         // Add a tooltipster instance to the shield button if needed.
         if (!shieldButton.classList.contains("tooltipstered")) {
-            $(shieldButton)
-                .tooltipster({
-                    animation: "fade",
-                    trigger: "click",
-                    arrow: false,
-                    content: htmlQuery(messageEl, "div.hover-content"),
-                    contentAsHTML: true,
-                    contentCloning: true,
-                    debug: BUILD_MODE === "development",
-                    interactive: true,
-                    side: ["top"],
-                    theme: "crb-hover",
-                    functionBefore: (): boolean => {
-                        const tokens = getTokens();
-                        if (tokens.length === 0) return false;
+            this.#tooltipsterElements.push(
+                $(shieldButton)
+                    .tooltipster({
+                        animation: "fade",
+                        trigger: "click",
+                        arrow: false,
+                        content: htmlQuery(messageEl, "div.hover-content"),
+                        contentAsHTML: true,
+                        contentCloning: true,
+                        debug: BUILD_MODE === "development",
+                        interactive: true,
+                        side: ["top"],
+                        theme: "crb-hover",
+                        functionBefore: (): boolean => {
+                            const tokens = getTokens();
+                            if (tokens.length === 0) return false;
 
-                        const nonBrokenShields = getNonBrokenShields(tokens);
-                        const hasMultipleShields = tokens.length === 1 && nonBrokenShields.length > 1;
-                        const shieldActivated = shieldButton.classList.contains("shield-activated");
+                            const nonBrokenShields = getNonBrokenShields(tokens);
+                            const hasMultipleShields = tokens.length === 1 && nonBrokenShields.length > 1;
+                            const shieldActivated = shieldButton.classList.contains("shield-activated");
 
-                        // More than one shield and no selection. Show tooltip.
-                        if (hasMultipleShields && !shieldActivated) {
-                            return true;
-                        }
+                            // More than one shield and no selection. Show tooltip.
+                            if (hasMultipleShields && !shieldActivated) {
+                                return true;
+                            }
 
-                        // More than one shield and one was previously selected. Remove selection and show tooltip.
-                        if (hasMultipleShields && shieldButton.dataset.shieldId) {
-                            shieldButton.attributes.removeNamedItem("data-shield-id");
-                            shieldButton.classList.remove("shield-activated");
-                            CONFIG.PF2E.chatDamageButtonShieldToggle = false;
-                            return true;
-                        }
+                            // More than one shield and one was previously selected. Remove selection and show tooltip.
+                            if (hasMultipleShields && shieldButton.dataset.shieldId) {
+                                shieldButton.attributes.removeNamedItem("data-shield-id");
+                                shieldButton.classList.remove("shield-activated");
+                                CONFIG.PF2E.chatDamageButtonShieldToggle = false;
+                                return true;
+                            }
 
-                        // Normal toggle behaviour. Tooltip is suppressed.
-                        shieldButton.classList.toggle("shield-activated");
-                        CONFIG.PF2E.chatDamageButtonShieldToggle = !CONFIG.PF2E.chatDamageButtonShieldToggle;
-                        return false;
-                    },
-                    functionFormat: (instance, _helper, contentEl: HTMLElement): string | JQuery => {
-                        const tokens = getTokens();
-                        const nonBrokenShields = getNonBrokenShields(tokens);
-                        const multipleShields = tokens.length === 1 && nonBrokenShields.length > 1;
-                        const shieldActivated = shieldButton.classList.contains("shield-activated");
+                            // Normal toggle behaviour. Tooltip is suppressed.
+                            shieldButton.classList.toggle("shield-activated");
+                            CONFIG.PF2E.chatDamageButtonShieldToggle = !CONFIG.PF2E.chatDamageButtonShieldToggle;
+                            return false;
+                        },
+                        functionFormat: (instance, _helper, contentEl: HTMLElement): string | JQuery => {
+                            const tokens = getTokens();
+                            const nonBrokenShields = getNonBrokenShields(tokens);
+                            const multipleShields = tokens.length === 1 && nonBrokenShields.length > 1;
+                            const shieldActivated = shieldButton.classList.contains("shield-activated");
 
-                        // If the actor is wielding more than one shield, have the user pick which shield to use for blocking.
-                        if (multipleShields && !shieldActivated) {
-                            // Populate the list with the shield options
-                            const listEl = htmlQuery(contentEl, "ul.shield-options");
-                            if (!listEl) return $(contentEl);
+                            // If the actor is wielding more than one shield, have the user pick which shield to use for blocking.
+                            if (multipleShields && !shieldActivated) {
+                                // Populate the list with the shield options
+                                const listEl = htmlQuery(contentEl, "ul.shield-options");
+                                if (!listEl) return $(contentEl);
 
-                            const shieldList = nonBrokenShields.map((shield): HTMLLIElement => {
-                                const input = document.createElement("input");
-                                input.classList.add("data");
-                                input.type = "radio";
-                                input.name = "shield-id";
-                                input.value = shield.id;
-                                input.addEventListener("click", () => {
-                                    shieldButton.dataset.shieldId = input.value;
-                                    shieldButton.classList.add("shield-activated");
-                                    CONFIG.PF2E.chatDamageButtonShieldToggle = true;
-                                    instance.close();
+                                const shieldList = nonBrokenShields.map((shield): HTMLLIElement => {
+                                    const input = document.createElement("input");
+                                    input.classList.add("data");
+                                    input.type = "radio";
+                                    input.name = "shield-id";
+                                    input.value = shield.id;
+                                    input.addEventListener("click", () => {
+                                        shieldButton.dataset.shieldId = input.value;
+                                        shieldButton.classList.add("shield-activated");
+                                        CONFIG.PF2E.chatDamageButtonShieldToggle = true;
+                                        instance.close();
+                                    });
+                                    const shieldName = document.createElement("span");
+                                    shieldName.classList.add("label");
+                                    shieldName.innerHTML = shield.name;
+
+                                    const hardness = document.createElement("span");
+                                    hardness.classList.add("tag");
+                                    const hardnessLabel = game.i18n.localize("PF2E.HardnessLabel");
+                                    hardness.innerHTML = `${hardnessLabel}: ${shield.hardness}`;
+
+                                    const itemLi = document.createElement("li");
+                                    itemLi.classList.add("item");
+                                    itemLi.append(input, shieldName, hardness);
+
+                                    return itemLi;
                                 });
-                                const shieldName = document.createElement("span");
-                                shieldName.classList.add("label");
-                                shieldName.innerHTML = shield.name;
 
-                                const hardness = document.createElement("span");
-                                hardness.classList.add("tag");
-                                const hardnessLabel = game.i18n.localize("PF2E.HardnessLabel");
-                                hardness.innerHTML = `${hardnessLabel}: ${shield.hardness}`;
+                                listEl.replaceChildren(...shieldList);
+                            }
 
-                                const itemLi = document.createElement("li");
-                                itemLi.classList.add("item");
-                                itemLi.append(input, shieldName, hardness);
-
-                                return itemLi;
-                            });
-
-                            listEl.replaceChildren(...shieldList);
-                        }
-
-                        return $(contentEl);
-                    },
-                })
-                .tooltipster("open");
+                            return $(contentEl);
+                        },
+                    })
+                    .tooltipster("open"),
+            );
         }
     }
 
@@ -460,6 +465,25 @@ class ChatLogPF2e extends ChatLog<ChatMessagePF2e> {
         );
 
         return options;
+    }
+
+    protected override _replaceHTML(
+        element: JQuery,
+        html: JQuery | HTMLElement,
+        options: Record<string, unknown>,
+    ): void {
+        this.#resetListeners();
+        super._replaceHTML(element, html, options);
+    }
+
+    #resetListeners() {
+        this.#tooltipsterElements.forEach((element) => element.tooltipster("destroy"));
+        this.#tooltipsterElements = [];
+    }
+
+    override async close(options?: { force?: boolean }): Promise<void> {
+        this.#resetListeners();
+        return super.close(options);
     }
 }
 

--- a/src/module/apps/sidebar/encounter-tracker.ts
+++ b/src/module/apps/sidebar/encounter-tracker.ts
@@ -65,7 +65,7 @@ export class EncounterTrackerPF2e<TEncounter extends EncounterPF2e | null> exten
 
     /** Make the combatants sortable */
     override activateListeners($html: JQuery): void {
-        this._resetListeners();
+        this.#resetListeners();
         const html = $html[0];
         const tracker = htmlQuery(html, "#combat-tracker");
         if (!tracker) throw ErrorPF2e("No tracker found");
@@ -191,7 +191,7 @@ export class EncounterTrackerPF2e<TEncounter extends EncounterPF2e | null> exten
         super.activateListeners($html);
     }
 
-    protected _resetListeners(): void {
+    #resetListeners(): void {
         this.#sortables.forEach((sortable) => sortable.destroy());
         this.#sortables = [];
     }
@@ -422,7 +422,7 @@ export class EncounterTrackerPF2e<TEncounter extends EncounterPF2e | null> exten
     }
 
     override async close(options?: { force?: boolean }): Promise<void> {
-        this._resetListeners();
+        this.#resetListeners();
         return super.close(options);
     }
 }

--- a/src/module/item/base/sheet/rule-element-form/actor-traits.ts
+++ b/src/module/item/base/sheet/rule-element-form/actor-traits.ts
@@ -6,7 +6,9 @@ class ActorTraitsForm extends RuleElementForm {
     override activateListeners(html: HTMLElement): void {
         super.activateListeners(html);
         for (const input of htmlQueryAll<HTMLInputElement>(html, "input.pf2e-tagify")) {
-            this.destroyables.push(tagify(input, { whitelist: CONFIG.PF2E.creatureTraits, enforceWhitelist: false }));
+            this.ensureDestroyableCleanup(
+                tagify(input, { whitelist: CONFIG.PF2E.creatureTraits, enforceWhitelist: false }),
+            );
         }
     }
 }

--- a/src/module/item/base/sheet/rule-element-form/actor-traits.ts
+++ b/src/module/item/base/sheet/rule-element-form/actor-traits.ts
@@ -2,23 +2,12 @@ import { htmlQueryAll, tagify } from "@util";
 import { RuleElementForm } from "./base.ts";
 
 class ActorTraitsForm extends RuleElementForm {
-    /** Active tagify instances. Have to be cleaned up to avoid memory leaks */
-    #tagifyInstances: Tagify<Record<"id" | "value", string>>[] = [];
-
     override template = "systems/pf2e/templates/items/rules/actor-traits.hbs";
     override activateListeners(html: HTMLElement): void {
         super.activateListeners(html);
         for (const input of htmlQueryAll<HTMLInputElement>(html, "input.pf2e-tagify")) {
-            this.#tagifyInstances.push(
-                tagify(input, { whitelist: CONFIG.PF2E.creatureTraits, enforceWhitelist: false }),
-            );
+            this.destroyables.push(tagify(input, { whitelist: CONFIG.PF2E.creatureTraits, enforceWhitelist: false }));
         }
-    }
-
-    protected override _resetListeners(): void {
-        super._resetListeners();
-        this.#tagifyInstances.forEach((tagified) => tagified.destroy());
-        this.#tagifyInstances = [];
     }
 }
 

--- a/src/module/item/base/sheet/rule-element-form/actor-traits.ts
+++ b/src/module/item/base/sheet/rule-element-form/actor-traits.ts
@@ -2,12 +2,23 @@ import { htmlQueryAll, tagify } from "@util";
 import { RuleElementForm } from "./base.ts";
 
 class ActorTraitsForm extends RuleElementForm {
+    /** Active tagify instances. Have to be cleaned up to avoid memory leaks */
+    #tagifyInstances: Tagify<Record<"id" | "value", string>>[] = [];
+
     override template = "systems/pf2e/templates/items/rules/actor-traits.hbs";
     override activateListeners(html: HTMLElement): void {
         super.activateListeners(html);
         for (const input of htmlQueryAll<HTMLInputElement>(html, "input.pf2e-tagify")) {
-            tagify(input, { whitelist: CONFIG.PF2E.creatureTraits, enforceWhitelist: false });
+            this.#tagifyInstances.push(
+                tagify(input, { whitelist: CONFIG.PF2E.creatureTraits, enforceWhitelist: false }),
+            );
         }
+    }
+
+    protected override _resetListeners(): void {
+        super._resetListeners();
+        this.#tagifyInstances.forEach((tagified) => tagified.destroy());
+        this.#tagifyInstances = [];
     }
 }
 

--- a/src/module/item/base/sheet/rule-element-form/aura.ts
+++ b/src/module/item/base/sheet/rule-element-form/aura.ts
@@ -35,7 +35,7 @@ class AuraForm extends RuleElementForm<AuraRuleElementSource, AuraRuleElement> {
         const traitsElement = htmlQuery<HTMLTagifyTagsElement>(html, "tagify-tags.tagify-traits");
         if (traitsElement) {
             const whitelist = { ...CONFIG.PF2E.spellTraits, ...CONFIG.PF2E.actionTraits };
-            this.destroyables.push(tagify(traitsElement, { whitelist, enforceWhitelist: false }));
+            this.ensureDestroyableCleanup(tagify(traitsElement, { whitelist, enforceWhitelist: false }));
         }
 
         for (const eventsElement of htmlQueryAll<HTMLTagifyTagsElement>(html, "tagify-tags.tagify-events")) {
@@ -44,7 +44,7 @@ class AuraForm extends RuleElementForm<AuraRuleElementSource, AuraRuleElement> {
                 ["turn-start", game.i18n.localize("PF2E.RuleEditor.Aura.Effects.EventsOptions.TurnStart")],
                 ["turn-end", game.i18n.localize("PF2E.RuleEditor.Aura.Effects.EventsOptions.TurnEnd")],
             ].sort((a, b) => a[1].localeCompare(b[1], game.i18n.lang));
-            this.destroyables.push(
+            this.ensureDestroyableCleanup(
                 tagify(eventsElement, {
                     whitelist: R.mapToObj(whitelist, (w) => [w[0], w[1]]),
                     enforceWhitelist: true,

--- a/src/module/item/base/sheet/rule-element-form/aura.ts
+++ b/src/module/item/base/sheet/rule-element-form/aura.ts
@@ -9,9 +9,6 @@ import { RuleElementForm, RuleElementFormSheetData, RuleElementFormTabData } fro
 class AuraForm extends RuleElementForm<AuraRuleElementSource, AuraRuleElement> {
     override template = "systems/pf2e/templates/items/rules/aura.hbs";
 
-    /** Active tagify instances. Have to be cleaned up to avoid memory leaks */
-    #tagifyInstances: Tagify<Record<"id" | "value", string>>[] = [];
-
     protected override tabs: RuleElementFormTabData = {
         names: ["basics", "effects", "appearance"],
         displayStyle: "grid",
@@ -38,7 +35,7 @@ class AuraForm extends RuleElementForm<AuraRuleElementSource, AuraRuleElement> {
         const traitsElement = htmlQuery<HTMLTagifyTagsElement>(html, "tagify-tags.tagify-traits");
         if (traitsElement) {
             const whitelist = { ...CONFIG.PF2E.spellTraits, ...CONFIG.PF2E.actionTraits };
-            this.#tagifyInstances.push(tagify(traitsElement, { whitelist, enforceWhitelist: false }));
+            this.destroyables.push(tagify(traitsElement, { whitelist, enforceWhitelist: false }));
         }
 
         for (const eventsElement of htmlQueryAll<HTMLTagifyTagsElement>(html, "tagify-tags.tagify-events")) {
@@ -47,7 +44,7 @@ class AuraForm extends RuleElementForm<AuraRuleElementSource, AuraRuleElement> {
                 ["turn-start", game.i18n.localize("PF2E.RuleEditor.Aura.Effects.EventsOptions.TurnStart")],
                 ["turn-end", game.i18n.localize("PF2E.RuleEditor.Aura.Effects.EventsOptions.TurnEnd")],
             ].sort((a, b) => a[1].localeCompare(b[1], game.i18n.lang));
-            this.#tagifyInstances.push(
+            this.destroyables.push(
                 tagify(eventsElement, {
                     whitelist: R.mapToObj(whitelist, (w) => [w[0], w[1]]),
                     enforceWhitelist: true,
@@ -125,12 +122,6 @@ class AuraForm extends RuleElementForm<AuraRuleElementSource, AuraRuleElement> {
                 }
             });
         }
-    }
-
-    protected override _resetListeners(): void {
-        super._resetListeners();
-        this.#tagifyInstances.forEach((tagified) => tagified.destroy());
-        this.#tagifyInstances = [];
     }
 
     override async getData(): Promise<AuraSheetData> {

--- a/src/module/item/base/sheet/rule-element-form/aura.ts
+++ b/src/module/item/base/sheet/rule-element-form/aura.ts
@@ -9,6 +9,9 @@ import { RuleElementForm, RuleElementFormSheetData, RuleElementFormTabData } fro
 class AuraForm extends RuleElementForm<AuraRuleElementSource, AuraRuleElement> {
     override template = "systems/pf2e/templates/items/rules/aura.hbs";
 
+    /** Active tagify instances. Have to be cleaned up to avoid memory leaks */
+    #tagifyInstances: Tagify<Record<"id" | "value", string>>[] = [];
+
     protected override tabs: RuleElementFormTabData = {
         names: ["basics", "effects", "appearance"],
         displayStyle: "grid",
@@ -35,7 +38,7 @@ class AuraForm extends RuleElementForm<AuraRuleElementSource, AuraRuleElement> {
         const traitsElement = htmlQuery<HTMLTagifyTagsElement>(html, "tagify-tags.tagify-traits");
         if (traitsElement) {
             const whitelist = { ...CONFIG.PF2E.spellTraits, ...CONFIG.PF2E.actionTraits };
-            tagify(traitsElement, { whitelist, enforceWhitelist: false });
+            this.#tagifyInstances.push(tagify(traitsElement, { whitelist, enforceWhitelist: false }));
         }
 
         for (const eventsElement of htmlQueryAll<HTMLTagifyTagsElement>(html, "tagify-tags.tagify-events")) {
@@ -44,7 +47,12 @@ class AuraForm extends RuleElementForm<AuraRuleElementSource, AuraRuleElement> {
                 ["turn-start", game.i18n.localize("PF2E.RuleEditor.Aura.Effects.EventsOptions.TurnStart")],
                 ["turn-end", game.i18n.localize("PF2E.RuleEditor.Aura.Effects.EventsOptions.TurnEnd")],
             ].sort((a, b) => a[1].localeCompare(b[1], game.i18n.lang));
-            tagify(eventsElement, { whitelist: R.mapToObj(whitelist, (w) => [w[0], w[1]]), enforceWhitelist: true });
+            this.#tagifyInstances.push(
+                tagify(eventsElement, {
+                    whitelist: R.mapToObj(whitelist, (w) => [w[0], w[1]]),
+                    enforceWhitelist: true,
+                }),
+            );
         }
 
         for (const element of htmlQueryAll(html, "a[data-action=remove-effect]")) {
@@ -117,6 +125,12 @@ class AuraForm extends RuleElementForm<AuraRuleElementSource, AuraRuleElement> {
                 }
             });
         }
+    }
+
+    protected override _resetListeners(): void {
+        super._resetListeners();
+        this.#tagifyInstances.forEach((tagified) => tagified.destroy());
+        this.#tagifyInstances = [];
     }
 
     override async getData(): Promise<AuraSheetData> {

--- a/src/module/item/base/sheet/rule-element-form/base.ts
+++ b/src/module/item/base/sheet/rule-element-form/base.ts
@@ -37,7 +37,7 @@ class RuleElementForm<
     #activeTab: Maybe<string> = null;
 
     /** Active tagify instances. Have to be cleaned up to avoid memory leaks */
-    #tagifyInstances: (Tagify<Record<"id" | "value", string>> | null)[] = [];
+    destroyables: { destroy(): void }[] = [];
 
     /** Base proprety path for the contained rule */
     get basePath(): string {
@@ -205,7 +205,8 @@ class RuleElementForm<
 
         // Tagify selectors lists
         const selectorElement = htmlQuery<HTMLTagifyTagsElement>(html, "tagify-tags.selector-list");
-        this.#tagifyInstances.push(tagify(selectorElement));
+        const tags = tagify(selectorElement);
+        if (tags) this.destroyables.push(tags);
 
         // Add event listener for priority. This exists because normal form submission won't work for text-area forms
         const priorityInput = htmlQuery<HTMLInputElement>(html, ".rule-element-header .priority input");
@@ -271,8 +272,8 @@ class RuleElementForm<
     }
 
     protected _resetListeners(): void {
-        this.#tagifyInstances.forEach((tagified) => tagified?.destroy());
-        this.#tagifyInstances = [];
+        this.destroyables.forEach((tagified) => tagified?.destroy());
+        this.destroyables = [];
     }
 
     protected async onDrop(event: DragEvent, _element: HTMLElement): Promise<ItemPF2e | null> {

--- a/src/module/item/base/sheet/rule-element-form/base.ts
+++ b/src/module/item/base/sheet/rule-element-form/base.ts
@@ -36,6 +36,9 @@ class RuleElementForm<
     /** The currently active tab */
     #activeTab: Maybe<string> = null;
 
+    /** Active tagify instances. Have to be cleaned up to avoid memory leaks */
+    #tagifyInstances: (Tagify<Record<"id" | "value", string>> | null)[] = [];
+
     /** Base proprety path for the contained rule */
     get basePath(): string {
         return `system.rules.${this.index}`;
@@ -197,11 +200,12 @@ class RuleElementForm<
     }
 
     activateListeners(html: HTMLElement): void {
+        this._resetListeners();
         this.element = html;
 
         // Tagify selectors lists
         const selectorElement = htmlQuery<HTMLTagifyTagsElement>(html, "tagify-tags.selector-list");
-        tagify(selectorElement);
+        this.#tagifyInstances.push(tagify(selectorElement));
 
         // Add event listener for priority. This exists because normal form submission won't work for text-area forms
         const priorityInput = htmlQuery<HTMLInputElement>(html, ".rule-element-header .priority input");
@@ -264,6 +268,11 @@ class RuleElementForm<
                 this.onDrop(event, dropZone);
             });
         }
+    }
+
+    protected _resetListeners(): void {
+        this.#tagifyInstances.forEach((tagified) => tagified?.destroy());
+        this.#tagifyInstances = [];
     }
 
     protected async onDrop(event: DragEvent, _element: HTMLElement): Promise<ItemPF2e | null> {
@@ -329,6 +338,14 @@ class RuleElementForm<
         // Update our reference so that equality matching works on the next data prep cycle
         // This allows form reuse to occur
         this.rule = source;
+    }
+
+    /**
+     * Subclassess should override this function if they need to handle custom cleanup tasks when the
+     * rule element is removed from the DOM, for example destroying tagify instances, etc.
+     */
+    destroy(): void {
+        this._resetListeners();
     }
 }
 

--- a/src/module/item/base/sheet/rule-element-form/base.ts
+++ b/src/module/item/base/sheet/rule-element-form/base.ts
@@ -37,7 +37,7 @@ class RuleElementForm<
     #activeTab: Maybe<string> = null;
 
     /** Active tagify instances. Have to be cleaned up to avoid memory leaks */
-    destroyables: { destroy(): void }[] = [];
+    #destroyables: { destroy(): void }[] = [];
 
     /** Base proprety path for the contained rule */
     get basePath(): string {
@@ -200,13 +200,13 @@ class RuleElementForm<
     }
 
     activateListeners(html: HTMLElement): void {
-        this._resetListeners();
+        this.resetListeners();
         this.element = html;
 
         // Tagify selectors lists
         const selectorElement = htmlQuery<HTMLTagifyTagsElement>(html, "tagify-tags.selector-list");
         const tags = tagify(selectorElement);
-        if (tags) this.destroyables.push(tags);
+        if (tags) this.#destroyables.push(tags);
 
         // Add event listener for priority. This exists because normal form submission won't work for text-area forms
         const priorityInput = htmlQuery<HTMLInputElement>(html, ".rule-element-header .priority input");
@@ -271,9 +271,13 @@ class RuleElementForm<
         }
     }
 
-    protected _resetListeners(): void {
-        this.destroyables.forEach((tagified) => tagified?.destroy());
-        this.destroyables = [];
+    protected ensureDestroyableCleanup(destroyable: { destroy(): void } | null): void {
+        if (destroyable) this.#destroyables.push(destroyable);
+    }
+
+    protected resetListeners(): void {
+        this.#destroyables.forEach((tagified) => tagified?.destroy());
+        this.#destroyables = [];
     }
 
     protected async onDrop(event: DragEvent, _element: HTMLElement): Promise<ItemPF2e | null> {
@@ -346,7 +350,7 @@ class RuleElementForm<
      * rule element is removed from the DOM, for example destroying tagify instances, etc.
      */
     destroy(): void {
-        this._resetListeners();
+        this.resetListeners();
     }
 }
 

--- a/src/module/item/base/sheet/rule-element-form/fast-healing.ts
+++ b/src/module/item/base/sheet/rule-element-form/fast-healing.ts
@@ -9,6 +9,10 @@ import { RuleElementForm, RuleElementFormSheetData } from "./base.ts";
 
 class FastHealingForm extends RuleElementForm<FastHealingSource, FastHealingRuleElement> {
     override template = "systems/pf2e/templates/items/rules/fast-healing.hbs";
+
+    /** Active tagify instances. Have to be cleaned up to avoid memory leaks */
+    #tagifyInstances: Tagify<Record<"id" | "value", string>>[] = [];
+
     override activateListeners(html: HTMLElement): void {
         super.activateListeners(html);
 
@@ -16,8 +20,14 @@ class FastHealingForm extends RuleElementForm<FastHealingSource, FastHealingRule
         const selectorElement = htmlQuery<HTMLTagifyTagsElement>(html, "tagify-tags.deactivated-by");
         if (selectorElement) {
             const whitelist = CONFIG.PF2E.weaknessTypes;
-            tagify(selectorElement, { whitelist, enforceWhitelist: false });
+            this.#tagifyInstances.push(tagify(selectorElement, { whitelist, enforceWhitelist: false }));
         }
+    }
+
+    protected override _resetListeners(): void {
+        super._resetListeners();
+        this.#tagifyInstances.forEach((tagified) => tagified.destroy());
+        this.#tagifyInstances = [];
     }
 
     override async getData(): Promise<FastHealingSheetData> {

--- a/src/module/item/base/sheet/rule-element-form/fast-healing.ts
+++ b/src/module/item/base/sheet/rule-element-form/fast-healing.ts
@@ -17,7 +17,7 @@ class FastHealingForm extends RuleElementForm<FastHealingSource, FastHealingRule
         const selectorElement = htmlQuery<HTMLTagifyTagsElement>(html, "tagify-tags.deactivated-by");
         if (selectorElement) {
             const whitelist = CONFIG.PF2E.weaknessTypes;
-            this.destroyables.push(tagify(selectorElement, { whitelist, enforceWhitelist: false }));
+            this.ensureDestroyableCleanup(tagify(selectorElement, { whitelist, enforceWhitelist: false }));
         }
     }
 

--- a/src/module/item/base/sheet/rule-element-form/fast-healing.ts
+++ b/src/module/item/base/sheet/rule-element-form/fast-healing.ts
@@ -10,9 +10,6 @@ import { RuleElementForm, RuleElementFormSheetData } from "./base.ts";
 class FastHealingForm extends RuleElementForm<FastHealingSource, FastHealingRuleElement> {
     override template = "systems/pf2e/templates/items/rules/fast-healing.hbs";
 
-    /** Active tagify instances. Have to be cleaned up to avoid memory leaks */
-    #tagifyInstances: Tagify<Record<"id" | "value", string>>[] = [];
-
     override activateListeners(html: HTMLElement): void {
         super.activateListeners(html);
 
@@ -20,14 +17,8 @@ class FastHealingForm extends RuleElementForm<FastHealingSource, FastHealingRule
         const selectorElement = htmlQuery<HTMLTagifyTagsElement>(html, "tagify-tags.deactivated-by");
         if (selectorElement) {
             const whitelist = CONFIG.PF2E.weaknessTypes;
-            this.#tagifyInstances.push(tagify(selectorElement, { whitelist, enforceWhitelist: false }));
+            this.destroyables.push(tagify(selectorElement, { whitelist, enforceWhitelist: false }));
         }
-    }
-
-    protected override _resetListeners(): void {
-        super._resetListeners();
-        this.#tagifyInstances.forEach((tagified) => tagified.destroy());
-        this.#tagifyInstances = [];
     }
 
     override async getData(): Promise<FastHealingSheetData> {

--- a/src/module/item/base/sheet/rule-element-form/roll-note.ts
+++ b/src/module/item/base/sheet/rule-element-form/roll-note.ts
@@ -26,7 +26,7 @@ class RollNoteForm extends RuleElementForm<NoteRESource, RollNoteRuleElement> {
         });
         const optionsEl = htmlQuery<HTMLTagifyTagsElement>(html, "tagify-tags.outcomes");
         const tags = tagify(optionsEl, { whitelist: [...DEGREE_OF_SUCCESS_STRINGS], maxTags: 3 });
-        if (tags) this.destroyables.push(tags);
+        if (tags) this.ensureDestroyableCleanup(tags);
     }
 
     override updateObject(ruleData: Partial<Record<string, JSONValue>>): void {

--- a/src/module/item/base/sheet/rule-element-form/roll-note.ts
+++ b/src/module/item/base/sheet/rule-element-form/roll-note.ts
@@ -8,9 +8,6 @@ import { RuleElementForm, RuleElementFormSheetData } from "./base.ts";
 class RollNoteForm extends RuleElementForm<NoteRESource, RollNoteRuleElement> {
     override template = "systems/pf2e/templates/items/rules/note.hbs";
 
-    /** Active tagify instances. Have to be cleaned up to avoid memory leaks */
-    #tagifyInstances: (Tagify<Record<"id" | "value", string>> | null)[] = [];
-
     override async getData(): Promise<RollNoteFormSheetData> {
         return {
             ...(await super.getData()),
@@ -28,13 +25,8 @@ class RollNoteForm extends RuleElementForm<NoteRESource, RollNoteRuleElement> {
             this.updateItem({ selector: newValue });
         });
         const optionsEl = htmlQuery<HTMLTagifyTagsElement>(html, "tagify-tags.outcomes");
-        this.#tagifyInstances.push(tagify(optionsEl, { whitelist: [...DEGREE_OF_SUCCESS_STRINGS], maxTags: 3 }));
-    }
-
-    protected override _resetListeners(): void {
-        super._resetListeners();
-        this.#tagifyInstances.forEach((tagified) => tagified?.destroy());
-        this.#tagifyInstances = [];
+        const tags = tagify(optionsEl, { whitelist: [...DEGREE_OF_SUCCESS_STRINGS], maxTags: 3 });
+        if (tags) this.destroyables.push(tags);
     }
 
     override updateObject(ruleData: Partial<Record<string, JSONValue>>): void {

--- a/src/module/item/base/sheet/sheet.ts
+++ b/src/module/item/base/sheet/sheet.ts
@@ -308,7 +308,7 @@ class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem, ItemSheetOp
     }
 
     override async close(options?: { force?: boolean }): Promise<void> {
-        this._resetListeners();
+        this.resetListeners();
         this._destroyRuleElementForms();
         this.#editingRuleElementIndex = null;
         return super.close(options);
@@ -605,7 +605,7 @@ class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem, ItemSheetOp
         this.#tooltipsterElements.push(element);
     }
 
-    protected _resetListeners(): void {
+    protected resetListeners(): void {
         this.#destroyables.forEach((destroyable) => destroyable.destroy());
         this.#destroyables = [];
         this.#tooltipsterElements.forEach((element) => element.tooltipster("destroy"));
@@ -670,7 +670,7 @@ class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem, ItemSheetOp
     }
 
     /**
-     * call destroy handler on rule elements. Has to be separated from _resetListeners because
+     * call destroy handler on rule elements. Has to be separated from resetListeners because
      * by the time _replaceHTML is called, the new rule elements have already been assigned and
      * the old ruleElementForms cannot be accessed anymore
      */
@@ -698,7 +698,7 @@ class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem, ItemSheetOp
         html: JQuery | HTMLElement,
         options: Record<string, unknown>,
     ): void {
-        this._resetListeners();
+        this.resetListeners();
         super._replaceHTML(element, html, options);
     }
 }

--- a/src/module/item/campaign-feature/sheet.ts
+++ b/src/module/item/campaign-feature/sheet.ts
@@ -6,6 +6,9 @@ import type { CampaignFeaturePF2e } from "./document.ts";
 import { KINGMAKER_CATEGORIES } from "./values.ts";
 
 class CampaignFeatureSheetPF2e extends ItemSheetPF2e<CampaignFeaturePF2e> {
+    /** Active tagify instances. Have to be cleaned up to avoid memory leaks */
+    #tagifyInstances: Tagify<Record<"id" | "value", string>>[] = [];
+
     static override get defaultOptions(): ItemSheetOptions {
         return { ...super.defaultOptions, hasSidebar: true };
     }
@@ -37,10 +40,18 @@ class CampaignFeatureSheetPF2e extends ItemSheetPF2e<CampaignFeaturePF2e> {
 
         const prerequisites = htmlQuery<HTMLTagifyTagsElement>(html, 'tagify-tags[name="system.prerequisites.value"]');
         if (prerequisites) {
-            tagify(prerequisites, {
-                editTags: 1,
-            });
+            this.#tagifyInstances.push(
+                tagify(prerequisites, {
+                    editTags: 1,
+                }),
+            );
         }
+    }
+
+    protected override _resetListeners(): void {
+        super._resetListeners();
+        this.#tagifyInstances.forEach((tagified) => tagified.destroy());
+        this.#tagifyInstances = [];
     }
 
     protected override _updateObject(event: Event, formData: Record<string, unknown>): Promise<void> {

--- a/src/module/item/campaign-feature/sheet.ts
+++ b/src/module/item/campaign-feature/sheet.ts
@@ -6,9 +6,6 @@ import type { CampaignFeaturePF2e } from "./document.ts";
 import { KINGMAKER_CATEGORIES } from "./values.ts";
 
 class CampaignFeatureSheetPF2e extends ItemSheetPF2e<CampaignFeaturePF2e> {
-    /** Active tagify instances. Have to be cleaned up to avoid memory leaks */
-    #tagifyInstances: Tagify<Record<"id" | "value", string>>[] = [];
-
     static override get defaultOptions(): ItemSheetOptions {
         return { ...super.defaultOptions, hasSidebar: true };
     }
@@ -40,18 +37,12 @@ class CampaignFeatureSheetPF2e extends ItemSheetPF2e<CampaignFeaturePF2e> {
 
         const prerequisites = htmlQuery<HTMLTagifyTagsElement>(html, 'tagify-tags[name="system.prerequisites.value"]');
         if (prerequisites) {
-            this.#tagifyInstances.push(
+            this.ensureDestroyableCleanup(
                 tagify(prerequisites, {
                     editTags: 1,
                 }),
             );
         }
-    }
-
-    protected override _resetListeners(): void {
-        super._resetListeners();
-        this.#tagifyInstances.forEach((tagified) => tagified.destroy());
-        this.#tagifyInstances = [];
     }
 
     protected override _updateObject(event: Event, formData: Record<string, unknown>): Promise<void> {

--- a/src/module/item/deity/sheet.ts
+++ b/src/module/item/deity/sheet.ts
@@ -9,6 +9,9 @@ import * as R from "remeda";
 import { DEITY_SANCTIFICATIONS } from "./values.ts";
 
 export class DeitySheetPF2e extends ItemSheetPF2e<DeityPF2e> {
+    /** Active tagify instances. Have to be cleaned up to avoid memory leaks */
+    #tagifyInstances: (Tagify<Record<"id" | "value", string>> | null)[] = [];
+
     static override get defaultOptions(): ItemSheetOptions {
         return {
             ...super.defaultOptions,
@@ -70,15 +73,23 @@ export class DeitySheetPF2e extends ItemSheetPF2e<DeityPF2e> {
         const getInput = (name: string): HTMLTagifyTagsElement | null =>
             htmlQuery<HTMLTagifyTagsElement>(html, `tagify-tags[name="${name}"]`);
 
-        tagify(getInput("system.attribute"), { whitelist: CONFIG.PF2E.abilities, maxTags: 2 });
+        this.#tagifyInstances.push(
+            tagify(getInput("system.attribute"), { whitelist: CONFIG.PF2E.abilities, maxTags: 2 }),
+        );
 
-        tagify(getInput("system.skill"), { whitelist: CONFIG.PF2E.skills, maxTags: 2 });
+        this.#tagifyInstances.push(tagify(getInput("system.skill"), { whitelist: CONFIG.PF2E.skills, maxTags: 2 }));
 
-        tagify(getInput("system.weapons"), { whitelist: CONFIG.PF2E.baseWeaponTypes, maxTags: 2 });
+        this.#tagifyInstances.push(
+            tagify(getInput("system.weapons"), { whitelist: CONFIG.PF2E.baseWeaponTypes, maxTags: 2 }),
+        );
 
         const domainWhitelist = R.omitBy(CONFIG.PF2E.deityDomains, (_v, k) => k.endsWith("-apocryphal"));
-        tagify(getInput("system.domains.primary"), { whitelist: domainWhitelist, maxTags: 6 });
-        tagify(getInput("system.domains.alternate"), { whitelist: domainWhitelist, maxTags: 6 });
+        this.#tagifyInstances.push(
+            tagify(getInput("system.domains.primary"), { whitelist: domainWhitelist, maxTags: 6 }),
+        );
+        this.#tagifyInstances.push(
+            tagify(getInput("system.domains.alternate"), { whitelist: domainWhitelist, maxTags: 6 }),
+        );
 
         const clericSpells = htmlQuery(html, ".cleric-spells");
         if (!clericSpells) return;
@@ -119,6 +130,12 @@ export class DeitySheetPF2e extends ItemSheetPF2e<DeityPF2e> {
                 }
             });
         }
+    }
+
+    protected override _resetListeners(): void {
+        super._resetListeners();
+        this.#tagifyInstances.forEach((tagifyInstance) => tagifyInstance?.destroy());
+        this.#tagifyInstances = [];
     }
 
     override async _onDrop(event: DragEvent): Promise<void> {

--- a/src/module/item/feat/sheet.ts
+++ b/src/module/item/feat/sheet.ts
@@ -30,7 +30,6 @@ import { featCanHaveKeyOptions } from "./helpers.ts";
 
 class FeatSheetPF2e extends ItemSheetPF2e<FeatPF2e> {
     /** Active tagify instances. Have to be cleaned up to avoid memory leaks */
-    #tagifyInstances: (Tagify<Record<"id" | "value", string>> | null)[] = [];
 
     static override get defaultOptions(): ItemSheetOptions {
         return {
@@ -217,8 +216,8 @@ class FeatSheetPF2e extends ItemSheetPF2e<FeatPF2e> {
         const getInput = (name: string): HTMLTagifyTagsElement | null =>
             htmlQuery<HTMLTagifyTagsElement>(html, `tagify-tags[name="${name}"]`);
 
-        this.#tagifyInstances.push(tagify(getInput("system.prerequisites.value"), { maxTags: 6, delimiters: ";" }));
-        this.#tagifyInstances.push(
+        this.ensureDestroyableCleanup(tagify(getInput("system.prerequisites.value"), { maxTags: 6, delimiters: ";" }));
+        this.ensureDestroyableCleanup(
             tagify(getInput("system.subfeatures.keyOptions"), { whitelist: CONFIG.PF2E.abilities, maxTags: 3 }),
         );
 
@@ -236,12 +235,6 @@ class FeatSheetPF2e extends ItemSheetPF2e<FeatPF2e> {
         this.#activateProficienciesListeners(html);
         this.#activateSensesListeners(html);
         this.#activateSuppressedFeaturesListeners(html);
-    }
-
-    protected override _resetListeners(): void {
-        super._resetListeners();
-        this.#tagifyInstances.forEach((tagifyInstance) => tagifyInstance?.destroy());
-        this.#tagifyInstances = [];
     }
 
     #activateLanguagesListeners(html: HTMLElement): void {

--- a/src/module/item/spell/sheet.ts
+++ b/src/module/item/spell/sheet.ts
@@ -41,9 +41,6 @@ const spellOverridable: Partial<Record<keyof SpellSystemData, string>> = {
 };
 
 export class SpellSheetPF2e extends ItemSheetPF2e<SpellPF2e> {
-    /** Active tagify instances. Have to be cleaned up to avoid memory leaks */
-    #tagifyInstances: (Tagify<Record<"id" | "value", string>> | null)[] = [];
-
     static override get defaultOptions(): ItemSheetOptions {
         return {
             ...super.defaultOptions,
@@ -151,7 +148,7 @@ export class SpellSheetPF2e extends ItemSheetPF2e<SpellPF2e> {
             if (levelInput) levelInput.readOnly = true;
         }
 
-        this.#tagifyInstances.push(
+        this.ensureDestroyableCleanup(
             tagify(htmlQuery<HTMLTagifyTagsElement>(html, 'tagify-tags[name="system.traits.traditions"]'), {
                 whitelist: CONFIG.PF2E.magicTraditions,
             }),
@@ -333,12 +330,6 @@ export class SpellSheetPF2e extends ItemSheetPF2e<SpellPF2e> {
                     : { primary: { check: "" }, secondary: { checks: "", casters: 0 } },
             });
         });
-    }
-
-    protected override _resetListeners(): void {
-        super._resetListeners();
-        this.#tagifyInstances.forEach((tagifyInstance) => tagifyInstance?.destroy());
-        this.#tagifyInstances = [];
     }
 
     protected override async _updateObject(event: Event, formData: Record<string, unknown>): Promise<void> {

--- a/src/module/scene/sheet.ts
+++ b/src/module/scene/sheet.ts
@@ -65,7 +65,7 @@ export class SceneConfigPF2e<TDocument extends ScenePF2e> extends SceneConfig<TD
 
     override activateListeners($html: JQuery): void {
         super.activateListeners($html);
-        this._resetListeners();
+        this.resetListeners();
         const html = $html[0];
 
         // Open world automation settings
@@ -88,7 +88,7 @@ export class SceneConfigPF2e<TDocument extends ScenePF2e> extends SceneConfig<TD
         this.#activateRBVListeners(html);
     }
 
-    protected _resetListeners(): void {
+    protected resetListeners(): void {
         this.#tagifyInstances.forEach((tagifyInstance) => tagifyInstance?.destroy());
         this.#tagifyInstances = [];
     }
@@ -172,7 +172,7 @@ export class SceneConfigPF2e<TDocument extends ScenePF2e> extends SceneConfig<TD
     }
 
     override async close(options?: { force?: boolean | undefined }): Promise<void> {
-        this._resetListeners();
+        this.resetListeners();
         return super.close(options);
     }
 }

--- a/src/module/system/settings/homebrew/languages.ts
+++ b/src/module/system/settings/homebrew/languages.ts
@@ -24,6 +24,9 @@ export class LanguagesManager {
     /** A separate list of module-provided languages */
     moduleLanguages: LanguageNotCommon[];
 
+    /** Active sortable instances. Have to be cleaned up to avoid memory leaks */
+    #sortables: Sortable[] = [];
+
     constructor(menu: HomebrewElements) {
         this.menu = menu;
 
@@ -74,13 +77,14 @@ export class LanguagesManager {
         });
 
         for (const list of htmlQueryAll(html, "ul[data-languages]")) {
-            new Sortable(list, {
+            const sortable = new Sortable(list, {
                 ...SORTABLE_BASE_OPTIONS,
                 group: "languages",
                 sort: false,
                 swapThreshold: 1,
                 onEnd: (event) => this.#onDropLanguage(event),
             });
+            this.#sortables.push(sortable);
         }
 
         const rarities: readonly string[] = LANGUAGE_RARITIES;
@@ -94,6 +98,11 @@ export class LanguagesManager {
             labelEl.innerHTML = localize(sluggify(rarity, { camel: "bactrian" }));
             game.pf2e.TextEditor.convertXMLNode(labelEl, "rarity", { classes: ["tag", "rarity", rarity] });
         }
+    }
+
+    resetListeners(): void {
+        this.#sortables.forEach((sortable) => sortable.destroy());
+        this.#sortables = [];
     }
 
     #isValidLanguage(language: string | undefined): language is LanguageNotCommon {

--- a/src/module/system/settings/homebrew/menu.ts
+++ b/src/module/system/settings/homebrew/menu.ts
@@ -149,7 +149,7 @@ class HomebrewElements extends SettingsMenuPF2e {
 
     override activateListeners($html: JQuery): void {
         super.activateListeners($html);
-        this._resetListeners();
+        this.resetListeners();
         const html = $html[0];
 
         // Handle all changes for traits
@@ -206,7 +206,7 @@ class HomebrewElements extends SettingsMenuPF2e {
         this.languagesManager.activateListeners(html);
     }
 
-    protected _resetListeners(): void {
+    protected resetListeners(): void {
         this.languagesManager?.resetListeners();
         this.#tagifyInstances.forEach((tagifyInstance) => tagifyInstance?.destroy());
         this.#tagifyInstances = [];
@@ -391,7 +391,7 @@ class HomebrewElements extends SettingsMenuPF2e {
     }
 
     override async close(options?: { force?: boolean } | undefined): Promise<void> {
-        this._resetListeners();
+        this.resetListeners();
         return super.close(options);
     }
 }

--- a/src/module/system/settings/homebrew/menu.ts
+++ b/src/module/system/settings/homebrew/menu.ts
@@ -31,6 +31,9 @@ class HomebrewElements extends SettingsMenuPF2e {
     /** Whether this is the first time the homebrew tags will have been injected into CONFIG and actor derived data */
     #initialRefresh = true;
 
+    /** Active tagify instances. Have to be cleaned up to avoid memory leaks */
+    #tagifyInstances: (Tagify | null)[] = [];
+
     declare languagesManager: LanguagesManager;
 
     static #reservedTerms: ReservedTermsRecord | null = null;
@@ -146,6 +149,7 @@ class HomebrewElements extends SettingsMenuPF2e {
 
     override activateListeners($html: JQuery): void {
         super.activateListeners($html);
+        this._resetListeners();
         const html = $html[0];
 
         // Handle all changes for traits
@@ -155,31 +159,33 @@ class HomebrewElements extends SettingsMenuPF2e {
             if (!input) throw ErrorPF2e("Unexpected error preparing form");
             const localize = localizer("PF2E.SETTINGS.Homebrew");
 
-            new Tagify(input, {
-                editTags: 1,
-                hooks: {
-                    beforeRemoveTag: (tags): Promise<void> => {
-                        if (tags.some((t) => reservedTerms.has(sluggify(t.data.value)))) {
-                            return Promise.resolve();
-                        }
+            this.#tagifyInstances.push(
+                new Tagify(input, {
+                    editTags: 1,
+                    hooks: {
+                        beforeRemoveTag: (tags): Promise<void> => {
+                            if (tags.some((t) => reservedTerms.has(sluggify(t.data.value)))) {
+                                return Promise.resolve();
+                            }
 
-                        const response: Promise<unknown> = (async () => {
-                            const content = localize("ConfirmDelete.Message", { element: tags[0].data.value });
-                            return await Dialog.confirm({
-                                title: localize("ConfirmDelete.Title"),
-                                content: `<p>${content}</p>`,
-                            });
-                        })();
-                        return (async () => ((await response) ? Promise.resolve() : Promise.reject()))();
+                            const response: Promise<unknown> = (async () => {
+                                const content = localize("ConfirmDelete.Message", { element: tags[0].data.value });
+                                return await Dialog.confirm({
+                                    title: localize("ConfirmDelete.Title"),
+                                    content: `<p>${content}</p>`,
+                                });
+                            })();
+                            return (async () => ((await response) ? Promise.resolve() : Promise.reject()))();
+                        },
                     },
-                },
-                validate: (data) => !reservedTerms.has(sluggify(data.value)),
-                transformTag: (data) => {
-                    if (reservedTerms.has(sluggify(data.value))) {
-                        ui.notifications.error(localize("ReservedTerm", { term: data.value }));
-                    }
-                },
-            });
+                    validate: (data) => !reservedTerms.has(sluggify(data.value)),
+                    transformTag: (data) => {
+                        if (reservedTerms.has(sluggify(data.value))) {
+                            ui.notifications.error(localize("ReservedTerm", { term: data.value }));
+                        }
+                    },
+                }),
+            );
         }
 
         htmlQuery(html, "[data-action=damage-add]")?.addEventListener("click", async () => {
@@ -198,6 +204,12 @@ class HomebrewElements extends SettingsMenuPF2e {
         }
 
         this.languagesManager.activateListeners(html);
+    }
+
+    protected _resetListeners(): void {
+        this.languagesManager?.resetListeners();
+        this.#tagifyInstances.forEach((tagifyInstance) => tagifyInstance?.destroy());
+        this.#tagifyInstances = [];
     }
 
     override async getData(): Promise<HomebrewElementsSheetData> {
@@ -376,6 +388,11 @@ class HomebrewElements extends SettingsMenuPF2e {
                 record[element.id] = element.value;
             }
         }
+    }
+
+    override async close(options?: { force?: boolean } | undefined): Promise<void> {
+        this._resetListeners();
+        return super.close(options);
     }
 }
 


### PR DESCRIPTION
This PR fixes memory leaks in character/npc/hazard/party/kingdom/item sheets and various other places.

Any application currently using `Sortable`, `tooltipster` or `Tagify` is currently leaking memory (some references + the entire detached application dom tree) because these utilities register global event handlers or other global references that survive the application elements being detached from the DOM.

The solution to this to use the respective `destroy` methods these libraries provide. Either `.destroy()` on the `Sortable` or `Tagify` instances or `$(element).tooltipster('destroy')` for tooltipster.
This is done by keeping references to the active instances and destroying and nulling them when the application is closed, new event handlers are registered or rule element forms are not used anymore.

The memory profiles in the coming examples were done the following way:
- Reload foundry
- perform activity once to trigger any lazy allocations that are done only once for each application
- trigger manual garbage collection in chrome memory profiler
- start memory profiling
- do the activity three more times, each time running manual garbage collection after the activity is performed
- stop memory profiling

Ideal results are: Three spikes in the allocation that reset to a flat line of exactly the same height as before the spike. 

These are the results:
<details>
<summary>NPC Sheet</summary> 

**before PR**
![00-npc_sheet_before](https://github.com/user-attachments/assets/98699b38-3726-470c-9489-60a0294c1cca)

**after PR**
![00-npc_sheet_after](https://github.com/user-attachments/assets/b694a92a-fb95-4d04-af80-bcf7091bacf7)

</details>


<details>
<summary>Character Sheet</summary> 

**before PR**
![01-character_sheet_before](https://github.com/user-attachments/assets/902a3c80-0991-40a7-bb1f-6253c59902fb)

**after PR**

![01-character_sheet_after](https://github.com/user-attachments/assets/cb808c93-4798-4c52-8861-35ff44e4bdd9)

</details>

<details>
<summary>Hazard Sheet</summary> 
_Note: Hazard has to be in "unlocked" mode for tagify to be instantianted and triggere the memory leak_

**before PR**
![02-hazard_sheet_before](https://github.com/user-attachments/assets/29b330ee-608c-4e5c-85c1-4a899cdd50fc)

**after PR**
![02-hazard_sheet_after](https://github.com/user-attachments/assets/9245751a-0edc-4b5a-b1d8-740a966bd0b1)

</details>

<details>
<summary>Kingdom Sheet</summary> 
_Note: I was unable to test this one as I don't have access to the Kingmaker Premium Module._

**before PR**
N/A
**after PR**
N/A
</details>


<details>
<summary>Party Sheet</summary> 

**before PR**
![03-party_sheet_before](https://github.com/user-attachments/assets/fc49fea2-002b-4cfd-9f0c-9aa1ebd555a1)

**after PR**
![03-party_sheet_after](https://github.com/user-attachments/assets/c14e2533-ec5a-4be6-a2c8-631f786df371)


</details>


<details>
<summary>IWR Editor</summary> 

**before PR**
![04-iwr_editor_before](https://github.com/user-attachments/assets/9d236735-2fac-476c-aab7-4c67cc81b0d0)

**after PR**
![04-iwr_editor_after](https://github.com/user-attachments/assets/621a3576-821d-4b86-815a-04b54838fc3a)

</details>


<details>
<summary>Compendium Browser</summary> 
_Note: This requires the compendiom browser to be opened with a tab that has tagify instances. The Equipment tab for example._

**before PR**
![05-compendium_browser_before](https://github.com/user-attachments/assets/f6ad9e16-0fac-4b0b-9148-1da18b960ff8)

**after PR**
![05-compendium_browser_after](https://github.com/user-attachments/assets/984242c0-e798-4487-a839-ba45ea47513d)

</details>


<details>
<summary>Pick a Thing Prompt</summary> 
_Note: TODO describe which thing was picked_

**before PR**
![06-pick_a_thing_before](https://github.com/user-attachments/assets/bd2d663f-5eb4-4302-b655-814fc1248126)

**after PR**
![06-pick_a_thing_after](https://github.com/user-attachments/assets/947589bd-a6e4-4c98-81be-750adc00fdab)

</details>


<details>
<summary>Encounter Tracker</summary> 
_Note: This occured whenever the listeners were activated again. For testing, the encounter turn was advanced by one step._

**before PR**
![07-encounter_tracker_before](https://github.com/user-attachments/assets/8bd69a57-8fb0-43db-971c-ca6f7f418b65)

**after PR**
![07-encounter_tracker_after](https://github.com/user-attachments/assets/2d75ad8d-93fd-406b-be86-8db9a2addd5b)

</details>

_Note for Rule Elements: This was tested by creating the rule element for a standalone item, then deleting the rule element again without closing the item sheet. Even closing the item sheet however, memory was not freed._
<details>
<summary>Rule Element Forms: Actor Traits </summary> 
_Note: TODO - how to test?_

**before PR**
![08-actor_traits_ref_before](https://github.com/user-attachments/assets/1589916f-31dc-444c-a988-46b69bd91227)

**after PR**
![08-actor_traits_ref_after](https://github.com/user-attachments/assets/f21573d6-49ac-4832-8ae7-764d34b371b2)

</details>


<details>
<summary>Rule Element Forms: Aura</summary> 

**before PR**
![09-aura_ref_before](https://github.com/user-attachments/assets/4c18050c-ea0e-45ae-9a95-25ab8af306dc)

**after PR**
![09-aura_ref_after](https://github.com/user-attachments/assets/04af962d-1cc3-4140-8c35-84eb9096cbb6)

</details>


<details>
<summary>Rule Element Forms: Fast Healing </summary> 
_Note: Type has to be set to "regeneration" for memory leak to trigger_

**before PR**
![10-fast_healing_ref_before](https://github.com/user-attachments/assets/a99b2dd3-3243-4920-b431-15874a561cc7)

**after PR**
![10-fast_healing_ref_after](https://github.com/user-attachments/assets/5a1da87f-080f-4b00-b471-b8c19eee75bd)


</details>


<details>
<summary>Rule Element Forms: Roll Note </summary> 

**before PR**
![11-roll_note_ref_before](https://github.com/user-attachments/assets/5caa70c8-b3ba-44a9-9309-d9f3bf88508a)

**after PR**
![11-roll_note_ref_after](https://github.com/user-attachments/assets/11c1cc75-bc23-4980-b598-aeef1b4c6a7d)

</details>


<details>
<summary>Campaign Feature</summary> 

**before PR**
![12-campaign_feat_sheet_before](https://github.com/user-attachments/assets/4bbb24cd-2af7-437d-b9aa-c4dd4c07e588)

**after PR**
![12-campaign_feat_sheet_after](https://github.com/user-attachments/assets/6743cf22-6295-4329-a278-bc89e55285f5)

</details>


<details>
<summary>Deity Sheet</summary> 

**before PR**
![13-deity_sheet_before](https://github.com/user-attachments/assets/ab639607-1040-4485-8eb2-5795327eb28a)

**after PR**
![13-deity_sheet_after](https://github.com/user-attachments/assets/70fd56ae-50a5-402e-af0d-400dc93e63e9)

</details>


<details>
<summary>Feat Sheet</summary> 

**before PR**
![14-feat_sheet_before](https://github.com/user-attachments/assets/51a5071c-fc9c-40dd-9654-587b6b5d0d0e)

**after PR**
![14-feat_sheet_after](https://github.com/user-attachments/assets/e7253802-4942-4f7e-b8fd-7667b8d02f6a)

</details>


<details>
<summary>Spell Sheet</summary> 

**before PR**
![15-spell_sheet_before](https://github.com/user-attachments/assets/a2448944-9435-4fdc-854b-48efb02a31e5)

**after PR*
![15-spell_sheet_after](https://github.com/user-attachments/assets/b85b2d3f-9e02-4f64-b1eb-6aee29ed9204)

</details>


<details>
<summary>Scene Config Sheet</summary> 

**before PR**
![16-scene_config_before](https://github.com/user-attachments/assets/9c1325f2-d0f9-4ab2-ac1c-79a99e6f17e7)

**after PR**
![16-scene_config_after](https://github.com/user-attachments/assets/a579b65e-f2ad-47ae-888f-6e074f3f03a0)

</details>


<details>
<summary>Homebrew Language Settings sheet</summary> 

**before PR**
![17-homebrew_language_before](https://github.com/user-attachments/assets/554a01c6-1392-4455-b559-34d6e3b56f9e)


**after PR**
![17-homebrew_language_after](https://github.com/user-attachments/assets/d8570935-caab-45d7-97ce-14b44100d2d7)

</details>


<details>
<summary>Skill Check Prompt Macro</summary> 

**before PR**
![18-request_check_macro_before](https://github.com/user-attachments/assets/09eac754-ae52-4683-a85c-3397b03dbd15)

**after PR**
![18-request_check_macro_after](https://github.com/user-attachments/assets/b52e97da-6623-4c80-ab64-1bd783d3d8ca)

</details>