### PR TITLE
Allow more characters to fit in transfer dialog quantity field

### DIFF
--- a/src/styles/actor/_item-transfer-dialog.scss
+++ b/src/styles/actor/_item-transfer-dialog.scss
@@ -26,7 +26,7 @@
             gap: var(--space-4);
             margin-left: auto;
             input {
-                width: 4ch;
+                width: 6ch;
             }
         }
     }


### PR DESCRIPTION
6ch fits 5 characters. Padding seems to be about 1 character wide.