### PR TITLE
Load all available compendium packs by default in the Compendium Browser

### DIFF
--- a/src/module/apps/compendium-browser/data.ts
+++ b/src/module/apps/compendium-browser/data.ts
@@ -4,6 +4,7 @@ interface PackInfo {
     load: boolean;
     name: string;
     package: string;
+    showFullId?: boolean;
 }
 
 interface SourceInfo {
@@ -24,7 +25,7 @@ interface BrowserTabs {
 type TabName = "action" | "bestiary" | "campaignFeature" | "equipment" | "feat" | "hazard" | "spell";
 type ContentTabName = Exclude<TabName, "settings">;
 type BrowserTab = InstanceType<(typeof browserTabs)[keyof typeof browserTabs]>;
-type TabData<T> = Record<TabName, T | null>;
+type TabData<T> = Record<TabName, T>;
 
 type CommonSortByOption = "name" | "level";
 type SortByOption = CommonSortByOption | "price";

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3371,10 +3371,10 @@
                 "DeleteAllQuestion": "Are you sure you want to reset all settings for included sources?",
                 "DeleteAllTitle": "Reset Settings",
                 "Hint": "Settings to display only entries with specified sources in the compendium browser.",
-                "IgnoreAsGM": "Let GMs ignore filtering and see all entries.",
+                "IgnoreAsGM": "Let GMs ignore these settings and see all entries.",
                 "Name": "Included Sources",
-                "ShowEmptySources": "Do not filter entries with empty sources.",
-                "ShowUnknownSources": "Do not filter entries with unknown sources.",
+                "ShowEmptySources": "Allow entries with empty sources.",
+                "ShowUnknownSources": "Allow entries with unknown sources.",
                 "SourcesListHeader": "Specified Sources"
             },
             "Core": {

--- a/static/templates/compendium-browser/settings/pack-settings.hbs
+++ b/static/templates/compendium-browser/settings/pack-settings.hbs
@@ -5,7 +5,15 @@
             <fieldset>
                 <legend>{{localize setting.label}}</legend>
                 {{#each setting.settings as |conf pack|}}
-                    <label for="{{key}}-{{pack}}"><input type="checkbox" id="{{key}}-{{pack}}" name="{{key}}-{{pack}}" {{checked conf.load}}>{{conf.name}} ({{conf.package}})</label>
+                    <label for="{{key}}-{{pack}}">
+                        <input
+                            type="checkbox"
+                            id="{{key}}-{{pack}}"
+                            name="{{key}}-{{pack}}"
+                            {{checked conf.load}}
+                        >
+                        {{conf.name}} ({{#if conf.showFullId}}{{pack}}{{else}}{{conf.package}}{{/if}})
+                    </label>
                 {{/each}}
             </fieldset>
         </div>


### PR DESCRIPTION
Every pack that is not unchecked in the settings is now included by default. This should only affect newly added packs as existing packs are already enabled or disabled in the existing settings object.

Also now shows the full pack id in cases where a module has multiple packs in the same category:

![image](https://github.com/user-attachments/assets/fb9c10ba-5d3e-4847-acfc-07c2d4e73843)
