### PR TITLE
Update weapon-selecting spell effects to be compatible with NPCs

### DIFF
--- a/packs/spell-effects/spell-effect-blink-charge.json
+++ b/packs/spell-effects/spell-effect-blink-charge.json
@@ -23,16 +23,17 @@
         "rules": [
             {
                 "choices": {
-                    "ownedItems": true,
+                    "attacks": true,
                     "predicate": [
-                        "item:equipped"
-                    ],
-                    "types": [
-                        "weapon"
+                        "item:equipped",
+                        {
+                            "not": "item:trait:unarmed"
+                        }
                     ]
                 },
                 "flag": "weapon",
-                "key": "ChoiceSet"
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
             {
                 "damageType": "force",

--- a/packs/spell-effects/spell-effect-ghostly-weapon.json
+++ b/packs/spell-effects/spell-effect-ghostly-weapon.json
@@ -23,18 +23,20 @@
         "rules": [
             {
                 "choices": {
-                    "ownedItems": true,
-                    "types": [
-                        "weapon"
+                    "attacks": true,
+                    "predicate": [
+                        {
+                            "not": "item:trait:unarmed"
+                        }
                     ]
                 },
-                "flag": "spellEffectGhostlyWeapon",
+                "flag": "weapon",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
             {
                 "definition": [
-                    "item:id:{item|flags.pf2e.rulesSelections.spellEffectGhostlyWeapon}"
+                    "item:slug:{item|flags.pf2e.rulesSelections.weapon}"
                 ],
                 "key": "AdjustStrike",
                 "mode": "add",
@@ -43,7 +45,7 @@
             },
             {
                 "definition": [
-                    "item:id:{item|flags.pf2e.rulesSelections.spellEffectGhostlyWeapon}"
+                    "item:slug:{item|flags.pf2e.rulesSelections.weapon}"
                 ],
                 "key": "AdjustStrike",
                 "mode": "add",

--- a/packs/spell-effects/spell-effect-object-memory-weapon.json
+++ b/packs/spell-effects/spell-effect-object-memory-weapon.json
@@ -4,7 +4,7 @@
     "name": "Spell Effect: Object Memory (Weapon)",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Object Memory].</p>\n<p>If you touch a weapon, your proficiency rank with that weapon temporarily increases to trained (if it is not already higher).</p>\n<hr />\n<p><strong>Heightened (6th)</strong> Your proficiency rank increases to expert instead of trained.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Object Memory].</p>\n<p>Your proficiency rank with the chosen weapon increases.</p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -23,9 +23,11 @@
         "rules": [
             {
                 "choices": {
-                    "ownedItems": true,
-                    "types": [
-                        "weapon"
+                    "attacks": true,
+                    "predicate": [
+                        {
+                            "not": "item:trait:unarmed"
+                        }
                     ]
                 },
                 "flag": "weapon",
@@ -34,12 +36,12 @@
             },
             {
                 "definition": [
-                    "item:id:{item|flags.pf2e.rulesSelections.weapon}"
+                    "item:slug:{item|flags.pf2e.rulesSelections.weapon}"
                 ],
                 "key": "MartialProficiency",
                 "label": "PF2E.SpecificRule.ObjectMemory",
                 "slug": "object-memory",
-                "value": "ternary(lt(@item.level, 6), 1, 2)"
+                "value": "ternary(lt(@item.level,6),1,2)"
             }
         ],
         "start": {

--- a/packs/spell-effects/spell-effect-serrate.json
+++ b/packs/spell-effects/spell-effect-serrate.json
@@ -4,7 +4,7 @@
     "name": "Spell Effect: Serrate",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Serrate]</p>\n<p>Strikes with the target weapon deal additional slashing damage until the start of your next turn.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Serrate]</p>\n<p>You deal additional slashing damage with the chosen weapon.</p>"
         },
         "duration": {
             "expiry": "turn-end",
@@ -23,12 +23,14 @@
         "rules": [
             {
                 "choices": {
-                    "ownedItems": true,
-                    "types": [
-                        "weapon"
+                    "attacks": true,
+                    "predicate": [
+                        {
+                            "not": "item:trait:unarmed"
+                        }
                     ]
                 },
-                "flag": "serrateWeapon",
+                "flag": "weapon",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
@@ -37,7 +39,7 @@
                 "diceNumber": "ceil(@item.level/2)",
                 "dieSize": "d4",
                 "key": "DamageDice",
-                "selector": "{item|flags.pf2e.rulesSelections.serrateWeapon}-damage"
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage"
             }
         ],
         "start": {

--- a/packs/spell-effects/spell-effect-suns-fury.json
+++ b/packs/spell-effects/spell-effect-suns-fury.json
@@ -4,7 +4,7 @@
     "name": "Spell Effect: Sun's Fury",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Sun's Fury]</p>\n<p>The weapon deals an additional 1d4 fire and 1 spirit damage on a successful Strike. In addition, the flame causes the weapon to glow as bright as a torch.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Sun's Fury]</p>\n<p>The weapon deals an additional 1d4 fire damage and 1 spirit damage. In addition, the weapon glows as bright as a torch.</p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -23,12 +23,17 @@
         "rules": [
             {
                 "choices": {
-                    "ownedItems": true,
-                    "types": [
-                        "weapon"
+                    "attacks": true,
+                    "predicate": [
+                        {
+                            "nor": [
+                                "item:trait:unarmed",
+                                "item:rune:property:unholy"
+                            ]
+                        }
                     ]
                 },
-                "flag": "effectSunsFury",
+                "flag": "weapon",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
@@ -37,12 +42,12 @@
                 "diceNumber": 1,
                 "dieSize": "d4",
                 "key": "DamageDice",
-                "selector": "{item|flags.pf2e.rulesSelections.effectSunsFury}-damage"
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage"
             },
             {
                 "damageType": "spirit",
                 "key": "FlatModifier",
-                "selector": "{item|flags.pf2e.rulesSelections.effectSunsFury}-damage",
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage",
                 "value": 1
             },
             {

--- a/packs/spell-effects/spell-effect-weapon-surge.json
+++ b/packs/spell-effects/spell-effect-weapon-surge.json
@@ -4,7 +4,7 @@
     "name": "Spell Effect: Weapon Surge",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Weapon Surge]</p>\n<p>On your next Strike with the weapon before the start of your next turn, you gain a +1 status bonus to the attack roll, the weapon deals additional spirit damage, and the Strike gains the sanctified trait.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Weapon Surge]</p>\n<p>You choose a weapon you're wielding. On your next Strike with that weapon, you gain a +1 status bonus to the attack roll and the weapon deals additional spirit damage, and the Strike gains the sanctified trait.</p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -23,21 +23,21 @@
         "rules": [
             {
                 "choices": {
-                    "ownedItems": true,
+                    "attacks": true,
                     "predicate": [
+                        {
+                            "not": "item:trait:unarmed"
+                        },
                         "item:equipped"
-                    ],
-                    "types": [
-                        "weapon"
                     ]
                 },
-                "flag": "spellEffectWeaponSurge",
+                "flag": "weapon",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
             {
                 "key": "FlatModifier",
-                "selector": "{item|flags.pf2e.rulesSelections.spellEffectWeaponSurge}-attack",
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-attack",
                 "type": "status",
                 "value": 1
             },
@@ -46,11 +46,11 @@
                 "diceNumber": "ternary(gte(@item.level,9),3,ternary(gte(@item.level,5),2,1))",
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "selector": "{item|flags.pf2e.rulesSelections.spellEffectWeaponSurge}-damage"
+                "selector": "{item|flags.pf2e.rulesSelections.weapon}-damage"
             },
             {
                 "definition": [
-                    "item:id:{item|flags.pf2e.rulesSelections.spellEffectWeaponSurge}"
+                    "item:slug:{item|flags.pf2e.rulesSelections.weapon}"
                 ],
                 "key": "AdjustStrike",
                 "mode": "add",


### PR DESCRIPTION
There are some effects that are seemingly incompatible with NPCs outright, such as Runic Weapon, and Shillelagh, since they give weapons fundamental runes, so those may be best handled on a case by case basis.

I also omitted Draw the Lightning, since that one will require a bit more thought.