### PR TITLE
Add Ephemeral Effect for Disarm's bonus to further attempts

### DIFF
--- a/packs/actions/skill-actions/disarm.json
+++ b/packs/actions/skill-actions/disarm.json
@@ -12,25 +12,14 @@
         },
         "category": "offensive",
         "description": {
-            "value": "<p><strong>Requirements</strong> You have at least one hand free. The target can't be more than one size larger than you.</p><hr /><p>You try to knock an item out of a creature's grasp. Attempt an [[/act disarm]]{Athletics} check against the target's Reflex DC.</p><hr /><p><strong>Critical Success</strong> You knock the item out of the target's grasp. It falls to the ground in the target's space.</p>\n<p><strong>Success</strong> You weaken your target's grasp on the item. Further attempts to @UUID[Compendium.pf2e.actionspf2e.Item.Disarm] the target of that item gain a +2 circumstance bonus, and the target takes a –2 circumstance penalty to attacks with the item or other checks requiring a firm grasp on the item. The creature can end the effect by Interacting to change its grip on the item; otherwise, it lasts as long as the creature holds the item.</p>\n<p><strong>Critical Failure</strong> You lose your balance and become @UUID[Compendium.pf2e.conditionitems.Item.Off-Guard] until the start of your next turn.</p>"
+            "value": "<p><strong>Requirements</strong> You have at least one hand free. The target can't be more than one size larger than you.</p><hr /><p>You try to knock an item out of a creature's grasp. Attempt an [[/act disarm]]{Athletics} check against the target's Reflex DC.</p><hr /><p><strong>Critical Success</strong> You knock the item out of the target's grasp. It falls to the ground in the target's space.</p>\n<p><strong>Success</strong> You weaken your target's grasp on the item. Further attempts to @UUID[Compendium.pf2e.actionspf2e.Item.Disarm] the target of that item gain a +2 circumstance bonus, and the target takes a –2 circumstance penalty to attacks with the item or other checks requiring a firm grasp on the item. The creature can end the effect by Interacting to change its grip on the item; otherwise, it lasts as long as the creature holds the item.</p>\n<p>@UUID[Compendium.pf2e.other-effects.Item.Effect: Disarm (Success)]</p>\n<p><strong>Critical Failure</strong> You lose your balance and become @UUID[Compendium.pf2e.conditionitems.Item.Off-Guard] until the start of your next turn.</p>"
         },
         "publication": {
             "license": "ORC",
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [
-            {
-                "key": "FlatModifier",
-                "predicate": [
-                    "action:disarm",
-                    "target:effect:disarm-success"
-                ],
-                "selector": "athletics",
-                "type": "circumstance",
-                "value": 2
-            }
-        ],
+        "rules": [],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/other-effects/effect-disarm-bonus.json
+++ b/packs/other-effects/effect-disarm-bonus.json
@@ -1,0 +1,48 @@
+{
+    "_id": "EpvyTaklBQAOr1eT",
+    "img": "icons/skills/melee/sword-damaged-broken-glow-red.webp",
+    "name": "Effect: Disarm (Bonus)",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.actionspf2e.Item.Disarm] via Ephemeral Effect.</p>\n<p>You gain a +2 circumstance bonus to Disarm.</p>"
+        },
+        "duration": {
+            "expiry": null,
+            "sustained": false,
+            "unit": "unlimited",
+            "value": -1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "label": "PF2E.SpecificRule.Disarm.WeakenedGraspBonusLabel",
+                "predicate": [
+                    "action:disarm"
+                ],
+                "selector": "skill-check",
+                "type": "circumstance",
+                "value": 2
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/other-effects/effect-disarm-success.json
+++ b/packs/other-effects/effect-disarm-success.json
@@ -1,10 +1,10 @@
 {
-    "_id": "z3ATL8DcRVrT0Uzt",
+    "_id": "PuDS0DEq0CnaSIFV",
     "img": "icons/skills/melee/sword-damaged-broken-glow-red.webp",
     "name": "Effect: Disarm (Success)",
     "system": {
         "description": {
-            "value": "<p>Granted by a successful @UUID[Compendium.pf2e.actionspf2e.Item.Disarm]</p>\n<p>You have a weakened grasp on an item. Further attempts to Disarm the item gain a +2 circumstance bonus, and you take a –2 circumstance penalty to attacks with the item or other checks requiring a firm grasp on the item. You can end the effect by Interacting to change your grip on the item; otherwise, it lasts as long as you hold the item.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.actionspf2e.Item.Disarm]</p>\n<p>You take a –2 circumstance penalty to attacks using the targeted item. Further attempts to Disarm you gain a +2 circumstance bonus.</p>"
         },
         "duration": {
             "expiry": null,
@@ -42,13 +42,10 @@
                 "value": -2
             },
             {
-                "key": "FlatModifier",
-                "predicate": [
-                    "action:disarm"
-                ],
-                "selector": "reflex-dc",
-                "type": "circumstance",
-                "value": -2
+                "affects": "origin",
+                "key": "EphemeralEffect",
+                "selectors": "skill-check",
+                "uuid": "Compendium.pf2e.other-effects.Item.Effect: Disarm (Bonus)"
             }
         ],
         "start": {

--- a/static/lang/action-en.json
+++ b/static/lang/action-en.json
@@ -290,7 +290,7 @@
                 "Notes": {
                     "criticalFailure": "<strong>Critical Failure</strong> You lose your balance and become @UUID[Compendium.pf2e.conditionitems.Item.AJh5ex99aV6VTggg]{Off-Guard} until the start of your next turn.",
                     "criticalSuccess": "<strong>Critical Success</strong> You knock the item out of the target's grasp. It falls to the ground in the target's space.",
-                    "success": "<strong>Success</strong> You weaken your target's grasp on the item. Further attempts to Disarm the target of that item gain a +2 circumstance bonus, and the target takes a -2 circumstance penalty to attacks with the item or other checks requiring a firm grasp on the item. The creature can end the effect by Interacting to change its grip on the item; otherwise, it lasts as long as the creature holds the item.<br>@UUID[Compendium.pf2e.equipment-effects.Item.z3ATL8DcRVrT0Uzt]{Effect: Disarm (Success)}"
+                    "success": "<strong>Success</strong> You weaken your target's grasp on the item. Further attempts to Disarm the target of that item gain a +2 circumstance bonus, and the target takes a -2 circumstance penalty to attacks with the item or other checks requiring a firm grasp on the item. The creature can end the effect by Interacting to change its grip on the item; otherwise, it lasts as long as the creature holds the item.<br>@UUID[Compendium.pf2e.other-effects.Item.PuDS0DEq0CnaSIFV]{Effect: Disarm (Success)}"
                 },
                 "Title": "Disarm"
             },

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -3010,6 +3010,9 @@
                     "AttackNote": "Your fangs Strike deals an additional @Damage[1d4[bleed]] on a critical hit."
                 }
             },
+            "Disarm": {
+                "WeakenedGraspBonusLabel": "Disarm (vs. weakened grasp)"
+            },
             "DivineAlly": {
                 "AllowedDrops": "champion class feature",
                 "Prompt": "Select a divine ally."


### PR DESCRIPTION
Also moved the effects to `other-effects` rather than `equipment-effects`. I didn't redirect since it was only linked in `action-en.json`, but I can add a redirect if deemed necessary.