### PR TITLE
Allow Class Might effect to select any attribute

### DIFF
--- a/packs/other-effects/effect-ancestral-might.json
+++ b/packs/other-effects/effect-ancestral-might.json
@@ -4,7 +4,7 @@
     "name": "Effect: Ancestral Might",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.quxPxuMub8k6abzN]{Ancestral Might}</p>\n<p>Until the start of your next turn, you gain a +2 status bonus to checks based on the attributes that are boosted by your ancestry (ignoring free boosts). If your ancestry only grants free boosts, select one attribute to gain the bonus to instead.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.quxPxuMub8k6abzN]{Ancestral Might}</p>\n<p>You gain a +2 status bonus to checks based on the attributes that are boosted by your ancestry (ignoring free boosts). If your ancestry only grants free boosts, select one attribute to gain the bonus to instead.</p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -23,88 +23,39 @@
         "rules": [
             {
                 "adjustName": false,
-                "choices": [
-                    {
-                        "label": "PF2E.AbilityStr",
-                        "value": "str-based"
-                    },
-                    {
-                        "label": "PF2E.AbilityDex",
-                        "value": "dex-based"
-                    },
-                    {
-                        "label": "PF2E.AbilityCon",
-                        "value": "con-based"
-                    },
-                    {
-                        "label": "PF2E.AbilityInt",
-                        "value": "int-based"
-                    },
-                    {
-                        "label": "PF2E.AbilityWis",
-                        "value": "wis-based"
-                    },
-                    {
-                        "label": "PF2E.AbilityCha",
-                        "value": "cha-based"
-                    }
-                ],
+                "choices": {
+                    "config": "abilities"
+                },
                 "flag": "firstBoost",
                 "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.HeroPointDeck.AncestralMight.FirstBoostPrompt"
+                "prompt": "PF2E.SpecificRule.HeroPointDeck.AncestralMight.FirstBoostPrompt",
+                "rollOption": "ancestral-might:first-boost"
             },
             {
                 "adjustName": false,
-                "choices": [
-                    {
-                        "label": "PF2E.SpecificRule.HeroPointDeck.AncestralMight.SkipChoice",
-                        "value": "skip"
-                    },
-                    {
-                        "label": "PF2E.AbilityStr",
-                        "value": "str-based"
-                    },
-                    {
-                        "label": "PF2E.AbilityDex",
-                        "value": "dex-based"
-                    },
-                    {
-                        "label": "PF2E.AbilityCon",
-                        "value": "con-based"
-                    },
-                    {
-                        "label": "PF2E.AbilityInt",
-                        "value": "int-based"
-                    },
-                    {
-                        "label": "PF2E.AbilityWis",
-                        "value": "wis-based"
-                    },
-                    {
-                        "label": "PF2E.AbilityCha",
-                        "value": "cha-based"
-                    }
-                ],
+                "allowNoSelection": true,
+                "choices": {
+                    "config": "abilities",
+                    "predicate": [
+                        {
+                            "not": "ancestral-might:first-boost:{choice|value}"
+                        }
+                    ]
+                },
                 "flag": "secondBoost",
                 "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.HeroPointDeck.AncestralMight.SecondBoostPrompt",
-                "rollOption": "ancestral-might"
+                "prompt": "PF2E.SpecificRule.HeroPointDeck.AncestralMight.SecondBoostPrompt"
             },
             {
                 "key": "FlatModifier",
-                "selector": "{item|flags.pf2e.rulesSelections.firstBoost}",
+                "selector": "{item|flags.pf2e.rulesSelections.firstBoost}-based",
                 "slug": "ancestral-might-first",
                 "type": "status",
                 "value": 2
             },
             {
                 "key": "FlatModifier",
-                "predicate": [
-                    {
-                        "not": "ancestral-might:skip"
-                    }
-                ],
-                "selector": "{item|flags.pf2e.rulesSelections.secondBoost}",
+                "selector": "{item|flags.pf2e.rulesSelections.secondBoost}-based",
                 "slug": "ancestral-might-second",
                 "type": "status",
                 "value": 2

--- a/packs/other-effects/effect-aura-of-protection.json
+++ b/packs/other-effects/effect-aura-of-protection.json
@@ -4,7 +4,7 @@
     "name": "Effect: Aura of Protection",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.7uERHpfJplGtYf8w]{Aura of Protection}</p>\n<p>Until the start of your next turn, you gain resistance to all damage equal to the rank of the spell that you just cast.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.7uERHpfJplGtYf8w]{Aura of Protection}</p>\n<p>You gain resistance to all damage equal to the rank of the spell that you just cast.</p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -143,7 +143,7 @@
             {
                 "key": "Resistance",
                 "type": "all-damage",
-                "value": "{item|flags.pf2e.rulesSelections.rank}"
+                "value": "@item.flags.pf2e.rulesSelections.rank"
             }
         ],
         "start": {

--- a/packs/other-effects/effect-called-foe.json
+++ b/packs/other-effects/effect-called-foe.json
@@ -4,7 +4,7 @@
     "name": "Effect: Called Foe",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.spzRl5CS4vnvcrm5]{Called Foe}</p>\n<p>Designate a foe that you can see. You gain a +2 status bonus to attack rolls made against that foe, but you take a -4 status penalty to attack rolls made against any other creature. This lasts until the end of your next turn or until you critically hit the designated foe, whichever comes first.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.spzRl5CS4vnvcrm5]{Called Foe}</p>\n<p>Designate a foe. You gain a +2 status bonus to attack rolls made against that foe, but you take a –4 status penalty to attack rolls made against any other creature.</p>"
         },
         "duration": {
             "expiry": "turn-end",
@@ -26,28 +26,20 @@
                 "slug": "called-foe"
             },
             {
-                "hideIfDisabled": true,
                 "key": "FlatModifier",
+                "selector": "attack-roll",
+                "type": "status",
+                "value": -4
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "upgrade",
                 "predicate": [
                     "target:mark:called-foe"
                 ],
                 "selector": "attack-roll",
-                "slug": "called-foe-bonus",
-                "type": "status",
+                "slug": "called-foe",
                 "value": 2
-            },
-            {
-                "hideIfDisabled": true,
-                "key": "FlatModifier",
-                "predicate": [
-                    {
-                        "not": "target:mark:called-foe"
-                    }
-                ],
-                "selector": "attack-roll",
-                "slug": "called-foe-penalty",
-                "type": "status",
-                "value": -4
             },
             {
                 "key": "Note",

--- a/packs/other-effects/effect-catch-your-breath.json
+++ b/packs/other-effects/effect-catch-your-breath.json
@@ -4,7 +4,7 @@
     "name": "Effect: Catch your Breath",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.LafJ1PXfnR4Ogyzh]{Catch your Breath}</p>\n<p>The creature you choose must have fewer than half their total Hit Points. The creature gains a number of temporary Hit Points equal to twice your level, which last until the end of the combat.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.LafJ1PXfnR4Ogyzh]{Catch your Breath}</p>\n<p>You gain a number of temporary Hit Points equal to twice the origin's level.</p>"
         },
         "duration": {
             "expiry": "turn-start",

--- a/packs/other-effects/effect-class-might.json
+++ b/packs/other-effects/effect-class-might.json
@@ -4,7 +4,7 @@
     "name": "Effect: Class Might",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.a68Phr1qsqVRPMVp]{Class Might}</p>\n<p>Until the start of your next turn you gain a +2 status bonus to checks based on the key attribute of your class. If your class grants a choice for its key attribute, select one of those attributes to gain the bonus.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.a68Phr1qsqVRPMVp]{Class Might}</p>\n<p>You gain a +2 status bonus to checks based on the key attribute of your class.</p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -22,8 +22,16 @@
         },
         "rules": [
             {
+                "choices": {
+                    "config": "abilities"
+                },
+                "flag": "attribute",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.Attribute"
+            },
+            {
                 "key": "FlatModifier",
-                "selector": "{actor|class.system.keyAbility.selected}-based",
+                "selector": "{actor|class.system.keyAbility.attribute}-based",
                 "type": "status",
                 "value": 2
             }

--- a/packs/other-effects/effect-critical-moment.json
+++ b/packs/other-effects/effect-critical-moment.json
@@ -4,7 +4,7 @@
     "name": "Effect: Critical Moment",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.P3mSUWRvCCwEouB0]{Critical Moment}</p>\n<p>Reroll the check twice and take the best result. This is a fortune effect. If you still fail this check, you become @UUID[Compendium.pf2e.conditionitems.Item.Doomed]{Doomed 1}.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.P3mSUWRvCCwEouB0]{Critical Moment}</p>\n<p>Reroll the check twice and take the best result. If you still fail this check, you become doomed 1.</p>"
         },
         "duration": {
             "expiry": "turn-end",
@@ -24,7 +24,6 @@
             {
                 "keep": "higher",
                 "key": "RollTwice",
-                "removeAfterRoll": true,
                 "selector": "check"
             },
             {

--- a/packs/other-effects/effect-daring-attempt.json
+++ b/packs/other-effects/effect-daring-attempt.json
@@ -4,7 +4,7 @@
     "name": "Effect: Daring Attempt",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.jHn1m1r95YgMQSvM]{Daring Attempt}</p>\n<p>Select one untrained skill. You are trained in that skill until the end of your next turn. If you use that skill before the end of your next turn and succeed at your skill check, you keep this benefit until the end of the combat, or for 1 minute if not in combat.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.jHn1m1r95YgMQSvM]{Daring Attempt}</p>\n<p>Select one untrained skill. You are trained in that skill.</p>"
         },
         "duration": {
             "expiry": null,
@@ -22,120 +22,12 @@
         },
         "rules": [
             {
-                "choices": [
-                    {
-                        "label": "PF2E.Skill.Acrobatics",
-                        "predicate": [
-                            "skill:acrobatics:rank:0"
-                        ],
-                        "value": "acrobatics"
-                    },
-                    {
-                        "label": "PF2E.Skill.Arcana",
-                        "predicate": [
-                            "skill:arcana:rank:0"
-                        ],
-                        "value": "arcana"
-                    },
-                    {
-                        "label": "PF2E.Skill.Athletics",
-                        "predicate": [
-                            "skill:athletics:rank:0"
-                        ],
-                        "value": "athletics"
-                    },
-                    {
-                        "label": "PF2E.Skill.Crafting",
-                        "predicate": [
-                            "skill:crafting:rank:0"
-                        ],
-                        "value": "crafting"
-                    },
-                    {
-                        "label": "PF2E.Skill.Deception",
-                        "predicate": [
-                            "skill:deception:rank:0"
-                        ],
-                        "value": "deception"
-                    },
-                    {
-                        "label": "PF2E.Skill.Diplomacy",
-                        "predicate": [
-                            "skill:diplomacy:rank:0"
-                        ],
-                        "value": "diplomacy"
-                    },
-                    {
-                        "label": "PF2E.Skill.Intimidation",
-                        "predicate": [
-                            "skill:intimidation:rank:0"
-                        ],
-                        "value": "intimidation"
-                    },
-                    {
-                        "label": "PF2E.Skill.Medicine",
-                        "predicate": [
-                            "skill:medicine:rank:0"
-                        ],
-                        "value": "medicine"
-                    },
-                    {
-                        "label": "PF2E.Skill.Nature",
-                        "predicate": [
-                            "skill:nature:rank:0"
-                        ],
-                        "value": "nature"
-                    },
-                    {
-                        "label": "PF2E.Skill.Occultism",
-                        "predicate": [
-                            "skill:occultism:rank:0"
-                        ],
-                        "value": "occultism"
-                    },
-                    {
-                        "label": "PF2E.Skill.Performance",
-                        "predicate": [
-                            "skill:performance:rank:0"
-                        ],
-                        "value": "performance"
-                    },
-                    {
-                        "label": "PF2E.Skill.Religion",
-                        "predicate": [
-                            "skill:religion:rank:0"
-                        ],
-                        "value": "religion"
-                    },
-                    {
-                        "label": "PF2E.Skill.Society",
-                        "predicate": [
-                            "skill:society:rank:0"
-                        ],
-                        "value": "society"
-                    },
-                    {
-                        "label": "PF2E.Skill.Stealth",
-                        "predicate": [
-                            "skill:stealth:rank:0"
-                        ],
-                        "value": "stealth"
-                    },
-                    {
-                        "label": "PF2E.Skill.Survival",
-                        "predicate": [
-                            "skill:survival:rank:0"
-                        ],
-                        "value": "survival"
-                    },
-                    {
-                        "label": "PF2E.Skill.Thievery",
-                        "predicate": [
-                            "skill:thievery:rank:0"
-                        ],
-                        "value": "thievery"
-                    }
-                ],
+                "choices": {
+                    "config": "skills",
+                    "predicate": [
+                        "skill:{choice|value}:rank:0"
+                    ]
+                },
                 "flag": "daringAttempt",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Prompt.Skill"

--- a/packs/other-effects/effect-desperate-swing.json
+++ b/packs/other-effects/effect-desperate-swing.json
@@ -4,7 +4,7 @@
     "name": "Effect: Desperate Swing",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.d15Zjdqplmj7ZTKK]{Desperate Swing}</p>\n<p>Make a Strike, ignoring the multiple attack penalty. If you roll a critical success, you get a normal success instead. If the attack fails, you release your weapon, or drop Prone if you were using an unarmed attack or otherwise can't release your weapon.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.d15Zjdqplmj7ZTKK]{Desperate Swing}</p>\n<p>Your Strike ignores the multiple attack penalty. If you roll a critical success, you get a normal success instead.</p>"
         },
         "duration": {
             "expiry": "turn-end",

--- a/packs/other-effects/effect-endure-the-onslaught.json
+++ b/packs/other-effects/effect-endure-the-onslaught.json
@@ -4,7 +4,7 @@
     "name": "Effect: Endure the Onslaught",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.TU21DvdpQG7U2Q9Y]{Endure the Onslaught}</p>\n<p>Give a creature you can see resistance 5 to all damage until the start of your next turn. If you are 7th level or higher, the resistance is 10, and if you are 12th level or higher, the resistance is 15.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.TU21DvdpQG7U2Q9Y]{Endure the Onslaught}</p>\n<p>You gain resistance to all damage.</p>"
         },
         "duration": {
             "expiry": "turn-start",

--- a/packs/other-effects/effect-fluid-motion.json
+++ b/packs/other-effects/effect-fluid-motion.json
@@ -4,7 +4,7 @@
     "name": "Effect: Fluid Motion",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.D6hqfmZUksRvqNFR]{Fluid Motion}</p>\n<p>For the rest of your turn, you gain a climb Speed and a swim Speed equal to half your Speed. If you make a horizontal Leap, increase the distance jumped by 10 feet.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.D6hqfmZUksRvqNFR]{Fluid Motion}</p>\n<p>You gain a climb Speed and a swim Speed equal to half your Speed.</p>"
         },
         "duration": {
             "expiry": "turn-end",

--- a/packs/other-effects/effect-impossible-shot.json
+++ b/packs/other-effects/effect-impossible-shot.json
@@ -4,7 +4,7 @@
     "name": "Effect: Impossible Shot",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.k0ue81dFKH4OKxed]{Impossible Shot}</p>\n<p>If you're attempting a Strike, double the range increment of the weapon or unarmed attack. If you're Casting a Spell, increase the range of the spell by half.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.k0ue81dFKH4OKxed]{Impossible Shot}</p>\n<p>You double the range increment of your weapon or unarmed attack.</p>"
         },
         "duration": {
             "expiry": "turn-end",

--- a/packs/other-effects/effect-rage-and-fury.json
+++ b/packs/other-effects/effect-rage-and-fury.json
@@ -4,7 +4,7 @@
     "name": "Effect: Rage and Fury",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.cQH9Syl1SQpbAi5A]{Rage and Fury}</p>\n<p>At the start of your next turn, you enter a rage (+2 damage to melee strikes, -1 AC penalty).</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.cQH9Syl1SQpbAi5A]{Rage and Fury}</p>\n<p>You gain a +2 bonus to damage to melee Strikes and a –1 AC penalty.</p>"
         },
         "duration": {
             "expiry": "turn-start",

--- a/packs/other-effects/effect-spark-of-courage.json
+++ b/packs/other-effects/effect-spark-of-courage.json
@@ -4,7 +4,7 @@
     "name": "Effect: Spark of Courage",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.EZZxz9jeEB0N3FPZ]{Spark of Courage}</p>\n<p>You gain a +2 status bonus to attack rolls and skill checks until the end of your next turn.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.EZZxz9jeEB0N3FPZ]{Spark of Courage}</p>\n<p>You gain a +2 status bonus to attack rolls and skill checks.</p>"
         },
         "duration": {
             "expiry": "turn-end",

--- a/packs/other-effects/effect-strike-true.json
+++ b/packs/other-effects/effect-strike-true.json
@@ -4,10 +4,10 @@
     "name": "Effect: Strike True",
     "system": {
         "description": {
-            "value": "<p>The target rolls twice and takes the higher result. This strike deals an extra die of damage on a hit if the attacker has fewer than half their maximum Hit Points, or two extra dice if they have fewer than one quarter their maximum Hit Points. This is a fortune effect.</p>\n<p>@UUID[Compendium.pf2e.other-effects.Item.Effect: Strike True]</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.journals.JournalEntry.BSp4LUSaOmUyjBko.JournalEntryPage.pS87Zh4QJnu0p8ES]{Strike True}</p>\n<p>You roll twice and take the higher result on your Strike. This Strike deals an extra die of damage on a hit if the attacker has fewer than half their maximum Hit Points, or two extra dice if they have fewer than one quarter their maximum Hit Points.</p>"
         },
         "duration": {
-            "expiry": "turn-end",
+            "expiry": "turn-start",
             "sustained": false,
             "unit": "rounds",
             "value": 1
@@ -24,6 +24,7 @@
             {
                 "keep": "higher",
                 "key": "RollTwice",
+                "removeAfterRoll": false,
                 "selector": "strike-attack-roll"
             },
             {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -3851,8 +3851,7 @@
             "HeroPointDeck": {
                 "AncestralMight": {
                     "FirstBoostPrompt": "Select one of your ancestry boosts, or pick any if it only had free boosts.",
-                    "SecondBoostPrompt": "Select another one of your ancestry boosts. Skip if it only had free boosts.",
-                    "SkipChoice": "Skip"
+                    "SecondBoostPrompt": "Select another one of your ancestry boosts. Decline if it only had free boosts."
                 },
                 "AuraOfProtection": {
                     "SpellRankPrompt": "Select the rank of the spell you just cast."
@@ -4550,6 +4549,7 @@
             "Prompt": {
                 "AdvancedMulticlassFeat": "Select a class feat up to half your character level.",
                 "Alignment": "Select an alignment.",
+                "Attribute": "Select an attribute.",
                 "Benefit": "Select a benefit.",
                 "Cantrip": "Select a cantrip.",
                 "CantripOrNonCantrip": "Select cantrip or non-cantrip spell.",


### PR DESCRIPTION
You choose among any of the possible key attributes for your class, so arbitrary choice is the best we can do.

Also clean up all the other Hero Point Deck effects.