### PR TITLE
Allow 3rd rank revelation spells to be chosen for Diverse Mystery

### DIFF
--- a/packs/feats/diverse-mystery.json
+++ b/packs/feats/diverse-mystery.json
@@ -35,7 +35,12 @@
                     "filter": [
                         "item:trait:focus",
                         "item:trait:oracle",
-                        "item:level:1"
+                        {
+                            "lte": [
+                                "item:rank",
+                                3
+                            ]
+                        }
                     ],
                     "itemType": "spell",
                     "slugsAsValues": true


### PR DESCRIPTION
Might need to look into a way of excluding spells from your own mystery, but not sure what the best way to go about that would be.