### PR TITLE
Ensure GM-only browser tabs are only viewable by GMs

### DIFF
--- a/src/module/actor/character/apps/abc-picker/app.svelte
+++ b/src/module/actor/character/apps/abc-picker/app.svelte
@@ -64,6 +64,7 @@
             <button
                 type="button"
                 class="confirm"
+                aria-labelledby="tooltip"
                 data-tooltip="PF2E.Actor.Character.ABCPicker.Tooltip.ConfirmSelection"
                 onclick={saveSelection}><i class="fa-solid fa-check"></i></button
             >

--- a/src/module/actor/character/apps/formula-picker/app.svelte
+++ b/src/module/actor/character/apps/formula-picker/app.svelte
@@ -66,7 +66,11 @@
                         <span>{formula.item.name}</span>
                         <ItemTraits traits={formula.item.traits} rarity={formula.item.rarity} />
                     </div>
-                    <button onclick={() => confirmSelection(formula.item.uuid)} data-tooltip="Confirm">
+                    <button
+                        onclick={() => confirmSelection(formula.item.uuid)}
+                        aria-labelledby="tooltip"
+                        data-tooltip="Confirm"
+                    >
                         <i class="fa-solid fa-fw fa-check"></i>
                     </button>
                     <ItemSummary

--- a/src/module/apps/compendium-browser/browser.ts
+++ b/src/module/apps/compendium-browser/browser.ts
@@ -150,7 +150,7 @@ class CompendiumBrowser extends SvelteApplicationMixin(foundryApp.ApplicationV2)
 
     resetListElement(): void {
         this.activeTab.resultLimit = CompendiumBrowser.RESULT_LIMIT;
-        this.$state.resultList.scrollTo({ top: 0, behavior: "instant" });
+        this.$state.resultList?.scrollTo({ top: 0, behavior: "instant" });
     }
 
     async openTab(tabName: TabName, options?: CompendiumBrowserOpenTabOptions): Promise<void> {

--- a/src/module/apps/compendium-browser/components/browser-tab.svelte
+++ b/src/module/apps/compendium-browser/components/browser-tab.svelte
@@ -25,6 +25,13 @@
             tab.resultLimit += CompendiumBrowser.RESULT_LIMIT;
         }
     }
+
+    $effect(() => {
+        if (tab.isGMOnly && !game.user.isGM) {
+            props.state.activeTabName = "";
+            console.error("PF2e System | This browser tab is flagged as GM-only!");
+        }
+    });
 </script>
 
 <div class="browser-tab" data-tab-name={activeTabName} data-tooltip-class="pf2e">

--- a/src/module/apps/compendium-browser/components/filters.svelte
+++ b/src/module/apps/compendium-browser/components/filters.svelte
@@ -53,18 +53,10 @@
                         {/each}
                     </select>
                     <button onclick={onChangeSortOrder} aria-labelledby="sort-order" type="button" class="order-button">
-                        {#if filter.order.type === "alpha"}
-                            {#if filter.order.direction === "asc"}
-                                <i class="fa-solid fa-sort-alpha-up"></i>
-                            {:else}
-                                <i class="fa-solid fa-sort-alpha-down-alt"></i>
-                            {/if}
-                        {:else if filter.order.type === "numeric"}
-                            {#if filter.order.direction === "asc"}
-                                <i class="fa-solid fa-sort-numeric-up"></i>
-                            {:else}
-                                <i class="fa-solid fa-sort-numeric-down-alt"></i>
-                            {/if}
+                        {#if filter.order.direction === "asc"}
+                            <i class="fa-solid fa-sort-{filter.order.type}-up"></i>
+                        {:else}
+                            <i class="fa-solid fa-sort-{filter.order.type}-down-alt"></i>
                         {/if}
                     </button>
                 </div>

--- a/src/module/apps/compendium-browser/components/filters/level.svelte
+++ b/src/module/apps/compendium-browser/components/filters/level.svelte
@@ -53,7 +53,6 @@
             justify-content: space-between;
             margin-top: 0.5em;
 
-            input,
             select {
                 width: 45%;
             }

--- a/src/module/apps/compendium-browser/tabs/base.svelte.ts
+++ b/src/module/apps/compendium-browser/tabs/base.svelte.ts
@@ -39,8 +39,6 @@ export abstract class CompendiumBrowserTab {
     protected abstract tabLabel: string;
     /** Whether this tab is visible in the browser */
     visible = $state(true);
-    /** Whether this tab is only visible to a GM */
-    isGMOnly = false;
     /** Minisearch */
     declare searchEngine: MiniSearch<CompendiumBrowserIndexData>;
     /** Names of the document fields to be indexed. */
@@ -55,6 +53,11 @@ export abstract class CompendiumBrowserTab {
     /** The localized label for this tab */
     get label(): string {
         return game.i18n.localize(this.tabLabel);
+    }
+
+    /** Whether this tab is only visible to a GM */
+    get isGMOnly(): boolean {
+        return false;
     }
 
     constructor(browser: CompendiumBrowser) {

--- a/src/module/apps/compendium-browser/tabs/bestiary.ts
+++ b/src/module/apps/compendium-browser/tabs/bestiary.ts
@@ -8,7 +8,6 @@ export class CompendiumBrowserBestiaryTab extends CompendiumBrowserTab {
     tabName: ContentTabName = "bestiary";
     tabLabel = "PF2E.CompendiumBrowser.TabBestiary";
     declare filterData: BestiaryFilters;
-    override isGMOnly = true;
 
     protected index = [
         "img",
@@ -27,6 +26,10 @@ export class CompendiumBrowserBestiaryTab extends CompendiumBrowserTab {
 
         // Set the filterData object of this tab
         this.filterData = this.prepareFilterData();
+    }
+
+    override get isGMOnly(): boolean {
+        return true;
     }
 
     protected override async loadData(): Promise<void> {

--- a/src/module/apps/compendium-browser/tabs/hazard.ts
+++ b/src/module/apps/compendium-browser/tabs/hazard.ts
@@ -8,7 +8,6 @@ export class CompendiumBrowserHazardTab extends CompendiumBrowserTab {
     tabName: ContentTabName = "hazard";
     tabLabel = "PF2E.Actor.Hazard.Plural";
     declare filterData: HazardFilters;
-    override isGMOnly = true;
 
     /* MiniSearch */
     override searchFields = ["name", "originalName"];
@@ -21,6 +20,10 @@ export class CompendiumBrowserHazardTab extends CompendiumBrowserTab {
 
         // Set the filterData object of this tab
         this.filterData = this.prepareFilterData();
+    }
+
+    override get isGMOnly(): boolean {
+        return true;
     }
 
     protected override async loadData(): Promise<void> {


### PR DESCRIPTION
There were still two ways to view GM-only tabs without GM persmission. Those should be adressed now.
Also includes minor cleanup and adresses some Svelte warnings in other files.