### PR TITLE
Correct Pilgrim's Token price

### DIFF
--- a/packs/equipment/pilgrims-token.json
+++ b/packs/equipment/pilgrims-token.json
@@ -9,7 +9,7 @@
         },
         "containerId": null,
         "description": {
-            "value": "<p>This wooden religious symbol is a small token of protection from a site holy to your faith. As long as this religious symbol is in your possession, when you tie an adversary's initiative roll, you go first.</p><p>If you lose this religious symbol, you must purchase or Craft a replacement and attune it. Such a token usually costs at least 1 sp, and the attunement takes 10 minutes of prayer. You can also attune a different religious symbol with the same amount of time, but you lose the benefit of the previous religious symbol.</p>"
+            "value": "<p>This wooden religious symbol is a small token of protection from a site holy to your faith. As long as this religious symbol is in your possession, when you tie an adversary's initiative roll, you go first.</p>\n<p>If you lose this religious symbol, you must purchase or Craft a replacement and attune it. Such a token usually costs at least 1 sp, and the attunement takes 10 minutes of prayer. You can also attune a different religious symbol with the same amount of time, but you lose the benefit of the previous religious symbol.</p>"
         },
         "hardness": 0,
         "hp": {

--- a/packs/equipment/pilgrims-token.json
+++ b/packs/equipment/pilgrims-token.json
@@ -25,7 +25,7 @@
         },
         "price": {
             "value": {
-                "sp": 2
+                "sp": 1
             }
         },
         "publication": {

--- a/packs/equipment/pilgrims-token.json
+++ b/packs/equipment/pilgrims-token.json
@@ -29,7 +29,7 @@
             }
         },
         "publication": {
-            "license": "OGL",
+            "license": "ORC",
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },

--- a/packs/equipment/pilgrims-token.json
+++ b/packs/equipment/pilgrims-token.json
@@ -5,11 +5,11 @@
     "system": {
         "baseItem": null,
         "bulk": {
-            "value": 0
+            "value": 0.1
         },
         "containerId": null,
         "description": {
-            "value": "<p>A small token of protection from a site holy to your faith, or you touched your religious symbol to a relic or altar at such a site. So long as this token is in your possession, when you tie an adversary's initiative roll, you go first.</p>\n<hr />\n<p><strong>Special</strong> If you select the @UUID[Compendium.pf2e.feats-srd.Item.Pilgrim's Token] feat at 1st level, you receive your pilgrim's token for free. Alternately, if you have a religious symbol, it is already attuned, as described above.</p>\n<p>If you select this feat at a later level, or if you lose your pilgrim's token, you must purchase or Craft a replacement and attune it at a holy site. Such a token usually costs at least 2 sp, and the attunement takes 10 minutes of prayer and requires a successful @Check[religion|dc:20|name:Attune to Pilgrim's Token] check. Your GM might adjust the price and DC depending on the token's material and quality and the religious significance of the site; the more significant the location, the easier the attunement.</p>"
+            "value": "<p>This wooden religious symbol is a small token of protection from a site holy to your faith. As long as this religious symbol is in your possession, when you tie an adversary's initiative roll, you go first.</p><p>If you lose this religious symbol, you must purchase or Craft a replacement and attune it. Such a token usually costs at least 1 sp, and the attunement takes 10 minutes of prayer. You can also attune a different religious symbol with the same amount of time, but you lose the benefit of the previous religious symbol.</p>"
         },
         "hardness": 0,
         "hp": {
@@ -30,8 +30,8 @@
         },
         "publication": {
             "license": "OGL",
-            "remaster": false,
-            "title": "Pathfinder Advanced Player's Guide"
+            "remaster": true,
+            "title": "Pathfinder Player Core 2"
         },
         "quantity": 1,
         "rules": [
@@ -48,7 +48,7 @@
             "value": []
         },
         "usage": {
-            "value": "worn"
+            "value": "other"
         }
     },
     "type": "equipment"


### PR DESCRIPTION
Item from the feat is a wooden religious symbol, so its price should be 1 sp instead of 2 sp.