### PR TITLE
Refresh Spellshape feats and Class Features for PC1/PC2 spellcaster iconics

### DIFF
--- a/packs/iconics/ezren-level-1.json
+++ b/packs/iconics/ezren-level-1.json
@@ -728,7 +728,36 @@
                     "remaster": true,
                     "title": "Pathfinder Player Core"
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "itemType": "spell",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "predicate": [
+                            "spellshape:reach-spell"
+                        ],
+                        "property": "description",
+                        "value": [
+                            {
+                                "text": "PF2E.SpecificRule.Spellshape.ReachSpell"
+                            }
+                        ]
+                    },
+                    {
+                        "key": "RollOption",
+                        "label": "PF2E.TraitSpellshape",
+                        "mergeable": true,
+                        "option": "spellshape",
+                        "placement": "spellcasting",
+                        "suboptions": [
+                            {
+                                "label": "{item|name}",
+                                "value": "reach-spell"
+                            }
+                        ],
+                        "toggleable": true
+                    }
+                ],
                 "slug": "reach-spell",
                 "traits": {
                     "rarity": "common",
@@ -865,7 +894,88 @@
                     "remaster": true,
                     "title": "Pathfinder Player Core"
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "key": "RollOption",
+                        "label": "PF2E.TraitSpellshape",
+                        "mergeable": true,
+                        "option": "spellshape",
+                        "placement": "spellcasting",
+                        "suboptions": [
+                            {
+                                "label": "{item|name}",
+                                "value": "widen-spell"
+                            }
+                        ],
+                        "toggleable": true
+                    },
+                    {
+                        "itemType": "spell",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "predicate": [
+                            "item:duration:0",
+                            {
+                                "or": [
+                                    {
+                                        "and": [
+                                            "item:area:type:burst",
+                                            {
+                                                "gte": [
+                                                    "item:area:size",
+                                                    10
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "and": [
+                                            {
+                                                "or": [
+                                                    "item:area:type:cone",
+                                                    "item:area:type:line"
+                                                ]
+                                            },
+                                            {
+                                                "lte": [
+                                                    "item:area:size",
+                                                    15
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "spellshape:widen-spell"
+                        ],
+                        "property": "area-size",
+                        "value": 5
+                    },
+                    {
+                        "itemType": "spell",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "predicate": [
+                            "item:duration:0",
+                            {
+                                "or": [
+                                    "item:area:type:line",
+                                    "item:area:type:cone"
+                                ]
+                            },
+                            {
+                                "gt": [
+                                    "item:area:size",
+                                    15
+                                ]
+                            },
+                            "spellshape:widen-spell"
+                        ],
+                        "priority": 119,
+                        "property": "area-size",
+                        "value": 10
+                    }
+                ],
                 "slug": "widen-spell",
                 "traits": {
                     "rarity": "common",
@@ -2946,7 +3056,7 @@
                     "type": "untyped"
                 },
                 "description": {
-                    "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> (manipulate)</p>\n<hr />\n<p>Elixirs of life accelerate a living creature's natural healing processes and immune system. Upon drinking this elixir, you regain @Damage[1d6[healing]] Hit Points and gain +1 item bonus to saving throws against diseases and poisons for 10 minutes.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Elixir of Life]</p>"
+                    "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> (manipulate)</p><hr /><p>Elixirs of life accelerate a living creature's natural healing processes and immune system. Upon drinking this elixir, you regain @Damage[1d6[healing]] Hit Points and gain +1 item bonus to saving throws against diseases and poisons for 10 minutes.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Elixir of Life]</p>"
                 },
                 "equipped": {
                     "carryType": "worn",
@@ -3019,7 +3129,7 @@
                     "type": "untyped"
                 },
                 "description": {
-                    "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> (manipulate)</p>\n<hr />\n<p>Elixirs of life accelerate a living creature's natural healing processes and immune system. Upon drinking this elixir, you regain @Damage[1d6[healing]] Hit Points and gain +1 item bonus to saving throws against diseases and poisons for 10 minutes.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Elixir of Life]</p>"
+                    "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> (manipulate)</p><hr /><p>Elixirs of life accelerate a living creature's natural healing processes and immune system. Upon drinking this elixir, you regain @Damage[1d6[healing]] Hit Points and gain +1 item bonus to saving throws against diseases and poisons for 10 minutes.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Elixir of Life]</p>"
                 },
                 "equipped": {
                     "carryType": "worn",

--- a/packs/iconics/ezren-level-3.json
+++ b/packs/iconics/ezren-level-3.json
@@ -106,7 +106,7 @@
                 },
                 "category": "skill",
                 "description": {
-                    "value": "<p>You can Earn Income using Diplomacy, spending your days hunting for bargains and reselling at a profit. You can also spend time specifically sniffing out a great bargain on an item; this works as if you were using Earn Income with Diplomacy, except instead of gaining money, you purchase the item at a discount equal to the money you would have gained, gaining the item for free if your earned income equals or exceeds its cost. Finally, if you select Bargain Hunter during character creation at 1st level, you start play with an additional 2 gp.</p>"
+                    "value": "<p>You can @UUID[Compendium.pf2e.actionspf2e.Item.Earn Income] using Diplomacy, spending your days hunting for bargains and reselling at a profit. You can also spend time specifically sniffing out a great bargain on an item; this works as if you were using Earn Income with Diplomacy, except instead of gaining money, you purchase the item at a discount equal to the money you would have gained, gaining the item for free if your earned income equals or exceeds its cost. Finally, if you select Bargain Hunter during character creation at 1st level, you start play with an additional 2 gp.</p>"
                 },
                 "level": {
                     "taken": 1,
@@ -121,9 +121,9 @@
                     ]
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Core Rulebook"
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
                 },
                 "rules": [],
                 "slug": "bargain-hunter",
@@ -165,9 +165,9 @@
                     "value": []
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Core Rulebook"
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
                 },
                 "rules": [
                     {
@@ -2228,7 +2228,88 @@
                     "remaster": true,
                     "title": "Pathfinder Player Core"
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "key": "RollOption",
+                        "label": "PF2E.TraitSpellshape",
+                        "mergeable": true,
+                        "option": "spellshape",
+                        "placement": "spellcasting",
+                        "suboptions": [
+                            {
+                                "label": "{item|name}",
+                                "value": "widen-spell"
+                            }
+                        ],
+                        "toggleable": true
+                    },
+                    {
+                        "itemType": "spell",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "predicate": [
+                            "item:duration:0",
+                            {
+                                "or": [
+                                    {
+                                        "and": [
+                                            "item:area:type:burst",
+                                            {
+                                                "gte": [
+                                                    "item:area:size",
+                                                    10
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "and": [
+                                            {
+                                                "or": [
+                                                    "item:area:type:cone",
+                                                    "item:area:type:line"
+                                                ]
+                                            },
+                                            {
+                                                "lte": [
+                                                    "item:area:size",
+                                                    15
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "spellshape:widen-spell"
+                        ],
+                        "property": "area-size",
+                        "value": 5
+                    },
+                    {
+                        "itemType": "spell",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "predicate": [
+                            "item:duration:0",
+                            {
+                                "or": [
+                                    "item:area:type:line",
+                                    "item:area:type:cone"
+                                ]
+                            },
+                            {
+                                "gt": [
+                                    "item:area:size",
+                                    15
+                                ]
+                            },
+                            "spellshape:widen-spell"
+                        ],
+                        "priority": 119,
+                        "property": "area-size",
+                        "value": 10
+                    }
+                ],
                 "slug": "widen-spell",
                 "traits": {
                     "rarity": "common",
@@ -2364,7 +2445,36 @@
                     "remaster": true,
                     "title": "Pathfinder Player Core"
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "itemType": "spell",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "predicate": [
+                            "spellshape:reach-spell"
+                        ],
+                        "property": "description",
+                        "value": [
+                            {
+                                "text": "PF2E.SpecificRule.Spellshape.ReachSpell"
+                            }
+                        ]
+                    },
+                    {
+                        "key": "RollOption",
+                        "label": "PF2E.TraitSpellshape",
+                        "mergeable": true,
+                        "option": "spellshape",
+                        "placement": "spellcasting",
+                        "suboptions": [
+                            {
+                                "label": "{item|name}",
+                                "value": "reach-spell"
+                            }
+                        ],
+                        "toggleable": true
+                    }
+                ],
                 "slug": "reach-spell",
                 "traits": {
                     "rarity": "common",
@@ -2776,7 +2886,42 @@
                     "remaster": true,
                     "title": "Pathfinder Player Core"
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "itemType": "spell",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "predicate": [
+                            "spellshape:nonlethal-spell",
+                            {
+                                "nor": [
+                                    "item:trait:death",
+                                    "item:trait:void"
+                                ]
+                            }
+                        ],
+                        "property": "description",
+                        "value": [
+                            {
+                                "text": "PF2E.SpecificRule.Spellshape.NonLethal"
+                            }
+                        ]
+                    },
+                    {
+                        "key": "RollOption",
+                        "label": "PF2E.TraitSpellshape",
+                        "mergeable": true,
+                        "option": "spellshape",
+                        "placement": "spellcasting",
+                        "suboptions": [
+                            {
+                                "label": "{item|name}",
+                                "value": "nonlethal-spell"
+                            }
+                        ],
+                        "toggleable": true
+                    }
+                ],
                 "slug": "nonlethal-spell",
                 "traits": {
                     "rarity": "common",

--- a/packs/iconics/ezren-level-5.json
+++ b/packs/iconics/ezren-level-5.json
@@ -1845,679 +1845,6 @@
             "type": "class"
         },
         {
-            "_id": "qwp3aS55AFDRyyWw",
-            "_stats": {
-                "compendiumSource": "Compendium.pf2e.classfeatures.Item.S6WW4Yyg4XonXGHD"
-            },
-            "flags": {
-                "pf2e": {
-                    "itemGrants": {
-                        "castASpell": {
-                            "id": "Uj9R4UBlsvejtP05",
-                            "onDelete": "detach"
-                        }
-                    }
-                }
-            },
-            "img": "icons/sundries/books/book-eye-purple.webp",
-            "name": "Wizard Spellcasting",
-            "sort": 0,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "classfeature",
-                "description": {
-                    "value": "<p>Through dedicated study and practice, you can construct spells with academic rigor by shaping arcane magic. You are a spellcaster, and you can cast spells of the arcane tradition using the Cast a Spell activity. As a wizard, when you cast spells, your incantations likely specify exactly what forces you call on and how to shape them, and your gestures precisely shape and direct your magic while circles of arcane runes flare to life.</p>\n<p>At 1st level, you can prepare up to two 1st-rank spells and five cantrips each morning from the spells in your spellbook (see below), as well as one extra curriculum cantrip and one extra curriculum spell of each rank you can cast from your arcane school. Prepared spells remain available to you until you cast them or until you prepare your spells again. The number of spells you can prepare is called your spell slots.</p>\n<p>As you increase in level as a wizard, the number of spells you can prepare each day increases, as does the highest rank of spell you can cast, as shown in the Wizard Spells per Day table.</p>\n<p>Some of your spells require you to attempt a spell attack to see how effective they are, or have your enemies roll against your spell DC (typically by attempting a saving throw). Since your key attribute is Intelligence, your spell attack modifier and spell DC use your Intelligence modifier. Details on calculating these statistics appear on page 403.</p>\n<h2>Heightening Spells</h2>\n<p>When you get spell slots of 2nd rank and higher, you can fill those slots with stronger versions of lower-rank spells. This increases the spell's rank, heightening it to match the spell slot. Many spells have specific improvements when they are heightened to certain ranks.</p>\n<h2>Cantrips</h2>\n<p>Some of your spells are cantrips. A cantrip is a special type of spell that doesn't use spell slots. You can cast a cantrip at will, any number of times per day. A cantrip is always automatically heightened to half your level rounded up—this is usually equal to the highest rank of wizard spell slot you have. For example, as a 1st-level wizard, your cantrips are 1st-rank spells, and as a 5th-level wizard, your cantrips are 3rd-rank spells.</p>\n<h2>Spellbook</h2>\n<p>Every arcane spell has a written version, which you record in your personalized book of spells. You start with a spellbook worth 10 sp or less, which you receive for free and must study each day to prepare your spells. Your spellbook's form and name are up to you. It might be a musty, leather-bound tome or an assortment of thin metal disks connected to a brass ring; its name might be esoteric, like <em>The Tome of Silent Shadows</em> or something more academic, like <em>Advanced Pyromantic Applications of Jalmeri Elemental Theory</em>.</p>\n<p>The spellbook contains your choice of 10 arcane cantrips and five 1st-rank arcane spells. You choose these from the common spells on the arcane spell list or from other arcane spells you gain access to. You also add two 1st-rank spells from the curriculum of your arcane school (except in the case of the school of unified magical theory, as described in that school).</p>\n<p>Each time you gain a level, you add two arcane spells to your spellbook, of any spell rank for which you have spell slots, chosen from common spells of your tradition or others you gain access to and learn via Learn a Spell. When you gain spell slots of a new rank, you also add an additional spell from your school's curriculum (unless it's the school of unified magical theory).</p>"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": "SqyK11ctUw5reoK2",
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core"
-                },
-                "rules": [
-                    {
-                        "flag": "castASpell",
-                        "key": "GrantItem",
-                        "uuid": "Compendium.pf2e.actionspf2e.Item.Cast a Spell"
-                    }
-                ],
-                "slug": "wizard-spellcasting",
-                "traits": {
-                    "rarity": "common",
-                    "selected": {},
-                    "value": [
-                        "wizard"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "KfPC7KCvXK3OhLeU",
-            "_stats": {
-                "compendiumSource": "Compendium.pf2e.classfeatures.Item.M89l9FOnjHe63wD7"
-            },
-            "flags": {
-                "pf2e": {
-                    "itemGrants": {
-                        "experimentalSpellshaping": {
-                            "id": "YpT2esGjBhRer8mc",
-                            "onDelete": "detach"
-                        }
-                    }
-                }
-            },
-            "img": "icons/sundries/scrolls/scroll-writing-tan-grey.webp",
-            "name": "Arcane Thesis",
-            "sort": 100,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "classfeature",
-                "description": {
-                    "value": "<p>During your studies to become a full-fledged wizard, you produced a thesis of unique magical research. You gain a special benefit depending on the topic of your thesis research. The arcane thesis topics presented in this book are below; your specific thesis probably has a much longer and more technical title like <em>\"On the Methods of Spell Interpolation and the Genesis of a New Understanding of the Building Blocks of Magic.\"</em></p>"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": "SqyK11ctUw5reoK2",
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core"
-                },
-                "rules": [
-                    {
-                        "adjustName": false,
-                        "choices": {
-                            "filter": [
-                                "item:tag:wizard-arcane-thesis"
-                            ]
-                        },
-                        "flag": "arcaneThesis",
-                        "key": "ChoiceSet",
-                        "prompt": "PF2E.SpecificRule.Wizard.ArcaneThesis.Prompt",
-                        "selection": "Compendium.pf2e.classfeatures.Item.Experimental Spellshaping"
-                    },
-                    {
-                        "flag": "experimentalSpellshaping",
-                        "key": "GrantItem",
-                        "uuid": "{item|flags.pf2e.rulesSelections.arcaneThesis}"
-                    }
-                ],
-                "slug": "arcane-thesis",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "wizard"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "ET3Jfet5tYasfx6U",
-            "_stats": {
-                "compendiumSource": "Compendium.pf2e.classfeatures.Item.7nbKDBGvwSx9T27G"
-            },
-            "flags": {
-                "pf2e": {
-                    "itemGrants": {
-                        "schoolOfUnifiedMagicalTheory": {
-                            "id": "KaGWdQebzlooHmmO",
-                            "onDelete": "detach"
-                        }
-                    }
-                }
-            },
-            "img": "icons/magic/symbols/question-stone-yellow.webp",
-            "name": "Arcane School",
-            "sort": 200,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "classfeature",
-                "description": {
-                    "value": "<p>Most wizards acquire their knowledge of spells from a formal educational institution, such as the Arcanamirium or the Magaambya. At 1st level, you choose your arcane school, which grants you magical abilities.</p>\n<p>You gain additional spells and spell slots from the curriculum taught at the school you attended. Arcane schools are described in detail on page 198. Some wizards follow the school of unified magical theory, which attempts to forge a new school by studying independently and drawing information from a multitude of texts and tutors. Though a wizard with this approach lacks the focus of formal training, they have greater flexibility.</p>"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": "SqyK11ctUw5reoK2",
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core"
-                },
-                "rules": [
-                    {
-                        "adjustName": false,
-                        "choices": {
-                            "filter": [
-                                "item:tag:wizard-arcane-school"
-                            ]
-                        },
-                        "flag": "arcaneSchool",
-                        "key": "ChoiceSet",
-                        "prompt": "PF2E.SpecificRule.Wizard.ArcaneSchool.Prompt",
-                        "selection": "Compendium.pf2e.classfeatures.Item.School of Unified Magical Theory"
-                    },
-                    {
-                        "flag": "schoolOfUnifiedMagicalTheory",
-                        "key": "GrantItem",
-                        "uuid": "{item|flags.pf2e.rulesSelections.arcaneSchool}"
-                    }
-                ],
-                "slug": "arcane-school",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "wizard"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "Y0XQXMCrHP5uFcqc",
-            "_stats": {
-                "compendiumSource": "Compendium.pf2e.classfeatures.Item.au0lwQ1nAcNQwcGh"
-            },
-            "flags": {
-                "pf2e": {
-                    "itemGrants": {
-                        "drainBondedItem": {
-                            "id": "PFDQahMpVrdzNWIp",
-                            "onDelete": "detach"
-                        }
-                    }
-                }
-            },
-            "img": "icons/weapons/wands/wand-carved-pink.webp",
-            "name": "Arcane Bond",
-            "sort": 300,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "classfeature",
-                "description": {
-                    "value": "<p>You place some of your magical power in a bonded item. Each day when you prepare your spells, you can designate a single item you own as your bonded item. This is typically an item associated with spellcasting, such as a wand, ring, or staff, but you are free to designate a weapon or other item. You gain the @UUID[Compendium.pf2e.actionspf2e.Item.Drain Bonded Item] free action.</p>"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": "SqyK11ctUw5reoK2",
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core"
-                },
-                "rules": [
-                    {
-                        "flag": "drainBondedItem",
-                        "key": "GrantItem",
-                        "predicate": [
-                            {
-                                "not": "feature:improved-familiar-attunement"
-                            }
-                        ],
-                        "uuid": "Compendium.pf2e.actionspf2e.Item.Drain Bonded Item"
-                    }
-                ],
-                "slug": "arcane-bond",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "wizard"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "HLbxlN7PSDLhFTrQ",
-            "_stats": {
-                "compendiumSource": "Compendium.pf2e.classfeatures.Item.TUOeATt52P43r5W0"
-            },
-            "img": "icons/magic/symbols/symbol-lightning-bolt.webp",
-            "name": "Reflex Expertise",
-            "sort": 2000,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "classfeature",
-                "description": {
-                    "value": "<p>You've developed a knack for dodging danger. Your proficiency rank for Reflex saves increases to expert.</p>"
-                },
-                "level": {
-                    "value": 5
-                },
-                "location": "SqyK11ctUw5reoK2",
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Core Rulebook"
-                },
-                "rules": [],
-                "slug": "reflex-expertise",
-                "subfeatures": {
-                    "proficiencies": {
-                        "reflex": {
-                            "rank": 2
-                        }
-                    }
-                },
-                "traits": {
-                    "rarity": "common",
-                    "value": []
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "Uj9R4UBlsvejtP05",
-            "_stats": {
-                "compendiumSource": "Compendium.pf2e.actionspf2e.Item.aBQ8ajvEBByv45yz"
-            },
-            "flags": {
-                "pf2e": {
-                    "grantedBy": {
-                        "id": "qwp3aS55AFDRyyWw",
-                        "onDelete": "cascade"
-                    }
-                }
-            },
-            "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Cast a Spell",
-            "sort": 0,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "interaction",
-                "description": {
-                    "value": "<p>You cast a spell you have prepared or in your repertoire. Casting a Spell is a special activity that takes a variable number of actions depending on the spell, as listed in each spell's stat block. As soon as the spellcasting actions are complete, the spell effect occurs.</p>\n<p>Some spells are cast as a reaction or free action. In those cases, you Cast the Spell as a reaction or free action (as appropriate) instead of as an activity. Such cases will be noted in the spell's stat block-for example, \"[reaction] verbal.\"</p>\n<p><strong>Long Casting</strong> Times Some spells take minutes or hours to cast. The Cast a Spell activity for these spells includes a mix of the listed spell components, but it's not necessary to break down which one you're providing at a given time. You can't use other actions or reactions while casting such a spell, though at the GM's discretion, you might be able to speak a few sentences. As with other activities that take a long time, these spells have the exploration trait, and you can't cast them in an encounter. If combat breaks out while you're casting one, your spell is disrupted.</p>\n<p><strong>Spell Components</strong> Each spell lists the spell components required to cast it after the action icons or text, such as \"[three-actions] material, somatic, verbal.\" The spell components, described in detail below, add traits and requirements to the Cast a Spell activity. If you can't provide the components, you fail to Cast the Spell.</p>\n<ul>\n<li>Material (manipulate)</li>\n<li>Somatic (manipulate)</li>\n<li>Verbal (concentrate)</li>\n<li>Focus (manipulate)</li>\n</ul>\n<p><strong>Disrupted and Lost Spells</strong> Some abilities and spells can disrupt a spell, causing it to have no effect and be lost. When you lose a spell, you've already expended the spell slot, spent the spell's costs and actions, and used the Cast a Spell activity. If a spell is disrupted during a @UUID[Compendium.pf2e.actionspf2e.Item.Sustain]{Sustain a Spell} action, the spell immediately ends.</p>"
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core"
-                },
-                "rules": [],
-                "slug": "cast-a-spell",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "general"
-                    ]
-                }
-            },
-            "type": "action"
-        },
-        {
-            "_id": "VsjqqOGvtsIb8KYc",
-            "_stats": {
-                "compendiumSource": "Compendium.pf2e.feats-srd.Item.FoWO4RnHRwfEIC7Q"
-            },
-            "flags": {
-                "pf2e": {
-                    "grantedBy": {
-                        "id": "YpT2esGjBhRer8mc",
-                        "onDelete": "cascade"
-                    }
-                }
-            },
-            "img": "icons/sundries/books/book-red-exclamation.webp",
-            "name": "Widen Spell",
-            "sort": 0,
-            "system": {
-                "actionType": {
-                    "value": "action"
-                },
-                "actions": {
-                    "value": 1
-                },
-                "category": "class",
-                "description": {
-                    "value": "<p>You manipulate the energy of your spell, causing it to spread out and affect a wider area. If the next action you use is to Cast a Spell that has an area of a burst, cone, or line and does not have a duration, increase the area of that spell. Add 5 feet to the radius of a burst that normally has a radius of at least 10 feet (a burst with a smaller radius is not affected). Add 5 feet to the length of a cone or line that is normally 15 feet long or smaller, and add 10 feet to the length of a larger cone or line.</p>"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": null,
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core"
-                },
-                "rules": [],
-                "slug": "widen-spell",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "druid",
-                        "manipulate",
-                        "oracle",
-                        "sorcerer",
-                        "spellshape",
-                        "witch",
-                        "wizard"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "YpT2esGjBhRer8mc",
-            "_stats": {
-                "compendiumSource": "Compendium.pf2e.classfeatures.Item.89zWKD2CN7nRu2xp"
-            },
-            "flags": {
-                "pf2e": {
-                    "grantedBy": {
-                        "id": "KfPC7KCvXK3OhLeU",
-                        "onDelete": "cascade"
-                    },
-                    "itemGrants": {
-                        "widenSpell": {
-                            "id": "VsjqqOGvtsIb8KYc",
-                            "onDelete": "detach"
-                        }
-                    }
-                }
-            },
-            "img": "icons/sundries/scrolls/scroll-runed-brown-purple.webp",
-            "name": "Experimental Spellshaping",
-            "sort": 0,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "classfeature",
-                "description": {
-                    "value": "<p>Your thesis posits that the magical practice of spellshaping can be realized more efficiently by altering variables and parameters as you cast, imitating the wizards of long ago who had to work out their own spells themselves. This allows you efficient access to various spellshape effects.</p>\n<p>You gain one 1st-level spellshape wizard feat of your choice. Starting at 4th level, during your daily preparations, you can gain a spellshape wizard feat of your choice that has a level requirement of no more than half your level, which you can use until your next daily preparations.</p>"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": null,
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core"
-                },
-                "rules": [
-                    {
-                        "adjustName": false,
-                        "choices": {
-                            "filter": [
-                                "item:level:1",
-                                "item:type:feat",
-                                "item:trait:spellshape",
-                                "item:trait:wizard"
-                            ]
-                        },
-                        "flag": "feat",
-                        "key": "ChoiceSet",
-                        "prompt": "PF2E.SpecificRule.Wizard.Spellshape1.Prompt",
-                        "selection": "Compendium.pf2e.feats-srd.Item.Widen Spell"
-                    },
-                    {
-                        "flag": "widenSpell",
-                        "key": "GrantItem",
-                        "uuid": "{item|flags.pf2e.rulesSelections.feat}"
-                    }
-                ],
-                "slug": "experimental-spellshaping",
-                "traits": {
-                    "otherTags": [
-                        "wizard-arcane-thesis"
-                    ],
-                    "rarity": "common",
-                    "value": [
-                        "wizard"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "kH4BvSUgtO5jnfqZ",
-            "_stats": {
-                "compendiumSource": "Compendium.pf2e.feats-srd.Item.BWomK7EVY0WXxWgh"
-            },
-            "flags": {
-                "pf2e": {
-                    "grantedBy": {
-                        "id": "KaGWdQebzlooHmmO",
-                        "onDelete": "cascade"
-                    }
-                }
-            },
-            "img": "icons/sundries/books/book-red-exclamation.webp",
-            "name": "Reach Spell",
-            "sort": 0,
-            "system": {
-                "actionType": {
-                    "value": "action"
-                },
-                "actions": {
-                    "value": 1
-                },
-                "category": "class",
-                "description": {
-                    "value": "<p>You can extend your spells' range. If the next action you use is to Cast a Spell that has a range, increase that spell's range by 30 feet. As is standard for increasing spell ranges, if the spell normally has a range of touch, you extend its range to 30 feet.</p>"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": null,
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core"
-                },
-                "rules": [],
-                "slug": "reach-spell",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "bard",
-                        "cleric",
-                        "concentrate",
-                        "druid",
-                        "oracle",
-                        "sorcerer",
-                        "spellshape",
-                        "witch",
-                        "wizard"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "KaGWdQebzlooHmmO",
-            "_stats": {
-                "compendiumSource": "Compendium.pf2e.classfeatures.Item.xYYhJtGhFSWNifcO"
-            },
-            "flags": {
-                "pf2e": {
-                    "grantedBy": {
-                        "id": "ET3Jfet5tYasfx6U",
-                        "onDelete": "cascade"
-                    },
-                    "itemGrants": {
-                        "reachSpell": {
-                            "id": "kH4BvSUgtO5jnfqZ",
-                            "onDelete": "detach"
-                        }
-                    }
-                }
-            },
-            "img": "icons/sundries/books/book-rounded-teal.webp",
-            "name": "School of Unified Magical Theory",
-            "sort": 0,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "classfeature",
-                "description": {
-                    "value": "<p>You eschew the idea that magic can be neatly expressed by the teachings of any single school or college, instead directing your self-study to pick up the best of every school of magic. In doing so, you'll find the truths that lie at the intersection of each school, coming closer to the ideal nature of arcane magic. One day, you'll uncover that single elegant theory detailing all magic (perhaps a theory bearing your name?), but until then, your studies continue.</p>\n<p><strong>No Curriculum</strong> You don't have a set curriculum, and so you don't have curriculum spells and can't benefit from abilities that specifically affect them. Instead, you gain an additional 1st-level wizard class feat, and you add one 1st-rank spell of your choice to your spellbook to represent your diverse studies.</p>\n<p>Your studies into the very nature of magic itself have let you use it more efficiently—instead of using @UUID[Compendium.pf2e.actionspf2e.Item.Drain Bonded Item] only once per day, you can use it once per day for each rank of spell you can cast, recalling a spell of that rank each time.</p>\n<p><strong>School Spells</strong> initial: @UUID[Compendium.pf2e.spells-srd.Item.Hand of the Apprentice]; advanced: @UUID[Compendium.pf2e.spells-srd.Item.Interdisciplinary Incantation]</p>"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": null,
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core"
-                },
-                "rules": [
-                    {
-                        "adjustName": false,
-                        "choices": {
-                            "filter": [
-                                "item:type:feat",
-                                "item:trait:wizard",
-                                "item:level:1"
-                            ]
-                        },
-                        "flag": "feat",
-                        "key": "ChoiceSet",
-                        "prompt": "PF2E.SpecificRule.Wizard.UnifiedMagicalTheory.Prompt",
-                        "selection": "Compendium.pf2e.feats-srd.Item.Reach Spell"
-                    },
-                    {
-                        "flag": "reachSpell",
-                        "key": "GrantItem",
-                        "uuid": "{item|flags.pf2e.rulesSelections.feat}"
-                    }
-                ],
-                "slug": "school-of-unified-magical-theory",
-                "traits": {
-                    "otherTags": [
-                        "wizard-arcane-school"
-                    ],
-                    "rarity": "common",
-                    "value": [
-                        "wizard"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "PFDQahMpVrdzNWIp",
-            "_stats": {
-                "compendiumSource": "Compendium.pf2e.actionspf2e.Item.v82XtjAVN4ffgVVR"
-            },
-            "flags": {
-                "pf2e": {
-                    "grantedBy": {
-                        "id": "Y0XQXMCrHP5uFcqc",
-                        "onDelete": "cascade"
-                    }
-                }
-            },
-            "img": "systems/pf2e/icons/actions/FreeAction.webp",
-            "name": "Drain Bonded Item",
-            "sort": 0,
-            "system": {
-                "actionType": {
-                    "value": "free"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "interaction",
-                "description": {
-                    "value": "<p><strong>Frequency</strong> once per day</p>\n<p><strong>Requirements</strong> Your bonded item is on your person.</p>\n<hr />\n<p>You expend the magical power stored in your bonded item. During the current turn, you can cast one spell you prepared today and already cast, without spending a spell slot. You must still Cast the Spell and meet the spell's other requirements.</p>"
-                },
-                "frequency": {
-                    "max": 1,
-                    "per": "day"
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core"
-                },
-                "rules": [],
-                "slug": "drain-bonded-item",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "arcane",
-                        "wizard"
-                    ]
-                }
-            },
-            "type": "action"
-        },
-        {
             "_id": "EY4KzK59p0QpUeup",
             "_stats": {
                 "compendiumSource": "Compendium.pf2e.feats-srd.Item.lwLcUHQMOqfaNND4"
@@ -2600,7 +1927,42 @@
                     "remaster": true,
                     "title": "Pathfinder Player Core"
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "itemType": "spell",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "predicate": [
+                            "spellshape:nonlethal-spell",
+                            {
+                                "nor": [
+                                    "item:trait:death",
+                                    "item:trait:void"
+                                ]
+                            }
+                        ],
+                        "property": "description",
+                        "value": [
+                            {
+                                "text": "PF2E.SpecificRule.Spellshape.NonLethal"
+                            }
+                        ]
+                    },
+                    {
+                        "key": "RollOption",
+                        "label": "PF2E.TraitSpellshape",
+                        "mergeable": true,
+                        "option": "spellshape",
+                        "placement": "spellcasting",
+                        "suboptions": [
+                            {
+                                "label": "{item|name}",
+                                "value": "nonlethal-spell"
+                            }
+                        ],
+                        "toggleable": true
+                    }
+                ],
                 "slug": "nonlethal-spell",
                 "traits": {
                     "rarity": "common",
@@ -3283,51 +2645,6 @@
                     "value": [
                         "general",
                         "skill"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "Ctd5K61E9ovsXkWs",
-            "_stats": {
-                "compendiumSource": "Compendium.pf2e.feats-srd.Item.sIeuPW0j39fTZm08"
-            },
-            "img": "icons/sundries/books/book-red-exclamation.webp",
-            "name": "Conceal Spell",
-            "sort": 0,
-            "system": {
-                "actionType": {
-                    "value": "action"
-                },
-                "actions": {
-                    "value": 1
-                },
-                "category": "class",
-                "description": {
-                    "value": "<p><strong>Witch</strong> Through sheer mental effort, you can simplify the incantations<br />and gestures needed to spellcast, leaving them barely<br />noticeable.</p>\n<p><strong>Wizard</strong> By shaping the magical energies and parameters of your spells all in your head through sheer concentration, you can simplify the incantations and gestures needed to spellcast, leaving them barely noticeable.</p>\n<hr />\n<p>If the next action you use is to Cast a Spell, the spell gains the subtle trait, hiding the shining runes, sparks of magic, and other manifestations that would usually give away your spellcasting. The trait hides only the spell's spellcasting actions and manifestations, not its effects, so an observer might still see a ray streak out from you or see you vanish into thin air.</p>"
-                },
-                "level": {
-                    "value": 2
-                },
-                "location": null,
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core"
-                },
-                "rules": [],
-                "slug": "conceal-spell",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "concentrate",
-                        "spellshape",
-                        "witch",
-                        "wizard"
                     ]
                 }
             },
@@ -5951,6 +5268,883 @@
                 }
             },
             "type": "spell"
+        },
+        {
+            "_id": "yxcbOHdaTA7b3KwF",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.classfeatures.Item.S6WW4Yyg4XonXGHD"
+            },
+            "flags": {
+                "pf2e": {
+                    "itemGrants": {
+                        "castASpell": {
+                            "id": "V9TX2qwNBFbFXsLO",
+                            "onDelete": "detach"
+                        }
+                    }
+                }
+            },
+            "img": "icons/sundries/books/book-eye-purple.webp",
+            "name": "Wizard Spellcasting",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "classfeature",
+                "description": {
+                    "value": "<p>Through dedicated study and practice, you can construct spells with academic rigor by shaping arcane magic. You are a spellcaster, and you can cast spells of the arcane tradition using the Cast a Spell activity. As a wizard, when you cast spells, your incantations likely specify exactly what forces you call on and how to shape them, and your gestures precisely shape and direct your magic while circles of arcane runes flare to life.</p>\n<p>At 1st level, you can prepare up to two 1st-rank spells and five cantrips each morning from the spells in your spellbook (see below), as well as one extra curriculum cantrip and one extra curriculum spell of each rank you can cast from your arcane school. Prepared spells remain available to you until you cast them or until you prepare your spells again. The number of spells you can prepare is called your spell slots.</p>\n<p>As you increase in level as a wizard, the number of spells you can prepare each day increases, as does the highest rank of spell you can cast, as shown in the Wizard Spells per Day table.</p>\n<p>Some of your spells require you to attempt a spell attack to see how effective they are, or have your enemies roll against your spell DC (typically by attempting a saving throw). Since your key attribute is Intelligence, your spell attack modifier and spell DC use your Intelligence modifier. Details on calculating these statistics appear on page 403.</p>\n<h2>Heightening Spells</h2>\n<p>When you get spell slots of 2nd rank and higher, you can fill those slots with stronger versions of lower-rank spells. This increases the spell's rank, heightening it to match the spell slot. Many spells have specific improvements when they are heightened to certain ranks.</p>\n<h2>Cantrips</h2>\n<p>Some of your spells are cantrips. A cantrip is a special type of spell that doesn't use spell slots. You can cast a cantrip at will, any number of times per day. A cantrip is always automatically heightened to half your level rounded up—this is usually equal to the highest rank of wizard spell slot you have. For example, as a 1st-level wizard, your cantrips are 1st-rank spells, and as a 5th-level wizard, your cantrips are 3rd-rank spells.</p>\n<h2>Spellbook</h2>\n<p>Every arcane spell has a written version, which you record in your personalized book of spells. You start with a spellbook worth 10 sp or less, which you receive for free and must study each day to prepare your spells. Your spellbook's form and name are up to you. It might be a musty, leather-bound tome or an assortment of thin metal disks connected to a brass ring; its name might be esoteric, like <em>The Tome of Silent Shadows</em> or something more academic, like <em>Advanced Pyromantic Applications of Jalmeri Elemental Theory</em>.</p>\n<p>The spellbook contains your choice of 10 arcane cantrips and five 1st-rank arcane spells. You choose these from the common spells on the arcane spell list or from other arcane spells you gain access to. You also add two 1st-rank spells from the curriculum of your arcane school (except in the case of the school of unified magical theory, as described in that school).</p>\n<p>Each time you gain a level, you add two arcane spells to your spellbook, of any spell rank for which you have spell slots, chosen from common spells of your tradition or others you gain access to and learn via Learn a Spell. When you gain spell slots of a new rank, you also add an additional spell from your school's curriculum (unless it's the school of unified magical theory).</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": "SqyK11ctUw5reoK2",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
+                },
+                "rules": [
+                    {
+                        "flag": "castASpell",
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.actionspf2e.Item.Cast a Spell"
+                    }
+                ],
+                "slug": "wizard-spellcasting",
+                "traits": {
+                    "rarity": "common",
+                    "selected": {},
+                    "value": [
+                        "wizard"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "BLme6pQ3mVQ4vclf",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.classfeatures.Item.M89l9FOnjHe63wD7"
+            },
+            "flags": {
+                "pf2e": {
+                    "itemGrants": {
+                        "experimentalSpellshaping": {
+                            "id": "BN8eodHFJo1OgIkf",
+                            "onDelete": "detach"
+                        }
+                    }
+                }
+            },
+            "img": "icons/sundries/scrolls/scroll-writing-tan-grey.webp",
+            "name": "Arcane Thesis",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "classfeature",
+                "description": {
+                    "value": "<p>During your studies to become a full-fledged wizard, you produced a thesis of unique magical research. You gain a special benefit depending on the topic of your thesis research. The arcane thesis topics presented in this book are below; your specific thesis probably has a much longer and more technical title like <em>\"On the Methods of Spell Interpolation and the Genesis of a New Understanding of the Building Blocks of Magic.\"</em></p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": "SqyK11ctUw5reoK2",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
+                },
+                "rules": [
+                    {
+                        "adjustName": false,
+                        "choices": {
+                            "filter": [
+                                "item:tag:wizard-arcane-thesis"
+                            ]
+                        },
+                        "flag": "arcaneThesis",
+                        "key": "ChoiceSet",
+                        "prompt": "PF2E.SpecificRule.Wizard.ArcaneThesis.Prompt",
+                        "selection": "Compendium.pf2e.classfeatures.Item.Experimental Spellshaping"
+                    },
+                    {
+                        "flag": "experimentalSpellshaping",
+                        "key": "GrantItem",
+                        "uuid": "{item|flags.pf2e.rulesSelections.arcaneThesis}"
+                    }
+                ],
+                "slug": "arcane-thesis",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "wizard"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "k662K6LcEkLmB7Gs",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.classfeatures.Item.7nbKDBGvwSx9T27G"
+            },
+            "flags": {
+                "pf2e": {
+                    "itemGrants": {
+                        "schoolOfUnifiedMagicalTheory": {
+                            "id": "Znyk1dllcghnmk9A",
+                            "onDelete": "detach"
+                        }
+                    }
+                }
+            },
+            "img": "icons/magic/symbols/question-stone-yellow.webp",
+            "name": "Arcane School",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "classfeature",
+                "description": {
+                    "value": "<p>Most wizards acquire their knowledge of spells from a formal educational institution, such as the Arcanamirium or the Magaambya. At 1st level, you choose your arcane school, which grants you magical abilities.</p>\n<p>You gain additional spells and spell slots from the curriculum taught at the school you attended. Arcane schools are described in detail on page 198. Some wizards follow the school of unified magical theory, which attempts to forge a new school by studying independently and drawing information from a multitude of texts and tutors. Though a wizard with this approach lacks the focus of formal training, they have greater flexibility.</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": "SqyK11ctUw5reoK2",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
+                },
+                "rules": [
+                    {
+                        "adjustName": false,
+                        "choices": {
+                            "filter": [
+                                "item:tag:wizard-arcane-school"
+                            ]
+                        },
+                        "flag": "arcaneSchool",
+                        "key": "ChoiceSet",
+                        "prompt": "PF2E.SpecificRule.Wizard.ArcaneSchool.Prompt",
+                        "selection": "Compendium.pf2e.classfeatures.Item.School of Unified Magical Theory"
+                    },
+                    {
+                        "flag": "schoolOfUnifiedMagicalTheory",
+                        "key": "GrantItem",
+                        "uuid": "{item|flags.pf2e.rulesSelections.arcaneSchool}"
+                    }
+                ],
+                "slug": "arcane-school",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "wizard"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "1uxpPX5O6Q2E2LsA",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.classfeatures.Item.au0lwQ1nAcNQwcGh"
+            },
+            "flags": {
+                "pf2e": {
+                    "itemGrants": {
+                        "drainBondedItem": {
+                            "id": "MkTMuAoVy3vNDvaY",
+                            "onDelete": "detach"
+                        }
+                    }
+                }
+            },
+            "img": "icons/weapons/wands/wand-carved-pink.webp",
+            "name": "Arcane Bond",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "classfeature",
+                "description": {
+                    "value": "<p>You place some of your magical power in a bonded item. Each day when you prepare your spells, you can designate a single item you own as your bonded item. This is typically an item associated with spellcasting, such as a wand, ring, or staff, but you are free to designate a weapon or other item. You gain the @UUID[Compendium.pf2e.actionspf2e.Item.Drain Bonded Item] free action.</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": "SqyK11ctUw5reoK2",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
+                },
+                "rules": [
+                    {
+                        "flag": "drainBondedItem",
+                        "key": "GrantItem",
+                        "predicate": [
+                            {
+                                "not": "feature:improved-familiar-attunement"
+                            }
+                        ],
+                        "uuid": "Compendium.pf2e.actionspf2e.Item.Drain Bonded Item"
+                    }
+                ],
+                "slug": "arcane-bond",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "wizard"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "V9TX2qwNBFbFXsLO",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.actionspf2e.Item.aBQ8ajvEBByv45yz"
+            },
+            "flags": {
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "yxcbOHdaTA7b3KwF",
+                        "onDelete": "cascade"
+                    }
+                }
+            },
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Cast a Spell",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "interaction",
+                "description": {
+                    "value": "<p>You cast a spell you have prepared or in your repertoire. Casting a Spell is a special activity that takes a variable number of actions depending on the spell, as listed in each spell's stat block. As soon as the spellcasting actions are complete, the spell effect occurs.</p>\n<p>Some spells are cast as a reaction or free action. In those cases, you Cast the Spell as a reaction or free action (as appropriate) instead of as an activity. Such cases will be noted in the spell's stat block-for example, \"[reaction] verbal.\"</p>\n<p><strong>Long Casting</strong> Times Some spells take minutes or hours to cast. The Cast a Spell activity for these spells includes a mix of the listed spell components, but it's not necessary to break down which one you're providing at a given time. You can't use other actions or reactions while casting such a spell, though at the GM's discretion, you might be able to speak a few sentences. As with other activities that take a long time, these spells have the exploration trait, and you can't cast them in an encounter. If combat breaks out while you're casting one, your spell is disrupted.</p>\n<p><strong>Spell Components</strong> Each spell lists the spell components required to cast it after the action icons or text, such as \"[three-actions] material, somatic, verbal.\" The spell components, described in detail below, add traits and requirements to the Cast a Spell activity. If you can't provide the components, you fail to Cast the Spell.</p>\n<ul>\n<li>Material (manipulate)</li>\n<li>Somatic (manipulate)</li>\n<li>Verbal (concentrate)</li>\n<li>Focus (manipulate)</li>\n</ul>\n<p><strong>Disrupted and Lost Spells</strong> Some abilities and spells can disrupt a spell, causing it to have no effect and be lost. When you lose a spell, you've already expended the spell slot, spent the spell's costs and actions, and used the Cast a Spell activity. If a spell is disrupted during a @UUID[Compendium.pf2e.actionspf2e.Item.Sustain]{Sustain a Spell} action, the spell immediately ends.</p>"
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
+                },
+                "rules": [],
+                "slug": "cast-a-spell",
+                "traits": {
+                    "value": [
+                        "general"
+                    ]
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "BN8eodHFJo1OgIkf",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.classfeatures.Item.89zWKD2CN7nRu2xp"
+            },
+            "flags": {
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "BLme6pQ3mVQ4vclf",
+                        "onDelete": "cascade"
+                    },
+                    "itemGrants": {
+                        "reachSpell": {
+                            "id": "zXcpx1vPKJoKjrZg",
+                            "onDelete": "detach"
+                        }
+                    }
+                }
+            },
+            "img": "icons/sundries/scrolls/scroll-runed-brown-purple.webp",
+            "name": "Experimental Spellshaping",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "classfeature",
+                "description": {
+                    "value": "<p>Your thesis posits that the magical practice of spellshaping can be realized more efficiently by altering variables and parameters as you cast, imitating the wizards of long ago who had to work out their own spells themselves. This allows you efficient access to various spellshape effects.</p>\n<p>You gain one 1st-level spellshape wizard feat of your choice. Starting at 4th level, during your daily preparations, you can gain a spellshape wizard feat of your choice that has a level requirement of no more than half your level, which you can use until your next daily preparations.</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
+                },
+                "rules": [
+                    {
+                        "adjustName": false,
+                        "choices": {
+                            "filter": [
+                                "item:level:1",
+                                "item:type:feat",
+                                "item:trait:spellshape",
+                                "item:trait:wizard"
+                            ]
+                        },
+                        "flag": "feat",
+                        "key": "ChoiceSet",
+                        "prompt": "PF2E.SpecificRule.Wizard.Spellshape1.Prompt",
+                        "selection": "Compendium.pf2e.feats-srd.Item.Reach Spell"
+                    },
+                    {
+                        "flag": "reachSpell",
+                        "key": "GrantItem",
+                        "uuid": "{item|flags.pf2e.rulesSelections.feat}"
+                    }
+                ],
+                "slug": "experimental-spellshaping",
+                "traits": {
+                    "otherTags": [
+                        "wizard-arcane-thesis"
+                    ],
+                    "rarity": "common",
+                    "value": [
+                        "wizard"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "zXcpx1vPKJoKjrZg",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.feats-srd.Item.BWomK7EVY0WXxWgh"
+            },
+            "flags": {
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "BN8eodHFJo1OgIkf",
+                        "onDelete": "cascade"
+                    }
+                }
+            },
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Reach Spell",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "category": "class",
+                "description": {
+                    "value": "<p>You can extend your spells' range. If the next action you use is to Cast a Spell that has a range, increase that spell's range by 30 feet. As is standard for increasing spell ranges, if the spell normally has a range of touch, you extend its range to 30 feet.</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
+                },
+                "rules": [
+                    {
+                        "itemType": "spell",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "predicate": [
+                            "spellshape:reach-spell"
+                        ],
+                        "property": "description",
+                        "value": [
+                            {
+                                "text": "PF2E.SpecificRule.Spellshape.ReachSpell"
+                            }
+                        ]
+                    },
+                    {
+                        "key": "RollOption",
+                        "label": "PF2E.TraitSpellshape",
+                        "mergeable": true,
+                        "option": "spellshape",
+                        "placement": "spellcasting",
+                        "suboptions": [
+                            {
+                                "label": "{item|name}",
+                                "value": "reach-spell"
+                            }
+                        ],
+                        "toggleable": true
+                    }
+                ],
+                "slug": "reach-spell",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "bard",
+                        "cleric",
+                        "concentrate",
+                        "druid",
+                        "oracle",
+                        "sorcerer",
+                        "spellshape",
+                        "witch",
+                        "wizard"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "Znyk1dllcghnmk9A",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.classfeatures.Item.xYYhJtGhFSWNifcO"
+            },
+            "flags": {
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "k662K6LcEkLmB7Gs",
+                        "onDelete": "cascade"
+                    },
+                    "itemGrants": {
+                        "widenSpell": {
+                            "id": "FdS1cm3bU2k70erf",
+                            "onDelete": "detach"
+                        }
+                    }
+                }
+            },
+            "img": "icons/sundries/books/book-rounded-teal.webp",
+            "name": "School of Unified Magical Theory",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "classfeature",
+                "description": {
+                    "value": "<p>You eschew the idea that magic can be neatly expressed by the teachings of any single school or college, instead directing your self-study to pick up the best of every school of magic. In doing so, you'll find the truths that lie at the intersection of each school, coming closer to the ideal nature of arcane magic. One day, you'll uncover that single elegant theory detailing all magic (perhaps a theory bearing your name?), but until then, your studies continue.</p>\n<p><strong>No Curriculum</strong> You don't have a set curriculum, and so you don't have curriculum spells and can't benefit from abilities that specifically affect them. Instead, you gain an additional 1st-level wizard class feat, and you add one 1st-rank spell of your choice to your spellbook to represent your diverse studies.</p>\n<p>Your studies into the very nature of magic itself have let you use it more efficiently—instead of using @UUID[Compendium.pf2e.actionspf2e.Item.Drain Bonded Item] only once per day, you can use it once per day for each rank of spell you can cast, recalling a spell of that rank each time.</p>\n<p><strong>School Spells</strong> initial: @UUID[Compendium.pf2e.spells-srd.Item.Hand of the Apprentice]; advanced: @UUID[Compendium.pf2e.spells-srd.Item.Interdisciplinary Incantation]</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
+                },
+                "rules": [
+                    {
+                        "adjustName": false,
+                        "choices": {
+                            "filter": [
+                                "item:type:feat",
+                                "item:trait:wizard",
+                                "item:level:1"
+                            ]
+                        },
+                        "flag": "feat",
+                        "key": "ChoiceSet",
+                        "prompt": "PF2E.SpecificRule.Wizard.UnifiedMagicalTheory.Prompt",
+                        "selection": "Compendium.pf2e.feats-srd.Item.Widen Spell"
+                    },
+                    {
+                        "flag": "widenSpell",
+                        "key": "GrantItem",
+                        "uuid": "{item|flags.pf2e.rulesSelections.feat}"
+                    }
+                ],
+                "slug": "school-of-unified-magical-theory",
+                "traits": {
+                    "otherTags": [
+                        "wizard-arcane-school"
+                    ],
+                    "rarity": "common",
+                    "value": [
+                        "wizard"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "FdS1cm3bU2k70erf",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.feats-srd.Item.FoWO4RnHRwfEIC7Q"
+            },
+            "flags": {
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "Znyk1dllcghnmk9A",
+                        "onDelete": "cascade"
+                    }
+                }
+            },
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Widen Spell",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "category": "class",
+                "description": {
+                    "value": "<p>You manipulate the energy of your spell, causing it to spread out and affect a wider area. If the next action you use is to Cast a Spell that has an area of a burst, cone, or line and does not have a duration, increase the area of that spell. Add 5 feet to the radius of a burst that normally has a radius of at least 10 feet (a burst with a smaller radius is not affected). Add 5 feet to the length of a cone or line that is normally 15 feet long or smaller, and add 10 feet to the length of a larger cone or line.</p>"
+                },
+                "level": {
+                    "value": 1
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
+                },
+                "rules": [
+                    {
+                        "key": "RollOption",
+                        "label": "PF2E.TraitSpellshape",
+                        "mergeable": true,
+                        "option": "spellshape",
+                        "placement": "spellcasting",
+                        "suboptions": [
+                            {
+                                "label": "{item|name}",
+                                "value": "widen-spell"
+                            }
+                        ],
+                        "toggleable": true
+                    },
+                    {
+                        "itemType": "spell",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "predicate": [
+                            "item:duration:0",
+                            {
+                                "or": [
+                                    {
+                                        "and": [
+                                            "item:area:type:burst",
+                                            {
+                                                "gte": [
+                                                    "item:area:size",
+                                                    10
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "and": [
+                                            {
+                                                "or": [
+                                                    "item:area:type:cone",
+                                                    "item:area:type:line"
+                                                ]
+                                            },
+                                            {
+                                                "lte": [
+                                                    "item:area:size",
+                                                    15
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "spellshape:widen-spell"
+                        ],
+                        "property": "area-size",
+                        "value": 5
+                    },
+                    {
+                        "itemType": "spell",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "predicate": [
+                            "item:duration:0",
+                            {
+                                "or": [
+                                    "item:area:type:line",
+                                    "item:area:type:cone"
+                                ]
+                            },
+                            {
+                                "gt": [
+                                    "item:area:size",
+                                    15
+                                ]
+                            },
+                            "spellshape:widen-spell"
+                        ],
+                        "priority": 119,
+                        "property": "area-size",
+                        "value": 10
+                    }
+                ],
+                "slug": "widen-spell",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "druid",
+                        "manipulate",
+                        "oracle",
+                        "sorcerer",
+                        "spellshape",
+                        "witch",
+                        "wizard"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "MkTMuAoVy3vNDvaY",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.actionspf2e.Item.v82XtjAVN4ffgVVR"
+            },
+            "flags": {
+                "pf2e": {
+                    "grantedBy": {
+                        "id": "1uxpPX5O6Q2E2LsA",
+                        "onDelete": "cascade"
+                    }
+                }
+            },
+            "img": "systems/pf2e/icons/actions/FreeAction.webp",
+            "name": "Drain Bonded Item",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "free"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "interaction",
+                "description": {
+                    "value": "<p><strong>Frequency</strong> once per day</p>\n<p><strong>Requirements</strong> Your bonded item is on your person.</p>\n<hr />\n<p>You expend the magical power stored in your bonded item. During the current turn, you can cast one spell you prepared today and already cast, without spending a spell slot. You must still Cast the Spell and meet the spell's other requirements.</p>"
+                },
+                "frequency": {
+                    "max": 1,
+                    "per": "day",
+                    "value": 1
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
+                },
+                "rules": [],
+                "slug": "drain-bonded-item",
+                "traits": {
+                    "value": [
+                        "arcane",
+                        "wizard"
+                    ]
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "pDGIwFhxySb31ju2",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.classfeatures.Item.TUOeATt52P43r5W0"
+            },
+            "img": "icons/magic/symbols/symbol-lightning-bolt.webp",
+            "name": "Reflex Expertise",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "classfeature",
+                "description": {
+                    "value": "<p>You've developed a knack for dodging danger. Your proficiency rank for Reflex saves increases to expert.</p>"
+                },
+                "level": {
+                    "value": 5
+                },
+                "location": "SqyK11ctUw5reoK2",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
+                },
+                "rules": [],
+                "slug": "reflex-expertise",
+                "subfeatures": {
+                    "proficiencies": {
+                        "reflex": {
+                            "rank": 2
+                        }
+                    }
+                },
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "barbarian",
+                        "bard",
+                        "champion",
+                        "cleric",
+                        "druid",
+                        "sorcerer",
+                        "witch",
+                        "wizard"
+                    ]
+                }
+            },
+            "type": "feat"
+        },
+        {
+            "_id": "iaCzN7LEGlPOZ0UK",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.feats-srd.Item.sIeuPW0j39fTZm08"
+            },
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Conceal Spell",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "action"
+                },
+                "actions": {
+                    "value": 1
+                },
+                "category": "class",
+                "description": {
+                    "value": "<p><strong>Animist</strong> You speak with the unheard voice of the spirits.</p>\n<p><strong>Witch</strong> Through sheer mental effort, you can simplify the incantations<br />and gestures needed to spellcast, leaving them barely<br />noticeable.</p>\n<p><strong>Wizard</strong> By shaping the magical energies and parameters of your spells all in your head through sheer concentration, you can simplify the incantations and gestures needed to spellcast, leaving them barely noticeable.</p><hr /><p>If the next action you use is to Cast a Spell, the spell gains the subtle trait, hiding the shining runes, sparks of magic, and other manifestations that would usually give away your spellcasting. The trait hides only the spell's spellcasting actions and manifestations, not its effects, so an observer might still see a ray streak out from you or see you vanish into thin air.</p>"
+                },
+                "level": {
+                    "taken": 5,
+                    "value": 2
+                },
+                "location": null,
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
+                },
+                "rules": [
+                    {
+                        "key": "RollOption",
+                        "label": "PF2E.TraitSpellshape",
+                        "mergeable": true,
+                        "option": "spellshape",
+                        "placement": "spellcasting",
+                        "suboptions": [
+                            {
+                                "label": "{item|name}",
+                                "value": "conceal-spell"
+                            }
+                        ],
+                        "toggleable": true
+                    },
+                    {
+                        "itemType": "spell",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "predicate": [
+                            "spellshape:conceal-spell"
+                        ],
+                        "property": "description",
+                        "value": [
+                            {
+                                "text": "PF2E.SpecificRule.Spellshape.ConcealSpell"
+                            }
+                        ]
+                    },
+                    {
+                        "itemType": "spell",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "predicate": [
+                            "spellshape:conceal-spell"
+                        ],
+                        "property": "traits",
+                        "value": "subtle"
+                    }
+                ],
+                "slug": "conceal-spell",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "animist",
+                        "concentrate",
+                        "spellshape",
+                        "witch",
+                        "wizard"
+                    ]
+                }
+            },
+            "type": "feat"
         }
     ],
     "name": "Ezren (Level 5)",

