### PR TITLE
Update Efficient Alchemy feat RE's for remaster Alchemist

### DIFF
--- a/packs/classfeatures/advanced-alchemy.json
+++ b/packs/classfeatures/advanced-alchemy.json
@@ -45,7 +45,7 @@
                 "predicate": [
                     "class:alchemist"
                 ],
-                "value": "@actor.level + @actor.abilities.int.mod"
+                "value": "4 + @actor.abilities.int.mod"
             },
             {
                 "key": "ActiveEffectLike",
@@ -56,7 +56,7 @@
                         "not": "class:alchemist"
                     }
                 ],
-                "value": "@actor.level"
+                "value": "4"
             }
         ],
         "traits": {

--- a/packs/feats/advanced-efficient-alchemy.json
+++ b/packs/feats/advanced-efficient-alchemy.json
@@ -28,7 +28,30 @@
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "system.resources.crafting.infusedReagents.max",
+                "predicate": [
+                    "class:alchemist"
+                ],
+                "value": {
+                    "brackets": [
+                        {
+                            "end": 15,
+                            "start": 10,
+                            "value": "8 + @actor.abilities.int.mod"
+                        },
+                        {
+                            "end": 20,
+                            "start": 16,
+                            "value": "10 + @actor.abilities.int.mod"
+                        }
+                    ]
+                }
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/efficient-alchemy-alchemist.json
+++ b/packs/feats/efficient-alchemy-alchemist.json
@@ -24,7 +24,17 @@
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "system.resources.crafting.infusedReagents.max",
+                "predicate": [
+                    "class:alchemist"
+                ],
+                "value": "6 + @actor.abilities.int.mod"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/efficient-alchemy-paragon.json
+++ b/packs/feats/efficient-alchemy-paragon.json
@@ -27,14 +27,14 @@
         "rules": [
             {
                 "key": "ActiveEffectLike",
-                "mode": "updgrade",
+                "mode": "upgrade",
                 "path": "system.crafting.entries.alchemist.batchSize",
                 "phase": "beforeDerived",
                 "value": 3
             },
             {
                 "key": "ActiveEffectLike",
-                "mode": "updgrade",
+                "mode": "upgrade",
                 "path": "system.crafting.entries.alchemist.fieldDiscoveryBatchSize",
                 "phase": "beforeDerived",
                 "value": 4


### PR DESCRIPTION
- Updates the Efficient Alchemy class feat REs to adjust the Infused Reagents for Daily Crafting for the Remaster Alchemist.
- Updates Advanced Alchemy class feature REs for the Remaster Alchemist Infused Reagents base number.
- Fixes typo in the RE for Efficient Alchemy (Paragon) feat.
