### PR TITLE
Hide disabled Bloody Debilitation dice in Debilitating Strike feature

### DIFF
--- a/packs/classfeatures/debilitating-strike.json
+++ b/packs/classfeatures/debilitating-strike.json
@@ -265,6 +265,7 @@
                 "damageType": "bleed",
                 "diceNumber": 3,
                 "dieSize": "d6",
+                "hideIfDisabled": true,
                 "key": "DamageDice",
                 "predicate": [
                     "debilitation:bloody",


### PR DESCRIPTION
This needs to be reworked eventually, but it'll require a migration