### PR TITLE
Rename Hellknight Signifier to Signifer in feat prerequisites

### DIFF
--- a/packs/crown-of-the-kobold-king-bestiary/dark-talon-kobold.json
+++ b/packs/crown-of-the-kobold-king-bestiary/dark-talon-kobold.json
@@ -279,7 +279,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p><strong>Frequency</strong> once per day; Requirement The Dark Talon kobold is adjacent to at least one enemy, and the Dark Talon has fewer than 12 Hit Points;</p>\n<p><strong>Effect</strong> The Dark Talon shrieks in fury and regains @Damage[2d6[healing]] Hit Points.</p>"
+                    "value": "<p><strong>Frequency</strong> once per day</p>\n<p><strong>Requirements</strong> The Dark Talon kobold is adjacent to at least one enemy, and the Dark Talon has fewer than 12 Hit Points.</p>\n<p><strong>Effect</strong> The Dark Talon shrieks in fury and regains @Damage[2d6[healing]] Hit Points.</p>"
                 },
                 "frequency": {
                     "max": 1,

--- a/packs/crown-of-the-kobold-king-bestiary/dark-talon-kobold.json
+++ b/packs/crown-of-the-kobold-king-bestiary/dark-talon-kobold.json
@@ -279,7 +279,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p><strong>Frequency</strong> once per day</p>\n<p><strong>Requirements</strong> The Dark Talon kobold is adjacent to at least one enemy, and the Dark Talon has fewer than 12 Hit Points.</p>\n<p><strong>Effect</strong> The Dark Talon shrieks in fury and regains @Damage[2d6[healing]] Hit Points.</p>"
+                    "value": "<p><strong>Frequency</strong> once per day</p>\n<p><strong>Requirement</strong> The Dark Talon kobold is adjacent to at least one enemy, and the Dark Talon has fewer than 12 Hit Points</p><hr /><p><strong>Effect</strong> The Dark Talon shrieks in fury and regains @Damage[2d6[healing]] Hit Points.</p>"
                 },
                 "frequency": {
                     "max": 1,

--- a/packs/crown-of-the-kobold-king-bestiary/kieragan-skross.json
+++ b/packs/crown-of-the-kobold-king-bestiary/kieragan-skross.json
@@ -514,7 +514,7 @@
                 "compendiumSource": "Compendium.pf2e.equipment-srd.Item.plplsXJsqrdqNQVI"
             },
             "img": "icons/commodities/treasure/broach-jeweled-green.webp",
-            "name": "Defiled Religions Symbol of Droskar",
+            "name": "Defiled Religious Symbol of Droskar",
             "sort": 700000,
             "system": {
                 "baseItem": null,

--- a/packs/equipment/hellknight-half-plate.json
+++ b/packs/equipment/hellknight-half-plate.json
@@ -12,7 +12,7 @@
         "checkPenalty": -3,
         "containerId": null,
         "description": {
-            "value": "<p>Hellknights wear a variety of armors decorated with designs specific to the order. Hellknight half plate is the armor of choice for Hellknight signifiers.</p>\n<p>A character who is a member of the Hellknights has access to these uncommon armors.</p>"
+            "value": "<p>Hellknights wear a variety of armors decorated with designs specific to the order. Hellknight half plate is the armor of choice for Hellknight signifers.</p>\n<p>A character who is a member of the Hellknights has access to these uncommon armors.</p>"
         },
         "dexCap": 1,
         "group": "plate",

--- a/packs/feats/advanced-order-training.json
+++ b/packs/feats/advanced-order-training.json
@@ -19,7 +19,10 @@
         "prerequisites": {
             "value": [
                 {
-                    "value": "Hellknight Armiger Dedication, Hellknight Dedication or Hellknight Signifer Dedication"
+                    "value": "Hellknight Armiger Dedication"
+                },
+                {
+                    "value": "Hellknight Dedication or Hellknight Signifer Dedication"
                 }
             ]
         },

--- a/packs/feats/advanced-order-training.json
+++ b/packs/feats/advanced-order-training.json
@@ -19,7 +19,7 @@
         "prerequisites": {
             "value": [
                 {
-                    "value": "Hellknight Armiger Dedication, Hellknight Dedication or Hellknight Signifier Dedication"
+                    "value": "Hellknight Armiger Dedication, Hellknight Dedication or Hellknight Signifer Dedication"
                 }
             ]
         },

--- a/packs/feats/gaze-of-veracity.json
+++ b/packs/feats/gaze-of-veracity.json
@@ -19,7 +19,7 @@
         "prerequisites": {
             "value": [
                 {
-                    "value": "Hellknight Signifier Dedication"
+                    "value": "Hellknight Signifer Dedication"
                 },
                 {
                     "value": "ability to cast focus spells"


### PR DESCRIPTION
So that the name matches the dedication name.
They are also called signifiers in Hellknight Half Plate description, but that's in flavor, so I didn't make a change there. Should I do that as well?

Also, fixed a typo and a minor formatting error in CotKK bestiary.