### PR TITLE
Add Note to Grievous Blow and Brutal Finish, and potency rune bonus to Core Cannon effect

### DIFF
--- a/packs/actions/furious-strike.json
+++ b/packs/actions/furious-strike.json
@@ -20,38 +20,7 @@
         },
         "rules": [
             {
-                "key": "DamageDice",
-                "predicate": [
-                    "melee",
-                    "furious-strike"
-                ],
-                "selector": "strike-damage",
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 9,
-                            "value": {
-                                "diceNumber": 1
-                            }
-                        },
-                        {
-                            "end": 17,
-                            "start": 10,
-                            "value": {
-                                "diceNumber": 2
-                            }
-                        },
-                        {
-                            "start": 18,
-                            "value": {
-                                "diceNumber": 3
-                            }
-                        }
-                    ]
-                }
-            },
-            {
-                "domain": "damage",
+                "domain": "melee-strike-damage",
                 "key": "RollOption",
                 "option": "furious-strike",
                 "toggleable": true
@@ -61,25 +30,17 @@
                 "predicate": [
                     "furious-strike"
                 ],
-                "selector": "strike-damage",
+                "selector": "melee-strike-damage",
                 "type": "circumstance",
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 9,
-                            "value": 1
-                        },
-                        {
-                            "end": 17,
-                            "start": 10,
-                            "value": 2
-                        },
-                        {
-                            "start": 18,
-                            "value": 3
-                        }
-                    ]
-                }
+                "value": "ternary(gte(@actor.level,18),3,ternary(gte(@actor.level,10),2,1))"
+            },
+            {
+                "diceNumber": "ternary(gte(@actor.level,18),3,ternary(gte(@actor.level,10),2,1))",
+                "key": "DamageDice",
+                "predicate": [
+                    "furious-strike"
+                ],
+                "selector": "melee-strike-damage"
             }
         ],
         "traits": {

--- a/packs/feat-effects/effect-core-cannon.json
+++ b/packs/feat-effects/effect-core-cannon.json
@@ -4,7 +4,7 @@
     "name": "Effect: Core Cannon",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Core Cannon]</p>\n<p>Your body transforms into a powerful magical cannon.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Core Cannon]</p>\n<p>Select a potency rune. You gain a Strike that deals 3d8 fire damage and 3d6 force damage, which increases to 4d8 fire damage and 4d6 force damage at level 20. The Strike has the item bonus from the selected rune, has a range increment of 120 feet, and on a critical hit the target takes 10 persistent fire damage.</p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -22,7 +22,6 @@
         },
         "rules": [
             {
-                "domain": "all",
                 "key": "RollOption",
                 "option": "core-cannon"
             },
@@ -32,6 +31,48 @@
                     "grantee": "restrict"
                 },
                 "uuid": "Compendium.pf2e.conditionitems.Item.Immobilized"
+            },
+            {
+                "adjustName": false,
+                "allowNoSelection": true,
+                "choices": [
+                    {
+                        "value": "Compendium.pf2e.equipment-srd.Item.Weapon Potency (+1)"
+                    },
+                    {
+                        "value": "Compendium.pf2e.equipment-srd.Item.Weapon Potency (+2)"
+                    },
+                    {
+                        "value": "Compendium.pf2e.equipment-srd.Item.Weapon Potency (+3)"
+                    }
+                ],
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.Rune",
+                "rollOption": "core-cannon:potency-rune"
+            },
+            {
+                "key": "WeaponPotency",
+                "predicate": [
+                    "core-cannon:potency-rune:weapon-potency-1"
+                ],
+                "selector": "core-cannon-attack",
+                "value": 1
+            },
+            {
+                "key": "WeaponPotency",
+                "predicate": [
+                    "core-cannon:potency-rune:weapon-potency-2"
+                ],
+                "selector": "core-cannon-attack",
+                "value": 2
+            },
+            {
+                "key": "WeaponPotency",
+                "predicate": [
+                    "core-cannon:potency-rune:weapon-potency-3"
+                ],
+                "selector": "core-cannon-attack",
+                "value": 3
             }
         ],
         "start": {

--- a/packs/feats/brilliant-crafter.json
+++ b/packs/feats/brilliant-crafter.json
@@ -33,40 +33,17 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.crafting.rank",
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 6,
-                            "start": 4,
-                            "value": 2
-                        },
-                        {
-                            "end": 14,
-                            "start": 7,
-                            "value": 3
-                        },
-                        {
-                            "start": 15,
-                            "value": 4
-                        }
-                    ]
-                }
-            },
-            {
-                "key": "ActiveEffectLike",
-                "mode": "upgrade",
-                "path": "system.proficiencies.classDCs.inventor.rank",
-                "predicate": [
-                    {
-                        "gte": [
-                            "self:level",
-                            15
-                        ]
-                    }
-                ],
-                "value": 2
+                "value": "ternary(gte(@actor.level,15),4,ternary(gte(@actor.level,7),3,2))"
             }
         ],
