### PR TITLE
Alter versatile vial traits with bomber class feature

### DIFF
--- a/packs/classfeatures/bomber.json
+++ b/packs/classfeatures/bomber.json
@@ -77,6 +77,28 @@
                     "versatile-vial-damage"
                 ],
                 "value": "{item|flags.pf2e.rulesSelections.bomberFieldVials}"
+            },
+            {
+              "key": "ItemAlteration",
+              "mode": "add",
+              "itemType": "weapon",
+              "predicate": [
+                "bomber-field-vials",
+                "item:slug:versatile-vial"
+              ],
+              "property": "traits",
+              "value": "{item|flags.pf2e.rulesSelections.bomberFieldVials}"
+            },
+            {
+              "key": "ItemAlteration",
+              "mode": "remove",
+              "itemType": "weapon",
+              "predicate": [
+                "bomber-field-vials",
+                "item:slug:versatile-vial"
+              ],
+              "property": "traits",
+              "value": "acid"
             }
         ],
         "traits": {


### PR DESCRIPTION
The acid, fire, electricity and cold trait are based on the damage type of the item. When the Bomber alchemist class feature changes the damage type of versatile vials it should also alter the damage trait of the item.