### PR TITLE
Update Debilitating Bomb automation

### DIFF
--- a/packs/feat-effects/effect-debilitating-bomb.json
+++ b/packs/feat-effects/effect-debilitating-bomb.json
@@ -16,9 +16,9 @@
             "value": 6
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": ""
+            "license": "ORC",
+            "remaster": true,
+            "title": "Player Core 2"
         },
         "rules": [
             {

--- a/packs/feat-effects/effect-debilitating-bomb.json
+++ b/packs/feat-effects/effect-debilitating-bomb.json
@@ -1,0 +1,94 @@
+{
+    "_id": "VTJ8D23sOIfApEt3",
+    "img": "icons/magic/control/debuff-energy-hold-yellow.webp",
+    "name": "Effect: Debilitating Bomb",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Debilitating Bomb]</p>\n<p>You are dazzled, deafened, off-guard, or take a -5 foot status penalty to Speeds.</p>"
+        },
+        "duration": {
+            "expiry": "turn-end",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 6
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": ""
+        },
+        "rules": [
+            {
+                "adjustName": false,
+                "choices": [
+                    {
+                        "label": "PF2E.condition.dazzled.name",
+                        "value": "dazzled"
+                    },
+                    {
+                        "label": "PF2E.condition.deafened.name",
+                        "value": "deafened"
+                    },
+                    {
+                        "label": "PF2E.condition.off-guard.name",
+                        "value": "off-guard"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Alchemist.DebilitatingBomb.SpeedPenalty.Label",
+                        "value": "speed-penalty"
+                    }
+                ],
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.Effect",
+                "rollOption": "debilitating-bomb"
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "debilitating-bomb:speed-penalty"
+                ],
+                "selector": "speed",
+                "type": "status",
+                "value": -5
+            },
+            {
+                "inMemoryOnly": true,
+                "key": "GrantItem",
+                "predicate": [
+                    "debilitating-bomb:off-guard"
+                ],
+                "uuid": "Compendium.pf2e.conditionitems.Item.Off-Guard"
+            },
+            {
+                "inMemoryOnly": true,
+                "key": "GrantItem",
+                "predicate": [
+                    "debilitating-bomb:deafened"
+                ],
+                "uuid": "Compendium.pf2e.conditionitems.Item.Deafened"
+            },
+            {
+                "inMemoryOnly": true,
+                "key": "GrantItem",
+                "predicate": [
+                    "debilitating-bomb:dazzled"
+                ],
+                "uuid": "Compendium.pf2e.conditionitems.Item.Dazzled"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feats/debilitating-bomb.json
+++ b/packs/feats/debilitating-bomb.json
@@ -33,20 +33,23 @@
             },
             {
                 "key": "Note",
+                "outcome": [
+                    "success",
+                    "criticalSuccess"
+                ],
                 "predicate": [
-                    "alchemical",
-                    "bomb",
+                    "item:base:alchemical-bomb",
                     "debilitating-bomb"
                 ],
                 "selector": "attack-roll",
-                "text": "If your bomb hits, the target must succed at a Fortitude save against your Class DC, or suffer one of the following @UUID[Compendium.pf2e.feats-srd.Item.Debilitating Bomb]{effects}",
+                "text": "PF2E.SpecificRule.Alchemist.DebilitatingBomb.AttackRollNote",
                 "title": "{item|name}"
             }
         ],
         "traits": {
             "rarity": "common",
             "value": [
-                "additive2",
+                "additive",
                 "alchemist"
             ]
         }

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -1962,6 +1962,12 @@
                     "CriticalNote": "If you critically succeed at a blowgun Strike using a poisoned dart, the target's initial save against the poison is one degree of success worse than the creature rolls; this is a misfortune effect.",
                     "StealthNote": "In addition, if you make a blowgun Strike while @UUID[Compendium.pf2e.conditionitems.Item.iU0fEDdBp3rXpTMC]{Hidden} or @UUID[Compendium.pf2e.conditionitems.Item.VRSef5y1LmL2Hkjf]{Undetected}, you don't automatically become @UUID[Compendium.pf2e.conditionitems.Item.1wQY3JYyhMYeeV2G]{Observed}. Instead, immediately attempt a @Check[stealth|against:perception] check against the Perception DC of the target. If you succeed, you don't become observed, and are hidden (if you were undetected, you still become hidden rather than remaining undetected)."
                 },
+                "DebilitatingBomb": {
+                    "AttackRollNote": "The target must succed at a @Check[fortitude|against:class], or suffer one of the following effects: dazzled, deafened, off-guard, or take a -5 foot status penalty to Speeds. @UUID[Compendium.pf2e.feat-effects.Item.VTJ8D23sOIfApEt3]{Effect: Debilitating Bomb}",
+                    "SpeedPenalty": {
+                        "Label": "-5 foot Speed Penalty"
+                    }
+                },
                 "ExpandedSplash": {
                     "Note": "The splash damage affects all creatures within 10 feet of the target instead of 5 feet."
                 },
@@ -4723,6 +4729,7 @@
                 "DeitysDomain": "Select a deity's domain.",
                 "DieSize": "Select a die size.",
                 "DragonBreathWeapon": "Select a dragon's breath weapon.",
+                "Effect": "Select an effect.",
                 "Element": "Select an element.",
                 "EnergyType": "Select an energy type.",
                 "EquipmentVariety": "Select an item variety.",


### PR DESCRIPTION
- updated the additive trait (no longer additive 2 per PC2).
- Localized and updated the attack-roll note. Should now proc on a hit/critical hit, with the Class DC for ease of access.
- Added an effect.

Also, Closes #17789