### PR TITLE
Fix memory leaks and failed cleanups in destroyables Mutation Observer

### DIFF
--- a/src/util/destroyables.ts
+++ b/src/util/destroyables.ts
@@ -29,8 +29,8 @@ class DestroyableManager {
         const destroyableEl =
             destroyable instanceof Sortable
                 ? destroyable.el
-                : destroyable instanceof TooltipsterTarget
-                  ? destroyable.element
+                : "elementOrigin" in destroyable
+                  ? destroyable.elementOrigin()
                   : destroyable.DOM.input;
         const contentEl = destroyableEl?.closest(".app, .application")?.querySelector(".window-content");
         if (!contentEl && !destroyableEl.closest(".chat-message"))
@@ -107,25 +107,12 @@ interface MutationObserverContext {
     elements: Set<{ node: Node; destroyable: Destroyable }>;
 }
 
-type Destroyable = Tagify<{ id: string; value: string }> | Tagify<Tagify.TagData> | Sortable | TooltipsterTarget;
-
-class TooltipsterTarget {
-    $element: JQuery;
-    instance: Destroyable;
-
-    constructor($element: JQuery, instance: Destroyable) {
-        this.$element = $element;
-        this.instance = instance;
-    }
-
-    get element(): HTMLElement {
-        return this.$element[0];
-    }
-
-    destroy(): void {
-        this.instance.destroy();
-    }
+interface Tooltipster {
+    destroy(): void;
+    elementOrigin(): HTMLElement;
 }
+
+type Destroyable = Tagify<{ id: string; value: string }> | Tagify<Tagify.TagData> | Sortable | Tooltipster;
 
 function createSortable(list: HTMLElement, options: Sortable.Options): Sortable {
     const sortable = new Sortable(list, options);
@@ -149,7 +136,7 @@ function createTooltipster(target: HTMLElement, options: JQueryTooltipster.ITool
         return $tooltipsterEl;
     }
     // create wrapper of instance and tooltipster element for cleanup after element has been removed from DOM
-    DestroyableManager.instance.observe(new TooltipsterTarget($tooltipsterEl, tooltipsterInstance));
+    DestroyableManager.instance.observe(tooltipsterInstance);
     return $tooltipsterEl;
 }
 

--- a/src/util/destroyables.ts
+++ b/src/util/destroyables.ts
@@ -105,12 +105,11 @@ interface MutationObserverContext {
     elements: Set<{ node: Node; destroyable: Destroyable }>;
 }
 
-interface Tooltipster {
-    destroy(): void;
-    elementOrigin(): HTMLElement;
-}
-
-type Destroyable = Tagify<{ id: string; value: string }> | Tagify<Tagify.TagData> | Sortable | Tooltipster;
+type Destroyable =
+    | Tagify<{ id: string; value: string }>
+    | Tagify<Tagify.TagData>
+    | Sortable
+    | JQueryTooltipster.ITooltipsterInstance;
 
 function createSortable(list: HTMLElement, options: Sortable.Options): Sortable {
     const sortable = new Sortable(list, options);
@@ -119,23 +118,9 @@ function createSortable(list: HTMLElement, options: Sortable.Options): Sortable 
 }
 
 function createTooltipster(target: HTMLElement, options: JQueryTooltipster.ITooltipsterOptions): JQuery {
-    const $element = $(target);
-    const $tooltipsterEl = $element.tooltipster(options);
-    // get tooltipster namespace key
-    const tooltipsterNs: string | undefined = $tooltipsterEl.data("tooltipster-ns")?.[0];
-    if (!tooltipsterNs) {
-        console.warn(ErrorPF2e("No tooltipster namespace found").message);
-        return $tooltipsterEl;
-    }
-    // get internal tooltipster instance
-    const tooltipsterInstance: Destroyable | undefined = $tooltipsterEl.data(tooltipsterNs);
-    if (!tooltipsterInstance) {
-        console.warn(ErrorPF2e("No tooltipster instance found").message);
-        return $tooltipsterEl;
-    }
-    // create wrapper of instance and tooltipster element for cleanup after element has been removed from DOM
-    DestroyableManager.instance.observe(tooltipsterInstance);
-    return $tooltipsterEl;
+    const $element = $(target).tooltipster(options);
+    DestroyableManager.instance.observe($element.tooltipster("instance"));
+    return $element;
 }
 
 export { DestroyableManager, createSortable, createTooltipster };

--- a/src/util/destroyables.ts
+++ b/src/util/destroyables.ts
@@ -33,9 +33,7 @@ class DestroyableManager {
                   ? destroyable.elementOrigin()
                   : destroyable.DOM.input;
         const contentEl = destroyableEl?.closest(".app, .application")?.querySelector(".window-content");
-        if (!contentEl && !destroyableEl.closest(".chat-message"))
-            return console.warn(ErrorPF2e("No application element found").message);
-        if (!contentEl) return;
+        if (!contentEl) return console.warn(ErrorPF2e("No application element found").message);
 
         let context = this.#appObservers.get(contentEl);
         if (context) {


### PR DESCRIPTION
I really do like the Idea of using Mutation Observer for the otherwise errorprone task of cleanup up the `tooltipster`, `Sortable` and `Tagify` instances. I wish I had thought of that when authoring my PR.

However, I have identified some issues with the current implementation that this PR aims to address:

1. **Tooltipster cleanup timing**
Tooltipster instances normally to be destroyed **before** their associated DOM elements are removed. Tooltipster relies on jQuery’s .data attribute to store references to its instances, and these attributes are cleared when elements are removed via jQuery. If the destroy method is called after this happens, Tooltipster logs warnings or even throws errors.
Additionally, the instance itself is not automatically destroyed, and it retains a reference to the original HTML element. This alone isn’t enough to cause a memory leak, but Tooltipster's internal `setInterval` that closes over the tooltipster instance creates one.

2. **Handling removed nodes in MutationObserver**
The `removedNodes` property in the MutationObserver callback does not include the node it was registered for (the target). While the current implementation addresses this by observing a parent element (the closest .window-content element), the mutation handler mistakenly tries to use removed nodes as keys to access destroyable items. This approach will never succeed since the observed target is not included in `removedNodes`.

3. **Memory Leaks from unmanaged MutationObservers**
MutationObservers themselves can lead to memory leaks if not explicitly `disconnect()`ed. They will continue observing their target nodes even after those nodes are removed from the DOM. An explicit call to disconnect is necessary to release connected nodes and prevent memory leaks.

### Proposed Fixes
This PR resolves these issues by:

* Ensuring Tooltipster instances are properly destroyed. That part uses some internal details like `$(el).data('tooltipster-ns')` to access the tooltipster instance, but is unavoidable.
* Correctly managing the mapping and cleanup of destroyable objects.
* Explicitly disconnecting `MutationObserver`s to avoid residual references.

I have verified that after these changes, no memory leaks occur in NPC sheets, item/feat sheets, and character sheets. However, **IWR tooltips in the chat log still exhibit memory leaks**. This is because chat messages and their tooltips are rendered before being inserted into the popped-out chat log application, complicating the setup of `MutationObserver`s. Addressing this specific issue will require a separate investigation.