### PR TITLE
Move Quick-Tempered effects to its Note

### DIFF
--- a/packs/actions/quick-tempered.json
+++ b/packs/actions/quick-tempered.json
@@ -11,7 +11,7 @@
         },
         "category": "offensive",
         "description": {
-            "value": "<p><strong>Trigger</strong> You roll initiative.</p>\n<p><strong>Requirements</strong> You are not @UUID[Compendium.pf2e.conditionitems.Item.Encumbered] or wearing heavy armor.</p><hr /><p>So long as you are able to move freely, your fury is instinctive and instantaneous. You @UUID[Compendium.pf2e.actionspf2e.Item.Rage].</p><hr /><p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Rage]</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Rage Temporary Hit Points Immunity]</p>"
+            "value": "<p><strong>Trigger</strong> You roll initiative.</p>\n<p><strong>Requirements</strong> You are not @UUID[Compendium.pf2e.conditionitems.Item.Encumbered] or wearing heavy armor.</p><hr /><p>So long as you are able to move freely, your fury is instinctive and instantaneous. You @UUID[Compendium.pf2e.actionspf2e.Item.Rage].</p>"
         },
         "publication": {
             "license": "ORC",
@@ -35,7 +35,7 @@
                     }
                 ],
                 "selector": "initiative",
-                "text": "{item|description}",
+                "text": "{item|description}\n@UUID[Compendium.pf2e.feat-effects.Item.Effect: Rage]\n@UUID[Compendium.pf2e.feat-effects.Item.Effect: Rage Temporary Hit Points Immunity]",
                 "title": "{item|name} <span class=\"action-glyph\">F</span>"
             }
         ],

--- a/packs/feat-effects/effect-rage-temporary-hit-points-immunity.json
+++ b/packs/feat-effects/effect-rage-temporary-hit-points-immunity.json
@@ -4,7 +4,7 @@
     "name": "Effect: Rage Temporary Hit Points Immunity",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.actionspf2e.Item.Rage]</p>\n<p>You can't gain temporary Hit Points from using the Rage action again for 1 minute.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.actionspf2e.Item.Rage]</p>\n<p>You can't gain temporary Hit Points from using the Rage action.</p>"
         },
         "duration": {
             "expiry": "turn-start",


### PR DESCRIPTION
The description looked real weird (see below). The feat has both a self-applied effect and a roll Note on initiative. This keeps both implementations happy.
![image](https://github.com/user-attachments/assets/4b1f3a21-657a-4b7c-be20-049d9a3e24ec)
