### PR TITLE
Add alchemical tool and alchemical food consumable tags

### DIFF
--- a/src/module/item/consumable/types.ts
+++ b/src/module/item/consumable/types.ts
@@ -3,6 +3,6 @@ import type { AMMO_STACK_GROUPS, CONSUMABLE_CATEGORIES } from "./values.ts";
 type AmmoStackGroup = SetElement<typeof AMMO_STACK_GROUPS>;
 type ConsumableCategory = SetElement<typeof CONSUMABLE_CATEGORIES>;
 type ConsumableTrait = keyof typeof CONFIG.PF2E.consumableTraits;
-type OtherConsumableTag = "alchemical-tool" | "herbal";
+type OtherConsumableTag = "alchemical-food" | "alchemical-tool" | "herbal";
 
 export type { AmmoStackGroup, ConsumableCategory, ConsumableTrait, OtherConsumableTag };

--- a/src/module/item/consumable/types.ts
+++ b/src/module/item/consumable/types.ts
@@ -3,6 +3,6 @@ import type { AMMO_STACK_GROUPS, CONSUMABLE_CATEGORIES } from "./values.ts";
 type AmmoStackGroup = SetElement<typeof AMMO_STACK_GROUPS>;
 type ConsumableCategory = SetElement<typeof CONSUMABLE_CATEGORIES>;
 type ConsumableTrait = keyof typeof CONFIG.PF2E.consumableTraits;
-type OtherConsumableTag = "herbal";
+type OtherConsumableTag = "alchemical-tool" | "herbal";
 
 export type { AmmoStackGroup, ConsumableCategory, ConsumableTrait, OtherConsumableTag };

--- a/src/scripts/config/traits.ts
+++ b/src/scripts/config/traits.ts
@@ -562,6 +562,7 @@ const otherArmorTags: Record<OtherArmorTag, string> = {
 };
 
 const otherConsumableTags: Record<OtherConsumableTag, string> = {
+    "alchemical-food": "PF2E.Item.Physical.OtherTag.AlchemicalFood",
     "alchemical-tool": "PF2E.Item.Physical.OtherTag.AlchemicalTool",
     herbal: "PF2E.Item.Physical.OtherTag.Herbal",
 };

--- a/src/scripts/config/traits.ts
+++ b/src/scripts/config/traits.ts
@@ -562,6 +562,7 @@ const otherArmorTags: Record<OtherArmorTag, string> = {
 };
 
 const otherConsumableTags: Record<OtherConsumableTag, string> = {
+    "alchemical-tool": "PF2E.Item.Physical.OtherTag.AlchemicalTool",
     herbal: "PF2E.Item.Physical.OtherTag.Herbal",
 };
 

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2479,6 +2479,7 @@
                 },
                 "LevelLabel": "Item {level}",
                 "OtherTag": {
+                    "AlchemicalTool": "Alchemical Tool",
                     "HandwrapsOfMightyBlows": "Handwraps of Mighty Blows",
                     "Herbal": "Herbal",
                     "Improvised": "Improvised",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2479,6 +2479,7 @@
                 },
                 "LevelLabel": "Item {level}",
                 "OtherTag": {
+                    "AlchemicalFood": "Alchemical Food",
                     "AlchemicalTool": "Alchemical Tool",
                     "HandwrapsOfMightyBlows": "Handwraps of Mighty Blows",
                     "Herbal": "Herbal",


### PR DESCRIPTION
This would be useful to build the investigator's Quick Tincture and Wandering Chef's Quick Alchemy Crafting Ability rule elements.