### PR TITLE
Update styling of known formulas

### DIFF
--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -1010,6 +1010,11 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
             }
         };
 
+        handlers["toggle-free-crafting"] = async () => {
+            const freeCrafting = !this.actor.flags.pf2e.freeCrafting;
+            this.actor.update({ "flags.pf2e.freeCrafting": freeCrafting });
+        };
+
         handlers["craft-item"] = async (event, anchor) => {
             const row = htmlClosest(anchor, "li");
             if (!row) return;

--- a/src/styles/actor/character/_crafting.scss
+++ b/src/styles/actor/character/_crafting.scss
@@ -1,6 +1,8 @@
 @use "sass:color";
 
 &.crafting {
+    --controls-width: 1.75rem;
+
     .crafting-options {
         @include frame-elegant;
         display: flex;
@@ -26,7 +28,6 @@
         }
     }
 
-    li.known-formulas,
     li.crafting-entry {
         display: flex;
         flex-wrap: wrap;
@@ -99,198 +100,253 @@
             text-align: center;
             width: 2em;
         }
+    }
 
-        ol.formula-list {
-            @include p-reset;
-            flex-basis: 100%;
+    ol.formula-list {
+        @include p-reset;
+        flex-basis: 100%;
 
-            .formula-item[data-expended-state="true"] {
-                h4 {
-                    color: var(--color-disabled);
-                    text-decoration: line-through;
-                }
-
-                .toggle-formula-expended {
-                    color: var(--color-pf-primary);
-                }
+        .formula-item[data-expended-state="true"] {
+            h4 {
+                color: var(--color-disabled);
+                text-decoration: line-through;
             }
 
-            .formula-header.empty {
+            .toggle-formula-expended {
+                color: var(--color-pf-primary);
+            }
+        }
+
+        .formula-header {
+            @include p-reset;
+            background: rgba($sub-color, 0.25);
+            border: 1px solid var(--sub);
+            color: var(--text-dark);
+            font: 600 var(--font-size-12) var(--sans-serif);
+            height: 1.75rem;
+
+            .item-name {
                 align-items: center;
                 display: flex;
-                justify-content: space-between;
+                flex-basis: 50%;
+                flex-wrap: nowrap;
+                justify-content: start;
+                justify-self: start;
+                line-height: 1.5;
+                gap: 0.5em;
+            }
+
+            h3 {
+                @include p-reset;
+                text-transform: capitalize;
+                font-size: var(--font-size-12);
+                font-weight: 500;
+                margin-left: 0;
+                padding: var(--space-4) 0;
+            }
+
+            .formula-number {
+                text-align: center;
+            }
+        }
+
+        .formula-header.resource {
+            display: flex;
+            justify-content: space-between;
+            padding: 0 var(--space-4);
+        }
+
+        li.formula-level-header,
+        li.formula-item {
+            display: grid;
+            grid:
+                "name dc price quantity button controls" 1fr
+                / 1fr 1.5rem 4.5rem 5.125rem min-content var(--controls-width);
+            align-items: center;
+            justify-items: center;
+
+            @include p-reset;
+            background: none;
+            border: none;
+            border-left: 1px solid var(--sub);
+            border-right: 1px solid var(--sub);
+            cursor: default;
+
+            &:nth-child(odd) {
+                background-color: rgba($alt-color, 0.1);
+            }
+
+            &:nth-child(even) .item-summary {
+                background: none;
+            }
+
+            &:last-child {
+                border-bottom: 1px solid var(--sub);
+            }
+
+            &.empty {
+                align-items: center;
+                display: flex;
                 min-height: 2em;
-                h4 {
-                    margin: 0;
-                    opacity: 0.8;
-                    padding-left: var(--space-6);
+                opacity: 0.85;
+                padding-left: 2.25rem;
+                white-space: nowrap;
+            }
+
+            &.formula-level-header {
+                background: rgba($sub-color, 0.25);
+                border: 1px solid var(--sub);
+                color: var(--text-dark);
+                font: 600 var(--font-size-12) var(--sans-serif);
+                height: 1.25rem;
+                margin: 0;
+
+                h3 {
+                    text-transform: capitalize;
+                    font-size: var(--font-size-12);
+                    font-weight: 500;
+                    margin-left: 0;
+                    padding: var(--space-4) 0;
+                }
+
+                .item-name {
+                    line-height: 1;
+                    padding-left: var(--space-4);
+
+                    h3 {
+                        @include p-reset;
+                    }
+                }
+
+                .controls {
+                    padding-right: var(--space-4);
                 }
             }
 
-            li.formula-level-header,
-            li.formula-item {
-                display: grid;
-                grid:
-                    "name dc price quantity controls" 1fr
-                    / 4fr 0.7fr 1fr 1fr 1fr;
+            .item-name {
+                grid-area: name;
+                cursor: pointer;
+
                 align-items: center;
-                justify-items: center;
+                display: flex;
+                flex-basis: 50%;
+                flex-wrap: nowrap;
+                justify-content: start;
+                justify-self: start;
+                line-height: 1.5;
 
-                @include p-reset;
-                background: none;
-                border: none;
-                border-left: 1px solid var(--sub);
-                border-right: 1px solid var(--sub);
-                cursor: default;
-
-                &.empty {
-                    align-items: center;
-                    display: flex;
-                    min-height: 2em;
-                    opacity: 0.85;
-                    padding-left: 2.25rem;
+                h3 {
                     white-space: nowrap;
                 }
 
-                &:nth-child(odd) {
-                    background-color: rgba($alt-color, 0.1);
+                .item-image {
+                    margin: var(--space-2) 0;
+                    margin-left: var(--space-4);
                 }
 
-                &:nth-child(even) .item-summary {
-                    background: none;
-                }
+                h4 {
+                    font-weight: 500;
+                    letter-spacing: -0.075em;
+                    line-height: 1;
+                    margin: 0 0 0 var(--space-8);
+                    padding: 0;
 
-                &:last-child {
-                    border-bottom: 1px solid var(--sub);
-                }
-
-                &.formula-level-header {
-                    background: rgba($sub-color, 0.25);
-                    border: 1px solid var(--sub);
-                    padding: 0 var(--space-4);
-                    color: var(--text-dark);
-                    font: 600 var(--font-size-12) var(--sans-serif);
-                    height: 1.25rem;
-                    margin: 0;
-
-                    h3 {
-                        text-transform: capitalize;
-                        font-size: var(--font-size-12);
-                        font-weight: 500;
-                        margin-left: 0;
-                        padding: var(--space-4) 0;
-                    }
-
-                    .level-name {
-                        line-height: 1;
-                        gap: 0.5em;
-
-                        h3 {
-                            @include p-reset;
-                        }
-                    }
-
-                    .formula-number {
-                        text-align: center;
+                    &:hover {
+                        color: var(--color-pf-secondary);
                     }
                 }
 
-                .item-name {
-                    cursor: pointer;
-                    min-height: 2em;
-                }
-
-                .level-name,
-                .item-name {
-                    align-items: center;
-                    display: flex;
-                    flex-basis: 50%;
-                    flex-wrap: nowrap;
-                    justify-content: start;
-                    justify-self: start;
-                    line-height: 1.5;
-
-                    h3 {
-                        white-space: nowrap;
-                    }
-                    + span:not(.flex0) {
-                        font-size: var(--font-size-12);
-                    }
-
-                    .item-image {
-                        margin: var(--space-2) 0;
-                        margin-left: var(--space-4);
-                    }
-
-                    h4 {
-                        font-weight: 500;
-                        letter-spacing: -0.075em;
-                        line-height: 1;
-                        margin: 0 0 0 var(--space-8);
-                        padding: 0;
-
-                        &:hover {
-                            color: var(--color-pf-secondary);
-                        }
-                    }
-
-                    &.aa-level,
-                    &.reagent-resource {
-                        justify-content: flex-end;
-                    }
-                }
-
-                .item-controls {
-                    justify-self: end;
-                    font-size: var(--font-size-12);
-                    margin-right: var(--space-4);
-                }
-
-                .item-summary {
-                    grid-column: 1 / 6;
-                    padding: var(--space-8);
-                    border-bottom: 1px solid var(--sub);
-                    border-top: 1px solid color.adjust($sub-color, $lightness: 30%);
-                    background-color: rgba($light-background-color, 0.5);
-
-                    p {
-                        margin-top: 0;
-                    }
-
-                    .item-buttons button {
-                        display: none;
-                    }
-                }
-
-                .quantity {
-                    align-items: center;
-                    display: flex;
-                    gap: var(--space-3);
-                    justify-content: center;
-
-                    .adjust {
-                        align-items: center;
-                        display: flex;
-                        font-size: var(--font-size-16);
-                        font-family: var(--sans-serif-monospace);
-                        justify-content: center;
-                        width: 1em;
-                    }
-
-                    input {
-                        width: 1.5rem;
-                        text-align: center;
-                    }
+                &.aa-level,
+                &.reagent-resource {
+                    justify-content: flex-end;
                 }
             }
 
-            li.formula-level-header.infused-reagents {
-                height: 1.75rem;
+            .price {
+                grid-area: price;
+            }
+
+            .quantity {
+                grid-area: quantity;
+
+                align-items: center;
+                display: flex;
+                gap: var(--space-3);
+                justify-content: center;
+
+                .adjust {
+                    align-items: center;
+                    display: flex;
+                    font-size: var(--font-size-16);
+                    font-family: var(--sans-serif-monospace);
+                    justify-content: center;
+                    width: 1em;
+                }
+
+                input {
+                    width: 1.5rem;
+                    text-align: center;
+                }
+            }
+
+            button.craft {
+                grid-area: button;
+                font: 500 var(--font-size-10) / 1.8em var(--sans-serif);
+                justify-self: end;
+                min-width: 2.5rem;
+                padding: 0 0.25em;
+                text-transform: uppercase;
+                width: fit-content;
+                &.invisible {
+                    visibility: hidden;
+                }
+            }
+
+            .item-controls {
+                grid-area: controls;
+                justify-self: end;
+                font-size: var(--font-size-12);
+                margin-right: var(--space-4);
+            }
+
+            .item-summary {
+                grid-column: 1 / 7;
+                padding: var(--space-8);
+                border-bottom: 1px solid var(--sub);
+                border-top: 1px solid color.adjust($sub-color, $lightness: 30%);
+                background-color: rgba($light-background-color, 0.5);
+                width: 100%;
+
+                p {
+                    margin-top: 0;
+                }
+
+                .item-buttons button {
+                    display: none;
+                }
             }
         }
     }
 
     li.crafting-entry button.perform-daily {
         width: 75%;
+    }
+
+    .crafting-entry {
+        --controls-width: 3rem;
+    }
+
+    .known-formulas {
+        padding-bottom: 2rem;
+        .empty {
+            display: flex;
+            align-items: center;
+            background: none;
+            border: none;
+            display: flex;
+            min-height: 2em;
+            opacity: 0.85;
+            white-space: nowrap;
+        }
     }
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -218,6 +218,8 @@
                         "Complete": "Daily crafting complete.",
                         "Perform": "Perform Daily Crafting"
                     },
+                    "FreeCrafting": "Free Crafting",
+                    "FreeCraftingTooltip": "If enabled, creates items immediately without spending gold",
                     "MissingResource": "You have insufficient resources to complete crafting.",
                     "RemainingSlots": "Empty Slot ({remaining} remaining)",
                     "Search": "Search Formulas"
@@ -1143,7 +1145,6 @@
             "QuickAddTitle": "Add this formula to one or more crafting entries",
             "RemoveFormulaDialogQuestion": "Are you sure you want to remove the formula for {name}?",
             "RemoveFormulaDialogTitle": "Remove Formula",
-            "ToggleFreeCrafting": "Toggle Free Crafting",
             "ToggleQuickAlchemy": "Quick Alchemy",
             "UndeletableTooltip": "This crafting formula is part of another item and cannot be individually deleted.",
             "UnprepareFormulaDialogQuestion": "Are you sure you want to unprepare the formula for {name}?",

--- a/static/templates/actors/character/tabs/crafting.hbs
+++ b/static/templates/actors/character/tabs/crafting.hbs
@@ -1,23 +1,17 @@
 <div class="tab crafting crafting-pane" data-group="primary" data-tab="crafting">
-    <div class="crafting-options item-list">
-        <div class="crafting-option item" data-toggle-property="{{toggle.inputName}}" data-toggle-label="{{localize toggle.label}}">
-            <label>
-                <input type="checkbox" name="flags.pf2e.freeCrafting" {{checked actor.flags.pf2e.freeCrafting}} />
-                <span>{{localize "PF2E.CraftingTab.ToggleFreeCrafting"}}</span>
-            </label>
-        </div>
-        {{#if crafting.hasQuickAlchemy}}
+    {{#if crafting.hasQuickAlchemy}}
+        <div class="crafting-options item-list">
             <div class="crafting-option item" data-toggle-property="{{toggle.inputName}}" data-toggle-label="{{localize toggle.label}}">
                 <label>
                     <input type="checkbox" name="flags.pf2e.quickAlchemy" {{checked actor.flags.pf2e.quickAlchemy}} />
                     <span>{{localize "PF2E.CraftingTab.ToggleQuickAlchemy"}}</span>
                 </label>
             </div>
-        {{/if}}
-    </div>
+        </div>
+    {{/if}}
     <ol class="directory-list item-list crafting-entry-list">
         {{#each crafting.abilities.spontaneous as |ability i|}}
-            <li class="crafting-entry formula-level-header spontaneous" data-ability="{{ability.slug}}">
+            <li class="crafting-entry formula-header spontaneous" data-ability="{{ability.slug}}">
                 <div class="name">
                     {{ability.label}}
                 </div>
@@ -49,13 +43,13 @@
                             <div class="action-header alchemical-title">{{ability.label}}</div>
 
                             <ol class="directory-list item-list formula-list">
-                                <li class="formula-level-header formula-header">
-                                    <div class="level-name reagent-cost">
+                                <li class="formula-header resource">
+                                    <div class="item-name reagent-cost">
                                         <h3>{{localize "PF2E.CraftingTab.Alchemical.ReagentCost"}}:</h3>
                                         <span class="formula-number">{{ability.resourceCost}}</span>
                                     </div>
 
-                                    <div class="level-name aa-level">
+                                    <div class="item-name reagent-resource">
                                         <h3>{{localize "PF2E.CraftingTab.Alchemical.AdvancedAlchemyLevel"}}:</h3>
                                         <span class="formula-number">{{ability.maxItemLevel}}</span>
                                     </div>
@@ -122,84 +116,107 @@
                 ><i class="fa-solid fa-redo"></i>{{localize "Reset"}}</button>
             </li>
         {{/if}}
-        <li class="known-formulas item-container" data-container-type="knownFormulas">
-            <div class="action-header">{{localize "PF2E.FormulaKnownTitle"}}</div>
-            <ol class="directory-list item-list formula-list">
-                {{!-- Add section for each formula level --}}
-                {{#each crafting.knownFormulas as |section|}}
-                    <li class="formula-level-header formula-header" data-item-type="formulaLevel" data-level="{{section.level}}">
-                        <div class="level-name flexrow">
-                            <h3>{{localize "PF2E.LevelN" level=section.level}}</h3>
+    </ol>
+    <section class="major item-container known-formulas" data-container-type="knownFormulas">
+        <header>
+            {{localize "PF2E.FormulaKnownTitle"}}
+            <div class="controls">
+                <button type="button" data-action="toggle-free-crafting" data-tooltip="PF2E.Actor.Character.Crafting.FreeCraftingTooltip">
+                    <input type="checkbox" {{checked actor.flags.pf2e.freeCrafting}} />
+                    {{localize "PF2E.Actor.Character.Crafting.FreeCrafting"}}
+                </button>
+                <button type="button" data-action="browse-equipment" data-action-type="{{sid}}">
+                    <i class="fa-solid fa-fw fa-search"></i>{{localize "PF2E.BrowseLabel"}}
+                </button>
+            </div>
+        </header>
+        <ol class="directory-list item-list formula-list">
+            {{!-- Add section for each formula level --}}
+            {{#each crafting.knownFormulas as |section|}}
+                <li class="formula-level-header formula-header" data-item-type="formulaLevel" data-level="{{section.level}}">
+                    <div class="item-name flexrow">
+                        <h3>{{localize "PF2E.LevelN" level=section.level}}</h3>
+                    </div>
+
+                    <div class="formula-dc-header">{{localize "PF2E.CraftDCTitle"}}</div>
+                    <div class="formula-cost-header">{{localize "PF2E.Actor.Character.Crafting.Cost"}}</div>
+                    <div class="formula-quantity-header">{{localize "PF2E.CraftingTab.CraftQuantityTitle"}}</div>
+
+                    {{!-- Exists only due to localization reasons regarding a resizing button. We hide this button--}}
+                    <button type="button" class="craft blue invisible">
+                        {{#if @root.actor.flags.pf2e.freeCrafting}}
+                            <i class="fa-solid fa-plus"></i>
+                            {{localize "PF2E.CreateLabelUniversal"}}
+                        {{else}}
+                            <i class="fa-solid fa-hammer"></i>
+                            {{localize "PF2E.CraftItemTitle"}}
+                        {{/if}}
+                    </button>
+
+                    {{#if @root.editable}}
+                        <div class="item-controls">
+                            <a data-action="browse-equipment" data-tooltip="PF2E.OpenInventoryBrowser" data-level="{{section.level}}"><i class="fa-solid fa-fw fa-search"></i></a>
+                        </div>
+                    {{/if}}
+                </li>
+                {{!-- Add formula items for each formula level --}}
+                {{#each section.formulas as |formula i|}}
+                    <li class="item formula-item" data-formula-lvl="{{section.level}}" data-item-uuid="{{formula.uuid}}" data-is-formula>
+                        <div class="name item-name">
+                            <a class="item-image framed" data-action="formula-to-chat">
+                                <img class="item-icon" src="{{formula.item.img}}" alt="{{formula.item.name}}">
+                                <i class="fa-solid fa-message"></i>
+                            </a>
+                            <h4 class="name"><a data-action="toggle-summary">{{formula.item.name}}</a></h4>
                         </div>
 
-                        <div class="formula-dc-header">{{localize "PF2E.CraftDCTitle"}}</div>
-                        <div class="formula-cost-header">{{localize "PF2E.Actor.Character.Crafting.Cost"}}</div>
-                        <div class="formula-quantity-header">{{localize "PF2E.CraftingTab.CraftQuantityTitle"}}</div>
+                        <div class="dc">{{formula.dc}}</div>
+                        <div class="cost">{{coinLabel formula.cost}}</div>
+                        <div class="quantity">
+                            <a class="adjust decrease" data-action="decrease-craft-quantity">&ndash;</a>
+                            <input type="number" data-craft-quantity value="{{#if @root.crafting.noCost}}{{formula.item.system.price.per}}{{else}}{{formula.batchSize}}{{/if}}" />
+                            <a class="adjust increase" data-action="increase-craft-quantity">+</a>
+                        </div>
+
+                        <button type="button" class="craft blue" data-action="craft-item">
+                            {{#if @root.actor.flags.pf2e.freeCrafting}}
+                                <i class="fa-solid fa-plus"></i>
+                                Create
+                            {{else}}
+                                <i class="fa-solid fa-hammer"></i>
+                                {{localize "PF2E.CraftItemTitle"}}
+                            {{/if}}
+                        </button>
 
                         {{#if @root.editable}}
                             <div class="item-controls">
-                                <a data-action="browse-equipment" data-tooltip="PF2E.OpenInventoryBrowser" data-level="{{section.level}}"><i class="fa-solid fa-fw fa-search"></i></a>
+                                <a
+                                    data-action="delete-formula"
+                                    data-tooltip="PF2E.DeleteItemTitle"
+                                ><i class="fa-solid fa-fw fa-trash"></i></a>
                             </div>
                         {{/if}}
+
+                        <div class="item-summary" hidden></div>
                     </li>
-                    {{!-- Add formula items for each formula level --}}
-                    {{#each section.formulas as |formula i|}}
-                        <li class="item formula-item" data-formula-lvl="{{section.level}}" data-item-uuid="{{formula.uuid}}" data-is-formula>
-                            <div class="item-name">
-                                <a class="item-image framed" data-action="formula-to-chat">
-                                    <img class="item-icon" src="{{formula.item.img}}" alt="{{formula.item.name}}">
-                                    <i class="fa-solid fa-message"></i>
-                                </a>
-                                <h4 class="name"><a data-action="toggle-summary">{{formula.item.name}}</a></h4>
-                            </div>
-
-                            <div class="dc">{{formula.dc}}</div>
-                            <div class="cost">{{coinLabel formula.cost}}</div>
-                            <div class="quantity">
-                                <a class="adjust decrease" data-action="decrease-craft-quantity">&ndash;</a>
-                                <input type="number" data-craft-quantity value="{{#if @root.crafting.noCost}}{{formula.item.system.price.per}}{{else}}{{formula.batchSize}}{{/if}}" />
-                                <a class="adjust increase" data-action="increase-craft-quantity">+</a>
-                            </div>
-
-                            {{#if @root.editable}}
-                                <div class="item-controls">
-                                    <a
-                                        data-action="craft-item"
-                                        data-tooltip="PF2E.CraftItemTitle"
-                                    ><i class="fa-solid fa-fw fa-hammer"></i></a>
-                                    <a
-                                        data-action="delete-formula"
-                                        data-tooltip="PF2E.DeleteItemTitle"
-                                    ><i class="fa-solid fa-fw fa-trash"></i></a>
-                                </div>
-                            {{/if}}
-
-                            <div class="item-summary" hidden></div>
-                        </li>
-                    {{/each}}
-                {{else}}
-                    {{#if @root.editable}}
-                        <li class="formula-header empty">
-                            <h4>{{localize "PF2E.FormulaListEmpty"}}</h4>
-                            <button type="button" class="blue" data-action="browse-equipment" data-level="{{section.level}}">
-                                <i class="fa-solid fa-fw fa-search"></i>{{localize "PF2E.OpenInventoryBrowser"}}
-                            </a>
-                        </li>
-                    {{/if}}
                 {{/each}}
-            </ol>
-        </li>
-    </ol>
+            {{else if @root.editable}}
+                <li class="empty">
+                    <h4>{{localize "PF2E.FormulaListEmpty"}}</h4>
+                </li>
+            {{/each}}
+        </ol>
+    </section>
 </div>
 
 {{#*inline "resourceRow"}}
-    <li class="formula-level-header formula-header infused-reagents">
-        <div class="level-name reagent-cost">
+    <li class="formula-header resource">
+        <div class="item-name reagent-cost">
             <h3>{{localize "PF2E.CraftingTab.Alchemical.TotalCost"}}:</h3>
             <div class="formula-number">{{resourceCost}}</div>
         </div>
 
-        <div class="level-name reagent-resource">
+        <div class="item-name reagent-resource">
             <h3>{{localize resource.label}}:</h3>
             <input
                 class="formula-number"


### PR DESCRIPTION
I wanted to move the free crafting from the fake trait toggles, as it only applied to known formulas and looked confusing separated visually where it was. I also wanted to get rid of another old style header.

![image](https://github.com/user-attachments/assets/a9780874-cd5a-4882-9ae7-63f4fe63b5f1)

![image](https://github.com/user-attachments/assets/b29282d2-a017-424b-a3a5-e1c699b37868)
