### PR TITLE
Add spell effect for Blink Charge

### DIFF
--- a/packs/spell-effects/spell-effect-blink-charge.json
+++ b/packs/spell-effects/spell-effect-blink-charge.json
@@ -1,0 +1,86 @@
+{
+    "_id": "lUL4nvIVYqFOwxAZ",
+    "img": "icons/magic/sonic/projectile-shock-wave-blue.webp",
+    "name": "Spell Effect: Blink Charge",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Blink Charge]</p>\n<p>Your Strike deals extra force damage, depending on the result of your Strike.</p>"
+        },
+        "duration": {
+            "expiry": "turn-end",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 0
+        },
+        "level": {
+            "value": 5
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Secrets of Magic"
+        },
+        "rules": [
+            {
+                "choices": {
+                    "ownedItems": true,
+                    "predicate": [
+                        {
+                            "gte": [
+                                "item:hands-held",
+                                1
+                            ]
+                        }
+                    ],
+                    "types": [
+                        "weapon"
+                    ]
+                },
+                "flag": "weapon",
+                "key": "ChoiceSet"
+            },
+            {
+                "damageType": "force",
+                "diceNumber": "ceil((@item.level - 2)/2)",
+                "dieSize": "d8",
+                "key": "DamageDice",
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.blinkCharge",
+                "value": "@item.level"
+            },
+            {
+                "key": "Note",
+                "outcome": [
+                    "failure"
+                ],
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-attack",
+                "text": "PF2E.SpecificRule.BlinkCharge.Note.Failure",
+                "title": "{item|name}"
+            },
+            {
+                "key": "Note",
+                "outcome": [
+                    "criticalFailure"
+                ],
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-attack",
+                "text": "PF2E.SpecificRule.BlinkCharge.Note.CriticalFailure",
+                "title": "{item|name}"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/spell-effects/spell-effect-blink-charge.json
+++ b/packs/spell-effects/spell-effect-blink-charge.json
@@ -25,12 +25,7 @@
                 "choices": {
                     "ownedItems": true,
                     "predicate": [
-                        {
-                            "gte": [
-                                "item:hands-held",
-                                1
-                            ]
-                        }
+                        "item:equipped"
                     ],
                     "types": [
                         "weapon"

--- a/packs/spells/blink-charge.json
+++ b/packs/spells/blink-charge.json
@@ -8,32 +8,14 @@
             "value": ""
         },
         "counteraction": false,
-        "damage": {
-            "0": {
-                "applyMod": false,
-                "category": null,
-                "formula": "2d8",
-                "kinds": [
-                    "damage"
-                ],
-                "materials": [],
-                "type": "force"
-            }
-        },
+        "damage": {},
         "defense": null,
         "description": {
-            "value": "<p>You propel yourself through the fabric of space to deal a blow carrying the momentum of your teleportation. You teleport to an empty space adjacent to a creature you can see within range, then make a Strike against the creature with a weapon you're wielding. The Strike deals damage, plus an extra 2d8 force damage, depending on the result of your Strike.</p>\n<hr />\n<p><strong>Critical Success</strong> Double damage, plus after the Strike, you can teleport the target into an empty space up to 5 feet away from its current position. The new space must be on the ground if it started on the ground, in the air if it was flying, and so on.</p>\n<p><strong>Success</strong> The Strike deals full damage.</p>\n<p><strong>Failure</strong> The Strike deals no damage, but the target takes @Damage[1d8[force]] damage.</p>\n<p><strong>Critical Failure</strong> The Strike deals no damage, and you take 1d8 force damage.</p>\n<hr />\n<p><strong>Heightened (+2)</strong> The spell's range increases by 60 feet, and any force damage the spell deals is increased by @Damage[1d8[force]].</p>"
+            "value": "<p>You propel yourself through the fabric of space to deal a blow carrying the momentum of your teleportation. You teleport to an empty space adjacent to a creature you can see within range, then make a Strike against the creature with a weapon you're wielding. The Strike deals damage, plus an extra 2d8 force damage, depending on the result of your Strike.</p><hr /><p><strong>Critical Success</strong> Double damage, plus after the Strike, you can teleport the target into an empty space up to 5 feet away from its current position. The new space must be on the ground if it started on the ground, in the air if it was flying, and so on.</p>\n<p><strong>Success</strong> The Strike deals full damage.</p>\n<p><strong>Failure</strong> The Strike deals no damage, but the target takes 1d8 force damage.</p>\n<p><strong>Critical Failure</strong> The Strike deals no damage, and you take 1d8 force damage.</p><hr /><p><strong>Heightened (+2)</strong> The spell's range increases by 60 feet, and any force damage the spell deals is increased by 1d8 force.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Blink Charge]</p>"
         },
         "duration": {
             "sustained": false,
             "value": ""
-        },
-        "heightening": {
-            "damage": {
-                "0": "1d8"
-            },
-            "interval": 2,
-            "type": "interval"
         },
         "level": {
             "value": 5

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2262,7 +2262,7 @@
             },
             "BlinkCharge": {
                 "Note": {
-                    "CriticalFailure": "The Strike deals no damage, and you take force @Damage[(ceil((@actor.flags.pf2e.blinkCharge - 4)/2))d8[force]] damage.",
+                    "CriticalFailure": "The Strike deals no damage, and you take @Damage[(ceil((@actor.flags.pf2e.blinkCharge - 4)/2))d8[force]] damage.",
                     "Failure": "The Strike deals no damage, but the target takes @Damage[(ceil((@actor.flags.pf2e.blinkCharge - 4)/2))d8[force]]."
                 }
             },

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2263,7 +2263,7 @@
             "BlinkCharge": {
                 "Note": {
                     "CriticalFailure": "On a critical failure, the Strike deals no damage and you take @Damage[(ceil((@actor.flags.pf2e.blinkCharge - 4)/2))d8[force]] damage.",
-                    "Failure": "The Strike deals no damage, but the target takes @Damage[(ceil((@actor.flags.pf2e.blinkCharge - 4)/2))d8[force]]."
+                    "Failure": "On a failure, the Strike deals no damage, but the target takes @Damage[(ceil((@actor.flags.pf2e.blinkCharge - 4)/2))d8[force]] damage."
                 }
             },
             "BloodlettingKukri": {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2262,7 +2262,7 @@
             },
             "BlinkCharge": {
                 "Note": {
-                    "CriticalFailure": "The Strike deals no damage, and you take @Damage[(ceil((@actor.flags.pf2e.blinkCharge - 4)/2))d8[force]] damage.",
+                    "CriticalFailure": "On a critical failure, the Strike deals no damage and you take @Damage[(ceil((@actor.flags.pf2e.blinkCharge - 4)/2))d8[force]] damage.",
                     "Failure": "The Strike deals no damage, but the target takes @Damage[(ceil((@actor.flags.pf2e.blinkCharge - 4)/2))d8[force]]."
                 }
             },

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2260,6 +2260,12 @@
             "BlessingOfDefiance": {
                 "Prompt": "Choose one saving throw."
             },
+            "BlinkCharge": {
+                "Note": {
+                    "CriticalFailure": "The Strike deals no damage, and you take force @Damage[(ceil((@actor.flags.pf2e.blinkCharge - 4)/2))d8[force]] damage.",
+                    "Failure": "The Strike deals no damage, but the target takes @Damage[(ceil((@actor.flags.pf2e.blinkCharge - 4)/2))d8[force]]."
+                }
+            },
             "BloodlettingKukri": {
                 "Note": "If the target didn't already have persistent bleed damage when you scored the critical hit, you also gain [[/r 1d8]] temporary Hit Points."
             },


### PR DESCRIPTION
Not completely on board with the Notes as they'd be missing spell context, but maybe it's an acceptable level of inaccuracy.