### PR TITLE
Adjust negative damage rolls

### DIFF
--- a/src/module/system/damage/iwr.ts
+++ b/src/module/system/damage/iwr.ts
@@ -48,13 +48,22 @@ function applyIWR(actor: ActorPF2e, roll: Rolled<DamageRoll>, rollOptions: Set<s
             const formalDescription = new Set([...instance.formalDescription, ...rollOptions]);
 
             // If the roll's total was increased to a minimum of 1, treat the first instance as having a total of 1
-            const wasIncreased = instance.total <= 0 && typeof roll.options.increasedFrom === "number";
+            const wasIncreased = instance.total <= 0 && typeof instance.options.increasedFrom === "number";
             const isFirst = instances.indexOf(instance) === 0;
             const instanceTotal = wasIncreased && isFirst ? 1 : Math.max(instance.total, 0);
+            const instanceApplications: IWRApplication[] = [];
 
             // Step 0: Inapplicable damage outside the IWR framework
             if (!actor.isAffectedBy(instance.type)) {
                 return [{ category: "unaffected", type: instance.type, adjustment: -1 * instanceTotal }];
+            }
+            // Step 0.5: adjust for 0 damage rolls
+            if (wasIncreased && isFirst){
+                instanceApplications.push({
+                    category: "weakness",
+                    type: "adjusment",
+                    adjustment: 1,
+                });
             }
 
             // Step 1: Immunities
@@ -71,7 +80,7 @@ function applyIWR(actor: ActorPF2e, roll: Rolled<DamageRoll>, rollOptions: Set<s
                 return [{ category: "immunity", type: appliedImmunity.label, adjustment: -1 * instanceTotal }];
             }
 
-            const instanceApplications: IWRApplication[] = [];
+            
 
             let redirectedFromImmunity: DamageType | null = null;
             for (const immunity of applicableImmunities) {

--- a/src/module/system/damage/roll.ts
+++ b/src/module/system/damage/roll.ts
@@ -488,9 +488,14 @@ class DamageInstance extends AbstractDamageRoll {
         return DAMAGE_TYPE_ICONS[this.type];
     }
 
-    /** Return 0 for persistent damage */
+    /** Return 0 for persistent damage and if damage is below 0 */
     protected override _evaluateTotal(): number {
-        return this.persistent && !this.options.evaluatePersistent ? 0 : super._evaluateTotal();
+        const total = super._evaluateTotal();
+        if (!this.persistent && total <= 0){
+            this.options.increasedFrom = total;
+            return 0;
+        }
+        else return this.persistent && !this.options.evaluatePersistent ? 0 : total;
     }
 
     override async render({ tooltips = true }: InstanceRenderOptions = {}): Promise<string> {
@@ -610,7 +615,7 @@ class DamageInstance extends AbstractDamageRoll {
                 result.hidden = true;
             }
         }
-
+        this._total = this._evaluateTotal();
         return this as Rolled<this>;
     }
 }


### PR DESCRIPTION
closes #16484 
Adjusts negative damage rolls to 0, then IWR adds damage so that damage rolls always deal at least 1 at base before adjusments. Should an adjustment IWR class be added so that this would not be counted as a weakness?