### PR TITLE
Fix corruption in grant item data when jumping multiple levels

### DIFF
--- a/packs/classfeatures/first-implement-and-esoterica.json
+++ b/packs/classfeatures/first-implement-and-esoterica.json
@@ -26,6 +26,13 @@
         },
         "rules": [
             {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.thaumaturge.adeptChoices",
+                "priority": 10,
+                "value": []
+            },
+            {
                 "adjustName": false,
                 "choices": {
                     "filter": [
@@ -39,13 +46,6 @@
             {
                 "key": "GrantItem",
                 "uuid": "{item|flags.pf2e.rulesSelections.implement}"
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "override",
-                "path": "flags.pf2e.thaumaturge.adeptChoices",
-                "priority": 10,
-                "value": []
             }
         ],
         "traits": {

--- a/packs/classfeatures/implement-adept.json
+++ b/packs/classfeatures/implement-adept.json
@@ -26,6 +26,13 @@
         },
         "rules": [
             {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.thaumaturge.paragonChoices",
+                "priority": 10,
+                "value": []
+            },
+            {
                 "adjustName": false,
                 "choices": "flags.pf2e.thaumaturge.adeptChoices",
                 "flag": "implementAdept",
@@ -41,13 +48,6 @@
             {
                 "key": "GrantItem",
                 "uuid": "{item|flags.pf2e.rulesSelections.implementAdept}"
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "override",
-                "path": "flags.pf2e.thaumaturge.paragonChoices",
-                "priority": 10,
-                "value": []
             }
         ],
         "traits": {

--- a/src/module/item/base/data/system.ts
+++ b/src/module/item/base/data/system.ts
@@ -148,6 +148,7 @@ export type {
     ItemGrantData,
     ItemGrantDeleteAction,
     ItemGrantSource,
+    ItemGranterSource,
     ItemSchemaPF2e,
     ItemSourceFlagsPF2e,
     ItemSystemData,

--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -620,6 +620,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
         })();
 
         const outputSources = items.map((i) => i._source);
+        const itemUpdates: EmbeddedDocumentUpdateData[] = [];
 
         // Process item preCreate rules for all items that are going to be added
         // This may add additional items (such as via GrantItem)
@@ -636,6 +637,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
                     ruleSource,
                     pendingItems: outputSources,
                     tempItems: items,
+                    itemUpdates,
                     operation,
                 });
             }
@@ -653,6 +655,11 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
             for (const feature of classFeatures) {
                 feature.sort = classFeatures.indexOf(feature) * 100 * (feature.system.level?.value ?? 1);
             }
+        }
+
+        // If there are any item updates, perform them first
+        if (itemUpdates.length) {
+            await actor.updateEmbeddedDocuments("Item", itemUpdates, { render: false });
         }
 
         const nonKits = outputSources.filter((source) => source.type !== "kit");

