### PR TITLE
Tighten logic for compendium browser trait filtering

### DIFF
--- a/src/module/apps/compendium-browser/tabs/base.svelte.ts
+++ b/src/module/apps/compendium-browser/tabs/base.svelte.ts
@@ -150,15 +150,13 @@ export abstract class CompendiumBrowserTab {
     ): boolean {
         const selectedTraits = selected.filter((s) => !s.not).map((s) => s.value);
         const notTraits = selected.filter((t) => t.not).map((s) => s.value);
-        if (selectedTraits.length || notTraits.length) {
-            if (notTraits.some((t) => traits.includes(t))) {
-                return false;
-            }
-            const fullfilled =
-                condition === "and"
-                    ? selectedTraits.every((t) => traits.includes(t))
-                    : selectedTraits.some((t) => traits.includes(t));
-            if (!fullfilled) return false;
+        if (notTraits.some((t) => traits.includes(t))) {
+            return false;
+        }
+        if (selectedTraits.length) {
+            return condition === "and"
+                ? selectedTraits.every((t) => traits.includes(t))
+                : selectedTraits.some((t) => traits.includes(t));
         }
         return true;
     }


### PR DESCRIPTION
Fixes a case where no results were shown when all selected traits were excluded.