### PR TITLE
Grant implement with Thaumaturge Dedication and add Note for Weapon Implement Adept

### DIFF
--- a/packs/actions/implements-interruption.json
+++ b/packs/actions/implements-interruption.json
@@ -18,7 +18,17 @@
             "remaster": false,
             "title": "Pathfinder Dark Archive"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "RollOption",
+                "option": "implements-interruption",
+                "predicate": [
+                    "parent:granter:tag:thaumaturge-implement-adept"
+                ],
+                "priority": 121,
+                "toggleable": true
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/classfeatures/bell.json
+++ b/packs/classfeatures/bell.json
@@ -26,7 +26,17 @@
         },
         "rules": [
             {
+                "allowDuplicate": false,
                 "key": "GrantItem",
+                "predicate": [
+                    {
+                        "or": [
+                            "class:thaumaturge",
+                            "feat:implement-initiate"
+                        ]
+                    }
+                ],
+                "reevaluateOnUpdate": true,
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Ring Bell"
             },
             {

--- a/packs/classfeatures/chalice.json
+++ b/packs/classfeatures/chalice.json
@@ -26,7 +26,17 @@
         },
         "rules": [
             {
+                "allowDuplicate": false,
                 "key": "GrantItem",
+                "predicate": [
+                    {
+                        "or": [
+                            "class:thaumaturge",
+                            "feat:implement-initiate"
+                        ]
+                    }
+                ],
+                "reevaluateOnUpdate": true,
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Drink from the Chalice"
             },
             {

--- a/packs/classfeatures/implements-empowerment.json
+++ b/packs/classfeatures/implements-empowerment.json
@@ -26,9 +26,15 @@
         },
         "rules": [
             {
-                "domain": "all",
+                "disabledIf": [
+                    {
+                        "not": "implement-held"
+                    }
+                ],
+                "disabledValue": false,
                 "key": "RollOption",
                 "option": "implements-empowerment",
+                "priority": 51,
                 "toggleable": true
             },
             {

--- a/packs/classfeatures/mirror.json
+++ b/packs/classfeatures/mirror.json
@@ -26,7 +26,17 @@
         },
         "rules": [
             {
+                "allowDuplicate": false,
                 "key": "GrantItem",
+                "predicate": [
+                    {
+                        "or": [
+                            "class:thaumaturge",
+                            "feat:implement-initiate"
+                        ]
+                    }
+                ],
+                "reevaluateOnUpdate": true,
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Mirror's Reflection"
             },
             {

--- a/packs/classfeatures/wand.json
+++ b/packs/classfeatures/wand.json
@@ -26,7 +26,17 @@
         },
         "rules": [
             {
+                "allowDuplicate": false,
                 "key": "GrantItem",
+                "predicate": [
+                    {
+                        "or": [
+                            "class:thaumaturge",
+                            "feat:implement-initiate"
+                        ]
+                    }
+                ],
+                "reevaluateOnUpdate": true,
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Fling Magic"
             },
             {

--- a/packs/classfeatures/weapon.json
+++ b/packs/classfeatures/weapon.json
@@ -26,7 +26,17 @@
         },
         "rules": [
             {
+                "allowDuplicate": false,
                 "key": "GrantItem",
+                "predicate": [
+                    {
+                        "or": [
+                            "class:thaumaturge",
+                            "feat:implement-initiate"
+                        ]
+                    }
+                ],
+                "reevaluateOnUpdate": true,
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Implement's Interruption"
             },
             {
@@ -75,6 +85,26 @@
                         "text": "@Embed[Compendium.pf2e.classfeatures.Item.YiDkrwaxiF7Gao7y inline]"
                     }
                 ]
+            },
+            {
+                "key": "CriticalSpecialization",
+                "predicate": [
+                    "item:id:{item|flags.pf2e.itemGrants.weaponImplement.id}",
+                    "feature:thaumaturge-weapon-expertise"
+                ]
+            },
+            {
+                "key": "Note",
+                "outcome": [
+                    "failure"
+                ],
+                "predicate": [
+                    "implements-interruption",
+                    "parent:tag:thaumaturge-implement-adept"
+                ],
+                "selector": "{item|flags.pf2e.itemGrants.weaponImplement.id}-attack",
+                "text": "PF2E.SpecificRule.Thaumaturge.Implement.Weapon.Adept.Note",
+                "title": "PF2E.SpecificRule.Thaumaturge.Implement.Adept.Label"
             }
         ],
         "traits": {

--- a/packs/feats/thaumaturge-dedication.json
+++ b/packs/feats/thaumaturge-dedication.json
@@ -31,6 +31,21 @@
         "rules": [
             {
                 "adjustName": false,
+                "choices": {
+                    "filter": [
+                        "item:tag:thaumaturge-implement"
+                    ]
+                },
+                "flag": "implement",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Thaumaturge.Implement.Prompt"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "{item|flags.pf2e.rulesSelections.implement}"
+            },
+            {
+                "adjustName": false,
                 "choices": [
                     {
                         "label": "PF2E.Skill.Arcana",

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -5683,15 +5683,16 @@
             },
             "Thaumaturge": {
                 "Implement": {
-                    "Amulet": "Amulet",
-                    "Bell": "Bell",
-                    "Chalice": "Chalice",
-                    "Lantern": "Lantern",
-                    "Mirror": "Mirror",
-                    "Regalia": "Regalia",
-                    "Tome": "Tome",
-                    "Wand": "Wand",
-                    "Weapon": "Weapon"
+                    "Adept": {
+                        "Label": "Implement Adept"
+                    },
+                    "Prompt": "Select an implement.",
+                    "Weapon": {
+                        "Adept": {
+                            "Note": "You deal @Damage[1[@item.system.damage.damageType]] damage, possibly applying any bonus damage due to the target's weakness."
+                        },
+                        "Label": "Weapon"
+                    }
                 },
                 "TalismanEsoterica": "Talisman Esoterica"
             },


### PR DESCRIPTION
This would supersede #16265 and #14678

The predicated `GrantItem` does require an actor update after the Implement Initiate feat has been taken, the same way Champion does, which isn't ideal. It might be good to consider if such an update could be triggered upon a feat being taken, or something along those lines. (Made an issue for it here #17698)



also disable Implement's Empowerment if no implement is being held, and deleted some unused localization keys. Some might be added back later as needed, but nothing is using them right now.