--- a/packs/iconics/lem-level-1.json
+++ b/packs/iconics/lem-level-1.json
@@ -723,7 +723,7 @@
                 "compendiumSource": "Compendium.pf2e.classfeatures.Item.6FsusoMYxxjyIkVh"
             },
             "img": "icons/sundries/books/book-symbol-spiral-silver-blue.webp",
-            "name": "Spell Repertoire (Bard)",
+            "name": "Spell Repertoire",
             "sort": 300,
             "system": {
                 "actionType": {
@@ -734,7 +734,7 @@
                 },
                 "category": "classfeature",
                 "description": {
-                    "value": "<p>The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank occult spells of your choice and five occult cantrips of your choice. You choose these from the common spells from the occult list or from other occult spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Bard Spells per Day table), you add a spell to your spell repertoire of the same rank. At 2nd level, you select another 1st-rank spell; at 3rd level, you select two 2nd-rank spells, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot, and vice versa.</p>\n<h2>Swapping Spells In Your Repertoire</h2>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p>"
+                    "value": "<p><strong>Bard</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank occult spells of your choice and five occult cantrips of your choice. You choose these from the common spells from the occult list or from other occult spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Bard Spells per Day table), you add a spell to your spell repertoire of the same rank. At 2nd level, you select another 1st-rank spell; at 3rd level, you select two 2nd-rank spells, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot, and vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Oracle</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank divine spells of your choice and five divine cantrips of your choice. You choose these from the common spells on the divine list or from other divine spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Oracle Spells per Day table), you add a spell to your spell repertoire of the same rank. At 2nd level, you select another 1st-rank spell; at 3rd level, you select two 2nd-rank spells, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell.</p>\n<p>Your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot, and vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Psychic</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn one 1st-rank occult spell of your choice and three occult cantrips of your choice. You choose these from the common spells from the occult list or from other occult spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank. Your choice of conscious mind also grants you additional spells in your repertoire, starting with an additional 1st-rabk spell and two cantrips listed in your conscious mind, which you cast as psi cantrips.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see Table 2), you add a spell to your spell repertoire of the same level. At 2nd level, you select another 1st-rank spell; at 3rd level, you select one 2nd-level spell, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell. Your conscious mind also adds additional spells to your repertoire as you gain spells of higher levels.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, such as the spells you gain from your conscious mind, it wouldn't give you another spell slot, and vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Sorcerer</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank spells of your choice and four cantrips of your choice, as well as an additional spell and cantrip from your bloodline. You choose these from the common spells from the tradition corresponding to your bloodline, or from other spells from that tradition to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Sorcerer Spells per Day table above), you add a spell to your spell repertoire of the same rank. When you gain a new rank of spells, your first new spell is always the sorcerous gift spell for that rank that's listed in your bloodline, but you can choose the other spells. At 2nd level, you select another 1st-rank spell; at 3rd level, you gain a new spell from your bloodline and two other 2nd-rank spells, and so on. When you add spells, you might select a higher-rank version of a spell you already know so that you can cast a heightened version of that spell.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot or vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your spell repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip, but you can't swap out bloodline spells. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Summoner</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank spells of your choice and five cantrips of your choice. You choose these from the common spells from the tradition corresponding to your eidolon, or from other spells from that tradition to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank. Your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it doesn't give you another spell slot, and vice versa.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see Table 2–4: Summoner Spells per Day), you add a spell of the same rank to your spell repertoire. At 2nd level, you select another 1st-rank spell. At 3rd level, you add the first 2nd-rank spell to your repertoire. At 4th level you gain your second and your spell repertoire reaches its maximum size of five spells.</p>\n<p>At 5th level, in addition to adding two 3rd-rank spells to your repertoire, you lose your lowest rank of spell slots. Any time you lose a rank of spell slots, you lose two spells in your repertoire as well. These can come from spells you already know or out of the number of new spells you're learning. On levels in which you don't change your spell slots, you can swap out multiple spells, as described below.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. If it's a rank at which you lose a set of lower-rank slots, you can replace the two in either order. You can also instead swap a cantrip. You can also swap out spells by retraining during downtime.</p>\n<p>At 6th level and every even level thereafter, you can swap out any number of your spells for different spells of a rank you can cast. When you do, you must keep at least one spell you can cast with your lowest rank of spell slots so you don't end up with slots you can't use. For instance, at 6th level you would need to keep at least one 2nd-rank spell, but all your other spells could be 3rd rank.</p>"
                 },
                 "level": {
                     "value": 1
@@ -748,12 +748,48 @@
                     "remaster": true,
                     "title": "Pathfinder Player Core"
                 },
-                "rules": [],
-                "slug": "spell-repertoire-bard",
+                "rules": [
+                    {
+                        "itemId": "{item|id}",
+                        "key": "ItemAlteration",
+                        "mode": "override",
+                        "property": "description",
+                        "value": [
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.PartOne"
+                            },
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.PartTwo"
+                            },
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.PartThree"
+                            },
+                            {
+                                "divider": true,
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.SpellSwapping"
+                            },
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.SpellSwapping"
+                            }
+                        ]
+                    },
+                    {
+                        "itemId": "{item|id}",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "property": "traits",
+                        "value": "{actor|class.slug}"
+                    }
+                ],
+                "slug": "spell-repertoire",
                 "traits": {
                     "rarity": "common",
                     "value": [
-                        "bard"
+                        "bard",
+                        "oracle",
+                        "psychic",
+                        "sorcerer",
+                        "summoner"
                     ]
                 }
             },

