### PR TITLE
Support suboptions from config in roll option rule element

### DIFF
--- a/src/module/rules/helpers.ts
+++ b/src/module/rules/helpers.ts
@@ -9,6 +9,7 @@ import {
 } from "@actor/modifiers.ts";
 import { ItemPF2e } from "@item";
 import { ConditionSource, EffectSource, ItemSourcePF2e } from "@item/base/data/index.ts";
+import { PickableThing } from "@module/apps/pick-a-thing-prompt.ts";
 import { RollNotePF2e } from "@module/notes.ts";
 import { BaseDamageData } from "@system/damage/index.ts";
 import { DegreeOfSuccessAdjustment } from "@system/degree-of-success.ts";
@@ -241,6 +242,31 @@ function createBatchRuleElementUpdate(
     return itemUpdates;
 }
 
+function processChoicesFromData(data: unknown): PickableThing<string>[] {
+    if (Array.isArray(data)) {
+        if (!data.every((c) => R.isPlainObject(c) && typeof c.value === "string")) {
+            return [];
+        }
+
+        return data;
+    }
+
+    // If this is an object with all string values or all string labels, optionally run the top level filter predicate
+    if (R.isObjectType(data)) {
+        const entries = Object.entries(data);
+        if (!entries.every(([_, c]) => typeof (R.isPlainObject(c) ? c.label : c) === "string")) {
+            return [];
+        }
+
+        return entries.map(([key, entryValue]) => {
+            const choice = typeof entryValue === "string" ? { label: entryValue } : entryValue;
+            return { ...choice, label: String(choice.label), value: key };
+        });
+    }
+
+    return [];
+}
+
 export {
     createBatchRuleElementUpdate,
     extractDamageAlterations,
@@ -253,6 +279,7 @@ export {
     extractRollSubstitutions,
     extractRollTwice,
     isBracketedValue,
+    processChoicesFromData,
     processDamageCategoryStacking,
     processPreUpdateActorHooks,
 };

--- a/src/module/rules/rule-element/roll-option/data.ts
+++ b/src/module/rules/rule-element/roll-option/data.ts
@@ -1,4 +1,10 @@
-import { DataUnionField, PredicateField, StrictBooleanField, StrictStringField } from "@system/schema-data-fields.ts";
+import {
+    DataUnionField,
+    PredicateField,
+    StrictArrayField,
+    StrictBooleanField,
+    StrictStringField,
+} from "@system/schema-data-fields.ts";
 import type * as fields from "types/foundry/common/data/fields.d.ts";
 import type { AELikeDataPrepPhase } from "../ae-like.ts";
 import type { ResolvableValueField, RuleElementSchema } from "../data.ts";
@@ -31,7 +37,19 @@ type RollOptionSchema = RuleElementSchema & {
     phase: fields.StringField<AELikeDataPrepPhase, AELikeDataPrepPhase, false, false, true>;
     option: fields.StringField<string, string, true, false, false>;
     /** Suboptions for a toggle, appended to the option string */
-    suboptions: fields.ArrayField<SuboptionField>;
+    suboptions: DataUnionField<
+        | fields.SchemaField<
+              SuboptionConfigSchema,
+              SourceFromSchema<SuboptionConfigSchema>,
+              ModelPropsFromSchema<SuboptionConfigSchema>,
+              false,
+              false
+          >
+        | StrictArrayField<SuboptionField>,
+        false,
+        false,
+        true
+    >;
     /**
      * The value of the roll option: either a boolean or a string resolves to a boolean If omitted, it defaults to
      * `true` unless also `togglable`, in which case to `false`.
@@ -67,6 +85,11 @@ type SuboptionSchema = {
 };
 type SuboptionSource = SourceFromSchema<SuboptionSchema>;
 type SuboptionField = fields.EmbeddedDataField<Suboption, true, false, false>;
+
+type SuboptionConfigSchema = {
+    config: fields.StringField<string, string, true, false, false>;
+    predicate: PredicateField<false, false>;
+};
 
 export { Suboption };
 export type { RollOptionSchema, SuboptionField, SuboptionSource };

--- a/src/module/rules/rule-element/roll-option/rule-element.ts
+++ b/src/module/rules/rule-element/roll-option/rule-element.ts
@@ -1,4 +1,12 @@
-import { DataUnionField, PredicateField, StrictBooleanField, StrictStringField } from "@system/schema-data-fields.ts";
+import { processChoicesFromData } from "@module/rules/helpers.ts";
+import { Predicate } from "@system/predication.ts";
+import {
+    DataUnionField,
+    PredicateField,
+    StrictArrayField,
+    StrictBooleanField,
+    StrictStringField,
+} from "@system/schema-data-fields.ts";
 import { ErrorPF2e, sluggify } from "@util";
 import * as R from "remeda";
 import { RollOptionToggle } from "../../synthetics.ts";
@@ -12,8 +20,13 @@ import { Suboption, type RollOptionSchema } from "./data.ts";
  * @category RuleElement
  */
 class RollOptionRuleElement extends RuleElementPF2e<RollOptionSchema> {
+    /** True if this roll option has a suboptions configuration */
+    hasSubOptions: boolean;
+
     constructor(source: RollOptionSource, options: RuleElementOptions) {
         super(source, options);
+        this.hasSubOptions = !Array.isArray(this.suboptions) || !!this.suboptions.length;
+
         if (this.invalid) return;
 
         if (source.removeAfterRoll && !this.item.isOfType("effect")) {
@@ -30,9 +43,12 @@ class RollOptionRuleElement extends RuleElementPF2e<RollOptionSchema> {
         this.option = this.#resolveOption();
 
         // If no suboption has been selected yet, set the first as selected
-        const firstSuboption = this.suboptions.at(0);
-        if (firstSuboption && !this.suboptions.some((s) => s.value === this.selection)) {
-            this.selection = firstSuboption.value;
+        // We need to consider removing this, but we are keeping it to exercise caution
+        if (Array.isArray(this.suboptions)) {
+            const firstSuboption = this.suboptions.at(0);
+            if (firstSuboption && !this.suboptions.some((s) => s.value === this.selection)) {
+                this.selection = firstSuboption.value;
+            }
         }
     }
 
@@ -58,11 +74,23 @@ class RollOptionRuleElement extends RuleElementPF2e<RollOptionSchema> {
                 choices: fu.deepClone(AELikeRuleElement.PHASES),
                 initial: "applyAEs",
             }),
-            suboptions: new fields.ArrayField(new fields.EmbeddedDataField(Suboption), {
-                required: false,
-                nullable: false,
-                initial: [],
-            }),
+            suboptions: new DataUnionField(
+                [
+                    new fields.SchemaField(
+                        {
+                            config: new fields.StringField({ required: true, nullable: false }),
+                            predicate: new PredicateField({ required: false, nullable: false, initial: undefined }),
+                        },
+                        { required: false, nullable: false, initial: undefined },
+                    ),
+                    new StrictArrayField(new fields.EmbeddedDataField(Suboption), {
+                        required: true,
+                        nullable: false,
+                        initial: [],
+                    }),
+                ],
+                { required: false, nullable: false, initial: [] },
+            ),
             mergeable: new fields.BooleanField({ required: false }),
             value: new ResolvableValueField({
                 required: false,
@@ -94,8 +122,9 @@ class RollOptionRuleElement extends RuleElementPF2e<RollOptionSchema> {
 
     static override validateJoint(source: SourceFromSchema<RollOptionSchema>): void {
         super.validateJoint(source);
+        const subOptionsIsEmpty = Array.isArray(source.suboptions) && source.suboptions.length === 0;
 
-        if (source.suboptions.length > 0 && !source.toggleable) {
+        if (!subOptionsIsEmpty && !source.toggleable) {
             throw Error("suboptions: must be omitted if not toggleable");
         }
 
@@ -111,7 +140,7 @@ class RollOptionRuleElement extends RuleElementPF2e<RollOptionSchema> {
             throw Error("disabledValue: may only be included if toggeable and there is a disabledIf predicate.");
         }
 
-        if (source.alwaysActive && (!source.toggleable || source.suboptions.length === 0)) {
+        if (source.alwaysActive && (!source.toggleable || subOptionsIsEmpty)) {
             throw Error("alwaysActive: must be false unless toggleable and containing suboptions");
         }
 
@@ -145,11 +174,40 @@ class RollOptionRuleElement extends RuleElementPF2e<RollOptionSchema> {
         return this.alwaysActive ? true : !!super.resolveValue(this.value);
     }
 
+    /** Retrieves the self sub options without handling any merge families */
+    getSelfSuboptions(): Suboption[] {
+        const suboptions = this.suboptions;
+        if (Array.isArray(suboptions)) return suboptions;
+
+        const data = fu.getProperty(CONFIG.PF2E, suboptions.config);
+        const choices = processChoicesFromData(data);
+        return choices.map(
+            (choice) =>
+                new Suboption(
+                    {
+                        label: choice.label,
+                        value: choice.value,
+                        predicate:
+                            choice.predicate || suboptions.predicate.length
+                                ? this.resolveInjectedProperties(
+                                      new Predicate(choice.predicate ?? fu.deepClone(suboptions.predicate)),
+                                      {
+                                          injectables: { choice },
+                                      },
+                                  )
+                                : null,
+                    },
+                    { parent: this },
+                ),
+        );
+    }
+
     /** Filter suboptions, including those among the same merge family. */
     #resolveSuboptions(test?: Set<string>): Suboption[] {
         // Extract local suboptions first. If any exist but all fail predication, return none so we can fail later.
-        const localSuboptions = this.suboptions.filter((s) => !test || s.predicate.test(test));
-        if (this.suboptions.length > 0 && localSuboptions.length === 0) {
+        const selfSuboptions = this.getSelfSuboptions();
+        const localSuboptions = selfSuboptions.filter((s) => !test || s.predicate.test(test));
+        if (this.hasSubOptions && localSuboptions.length === 0) {
             return [];
         }
 
@@ -163,7 +221,7 @@ class RollOptionRuleElement extends RuleElementPF2e<RollOptionSchema> {
                   r.domain === this.domain &&
                   r.option === this.option &&
                   (!test || r.test(test))
-                      ? r.suboptions
+                      ? r.getSelfSuboptions()
                       : [],
               )
             : [];
@@ -236,7 +294,7 @@ class RollOptionRuleElement extends RuleElementPF2e<RollOptionSchema> {
 
             // If no suboptions remain after predicate testing, don't set the roll option or expose the toggle.
             // Also prevent further processing, such as from beforeRoll().
-            if (this.suboptions.length > 0 && suboptions.length === 0) {
+            if (this.hasSubOptions && suboptions.length === 0) {
                 this.ignored = true;
                 return;
             }


### PR DESCRIPTION
Created to purify some frankly scary thaumaturge related rule elements

```json
{
  "key": "RollOption",
  "option": "super-skill",
  "toggleable": true,
  "phase": "beforeDerived",
  "suboptions": {
    "config": "skills",
    "predicate": [
      {
        "gt": [
          "skill:{choice|value}:rank",
          0
        ]
      }
    ]
  }
}
```