### PR TITLE
Correct Greatpick price

### DIFF
--- a/packs/equipment/greatpick.json
+++ b/packs/equipment/greatpick.json
@@ -38,7 +38,7 @@
         },
         "price": {
             "value": {
-                "gp": 2
+                "gp": 1
             }
         },
         "publication": {


### PR DESCRIPTION
Greatpick price was incorrectly listed as 2 gp instead of 1 gp.