### PR TITLE
Restore deleted roll inspector localization strings

### DIFF
--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -920,7 +920,11 @@
         "CharacterTraits": "Character Traits",
         "CharacterTraitsHeader": "Traits & Other Details",
         "ChatRollDetails": {
+            "ContextualOptions": {
+                "postRoll": "Post Roll Options"
+            },
             "DiceAndModifiers": "Dice and Modifiers",
+            "DiceRollOptionsHint": "Dice and modifier roll options are used when predicating DamageAlteration rule elements.",
             "FlatCheckNoModifiers": "Flat checks never include any modifiers, bonuses, or penalties.",
             "RollOptions": "Roll Options",
             "Select": "Inspect Roll",


### PR DESCRIPTION
These were deleted in #17653, I assume accidentally since no alternative was added, and those parts were left calling now non-existent strings.