### PR TITLE
Add localized notes to Wild Witch's Armaments feat

### DIFF
--- a/packs/feats/wild-witchs-armaments.json
+++ b/packs/feats/wild-witchs-armaments.json
@@ -31,7 +31,7 @@
         "rules": [
             {
                 "key": "RollOption",
-                "label": "You hit the same enemy with two consecutive nails strikes",
+                "label": "PF2E.SpecificRule.Witch.WildWitchsArmaments.EldritchNails.RollOptionLabel",
                 "option": "wild-witchs-armaments:nails",
                 "predicate": [
                     "witchs-armaments:nails"
@@ -55,7 +55,7 @@
                     "witchs-armaments:teeth"
                 ],
                 "selector": "iron-teeth-damage",
-                "text": "Like a true predator, your teeth can crunch bone. A creature that you critically hit with a jaws Strike must succeed at a @Check[fortitude|against:class] save against your class DC or become @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 1}.",
+                "text": "PF2E.SpecificRule.Witch.WildWitchsArmaments.IronTeeth.Note",
                 "title": "{item|name}"
             },
             {
@@ -69,7 +69,7 @@
                 },
                 "img": "icons/weapons/thrown/dart-feathered.webp",
                 "key": "Strike",
-                "label": "Quills",
+                "label": "PF2E.SpecificRule.Witch.WildWitchsArmaments.LivingHair.StrikeLabel",
                 "predicate": [
                     "witchs-armaments:hair"
                 ],

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -6049,10 +6049,10 @@
                         "RollOptionLabel": "You hit the same enemy with two consecutive nail strikes"
                     },
                     "IronTeeth": {
-                        "Note": "A creature that you critically hit with a jaws Strike must succeed at a @Check[fortitude|against:witch] save or become @UUID[Compendium.pf2e.conditionitems.Item.fesd1n5eVhpCSS18]{Sickened 1}."
+                        "Note": "A creature that you critically hit with a jaws Strike must succeed at a @Check[fortitude|against:class-spell] save gainst your class DC or Spell DC or become @UUID[Compendium.pf2e.conditionitems.Item.fesd1n5eVhpCSS18]{Sickened 1}."
                     },
                     "LivingHair": {
-                        "SrikeLabel": "Quill"
+                        "StrikeLabel": "Quill"
                     }
                 },
                 "WitchsArmaments": {


### PR DESCRIPTION
Also, corrects a typo in the localization and updated iron teeth note to match errata.