### PR TITLE
Add Nonlethal Attack effect

### DIFF
--- a/packs/other-effects/effect-nonlethal-attacks.json
+++ b/packs/other-effects/effect-nonlethal-attacks.json
@@ -1,0 +1,57 @@
+{
+    "_id": "FTT3F3ROOZEKpGi9",
+    "img": "icons/skills/melee/unarmed-punch-fist-white.webp",
+    "name": "Effect: Nonlethal Attacks",
+    "system": {
+        "description": {
+            "value": "<p>You take a –2 circumstance penalty to the attack roll when you make a nonlethal attack using a weapon or unarmed attack that doesn’t have the nonlethal trait.</p>"
+        },
+        "duration": {
+            "expiry": null,
+            "sustained": false,
+            "unit": "unlimited",
+            "value": -1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "option": "nonlethal-attacks",
+                "toggleable": true
+            },
+            {
+                "hideIfDisabled": true,
+                "key": "FlatModifier",
+                "predicate": [
+                    "nonlethal-attacks",
+                    {
+                        "not": "item:trait:nonlethal"
+                    }
+                ],
+                "selector": "attack",
+                "slug": "npnlethal-attack-penalty",
+                "type": "circumstance",
+                "value": -2
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/other-effects/effect-nonlethal-attacks.json
+++ b/packs/other-effects/effect-nonlethal-attacks.json
@@ -37,7 +37,7 @@
                     }
                 ],
                 "selector": "attack",
-                "slug": "npnlethal-attack-penalty",
+                "slug": "nonlethal-attack-penalty",
                 "type": "circumstance",
                 "value": -2
             }


### PR DESCRIPTION
Use case - was in game where everyone was trying to use nonlethal attacks (no Monks) and forgot to apply their Circumstance Penalty.