### PR TITLE
Round Efficient Alchemy & Advanced Efficient Alchemy Slots Down

### DIFF
--- a/packs/classfeatures/advanced-alchemy.json
+++ b/packs/classfeatures/advanced-alchemy.json
@@ -33,7 +33,7 @@
                 "isDailyPrep": true,
                 "key": "CraftingAbility",
                 "label": "PF2E.SpecificRule.Alchemist.AdvancedAlchemy",
-                "maxSlots": "4 + @actor.system.abilities.int.mod",
+                "maxSlots": "floor(4 + @actor.system.abilities.int.mod)",
                 "slug": "advanced-alchemy"
             }
         ],

--- a/packs/feats/advanced-efficient-alchemy.json
+++ b/packs/feats/advanced-efficient-alchemy.json
@@ -33,7 +33,7 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.crafting.entries.advancedAlchemy.maxSlots",
-                "value": "ternary(gte(@actor.level,16),10,8) + @actor.system.abilities.int.mod"
+                "value": "floor(ternary(gte(@actor.level,16),10,8) + @actor.system.abilities.int.mod)"
             }
         ],
         "traits": {

--- a/packs/feats/efficient-alchemy-alchemist.json
+++ b/packs/feats/efficient-alchemy-alchemist.json
@@ -29,7 +29,7 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.crafting.entries.advancedAlchemy.maxSlots",
-                "value": "6 + @actor.system.abilities.int.mod"
+                "value": "floor(6 + @actor.system.abilities.int.mod)"
             }
         ],
         "traits": {


### PR DESCRIPTION
If you have a partial boost to intelligence the upgrade is giving you an additional 0.5 slots for your daily crafting, this makes sure that they are getting round down.