### PR TITLE
Roll item macros for linked actors even if another actor is selected

### DIFF
--- a/src/module/apps/hotbar.ts
+++ b/src/module/apps/hotbar.ts
@@ -83,7 +83,8 @@ class HotbarPF2e extends Hotbar<MacroPF2e> {
      * @param slot     The hotbar slot to use
      */
     static async #createItemMacro(item: ItemPF2e, slot: number): Promise<void> {
-        const command = `game.pf2e.rollItemMacro("${item.id}", event);`;
+        const isLinked = !!item.actor?.prototypeToken.actorLink;
+        const command = `game.pf2e.rollItemMacro("${isLinked ? item.uuid : item.id}", event);`;
         const macro =
             game.macros.find((m) => m.name === item.name && m.command === command) ??
             (await MacroPF2e.create(


### PR DESCRIPTION
Use UUID for item macros created from linked actors.