### PR TITLE
Brush up Rotting Aura

### DIFF
--- a/packs/agents-of-edgewatch-bestiary/ofalth-zombie.json
+++ b/packs/agents-of-edgewatch-bestiary/ofalth-zombie.json
@@ -189,7 +189,7 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p>10 feet. The zombie emits an aura of rot and disease that causes wounds to fester and turn sour. Any living creature that starts its turn within 10 feet of the Ofalth Zombie and is not at full Hit Points takes [[/r 1d6]] damage as its wounds fester.</p>\n<p>Creatures that take a critical hit from the Ofalth Zombie also take this damage immediately.</p>\n<hr />\n<p><em>Note: This ability lists a DC 24 in the source, but the glossary ability lacks a save to make.</em></p>"
+                    "value": "<p>10 feet. The zombie emits an aura of rot and disease that causes wounds to fester and turn sour. Any living creature that starts its turn within 10 feet of the Ofalth Zombie and is not at full Hit Points takes @Damage[2d6[untyped]] damage as its wounds fester.</p>\n<p>Creatures that take a critical hit from the Ofalth Zombie also take this damage immediately.</p>\n<hr />\n<p><em>Note: This ability lists a DC 24 in the source, but the glossary ability lacks a save to make.</em></p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -204,6 +204,14 @@
                         "traits": [
                             "disease"
                         ]
+                    },
+                    {
+                        "critical": true,
+                        "damageType": "untyped",
+                        "diceNumber": 2,
+                        "dieSize": "d6",
+                        "key": "DamageDice",
+                        "selector": "strike-damage"
                     }
                 ],
                 "slug": null,

--- a/packs/bestiary-family-ability-glossary/zombie-rotting-aura.json
+++ b/packs/bestiary-family-ability-glossary/zombie-rotting-aura.json
@@ -11,7 +11,7 @@
         },
         "category": "defensive",
         "description": {
-            "value": "<p>10 feet. The zombie emits an aura of rot and disease that causes wounds to fester and turn sour.</p>\n<p>Any living creature that starts its turn within 10 feet of the zombie and is not at full Hit Points takes [[/r {1d6}]]{1d6 damage} as its wounds fester. This damage increases by 1d6 for every 6 levels the zombie has.</p>"
+            "value": "<p>10 feet. The zombie emits an aura of rot and disease that causes wounds to fester.</p>\n<p>Any living creature that starts its turn within 10 feet of the zombie and is not at full Hit Points takes @Damage[1d6[void]] damage. This damage increases by 1d6 for every 6 levels the zombie has.</p>"
         },
         "publication": {
             "license": "ORC",
@@ -24,7 +24,8 @@
                 "radius": 10,
                 "slug": "rotting-aura",
                 "traits": [
-                    "disease"
+                    "disease",
+                    "void"
                 ]
             }
         ],
@@ -32,7 +33,8 @@
             "rarity": "common",
             "value": [
                 "aura",
-                "disease"
+                "disease",
+                "void"
             ]
         }
     },

--- a/packs/pfs-season-1-bestiary/1-03/zombie-riding-horse.json
+++ b/packs/pfs-season-1-bestiary/1-03/zombie-riding-horse.json
@@ -171,7 +171,7 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p>10 feet. The zombie riding horse emits an aura of rot and disease that causes wounds to fester and turn sour.</p>\n<p>Any living creature that starts its turn within 10 feet of the zombie and is not at full Hit Points takes [[/r 1d6]]{1d6 damage}(@Check[fortitude|dc:14|basic] save) as its wounds fester.</p>"
+                    "value": "<p>10 feet. The zombie riding horse emits an aura of rot and disease that causes wounds to fester and turn sour.</p>\n<p>Any living creature that starts its turn within 10 feet of the zombie and is not at full Hit Points takes @Damage[1d6[untyped]] damage (@Check[fortitude|dc:14|basic] save) as its wounds fester.</p>"
                 },
                 "publication": {
                     "license": "OGL",

--- a/packs/pfs-season-1-bestiary/1-03/zombie-warhorse.json
+++ b/packs/pfs-season-1-bestiary/1-03/zombie-warhorse.json
@@ -174,7 +174,7 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p>10 feet. The zombie riding horse emits an aura of rot and disease that causes wounds to fester and turn sour.</p>\n<p>Any living creature that starts its turn within 10 feet of the zombie and is not at full Hit Points takes [[/r 1d6]]{1d6 damage}(@Check[fortitude|dc:17|basic] save) as its wounds fester.</p>"
+                    "value": "<p>10 feet. The zombie riding horse emits an aura of rot and disease that causes wounds to fester and turn sour.</p>\n<p>Any living creature that starts its turn within 10 feet of the zombie and is not at full Hit Points takes @Damage[1d6[untyped]] damage (@Check[fortitude|dc:17|basic] save) as its wounds fester.</p>"
                 },
                 "publication": {
                     "license": "OGL",

--- a/packs/pfs-season-1-bestiary/1-18/zombie-brute-pfs-1-18.json
+++ b/packs/pfs-season-1-bestiary/1-18/zombie-brute-pfs-1-18.json
@@ -133,7 +133,7 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p>10 feet. The zombie emits an aura of rot and disease that causes wounds to fester and turn sour.</p>\n<p>Any living creature that starts its turn within 10 feet of the zombie and is not at full Hit Points takes [[/r 1d6]]{1d6 damage} as its wounds fester. Creatures that take a critical hit from the zombie also take this damage immediately.</p>"
+                    "value": "<p>10 feet. The zombie emits an aura of rot and disease that causes wounds to fester and turn sour.</p>\n<p>Any living creature that starts its turn within 10 feet of the zombie and is not at full Hit Points takes @Damage[1d6[untyped]] damage as its wounds fester. Creatures that take a critical hit from the zombie also take this damage immediately.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -148,6 +148,14 @@
                         "traits": [
                             "disease"
                         ]
+                    },
+                    {
+                        "critical": true,
+                        "damageType": "untyped",
+                        "diceNumber": 1,
+                        "dieSize": "d6",
+                        "key": "DamageDice",
+                        "selector": "strike-damage"
                     }
                 ],
                 "slug": "zombie-rotting-aura",

--- a/packs/pfs-season-1-bestiary/1-18/zombie-charger.json
+++ b/packs/pfs-season-1-bestiary/1-18/zombie-charger.json
@@ -106,7 +106,7 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p>10 feet. The zombie emits an aura of rot and disease that causes wounds to fester and turn sour.</p>\n<p>Any living creature that starts its turn within 10 feet of the zombie and is not at full Hit Points takes [[/r 1d6]]{1d6 damage} as its wounds fester.</p>"
+                    "value": "<p>10 feet. The zombie emits an aura of rot and disease that causes wounds to fester and turn sour.</p>\n<p>Any living creature that starts its turn within 10 feet of the zombie and is not at full Hit Points takes @Damage[1d6[untyped]] damage as its wounds fester.</p>"
                 },
                 "publication": {
                     "license": "OGL",


### PR DESCRIPTION
Convert inline damage to `@Damage`.
Update bestiary ability to remaster text, damage type, and traits (legacy abilities remain as untyped).
Update Ofalth Zombie's damage to 2d6, as it's level 7.
Automate Ofalth Zombie and Zombie Brute (PFS 1-18) to add damage on critical hit.