### PR TITLE
Remove extraneous UUID redirect for Adventure actor

### DIFF
--- a/build/uuid-redirects.json
+++ b/build/uuid-redirects.json
@@ -527,7 +527,6 @@
     "Compendium.pf2e.pfs-season-1-bestiary.Actor.pJck5AXRMWcAequ5": "Compendium.pf2e.pathfinder-monster-core.Actor.Boggard Warrior",
     "Compendium.pf2e.pfs-season-4-bestiary.Actor.8xeZ6N46DLqnOw32": "Compendium.pf2e.npc-gallery.Actor.Charlatan",
     "Compendium.pf2e.pfs-season-4-bestiary.Actor.oH2KT9LhUs299AN9": "Compendium.pf2e.pathfinder-monster-core.Actor.Dero Stalker",
-    "Compendium.pf2e.seven-dooms-for-sandpoint-bestiary.Actor.6zMzd6ICd3p1Ye4q": "Compendium.pf2e.book-of-the-dead-bestiary.Actor.Geist",
     "Compendium.pf2e.spell-effects.Item.0o984LjzIFXxeXIF": "Compendium.pf2e.spell-effects.Item.Spell Effect: Evolution Surge",
     "Compendium.pf2e.spell-effects.Item.0q2716S34XL1y9Hh": "Compendium.pf2e.spell-effects.Item.Spell Effect: Rapid Adaptation",
     "Compendium.pf2e.spell-effects.Item.0R42NyuEZMVALjQs": "Compendium.pf2e.spell-effects.Item.Spell Effect: Traveler's Transit",


### PR DESCRIPTION
Geist in Seven Dooms for Sandpoint does not need a redirect to Monster Core.  These are different actors.