### PR TITLE
Add effect for Instructive Strike and automate Implement's Flight

### DIFF
--- a/packs/classfeatures/mirror.json
+++ b/packs/classfeatures/mirror.json
@@ -58,7 +58,7 @@
                             "not": "feature:adept-benefit-mirror"
                         }
                     ],
-                    "value": "Compendium.pf2e.classfeatures.Item.Adept Benefit (Lantern)"
+                    "value": "Compendium.pf2e.classfeatures.Item.Adept Benefit (Mirror)"
                 }
             }
         ],

--- a/packs/classfeatures/second-adept.json
+++ b/packs/classfeatures/second-adept.json
@@ -28,7 +28,7 @@
             {
                 "adjustName": false,
                 "choices": "flags.pf2e.thaumaturge.adeptChoices",
-                "flag": "implementAdept",
+                "flag": "secondAdept",
                 "key": "ChoiceSet"
             },
             {
@@ -40,7 +40,7 @@
             },
             {
                 "key": "GrantItem",
-                "uuid": "{item|flags.pf2e.rulesSelections.implementAdept}"
+                "uuid": "{item|flags.pf2e.rulesSelections.secondAdept}"
             }
         ],
         "traits": {

--- a/packs/feat-effects/effect-instructive-strike.json
+++ b/packs/feat-effects/effect-instructive-strike.json
@@ -1,0 +1,47 @@
+{
+    "_id": "GAKXSLDwFpE5VLyx",
+    "img": "icons/skills/melee/hand-grip-sword-strike-orange.webp",
+    "name": "Effect: Instructive Strike",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Instructive Strike]</p>\n<p>You gain a +2 circumstance bonus to your check to Recall Knowledge.</p>"
+        },
+        "duration": {
+            "expiry": null,
+            "sustained": false,
+            "unit": "unlimited",
+            "value": -1
+        },
+        "level": {
+            "value": 4
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Dark Archive"
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "action:recall-knowledge"
+                ],
+                "removeAfterRoll": true,
+                "selector": "skill-check",
+                "type": "circumstance",
+                "value": 2
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feats/cursed-effigy.json
+++ b/packs/feats/cursed-effigy.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p><strong>Requirements</strong> Your last action was a successful Strike against the target of your Exploit Vulnerability, and the Strike dealt physical damage.</p>\n<hr />\n<p>After your attack, you grab a bit of blood, cut hair, or other piece of the creature's body. You incorporate the material into a premade doll, paper figure, or other effigy to create a sympathetic link that makes it harder to resist your abilities. As long as you are Exploiting Vulnerability against that creature, it takes a -2 status penalty to its saving throws against thaumaturge abilities or items that use your thaumaturge class DC.</p>"
+            "value": "<p><strong>Requirements</strong> Your last action was a successful Strike against the target of your @UUID[Compendium.pf2e.actionspf2e.Item.Exploit Vulnerability], and the Strike dealt physical damage.</p><hr /><p>After your attack, you grab a bit of blood, cut hair, or other piece of the creature's body. You incorporate the material into a premade doll, paper figure, or other effigy to create a sympathetic link that makes it harder to resist your abilities. As long as you are Exploiting Vulnerability against that creature, it takes a -2 status penalty to its saving throws against thaumaturge abilities or items that use your thaumaturge class DC.</p>"
         },
         "level": {
             "value": 8

--- a/packs/feats/implements-flight.json
+++ b/packs/feats/implements-flight.json
@@ -24,7 +24,16 @@
             "remaster": false,
             "title": "Pathfinder Dark Archive"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "BaseSpeed",
+                "predicate": [
+                    "implement-held"
+                ],
+                "selector": "fly",
+                "value": "@actor.attributes.speed.total"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/instructive-strike.json
+++ b/packs/feats/instructive-strike.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>You attack your foe and analyze how it reacts. Make a Strike. On a hit, you can immediately attempt a check to Recall Knowledge about the target. On a critical hit, you gain a +2 circumstance bonus to the check to Recall Knowledge.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Instructive Strike]</p>"
+            "value": "<p>You attack your foe and analyze how it reacts. Make a Strike. On a hit, you can immediately attempt a check to @UUID[Compendium.pf2e.actionspf2e.Item.Recall Knowledge] about the target. On a critical hit, you gain a +2 circumstance bonus to the check to Recall Knowledge.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Instructive Strike]</p>"
         },
         "level": {
             "value": 4

--- a/packs/feats/instructive-strike.json
+++ b/packs/feats/instructive-strike.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>You attack your foe and analyze how it reacts. Make a Strike. On a hit, you can immediately attempt a check to Recall Knowledge about the target. On a critical hit, you gain a +2 circumstance bonus to the check to Recall Knowledge.</p>"
+            "value": "<p>You attack your foe and analyze how it reacts. Make a Strike. On a hit, you can immediately attempt a check to Recall Knowledge about the target. On a critical hit, you gain a +2 circumstance bonus to the check to Recall Knowledge.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Instructive Strike]</p>"
         },
         "level": {
             "value": 4

--- a/packs/feats/intense-implement.json
+++ b/packs/feats/intense-implement.json
@@ -26,28 +26,21 @@
         },
         "rules": [
             {
-                "choices": {
-                    "ownedItems": true,
-                    "predicate": [
-                        "item:tag:thaumaturge-implement",
-                        {
-                            "not": "item:tag:thaumaturge-implement-adept"
-                        }
-                    ],
-                    "types": [
-                        "feat"
-                    ]
-                },
-                "flag": "intenseImplement",
-                "key": "ChoiceSet",
-                "prompt": "PF2E.UI.RuleElements.ChoiceSet.Prompt"
+                "adjustName": false,
+                "choices": "flags.pf2e.thaumaturge.adeptChoices",
+                "flag": "thirdAdept",
+                "key": "ChoiceSet"
             },
             {
-                "itemId": "{item|flags.pf2e.rulesSelections.intenseImplement}",
+                "itemId": "{item|flags.pf2e.rulesSelections.thirdAdept}",
                 "key": "ItemAlteration",
                 "mode": "add",
                 "property": "other-tags",
                 "value": "thaumaturge-implement-adept"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "{item|flags.pf2e.rulesSelections.thirdAdept}"
             }
         ],
         "traits": {

--- a/packs/feats/seven-part-link.json
+++ b/packs/feats/seven-part-link.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>Many traditions hold the number seven as significant. By exchanging pieces of a seven-part set of esoterica, you create a magical web by which your allies can affect each other at a distance. When you use Paired Link during your daily preparations, you can exchange linking esoterica with up to six willing allies, keeping one piece for yourself. In addition to the normal effects of Paired Link, if a linked ally casts a spell with a range of touch, they can target linked allies within 30 feet with that spell.</p>"
+            "value": "<p>Many traditions hold the number seven as significant. By exchanging pieces of a seven-part set of esoterica, you create a magical web by which your allies can affect each other at a distance. When you use @UUID[Compendium.pf2e.feats-srd.Item.Paired Link] during your daily preparations, you can exchange linking esoterica with up to six willing allies, keeping one piece for yourself. In addition to the normal effects of Paired Link, if a linked ally casts a spell with a range of touch, they can target linked allies within 30 feet with that spell.</p>"
         },
         "level": {
             "value": 16

--- a/packs/feats/shared-warding.json
+++ b/packs/feats/shared-warding.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>You ward your allies from the attacks of your foes whenever you apply those protections to yourself. When you gain a status bonus to AC and saves from Esoteric Warden, you can choose to grant the same benefit to all allies within 30 feet.</p>"
+            "value": "<p>You ward your allies from the attacks of your foes whenever you apply those protections to yourself. When you gain a status bonus to AC and saves from @UUID[Compendium.pf2e.feats-srd.Item.Esoteric Warden], you can choose to grant the same benefit to all allies within 30 feet.</p>"
         },
         "level": {
             "value": 12

--- a/packs/feats/thaumaturges-investiture.json
+++ b/packs/feats/thaumaturges-investiture.json
@@ -37,30 +37,7 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.resources.investiture.max",
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 4.5,
-                            "start": 4,
-                            "value": 14
-                        },
-                        {
-                            "end": 5.5,
-                            "start": 5,
-                            "value": 16
-                        },
-                        {
-                            "end": 6.5,
-                            "start": 6,
-                            "value": 18
-                        },
-                        {
-                            "start": 7,
-                            "value": 20
-                        }
-                    ],
-                    "field": "system.abilities.cha.mod"
-                }
+                "value": "ternary(gte(@actor.system.abilities.cha.mod,7),20,ternary(gte(@actor.system.abilities.cha.mod,6),18,ternary(gte(@actor.system.abilities.cha.mod,5),16,ternary(gte(@actor.system.abilities.cha.mod,4),14,12))))"
             }
         ],
         "traits": {

--- a/packs/feats/thaumaturgic-ritualist.json
+++ b/packs/feats/thaumaturgic-ritualist.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>Your studies into the supernatural have resulted in an especially strong knowledge of rituals. You gain a +2 circumstance bonus to all primary checks to perform a ritual. You learn two uncommon rituals with a level no higher than half your level; you must meet all prerequisites for casting the ritual to choose it. You can cast these as the primary caster, but you can't teach them to anyone else or allow someone else to serve as primary caster unless they know the ritual as well.</p>\n<p>At 8th level and every 4 levels thereafter, you learn another uncommon ritual with a level no higher than half your level and for which you meet the prerequisites.</p>"
+            "value": "<p>Your studies into the supernatural have resulted in an especially strong knowledge of rituals. You gain a +2 circumstance bonus to all primary checks to perform a ritual. You learn two uncommon rituals with a rank no higher than half your level; you must meet all prerequisites for casting the ritual to choose it. You can cast these as the primary caster, but you can't teach them to anyone else or allow someone else to serve as primary caster unless they know the ritual as well.</p>\n<p>At 8th level and every 4 levels thereafter, you learn another uncommon ritual with a rank no higher than half your level and for which you meet the prerequisites.</p>"
         },
         "level": {
             "value": 4

--- a/packs/feats/ubiquitous-weakness.json
+++ b/packs/feats/ubiquitous-weakness.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>You've nurtured your bonds with your comrades, allowing you to share the benefits of your esoterica. When you use Exploit Vulnerability and choose mortal weakness, select any number of allies within 30 feet of you. Their Strikes apply the weakness from mortal weakness the same way your Strikes do. This benefit ends when you stop benefiting from Exploit Vulnerability. Since this effect depends on magically strengthening your bond to your allies, only allies with whom you've developed a rapport over the course of one or more days gain the benefit.</p>"
+            "value": "<p>You've nurtured your bonds with your comrades, allowing you to share the benefits of your esoterica. When you use @UUID[Compendium.pf2e.actionspf2e.Item.Exploit Vulnerability] and choose mortal weakness, select any number of allies within 30 feet of you. Their Strikes apply the weakness from mortal weakness the same way your Strikes do. This benefit ends when you stop benefiting from Exploit Vulnerability. Since this effect depends on magically strengthening your bond to your allies, only allies with whom you've developed a rapport over the course of one or more days gain the benefit.</p>"
         },
         "level": {
             "value": 20


### PR DESCRIPTION
Also
- Fix wrong Adept Benefit being linked in Mirror class feature
- Change Second Adept's Choice Set item flag to `secondAdept`
- Automate Intense Implement
- Use ternary over brackets in Thaumaturge's Investiture
- Add compendium links to various feat descriptions