### PR TITLE
Add adept and paragon benefits description addenda to Ring Bell and Mirror's Reflection

### DIFF
--- a/packs/classfeatures/adept-benefit-bell.json
+++ b/packs/classfeatures/adept-benefit-bell.json
@@ -34,6 +34,21 @@
                     "label": "PF2E.SpecificRule.Thaumaturge.Implement.Bell.Label",
                     "value": "Compendium.pf2e.classfeatures.Item.Paragon Benefit (Bell)"
                 }
+            },
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Thaumaturge.Implement.Adept.Label",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:ring-bell"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "{item|description}"
+                    }
+                ]
             }
         ],
         "traits": {

--- a/packs/classfeatures/adept-benefit-mirror.json
+++ b/packs/classfeatures/adept-benefit-mirror.json
@@ -11,7 +11,7 @@
         },
         "category": "classfeature",
         "description": {
-            "value": "<p>Your mirror self shatters into punishing shards when damaged. While Mirror's Reflection is in effect, when an enemy adjacent to one of your spaces damages you, that version of you explodes into mirror shards. This ends Mirror's Reflection (establishing the remaining version of you as the real one) and deals slashing damage to all creatures in a @Template[emanation|distance:5] around where your mirror self was. The damage is equal to 2 + half your level or the damage of the triggering attack, whichever is lower. You're immune to this damage.</p>"
+            "value": "<p>Your mirror self shatters into punishing shards when damaged. While Mirror's Reflection is in effect, when an enemy adjacent to one of your spaces damages you, that version of you explodes into mirror shards. This ends Mirror's Reflection (establishing the remaining version of you as the real one) and deals slashing damage to all creatures in a @Template[emanation|distance:5] around where your mirror self was. The damage is equal to @Damage[(2 + floor(@actor.level / 2))[slashing]|options:area-damage]{2 + half your level} or the damage of the triggering attack, whichever is lower. You're immune to this damage.</p>"
         },
         "level": {
             "value": 7

--- a/packs/classfeatures/paragon-benefit-bell.json
+++ b/packs/classfeatures/paragon-benefit-bell.json
@@ -24,7 +24,23 @@
             "remaster": false,
             "title": "Pathfinder Dark Archive"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Thaumaturge.Implement.Paragon.Label",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:ring-bell"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "{item|description}"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/classfeatures/paragon-benefit-mirror.json
+++ b/packs/classfeatures/paragon-benefit-mirror.json
@@ -11,7 +11,7 @@
         },
         "category": "classfeature",
         "description": {
-            "value": "<p>You've become so skilled at reflecting yourself that you can combine making a reflection with your other movements to act right away. When you use Mirror's Reflection, you can have one of your selves immediately @UUID[Compendium.pf2e.actionspf2e.Item.Interact], @UUID[Compendium.pf2e.actionspf2e.Item.Seek], or @UUID[Compendium.pf2e.actionspf2e.Item.Strike].</p>"
+            "value": "<p>You've become so skilled at reflecting yourself that you can combine making a reflection with your other movements to act right away. When you use @UUID[Compendium.pf2e.actionspf2e.Item.Mirror's Reflection], you can have one of your selves immediately @UUID[Compendium.pf2e.actionspf2e.Item.Interact], @UUID[Compendium.pf2e.actionspf2e.Item.Seek], or @UUID[Compendium.pf2e.actionspf2e.Item.Strike].</p>"
         },
         "level": {
             "value": 17
@@ -24,7 +24,23 @@
             "remaster": false,
             "title": "Pathfinder Dark Archive"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Thaumaturge.Implement.Paragon.Label",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:mirrors-reflection"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "{item|description}"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feat-effects/effect-chalice-adept-benefit-self.json
+++ b/packs/feat-effects/effect-chalice-adept-benefit-self.json
@@ -35,6 +35,21 @@
                 ],
                 "property": "other-tags",
                 "value": "chalice-adept-benefit"
+            },
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.Thaumaturge.Implement.Adept.Label",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:drink-from-the-chalice"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Thaumaturge.Implement.Chalice.Adept.DescriptionAlteration"
+                    }
+                ]
             }
         ],
         "start": {

--- a/packs/feat-effects/effect-drink-from-the-chalice.json
+++ b/packs/feat-effects/effect-drink-from-the-chalice.json
@@ -4,7 +4,7 @@
     "name": "Effect: Drink from the Chalice",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.actionspf2e.Item.Drink from the Chalice]</p>\n<p>You gain temporary Hit Points equal to 2 + half the origin's level.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.actionspf2e.Item.Drink from the Chalice]</p>\n<p>You gain temporary Hit Points equal to 2 + half the origin's level. If the origin is under the effects of the chalice's adept benefit, these temporary Hit Points increase to 2 + their Charisma modifier + their level.</p>"
         },
         "duration": {
             "expiry": "turn-end",

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -5745,6 +5745,7 @@
                     },
                     "Chalice": {
                         "Adept": {
+                            "DescriptionAlteration": "On a sip, the temporary Hit Points granted to the creature increase to 2 + your Charisma modifier + your level. When drained, the chalice heals the creature 5 Hit Points for each level you have.",
                             "Note": "If you or an ally within 30 feet takes piercing or slashing damage from a foe's critical hit or takes persistent bleed damage, Drinking from the Chalice before the end of your next turn grants that injured creature greater restoration to make up for its lost vitality. On a sip, the temporary Hit Points granted to the creature increase to 2 + your Charisma modifier + your level. When drained, the chalice heals the creature 5 Hit Points for each level you have. @UUID[Compendium.pf2e.feat-effects.Item.Sq558879cgEc1lGC]{Effect: Chalice Adept Benefit (Self)}"
                         },
                         "Label": "Chalice"


### PR DESCRIPTION
Also have the Chalice Adept Benefit's effect add a description addendum to Drink from the Chalice to make it clearer to the user