### PR TITLE
Update Snare feats and Gadget Specialist crafting abilities

### DIFF
--- a/packs/feats/elaborate-talisman-esoterica.json
+++ b/packs/feats/elaborate-talisman-esoterica.json
@@ -32,10 +32,10 @@
         "rules": [
             {
                 "key": "ActiveEffectLike",
-                "mode": "add",
+                "mode": "upgrade",
                 "path": "system.crafting.entries.talismanEsoterica.maxSlots",
                 "phase": "beforeDerived",
-                "value": 2
+                "value": "2*(@item.timesTaken + 1)"
             }
         ],
         "traits": {

--- a/packs/feats/gadget-specialist.json
+++ b/packs/feats/gadget-specialist.json
@@ -35,34 +35,8 @@
                 ],
                 "isDailyPrep": true,
                 "key": "CraftingAbility",
-                "label": "Gadget Specialist",
+                "maxSlots": "max(2,@actor.system.skills.crafting.rank)",
                 "slug": "gadget-specialist"
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "add",
-                "path": "system.crafting.entries.gadgetSpecialist.maxSlots",
-                "phase": "beforeDerived",
-                "priority": 41,
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 2,
-                            "start": 2,
-                            "value": 2
-                        },
-                        {
-                            "end": 3,
-                            "start": 3,
-                            "value": 3
-                        },
-                        {
-                            "start": 4,
-                            "value": 4
-                        }
-                    ],
-                    "field": "actor|system.skills.crafting.rank"
-                }
             }
         ],
         "traits": {

--- a/packs/feats/plentiful-snares.json
+++ b/packs/feats/plentiful-snares.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>You can prepare incredible numbers of snares each day out of simple ingredients. Double the number of prepared snares granted by Snarecrafter Dedication.</p>"
+            "value": "<p>You can prepare incredible numbers of snares each day out of simple ingredients. Double the number of prepared snares granted by @UUID[Compendium.pf2e.feats-srd.Item.Snarecrafter Dedication].</p>"
         },
         "level": {
             "value": 12
@@ -31,28 +31,11 @@
         "rules": [
             {
                 "key": "ActiveEffectLike",
-                "mode": "add",
-                "path": "system.crafting.entries.snareCrafting.maxSlots",
+                "mode": "multiply",
+                "path": "system.crafting.entries.snarecrafter.maxSlots",
                 "phase": "beforeDerived",
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 2,
-                            "start": 1,
-                            "value": 4
-                        },
-                        {
-                            "end": 3,
-                            "start": 3,
-                            "value": 6
-                        },
-                        {
-                            "start": 4,
-                            "value": 8
-                        }
-                    ],
-                    "field": "actor|system.skills.crafting.rank"
-                }
+                "priority": 41,
+                "value": 2
             }
         ],
         "traits": {

--- a/packs/feats/snare-genius.json
+++ b/packs/feats/snare-genius.json
@@ -36,36 +36,10 @@
                 "craftableItems": [
                     "item:trait:snare"
                 ],
-                "isDailyPrep": false,
                 "isPrepared": true,
                 "key": "CraftingAbility",
-                "label": "Snare Crafting",
-                "slug": "snare-crafting"
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "add",
-                "path": "system.crafting.entries.snareCrafting.maxSlots",
-                "phase": "beforeDerived",
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 2,
-                            "start": 2,
-                            "value": 3
-                        },
-                        {
-                            "end": 3,
-                            "start": 3,
-                            "value": 4
-                        },
-                        {
-                            "start": 4,
-                            "value": 5
-                        }
-                    ],
-                    "field": "actor|system.skills.crafting.rank"
-                }
+                "maxSlots": "1 + @actor.system.skills.crafting.rank",
+                "slug": "snare-genius"
             }
         ],
         "traits": {

--- a/packs/feats/snare-specialist.json
+++ b/packs/feats/snare-specialist.json
@@ -36,36 +36,10 @@
                 "craftableItems": [
                     "item:trait:snare"
                 ],
-                "isDailyPrep": false,
                 "isPrepared": true,
                 "key": "CraftingAbility",
-                "label": "Snare Crafting",
-                "slug": "snare-crafting"
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "add",
-                "path": "system.crafting.entries.snareCrafting.maxSlots",
-                "phase": "beforeDerived",
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 2,
-                            "start": 1,
-                            "value": 4
-                        },
-                        {
-                            "end": 3,
-                            "start": 3,
-                            "value": 6
-                        },
-                        {
-                            "start": 4,
-                            "value": 8
-                        }
-                    ],
-                    "field": "actor|system.skills.crafting.rank"
-                }
+                "maxSlots": "max(4,2*@actor.system.skills.crafting.rank)",
+                "slug": "snare-specialist"
             }
         ],
         "traits": {

--- a/packs/feats/snarecrafter-dedication.json
+++ b/packs/feats/snarecrafter-dedication.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>You have studied the art of crafting snares and laying traps, and few have shown more talent in these arts than you. You gain the Snare Crafting feat. When you set a snare, the DC of any saving throw it requires uses the higher of your class DC or the snare's DC. If a snare normally takes 1 minute to Craft, you can Craft it with 3 Interact actions instead.</p>\n<p>Each day during your daily preparations, you can prepare four snares from your formula book for quick deployment (increasing to six snares if you're a master in Crafting and eight if you're legendary). Snares prepared in this way don't cost you any resources to Craft.</p>\n<p>When you increase your proficiency rank in Crafting to expert, master, or legendary, add three additional snare formulas to your formula book. The snares must be of your level or lower.</p><hr /><p><strong>Special</strong> Rangers can adapt snare crafting techniques to create snares from natural materials. If you are a ranger, you can use Survival instead of Crafting for all prerequisites and functions of feats from this archetype. (This includes using Survival to Craft a snare.)</p>\n<p>@UUID[Compendium.pf2e.journals.JournalEntry.vx5FGEG34AxI2dow.JournalEntryPage.G9Fzy5ZK4KtAmcFb]{Snarecrafter}</p>"
+            "value": "<p>You have studied the art of crafting snares and laying traps, and few have shown more talent in these arts than you. You gain the @UUID[Compendium.pf2e.feats-srd.Item.Snare Crafting] feat. When you set a snare, the DC of any saving throw it requires uses the higher of your class DC or the snare's DC. If a snare normally takes 1 minute to Craft, you can Craft it with 3 Interact actions instead.</p>\n<p>Each day during your daily preparations, you can prepare four snares from your formula book for quick deployment (increasing to six snares if you're a master in Crafting and eight if you're legendary). Snares prepared in this way don't cost you any resources to Craft.</p>\n<p>When you increase your proficiency rank in Crafting to expert, master, or legendary, add three additional snare formulas to your formula book. The snares must be of your level or lower.</p><hr /><p><strong>Special</strong> Rangers can adapt snare crafting techniques to create snares from natural materials. If you are a ranger, you can use Survival instead of Crafting for all prerequisites and functions of feats from this archetype. (This includes using Survival to Craft a snare.)</p>\n<p>@UUID[Compendium.pf2e.journals.JournalEntry.vx5FGEG34AxI2dow.JournalEntryPage.G9Fzy5ZK4KtAmcFb]{Snarecrafter}</p>"
         },
         "level": {
             "value": 2
@@ -36,36 +36,25 @@
                 "craftableItems": [
                     "item:trait:snare"
                 ],
-                "isDailyPrep": false,
                 "isPrepared": true,
                 "key": "CraftingAbility",
                 "label": "PF2E.SpecificRule.DedicationCraftingEntry.Snarecrafter",
-                "slug": "snare-crafting"
+                "maxSlots": "max(4,2*@actor.system.skills.crafting.rank)",
+                "slug": "snarecrafter"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.feats-srd.Item.Snare Crafting"
             },
             {
                 "key": "ActiveEffectLike",
-                "mode": "add",
-                "path": "system.crafting.entries.snareCrafting.maxSlots",
+                "mode": "upgrade",
+                "path": "system.crafting.entries.snareSpecialist.maxSlots",
                 "phase": "beforeDerived",
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 2,
-                            "start": 1,
-                            "value": 4
-                        },
-                        {
-                            "end": 3,
-                            "start": 3,
-                            "value": 6
-                        },
-                        {
-                            "start": 4,
-                            "value": 8
-                        }
-                    ],
-                    "field": "actor|system.skills.crafting.rank"
-                }
+                "predicate": [
+                    "class:ranger"
+                ],
+                "value": "max(4,2*@actor.system.skills.survival.rank)"
             }
         ],
         "traits": {

--- a/packs/feats/ubiquitous-snares.json
+++ b/packs/feats/ubiquitous-snares.json
@@ -11,7 +11,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>You can prepare a seemingly impossible number of snares in advance, and you're ready to spring them on unsuspecting foes. Double the number of prepared snares from Snare Specialist.</p>"
+            "value": "<p>You can prepare a seemingly impossible number of snares in advance, and you're ready to spring them on unsuspecting foes. Double the number of prepared snares from @UUID[Compendium.pf2e.feats-srd.Item.Snare Specialist].</p>"
         },
         "level": {
             "value": 16
@@ -31,28 +31,10 @@
         "rules": [
             {
                 "key": "ActiveEffectLike",
-                "mode": "add",
-                "path": "system.crafting.entries.snareCrafting.maxSlots",
+                "mode": "multiply",
+                "path": "system.crafting.entries.snareSpecialist.maxSlots",
                 "phase": "beforeDerived",
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 2,
-                            "start": 1,
-                            "value": 4
-                        },
-                        {
-                            "end": 3,
-                            "start": 3,
-                            "value": 6
-                        },
-                        {
-                            "start": 4,
-                            "value": 8
-                        }
-                    ],
-                    "field": "actor|system.skills.crafting.rank"
-                }
+                "value": 2
             }
         ],
         "traits": {


### PR DESCRIPTION
The snare feats (Snarecrafter Dedication, Snare Genius and Snare Specialist) were sharing a slug (what used to be a selector), which combined their slots into one. Unlike alchemy archetypes, this doesn't seem to be supported by the rules, so I've separated them into their own Crafting Abilities.