### PR TITLE
Add tab support to svelte mixin

### DIFF
--- a/types/foundry/client-esm/applications/_types.d.ts
+++ b/types/foundry/client-esm/applications/_types.d.ts
@@ -14,7 +14,7 @@ export interface ApplicationConfiguration {
     /** Click actions supported by the Application and their event handler functions */
     actions: Record<string, ApplicationClickAction>;
     /** Configuration used if the application top-level element is a form */
-    form?: ApplicationFormConfiguration;
+    form?: DeepPartial<ApplicationFormConfiguration>;
     /** Default positioning data for the application */
     position: Partial<ApplicationPosition>;
 }

--- a/types/foundry/client/apps/app.d.ts
+++ b/types/foundry/client/apps/app.d.ts
@@ -393,8 +393,8 @@ declare global {
     }
 
     interface ApplicationPosition {
-        width?: Maybe<number>;
-        height?: Maybe<string | number>;
+        width?: number | "auto";
+        height?: number | "auto";
         left?: Maybe<number>;
         top?: Maybe<number>;
         scale?: Maybe<number>;


### PR DESCRIPTION
Allows the use of tabGroups as a responsive object for the rendering.