--- a/packs/iconics/lem-level-3.json
+++ b/packs/iconics/lem-level-3.json
@@ -723,7 +723,7 @@
                 "compendiumSource": "Compendium.pf2e.classfeatures.Item.6FsusoMYxxjyIkVh"
             },
             "img": "icons/sundries/books/book-symbol-spiral-silver-blue.webp",
-            "name": "Spell Repertoire (Bard)",
+            "name": "Spell Repertoire",
             "sort": 300,
             "system": {
                 "actionType": {
@@ -734,7 +734,7 @@
                 },
                 "category": "classfeature",
                 "description": {
-                    "value": "<p>The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank occult spells of your choice and five occult cantrips of your choice. You choose these from the common spells from the occult list or from other occult spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Bard Spells per Day table), you add a spell to your spell repertoire of the same rank. At 2nd level, you select another 1st-rank spell; at 3rd level, you select two 2nd-rank spells, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot, and vice versa.</p>\n<h2>Swapping Spells In Your Repertoire</h2>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p>"
+                    "value": "<p><strong>Bard</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank occult spells of your choice and five occult cantrips of your choice. You choose these from the common spells from the occult list or from other occult spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Bard Spells per Day table), you add a spell to your spell repertoire of the same rank. At 2nd level, you select another 1st-rank spell; at 3rd level, you select two 2nd-rank spells, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot, and vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Oracle</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank divine spells of your choice and five divine cantrips of your choice. You choose these from the common spells on the divine list or from other divine spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Oracle Spells per Day table), you add a spell to your spell repertoire of the same rank. At 2nd level, you select another 1st-rank spell; at 3rd level, you select two 2nd-rank spells, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell.</p>\n<p>Your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot, and vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Psychic</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn one 1st-rank occult spell of your choice and three occult cantrips of your choice. You choose these from the common spells from the occult list or from other occult spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank. Your choice of conscious mind also grants you additional spells in your repertoire, starting with an additional 1st-rabk spell and two cantrips listed in your conscious mind, which you cast as psi cantrips.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see Table 2), you add a spell to your spell repertoire of the same level. At 2nd level, you select another 1st-rank spell; at 3rd level, you select one 2nd-level spell, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell. Your conscious mind also adds additional spells to your repertoire as you gain spells of higher levels.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, such as the spells you gain from your conscious mind, it wouldn't give you another spell slot, and vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Sorcerer</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank spells of your choice and four cantrips of your choice, as well as an additional spell and cantrip from your bloodline. You choose these from the common spells from the tradition corresponding to your bloodline, or from other spells from that tradition to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Sorcerer Spells per Day table above), you add a spell to your spell repertoire of the same rank. When you gain a new rank of spells, your first new spell is always the sorcerous gift spell for that rank that's listed in your bloodline, but you can choose the other spells. At 2nd level, you select another 1st-rank spell; at 3rd level, you gain a new spell from your bloodline and two other 2nd-rank spells, and so on. When you add spells, you might select a higher-rank version of a spell you already know so that you can cast a heightened version of that spell.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot or vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your spell repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip, but you can't swap out bloodline spells. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Summoner</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank spells of your choice and five cantrips of your choice. You choose these from the common spells from the tradition corresponding to your eidolon, or from other spells from that tradition to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank. Your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it doesn't give you another spell slot, and vice versa.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see Table 2–4: Summoner Spells per Day), you add a spell of the same rank to your spell repertoire. At 2nd level, you select another 1st-rank spell. At 3rd level, you add the first 2nd-rank spell to your repertoire. At 4th level you gain your second and your spell repertoire reaches its maximum size of five spells.</p>\n<p>At 5th level, in addition to adding two 3rd-rank spells to your repertoire, you lose your lowest rank of spell slots. Any time you lose a rank of spell slots, you lose two spells in your repertoire as well. These can come from spells you already know or out of the number of new spells you're learning. On levels in which you don't change your spell slots, you can swap out multiple spells, as described below.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. If it's a rank at which you lose a set of lower-rank slots, you can replace the two in either order. You can also instead swap a cantrip. You can also swap out spells by retraining during downtime.</p>\n<p>At 6th level and every even level thereafter, you can swap out any number of your spells for different spells of a rank you can cast. When you do, you must keep at least one spell you can cast with your lowest rank of spell slots so you don't end up with slots you can't use. For instance, at 6th level you would need to keep at least one 2nd-rank spell, but all your other spells could be 3rd rank.</p>"
                 },
                 "level": {
                     "value": 1
@@ -748,12 +748,48 @@
                     "remaster": true,
                     "title": "Pathfinder Player Core"
                 },
-                "rules": [],
-                "slug": "spell-repertoire-bard",
+                "rules": [
+                    {
+                        "itemId": "{item|id}",
+                        "key": "ItemAlteration",
+                        "mode": "override",
+                        "property": "description",
+                        "value": [
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.PartOne"
+                            },
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.PartTwo"
+                            },
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.PartThree"
+                            },
+                            {
+                                "divider": true,
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.SpellSwapping"
+                            },
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.SpellSwapping"
+                            }
+                        ]
+                    },
+                    {
+                        "itemId": "{item|id}",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "property": "traits",
+                        "value": "{actor|class.slug}"
+                    }
+                ],
+                "slug": "spell-repertoire",
                 "traits": {
                     "rarity": "common",
                     "value": [
-                        "bard"
+                        "bard",
+                        "oracle",
+                        "psychic",
+                        "sorcerer",
+                        "summoner"
                     ]
                 }
             },