+        "subfeatures": {
+            "proficiencies": {
+                "inventor": {
+                    "attribute": null,
+                    "rank": 2
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/brutal-finish.json
+++ b/packs/feats/brutal-finish.json
@@ -26,34 +26,31 @@
         },
         "rules": [
             {
-                "domain": "damage",
                 "key": "RollOption",
                 "option": "brutal-finish",
                 "toggleable": true
             },
             {
+                "diceNumber": "ternary(gte(@actor.level,18),2,1)",
                 "key": "DamageDice",
                 "predicate": [
-                    "melee",
+                    "item:type:weapon",
                     "brutal-finish"
                 ],
-                "selector": "strike-damage",
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 17,
-                            "value": {
-                                "diceNumber": 1
-                            }
-                        },
-                        {
-                            "start": 18,
-                            "value": {
-                                "diceNumber": 2
-                            }
-                        }
-                    ]
-                }
+                "selector": "melee-strike-damage"
+            },
+            {
+                "key": "Note",
+                "outcome": [
+                    "failure"
+                ],
+                "predicate": [
+                    "brutal-finish",
+                    "item:type:weapon"
+                ],
+                "selector": "melee-strike-attack-roll",
+                "text": "PF2E.SpecificRule.Fighter.BrutalFinish.Note",
+                "title": "PF2E.Check.Result.Degree.Check.failure"
             }
         ],
         "traits": {

--- a/packs/feats/core-cannon.json
+++ b/packs/feats/core-cannon.json
@@ -34,7 +34,7 @@
                 "damage": {
                     "base": {
                         "damageType": "fire",
-                        "dice": 3,
+                        "dice": "ternary(lt(@actor.level,20),3,4)",
                         "die": "d8"
                     }
                 },
@@ -52,46 +52,18 @@
             },
             {
                 "damageType": "force",
-                "diceNumber": 3,
+                "diceNumber": "ternary(lt(@actor.level,20),3,4)",
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "selector": "{item|_id}-damage"
+                "selector": "{item|id}-damage"
             },
             {
                 "critical": true,
                 "damageCategory": "persistent",
                 "damageType": "fire",
                 "key": "FlatModifier",
-                "selector": "{item|_id}-damage",
+                "selector": "{item|id}-damage",
                 "value": 10
-            },
-            {
-                "key": "Note",
-                "selector": "{item|_id}-attack",
-                "text": "<em>@Localize[PF2E.SpecificRule.Automaton.CoreCannon.AttackNote]</em>",
-                "title": "{item|name}"
-            },
-            {
-                "damageType": "fire",
-                "dieSize": "d8",
-                "key": "DamageDice",
-                "selector": "{item|_id}-damage",
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 19,
-                            "value": {
-                                "diceNumber": 0
-                            }
-                        },
-                        {
-                            "start": 20,
-                            "value": {
-                                "diceNumber": 1
-                            }
-                        }
-                    ]
-                }
             }
         ],
         "selfEffect": {

--- a/packs/feats/grievous-blow.json
+++ b/packs/feats/grievous-blow.json
@@ -30,34 +30,29 @@
         },
         "rules": [
             {
-                "key": "DamageDice",
-                "predicate": [
-                    "grievous-blow",
-                    "unarmed"
-                ],
-                "selector": "strike-damage",
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 17,
-                            "value": {
-                                "diceNumber": 2
-                            }
-                        },
-                        {
-                            "start": 18,
-                            "value": {
-                                "diceNumber": 3
-                            }
-                        }
-                    ]
-                }
-            },
-            {
-                "domain": "damage",
+                "domain": "unarmed-damage",
                 "key": "RollOption",
                 "option": "grievous-blow",
                 "toggleable": true
+            },
+            {
+                "diceNumber": "ternary(gte(@actor.level,18),3,2)",
+                "key": "DamageDice",
+                "predicate": [
+                    "grievous-blow",
+                    "item:melee"
+                ],
+                "selector": "unarmed-damage"
+            },
+            {
+                "key": "Note",
+                "predicate": [
+                    "item:melee",
+                    "grievous-blow"
+                ],
+                "selector": "unarmed-damage",
+                "text": "PF2E.SpecificRule.MartialArtist.GrievousBlow.Note",
+                "title": "{item|name}"
             }
         ],
         "traits": {

--- a/packs/feats/skeletal-resistance.json
+++ b/packs/feats/skeletal-resistance.json
@@ -34,23 +34,7 @@
                     "piercing",
                     "slashing"
                 ],
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 12,
-                            "value": 2
-                        },
-                        {
-                            "end": 16,
-                            "start": 13,
-                            "value": 3
-                        },
-                        {
-                            "start": 17,
-                            "value": 4
-                        }
-                    ]
-                }
+                "value": "clamp(floor((@actor.level - 1) / 4),2,4)"
             }
         ],
         "traits": {

--- a/packs/feats/soul-warden-dedication.json
+++ b/packs/feats/soul-warden-dedication.json
@@ -38,33 +38,9 @@
                     "undead-nearby"
                 ],
                 "value": {
-                    "bright": {
-                        "brackets": [
-                            {
-                                "end": 2,
-                                "value": 0
-                            },
-                            {
-                                "start": 3,
-                                "value": 10
-                            }
-                        ],
-                        "field": "actor|flags.pf2e.soulWarden.featCount"
-                    },
+                    "bright": "ternary(gte(@actor.flags.pf2e.soulWarden.featCount,3),10,0)",
                     "color": "#0056a1",
-                    "dim": {
-                        "brackets": [
-                            {
-                                "end": 2,
-                                "value": 10
-                            },
-                            {
-                                "start": 3,
-                                "value": 20
-                            }
-                        ],
-                        "field": "actor|flags.pf2e.soulWarden.featCount"
-                    },
+                    "dim": "ternary(gte(@actor.flags.pf2e.soulWarden.featCount,3),20,10)",
                     "luminosity": 0.4
                 }
             },

