### PR TITLE
Remove effects from Eye of the Unseen

### DIFF
--- a/packs/equipment-effects/effect-eye-of-the-unseen-greater.json
+++ b/packs/equipment-effects/effect-eye-of-the-unseen-greater.json
@@ -24,7 +24,7 @@
             {
                 "key": "FlatModifier",
                 "predicate": [
-                    "visual"
+                    "item:trait:visual"
                 ],
                 "selector": "perception",
                 "type": "item",

--- a/packs/equipment-effects/effect-eye-of-the-unseen.json
+++ b/packs/equipment-effects/effect-eye-of-the-unseen.json
@@ -24,7 +24,7 @@
             {
                 "key": "FlatModifier",
                 "predicate": [
-                    "visual"
+                    "item:trait:visual"
                 ],
                 "selector": "perception",
                 "type": "item",

--- a/packs/equipment/eye-of-the-unseen-greater.json
+++ b/packs/equipment/eye-of-the-unseen-greater.json
@@ -9,7 +9,7 @@
         },
         "containerId": null,
         "description": {
-            "value": "<p>This prosthetic eye was designed by elven crafters but comes in a range of appearances for different ancestries. While wearing the eye, you gain a +2 item bonus to visual Perception checks.</p>\n<hr />\n<p><strong>Activate</strong> <span class=\"action-glyph\">2</span> command, envision</p>\n<p><strong>Frequency</strong> once per day</p>\n<hr />\n<p><strong>Effect</strong> You focus on the eye to see the unseen. The eye casts 5th-rank @UUID[Compendium.pf2e.spells-srd.Item.See the Unseen] on you.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Eye of the Unseen (Greater)]</p>"
+            "value": "<p>This prosthetic eye was designed by elven crafters but comes in a range of appearances for different ancestries. While wearing the eye, you gain a +2 item bonus to visual Perception checks.</p><hr /><p><strong>Activate</strong> <span class=\"action-glyph\">2</span> command, envision</p>\n<p><strong>Frequency</strong> once per day</p><hr /><p><strong>Effect</strong> You focus on the eye to see the unseen. The eye casts 5th-rank @UUID[Compendium.pf2e.spells-srd.Item.See the Unseen] on you.</p>"
         },
         "hardness": 0,
         "hp": {
@@ -38,7 +38,7 @@
             {
                 "key": "FlatModifier",
                 "predicate": [
-                    "visual"
+                    "item:trait:visual"
                 ],
                 "selector": "perception",
                 "type": "item",

--- a/packs/equipment/eye-of-the-unseen.json
+++ b/packs/equipment/eye-of-the-unseen.json
@@ -9,7 +9,7 @@
         },
         "containerId": null,
         "description": {
-            "value": "<p>This prosthetic eye was designed by elven crafters but comes in a range of appearances for different ancestries. While wearing the eye, you gain a +1 item bonus to visual Perception checks.</p>\n<hr />\n<p><strong>Activate</strong> <span class=\"action-glyph\">2</span> command, envision</p>\n<p><strong>Frequency</strong> once per day</p>\n<hr />\n<p><strong>Effect</strong> You focus on the eye to see the unseen. The eye casts @UUID[Compendium.pf2e.spells-srd.Item.See the Unseen] on you.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Eye of the Unseen]</p>"
+            "value": "<p>This prosthetic eye was designed by elven crafters but comes in a range of appearances for different ancestries. While wearing the eye, you gain a +1 item bonus to visual Perception checks.</p><hr /><p><strong>Activate</strong> <span class=\"action-glyph\">2</span> command, envision</p>\n<p><strong>Frequency</strong> once per day</p><hr /><p><strong>Effect</strong> You focus on the eye to see the unseen. The eye casts @UUID[Compendium.pf2e.spells-srd.Item.See the Unseen] on you.</p>"
         },
         "hardness": 0,
         "hp": {
@@ -38,7 +38,7 @@
             {
                 "key": "FlatModifier",
                 "predicate": [
-                    "visual"
+                    "item:trait:visual"
                 ],
                 "selector": "perception",
                 "type": "item",


### PR DESCRIPTION
Turns out the RE was already in the item - nobody bothered to remove the links to the effects. 