### PR TITLE
Remove relative path to Foundry types

### DIFF
--- a/src/module/data.ts
+++ b/src/module/data.ts
@@ -1,6 +1,6 @@
 import type { ActorPF2e } from "@actor";
 import type { ItemPF2e } from "@item";
-import type * as fields from "../../types/foundry/common/data/fields.d.ts";
+import type * as fields from "types/foundry/common/data/fields.d.ts";
 
 /** The size property of creatures and equipment */
 const SIZES = ["tiny", "sm", "med", "lg", "huge", "grg"] as const;


### PR DESCRIPTION
This is the only instance where it's importing something from the Foundry types using a relative path, every where else it's import via `types/foundry/*`. Doesn't really change much but it was bugging me since I had to write a special rule for this one instance.