### PR TITLE
Fix `Craft` button being a submit button

### DIFF
--- a/static/templates/actors/character/tabs/crafting.hbs
+++ b/static/templates/actors/character/tabs/crafting.hbs
@@ -30,7 +30,7 @@
                         {{resource.max}}
                     </div>
                 </div>
-                <button class="blue" data-action="craft-item"><i class="fa-solid fa-hammer"></i> Craft</button>
+                <button type="button" class="blue" data-action="craft-item"><i class="fa-solid fa-hammer"></i> Craft</button>
             </li>
         {{/each}}
         {{#if crafting.abilities.alchemical.entries}}


### PR DESCRIPTION
This prevent the form to be submitted when pressing `enter` in any input field on the sheet.