### PR TITLE
Correct Ka Stone localization path and string

### DIFF
--- a/packs/equipment/ka-stone.json
+++ b/packs/equipment/ka-stone.json
@@ -35,7 +35,7 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "PF2E.SpecificRule.GenericLabel.ItemVs.DeathVoid",
+                "label": "PF2E.GenericLabel.ItemVs.DeathVoid",
                 "predicate": [
                     {
                         "or": [

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -662,7 +662,7 @@
         },
         "GenericLabel": {
             "ItemVs": {
-                "DeathVoid": "{Item} vs. Death and Void effects",
+                "DeathVoid": "{item} vs. Death and Void effects",
                 "Fear": "{item} vs. fear"
             },
             "PreviousAction": {


### PR DESCRIPTION
`{item}` was capitalized