### PR TITLE
Add applicable modifiers to battle form unarmed modifier comparison

### DIFF
--- a/src/module/rules/rule-element/battle-form/rule-element.ts
+++ b/src/module/rules/rule-element/battle-form/rule-element.ts
@@ -428,17 +428,13 @@ class BattleFormRuleElement extends RuleElementPF2e<BattleFormRuleSchema> {
         const strikeActions = actor.system.actions.flatMap((s): CharacterStrike[] => [s, ...s.altUsages]);
 
         for (const action of strikeActions) {
-            const strike = (strikes[action.slug ?? ""] ?? null) as BattleFormStrike | null;
-            const applicableModifiers = action.modifiers
+            const strike = strikes[action.slug ?? ""];
+            if (!strike) continue;
+            const addend = action.modifiers
                 .filter((m) => m.enabled && this.#filterModifier(m))
-                .reduce((partialSum, m) => partialSum + m.modifier, 0);
-
-            if (
-                !this.ownUnarmed &&
-                strike &&
-                (Number(this.resolveValue(strike.modifier)) + applicableModifiers >= action.totalModifier ||
-                    !strike.ownIfHigher)
-            ) {
+                .reduce((sum, m) => sum + m.modifier, 0);
+            const formModifier = Number(this.resolveValue(strike.modifier)) + addend;
+            if (!this.ownUnarmed && (formModifier >= action.totalModifier || !strike.ownIfHigher)) {
                 // The battle form's static attack-roll modifier is >= the character's unarmed attack modifier:
                 // replace inapplicable attack-roll modifiers with the battle form's
                 this.#suppressModifiers(action);

--- a/src/module/rules/rule-element/battle-form/rule-element.ts
+++ b/src/module/rules/rule-element/battle-form/rule-element.ts
@@ -429,15 +429,15 @@ class BattleFormRuleElement extends RuleElementPF2e<BattleFormRuleSchema> {
 
         for (const action of strikeActions) {
             const strike = (strikes[action.slug ?? ""] ?? null) as BattleFormStrike | null;
-            
             const applicableModifiers = action.modifiers
-                .filter((m) => (m.enabled && this.#filterModifier(m)))
+                .filter((m) => m.enabled && this.#filterModifier(m))
                 .reduce((partialSum, m) => partialSum + m.modifier, 0);
 
             if (
                 !this.ownUnarmed &&
                 strike &&
-                ((Number(this.resolveValue(strike.modifier)) + applicableModifiers) >= action.totalModifier || !strike.ownIfHigher)
+                (Number(this.resolveValue(strike.modifier)) + applicableModifiers >= action.totalModifier ||
+                    !strike.ownIfHigher)
             ) {
                 // The battle form's static attack-roll modifier is >= the character's unarmed attack modifier:
                 // replace inapplicable attack-roll modifiers with the battle form's


### PR DESCRIPTION
Fixes #17563 

When comparing a battle form's static bonus to a character's unarmed attack bonus to choose which was higher, Foundry did not consider modifiers. This change grabs the applicable modifiers (status/circumstance bonuses, and penalties) and applies them in the comparison before setting the generated Strike's modifiers.

This will result in a slight (but acceptable) change in functionality. If a character's unarmed attack modifier is higher than the battle form's modifier, their modifiers will always be used, no matter what penalties are applied. This should work in reverse too (with bonuses and a lower unarmed attack modifier). **The total modifier won't change**, but the calculation will, since previously, the calculation would switch to the battle form's modifier once the character got enough penalties. This should be a low-risk change.