--- a/packs/iconics/lem-level-5.json
+++ b/packs/iconics/lem-level-5.json
@@ -2592,7 +2592,7 @@
                 "compendiumSource": "Compendium.pf2e.classfeatures.Item.6FsusoMYxxjyIkVh"
             },
             "img": "icons/sundries/books/book-symbol-spiral-silver-blue.webp",
-            "name": "Spell Repertoire (Bard)",
+            "name": "Spell Repertoire",
             "sort": 0,
             "system": {
                 "actionType": {
@@ -2603,7 +2603,7 @@
                 },
                 "category": "classfeature",
                 "description": {
-                    "value": "<p>The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank occult spells of your choice and five occult cantrips of your choice. You choose these from the common spells from the occult list or from other occult spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Bard Spells per Day table), you add a spell to your spell repertoire of the same rank. At 2nd level, you select another 1st-rank spell; at 3rd level, you select two 2nd-rank spells, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot, and vice versa.</p>\n<h2>Swapping Spells In Your Repertoire</h2>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p>"
+                    "value": "<p><strong>Bard</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank occult spells of your choice and five occult cantrips of your choice. You choose these from the common spells from the occult list or from other occult spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Bard Spells per Day table), you add a spell to your spell repertoire of the same rank. At 2nd level, you select another 1st-rank spell; at 3rd level, you select two 2nd-rank spells, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot, and vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Oracle</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank divine spells of your choice and five divine cantrips of your choice. You choose these from the common spells on the divine list or from other divine spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Oracle Spells per Day table), you add a spell to your spell repertoire of the same rank. At 2nd level, you select another 1st-rank spell; at 3rd level, you select two 2nd-rank spells, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell.</p>\n<p>Your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot, and vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Psychic</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn one 1st-rank occult spell of your choice and three occult cantrips of your choice. You choose these from the common spells from the occult list or from other occult spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank. Your choice of conscious mind also grants you additional spells in your repertoire, starting with an additional 1st-rabk spell and two cantrips listed in your conscious mind, which you cast as psi cantrips.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see Table 2), you add a spell to your spell repertoire of the same level. At 2nd level, you select another 1st-rank spell; at 3rd level, you select one 2nd-level spell, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell. Your conscious mind also adds additional spells to your repertoire as you gain spells of higher levels.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, such as the spells you gain from your conscious mind, it wouldn't give you another spell slot, and vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Sorcerer</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank spells of your choice and four cantrips of your choice, as well as an additional spell and cantrip from your bloodline. You choose these from the common spells from the tradition corresponding to your bloodline, or from other spells from that tradition to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Sorcerer Spells per Day table above), you add a spell to your spell repertoire of the same rank. When you gain a new rank of spells, your first new spell is always the sorcerous gift spell for that rank that's listed in your bloodline, but you can choose the other spells. At 2nd level, you select another 1st-rank spell; at 3rd level, you gain a new spell from your bloodline and two other 2nd-rank spells, and so on. When you add spells, you might select a higher-rank version of a spell you already know so that you can cast a heightened version of that spell.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot or vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your spell repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip, but you can't swap out bloodline spells. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Summoner</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank spells of your choice and five cantrips of your choice. You choose these from the common spells from the tradition corresponding to your eidolon, or from other spells from that tradition to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank. Your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it doesn't give you another spell slot, and vice versa.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see Table 2–4: Summoner Spells per Day), you add a spell of the same rank to your spell repertoire. At 2nd level, you select another 1st-rank spell. At 3rd level, you add the first 2nd-rank spell to your repertoire. At 4th level you gain your second and your spell repertoire reaches its maximum size of five spells.</p>\n<p>At 5th level, in addition to adding two 3rd-rank spells to your repertoire, you lose your lowest rank of spell slots. Any time you lose a rank of spell slots, you lose two spells in your repertoire as well. These can come from spells you already know or out of the number of new spells you're learning. On levels in which you don't change your spell slots, you can swap out multiple spells, as described below.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. If it's a rank at which you lose a set of lower-rank slots, you can replace the two in either order. You can also instead swap a cantrip. You can also swap out spells by retraining during downtime.</p>\n<p>At 6th level and every even level thereafter, you can swap out any number of your spells for different spells of a rank you can cast. When you do, you must keep at least one spell you can cast with your lowest rank of spell slots so you don't end up with slots you can't use. For instance, at 6th level you would need to keep at least one 2nd-rank spell, but all your other spells could be 3rd rank.</p>"
                 },
                 "level": {
                     "value": 1
@@ -2617,12 +2617,48 @@
                     "remaster": true,
                     "title": "Pathfinder Player Core"
                 },
-                "rules": [],
-                "slug": "spell-repertoire-bard",
+                "rules": [
+                    {
+                        "itemId": "{item|id}",
+                        "key": "ItemAlteration",
+                        "mode": "override",
+                        "property": "description",
+                        "value": [
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.PartOne"
+                            },
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.PartTwo"
+                            },
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.PartThree"
+                            },
+                            {
+                                "divider": true,
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.SpellSwapping"
+                            },
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.SpellSwapping"
+                            }
+                        ]
+                    },
+                    {
+                        "itemId": "{item|id}",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "property": "traits",
+                        "value": "{actor|class.slug}"
+                    }
+                ],
+                "slug": "spell-repertoire",
                 "traits": {
                     "rarity": "common",
                     "value": [
-                        "bard"
+                        "bard",
+                        "oracle",
+                        "psychic",
+                        "sorcerer",
+                        "summoner"
                     ]
                 }
             },

