### PR TITLE
Allow held items to stack with other held items

### DIFF
--- a/src/module/item/container/document.ts
+++ b/src/module/item/container/document.ts
@@ -77,6 +77,11 @@ class ContainerPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends
         await this.actor.updateEmbeddedDocuments("Item", updates, { render: false });
     }
 
+    /** Containers never stack, otherwise their contents can have strange results */
+    override isStackableWith(_item: PhysicalItemPF2e): boolean {
+        return false;
+    }
+
     override async getChatData(
         this: ContainerPF2e<TParent>,
         htmlOptions: EnrichmentOptions = {},

--- a/src/module/item/physical/document.ts
+++ b/src/module/item/physical/document.ts
@@ -464,14 +464,18 @@ abstract class PhysicalItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | n
         return super.getEmbeddedDocument(embeddedName, id, options);
     }
 
-    /** Can the provided item stack with this item? */
+    /**
+     * Can the provided item stack with this item?
+     * @param item an item we are trying to add to the inventory
+     */
     isStackableWith(item: PhysicalItemPF2e): boolean {
         const preCheck =
             this !== item &&
             this.type === item.type &&
             this.name === item.name &&
             this.isIdentified === item.isIdentified &&
-            ![this, item].some((i) => i.isHeld || i.isOfType("backpack"));
+            this.isHeld === item.isHeld &&
+            (!this.isHeld || this.quantity === 0 || item.quantity === 0);
         if (!preCheck) return false;
 
         const thisData = this.toObject().system;


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/17807

An alternative idea if we want to keep held items separate is to allow stacking held items if the quantity of any of them is 0, and to auto-delete if reduced to 0 and a stack exists, but that's significantly more complicated to solve and I don't think it ended up being worth it after all.

