### PR TITLE
Prevent recursively creating a resource by expending that same resource

### DIFF
--- a/src/module/actor/character/crafting/ability.ts
+++ b/src/module/actor/character/crafting/ability.ts
@@ -9,6 +9,7 @@ import type {
     CraftingAbilityRuleSource,
 } from "@module/rules/rule-element/crafting-ability.ts";
 import { Predicate } from "@system/predication.ts";
+import { sluggify } from "@util";
 import * as R from "remeda";
 import type {
     CraftableItemDefinition,
@@ -148,6 +149,14 @@ class CraftingAbility implements CraftingAbilityData {
                     game.i18n.format("PF2E.CraftingTab.Alerts.MaxItemLevel", { level: this.maxItemLevel }),
                 );
             }
+            return false;
+        }
+
+        // Avoid granting the ability to expend a resource to craft that same resource
+        const resourceUUID = this.resource
+            ? this.actor.synthetics.resources[sluggify(this.resource, { camel: "dromedary" })]?.itemUUID
+            : null;
+        if (item.uuid === resourceUUID) {
             return false;
         }
 


### PR DESCRIPTION
People were trying to do this in order to use quick vial, and understandably it was not working as expected