--- a/packs/iconics/lini-level-3.json
+++ b/packs/iconics/lini-level-3.json
@@ -3601,7 +3601,36 @@
                     "remaster": true,
                     "title": "Pathfinder Player Core"
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "itemType": "spell",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "predicate": [
+                            "spellshape:reach-spell"
+                        ],
+                        "property": "description",
+                        "value": [
+                            {
+                                "text": "PF2E.SpecificRule.Spellshape.ReachSpell"
+                            }
+                        ]
+                    },
+                    {
+                        "key": "RollOption",
+                        "label": "PF2E.TraitSpellshape",
+                        "mergeable": true,
+                        "option": "spellshape",
+                        "placement": "spellcasting",
+                        "suboptions": [
+                            {
+                                "label": "{item|name}",
+                                "value": "reach-spell"
+                            }
+                        ],
+                        "toggleable": true
+                    }
+                ],
                 "slug": "reach-spell",
                 "traits": {
                     "rarity": "common",

--- a/packs/iconics/lini-level-5.json
+++ b/packs/iconics/lini-level-5.json
@@ -2756,7 +2756,36 @@
                     "remaster": true,
                     "title": "Pathfinder Player Core"
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "itemType": "spell",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "predicate": [
+                            "spellshape:reach-spell"
+                        ],
+                        "property": "description",
+                        "value": [
+                            {
+                                "text": "PF2E.SpecificRule.Spellshape.ReachSpell"
+                            }
+                        ]
+                    },
+                    {
+                        "key": "RollOption",
+                        "label": "PF2E.TraitSpellshape",
+                        "mergeable": true,
+                        "option": "spellshape",
+                        "placement": "spellcasting",
+                        "suboptions": [
+                            {
+                                "label": "{item|name}",
+                                "value": "reach-spell"
+                            }
+                        ],
+                        "toggleable": true
+                    }
+                ],
                 "slug": "reach-spell",
                 "traits": {
                     "rarity": "common",

--- a/packs/iconics/seelah-level-1.json
+++ b/packs/iconics/seelah-level-1.json
@@ -2880,7 +2880,8 @@
                         "property": "description",
                         "value": [
                             {
-                                "text": "PF2E.SpecificRule.Champion.RangedReprisal"
+                                "divider": true,
+                                "text": "PF2E.SpecificRule.Champion.RangedReprisal.Description"
                             }
                         ]
                     }

