### PR TITLE
Show selectors when inspecting damage taken messages

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -1428,6 +1428,7 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
                     appliedDamage,
                     context: {
                         type: "damage-taken",
+                        domains: [domain],
                         options: Array.from(rollOptions),
                     },
                     origin: item?.getOriginData(),

--- a/src/module/chat-message/data.ts
+++ b/src/module/chat-message/data.ts
@@ -129,7 +129,7 @@ interface SelfEffectContextFlag {
 
 interface DamageTakenContextFlag {
     type: "damage-taken";
-    domains?: never;
+    domains?: string[];
     options?: string[];
     outcome?: never;
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0187f9cd-77df-480c-9e85-2184b56c5543)
