### PR TITLE
Fix RollOption option injected with flags introduced later in data preparation

### DIFF
--- a/src/module/rules/rule-element/roll-option/rule-element.ts
+++ b/src/module/rules/rule-element/roll-option/rule-element.ts
@@ -194,7 +194,7 @@ class RollOptionRuleElement extends RuleElementPF2e<RollOptionSchema> {
     }
 
     #resolveOption({ withSuboption = false } = {}): string {
-        const baseOption = this.resolveInjectedProperties(this.option)
+        const baseOption = this.resolveInjectedProperties(this._source.option)
             .replace(/[^-:\w]/g, "")
             .replace(/:+/g, ":")
             .replace(/-+/g, "-")


### PR DESCRIPTION
This fixes kineticist when jumping from levels 4 to 9 and doing 2 back to back gate junctions on the same element.

The cause of the bug is `this.option = this.#resolveOption()` called directly in the constructor on line 30, snapshotting the value. Subsequent calls to #resolveOption() don't actually do anything on master.

I'm ok with trying a different approach where we store `#initialOption` in the rule element if you prefer that.