--- a/packs/iconics/seoni-level-1.json
+++ b/packs/iconics/seoni-level-1.json
@@ -2374,7 +2374,7 @@
                 "compendiumSource": "Compendium.pf2e.classfeatures.Item.lURKSJZAGKVD6cH9"
             },
             "img": "icons/sundries/books/book-symbol-spiral-silver-blue.webp",
-            "name": "Spell Repertoire (Sorcerer)",
+            "name": "Spell Repertoire",
             "sort": 0,
             "system": {
                 "actionType": {
@@ -2385,7 +2385,7 @@
                 },
                 "category": "classfeature",
                 "description": {
-                    "value": "<p>The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank spells of your choice and four cantrips of your choice, as well as an additional spell and cantrip from your bloodline. You choose these from the common spells from the tradition corresponding to your bloodline, or from other spells from that tradition to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Sorcerer Spells per Day table above), you add a spell to your spell repertoire of the same rank. When you gain a new rank of spells, your first new spell is always the sorcerous gift spell for that rank that's listed in your bloodline, but you can choose the other spells. At 2nd level, you select another 1st-rank spell; at 3rd level, you gain a new spell from your bloodline and two other 2nd-rank spells, and so on. When you add spells, you might select a higher-rank version of a spell you already know so that you can cast a heightened version of that spell.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot or vice versa.</p><h3>Swapping Spells in Your Repertoire</h3><p>As you gain new spells in your spell repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip, but you can't swap out bloodline spells. You can also swap out spells by retraining during downtime.</p>"
+                    "value": "<p><strong>Bard</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank occult spells of your choice and five occult cantrips of your choice. You choose these from the common spells from the occult list or from other occult spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Bard Spells per Day table), you add a spell to your spell repertoire of the same rank. At 2nd level, you select another 1st-rank spell; at 3rd level, you select two 2nd-rank spells, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot, and vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Oracle</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank divine spells of your choice and five divine cantrips of your choice. You choose these from the common spells on the divine list or from other divine spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Oracle Spells per Day table), you add a spell to your spell repertoire of the same rank. At 2nd level, you select another 1st-rank spell; at 3rd level, you select two 2nd-rank spells, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell.</p>\n<p>Your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot, and vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Psychic</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn one 1st-rank occult spell of your choice and three occult cantrips of your choice. You choose these from the common spells from the occult list or from other occult spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank. Your choice of conscious mind also grants you additional spells in your repertoire, starting with an additional 1st-rabk spell and two cantrips listed in your conscious mind, which you cast as psi cantrips.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see Table 2), you add a spell to your spell repertoire of the same level. At 2nd level, you select another 1st-rank spell; at 3rd level, you select one 2nd-level spell, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell. Your conscious mind also adds additional spells to your repertoire as you gain spells of higher levels.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, such as the spells you gain from your conscious mind, it wouldn't give you another spell slot, and vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Sorcerer</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank spells of your choice and four cantrips of your choice, as well as an additional spell and cantrip from your bloodline. You choose these from the common spells from the tradition corresponding to your bloodline, or from other spells from that tradition to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Sorcerer Spells per Day table above), you add a spell to your spell repertoire of the same rank. When you gain a new rank of spells, your first new spell is always the sorcerous gift spell for that rank that's listed in your bloodline, but you can choose the other spells. At 2nd level, you select another 1st-rank spell; at 3rd level, you gain a new spell from your bloodline and two other 2nd-rank spells, and so on. When you add spells, you might select a higher-rank version of a spell you already know so that you can cast a heightened version of that spell.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot or vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your spell repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip, but you can't swap out bloodline spells. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Summoner</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank spells of your choice and five cantrips of your choice. You choose these from the common spells from the tradition corresponding to your eidolon, or from other spells from that tradition to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank. Your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it doesn't give you another spell slot, and vice versa.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see Table 2–4: Summoner Spells per Day), you add a spell of the same rank to your spell repertoire. At 2nd level, you select another 1st-rank spell. At 3rd level, you add the first 2nd-rank spell to your repertoire. At 4th level you gain your second and your spell repertoire reaches its maximum size of five spells.</p>\n<p>At 5th level, in addition to adding two 3rd-rank spells to your repertoire, you lose your lowest rank of spell slots. Any time you lose a rank of spell slots, you lose two spells in your repertoire as well. These can come from spells you already know or out of the number of new spells you're learning. On levels in which you don't change your spell slots, you can swap out multiple spells, as described below.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. If it's a rank at which you lose a set of lower-rank slots, you can replace the two in either order. You can also instead swap a cantrip. You can also swap out spells by retraining during downtime.</p>\n<p>At 6th level and every even level thereafter, you can swap out any number of your spells for different spells of a rank you can cast. When you do, you must keep at least one spell you can cast with your lowest rank of spell slots so you don't end up with slots you can't use. For instance, at 6th level you would need to keep at least one 2nd-rank spell, but all your other spells could be 3rd rank.</p>"
                 },
                 "level": {
                     "value": 1
@@ -2397,17 +2397,50 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core 2"
+                    "title": "Pathfinder Player Core"
                 },
-                "rules": [],
-                "slug": "spell-repertoire-sorcerer",
+                "rules": [
+                    {
+                        "itemId": "{item|id}",
+                        "key": "ItemAlteration",
+                        "mode": "override",
+                        "property": "description",
+                        "value": [
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.PartOne"
+                            },
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.PartTwo"
+                            },
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.PartThree"
+                            },
+                            {
+                                "divider": true,
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.SpellSwapping"
+                            },
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.SpellSwapping"
+                            }
+                        ]
+                    },
+                    {
+                        "itemId": "{item|id}",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "property": "traits",
+                        "value": "{actor|class.slug}"
+                    }
+                ],
+                "slug": "spell-repertoire",
                 "traits": {
                     "rarity": "common",
-                    "selected": {
-                        "sorcerer": "Sorcerer"
-                    },
                     "value": [
-                        "sorcerer"
+                        "bard",
+                        "oracle",
+                        "psychic",
+                        "sorcerer",
+                        "summoner"
                     ]
                 }
             },