--- a/packs/heritages/ghoran/ancient-ash.json
+++ b/packs/heritages/ghoran/ancient-ash.json
@@ -28,20 +28,9 @@
             },
             {
                 "key": "ActiveEffectLike",
-                "mode": "add",
+                "mode": "upgrade",
                 "path": "system.skills.{item|flags.pf2e.rulesSelections.skill}.rank",
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 4,
-                            "value": 1
-                        },
-                        {
-                            "start": 5,
-                            "value": 2
-                        }
-                    ]
-                }
+                "value": "ternary(gte(@actor.level,5),2,1)"
             }
         ],
         "traits": {

--- a/packs/spell-effects/spell-effect-soothing-words.json
+++ b/packs/spell-effects/spell-effect-soothing-words.json
@@ -4,7 +4,7 @@
     "name": "Spell Effect: Soothing Words",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Soothing Words]</p>\n<p>You gain a +1 status bonus to Will saving throws. This bonus increases to +2 against emotion effects.</p><hr /><p><strong>Heightened (5th)</strong> The bonus to saves increases to +2, or +3 against emotion effects.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Soothing Words]</p>\n<p>You gain a status bonus to Will saving throws. This bonus increases against emotion effects.</p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -24,42 +24,19 @@
             {
                 "key": "FlatModifier",
                 "selector": "will",
+                "slug": "soothing-words",
                 "type": "status",
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 4,
-                            "value": 1
-                        },
-                        {
-                            "start": 5,
-                            "value": 2
-                        }
-                    ],
-                    "field": "item|system.level.value"
-                }
+                "value": "ternary(gte(@item.level,5),2,1)"
             },
             {
-                "key": "FlatModifier",
-                "label": "Soothing Words (vs. emotion)",
+                "key": "AdjustModifier",
+                "mode": "upgrade",
                 "predicate": [
                     "item:trait:emotion"
                 ],
                 "selector": "will",
-                "type": "status",
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 4,
-                            "value": 2
-                        },
-                        {
-                            "start": 5,
-                            "value": 3
-                        }
-                    ],
-                    "field": "item|system.level.value"
-                }
+                "slug": "soothing-words",
+                "value": "ternary(gte(@item.level,5),3,2)"
             }
         ],
         "start": {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -3793,6 +3793,9 @@
                 }
             },
             "Fighter": {
+                "BrutalFinish": {
+                    "Note": "You deal @Damage[(ternary(gte(@actor.level,18),2,1))@item.system.damage.die[@item.system.damage.damageType]] damage."
+                },
                 "DazingBlow": {
                     "Note": "If the Strike hits, the creature must attempt a @Check[fortitude|against:class|traits:incapacitation] save against your class DC; this is an incapacitation effect.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature is unaffected.</p>\n<p><strong>Success</strong> The creature is @UUID[Compendium.pf2e.conditionitems.Item.dfCMdR4wnpbYNTix]{Stunned 1}.</p>\n<p><strong>Failure</strong> The creature is @UUID[Compendium.pf2e.conditionitems.Item.dfCMdR4wnpbYNTix]{Stunned 2}.</p>\n<p><strong>Critical Failure</strong> The creature is @UUID[Compendium.pf2e.conditionitems.Item.dfCMdR4wnpbYNTix]{Stunned 3}."
                 },
@@ -4388,6 +4391,11 @@
                 "DreadMarshalStance": {
                     "Note": "When you critically hit an enemy with a Strike, that enemy is @UUID[Compendium.pf2e.conditionitems.Item.TBSHQspnbcqxsmjL]{Frightened 1}.",
                     "Title": "Dread Marshal Aura"
+                }
+            },
+            "MartialArtist": {
+                "GrievousBlow": {
+                    "Note": "This Strike ignores an amount of resistance to physical damage (or to a specific physical damage type) equal to your level."
                 }
             },
             "MartialProficiency": {


### PR DESCRIPTION
Also move more brackets to other formulas.

Core Cannon has its Strike inside the feat itself, predicated on a roll option in the effect. I'm not 100% sure why it's set up that way, but I'm open to changing it if someone sees the need to do so.