### PR TITLE
Replace Blast Resistance Note RE with DoS adjustment, Remove Tide Hardened Note RE

### DIFF
--- a/packs/feats/blast-resistance.json
+++ b/packs/feats/blast-resistance.json
@@ -35,7 +35,7 @@
                     "condition:deafened"
                 ],
                 "selector": "saving-throw",
-                "text": "When you roll a success on a save against a cold or water effect, you get a critical success instead.",
+                "text": "PF2E.SpecificRule.Dwarf.BlastResistance.Note",
                 "title": "{item|name}"
             },
             {

--- a/packs/feats/blast-resistance.json
+++ b/packs/feats/blast-resistance.json
@@ -32,7 +32,7 @@
                 ],
                 "predicate": [
                     "auditory",
-                    "condition:deafened"
+                    "inflicts:deafened"
                 ],
                 "selector": "saving-throw",
                 "text": "PF2E.SpecificRule.Dwarf.BlastResistance.Note",

--- a/packs/feats/blast-resistance.json
+++ b/packs/feats/blast-resistance.json
@@ -26,17 +26,16 @@
         },
         "rules": [
             {
-                "key": "Note",
-                "outcome": [
-                    "success"
-                ],
+                "adjustment": {
+                    "success": "one-degree-better"
+                },
+                "key": "AdjustDegreeOfSuccess",
                 "predicate": [
                     "auditory",
                     "inflicts:deafened"
                 ],
                 "selector": "saving-throw",
-                "text": "PF2E.SpecificRule.Dwarf.BlastResistance.Note",
-                "title": "{item|name}"
+                "type": "save"
             },
             {
                 "key": "Resistance",

--- a/packs/feats/tide-hardened.json
+++ b/packs/feats/tide-hardened.json
@@ -26,23 +26,6 @@
         },
         "rules": [
             {
-                "key": "Note",
-                "outcome": [
-                    "success"
-                ],
-                "predicate": [
-                    {
-                        "or": [
-                            "cold",
-                            "water"
-                        ]
-                    }
-                ],
-                "selector": "saving-throw",
-                "text": "PF2E.SpecificRule.Undine.TideHardened.Note",
-                "title": "{item|name}"
-            },
-            {
                 "adjustment": {
                     "success": "one-degree-better"
                 },

--- a/packs/feats/tide-hardened.json
+++ b/packs/feats/tide-hardened.json
@@ -39,7 +39,7 @@
                     }
                 ],
                 "selector": "saving-throw",
-                "text": "When you roll a success on a save against a cold or water effect, you get a critical success instead.",
+                "text": "PF2E.SpecificRule.Undine.TideHardened.Note",
                 "title": "{item|name}"
             },
             {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -3046,9 +3046,6 @@
                 "Note": "When you fail (but don't critically fail) a Recall Knowledge check using any skill, you learn the correct answer and an erroneous answer, but you don't have any way to differentiate which is which."
             },
             "Dwarf": {
-                "BlastResistance": {
-                    "Note": "If you roll a success on a saving throw against an auditory effect that causes the @UUID[Compendium.pf2e.conditionitems.Item.9PR9y0bi4JPKnHPR]{Deafened} condition, you get a critical success instead."
-                },
                 "DeathWardenDwarf": {
                     "Note": "If you roll a success on a saving throw against an effect that has the void trait or was created by an undead creature, you get a critical success instead."
                 },
@@ -5642,11 +5639,6 @@
             "UndeadSlayer": {
                 "SlayersPresence": {
                     "Note": "The target is @UUID[Compendium.pf2e.conditionitems.Item.sDPxOjQ9kx2RZE8D]{Fleeing} for 1 round."
-                }
-            },
-            "Undine": {
-                "TideHardened": {
-                    "Note": "When you roll a success on a save against a cold or water effect, you get a critical success instead."
                 }
             },
             "UntamedShift": {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2675,7 +2675,7 @@
                     "witch": {
                         "Expert": "You've learned to better control the power your patron has granted you. Your proficiency ranks for spell attack modifier and spell DC increase to expert.",
                         "Legendary": "You've perfected your command of the magic your patron provides. Your proficiency ranks for spell attack modifier and spell DC increase to legendary.",
-                        "Master": "You've achieved mastery over your patron's magic. Your proficiency ranks for spell attack modifier and spell DC increase to master."                        
+                        "Master": "You've achieved mastery over your patron's magic. Your proficiency ranks for spell attack modifier and spell DC increase to master."
                     },
                     "wizard": {
                         "Expert": "Extended practice of the arcane has improved your capabilities. Your proficiency ranks for spell attack modifier and spell DC increase to expert.",
@@ -3046,6 +3046,9 @@
                 "Note": "When you fail (but don't critically fail) a Recall Knowledge check using any skill, you learn the correct answer and an erroneous answer, but you don't have any way to differentiate which is which."
             },
             "Dwarf": {
+                "BlastResistance": {
+                    "Note": "If you roll a success on a saving throw against an auditory effect that causes the @UUID[Compendium.pf2e.conditionitems.Item.9PR9y0bi4JPKnHPR]{Deafened} condition, you get a critical success instead."
+                },
                 "DeathWardenDwarf": {
                     "Note": "If you roll a success on a saving throw against an effect that has the void trait or was created by an undead creature, you get a critical success instead."
                 },
@@ -5639,6 +5642,11 @@
             "UndeadSlayer": {
                 "SlayersPresence": {
                     "Note": "The target is @UUID[Compendium.pf2e.conditionitems.Item.sDPxOjQ9kx2RZE8D]{Fleeing} for 1 round."
+                }
+            },
+            "Undine": {
+                "TideHardened": {
+                    "Note": "When you roll a success on a save against a cold or water effect, you get a critical success instead."
                 }
             },
             "UntamedShift": {


### PR DESCRIPTION
It used to be the same as Undine's Tide Hardened.
Added both to re-en.json

Also, I'm not sure that this Blast Resistance RE even works properly. Is there anything that even uses `condition:deafened` as a roll option? Maybe it's better to remove this part of the predicate, so that the note still pops up at times?