--- a/packs/iconics/seoni-level-3.json
+++ b/packs/iconics/seoni-level-3.json
@@ -2488,7 +2488,7 @@
                 "compendiumSource": "Compendium.pf2e.classfeatures.Item.lURKSJZAGKVD6cH9"
             },
             "img": "icons/sundries/books/book-symbol-spiral-silver-blue.webp",
-            "name": "Spell Repertoire (Sorcerer)",
+            "name": "Spell Repertoire",
             "sort": 0,
             "system": {
                 "actionType": {
@@ -2499,7 +2499,7 @@
                 },
                 "category": "classfeature",
                 "description": {
-                    "value": "<p>The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank spells of your choice and four cantrips of your choice, as well as an additional spell and cantrip from your bloodline. You choose these from the common spells from the tradition corresponding to your bloodline, or from other spells from that tradition to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Sorcerer Spells per Day table above), you add a spell to your spell repertoire of the same rank. When you gain a new rank of spells, your first new spell is always the sorcerous gift spell for that rank that's listed in your bloodline, but you can choose the other spells. At 2nd level, you select another 1st-rank spell; at 3rd level, you gain a new spell from your bloodline and two other 2nd-rank spells, and so on. When you add spells, you might select a higher-rank version of a spell you already know so that you can cast a heightened version of that spell.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot or vice versa.</p><h3>Swapping Spells in Your Repertoire</h3><p>As you gain new spells in your spell repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip, but you can't swap out bloodline spells. You can also swap out spells by retraining during downtime.</p>"
+                    "value": "<p><strong>Bard</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank occult spells of your choice and five occult cantrips of your choice. You choose these from the common spells from the occult list or from other occult spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Bard Spells per Day table), you add a spell to your spell repertoire of the same rank. At 2nd level, you select another 1st-rank spell; at 3rd level, you select two 2nd-rank spells, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot, and vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Oracle</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank divine spells of your choice and five divine cantrips of your choice. You choose these from the common spells on the divine list or from other divine spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Oracle Spells per Day table), you add a spell to your spell repertoire of the same rank. At 2nd level, you select another 1st-rank spell; at 3rd level, you select two 2nd-rank spells, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell.</p>\n<p>Your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot, and vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Psychic</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn one 1st-rank occult spell of your choice and three occult cantrips of your choice. You choose these from the common spells from the occult list or from other occult spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank. Your choice of conscious mind also grants you additional spells in your repertoire, starting with an additional 1st-rabk spell and two cantrips listed in your conscious mind, which you cast as psi cantrips.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see Table 2), you add a spell to your spell repertoire of the same level. At 2nd level, you select another 1st-rank spell; at 3rd level, you select one 2nd-level spell, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell. Your conscious mind also adds additional spells to your repertoire as you gain spells of higher levels.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, such as the spells you gain from your conscious mind, it wouldn't give you another spell slot, and vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Sorcerer</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank spells of your choice and four cantrips of your choice, as well as an additional spell and cantrip from your bloodline. You choose these from the common spells from the tradition corresponding to your bloodline, or from other spells from that tradition to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Sorcerer Spells per Day table above), you add a spell to your spell repertoire of the same rank. When you gain a new rank of spells, your first new spell is always the sorcerous gift spell for that rank that's listed in your bloodline, but you can choose the other spells. At 2nd level, you select another 1st-rank spell; at 3rd level, you gain a new spell from your bloodline and two other 2nd-rank spells, and so on. When you add spells, you might select a higher-rank version of a spell you already know so that you can cast a heightened version of that spell.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot or vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your spell repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip, but you can't swap out bloodline spells. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Summoner</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank spells of your choice and five cantrips of your choice. You choose these from the common spells from the tradition corresponding to your eidolon, or from other spells from that tradition to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank. Your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it doesn't give you another spell slot, and vice versa.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see Table 2–4: Summoner Spells per Day), you add a spell of the same rank to your spell repertoire. At 2nd level, you select another 1st-rank spell. At 3rd level, you add the first 2nd-rank spell to your repertoire. At 4th level you gain your second and your spell repertoire reaches its maximum size of five spells.</p>\n<p>At 5th level, in addition to adding two 3rd-rank spells to your repertoire, you lose your lowest rank of spell slots. Any time you lose a rank of spell slots, you lose two spells in your repertoire as well. These can come from spells you already know or out of the number of new spells you're learning. On levels in which you don't change your spell slots, you can swap out multiple spells, as described below.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. If it's a rank at which you lose a set of lower-rank slots, you can replace the two in either order. You can also instead swap a cantrip. You can also swap out spells by retraining during downtime.</p>\n<p>At 6th level and every even level thereafter, you can swap out any number of your spells for different spells of a rank you can cast. When you do, you must keep at least one spell you can cast with your lowest rank of spell slots so you don't end up with slots you can't use. For instance, at 6th level you would need to keep at least one 2nd-rank spell, but all your other spells could be 3rd rank.</p>"
                 },
                 "level": {
                     "value": 1
@@ -2511,17 +2511,50 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core 2"
+                    "title": "Pathfinder Player Core"
                 },
-                "rules": [],
-                "slug": "spell-repertoire-sorcerer",
+                "rules": [
+                    {
+                        "itemId": "{item|id}",
+                        "key": "ItemAlteration",
+                        "mode": "override",
+                        "property": "description",
+                        "value": [
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.PartOne"
+                            },
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.PartTwo"
+                            },
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.PartThree"
+                            },
+                            {
+                                "divider": true,
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.SpellSwapping"
+                            },
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.SpellSwapping"
+                            }
+                        ]
+                    },
+                    {
+                        "itemId": "{item|id}",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "property": "traits",
+                        "value": "{actor|class.slug}"
+                    }
+                ],
+                "slug": "spell-repertoire",
                 "traits": {
                     "rarity": "common",
-                    "selected": {
-                        "sorcerer": "Sorcerer"
-                    },
                     "value": [
-                        "sorcerer"
+                        "bard",
+                        "oracle",
+                        "psychic",
+                        "sorcerer",
+                        "summoner"
                     ]
                 }
             },

--- a/packs/iconics/seoni-level-5.json
+++ b/packs/iconics/seoni-level-5.json
@@ -2858,7 +2858,7 @@
                 "compendiumSource": "Compendium.pf2e.classfeatures.Item.lURKSJZAGKVD6cH9"
             },
             "img": "icons/sundries/books/book-symbol-spiral-silver-blue.webp",
