### PR TITLE
Update Aiuvarin and Droomar to be versatile heritages

### DIFF
--- a/packs/heritages/versatile-heritages/aiuvarin.json
+++ b/packs/heritages/versatile-heritages/aiuvarin.json
@@ -4,11 +4,7 @@
     "img": "systems/pf2e/icons/features/ancestry/half-elf.webp",
     "name": "Aiuvarin",
     "system": {
-        "ancestry": {
-            "name": "Human",
-            "slug": "human",
-            "uuid": "Compendium.pf2e.ancestries.Item.IiG7DgeLWYrSNXuX"
-        },
+        "ancestry": null,
         "description": {
             "value": "<p>You have elves, or possibly other aiuvarins, in your family tree. You have pointed ears and other telltale signs of elf heritage. You gain the elf trait, the aiuvarin trait, and low-light vision. In addition, when you gain an ancestry feat, you can choose from aiuvarin and elf feats in addition to those from your ancestry.</p>"
         },

--- a/packs/heritages/versatile-heritages/dromaar.json
+++ b/packs/heritages/versatile-heritages/dromaar.json
@@ -4,11 +4,7 @@
     "img": "systems/pf2e/icons/features/ancestry/half-orc.webp",
     "name": "Dromaar",
     "system": {
-        "ancestry": {
-            "name": "Human",
-            "slug": "human",
-            "uuid": "Compendium.pf2e.ancestries.Item.IiG7DgeLWYrSNXuX"
-        },
+        "ancestry": null,
         "description": {
             "value": "<p>Orcish strength emboldens your bloodline. You have a green tinge to your skin and other indicators of orc heritage. You gain the orc trait, the dromaar trait, and low-light vision. When you gain an ancestry feat, you can choose from dromaar and orc feats in addition to those from your ancestry.</p>"
         },


### PR DESCRIPTION
As of Player Core, these are versatile heritages available to any ancestry (although most of them are human lorewise!)