### PR TITLE
Remove spontaneous quick craft button from crafting tab

### DIFF
--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -1041,17 +1041,7 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
             // Handle ability crafting first if we're crafting for an ability
             const ability = this.actor.crafting.abilities.get(row.dataset.ability ?? "");
             if (ability) {
-                const craftParam = await (async () => {
-                    if (ability.isPrepared) return row.dataset.itemIndex ? Number(row.dataset.itemIndex) : null;
-
-                    if (ability.resource) {
-                        const picker = new FormulaPicker({ actor: this.actor, ability });
-                        return await picker.resolveSelection();
-                    }
-
-                    return null;
-                })();
-
+                const craftParam = ability.isPrepared && row.dataset.itemIndex ? Number(row.dataset.itemIndex) : null;
                 const consume = !ability.resource || !!this.actor.getResource(ability.resource)?.value;
                 const item = craftParam !== null ? await ability.craft(craftParam, { consume }) : null;
                 if (item) {

--- a/src/styles/actor/character/_crafting.scss
+++ b/src/styles/actor/character/_crafting.scss
@@ -48,31 +48,6 @@
             }
         }
 
-        &.spontaneous {
-            border: 1px solid var(--color-pf-alternate);
-            background-color: rgba($sub-color, 0.25);
-            align-items: center;
-            justify-content: start;
-            font-family: var(--sans-serif);
-            padding: var(--space-5);
-            margin-bottom: var(--space-6);
-
-            .name {
-                font-weight: 500;
-                flex: 1;
-            }
-
-            .resource {
-                align-items: center;
-                display: flex;
-                gap: var(--space-2);
-            }
-
-            button {
-                margin-left: var(--space-8);
-            }
-        }
-
         .action-header {
             color: var(--text-light);
             font-size: var(--font-size-16);

--- a/static/templates/actors/character/tabs/crafting.hbs
+++ b/static/templates/actors/character/tabs/crafting.hbs
@@ -10,29 +10,6 @@
         </div>
     {{/if}}
     <ol class="directory-list item-list crafting-entry-list">
-        {{#each crafting.abilities.spontaneous as |ability i|}}
-            <li class="crafting-entry formula-header spontaneous" data-ability="{{ability.slug}}">
-                <div class="name">
-                    {{ability.label}}
-                </div>
-                <div class="resource">
-                    <span>{{localize resource.label}}:</span>
-                    <input
-                        class="formula-number"
-                        type="number"
-                        data-action="adjust-resource"
-                        data-resource="{{resource.slug}}"
-                        value="{{resource.value}}"
-                        placeholder="0"
-                    />
-                    <span>/</span>
-                    <div class="formula-number">
-                        {{resource.max}}
-                    </div>
-                </div>
-                <button type="button" class="blue" data-action="craft-item"><i class="fa-solid fa-hammer"></i> Craft</button>
-            </li>
-        {{/each}}
         {{#if crafting.abilities.alchemical.entries}}
             <li class="crafting-entry item-container" data-container-type="craftingEntryGroup">
                 <div class="action-header">{{localize "PF2E.CraftingTab.Alchemical.AdvancedAlchemy"}}</div>


### PR DESCRIPTION
This removes the ability for spontaneous crafting that is independent of activations. There is a point of disconnect where quick alchemy done via the crafting tab is slightly different than quick alchemy done via the actions tab. I would prefer gather data first, as its easier to add features than remove as far as perception goes.

### Rationale
I have a suspicion that the `use` button being how you craft with quick alchemy won't be that intuitive. If so, duplicating crafting actions in the actions tab to the crafting tab may help teach that its related and also allow better UX in certain out of combat scenarios.  However this is different from the current implementation that allows you to quick craft items even without being associated with an action.

The future has a few different approaches:
1) Leave as is
2) Bring back spontaneous crafting as it was, leaving it disconnected from the ability even if it has an ability associated
3) Duplicate crafting related activations to the crafting tab as crafting actions, but omit spontaneous abilities without actions
4) Duplicate crafting related activations and include those that aren't actions displayed in a different way

It would be best to get more data first.