-            "name": "Spell Repertoire (Sorcerer)",
+            "name": "Spell Repertoire",
             "sort": 0,
             "system": {
                 "actionType": {
@@ -2869,7 +2869,7 @@
                 },
                 "category": "classfeature",
                 "description": {
-                    "value": "<p>The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank spells of your choice and four cantrips of your choice, as well as an additional spell and cantrip from your bloodline. You choose these from the common spells from the tradition corresponding to your bloodline, or from other spells from that tradition to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Sorcerer Spells per Day table above), you add a spell to your spell repertoire of the same rank. When you gain a new rank of spells, your first new spell is always the sorcerous gift spell for that rank that's listed in your bloodline, but you can choose the other spells. At 2nd level, you select another 1st-rank spell; at 3rd level, you gain a new spell from your bloodline and two other 2nd-rank spells, and so on. When you add spells, you might select a higher-rank version of a spell you already know so that you can cast a heightened version of that spell.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot or vice versa.</p><h3>Swapping Spells in Your Repertoire</h3><p>As you gain new spells in your spell repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip, but you can't swap out bloodline spells. You can also swap out spells by retraining during downtime.</p>"
+                    "value": "<p><strong>Bard</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank occult spells of your choice and five occult cantrips of your choice. You choose these from the common spells from the occult list or from other occult spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Bard Spells per Day table), you add a spell to your spell repertoire of the same rank. At 2nd level, you select another 1st-rank spell; at 3rd level, you select two 2nd-rank spells, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot, and vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Oracle</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank divine spells of your choice and five divine cantrips of your choice. You choose these from the common spells on the divine list or from other divine spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Oracle Spells per Day table), you add a spell to your spell repertoire of the same rank. At 2nd level, you select another 1st-rank spell; at 3rd level, you select two 2nd-rank spells, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell.</p>\n<p>Your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot, and vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Psychic</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn one 1st-rank occult spell of your choice and three occult cantrips of your choice. You choose these from the common spells from the occult list or from other occult spells to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank. Your choice of conscious mind also grants you additional spells in your repertoire, starting with an additional 1st-rabk spell and two cantrips listed in your conscious mind, which you cast as psi cantrips.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see Table 2), you add a spell to your spell repertoire of the same level. At 2nd level, you select another 1st-rank spell; at 3rd level, you select one 2nd-level spell, and so on. When you add spells, you might add a higher-rank version of a spell you already have, so you can cast a heightened version of that spell. Your conscious mind also adds additional spells to your repertoire as you gain spells of higher levels.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, such as the spells you gain from your conscious mind, it wouldn't give you another spell slot, and vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Sorcerer</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank spells of your choice and four cantrips of your choice, as well as an additional spell and cantrip from your bloodline. You choose these from the common spells from the tradition corresponding to your bloodline, or from other spells from that tradition to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see the Sorcerer Spells per Day table above), you add a spell to your spell repertoire of the same rank. When you gain a new rank of spells, your first new spell is always the sorcerous gift spell for that rank that's listed in your bloodline, but you can choose the other spells. At 2nd level, you select another 1st-rank spell; at 3rd level, you gain a new spell from your bloodline and two other 2nd-rank spells, and so on. When you add spells, you might select a higher-rank version of a spell you already know so that you can cast a heightened version of that spell.</p>\n<p>Though you gain them at the same rate, your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it wouldn't give you another spell slot or vice versa.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your spell repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. This spell can be a cantrip, but you can't swap out bloodline spells. You can also swap out spells by retraining during downtime.</p><hr /><p><strong>Summoner</strong> The collection of spells you can cast is called your spell repertoire. At 1st level, you learn two 1st-rank spells of your choice and five cantrips of your choice. You choose these from the common spells from the tradition corresponding to your eidolon, or from other spells from that tradition to which you have access. You can cast any spell in your spell repertoire by using a spell slot of an appropriate spell rank. Your spell slots and the spells in your spell repertoire are separate. If a feat or other ability adds a spell to your spell repertoire, it doesn't give you another spell slot, and vice versa.</p>\n<p>You add to this spell repertoire as you increase in level. Each time you get a spell slot (see Table 2–4: Summoner Spells per Day), you add a spell of the same rank to your spell repertoire. At 2nd level, you select another 1st-rank spell. At 3rd level, you add the first 2nd-rank spell to your repertoire. At 4th level you gain your second and your spell repertoire reaches its maximum size of five spells.</p>\n<p>At 5th level, in addition to adding two 3rd-rank spells to your repertoire, you lose your lowest rank of spell slots. Any time you lose a rank of spell slots, you lose two spells in your repertoire as well. These can come from spells you already know or out of the number of new spells you're learning. On levels in which you don't change your spell slots, you can swap out multiple spells, as described below.</p>\n<p><strong>Swapping Spells in Your Repertoire</strong></p>\n<p>As you gain new spells in your repertoire, you might want to replace some of the spells you previously learned. Each time you gain a level and learn new spells, you can swap out one of your old spells for a different spell of the same rank. If it's a rank at which you lose a set of lower-rank slots, you can replace the two in either order. You can also instead swap a cantrip. You can also swap out spells by retraining during downtime.</p>\n<p>At 6th level and every even level thereafter, you can swap out any number of your spells for different spells of a rank you can cast. When you do, you must keep at least one spell you can cast with your lowest rank of spell slots so you don't end up with slots you can't use. For instance, at 6th level you would need to keep at least one 2nd-rank spell, but all your other spells could be 3rd rank.</p>"
                 },
                 "level": {
                     "value": 1
@@ -2881,17 +2881,50 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core 2"
+                    "title": "Pathfinder Player Core"
                 },
-                "rules": [],
-                "slug": "spell-repertoire-sorcerer",
+                "rules": [
+                    {
+                        "itemId": "{item|id}",
+                        "key": "ItemAlteration",
+                        "mode": "override",
+                        "property": "description",
+                        "value": [
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.PartOne"
+                            },
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.PartTwo"
+                            },
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.PartThree"
+                            },
+                            {
+                                "divider": true,
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.SpellSwapping"
+                            },
+                            {
+                                "text": "PF2E.SpecificRule.ClassFeatures.SpellRepertoire.{actor|class.slug}.SpellSwapping"
+                            }
+                        ]
+                    },
+                    {
+                        "itemId": "{item|id}",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "property": "traits",
+                        "value": "{actor|class.slug}"
+                    }
+                ],
+                "slug": "spell-repertoire",
                 "traits": {
                     "rarity": "common",
-                    "selected": {
-                        "sorcerer": "Sorcerer"
-                    },
                     "value": [
-                        "sorcerer"
+                        "bard",
+                        "oracle",
+                        "psychic",
+                        "sorcerer",
+                        "summoner"
                     ]
                 }
             },
@@ -3270,59 +3303,6 @@
                 "traits": {
                     "rarity": "common",
                     "value": [
-                        "sorcerer"
-                    ]
-                }
-            },
-            "type": "feat"
-        },
-        {
-            "_id": "n8sE1TCw5seNf1l3",
-            "_stats": {
-                "compendiumSource": "Compendium.pf2e.feats-srd.Item.den5wwGUjHDXLkpv"
-            },
-            "img": "icons/sundries/books/book-red-exclamation.webp",
-            "name": "Bespell Weapon",
-            "sort": 0,
-            "system": {
-                "actionType": {
-                    "value": "free"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "class",
-                "description": {
-                    "value": "<p><strong>Frequency</strong> once per turn</p>\n<p><strong>Requirements</strong> Your most recent action was to cast a non-cantrip spell.</p><hr /><p>You siphon the residual energy from the last spell you cast into one weapon you're wielding. Until the end of your turn, the weapon deals an extra 1d6 damage of a type depending on the school of the spell you just cast.</p><ul><li><strong>Abjuration</strong> force damage</li><li><strong>Conjuration or Transmutation</strong> the same type as the weapon</li><li><strong>Divination, Enchantment, or Illusion</strong> mental damage</li><li><strong>Evocation</strong> a type the spell dealt, or force damage if the spell didn't deal damage</li><li><strong>Necromancy</strong> void damage</li></ul>"
-                },
-                "frequency": {
-                    "max": 1,
-                    "per": "turn",
-                    "value": 1
-                },
-                "level": {
-                    "taken": 4,
-                    "value": 4
-                },
-                "location": "class-4",
-                "prerequisites": {
-                    "value": []
-                },
-                "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Advanced Player's Guide"
-                },
-                "rules": [],
-                "selfEffect": {
-                    "name": "Effect: Bespell Strikes",
-                    "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Bespell Strikes"
-                },
-                "slug": "bespell-weapon",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "oracle",
                         "sorcerer"
                     ]
                 }
@@ -4574,6 +4554,111 @@
                 }
             },
             "type": "spell"
+        },
+        {
+            "_id": "a9vVIyvuuXj6RhDu",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.feats-srd.Item.tWBK7Zbt80JlPryC"
+            },
+            "img": "icons/sundries/books/book-red-exclamation.webp",
+            "name": "Bespell Strikes",
+            "sort": 0,
+            "system": {
+                "actionType": {
+                    "value": "free"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "class",
+                "description": {
+                    "value": "<p><strong>Frequency</strong> once per turn</p>\n<p><strong>Requirements</strong> Your most recent action was to cast a non-cantrip spell.</p><hr /><p><strong>Oracle</strong> You siphon spell energy into one weapon you're wielding, or into one of your unarmed attacks, such as a fist. Until the end of your turn, the weapon or unarmed attack deals an extra 1d6 force damage and gains the divine trait if it didn't have it already. If the spell dealt a different type of damage, the Strike deals this type of damage instead (or one type of your choice if the spell could deal multiple types of damage).</p>\n<p><strong>Sorcerer</strong> You siphon spell energy into one weapon you're wielding or into one of your unarmed attacks, such as a fist. Until the end of your turn, the weapon or unarmed attack deals an extra 1d6 force damage and gains the trait of your bloodline's magical tradition if it didn't have it already. If the spell dealt a different type of damage, the Strike deals this type of damage instead (or one type of your choice if the spell could deal multiple types of damage).</p>\n<p><strong>Wizard</strong> You siphon spell energy into one weapon you're wielding, or into one of your unarmed attacks, such as a fist. Until the end of your turn, the weapon or unarmed attack deals an extra 1d6 force damage and gains the arcane trait if it didn't have it already. If the spell dealt a different type of damage, the Strike deals this type of damage instead (or one type of your choice if the spell could deal multiple types of damage).</p>"
+                },
+                "frequency": {
+                    "max": 1,
+                    "per": "turn",
+                    "value": 1
+                },
+                "level": {
+                    "taken": 4,
+                    "value": 4
+                },
+                "location": "class-4",
+                "prerequisites": {
+                    "value": []
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
+                },
+                "rules": [
+                    {
+                        "itemId": "{item|id}",
+                        "key": "ItemAlteration",
+                        "mode": "override",
+                        "property": "description",
+                        "value": [
+                            {
+                                "text": "PF2E.FeatDescription.Frequency.OncePerTurn",
+                                "title": "PF2E.Frequency.Label"
+                            },
+                            {
+                                "divider": true,
+                                "text": "PF2E.SpecificRule.Feat.BespellStrikes.Requirements",
+                                "title": "PF2E.FeatDescription.Requirements.Label"
+                            },
+                            {
+                                "predicate": [
+                                    {
+                                        "or": [
+                                            "class:oracle",
+                                            "feat:oracle-dedication"
+                                        ]
+                                    }
+                                ],
+                                "text": "PF2E.SpecificRule.Feat.BespellStrikes.Oracle"
+                            },
+                            {
+                                "predicate": [
+                                    {
+                                        "or": [
+                                            "class:sorcerer",
+                                            "feat:sorcerer-dedication"
+                                        ]
+                                    }
+                                ],
+                                "text": "PF2E.SpecificRule.Feat.BespellStrikes.Sorcerer"
+                            },
+                            {
+                                "predicate": [
+                                    {
+                                        "or": [
+                                            "class:wizard",
+                                            "feat:wizard-dedication"
+                                        ]
+                                    }
+                                ],
+                                "text": "PF2E.SpecificRule.Feat.BespellStrikes.Wizard"
+                            }
+                        ]
+                    }
+                ],
+                "selfEffect": {
+                    "name": "Effect: Bespell Strikes",
+                    "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Bespell Strikes"
+                },
+                "slug": "bespell-strikes",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "oracle",
+                        "sorcerer",
+                        "wizard"
+                    ]
+                }
+            },
+            "type": "feat"
         }
     ],
     "name": "Seoni (Level 5)",


### PR DESCRIPTION
Note - Seoni still has Bespell Weapon; Bespell Strikes replaced that feat. I replaced it here but if you want to keep Bespell Weapon until Paizo issues a correction, let me know.