--- a/src/module/rules/rule-element/base.ts
+++ b/src/module/rules/rule-element/base.ts
@@ -519,6 +519,8 @@ namespace RuleElementPF2e {
         pendingItems: ItemSourcePF2e[];
         /** Items temporarily constructed from pending item source */
         tempItems: ItemPF2e<ActorPF2e>[];
+        /** Updates that should be performed to items after pre creates conclude */
+        itemUpdates: EmbeddedDocumentUpdateData[];
         /** The `operation` object from the `ItemPF2e.createDocuments` call */
         operation: Partial<DatabaseCreateOperation<ActorPF2e | null>>;
         /** Whether this preCreate run is from a pre-update reevaluation */

--- a/src/module/rules/rule-element/grant-item/rule-element.ts
+++ b/src/module/rules/rule-element/grant-item/rule-element.ts
@@ -1,7 +1,7 @@
 import type { ActorPF2e, ActorType } from "@actor";
 import { ConditionPF2e, ItemPF2e, ItemProxyPF2e } from "@item";
 import type { ItemSourcePF2e } from "@item/base/data/index.ts";
-import { ItemGrantDeleteAction, ItemSourceFlagsPF2e } from "@item/base/data/system.ts";
+import { ItemGrantDeleteAction, ItemGranterSource, ItemSourceFlagsPF2e } from "@item/base/data/system.ts";
 import { PHYSICAL_ITEM_TYPES } from "@item/physical/values.ts";
 import { SlugField, StrictArrayField } from "@system/schema-data-fields.ts";
 import { ErrorPF2e, isObject, setHasElement, sluggify, tupleHasValue } from "@util";
@@ -108,7 +108,7 @@ class GrantItemRuleElement extends RuleElementPF2e<GrantItemSchema> {
     override async preCreate(args: RuleElementPF2e.PreCreateParams): Promise<void> {
         if (this.inMemoryOnly || this.invalid) return;
 
-        const { itemSource, pendingItems, operation } = args;
+        const { itemSource, pendingItems, itemUpdates, operation } = args;
         const ruleSource: GrantItemSource = args.ruleSource;
 
         const uuid = this.resolveInjectedProperties(this.uuid);
@@ -141,7 +141,7 @@ class GrantItemRuleElement extends RuleElementPF2e<GrantItemSchema> {
         // If we shouldn't allow duplicates, check for an existing item with this source ID
         const existingItem = this.actor.items.find((i) => i.sourceId === uuid);
         if (!this.allowDuplicate && existingItem) {
-            this.#setGrantFlags(itemSource, existingItem);
+            this.#setGrantFlags(itemSource, existingItem, itemUpdates);
 
             ui.notifications.info(
                 game.i18n.format("PF2E.UI.RuleElements.GrantItem.AlreadyHasItem", {
@@ -212,7 +212,7 @@ class GrantItemRuleElement extends RuleElementPF2e<GrantItemSchema> {
         this.grantedId = grantedSource._id;
         operation.keepId = true;
 
-        this.#setGrantFlags(itemSource, grantedSource);
+        this.#setGrantFlags(itemSource, grantedSource, itemUpdates);
         this.#trackItem(tempGranted);
 
         // Add to pending items before running pre-creates to preserve creation order
@@ -245,7 +245,20 @@ class GrantItemRuleElement extends RuleElementPF2e<GrantItemSchema> {
 
         const pendingItems: ItemSourcePF2e[] = [];
         const operation = { parent: this.actor, render: false };
-        await this.preCreate({ itemSource, pendingItems, ruleSource, tempItems: [], operation, reevaluation: true });
+        const itemUpdates: EmbeddedDocumentUpdateData[] = [];
+        await this.preCreate({
+            itemSource,
+            pendingItems,
+            ruleSource,
+            tempItems: [],
+            itemUpdates,
+            operation,
+            reevaluation: true,
+        });
+
+        if (itemUpdates.length) {
+            await this.actor.updateEmbeddedDocuments("Item", itemUpdates, { render: false });
+        }
 
         if (pendingItems.length > 0) {
             const updatedGrants = itemSource.flags.pf2e?.itemGrants ?? {};
@@ -294,13 +307,14 @@ class GrantItemRuleElement extends RuleElementPF2e<GrantItemSchema> {
     }
 
     /** Set flags on granting and grantee items to indicate relationship between the two */
-    #setGrantFlags(granter: PreCreate<ItemSourcePF2e>, grantee: ItemSourcePF2e | ItemPF2e<ActorPF2e>): void {
-        const flags: ItemSourceFlagsPF2e & { pf2e: { itemGrants: Record<string, object> } } = fu.mergeObject(
-            granter.flags ?? {},
-            { pf2e: { itemGrants: {} } },
-        );
+    #setGrantFlags(
+        granter: PreCreate<ItemSourcePF2e>,
+        grantee: ItemSourcePF2e | ItemPF2e<ActorPF2e>,
+        itemUpdates: EmbeddedDocumentUpdateData[],
+    ): void {
         if (!this.flag) throw ErrorPF2e("Unexpected failure looking up RE flag key");
-        flags.pf2e.itemGrants[this.flag] = {
+
+        const newFlagData: ItemGranterSource = {
             // The granting item records the granted item's ID in an array at `flags.pf2e.itemGrants`
             id: grantee instanceof ItemPF2e ? grantee.id : grantee._id!,
             // The on-delete action determines what will happen to the granter item when the granted item is deleted:
@@ -308,8 +322,20 @@ class GrantItemRuleElement extends RuleElementPF2e<GrantItemSchema> {
             onDelete: this.onDeleteActions?.grantee ?? "detach",
         };
         if (granter.type === "feat" && grantee.type === "feat" && this.nestUnderGranter === false) {
-            flags.pf2e.itemGrants[this.flag].nested = this.nestUnderGranter;
+            newFlagData.nested = this.nestUnderGranter;
         }
+
+        // Assign flag data to the granter source, but also to the prepared item data for later rule elements
+        const flags: ItemSourceFlagsPF2e & { pf2e: { itemGrants: Record<string, object> } } = fu.mergeObject(
+            granter.flags ?? {},
+            { pf2e: { itemGrants: {} } },
+        );
+        flags.pf2e.itemGrants[this.flag] = newFlagData;
+        this.item.flags.pf2e.itemGrants[this.flag] = {
+            ...newFlagData,
+            onDelete: newFlagData.onDelete ?? "detach",
+            nested: newFlagData.nested ?? null,
+        };
 
         // The granted item records its granting item's ID at `flags.pf2e.grantedBy`
         const grantedBy = {
@@ -321,12 +347,10 @@ class GrantItemRuleElement extends RuleElementPF2e<GrantItemSchema> {
                 (setHasElement(PHYSICAL_ITEM_TYPES, grantee.type) ? "detach" : "cascade"),
         };
 
-        if (grantee instanceof ItemPF2e) {
+        grantee.flags = fu.mergeObject(grantee.flags ?? {}, { pf2e: { grantedBy } });
+        if (grantee instanceof ItemPF2e && grantee._id && this.actor.items.has(grantee._id)) {
             // This is a previously granted item: update its grantedBy flag
-            // Don't await since it will trigger a data reset, possibly wiping temporary roll options
-            grantee.update({ "flags.pf2e.grantedBy": grantedBy }, { render: false });
-        } else {
-            grantee.flags = fu.mergeObject(grantee.flags ?? {}, { pf2e: { grantedBy } });
+            itemUpdates.push({ _id: grantee._id, "flags.pf2e.grantedBy": grantedBy });
         }
     }
 


### PR DESCRIPTION
There are 3 different bugfixes here, but as each one is useless on its own, I submitted them altogether
1) Move the AELike initializing adeptChoices and paragonChoices earlier. AELikes and Grant items resolve immediately during preCreate and ignore priority.
2) While granter flags are set in source data to be saved, AELikes referring to them were initially incorrect. We assign to the item during data preparation so that those AELikes function appropriately.
3) item updates performed in preCreate() immediately trigger actor data preparation and caused us to lose all temporary changes applied during preCreate. This was the real reason the array did not exist in the adept choice.