### PR TITLE
Fix chat token images blocking saves posted to chat

### DIFF
--- a/src/styles/ui/sidebar/chat/_index.scss
+++ b/src/styles/ui/sidebar/chat/_index.scss
@@ -23,6 +23,7 @@
                 border: none;
                 height: 2.25rem;
                 object-fit: contain;
+                pointer-events: none;
                 width: 2.25rem;
             }
 


### PR DESCRIPTION
The portrait itself still handles click events, but the image which overflows intentionally no longer blocks

![image](https://github.com/user-attachments/assets/6c85f92d-308a-49a1-aa3f-37410fa37732)
