### PR TITLE
Address Sass deprecations

### DIFF
--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -1,375 +1,387 @@
 @use "sass:color";
 
-/* ----------------------------------------- */
-/* Color definitions                         */
-/* ----------------------------------------- */
+// -----------------------------------------
+// Color definitions
+// -----------------------------------------
 
-/* Colors */
+// Colors
 $light-gray-color: #ababab;
 $dark-gray-color: #545454;
 
-/* Global */
+// Global
 $primary-color: #5e0000;
-$secondary-color: #171f69; /* used for mini headers, alternate primary color */
-$tertiary-color: #e9d7a1; /* compliments the primary color, usually used in combination */
+$secondary-color: #171f69; // used for mini headers, alternate primary color
+$tertiary-color: #e9d7a1; // compliments the primary color, usually used in combination
 
-$alt-color: #786452 !default; /* for all other uses */
+$alt-color: #786452 !default; // for all other uses
 $alt-dark: #443730;
 $light-background-color: #f8f4f1;
 $less-light-background-color: color.adjust($light-background-color, $lightness: -10%);
 $sub-color: #605856;
 
-/* Text */
+// Text
 $text-dark-color: #1c1c1c !default;
 
-/* ----------------------------------------- */
-/* Color schemes                             */
-/* ----------------------------------------- */
+// -----------------------------------------
+// Color schemes
+// -----------------------------------------
 
-/* Degrees of success */
+// Degrees of success
 $degree-success-critical: rgb(0, 128, 0);
 $degree-success: rgb(0, 0, 255);
 $degree-failure: rgb(255, 69, 0);
 $degree-failure-critical: rgb(255, 0, 0);
 
-/* Value adjustments (e.g. weak/elite) */
+// Value adjustments (e.g. weak/elite)
 $adjusted-higher: #009988;
 $adjusted-lower: #cc3311;
 
-/* ----------------------------------------- */
-/* CSS Custom Properties                     */
-/* ----------------------------------------- */
+// -----------------------------------------
+// CSS Custom Properties
+// -----------------------------------------
 
-:root {
-    /* Global */
-    --color-pf-primary: #{$primary-color};
-    --color-pf-primary-dark: #{color.adjust($primary-color, $lightness: -5%)};
-    --color-pf-primary-darker: #{color.adjust($primary-color, $lightness: -10%)};
-    --color-pf-primary-light: #{color.adjust($primary-color, $lightness: 5%)};
-    --color-pf-primary-lighter: #{color.adjust($primary-color, $lightness: 10%)};
-    --color-pf-alternate: #{$alt-color};
-    --color-pf-alternate-dark: #{$alt-dark};
-    --color-pf-alternate-darker: #{color.adjust($alt-dark, $lightness: -10%)};
-    --color-pf-alternate-light: #{color.adjust($alt-color, $lightness: 10%)};
-    --color-pf-secondary: #{$secondary-color};
-    --color-pf-secondary-dark: #{color.adjust($secondary-color, $lightness: -10%)};
-    --color-pf-secondary-light: #{color.adjust($secondary-color, $lightness: 10%)};
-    --color-pf-secondary-lighter: #{color.adjust($secondary-color, $lightness: 20%)};
-    --color-pf-tertiary: #{$tertiary-color};
-    --color-pf-tertiary-dark: #{color.adjust($tertiary-color, $lightness: -10%)};
-    --color-pf-tertiary-darker: #{color.adjust($tertiary-color, $lightness: -20%)};
-    --color-pf-tertiary-darkest: #{color.adjust($tertiary-color, $lightness: -51%)};
-    --color-pf-tertiary-light: #{color.adjust($tertiary-color, $lightness: 10%)};
-    --primary: var(--color-pf-primary);
-    --secondary: var(--color-pf-secondary);
-    --tertiary: var(--color-pf-tertiary);
+@mixin root {
+    :root {
+        // Global
+        --color-pf-primary: #{$primary-color};
+        --color-pf-primary-dark: #{color.adjust($primary-color, $lightness: -5%)};
+        --color-pf-primary-darker: #{color.adjust($primary-color, $lightness: -10%)};
+        --color-pf-primary-light: #{color.adjust($primary-color, $lightness: 5%)};
+        --color-pf-primary-lighter: #{color.adjust($primary-color, $lightness: 10%)};
+        --color-pf-alternate: #{$alt-color};
+        --color-pf-alternate-dark: #{$alt-dark};
+        --color-pf-alternate-darker: #{color.adjust($alt-dark, $lightness: -10%)};
+        --color-pf-alternate-light: #{color.adjust($alt-color, $lightness: 10%)};
+        --color-pf-secondary: #{$secondary-color};
+        --color-pf-secondary-dark: #{color.adjust($secondary-color, $lightness: -10%)};
+        --color-pf-secondary-light: #{color.adjust($secondary-color, $lightness: 10%)};
+        --color-pf-secondary-lighter: #{color.adjust($secondary-color, $lightness: 20%)};
+        --color-pf-tertiary: #{$tertiary-color};
+        --color-pf-tertiary-dark: #{color.adjust($tertiary-color, $lightness: -10%)};
+        --color-pf-tertiary-darker: #{color.adjust($tertiary-color, $lightness: -20%)};
+        --color-pf-tertiary-darkest: #{color.adjust($tertiary-color, $lightness: -51%)};
+        --color-pf-tertiary-light: #{color.adjust($tertiary-color, $lightness: 10%)};
+        --primary: var(--color-pf-primary);
+        --secondary: var(--color-pf-secondary);
+        --tertiary: var(--color-pf-tertiary);
 
-    --alt: var(--color-pf-alternate);
-    --alt-dark: var(--color-pf-alternate-dark);
-    --bg: #{$light-background-color};
-    --bg-dark: #{$less-light-background-color};
-    --sub: #{$sub-color};
-    --color-disabled: var(--color-text-dark-4);
+        --alt: var(--color-pf-alternate);
+        --alt-dark: var(--color-pf-alternate-dark);
+        --bg: #{$light-background-color};
+        --bg-dark: #{$less-light-background-color};
+        --sub: #{$sub-color};
+        --color-disabled: var(--color-text-dark-4);
 
-    // Inline links and user visibility
-    --inline-link-bg: #ddd;
-    --inline-repost-bg: #{color.adjust(#ddd, $lightness: 5%)};
-    --visibility-gm-bg: #e8e8ef;
-    --visibility-owner-bg: #ddebe1;
-    --blind-roll: #f5eaf5;
+        // Inline links and user visibility
+        --inline-link-bg: #ddd;
+        --inline-repost-bg: #{color.adjust(#ddd, $lightness: 5%)};
+        --visibility-gm-bg: #e8e8ef;
+        --visibility-owner-bg: #ddebe1;
+        --blind-roll: #f5eaf5;
 
-    /* Lighter / Darker */
-    --primary-dark: var(--color-pf-primary-dark);
-    --primary-darker: var(--color-pf-primary-darker);
-    --tertiary-dark: var(--color-pf-tertiary-dark);
-    --tertiary-light: var(--color-pf-tertiary-light);
+        // Lighter / Darker
+        --primary-dark: var(--color-pf-primary-dark);
+        --primary-darker: var(--color-pf-primary-darker);
+        --tertiary-dark: var(--color-pf-tertiary-dark);
+        --tertiary-light: var(--color-pf-tertiary-light);
 
-    /* Text */
-    --text-dark: var(--color-text-dark-primary);
-    --text-light: #f5efe0;
-    --text-light-disabled: #a6a092;
-    --color-text-dark-input: #333;
-    --color-text-dark-improved: #006644;
+        // Text
+        --text-dark: var(--color-text-dark-primary);
+        --text-light: #f5efe0;
+        --text-light-disabled: #a6a092;
+        --color-text-dark-input: #333;
+        --color-text-dark-improved: #006644;
 
-    /* Borders */
-    --color-border-divider: #baa991;
-    --color-border-dark-input: #d3ccbc;
-    --color-border-medium: gray;
+        // Borders
+        --color-border-divider: #baa991;
+        --color-border-dark-input: #d3ccbc;
+        --color-border-medium: gray;
 
-    /* Headers w/ boxes */
-    --header-color: var(--text-light);
-    --header-bg: var(--secondary);
+        // Headers w/ boxes
+        --header-color: var(--text-light);
+        --header-bg: var(--secondary);
 
-    /* Sidebar */
-    --sidebar-label: var(--tertiary-dark);
-    --sidebar-title: var(--tertiary);
+        // Sidebar
+        --sidebar-label: var(--tertiary-dark);
+        --sidebar-title: var(--tertiary);
 
-    /** Traits */
-    --color-bg-size: #3a7b59;
-    --color-bg-trait: #{$primary-color};
-    --color-border-trait: #d8c384;
-    --color-text-trait: white;
+        // Degree of success
+        --color-degree-success-critical: #{$degree-success-critical};
+        --color-degree-success: #{$degree-success};
+        --color-degree-failure: #{$degree-failure};
+        --color-degree-failure-critical: #{$degree-failure-critical};
 
-    /* Rarity */
-    --color-rarity-common: #323232;
-    --color-rarity-uncommon: #98513d;
-    --color-rarity-rare: #002664;
-    --color-rarity-unique: #54166e;
+        // Value adjustments (e.g. weak/elite)
+        --color-adjusted-higher: #{$adjusted-higher};
+        --color-adjusted-lower: #{$adjusted-lower};
 
-    /** Proficiency ranks */
-    --color-proficiency-untrained: #424242;
-    --color-proficiency-trained: #171f69;
-    --color-proficiency-expert: #3c005e;
-    --color-proficiency-master: #664400;
-    --color-proficiency-legendary: #{$primary-color};
+        // Traits
+        --color-bg-size: #3a7b59;
+        --color-bg-trait: #{$primary-color};
+        --color-border-trait: #d8c384;
+        --color-text-trait: white;
 
-    /* Damage colors */
-    .damage {
-        $damage-physical: #3c3c3c;
-        $damage-acid: #007300;
-        $damage-bleed: #99001a;
-        $damage-chaotic: #a600a6;
-        $damage-cold: #2f2fa6;
-        $damage-electricity: darkgoldenrod;
-        $damage-evil: indigo;
-        $damage-fire: #a62f00;
-        $damage-force: #6300aa;
-        $damage-good: #9d730a;
-        $damage-lawful: #402600;
-        $damage-mental: midnightblue;
-        $damage-poison: #5b7332;
-        $damage-sonic: darkcyan;
-        $damage-spirit: #5a5585;
-        $damage-vitality: #ffffe0;
-        $damage-void: #00001f;
-        $darker: -12.5%;
-        $transparenter: -87.5%;
+        // Rarity
+        --color-rarity-common: #323232;
+        --color-rarity-uncommon: #98513d;
+        --color-rarity-rare: #002664;
+        --color-rarity-unique: #54166e;
 
-        --color-bg-acid: #{color.scale($damage-acid, $alpha: $transparenter)};
-        --color-bg-bleed: #{color.scale($damage-bleed, $alpha: $transparenter)};
-        --color-bg-chaotic: #{color.scale($damage-chaotic, $alpha: $transparenter)};
-        --color-bg-cold: #{color.scale($damage-cold, $alpha: $transparenter)};
-        --color-bg-electricity: #{color.scale($damage-electricity, $alpha: $transparenter)};
-        --color-bg-evil: #{color.scale($damage-evil, $alpha: $transparenter)};
-        --color-bg-fire: #{color.scale($damage-fire, $alpha: $transparenter)};
-        --color-bg-force: #{color.scale($damage-force, $alpha: $transparenter)};
-        --color-bg-good: #{color.scale($damage-good, $alpha: $transparenter)};
-        --color-bg-lawful: #{color.scale($damage-lawful, $alpha: $transparenter)};
-        --color-bg-mental: #{color.scale($damage-mental, $alpha: $transparenter)};
-        --color-bg-physical: #{color.scale($damage-physical, $alpha: $transparenter)};
-        --color-bg-poison: #{color.scale($damage-poison, $alpha: $transparenter)};
-        --color-bg-sonic: #{color.scale($damage-sonic, $alpha: $transparenter)};
-        --color-bg-spirit: #{color.scale($damage-spirit, $alpha: $transparenter)};
-        --color-bg-vitality: #{color.scale($damage-vitality, $alpha: $transparenter)};
-        --color-bg-void: #{color.scale($damage-void, $alpha: $transparenter)};
+        // Proficiency ranks
+        --color-proficiency-untrained: #424242;
+        --color-proficiency-trained: #171f69;
+        --color-proficiency-expert: #3c005e;
+        --color-proficiency-master: #664400;
+        --color-proficiency-legendary: #{$primary-color};
 
-        --color-border-acid: #{$damage-acid};
-        --color-border-bleed: #{$damage-bleed};
-        --color-border-chaotic: #{$damage-chaotic};
-        --color-border-cold: #{$damage-cold};
-        --color-border-electricity: #{$damage-electricity};
-        --color-border-evil: #{$damage-evil};
-        --color-border-fire: #{$damage-fire};
-        --color-border-force: #{$damage-force};
-        --color-border-good: #{$damage-good};
-        --color-border-lawful: #{$damage-lawful};
-        --color-border-mental: #{$damage-mental};
-        --color-border-physical: #{$damage-physical};
-        --color-border-poison: #{$damage-poison};
-        --color-border-sonic: #{$damage-sonic};
-        --color-border-spirit: #{$damage-spirit};
-        --color-border-vitality: #{$damage-vitality};
-        --color-border-void: #{$damage-void};
+        // Damage colors
+        .damage {
+            $damage-physical: #3c3c3c;
+            $damage-acid: #007300;
+            $damage-bleed: #99001a;
+            $damage-chaotic: #a600a6;
+            $damage-cold: #2f2fa6;
+            $damage-electricity: darkgoldenrod;
+            $damage-evil: indigo;
+            $damage-fire: #a62f00;
+            $damage-force: #6300aa;
+            $damage-good: #9d730a;
+            $damage-lawful: #402600;
+            $damage-mental: midnightblue;
+            $damage-poison: #5b7332;
+            $damage-sonic: darkcyan;
+            $damage-spirit: #5a5585;
+            $damage-vitality: #ffffe0;
+            $damage-void: #00001f;
+            $darker: -12.5%;
+            $transparenter: -87.5%;
 
-        --color-text-acid: #{color.adjust($damage-acid, $lightness: $darker)};
-        --color-text-bleed: #{color.adjust($damage-bleed, $lightness: $darker)};
-        --color-text-chaotic: #{color.adjust($damage-chaotic, $lightness: $darker)};
-        --color-text-cold: #{color.adjust($damage-cold, $lightness: $darker)};
-        --color-text-electricity: #{color.adjust($damage-electricity, $lightness: $darker)};
-        --color-text-evil: #{color.adjust($damage-evil, $lightness: $darker)};
-        --color-text-fire: #{color.adjust($damage-fire, $lightness: $darker)};
-        --color-text-force: #{color.adjust($damage-force, $lightness: $darker)};
-        --color-text-good: #{color.adjust($damage-good, $lightness: $darker)};
-        --color-text-lawful: #{color.adjust($damage-lawful, $lightness: $darker)};
-        --color-text-mental: #{color.adjust($damage-mental, $lightness: $darker)};
-        --color-text-physical: #{color.adjust($damage-physical, $lightness: $darker)};
-        --color-text-poison: #{color.adjust($damage-poison, $lightness: $darker)};
-        --color-text-sonic: #{color.adjust($damage-sonic, $lightness: $darker)};
-        --color-text-spirit: #{color.adjust($damage-spirit, $lightness: $darker)};
-        --color-text-vitality: #{color.adjust($damage-vitality, $lightness: $darker)};
-        --color-text-void: #{color.adjust($damage-void, $lightness: $darker)};
+            --color-bg-acid: #{color.scale($damage-acid, $alpha: $transparenter)};
+            --color-bg-bleed: #{color.scale($damage-bleed, $alpha: $transparenter)};
+            --color-bg-chaotic: #{color.scale($damage-chaotic, $alpha: $transparenter)};
+            --color-bg-cold: #{color.scale($damage-cold, $alpha: $transparenter)};
+            --color-bg-electricity: #{color.scale($damage-electricity, $alpha: $transparenter)};
+            --color-bg-evil: #{color.scale($damage-evil, $alpha: $transparenter)};
+            --color-bg-fire: #{color.scale($damage-fire, $alpha: $transparenter)};
+            --color-bg-force: #{color.scale($damage-force, $alpha: $transparenter)};
+            --color-bg-good: #{color.scale($damage-good, $alpha: $transparenter)};
+            --color-bg-lawful: #{color.scale($damage-lawful, $alpha: $transparenter)};
+            --color-bg-mental: #{color.scale($damage-mental, $alpha: $transparenter)};
+            --color-bg-physical: #{color.scale($damage-physical, $alpha: $transparenter)};
+            --color-bg-poison: #{color.scale($damage-poison, $alpha: $transparenter)};
+            --color-bg-sonic: #{color.scale($damage-sonic, $alpha: $transparenter)};
+            --color-bg-spirit: #{color.scale($damage-spirit, $alpha: $transparenter)};
+            --color-bg-vitality: #{color.scale($damage-vitality, $alpha: $transparenter)};
+            --color-bg-void: #{color.scale($damage-void, $alpha: $transparenter)};
 
-        &.color {
-            &.acid {
-                background-color: var(--color-bg-acid);
-                border-color: var(--color-border-acid);
-                color: var(--color-text-acid);
+            --color-border-acid: #{$damage-acid};
+            --color-border-bleed: #{$damage-bleed};
+            --color-border-chaotic: #{$damage-chaotic};
+            --color-border-cold: #{$damage-cold};
+            --color-border-electricity: #{$damage-electricity};
+            --color-border-evil: #{$damage-evil};
+            --color-border-fire: #{$damage-fire};
+            --color-border-force: #{$damage-force};
+            --color-border-good: #{$damage-good};
+            --color-border-lawful: #{$damage-lawful};
+            --color-border-mental: #{$damage-mental};
+            --color-border-physical: #{$damage-physical};
+            --color-border-poison: #{$damage-poison};
+            --color-border-sonic: #{$damage-sonic};
+            --color-border-spirit: #{$damage-spirit};
+            --color-border-vitality: #{$damage-vitality};
+            --color-border-void: #{$damage-void};
 
-                i[class^="fa-"] {
-                    color: var(--color-border-acid);
+            --color-text-acid: #{color.adjust($damage-acid, $lightness: $darker)};
+            --color-text-bleed: #{color.adjust($damage-bleed, $lightness: $darker)};
+            --color-text-chaotic: #{color.adjust($damage-chaotic, $lightness: $darker)};
+            --color-text-cold: #{color.adjust($damage-cold, $lightness: $darker)};
+            --color-text-electricity: #{color.adjust($damage-electricity, $lightness: $darker)};
+            --color-text-evil: #{color.adjust($damage-evil, $lightness: $darker)};
+            --color-text-fire: #{color.adjust($damage-fire, $lightness: $darker)};
+            --color-text-force: #{color.adjust($damage-force, $lightness: $darker)};
+            --color-text-good: #{color.adjust($damage-good, $lightness: $darker)};
+            --color-text-lawful: #{color.adjust($damage-lawful, $lightness: $darker)};
+            --color-text-mental: #{color.adjust($damage-mental, $lightness: $darker)};
+            --color-text-physical: #{color.adjust($damage-physical, $lightness: $darker)};
+            --color-text-poison: #{color.adjust($damage-poison, $lightness: $darker)};
+            --color-text-sonic: #{color.adjust($damage-sonic, $lightness: $darker)};
+            --color-text-spirit: #{color.adjust($damage-spirit, $lightness: $darker)};
+            --color-text-vitality: #{color.adjust($damage-vitality, $lightness: $darker)};
+            --color-text-void: #{color.adjust($damage-void, $lightness: $darker)};
+
+            &.color {
+                &.acid {
+                    background-color: var(--color-bg-acid);
+                    border-color: var(--color-border-acid);
+                    color: var(--color-text-acid);
+
+                    i[class^="fa-"] {
+                        color: var(--color-border-acid);
+                    }
                 }
-            }
 
-            &.bleed {
-                background-color: var(--color-bg-bleed);
-                border-color: var(--color-border-bleed);
-                color: var(--color-text-bleed);
+                &.bleed {
+                    background-color: var(--color-bg-bleed);
+                    border-color: var(--color-border-bleed);
+                    color: var(--color-text-bleed);
 
-                i[class^="fa-"] {
-                    color: var(--color-border-bleed);
+                    i[class^="fa-"] {
+                        color: var(--color-border-bleed);
+                    }
                 }
-            }
 
-            &.bludgeoning,
-            &.piercing,
-            &.slashing {
-                background-color: var(--color-bg-physical);
-                border-color: var(--color-border-physical);
-                color: var(--color-text-physical);
+                &.bludgeoning,
+                &.piercing,
+                &.slashing {
+                    background-color: var(--color-bg-physical);
+                    border-color: var(--color-border-physical);
+                    color: var(--color-text-physical);
 
-                i[class^="fa-"] {
-                    color: var(--color-border-physical);
+                    i[class^="fa-"] {
+                        color: var(--color-border-physical);
+                    }
                 }
-            }
 
-            &.chaotic {
-                background-color: var(--color-bg-chaotic);
-                border-color: var(--color-border-chaotic);
-                color: var(--color-text-chaotic);
+                &.chaotic {
+                    background-color: var(--color-bg-chaotic);
+                    border-color: var(--color-border-chaotic);
+                    color: var(--color-text-chaotic);
 
-                i[class^="fa-"] {
-                    color: var(--color-border-chaotic);
+                    i[class^="fa-"] {
+                        color: var(--color-border-chaotic);
+                    }
                 }
-            }
 
-            &.cold {
-                background-color: var(--color-bg-cold);
-                border-color: var(--color-border-cold);
-                color: var(--color-text-cold);
+                &.cold {
+                    background-color: var(--color-bg-cold);
+                    border-color: var(--color-border-cold);
+                    color: var(--color-text-cold);
 
-                i[class^="fa-"] {
-                    color: var(--color-border-cold);
+                    i[class^="fa-"] {
+                        color: var(--color-border-cold);
+                    }
                 }
-            }
 
-            &.electricity {
-                background-color: var(--color-bg-electricity);
-                border-color: var(--color-border-electricity);
-                color: var(--color-text-electricity);
+                &.electricity {
+                    background-color: var(--color-bg-electricity);
+                    border-color: var(--color-border-electricity);
+                    color: var(--color-text-electricity);
 
-                i[class^="fa-"] {
-                    color: var(--color-border-electricity);
+                    i[class^="fa-"] {
+                        color: var(--color-border-electricity);
+                    }
                 }
-            }
 
-            &.evil {
-                background-color: var(--color-bg-evil);
-                border-color: var(--color-border-evil);
-                color: var(--color-text-evil);
+                &.evil {
+                    background-color: var(--color-bg-evil);
+                    border-color: var(--color-border-evil);
+                    color: var(--color-text-evil);
 
-                i[class^="fa-"] {
-                    color: var(--color-border-evil);
+                    i[class^="fa-"] {
+                        color: var(--color-border-evil);
+                    }
                 }
-            }
 
-            &.fire {
-                background-color: var(--color-bg-fire);
-                border-color: var(--color-border-fire);
-                color: var(--color-text-fire);
+                &.fire {
+                    background-color: var(--color-bg-fire);
+                    border-color: var(--color-border-fire);
+                    color: var(--color-text-fire);
 
-                i[class^="fa-"] {
-                    color: var(--color-border-fire);
+                    i[class^="fa-"] {
+                        color: var(--color-border-fire);
+                    }
                 }
-            }
 
-            &.force {
-                background-color: var(--color-bg-force);
-                border-color: var(--color-border-force);
-                color: var(--color-text-force);
+                &.force {
+                    background-color: var(--color-bg-force);
+                    border-color: var(--color-border-force);
+                    color: var(--color-text-force);
 
-                i[class^="fa-"] {
-                    color: var(--color-border-force);
+                    i[class^="fa-"] {
+                        color: var(--color-border-force);
+                    }
                 }
-            }
 
-            &.good {
-                background-color: var(--color-bg-good);
-                border-color: var(--color-border-good);
-                color: var(--color-text-good);
+                &.good {
+                    background-color: var(--color-bg-good);
+                    border-color: var(--color-border-good);
+                    color: var(--color-text-good);
 
-                i[class^="fa-"] {
-                    color: var(--color-border-good);
+                    i[class^="fa-"] {
+                        color: var(--color-border-good);
+                    }
                 }
-            }
 
-            &.lawful {
-                background-color: var(--color-bg-lawful);
-                border-color: var(--color-border-lawful);
-                color: var(--color-text-lawful);
+                &.lawful {
+                    background-color: var(--color-bg-lawful);
+                    border-color: var(--color-border-lawful);
+                    color: var(--color-text-lawful);
 
-                i[class^="fa-"] {
-                    color: var(--color-border-lawful);
+                    i[class^="fa-"] {
+                        color: var(--color-border-lawful);
+                    }
                 }
-            }
 
-            &.mental {
-                background-color: var(--color-bg-mental);
-                border-color: var(--color-border-mental);
-                color: var(--color-text-mental);
+                &.mental {
+                    background-color: var(--color-bg-mental);
+                    border-color: var(--color-border-mental);
+                    color: var(--color-text-mental);
 
-                i[class^="fa-"] {
-                    color: var(--color-border-mental);
+                    i[class^="fa-"] {
+                        color: var(--color-border-mental);
+                    }
                 }
-            }
 
-            &.poison {
-                background-color: var(--color-bg-poison);
-                border-color: var(--color-border-poison);
-                color: var(--color-text-poison);
+                &.poison {
+                    background-color: var(--color-bg-poison);
+                    border-color: var(--color-border-poison);
+                    color: var(--color-text-poison);
 
-                i[class^="fa-"] {
-                    color: var(--color-border-poison);
+                    i[class^="fa-"] {
+                        color: var(--color-border-poison);
+                    }
                 }
-            }
 
-            &.sonic {
-                border-color: var(--color-border-sonic);
-                background-color: var(--color-bg-sonic);
-                color: var(--color-text-sonic);
+                &.sonic {
+                    border-color: var(--color-border-sonic);
+                    background-color: var(--color-bg-sonic);
+                    color: var(--color-text-sonic);
 
-                i[class^="fa-"] {
-                    color: var(--color-border-sonic);
+                    i[class^="fa-"] {
+                        color: var(--color-border-sonic);
+                    }
                 }
-            }
 
-            &.spirit {
-                border-color: var(--color-border-spirit);
-                background-color: var(--color-bg-spirit);
-                color: var(--color-text-spirit);
+                &.spirit {
+                    border-color: var(--color-border-spirit);
+                    background-color: var(--color-bg-spirit);
+                    color: var(--color-text-spirit);
 
-                i[class^="fa-"] {
-                    color: var(--color-border-spirit);
+                    i[class^="fa-"] {
+                        color: var(--color-border-spirit);
+                    }
                 }
-            }
 
-            &.vitality {
-                background-color: var(--color-bg-physical); // Improve contrast with bright color
-                border-color: var(--color-border-vitality);
-                color: var(--color-text-vitality);
-                text-shadow: 1px 1px var(--color-text-dark-1);
+                &.vitality {
+                    background-color: var(--color-bg-physical); // Improve contrast with bright color
+                    border-color: var(--color-border-vitality);
+                    color: var(--color-text-vitality);
+                    text-shadow: 1px 1px var(--color-text-dark-1);
 
-                i[class^="fa-"] {
-                    color: var(--color-border-vitality);
+                    i[class^="fa-"] {
+                        color: var(--color-border-vitality);
+                    }
                 }
-            }
 
-            &.void {
-                background-color: var(--color-bg-void);
-                border-color: var(--color-border-void);
-                color: var(--color-text-void);
+                &.void {
+                    background-color: var(--color-bg-void);
+                    border-color: var(--color-border-void);
+                    color: var(--color-text-void);
 
-                i[class^="fa-"] {
-                    color: var(--color-border-void);
+                    i[class^="fa-"] {
+                        color: var(--color-border-void);
+                    }
                 }
             }
         }

--- a/src/styles/_forms.scss
+++ b/src/styles/_forms.scss
@@ -1,3 +1,5 @@
+@use "colors";
+
 .crb-style {
     display: flex;
 
@@ -15,7 +17,7 @@
         font-weight: bold;
         width: calc(100% - 6px);
         border-bottom: 1px solid var(--color-border-dark-input);
-        background-color: rgba($text-dark-color, 0.1);
+        background-color: rgba(colors.$text-dark-color, 0.1);
 
         &::placeholder {
             filter: opacity(0.5);

--- a/src/styles/_globals.scss
+++ b/src/styles/_globals.scss
@@ -1,4 +1,5 @@
 @use "sass:meta";
+@use "colors";
 @use "mixins/animations";
 @use "mixins/frames";
 @use "mixins/typography";
@@ -26,6 +27,8 @@
     --space-14: 0.875rem;
     --space-15: 0.9375rem;
 }
+
+@include colors.root;
 
 /* ----------------------------------------- */
 /* Layout                                    */

--- a/src/styles/_globals.scss
+++ b/src/styles/_globals.scss
@@ -1,3 +1,8 @@
+@use "sass:meta";
+@use "mixins/animations";
+@use "mixins/frames";
+@use "mixins/typography";
+
 /* ----------------------------------------- */
 /* Sub-font-size spacing                     */
 /* (margin, padding, gap, etc.)              */
@@ -352,7 +357,7 @@ span[data-pf2-effect-area] {
 /* ----------------------------------------- */
 
 i[data-pf2-repost] {
-    @include quick-transition;
+    @include animations.quick-transition;
     background: var(--inline-repost-bg);
     color: var(--color-text-dark-inactive);
     border-left: 1px solid var(--color-border-dark-tertiary);
@@ -395,7 +400,7 @@ i[data-pf2-repost] {
 /* ----------------------------------------- */
 /* Forms                                     */
 /* ----------------------------------------- */
-@import "forms";
+@include meta.load-css("forms");
 
 a[href]:hover {
     text-shadow: 0 0 8px var(--color-text-hyperlink);
@@ -406,11 +411,11 @@ a[href]:hover {
 }
 
 #tinymce {
-    @include journal-styling;
+    @include typography.journal-styling;
 }
 
 #prosemirror-dropdown {
-    @include journal-styling;
+    @include typography.journal-styling;
 
     .info:hover {
         color: black;
@@ -455,7 +460,7 @@ a[href]:hover {
 // System theme Foundry tooltips
 #tooltip.pf2e,
 aside.locked-tooltip.pf2e {
-    @include corner-boxes;
+    @include frames.corner-boxes;
     background: rgba(black, 0.9);
     font-size: var(--font-size-14);
     padding: var(--space-4) 0;

--- a/src/styles/_reset.scss
+++ b/src/styles/_reset.scss
@@ -1,27 +1,29 @@
 // Reset for foundry global stylings
 
-& {
-    --animate-delay: 1s;
-    --animate-duration: 1s;
-    --animate-repeat: 1;
-    --form-field-height: 1.5rem;
-}
+@mixin reset {
+    & {
+        --animate-delay: 1s;
+        --animate-duration: 1s;
+        --animate-repeat: 1;
+        --form-field-height: 1.5rem;
+    }
 
-input[type="checkbox"] {
-    flex: 0 0 var(--font-size-20);
-    height: var(--font-size-20);
-    margin: var(--space-3) var(--space-5);
-    width: var(--font-size-20);
-}
+    input[type="checkbox"] {
+        flex: 0 0 var(--font-size-20);
+        height: var(--font-size-20);
+        margin: var(--space-3) var(--space-5);
+        width: var(--font-size-20);
+    }
 
-select {
-    height: var(--form-field-height);
-}
+    select {
+        height: var(--form-field-height);
+    }
 
-h3 {
-    border-bottom: none;
-}
+    h3 {
+        border-bottom: none;
+    }
 
-button > i {
-    margin-right: 0;
+    button > i {
+        margin-right: 0;
+    }
 }

--- a/src/styles/_tags.scss
+++ b/src/styles/_tags.scss
@@ -1,3 +1,5 @@
+@use "mixins/typography";
+
 // Note: tags html element is tagify, and .tags is paizo tag/traits styling. They are not mutually exclusive.
 
 // Temporary measure since V12 introduced core `.tags > .tag` styling
@@ -12,7 +14,7 @@
 
     .tag,
     .tag option {
-        @include micro;
+        @include typography.micro;
         align-items: center;
         background-color: var(--color-bg-trait);
         border-radius: 2px;

--- a/src/styles/actor/_coinage.scss
+++ b/src/styles/actor/_coinage.scss
@@ -1,5 +1,10 @@
+@use "../mixins/buttons";
+@use "../mixins/frames";
+@use "../mixins/layout";
+@use "../mixins/typography";
+
 .currency {
-    @include button;
+    @include buttons.button;
     align-items: center;
     background-color: var(--sub);
     display: flex;
@@ -41,7 +46,7 @@
             text-shadow:
                 1px 1px 1px rgba(white, 0.2),
                 -1px -1px 1px rgba(black, 0.2);
-            @include micro;
+            @include typography.micro;
         }
 
         span {
@@ -71,7 +76,7 @@
         }
 
         .currency-image {
-            @include gold-border;
+            @include frames.gold-border;
             height: 1.5rem;
             width: 1.5rem;
             background-size: cover !important;
@@ -79,8 +84,8 @@
     }
 
     li > button {
-        @include flex-center;
-        @include p-reset;
+        @include layout.flex-center;
+        @include layout.p-reset;
         background-color: var(--tertiary);
         border-radius: 1px;
         border: none;
@@ -97,7 +102,7 @@
         width: 1.875rem;
 
         > i {
-            @include p-reset;
+            @include layout.p-reset;
         }
 
         &:disabled {
@@ -113,8 +118,8 @@
 }
 
 .wealth {
-    @include micro;
-    @include button;
+    @include typography.micro;
+    @include buttons.button;
     align-items: center;
     background-color: var(--alt);
     display: flex;

--- a/src/styles/actor/_header.scss
+++ b/src/styles/actor/_header.scss
@@ -1,3 +1,5 @@
+@use "../mixins/typography";
+
 header.char-header {
     display: flex;
     justify-content: space-between;
@@ -5,7 +7,7 @@ header.char-header {
     color: var(--text-light);
 
     .char-details {
-        @include micro;
+        @include typography.micro;
         margin-left: 8px;
 
         h1.char-name {
@@ -65,7 +67,7 @@ header.char-header {
             padding-top: 2px;
             label {
                 color: var(--sidebar-label);
-                @include micro;
+                @include typography.micro;
                 line-height: 1.5;
             }
             input {

--- a/src/styles/actor/_index.scss
+++ b/src/styles/actor/_index.scss
@@ -1,11 +1,17 @@
-@import "character/attribute-builder";
-@import "iwr-editor";
+@use "sass:meta";
+@use "character/attribute-builder";
+@use "iwr-editor";
+@use "../colors";
+@use "../mixins/animations";
+@use "../mixins/frames";
+@use "../mixins/typography";
+@use "../reset" as *;
 
 .actor.sheet section.window-content {
     font-family: var(--sans-serif);
     overflow: hidden;
     padding: 0;
-    @import "../reset";
+    @include reset;
 
     h1,
     h2,
@@ -57,8 +63,8 @@
         }
     }
 
-    @import "inventory";
-    @import "item-summary";
+    @include meta.load-css("inventory");
+    @include meta.load-css("item-summary");
 
     .item-image {
         display: flex;
@@ -76,7 +82,7 @@
 
             &,
             i {
-                @include frame-icon;
+                @include frames.frame-icon;
             }
         }
 
@@ -214,7 +220,7 @@
             height: var(--font-size-19);
         }
 
-        @import "header";
+        @include meta.load-css("header");
 
         .char-header {
             grid-area: header;
@@ -256,7 +262,7 @@
                     }
                 }
 
-                @import "spell-collection";
+                @include meta.load-css("spell-collection");
 
                 .directory-list {
                     > h3,
@@ -339,11 +345,11 @@
                 }
 
                 .tab.actions {
-                    @import "tabs/actions";
+                    @include meta.load-css("tabs/actions");
                 }
 
                 footer {
-                    @include micro;
+                    @include typography.micro;
                     color: var(--color-pf-primary);
                     text-align: right;
                     line-height: 1.4;
@@ -353,7 +359,7 @@
         }
 
         /* Navigation */
-        @import "nav";
+        @include meta.load-css("nav");
 
         section.major > header,
         section.major > .subsection > header {
@@ -393,7 +399,7 @@
                 width: auto;
 
                 &.has-unallocated {
-                    @include requires-user-attention;
+                    @include animations.requires-user-attention;
                 }
             }
 
@@ -424,12 +430,12 @@
 
         /* Read-Only Sheet */
         &.limited {
-            @import "limited";
+            @include meta.load-css("limited");
         }
 
         input.adjusted:not(:focus) {
             font-weight: 700;
-            color: $adjusted-higher;
+            color: colors.$adjusted-higher;
         }
 
         button.tag:disabled {
@@ -459,13 +465,13 @@
         opacity: 0.75;
     }
 
-    @import "coinage";
+    @include meta.load-css("coinage");
 }
 
 .actor.sheet {
     &.character section.window-content {
         .crb-style {
-            @import "character";
+            @include meta.load-css("character");
         }
     }
 
@@ -473,27 +479,27 @@
         background-image: url("/assets/sheet/background.webp");
         background-position: 75% 10%;
 
-        @import "character/attack-popout";
+        @include meta.load-css("character/attack-popout");
     }
 
     &.vehicle .crb-style {
-        @import "vehicle";
+        @include meta.load-css("vehicle");
     }
 }
 
-@import "spell-preparation";
+@include meta.load-css("spell-preparation");
 
 /* Actor-type Imports */
-@import "familiar";
+@include meta.load-css("familiar");
 
-@import "hazard";
+@include meta.load-css("hazard");
 
-@import "npc";
+@include meta.load-css("npc");
 
-@import "loot";
+@include meta.load-css("loot");
 
-@import "party";
+@include meta.load-css("party");
 
-@import "army";
+@include meta.load-css("army");
 
-@import "item-transfer-dialog";
+@include meta.load-css("item-transfer-dialog");

--- a/src/styles/actor/_index.scss
+++ b/src/styles/actor/_index.scss
@@ -1,7 +1,6 @@
 @use "sass:meta";
 @use "character/attribute-builder";
 @use "iwr-editor";
-@use "../colors";
 @use "../mixins/animations";
 @use "../mixins/frames";
 @use "../mixins/typography";
@@ -435,7 +434,7 @@
 
         input.adjusted:not(:focus) {
             font-weight: 700;
-            color: colors.$adjusted-higher;
+            color: var(--color-adjusted-higher);
         }
 
         button.tag:disabled {

--- a/src/styles/actor/_inventory.scss
+++ b/src/styles/actor/_inventory.scss
@@ -1,3 +1,10 @@
+@use "../colors";
+@use "../mixins/animations";
+@use "../mixins/buttons";
+@use "../mixins/frames";
+@use "../mixins/layout";
+@use "../mixins/typography";
+
 .inventory {
     --border-color: var(--color-pf-alternate);
 
@@ -83,7 +90,7 @@
 
     .inventory-list > header,
     .total-bulk {
-        @include button;
+        @include buttons.button;
         align-items: center;
         background-color: var(--color-pf-alternate);
         color: var(--color-text-light-0);
@@ -146,7 +153,7 @@
             width: 100%;
 
             &:nth-of-type(even) {
-                background-color: rgba($alt-color, 0.1);
+                background-color: rgba(colors.$alt-color, 0.1);
             }
 
             &:last-child .item-summary {
@@ -243,7 +250,7 @@
 
                     .decrease,
                     .increase {
-                        @include flex-center;
+                        @include layout.flex-center;
                         font-family: var(--sans-serif-monospace);
                         height: 100%;
                         text-align: center;
@@ -286,7 +293,7 @@
                         }
 
                         &.notify {
-                            @include requires-user-attention;
+                            @include animations.requires-user-attention;
                         }
                     }
                 }
@@ -313,7 +320,7 @@
                 flex-basis: 100%;
 
                 .capacity {
-                    @include micro;
+                    @include typography.micro;
                     background-color: rgba(black, 0.75);
                     box-shadow: inset 0 0 4px black;
                     color: var(--color-text-light-0);
@@ -354,7 +361,7 @@
                     position: relative;
 
                     &:nth-of-type(even) {
-                        background-color: rgba($alt-color, 0.1);
+                        background-color: rgba(colors.$alt-color, 0.1);
                     }
 
                     &:first-of-type .item::before {
@@ -429,7 +436,7 @@
             flex: 1;
 
             img {
-                @include frame-icon;
+                @include frames.frame-icon;
                 border-radius: 0;
                 grid-area: img;
                 position: relative;
@@ -530,7 +537,7 @@
         margin-bottom: var(--space-11);
 
         img {
-            @include frame-icon;
+            @include frames.frame-icon;
             height: 1.5rem;
             width: 1.5rem;
             z-index: 1;

--- a/src/styles/actor/_item-summary.scss
+++ b/src/styles/actor/_item-summary.scss
@@ -1,5 +1,9 @@
+@use "../colors";
+@use "../mixins/frames";
+@use "../mixins/typography";
+
 .item-summary {
-    @include journal-styling;
+    @include typography.journal-styling;
     line-height: normal;
     overflow: hidden;
     padding: var(--space-4);
@@ -37,8 +41,8 @@
         }
 
         .addendum {
-            @include frame-elegant;
-            background: rgba($alt-dark, 0.1);
+            @include frames.frame-elegant;
+            background: rgba(colors.$alt-dark, 0.1);
             border-radius: 2px;
             color: var(--color-pf-alternate-darker);
             padding: var(--space-4);

--- a/src/styles/actor/_limited.scss
+++ b/src/styles/actor/_limited.scss
@@ -1,3 +1,6 @@
+@use "../mixins/frames";
+@use "../mixins/layout";
+
 .sidebar {
     align-items: center;
     display: flex;
@@ -13,7 +16,7 @@
         background-color: var(--tertiary);
         background-size: cover;
         background-position: top center;
-        @include frame-silver;
+        @include frames.frame-silver;
     }
 
     .appearance {
@@ -48,12 +51,12 @@
     }
 
     ul.stats {
-        @include p-reset;
+        @include layout.p-reset;
         list-style: none;
         text-align: center;
 
         li {
-            @include p-reset;
+            @include layout.p-reset;
         }
     }
 }

--- a/src/styles/actor/_nav.scss
+++ b/src/styles/actor/_nav.scss
@@ -1,3 +1,5 @@
+@use "../mixins/layout";
+
 nav.sheet-navigation {
     align-items: center;
     background:
@@ -22,7 +24,7 @@ nav.sheet-navigation {
     }
 
     > a {
-        @include flex-center;
+        @include layout.flex-center;
         font-size: var(--font-size-12);
     }
 

--- a/src/styles/actor/_spell-collection.scss
+++ b/src/styles/actor/_spell-collection.scss
@@ -1,7 +1,6 @@
+@use "sass:color";
 @use "../colors";
 @use "../mixins/layout";
-
-@use "sass:color";
 
 ol.spell-list {
     border-bottom: 1px solid var(--color-border-light-2);

--- a/src/styles/actor/_spell-collection.scss
+++ b/src/styles/actor/_spell-collection.scss
@@ -1,3 +1,6 @@
+@use "../colors";
+@use "../mixins/layout";
+
 @use "sass:color";
 
 ol.spell-list {
@@ -31,7 +34,7 @@ ol.spell-list {
         }
 
         &:nth-child(odd) {
-            background-color: rgba($alt-color, 0.1);
+            background-color: rgba(colors.$alt-color, 0.1);
         }
 
         &:nth-child(even) .item-summary {
@@ -43,7 +46,7 @@ ol.spell-list {
         }
 
         &.header-row {
-            background: rgba($sub-color, 0.25);
+            background: rgba(colors.$sub-color, 0.25);
             border: 1px solid var(--color-border-light-2);
             border-radius: 2px;
             font: 500 var(--font-size-12) var(--sans-serif);
@@ -175,7 +178,7 @@ ol.spell-list {
             }
 
             h4 {
-                @include p-reset;
+                @include layout.p-reset;
                 font: 500 var(--font-size-14) / 1 var(--body-serif);
                 letter-spacing: -0.025em;
                 margin-left: 0.5em;
@@ -213,9 +216,9 @@ ol.spell-list {
         }
 
         .item-summary {
-            background-color: rgba($light-background-color, 0.5);
+            background-color: rgba(colors.$light-background-color, 0.5);
             border-bottom: 1px solid var(--sub);
-            border-top: 1px solid color.adjust($sub-color, $lightness: -30%);
+            border-top: 1px solid color.adjust(colors.$sub-color, $lightness: -30%);
             display: block;
             grid-column: span 5;
             padding: var(--space-4) 0 var(--space-8);

--- a/src/styles/actor/_spell-preparation.scss
+++ b/src/styles/actor/_spell-preparation.scss
@@ -1,10 +1,9 @@
+@use "sass:color";
 @use "sass:meta";
 @use "../colors";
 @use "../mixins/frames";
 @use "../mixins/layout";
 @use "../reset" as *;
-
-@use "sass:color";
 
 // Spellcasting Preparation Sheet Styling
 .spellcasting-entry.preparation > .window-content {

--- a/src/styles/actor/_spell-preparation.scss
+++ b/src/styles/actor/_spell-preparation.scss
@@ -1,8 +1,14 @@
+@use "sass:meta";
+@use "../colors";
+@use "../mixins/frames";
+@use "../mixins/layout";
+@use "../reset" as *;
+
 @use "sass:color";
 
 // Spellcasting Preparation Sheet Styling
 .spellcasting-entry.preparation > .window-content {
-    @import "../reset";
+    @include reset;
 
     form {
         display: flex;
@@ -76,7 +82,7 @@
             }
 
             &:nth-child(odd) {
-                background-color: rgba($alt-color, 0.1);
+                background-color: rgba(colors.$alt-color, 0.1);
             }
 
             &:nth-child(even) .item-summary {
@@ -88,7 +94,7 @@
             }
 
             &.header-row {
-                background: rgba($sub-color, 0.25);
+                background: rgba(colors.$sub-color, 0.25);
                 border: 1px solid var(--color-border-light-2);
                 border-radius: 2px;
                 font: 500 var(--font-size-12) var(--sans-serif);
@@ -147,7 +153,7 @@
 
                     &,
                     i {
-                        @include frame-icon;
+                        @include frames.frame-icon;
                     }
 
                     i {
@@ -172,7 +178,7 @@
                 }
 
                 h4 {
-                    @include p-reset;
+                    @include layout.p-reset;
                     font: 500 var(--font-size-14) / 1 var(--body-serif);
                     letter-spacing: -0.025em;
                     margin-left: 0.5em;
@@ -195,9 +201,9 @@
             }
 
             .item-summary {
-                background-color: rgba($light-background-color, 0.5);
+                background-color: rgba(colors.$light-background-color, 0.5);
                 border-bottom: 1px solid var(--sub);
-                border-top: 1px solid color.adjust($sub-color, $lightness: 30%);
+                border-top: 1px solid color.adjust(colors.$sub-color, $lightness: 30%);
                 display: block;
                 grid-column: span 5;
                 padding: var(--space-4) 0 var(--space-8);

--- a/src/styles/actor/army/_index.scss
+++ b/src/styles/actor/army/_index.scss
@@ -1,3 +1,6 @@
+@use "../../colors";
+@use "../../mixins/frames";
+
 .sheet.army form {
     display: grid;
     grid-template:
@@ -26,11 +29,11 @@
 
     input {
         &.adjusted-higher {
-            color: $adjusted-higher;
+            color: colors.$adjusted-higher;
         }
 
         &.adjusted-lower {
-            color: $adjusted-lower;
+            color: colors.$adjusted-lower;
         }
     }
 
@@ -63,7 +66,7 @@
                 width: 4rem;
                 height: 4rem;
                 cursor: pointer;
-                @include brown-border;
+                @include frames.brown-border;
             }
         }
 

--- a/src/styles/actor/army/_index.scss
+++ b/src/styles/actor/army/_index.scss
@@ -1,4 +1,3 @@
-@use "../../colors";
 @use "../../mixins/frames";
 
 .sheet.army form {
@@ -29,11 +28,11 @@
 
     input {
         &.adjusted-higher {
-            color: colors.$adjusted-higher;
+            color: var(--color-adjusted-higher);
         }
 
         &.adjusted-lower {
-            color: colors.$adjusted-lower;
+            color: var(--color-adjusted-lower);
         }
     }
 

--- a/src/styles/actor/character/_actions.scss
+++ b/src/styles/actor/character/_actions.scss
@@ -1,286 +1,290 @@
-&.actions {
-    padding: 0;
+@use "../../colors";
 
-    ol.actions-list {
-        & + .actions-list {
-            margin-top: var(--space-8);
-        }
+@mixin tab {
+    &.actions {
+        padding: 0;
 
-        .toggles {
-            align-items: center;
-            display: flex;
-            font-size: var(--font-size-14);
-            gap: var(--space-2);
-            justify-content: center;
-            padding: 0 var(--space-3);
-
-            button {
-                align-items: center;
-                border: none;
-                box-shadow:
-                    inset 0 0 0 1px rgba(black, 0.3),
-                    inset 0 0 0 2px rgba(white, 0.2);
-                display: flex;
-                height: 1.25rem;
-                justify-content: center;
-                width: 3ch;
-
-                &.double-barrel {
-                    i.barrels {
-                        left: 0;
-                        height: 1rem;
-                        top: var(--space-5);
-                        overflow: hidden;
-                        opacity: 80%;
-                    }
-
-                    i.blast {
-                        color: var(--color-pf-primary-dark);
-                        overflow: hidden;
-                        height: 1.1875rem;
-                        top: var(--space-4);
-                        left: var(--space-5);
-                        width: initial;
-                    }
-                }
-
-                &.selected {
-                    background: var(--text-dark);
-                    color: var(--bg-dark);
-
-                    i.fa-solid,
-                    i.fa-solid.blast {
-                        color: var(--bg-dark);
-                    }
-
-                    i.barrels {
-                        opacity: 80%;
-                    }
-                }
-
-                &:not(disabled):hover {
-                    box-shadow: inset 0 0 0 1px rgba($primary-color, 0.5);
-                    text-shadow: none;
-                }
-
-                &:active {
-                    text-shadow: 0 0 1px var(--color-pf-primary);
-                }
-            }
-        }
-
-        li.strike {
-            display: grid;
-            grid-template:
-                "img content" min-content
-                "summary summary" min-content /
-                2.5rem 1fr;
-
-            .item-image {
-                grid-area: img;
-                width: 2rem;
-                height: 2rem;
-                margin-top: var(--space-2);
+        ol.actions-list {
+            & + .actions-list {
+                margin-top: var(--space-8);
             }
 
-            h4.name {
-                align-items: baseline;
-                display: flex;
-                width: 100%;
-                gap: var(--space-4);
-                margin: 0;
-                line-height: 1;
-
-                // Elemental blasts
-                .item-controls {
-                    margin-left: auto;
-                }
-            }
-
-            .button-group {
+            .toggles {
                 align-items: center;
                 display: flex;
-                flex-direction: row;
-                flex-wrap: nowrap;
                 font-size: var(--font-size-14);
-                margin-bottom: 0;
-                padding: var(--space-2) 0;
+                gap: var(--space-2);
+                justify-content: center;
+                padding: 0 var(--space-3);
 
                 button {
+                    align-items: center;
                     border: none;
-                    flex: 0;
-                    gap: var(--space-2);
+                    box-shadow:
+                        inset 0 0 0 1px rgba(black, 0.3),
+                        inset 0 0 0 2px rgba(white, 0.2);
+                    display: flex;
                     height: 1.25rem;
-                    line-height: unset;
-                    margin: 0;
-                    padding: 0 0.5em;
-                    white-space: nowrap;
+                    justify-content: center;
+                    width: 3ch;
 
-                    &:not(:disabled):hover {
-                        box-shadow: none;
-                        text-shadow: 0 0 2px var(--text-light);
-                    }
-                }
-            }
+                    &.double-barrel {
+                        i.barrels {
+                            left: 0;
+                            height: 1rem;
+                            top: var(--space-5);
+                            overflow: hidden;
+                            opacity: 80%;
+                        }
 
-            .alt-usage {
-                flex-basis: 100%;
-                position: relative;
-
-                .alt-usage-icon {
-                    border: none;
-                    height: 1rem;
-                    position: absolute;
-                    left: -1.5em;
-                    top: 0.2em;
-                }
-            }
-
-            .ammo {
-                align-items: center;
-                display: flex;
-                gap: 3px;
-                margin-bottom: 2px;
-
-                select.linked {
-                    font: normal var(--font-size-12) var(--sans-serif);
-                    line-height: var(--font-size-12);
-                    padding-top: 3px;
-                    width: fit-content;
-
-                    &[data-compatible="false"] {
-                        color: #ffffff99;
-                    }
-
-                    option,
-                    optgroup {
-                        color: var(--text-light);
-                    }
-                }
-
-                .magazine {
-                    margin-right: 0.5rem;
-                    font-family: var(--sans-serif);
-                    font-weight: 600;
-
-                    .icon {
-                        display: inline-block;
-                        width: 0.9rem;
-                        height: 0.9rem;
-                        background-image: url("/assets/icons/heavy-bullets.svg");
-                        background-size: cover;
-                    }
-                }
-            }
-
-            .auxiliary-actions {
-                display: flex;
-                gap: 3px;
-                padding: var(--space-2) 0;
-
-                button {
-                    // Modular damage select menu
-                    select.modular {
-                        appearance: auto;
-                        background: none;
-                        color: var(--text-dark);
-                        cursor: default;
-                        font: inherit;
-                        margin-left: 0.5em;
-                        padding: 0.15em 0.2em;
-                        text-transform: uppercase;
-
-                        option {
-                            background: var(--bg-dark);
+                        i.blast {
+                            color: var(--color-pf-primary-dark);
+                            overflow: hidden;
+                            height: 1.1875rem;
+                            top: var(--space-4);
+                            left: var(--space-5);
+                            width: initial;
                         }
                     }
 
-                    &:has(select.modular:hover) {
+                    &.selected {
+                        background: var(--text-dark);
+                        color: var(--bg-dark);
+
+                        i.fa-solid,
+                        i.fa-solid.blast {
+                            color: var(--bg-dark);
+                        }
+
+                        i.barrels {
+                            opacity: 80%;
+                        }
+                    }
+
+                    &:not(disabled):hover {
+                        box-shadow: inset 0 0 0 1px rgba(colors.$primary-color, 0.5);
                         text-shadow: none;
+                    }
+
+                    &:active {
+                        text-shadow: 0 0 1px var(--color-pf-primary);
                     }
                 }
             }
 
-            .item-summary {
-                grid-area: summary;
-            }
+            li.strike {
+                display: grid;
+                grid-template:
+                    "img content" min-content
+                    "summary summary" min-content /
+                    2.5rem 1fr;
 
-            &:not(.ready) {
                 .item-image {
-                    cursor: default;
-                    filter: grayscale(1);
-
-                    &:hover i {
-                        display: none;
-                    }
+                    grid-area: img;
+                    width: 2rem;
+                    height: 2rem;
+                    margin-top: var(--space-2);
                 }
 
                 h4.name {
-                    color: var(--color-text-dark-4);
+                    align-items: baseline;
+                    display: flex;
+                    width: 100%;
+                    gap: var(--space-4);
+                    margin: 0;
+                    line-height: 1;
+
+                    // Elemental blasts
+                    .item-controls {
+                        margin-left: auto;
+                    }
                 }
 
-                .hands-occupied {
-                    font: italic 500 var(--font-size-10) var(--sans-serif);
-                    letter-spacing: 0.05em;
-                    text-rendering: optimizeLegibility;
-                    text-transform: uppercase;
+                .button-group {
+                    align-items: center;
+                    display: flex;
+                    flex-direction: row;
+                    flex-wrap: nowrap;
+                    font-size: var(--font-size-14);
+                    margin-bottom: 0;
+                    padding: var(--space-2) 0;
+
+                    button {
+                        border: none;
+                        flex: 0;
+                        gap: var(--space-2);
+                        height: 1.25rem;
+                        line-height: unset;
+                        margin: 0;
+                        padding: 0 0.5em;
+                        white-space: nowrap;
+
+                        &:not(:disabled):hover {
+                            box-shadow: none;
+                            text-shadow: 0 0 2px var(--text-light);
+                        }
+                    }
+                }
+
+                .alt-usage {
+                    flex-basis: 100%;
+                    position: relative;
+
+                    .alt-usage-icon {
+                        border: none;
+                        height: 1rem;
+                        position: absolute;
+                        left: -1.5em;
+                        top: 0.2em;
+                    }
+                }
+
+                .ammo {
+                    align-items: center;
+                    display: flex;
+                    gap: 3px;
+                    margin-bottom: 2px;
+
+                    select.linked {
+                        font: normal var(--font-size-12) var(--sans-serif);
+                        line-height: var(--font-size-12);
+                        padding-top: 3px;
+                        width: fit-content;
+
+                        &[data-compatible="false"] {
+                            color: #ffffff99;
+                        }
+
+                        option,
+                        optgroup {
+                            color: var(--text-light);
+                        }
+                    }
+
+                    .magazine {
+                        margin-right: 0.5rem;
+                        font-family: var(--sans-serif);
+                        font-weight: 600;
+
+                        .icon {
+                            display: inline-block;
+                            width: 0.9rem;
+                            height: 0.9rem;
+                            background-image: url("/assets/icons/heavy-bullets.svg");
+                            background-size: cover;
+                        }
+                    }
+                }
+
+                .auxiliary-actions {
+                    display: flex;
+                    gap: 3px;
+                    padding: var(--space-2) 0;
+
+                    button {
+                        // Modular damage select menu
+                        select.modular {
+                            appearance: auto;
+                            background: none;
+                            color: var(--text-dark);
+                            cursor: default;
+                            font: inherit;
+                            margin-left: 0.5em;
+                            padding: 0.15em 0.2em;
+                            text-transform: uppercase;
+
+                            option {
+                                background: var(--bg-dark);
+                            }
+                        }
+
+                        &:has(select.modular:hover) {
+                            text-shadow: none;
+                        }
+                    }
+                }
+
+                .item-summary {
+                    grid-area: summary;
+                }
+
+                &:not(.ready) {
+                    .item-image {
+                        cursor: default;
+                        filter: grayscale(1);
+
+                        &:hover i {
+                            display: none;
+                        }
+                    }
+
+                    h4.name {
+                        color: var(--color-text-dark-4);
+                    }
+
+                    .hands-occupied {
+                        font: italic 500 var(--font-size-10) var(--sans-serif);
+                        letter-spacing: 0.05em;
+                        text-rendering: optimizeLegibility;
+                        text-transform: uppercase;
+                    }
+                }
+            }
+
+            li.action {
+                .item-image:hover {
+                    background: none;
+                }
+
+                .frequency {
+                    align-items: center;
+                    display: flex;
+                    flex-direction: row;
+                    flex-wrap: nowrap;
+
+                    input {
+                        width: 0;
+                        flex: 0 1 4rem;
+                        text-align: center;
+                    }
+
+                    span {
+                        white-space: nowrap;
+                    }
+                }
+
+                .item-summary .level {
+                    display: none;
                 }
             }
         }
 
-        li.action {
-            .item-image:hover {
-                background: none;
-            }
+        h4 {
+            flex: 1;
+        }
 
-            .frequency {
-                align-items: center;
-                display: flex;
-                flex-direction: row;
-                flex-wrap: nowrap;
+        button.activate {
+            background: none;
+            border: 1px solid var(--color-border-dark);
+            border-radius: 5px;
+            flex: 0;
+            line-height: 1.25em;
+            opacity: 0.7;
+            margin-right: 0.5rem;
+            padding: 0 0.25rem;
 
-                input {
-                    width: 0;
-                    flex: 0 1 4rem;
-                    text-align: center;
-                }
-
-                span {
-                    white-space: nowrap;
-                }
-            }
-
-            .item-summary .level {
-                display: none;
+            &.active,
+            &:hover {
+                background-color: var(--color-pf-primary);
+                color: var(--text-light);
+                opacity: 1;
             }
         }
-    }
 
-    h4 {
-        flex: 1;
-    }
-
-    button.activate {
-        background: none;
-        border: 1px solid var(--color-border-dark);
-        border-radius: 5px;
-        flex: 0;
-        line-height: 1.25em;
-        opacity: 0.7;
-        margin-right: 0.5rem;
-        padding: 0 0.25rem;
-
-        &.active,
-        &:hover {
-            background-color: var(--color-pf-primary);
-            color: var(--text-light);
-            opacity: 1;
+        .item-controls {
+            display: flex;
+            min-width: 2.5em;
+            justify-content: end;
         }
-    }
-
-    .item-controls {
-        display: flex;
-        min-width: 2.5em;
-        justify-content: end;
     }
 }

--- a/src/styles/actor/character/_attack-popout.scss
+++ b/src/styles/actor/character/_attack-popout.scss
@@ -1,10 +1,11 @@
+@use "sass:meta";
 .tab {
-    @import "actions";
+    @include meta.load-css("actions");
 }
 
 .tab.actions {
-    @import "../tabs/actions";
-    @import "option-toggles";
+    @include meta.load-css("../tabs/actions");
+    @include meta.load-css("option-toggles");
 
     margin: 0.25em var(--space-4) 0;
 

--- a/src/styles/actor/character/_attribute-builder.scss
+++ b/src/styles/actor/character/_attribute-builder.scss
@@ -1,3 +1,5 @@
+@use "../../mixins/animations";
+
 .attribute-builder .window-content {
     background: url("/assets/sheet/background.webp");
     background-repeat: repeat-x, no-repeat;
@@ -162,7 +164,7 @@
             text-align: center;
 
             &.extra {
-                @include requires-user-attention;
+                @include animations.requires-user-attention;
             }
         }
 

--- a/src/styles/actor/character/_biography.scss
+++ b/src/styles/actor/character/_biography.scss
@@ -1,182 +1,188 @@
-&.biography {
-    padding-bottom: 1rem;
+@use "../../colors";
+@use "../../mixins/layout";
+@use "../../mixins/typography";
 
-    & > header {
-        align-items: baseline;
-        display: flex;
-        justify-content: space-between;
-        padding: 0 var(--space-1);
+@mixin tab {
+    &.biography {
+        padding-bottom: 1rem;
 
-        i.fa-eye-slash {
-            opacity: 75%;
-        }
-    }
-
-    section {
-        &.editable {
-            .editor,
-            input {
-                background: rgba(0, 0, 0, 5%);
-            }
-
-            .editor-content {
-                min-height: 4rem;
-            }
-        }
-
-        &:not(.editable) .editor-content {
-            min-height: 2rem;
-        }
-
-        // Override core input:disabled coloration
-        input:disabled {
-            color: var(--text-dark);
-        }
-
-        &.appearance-details {
-            display: grid;
-            grid-template:
-                "bio bio" 1fr
-                "height weight" min-content
-                / 1fr 1fr;
-            .bio {
-                grid-area: bio;
-            }
-        }
-
-        &.personality {
+        & > header {
+            align-items: baseline;
             display: flex;
-            flex-wrap: wrap;
+            justify-content: space-between;
+            padding: 0 var(--space-1);
 
-            .bio {
-                align-items: start;
-                display: flex;
-                flex-direction: column;
-                flex: 50%;
-                justify-content: start;
-                margin-bottom: var(--space-8);
+            i.fa-eye-slash {
+                opacity: 75%;
+            }
+        }
 
-                span {
-                    width: 100%;
+        section {
+            &.editable {
+                .editor,
+                input {
+                    background: rgba(0, 0, 0, 5%);
+                }
+
+                .editor-content {
+                    min-height: 4rem;
                 }
             }
 
-            .edicts,
-            .anathema {
-                flex-basis: 100%;
+            &:not(.editable) .editor-content {
+                min-height: 2rem;
+            }
 
-                > * {
-                    width: 100%;
+            // Override core input:disabled coloration
+            input:disabled {
+                color: var(--text-dark);
+            }
+
+            &.appearance-details {
+                display: grid;
+                grid-template:
+                    "bio bio" 1fr
+                    "height weight" min-content
+                    / 1fr 1fr;
+                .bio {
+                    grid-area: bio;
                 }
+            }
 
-                .label-add {
-                    align-items: center;
+            &.personality {
+                display: flex;
+                flex-wrap: wrap;
+
+                .bio {
+                    align-items: start;
                     display: flex;
-                    justify-content: space-between;
-                    width: calc(100% - 0.75em);
+                    flex-direction: column;
+                    flex: 50%;
+                    justify-content: start;
+                    margin-bottom: var(--space-8);
+
+                    span {
+                        width: 100%;
+                    }
                 }
 
-                ol {
-                    list-style-type: decimal;
-                    margin-top: 0;
+                .edicts,
+                .anathema {
+                    flex-basis: 100%;
 
-                    li {
-                        white-space: nowrap;
+                    > * {
+                        width: 100%;
+                    }
 
-                        input {
-                            margin: 0.2em;
-                            max-width: calc(100% - 2rem);
+                    .label-add {
+                        align-items: center;
+                        display: flex;
+                        justify-content: space-between;
+                        width: calc(100% - 0.75em);
+                    }
+
+                    ol {
+                        list-style-type: decimal;
+                        margin-top: 0;
+
+                        li {
+                            white-space: nowrap;
+
+                            input {
+                                margin: 0.2em;
+                                max-width: calc(100% - 2rem);
+                            }
                         }
                     }
                 }
             }
-        }
 
-        &.campaign {
-            display: flex;
-            flex-direction: column;
-            gap: 0.5rem;
-        }
-
-        input {
-            background: none;
-            border-bottom: 1px solid var(--color-border-input);
-            font-family: var(--body-serif);
-            width: calc(100% - 6px);
-
-            &::placeholder {
-                filter: opacity(0.5);
-                color: var(--text-dark);
+            &.campaign {
+                display: flex;
+                flex-direction: column;
+                gap: 0.5rem;
             }
 
-            &:focus {
-                border-bottom: 1px solid #644f33;
-
-                &::placeholder {
-                    color: transparent;
-                }
-            }
-
-            &[type="number"] {
-                padding-bottom: 0;
-                padding-left: var(--space-4);
-            }
-        }
-
-        hr {
-            margin: var(--space-10) var(--space-6) var(--space-10) 0;
-        }
-
-        .bio {
-            > h3 {
-                @include p-reset;
-                background-color: rgba($text-dark-color, 0.1);
-                border: none;
-                color: var(--text-dark);
-                font: 700 var(--font-size-14) var(--body-serif);
-                grid-area: mod;
-                height: 1.625rem;
-                padding: var(--space-8) var(--space-4) var(--space-6);
+            input {
+                background: none;
+                border-bottom: 1px solid var(--color-border-input);
+                font-family: var(--body-serif);
                 width: calc(100% - 6px);
 
-                i {
-                    float: right;
-                    position: relative;
-                    right: calc(-1 * var(--space-2));
-                    top: calc(-1 * var(--space-2));
+                &::placeholder {
+                    filter: opacity(0.5);
+                    color: var(--text-dark);
                 }
 
-                span.value {
-                    display: inline-block;
-                    max-width: 87%;
-                    overflow: hidden;
-                    text-overflow: ellipsis;
-                    white-space: nowrap;
+                &:focus {
+                    border-bottom: 1px solid #644f33;
+
+                    &::placeholder {
+                        color: transparent;
+                    }
+                }
+
+                &[type="number"] {
+                    padding-bottom: 0;
+                    padding-left: var(--space-4);
                 }
             }
 
-            h4.details-label {
-                margin-bottom: var(--space-1);
-                width: 100%;
-            }
-        }
-
-        // Styling for the editor and editor content, especially to fit better in a small space
-        .editor {
-            .editor-content {
-                @include journal-styling;
-                padding: 0 var(--space-4);
+            hr {
+                margin: var(--space-10) var(--space-6) var(--space-10) 0;
             }
 
-            .editor-edit {
-                background: var(--color-pf-primary);
-                color: var(--text-light);
+            .bio {
+                > h3 {
+                    @include layout.p-reset;
+                    background-color: rgba(colors.$text-dark-color, 0.1);
+                    border: none;
+                    color: var(--text-dark);
+                    font: 700 var(--font-size-14) var(--body-serif);
+                    grid-area: mod;
+                    height: 1.625rem;
+                    padding: var(--space-8) var(--space-4) var(--space-6);
+                    width: calc(100% - 6px);
+
+                    i {
+                        float: right;
+                        position: relative;
+                        right: calc(-1 * var(--space-2));
+                        top: calc(-1 * var(--space-2));
+                    }
+
+                    span.value {
+                        display: inline-block;
+                        max-width: 87%;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                        white-space: nowrap;
+                    }
+                }
+
+                h4.details-label {
+                    margin-bottom: var(--space-1);
+                    width: 100%;
+                }
             }
 
-            &.prosemirror {
-                height: 13.5rem; // When the editor is open, fill more space
-                .editor-container {
-                    margin: var(--space-4) 0;
+            // Styling for the editor and editor content, especially to fit better in a small space
+            .editor {
+                .editor-content {
+                    @include typography.journal-styling;
+                    padding: 0 var(--space-4);
+                }
+
+                .editor-edit {
+                    background: var(--color-pf-primary);
+                    color: var(--text-light);
+                }
+
+                &.prosemirror {
+                    height: 13.5rem; // When the editor is open, fill more space
+                    .editor-container {
+                        margin: var(--space-4) 0;
+                    }
                 }
             }
         }

--- a/src/styles/actor/character/_character.scss
+++ b/src/styles/actor/character/_character.scss
@@ -1,322 +1,328 @@
+@use "../../colors";
+@use "../../mixins/animations";
+@use "../../mixins/frames";
+
 @use "sass:color";
 
-&.character {
-    gap: 1rem;
+@mixin tab {
+    &.character {
+        gap: 1rem;
 
-    select {
-        background-color: var(--color-pf-alternate);
-        border: 1px solid color.adjust($alt-color, $lightness: -8%);
-        width: calc(100% - var(--space-6));
+        select {
+            background-color: var(--color-pf-alternate);
+            border: 1px solid color.adjust(colors.$alt-color, $lightness: -8%);
+            width: calc(100% - var(--space-6));
 
-        &:disabled {
-            cursor: initial;
-        }
-    }
-
-    .subsection {
-        margin: 0;
-    }
-
-    .subsection.details {
-        align-items: start;
-        display: grid;
-        grid:
-            "img details" auto
-            / 7.5rem minmax(0, 1fr);
-        margin-top: var(--space-4);
-
-        .image-container {
-            display: flex;
-            flex: 0 0 8rem;
-            flex-direction: column;
-            grid-area: img;
-            max-height: 10.5rem;
-            position: relative;
-            z-index: 3;
-
-            .actor-image {
-                @include brown-border;
-                border-radius: 0;
-                max-height: 10.5rem;
-                object-fit: cover;
-                object-position: top;
-                width: 100%;
+            &:disabled {
+                cursor: initial;
             }
         }
 
-        .abcd {
+        .subsection {
+            margin: 0;
+        }
+
+        .subsection.details {
+            align-items: start;
             display: grid;
-            flex: 1;
-            grid-row-gap: var(--space-8);
-            grid-template-columns: repeat(2, 50%);
-            justify-content: start;
-            padding-left: var(--space-12);
+            grid:
+                "img details" auto
+                / 7.5rem minmax(0, 1fr);
+            margin-top: var(--space-4);
 
-            .detail {
+            .image-container {
                 display: flex;
-                flex-wrap: wrap;
-                gap: var(--space-2);
+                flex: 0 0 8rem;
+                flex-direction: column;
+                grid-area: img;
+                max-height: 10.5rem;
+                position: relative;
+                z-index: 3;
 
-                .details-label {
-                    flex-basis: 100%;
+                .actor-image {
+                    @include frames.brown-border;
+                    border-radius: 0;
+                    max-height: 10.5rem;
+                    object-fit: cover;
+                    object-position: top;
+                    width: 100%;
                 }
+            }
 
-                h3 {
-                    align-items: center;
-                    background-color: rgba($text-dark-color, 0.1);
-                    border: none;
-                    color: var(--text-dark);
+            .abcd {
+                display: grid;
+                flex: 1;
+                grid-row-gap: var(--space-8);
+                grid-template-columns: repeat(2, 50%);
+                justify-content: start;
+                padding-left: var(--space-12);
+
+                .detail {
                     display: flex;
-                    font: 700 var(--font-size-14) / 1em var(--body-serif);
-                    margin: 0;
-                    padding: 0.5em 0.25em;
-                    position: relative;
-                    width: calc(100% - 0.5em);
+                    flex-wrap: wrap;
+                    gap: var(--space-2);
 
-                    span.value {
+                    .details-label {
                         flex-basis: 100%;
-                        overflow: hidden;
-                        text-overflow: ellipsis;
-                        white-space: nowrap;
+                    }
+
+                    h3 {
+                        align-items: center;
+                        background-color: rgba(colors.$text-dark-color, 0.1);
+                        border: none;
+                        color: var(--text-dark);
+                        display: flex;
+                        font: 700 var(--font-size-14) / 1em var(--body-serif);
+                        margin: 0;
+                        padding: 0.5em 0.25em;
+                        position: relative;
+                        width: calc(100% - 0.5em);
+
+                        span.value {
+                            flex-basis: 100%;
+                            overflow: hidden;
+                            text-overflow: ellipsis;
+                            white-space: nowrap;
+                        }
+                    }
+                }
+
+                .traits {
+                    grid-column: span 2;
+                    margin: calc(-1 * var(--space-4)) 0 0 calc(-1 * var(--space-2));
+                    padding: 0;
+                }
+
+                .deity.selected {
+                    min-width: max-content;
+
+                    h3 {
+                        border-radius: 0 var(--space-12) var(--space-12) 0;
+                        flex-basis: auto;
+                        gap: var(--space-4);
+
+                        span.value {
+                            text-overflow: unset;
+                        }
+
+                        .emblem {
+                            flex: 0 0 1.75rem;
+                            margin: 0 calc(-1 * var(--space-3)) 0 var(--space-4);
+                            position: relative;
+
+                            img {
+                                @include frames.brown-border;
+                                border-radius: 50%;
+                                height: 1.75rem;
+                                left: calc(-1 * var(--space-4));
+                                position: absolute;
+                                top: calc(-1 * var(--space-14));
+                                width: 1.75rem;
+                            }
+                        }
                     }
                 }
             }
 
-            .traits {
+            hr {
                 grid-column: span 2;
-                margin: calc(-1 * var(--space-4)) 0 0 calc(-1 * var(--space-2));
-                padding: 0;
+                margin: var(--space-10) var(--space-6) var(--space-2) 0;
             }
 
-            .deity.selected {
-                min-width: max-content;
+            .detail-item-control {
+                cursor: pointer;
 
-                h3 {
-                    border-radius: 0 var(--space-12) var(--space-12) 0;
-                    flex-basis: auto;
-                    gap: var(--space-4);
+                > i:hover {
+                    text-shadow: 0 0 8px var(--color-shadow-primary);
+                }
 
-                    span.value {
-                        text-overflow: unset;
-                    }
+                #context-menu {
+                    min-width: 7rem;
+                    padding: 0;
+                    text-align: left;
+                    width: fit-content;
 
-                    .emblem {
-                        flex: 0 0 1.75rem;
-                        margin: 0 calc(-1 * var(--space-3)) 0 var(--space-4);
-                        position: relative;
+                    .context-item {
+                        font-family: var(--sans-serif);
+                        font-weight: normal;
+                        line-height: 2rem;
+                        white-space: nowrap;
 
-                        img {
-                            @include brown-border;
-                            border-radius: 50%;
-                            height: 1.75rem;
-                            left: calc(-1 * var(--space-4));
-                            position: absolute;
-                            top: calc(-1 * var(--space-14));
-                            width: 1.75rem;
+                        i {
+                            position: static;
+                            float: none;
                         }
                     }
                 }
             }
         }
 
-        hr {
-            grid-column: span 2;
-            margin: var(--space-10) var(--space-6) var(--space-2) 0;
+        .subsection.background {
+            display: flex;
+            flex-wrap: wrap;
+            margin-bottom: var(--space-4);
+
+            label {
+                align-items: start;
+                display: flex;
+                flex: 1 0 0;
+                flex-direction: column;
+                justify-content: start;
+
+                span {
+                    width: 100%;
+                }
+            }
         }
 
-        .detail-item-control {
-            cursor: pointer;
+        .subsection.languages {
+            ul {
+                display: flex;
+                flex-wrap: wrap;
+                gap: var(--space-4);
+                margin: 0;
 
-            > i:hover {
-                text-shadow: 0 0 8px var(--color-shadow-primary);
+                > li.over-limit {
+                    --tag-color: var(--color-pf-primary);
+                }
+
+                > li.unallocated {
+                    --tag-color: var(--color-pf-alternate);
+                    font-style: italic;
+                }
             }
 
-            #context-menu {
-                min-width: 7rem;
-                padding: 0;
-                text-align: left;
-                width: fit-content;
+            .details {
+                padding: 0 0.25em;
+            }
+        }
 
-                .context-item {
-                    font-family: var(--sans-serif);
-                    font-weight: normal;
-                    line-height: 2rem;
-                    white-space: nowrap;
+        .subsection.speeds {
+            display: flex;
+
+            .speed {
+                align-items: center;
+                display: flex;
+                flex: 1 0 0;
+                flex-direction: column;
+                text-align: center;
+
+                & + .speed {
+                    border-left: 1px solid #d3ccbc;
+                }
+
+                .label {
+                    color: var(--color-pf-alternate-dark);
+                    font: 500 var(--font-size-14) var(--sans-serif);
+                    font-variant: small-caps;
+                    position: relative;
+                }
+
+                .value {
+                    align-items: baseline;
+                    color: var(--color-text-dark-2);
+                    display: flex;
+                    font: 500 var(--font-size-18) / 1 var(--serif);
+                    gap: 0.25ch;
+                    padding: var(--space-4) var(--space-4) 0;
+                    position: relative;
 
                     i {
-                        position: static;
-                        float: none;
+                        color: var(--color-pf-alternate-dark);
+                        font-size: var(--font-size-13);
+                        opacity: 0.85;
+                    }
+
+                    .unit {
+                        font-size: var(--font-size-14);
+                    }
+
+                    &.rollable {
+                        svg {
+                            width: 1rem;
+                            height: 1rem;
+
+                            path {
+                                fill: var(--color-text-dark-2);
+                            }
+                        }
+
+                        &:hover svg {
+                            @include animations.die-spin;
+                        }
                     }
                 }
             }
         }
-    }
 
-    .subsection.background {
-        display: flex;
-        flex-wrap: wrap;
-        margin-bottom: var(--space-4);
-
-        label {
-            align-items: start;
-            display: flex;
-            flex: 1 0 0;
-            flex-direction: column;
-            justify-content: start;
-
-            span {
-                width: 100%;
-            }
-        }
-    }
-
-    .subsection.languages {
-        ul {
-            display: flex;
-            flex-wrap: wrap;
-            gap: var(--space-4);
-            margin: 0;
-
-            > li.over-limit {
-                --tag-color: var(--color-pf-primary);
-            }
-
-            > li.unallocated {
-                --tag-color: var(--color-pf-alternate);
-                font-style: italic;
-            }
-        }
-
-        .details {
-            padding: 0 0.25em;
-        }
-    }
-
-    .subsection.speeds {
-        display: flex;
-
-        .speed {
+        .subsection.attributes ul {
             align-items: center;
-            display: flex;
-            flex: 1 0 0;
-            flex-direction: column;
-            text-align: center;
+            column-gap: var(--space-10);
+            display: grid;
+            grid: 1fr 1fr / repeat(6, 1fr);
+            list-style: none;
+            margin: 0;
+            padding: 0;
 
-            & + .speed {
-                border-left: 1px solid #d3ccbc;
+            &:focus-within .abbreviation {
+                filter: opacity(1);
+            }
+
+            &.key {
+                .abbreviation,
+                .modifier {
+                    color: var(--color-pf-secondary);
+                }
+            }
+
+            .abbreviation {
+                border: none;
+                color: var(--color-pf-primary);
+                font: 400 var(--font-size-22) var(--serif-condensed);
+                margin: 0;
+                padding: 0;
+                position: relative;
+                text-align: center;
+                text-transform: capitalize;
+
+                i.key,
+                i.apex {
+                    bottom: var(--space-4);
+                    position: absolute;
+                    font-size: var(--font-size-12);
+                }
+
+                i.key {
+                    left: var(--space-2);
+                }
+
+                i.apex {
+                    right: var(--space-2);
+
+                    &.unselected:not(:hover) {
+                        opacity: 0.75;
+                    }
+                }
+            }
+
+            h3.modifier {
+                @include frames.frame-elegant;
+                align-items: center;
+                display: flex;
+                font: 700 var(--font-size-24) var(--serif);
+                height: 2.875rem;
+                justify-content: center;
+                margin: 0;
+                padding-right: var(--space-4);
             }
 
             .label {
-                color: var(--color-pf-alternate-dark);
-                font: 500 var(--font-size-14) var(--sans-serif);
-                font-variant: small-caps;
-                position: relative;
+                color: var(--text-dark);
+                margin: 0;
+                opacity: 0.4;
+                padding: var(--space-2);
+                text-align: center;
             }
-
-            .value {
-                align-items: baseline;
-                color: var(--color-text-dark-2);
-                display: flex;
-                font: 500 var(--font-size-18) / 1 var(--serif);
-                gap: 0.25ch;
-                padding: var(--space-4) var(--space-4) 0;
-                position: relative;
-
-                i {
-                    color: var(--color-pf-alternate-dark);
-                    font-size: var(--font-size-13);
-                    opacity: 0.85;
-                }
-
-                .unit {
-                    font-size: var(--font-size-14);
-                }
-
-                &.rollable {
-                    svg {
-                        width: 1rem;
-                        height: 1rem;
-
-                        path {
-                            fill: var(--color-text-dark-2);
-                        }
-                    }
-
-                    &:hover svg {
-                        @include die-spin;
-                    }
-                }
-            }
-        }
-    }
-
-    .subsection.attributes ul {
-        align-items: center;
-        column-gap: var(--space-10);
-        display: grid;
-        grid: 1fr 1fr / repeat(6, 1fr);
-        list-style: none;
-        margin: 0;
-        padding: 0;
-
-        &:focus-within .abbreviation {
-            filter: opacity(1);
-        }
-
-        &.key {
-            .abbreviation,
-            .modifier {
-                color: var(--color-pf-secondary);
-            }
-        }
-
-        .abbreviation {
-            border: none;
-            color: var(--color-pf-primary);
-            font: 400 var(--font-size-22) var(--serif-condensed);
-            margin: 0;
-            padding: 0;
-            position: relative;
-            text-align: center;
-            text-transform: capitalize;
-
-            i.key,
-            i.apex {
-                bottom: var(--space-4);
-                position: absolute;
-                font-size: var(--font-size-12);
-            }
-
-            i.key {
-                left: var(--space-2);
-            }
-
-            i.apex {
-                right: var(--space-2);
-
-                &.unselected:not(:hover) {
-                    opacity: 0.75;
-                }
-            }
-        }
-
-        h3.modifier {
-            @include frame-elegant;
-            align-items: center;
-            display: flex;
-            font: 700 var(--font-size-24) var(--serif);
-            height: 2.875rem;
-            justify-content: center;
-            margin: 0;
-            padding-right: var(--space-4);
-        }
-
-        .label {
-            color: var(--text-dark);
-            margin: 0;
-            opacity: 0.4;
-            padding: var(--space-2);
-            text-align: center;
         }
     }
 }

--- a/src/styles/actor/character/_crafting.scss
+++ b/src/styles/actor/character/_crafting.scss
@@ -1,182 +1,122 @@
+@use "../../colors";
+@use "../../mixins/frames";
+@use "../../mixins/layout";
 @use "sass:color";
 
-&.crafting {
-    --controls-width: 1.75rem;
+@mixin tab {
+    &.crafting {
+        --controls-width: 1.75rem;
 
-    .crafting-options {
-        @include frame-elegant;
-        display: flex;
-        flex-direction: column;
-        gap: var(--space-4);
-        margin: 0 1rem 1rem;
-        padding: 0.5rem 1rem;
-
-        .crafting-option {
+        .crafting-options {
+            @include frames.frame-elegant;
             display: flex;
-            align-items: center;
-            flex-basis: 100%;
+            flex-direction: column;
+            gap: var(--space-4);
+            margin: 0 1rem 1rem;
+            padding: 0.5rem 1rem;
 
-            label {
-                * {
-                    vertical-align: middle;
-                }
-
-                input {
-                    @include p-reset;
-                }
-            }
-        }
-    }
-
-    li.crafting-entry {
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: space-evenly;
-        align-items: center;
-        background: none;
-        border: none;
-
-        &.item-container {
-            margin-bottom: var(--space-6);
-        }
-
-        &.alchemical-entry {
-            margin-bottom: 0;
-
-            &:last-child {
-                margin-bottom: 0.5em;
-            }
-        }
-
-        .action-header {
-            color: var(--text-light);
-            font-size: var(--font-size-16);
-            font-weight: 500;
-            height: 1.75rem;
-
-            .level {
-                white-space: nowrap;
-            }
-
-            &.alchemical-title {
-                background: var(--color-pf-secondary);
-                font-size: var(--font-size-14);
-                height: 1.5rem;
-            }
-        }
-
-        input.formula-number {
-            background: var(--color-pf-alternate);
-            height: unset;
-            border-radius: 3px;
-            border: 1px solid var(--sub);
-            color: var(--text-light);
-            font: var(--font-size-12) var(--sans-serif);
-            text-align: center;
-            width: 2em;
-        }
-    }
-
-    ol.formula-list {
-        @include p-reset;
-        flex-basis: 100%;
-
-        .formula-item[data-expended-state="true"] {
-            h4 {
-                color: var(--color-disabled);
-                text-decoration: line-through;
-            }
-
-            .toggle-formula-expended {
-                color: var(--color-pf-primary);
-            }
-        }
-
-        .formula-header {
-            @include p-reset;
-            background: rgba($sub-color, 0.25);
-            border: 1px solid var(--sub);
-            color: var(--text-dark);
-            font: 600 var(--font-size-12) var(--sans-serif);
-            height: 1.75rem;
-
-            .item-name {
-                align-items: center;
+            .crafting-option {
                 display: flex;
-                flex-basis: 50%;
-                flex-wrap: nowrap;
-                justify-content: start;
-                justify-self: start;
-                line-height: 1.5;
-                gap: 0.5em;
-            }
+                align-items: center;
+                flex-basis: 100%;
 
-            h3 {
-                @include p-reset;
-                text-transform: capitalize;
-                font-size: var(--font-size-12);
-                font-weight: 500;
-                margin-left: 0;
-                padding: var(--space-4) 0;
-            }
+                label {
+                    * {
+                        vertical-align: middle;
+                    }
 
-            .formula-number {
-                text-align: center;
+                    input {
+                        @include layout.p-reset;
+                    }
+                }
             }
         }
 
-        .formula-header.resource {
+        li.crafting-entry {
             display: flex;
-            justify-content: space-between;
-            padding: 0 var(--space-4);
-        }
-
-        li.formula-level-header,
-        li.formula-item {
-            display: grid;
-            grid:
-                "name dc price quantity button controls" 1fr
-                / 1fr 1.5rem 4.5rem 5.125rem min-content var(--controls-width);
+            flex-wrap: wrap;
+            justify-content: space-evenly;
             align-items: center;
-            justify-items: center;
-
-            @include p-reset;
             background: none;
             border: none;
-            border-left: 1px solid var(--sub);
-            border-right: 1px solid var(--sub);
-            cursor: default;
 
-            &:nth-child(odd) {
-                background-color: rgba($alt-color, 0.1);
+            &.item-container {
+                margin-bottom: var(--space-6);
             }
 
-            &:nth-child(even) .item-summary {
-                background: none;
+            &.alchemical-entry {
+                margin-bottom: 0;
+
+                &:last-child {
+                    margin-bottom: 0.5em;
+                }
             }
 
-            &:last-child {
-                border-bottom: 1px solid var(--sub);
+            .action-header {
+                color: var(--text-light);
+                font-size: var(--font-size-16);
+                font-weight: 500;
+                height: 1.75rem;
+
+                .level {
+                    white-space: nowrap;
+                }
+
+                &.alchemical-title {
+                    background: var(--color-pf-secondary);
+                    font-size: var(--font-size-14);
+                    height: 1.5rem;
+                }
             }
 
-            &.empty {
-                align-items: center;
-                display: flex;
-                min-height: 2em;
-                opacity: 0.85;
-                padding-left: 1.25rem;
-                white-space: nowrap;
+            input.formula-number {
+                background: var(--color-pf-alternate);
+                height: unset;
+                border-radius: 3px;
+                border: 1px solid var(--sub);
+                color: var(--text-light);
+                font: var(--font-size-12) var(--sans-serif);
+                text-align: center;
+                width: 2em;
+            }
+        }
+
+        ol.formula-list {
+            @include layout.p-reset;
+            flex-basis: 100%;
+
+            .formula-item[data-expended-state="true"] {
+                h4 {
+                    color: var(--color-disabled);
+                    text-decoration: line-through;
+                }
+
+                .toggle-formula-expended {
+                    color: var(--color-pf-primary);
+                }
             }
 
-            &.formula-level-header {
-                background: rgba($sub-color, 0.25);
+            .formula-header {
+                @include layout.p-reset;
+                background: rgba(colors.$sub-color, 0.25);
                 border: 1px solid var(--sub);
                 color: var(--text-dark);
                 font: 600 var(--font-size-12) var(--sans-serif);
-                height: 1.25rem;
-                margin: 0;
+                height: 1.75rem;
+
+                .item-name {
+                    align-items: center;
+                    display: flex;
+                    flex-basis: 50%;
+                    flex-wrap: nowrap;
+                    justify-content: start;
+                    justify-self: start;
+                    line-height: 1.5;
+                    gap: 0.5em;
+                }
 
                 h3 {
+                    @include layout.p-reset;
                     text-transform: capitalize;
                     font-size: var(--font-size-12);
                     font-weight: 500;
@@ -184,144 +124,209 @@
                     padding: var(--space-4) 0;
                 }
 
-                .item-name {
-                    line-height: 1;
-                    padding-left: var(--space-4);
-
-                    h3 {
-                        @include p-reset;
-                    }
-                }
-
-                .controls {
-                    padding-right: var(--space-4);
-                }
-            }
-
-            .item-name {
-                grid-area: name;
-                cursor: pointer;
-
-                align-items: center;
-                display: flex;
-                flex-basis: 50%;
-                flex-wrap: nowrap;
-                justify-content: start;
-                justify-self: start;
-                line-height: 1.5;
-
-                h3 {
-                    white-space: nowrap;
-                }
-
-                .item-image {
-                    margin: var(--space-2) 0;
-                    margin-left: var(--space-4);
-                }
-
-                h4 {
-                    font-weight: 500;
-                    letter-spacing: -0.075em;
-                    line-height: 1;
-                    margin: 0 0 0 var(--space-8);
-                    padding: 0;
-
-                    &:hover {
-                        color: var(--color-pf-secondary);
-                    }
-                }
-
-                &.aa-level,
-                &.reagent-resource {
-                    justify-content: flex-end;
-                }
-            }
-
-            .price {
-                grid-area: price;
-            }
-
-            .quantity {
-                grid-area: quantity;
-
-                align-items: center;
-                display: flex;
-                gap: var(--space-3);
-                justify-content: center;
-
-                .adjust {
-                    align-items: center;
-                    display: flex;
-                    font-size: var(--font-size-16);
-                    font-family: var(--sans-serif-monospace);
-                    justify-content: center;
-                    width: 1em;
-                }
-
-                input {
-                    width: 1.5rem;
+                .formula-number {
                     text-align: center;
                 }
             }
 
-            button.craft {
-                grid-area: button;
-                font: 500 var(--font-size-10) / 1.8em var(--sans-serif);
-                justify-self: end;
-                min-width: 2.5rem;
-                padding: 0 0.25em;
-                text-transform: uppercase;
-                width: fit-content;
-                &.invisible {
-                    visibility: hidden;
-                }
+            .formula-header.resource {
+                display: flex;
+                justify-content: space-between;
+                padding: 0 var(--space-4);
             }
 
-            .item-controls {
-                grid-area: controls;
-                justify-self: end;
-                font-size: var(--font-size-12);
-                margin-right: var(--space-4);
-            }
+            li.formula-level-header,
+            li.formula-item {
+                display: grid;
+                grid:
+                    "name dc price quantity button controls" 1fr
+                    / 1fr 1.5rem 4.5rem 5.125rem min-content var(--controls-width);
+                align-items: center;
+                justify-items: center;
 
-            .item-summary {
-                grid-column: 1 / 7;
-                padding: var(--space-8);
-                border-bottom: 1px solid var(--sub);
-                border-top: 1px solid color.adjust($sub-color, $lightness: 30%);
-                background-color: rgba($light-background-color, 0.5);
-                width: 100%;
+                @include layout.p-reset;
+                background: none;
+                border: none;
+                border-left: 1px solid var(--sub);
+                border-right: 1px solid var(--sub);
+                cursor: default;
 
-                p {
-                    margin-top: 0;
+                &:nth-child(odd) {
+                    background-color: rgba(colors.$alt-color, 0.1);
                 }
 
-                .item-buttons button {
-                    display: none;
+                &:nth-child(even) .item-summary {
+                    background: none;
+                }
+
+                &:last-child {
+                    border-bottom: 1px solid var(--sub);
+                }
+
+                &.empty {
+                    align-items: center;
+                    display: flex;
+                    min-height: 2em;
+                    opacity: 0.85;
+                    padding-left: 1.25rem;
+                    white-space: nowrap;
+                }
+
+                &.formula-level-header {
+                    background: rgba(colors.$sub-color, 0.25);
+                    border: 1px solid var(--sub);
+                    color: var(--text-dark);
+                    font: 600 var(--font-size-12) var(--sans-serif);
+                    height: 1.25rem;
+                    margin: 0;
+
+                    h3 {
+                        text-transform: capitalize;
+                        font-size: var(--font-size-12);
+                        font-weight: 500;
+                        margin-left: 0;
+                        padding: var(--space-4) 0;
+                    }
+
+                    .item-name {
+                        line-height: 1;
+                        padding-left: var(--space-4);
+
+                        h3 {
+                            @include layout.p-reset;
+                        }
+                    }
+
+                    .controls {
+                        padding-right: var(--space-4);
+                    }
+                }
+
+                .item-name {
+                    grid-area: name;
+                    cursor: pointer;
+
+                    align-items: center;
+                    display: flex;
+                    flex-basis: 50%;
+                    flex-wrap: nowrap;
+                    justify-content: start;
+                    justify-self: start;
+                    line-height: 1.5;
+
+                    h3 {
+                        white-space: nowrap;
+                    }
+
+                    .item-image {
+                        margin: var(--space-2) 0;
+                        margin-left: var(--space-4);
+                    }
+
+                    h4 {
+                        font-weight: 500;
+                        letter-spacing: -0.075em;
+                        line-height: 1;
+                        margin: 0 0 0 var(--space-8);
+                        padding: 0;
+
+                        &:hover {
+                            color: var(--color-pf-secondary);
+                        }
+                    }
+
+                    &.aa-level,
+                    &.reagent-resource {
+                        justify-content: flex-end;
+                    }
+                }
+
+                .price {
+                    grid-area: price;
+                }
+
+                .quantity {
+                    grid-area: quantity;
+
+                    align-items: center;
+                    display: flex;
+                    gap: var(--space-3);
+                    justify-content: center;
+
+                    .adjust {
+                        align-items: center;
+                        display: flex;
+                        font-size: var(--font-size-16);
+                        font-family: var(--sans-serif-monospace);
+                        justify-content: center;
+                        width: 1em;
+                    }
+
+                    input {
+                        width: 1.5rem;
+                        text-align: center;
+                    }
+                }
+
+                button.craft {
+                    grid-area: button;
+                    font: 500 var(--font-size-10) / 1.8em var(--sans-serif);
+                    justify-self: end;
+                    min-width: 2.5rem;
+                    padding: 0 0.25em;
+                    text-transform: uppercase;
+                    width: fit-content;
+                    &.invisible {
+                        visibility: hidden;
+                    }
+                }
+
+                .item-controls {
+                    grid-area: controls;
+                    justify-self: end;
+                    font-size: var(--font-size-12);
+                    margin-right: var(--space-4);
+                }
+
+                .item-summary {
+                    grid-column: 1 / 7;
+                    padding: var(--space-8);
+                    border-bottom: 1px solid var(--sub);
+                    border-top: 1px solid color.adjust(colors.$sub-color, $lightness: 30%);
+                    background-color: rgba(colors.$light-background-color, 0.5);
+                    width: 100%;
+
+                    p {
+                        margin-top: 0;
+                    }
+
+                    .item-buttons button {
+                        display: none;
+                    }
                 }
             }
         }
-    }
 
-    li.crafting-entry button.perform-daily {
-        width: 75%;
-    }
+        li.crafting-entry button.perform-daily {
+            width: 75%;
+        }
 
-    .crafting-entry {
-        --controls-width: 3rem;
-    }
+        .crafting-entry {
+            --controls-width: 3rem;
+        }
 
-    .known-formulas {
-        padding-bottom: 2rem;
-        .empty {
-            display: flex;
-            align-items: center;
-            background: none;
-            border: none;
-            display: flex;
-            min-height: 2em;
-            opacity: 0.85;
-            white-space: nowrap;
+        .known-formulas {
+            padding-bottom: 2rem;
+            .empty {
+                display: flex;
+                align-items: center;
+                background: none;
+                border: none;
+                display: flex;
+                min-height: 2em;
+                opacity: 0.85;
+                white-space: nowrap;
+            }
         }
     }
 }

--- a/src/styles/actor/character/_effects.scss
+++ b/src/styles/actor/character/_effects.scss
@@ -1,27 +1,31 @@
+@use "../../colors";
+
 @use "sass:color";
 @use "../../mixins/effects-list";
 
-&.effects {
-    @include configure($alt-color: $alt-color);
+@mixin tab {
+    &.effects {
+        @include effects-list.configure($alt-color: colors.$alt-color);
 
-    .effects-list {
-        @include effects-list;
-        padding-bottom: 1em;
+        .effects-list {
+            @include effects-list.effects-list;
+            padding-bottom: 1em;
 
-        .item {
-            border-top: 1px solid color.adjust($-alt-color, $lightness: 40%);
-            $border-color: color.adjust($-alt-color, $lightness: 40%);
-            border: solid transparent;
-            border-width: 0 0 1px;
-            border-image: linear-gradient(90deg, #f1edea, $border-color) 1 repeat;
-        }
+            .item {
+                border-top: 1px solid color.adjust(effects-list.$alt-color, $lightness: 40%);
+                $border-color: color.adjust(effects-list.$alt-color, $lightness: 40%);
+                border: solid transparent;
+                border-width: 0 0 1px;
+                border-image: linear-gradient(90deg, #f1edea, $border-color) 1 repeat;
+            }
 
-        .item:last-child {
-            border-bottom: none;
-        }
+            .item:last-child {
+                border-bottom: none;
+            }
 
-        .item-name h4 {
-            font-family: var(--serif);
+            .item-name h4 {
+                font-family: var(--serif);
+            }
         }
     }
 }

--- a/src/styles/actor/character/_effects.scss
+++ b/src/styles/actor/character/_effects.scss
@@ -1,6 +1,5 @@
-@use "../../colors";
-
 @use "sass:color";
+@use "../../colors";
 @use "../../mixins/effects-list";
 
 @mixin tab {

--- a/src/styles/actor/character/_feats.scss
+++ b/src/styles/actor/character/_feats.scss
@@ -1,162 +1,166 @@
-&.feats {
-    .feat-section {
-        padding-bottom: 1em;
-        header .limit {
-            input {
-                background: rgba(0, 0, 0, 0.05);
-                display: inline;
-                color: inherit;
-                font: inherit;
-                height: 1em;
-                width: 2.2ch;
+@use "../../colors";
+
+@mixin tab {
+    &.feats {
+        .feat-section {
+            padding-bottom: 1em;
+            header .limit {
+                input {
+                    background: rgba(0, 0, 0, 0.05);
+                    display: inline;
+                    color: inherit;
+                    font: inherit;
+                    height: 1em;
+                    width: 2.2ch;
+                }
             }
         }
-    }
 
-    ol.feats-list {
-        padding-left: 0;
-    }
-
-    ol.feats-list li.slot {
-        align-items: center;
-        display: grid;
-        grid:
-            "name ctrl" min-content
-            "content content" min-content
-            / 1fr min-content;
-        padding: var(--space-5) 0 var(--space-4);
-        position: relative;
-        row-gap: var(--space-2);
-
-        &:nth-child(odd) {
-            background-color: rgba($alt-color, 0.1);
+        ol.feats-list {
+            padding-left: 0;
         }
 
-        .item-name,
-        .item-controls {
-            margin: 0;
-        }
-
-        .item-name {
+        ol.feats-list li.slot {
             align-items: center;
-            display: flex;
-            flex: 1;
-            gap: var(--space-8);
-            grid-area: name;
-            height: var(--font-size-25);
-            width: 100%;
+            display: grid;
+            grid:
+                "name ctrl" min-content
+                "content content" min-content
+                / 1fr min-content;
+            padding: var(--space-5) 0 var(--space-4);
+            position: relative;
+            row-gap: var(--space-2);
 
-            .feat-slot-title {
-                display: flex;
-                font: 600 var(--font-size-15) var(--serif);
-                color: var(--color-pf-secondary);
-                justify-content: center;
-                width: 1.25rem;
-                margin-left: var(--space-6);
+            &:nth-child(odd) {
+                background-color: rgba(colors.$alt-color, 0.1);
             }
 
-            .item-placeholder {
-                margin-left: 2.5rem;
-                margin-right: var(--space-4);
-            }
-
-            h4 {
-                display: inline-flex;
-                max-width: 20rem;
+            .item-name,
+            .item-controls {
                 margin: 0;
-
-                &:hover {
-                    color: var(--color-pf-primary);
-                    text-shadow: 0 0 3px var(--color-pf-tertiary);
-                }
-
-                a {
-                    font-size: var(--font-size-13);
-                    overflow: hidden;
-                    text-overflow: ellipsis;
-                    white-space: nowrap;
-                }
-            }
-        }
-
-        .item-controls {
-            align-items: center;
-            display: flex;
-            font-size: var(--font-size-12);
-            grid-area: ctrl;
-            height: 100%;
-            white-space: nowrap;
-            width: 100%;
-
-            a {
-                &:last-child {
-                    margin-right: var(--space-6);
-                }
-            }
-        }
-
-        .item-summary {
-            grid-area: content;
-            margin: var(--space-4) 0;
-            padding: 0 var(--space-4);
-
-            .tags {
-                padding: var(--space-2) 0 0;
             }
 
-            .level {
-                font-weight: 600;
-                position: absolute;
-                right: 3rem;
-                top: var(--space-8);
-            }
-        }
-
-        > .item-summary {
-            margin-left: 1.75rem;
-        }
-
-        ol.nested-items {
-            border-left: var(--space-3) dotted var(--color-pf-alternate);
-            display: flex;
-            flex-basis: 100%;
-            flex-direction: column;
-            grid-column: span 2;
-            margin: var(--space-1) 0 0 2.85rem;
-            padding: 0;
-            row-gap: var(--space-4);
-
-            > li {
+            .item-name {
                 align-items: center;
                 display: flex;
-                flex-wrap: wrap;
-                margin: 0;
-                padding-left: 0.875rem;
-                position: relative;
+                flex: 1;
+                gap: var(--space-8);
+                grid-area: name;
+                height: var(--font-size-25);
+                width: 100%;
 
-                .item-name {
+                .feat-slot-title {
+                    display: flex;
+                    font: 600 var(--font-size-15) var(--serif);
+                    color: var(--color-pf-secondary);
+                    justify-content: center;
+                    width: 1.25rem;
+                    margin-left: var(--space-6);
+                }
+
+                .item-placeholder {
+                    margin-left: 2.5rem;
+                    margin-right: var(--space-4);
+                }
+
+                h4 {
+                    display: inline-flex;
+                    max-width: 20rem;
                     margin: 0;
 
-                    .feat-slot-title {
-                        display: none;
+                    &:hover {
+                        color: var(--color-pf-primary);
+                        text-shadow: 0 0 3px var(--color-pf-tertiary);
+                    }
+
+                    a {
+                        font-size: var(--font-size-13);
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                        white-space: nowrap;
                     }
                 }
+            }
 
-                .item-controls {
-                    flex: 0;
-                }
+            .item-controls {
+                align-items: center;
+                display: flex;
+                font-size: var(--font-size-12);
+                grid-area: ctrl;
+                height: 100%;
+                white-space: nowrap;
+                width: 100%;
 
-                .item-summary {
-                    margin-left: 0;
-                    padding-left: 0;
-
-                    .level {
-                        top: var(--space-3);
+                a {
+                    &:last-child {
+                        margin-right: var(--space-6);
                     }
                 }
+            }
 
-                ol.nested-items {
-                    margin: var(--space-3) 0 0 var(--space-11);
+            .item-summary {
+                grid-area: content;
+                margin: var(--space-4) 0;
+                padding: 0 var(--space-4);
+
+                .tags {
+                    padding: var(--space-2) 0 0;
+                }
+
+                .level {
+                    font-weight: 600;
+                    position: absolute;
+                    right: 3rem;
+                    top: var(--space-8);
+                }
+            }
+
+            > .item-summary {
+                margin-left: 1.75rem;
+            }
+
+            ol.nested-items {
+                border-left: var(--space-3) dotted var(--color-pf-alternate);
+                display: flex;
+                flex-basis: 100%;
+                flex-direction: column;
+                grid-column: span 2;
+                margin: var(--space-1) 0 0 2.85rem;
+                padding: 0;
+                row-gap: var(--space-4);
+
+                > li {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: wrap;
+                    margin: 0;
+                    padding-left: 0.875rem;
+                    position: relative;
+
+                    .item-name {
+                        margin: 0;
+
+                        .feat-slot-title {
+                            display: none;
+                        }
+                    }
+
+                    .item-controls {
+                        flex: 0;
+                    }
+
+                    .item-summary {
+                        margin-left: 0;
+                        padding-left: 0;
+
+                        .level {
+                            top: var(--space-3);
+                        }
+                    }
+
+                    ol.nested-items {
+                        margin: var(--space-3) 0 0 var(--space-11);
+                    }
                 }
             }
         }

--- a/src/styles/actor/character/_index.scss
+++ b/src/styles/actor/character/_index.scss
@@ -1,6 +1,18 @@
-@import "proficiency-ranks";
-@import "sidebar";
-@import "header";
+@use "sass:meta";
+@use "actions";
+@use "biography";
+@use "crafting";
+@use "character";
+@use "effects";
+@use "feats";
+@use "inventory";
+@use "pfs";
+@use "proficiencies";
+@use "spellcasting";
+@use "proficiency-ranks";
+@use "sidebar";
+@use "header";
+@use "../../mixins/frames";
 
 nav.sheet-navigation {
     .item {
@@ -38,7 +50,7 @@ nav.sheet-navigation {
         display: flex;
         height: 100%;
 
-        @import "option-toggles";
+        @include meta.load-css("option-toggles");
     }
 
     & > .tab:not(.inventory, .actions),
@@ -64,7 +76,7 @@ nav.sheet-navigation {
 
             &,
             i {
-                @include frame-icon;
+                @include frames.frame-icon;
             }
         }
 
@@ -90,8 +102,16 @@ nav.sheet-navigation {
         display: flex;
         flex-direction: column;
 
-        @import "character", "actions", "effects", "spellcasting", "proficiencies", "feats", "biography", "inventory",
-            "pfs", "crafting";
+        @include actions.tab;
+        @include biography.tab;
+        @include crafting.tab;
+        @include character.tab;
+        @include effects.tab;
+        @include feats.tab;
+        @include inventory.tab;
+        @include pfs.tab;
+        @include proficiencies.tab;
+        @include spellcasting.tab;
     }
 
     .directory-list {

--- a/src/styles/actor/character/_inventory.scss
+++ b/src/styles/actor/character/_inventory.scss
@@ -1,7 +1,9 @@
-&.inventory {
-    padding-bottom: 1.5rem;
+@mixin tab {
+    &.inventory {
+        padding-bottom: 1.5rem;
 
-    .inventory-list {
-        padding-right: 0.1rem;
+        .inventory-list {
+            padding-right: 0.1rem;
+        }
     }
 }

--- a/src/styles/actor/character/_option-toggles.scss
+++ b/src/styles/actor/character/_option-toggles.scss
@@ -1,5 +1,7 @@
+@use "../../mixins/frames";
+
 ul.option-toggles {
-    @include frame-elegant;
+    @include frames.frame-elegant;
     display: flex;
     flex-flow: column wrap;
     font-family: var(--body-serif);

--- a/src/styles/actor/character/_pfs.scss
+++ b/src/styles/actor/character/_pfs.scss
@@ -1,127 +1,132 @@
-&.pfs {
-    @include effects-list;
+@use "../../mixins/effects-list";
+@use "../../mixins/typography";
 
-    > section {
-        display: flex;
-        flex-direction: column;
-        gap: 0.25em;
-        margin: 0.75rem 0;
+@mixin tab {
+    &.pfs {
+        @include effects-list.effects-list;
 
-        &:first-child {
-            margin-top: 0.25rem;
-        }
+        > section {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25em;
+            margin: 0.75rem 0;
 
-        &.organized-play {
-            align-items: center;
-            display: grid;
-            grid-template-columns: 6em 1em 4em;
-
-            > * {
-                width: 100%;
+            &:first-child {
+                margin-top: 0.25rem;
             }
 
-            input {
-                text-align: center;
+            &.organized-play {
+                align-items: center;
+                display: grid;
+                grid-template-columns: 6em 1em 4em;
+
+                > * {
+                    width: 100%;
+                }
+
+                input {
+                    text-align: center;
+                }
+
+                .dash {
+                    font-weight: bold;
+                    text-align: center;
+                }
+
+                label.player-number {
+                    grid-column: span 2;
+                }
             }
 
-            .dash {
-                font-weight: bold;
-                text-align: center;
-            }
+            &.level-bump {
+                align-items: center;
+                flex-direction: row;
 
-            label.player-number {
-                grid-column: span 2;
-            }
-        }
-
-        &.level-bump {
-            align-items: center;
-            flex-direction: row;
-
-            .toggle {
-                width: 42px;
-                height: 1rem;
-                background: rgba(0, 0, 0, 0.5);
-                position: relative;
-                border-radius: 50px;
-                box-shadow:
-                    inset 0px 1px 1px rgba(0, 0, 0, 0.5),
-                    0px 1px 0px rgba(255, 255, 255, 0.2);
-
-                &.enabled {
-                    background: var(--secondary);
-                }
-
-                &::after {
-                    content: "OFF";
-                    color: var(--text-dark);
-                    position: absolute;
-                    right: 5px;
-                    z-index: 0;
-                    text-shadow: 1px 1px 0px rgba(255, 255, 255, 0.15);
-                }
-
-                &::before {
-                    content: "ON";
-                    color: var(--text-light);
-                    position: absolute;
-                    left: 6px;
-                    z-index: 0;
-                }
-
-                &::after,
-                &::before {
-                    @include micro;
-                    top: 4px;
-                }
-
-                label {
-                    display: block;
-                    width: 18px;
-                    height: 14px;
-                    position: absolute;
-                    top: 1px;
-                    right: 20px;
-                    cursor: pointer;
-                    background: #fcfff4;
-                    z-index: 1;
-                    background: linear-gradient(to bottom, #fcfff4 0%, #dfe5d7 40%, #b3bead 100%);
-                    border-radius: 50%;
+                .toggle {
+                    width: 42px;
+                    height: 1rem;
+                    background: rgba(0, 0, 0, 0.5);
+                    position: relative;
+                    border-radius: 50px;
                     box-shadow:
-                        0 0 0 1px rgba(black, 0.2),
-                        0px 2px 5px 0px rgba(0, 0, 0, 0.3);
-                    transition: all 0.4s ease;
-                }
+                        inset 0px 1px 1px rgba(0, 0, 0, 0.5),
+                        0px 1px 0px rgba(255, 255, 255, 0.2);
 
-                input[type="checkbox"] {
-                    visibility: hidden;
+                    &.enabled {
+                        background: var(--secondary);
+                    }
 
-                    &:checked + label {
-                        right: 1px;
+                    &::after {
+                        content: "OFF";
+                        color: var(--text-dark);
+                        position: absolute;
+                        right: 5px;
+                        z-index: 0;
+                        text-shadow: 1px 1px 0px rgba(255, 255, 255, 0.15);
+                    }
+
+                    &::before {
+                        content: "ON";
+                        color: var(--text-light);
+                        position: absolute;
+                        left: 6px;
+                        z-index: 0;
+                    }
+
+                    &::after,
+                    &::before {
+                        @include typography.micro;
+                        top: 4px;
+                    }
+
+                    label {
+                        display: block;
+                        width: 18px;
+                        height: 14px;
+                        position: absolute;
+                        top: 1px;
+                        right: 20px;
+                        cursor: pointer;
+                        background: #fcfff4;
+                        z-index: 1;
+                        background: linear-gradient(to bottom, #fcfff4 0%, #dfe5d7 40%, #b3bead 100%);
+                        border-radius: 50%;
+                        box-shadow:
+                            0 0 0 1px rgba(black, 0.2),
+                            0px 2px 5px 0px rgba(0, 0, 0, 0.3);
+                        transition: all 0.4s ease;
+                    }
+
+                    input[type="checkbox"] {
+                        visibility: hidden;
+
+                        &:checked + label {
+                            right: 1px;
+                        }
                     }
                 }
             }
-        }
 
-        &.faction {
-            max-width: fit-content;
-        }
+            &.faction {
+                max-width: fit-content;
+            }
 
-        &.reputations {
-            font-family: var(--serif);
-            gap: 0.2em;
-
-            .reputation {
-                align-items: center;
-                display: flex;
+            &.reputations {
+                font-family: var(--serif);
                 gap: 0.2em;
-                justify-content: space-between;
-                width: 12em;
 
-                input {
-                    padding: 0 0.3em;
-                    text-align: right;
-                    width: 3em;
+                .reputation {
+                    align-items: center;
+                    display: flex;
+                    gap: 0.2em;
+                    justify-content: space-between;
+                    width: 12em;
+
+                    input {
+                        padding: 0 0.3em;
+                        text-align: right;
+                        width: 3em;
+                    }
                 }
             }
         }

--- a/src/styles/actor/character/_proficiencies.scss
+++ b/src/styles/actor/character/_proficiencies.scss
@@ -1,107 +1,114 @@
-&.proficiencies {
-    h1,
-    h4,
-    h6 {
-        @include p-reset;
-        align-items: center;
-        display: flex;
-        line-height: 1;
-    }
+@use "../../mixins/animations";
+@use "../../mixins/frames";
+@use "../../mixins/layout";
+@use "../../mixins/typography";
 
-    h6 {
-        @include micro;
-        border-radius: 2px;
-        box-shadow: inset 0 0 0 1px rgba(black, 0.5);
-        color: var(--text-light);
-        padding: var(--space-2) var(--space-4);
-    }
-
-    ul.proficiencies-list {
-        @include p-reset;
-        align-items: center;
-        display: grid;
-        gap: var(--space-8);
-        grid-template-columns: repeat(2, 1fr);
-        list-style: none;
-        margin-bottom: var(--space-12);
-
-        li {
-            @include frame-elegant;
+@mixin tab {
+    &.proficiencies {
+        h1,
+        h4,
+        h6 {
+            @include layout.p-reset;
             align-items: center;
             display: flex;
-            font-family: var(--serif);
-            font-size: var(--font-size-16);
-            min-height: 2.25rem;
-            padding: 0 var(--space-8) 0 var(--space-4);
-
-            a.d20 {
-                filter: drop-shadow(0 0 1px var(--color-shadow-dark)) drop-shadow(0 0 3px var(--color-text-dark-4))
-                    drop-shadow(0 0 12px var(--color-text-light-3));
-                padding: var(--space-4);
-
-                &:hover {
-                    @include die-spin;
-                }
-
-                path {
-                    fill: var(--color-text-light-1);
-                }
-            }
-
-            .name,
-            .modifier,
-            .dc {
-                // Compensation for the font's alignment
-                margin-bottom: -0.1em;
-                padding-top: 0.1em;
-            }
-
-            .modifier,
-            .dc {
-                color: var(--color-pf-primary);
-                font-weight: 600;
-                margin-right: var(--space-4);
-                text-align: end;
-                width: 1.75rem;
-            }
-
-            a.hover {
-                text-decoration: underline var(--color-pf-primary-dark);
-                text-underline-offset: 0.125em;
-            }
-
-            .name {
-                flex: 1;
-                line-height: 0.9em;
-                margin-right: var(--space-4);
-            }
-
-            // Proficiencies added by the user
-            &.custom {
-                position: relative;
-
-                a.delete {
-                    font-size: var(--font-size-12);
-                    opacity: 0.65;
-                    position: absolute;
-                    right: -0.5rem;
-                    top: -0.5rem;
-                }
-
-                &:hover a.delete {
-                    opacity: 1;
-                }
-            }
+            line-height: 1;
         }
 
-        &.lores-list > li .item-controls {
-            font-size: var(--font-size-12);
-            margin-left: var(--space-8);
+        h6 {
+            @include typography.micro;
+            border-radius: 2px;
+            box-shadow: inset 0 0 0 1px rgba(black, 0.5);
+            color: var(--text-light);
+            padding: var(--space-2) var(--space-4);
         }
 
-        &.lores-list > li,
-        li.all-by-myself {
-            grid-column: span 2;
+        ul.proficiencies-list {
+            @include layout.p-reset;
+            align-items: center;
+            display: grid;
+            gap: var(--space-8);
+            grid-template-columns: repeat(2, 1fr);
+            list-style: none;
+            margin-bottom: var(--space-12);
+
+            li {
+                @include frames.frame-elegant;
+                align-items: center;
+                display: flex;
+                font-family: var(--serif);
+                font-size: var(--font-size-16);
+                min-height: 2.25rem;
+                padding: 0 var(--space-8) 0 var(--space-4);
+
+                a.d20 {
+                    filter: drop-shadow(0 0 1px var(--color-shadow-dark)) drop-shadow(0 0 3px var(--color-text-dark-4))
+                        drop-shadow(0 0 12px var(--color-text-light-3));
+                    padding: var(--space-4);
+
+                    &:hover {
+                        @include animations.die-spin;
+                    }
+
+                    path {
+                        fill: var(--color-text-light-1);
+                    }
+                }
+
+                .name,
+                .modifier,
+                .dc {
+                    // Compensation for the font's alignment
+                    margin-bottom: -0.1em;
+                    padding-top: 0.1em;
+                }
+
+                .modifier,
+                .dc {
+                    color: var(--color-pf-primary);
+                    font-weight: 600;
+                    margin-right: var(--space-4);
+                    text-align: end;
+                    width: 1.75rem;
+                }
+
+                a.hover {
+                    text-decoration: underline var(--color-pf-primary-dark);
+                    text-underline-offset: 0.125em;
+                }
+
+                .name {
+                    flex: 1;
+                    line-height: 0.9em;
+                    margin-right: var(--space-4);
+                }
+
+                // Proficiencies added by the user
+                &.custom {
+                    position: relative;
+
+                    a.delete {
+                        font-size: var(--font-size-12);
+                        opacity: 0.65;
+                        position: absolute;
+                        right: -0.5rem;
+                        top: -0.5rem;
+                    }
+
+                    &:hover a.delete {
+                        opacity: 1;
+                    }
+                }
+            }
+
+            &.lores-list > li .item-controls {
+                font-size: var(--font-size-12);
+                margin-left: var(--space-8);
+            }
+
+            &.lores-list > li,
+            li.all-by-myself {
+                grid-column: span 2;
+            }
         }
     }
 }

--- a/src/styles/actor/character/_proficiency-ranks.scss
+++ b/src/styles/actor/character/_proficiency-ranks.scss
@@ -1,5 +1,7 @@
+@use "../../mixins/typography";
+
 .pf-rank {
-    @include micro;
+    @include typography.micro;
     background: var(--color-proficiency-untrained);
     border: 1px solid rgba(black, 0.5);
     border-radius: 2px;

--- a/src/styles/actor/character/_sidebar.scss
+++ b/src/styles/actor/character/_sidebar.scss
@@ -1,9 +1,8 @@
+@use "sass:color";
 @use "../../colors";
 @use "../../mixins/animations";
 @use "../../mixins/forms";
 @use "../../mixins/typography";
-
-@use "sass:color";
 
 aside {
     background-image: url("/assets/sheet/red_sidebar_top.webp"), url("/assets/sheet/red_sidebar_bottom.webp");

--- a/src/styles/actor/character/_sidebar.scss
+++ b/src/styles/actor/character/_sidebar.scss
@@ -1,3 +1,8 @@
+@use "../../colors";
+@use "../../mixins/animations";
+@use "../../mixins/forms";
+@use "../../mixins/typography";
+
 @use "sass:color";
 
 aside {
@@ -36,12 +41,12 @@ aside {
         }
 
         &:hover {
-            @include input-glow;
+            @include forms.input-glow;
         }
     }
 
     select {
-        @include input-border;
+        @include forms.input-border;
         background-color: var(--color-pf-primary);
         font-size: var(--font-size-15);
         max-width: 100%;
@@ -124,7 +129,7 @@ aside {
         }
 
         .sidebar_label {
-            @include micro;
+            @include typography.micro;
             color: var(--sidebar-label);
             white-space: nowrap;
         }
@@ -179,7 +184,7 @@ aside {
                     transform: scale(1.25);
                 }
                 svg {
-                    @include die-spin;
+                    @include animations.die-spin;
                 }
             }
 
@@ -248,9 +253,9 @@ aside {
                         background-color: var(--color-pf-primary);
                         background-image: linear-gradient(
                             90deg,
-                            color.adjust($primary-color, $lightness: -5%) 0%,
-                            color.adjust($primary-color, $lightness: 8%) 50%,
-                            color.adjust($primary-color, $lightness: -5%) 100%
+                            color.adjust(colors.$primary-color, $lightness: -5%) 0%,
+                            color.adjust(colors.$primary-color, $lightness: 8%) 50%,
+                            color.adjust(colors.$primary-color, $lightness: -5%) 100%
                         );
                         border: 1px solid var(--sidebar-title);
                         border-radius: 0 0 4px 4px;
@@ -304,7 +309,7 @@ aside {
 
                 h4,
                 label {
-                    @include micro;
+                    @include typography.micro;
                 }
 
                 i.fa-regular,
@@ -439,7 +444,7 @@ aside {
                         }
 
                         .data-value {
-                            @include input-border;
+                            @include forms.input-border;
                             color: var(--color-pf-tertiary);
                             flex-basis: 3.125rem;
                             font-size: var(--font-size-14);

--- a/src/styles/actor/character/_spellcasting.scss
+++ b/src/styles/actor/character/_spellcasting.scss
@@ -1,159 +1,163 @@
-&.spellcasting {
-    padding: 0;
-    overflow-y: hidden;
-    scrollbar-gutter: initial;
+@use "../../mixins/animations";
 
-    nav.spell-collections a.rituals {
-        flex-basis: 20%;
-    }
+@mixin tab {
+    &.spellcasting {
+        padding: 0;
+        overflow-y: hidden;
+        scrollbar-gutter: initial;
 
-    .spell-collections {
-        overflow-y: auto;
-        scrollbar-gutter: stable;
-        padding: var(--space-8) var(--space-4) 0;
-
-        ul.option-toggles {
-            margin: var(--space-4) var(--space-4) 0;
+        nav.spell-collections a.rituals {
+            flex-basis: 20%;
         }
 
-        > .tab {
-            padding: var(--space-10) 0 0;
+        .spell-collections {
+            overflow-y: auto;
+            scrollbar-gutter: stable;
+            padding: var(--space-8) var(--space-4) 0;
 
-            &:first-child {
-                padding-top: 0;
+            ul.option-toggles {
+                margin: var(--space-4) var(--space-4) 0;
             }
 
-            > ol {
-                gap: var(--space-12);
-            }
-        }
-    }
+            > .tab {
+                padding: var(--space-10) 0 0;
 
-    .spellcasting-entry {
-        align-items: center;
-        display: flex;
-        flex-wrap: wrap;
-        margin-bottom: 0.25em;
-
-        &:first-child {
-            .action-header {
-                justify-content: start;
-            }
-        }
-
-        .rollable {
-            .d20-svg {
-                width: var(--font-size-14);
-                height: var(--font-size-14);
-                path {
-                    fill: var(--color-text-dark-1);
+                &:first-child {
+                    padding-top: 0;
                 }
-            }
 
-            &:hover {
-                text-shadow: none;
-                svg {
-                    @include die-spin;
+                > ol {
+                    gap: var(--space-12);
                 }
             }
         }
 
-        .spell-ability-data {
+        .spellcasting-entry {
             align-items: center;
             display: flex;
-            flex: 1;
-            gap: 1rem;
-            margin: 0.5em var(--space-4);
+            flex-wrap: wrap;
+            margin-bottom: 0.25em;
 
-            section {
-                display: flex;
-                align-items: center;
-            }
-
-            .skill-score {
-                font: 700 var(--font-size-16) / 1 var(--serif);
-                letter-spacing: -1px;
-                color: var(--secondary);
-            }
-
-            h4 {
-                margin: 0;
-            }
-
-            button.prepare-spells {
-                font-family: var(--serif);
-                font-size: var(--font-size-14);
-                white-space: nowrap;
-            }
-
-            .statistic-values {
-                display: flex;
-                gap: var(--space-8);
-
-                .skill-data {
-                    display: flex;
-                    gap: var(--space-4);
-                    white-space: nowrap;
-                }
-
-                h4 {
-                    white-space: nowrap;
-                }
-
-                .rollable {
-                    gap: 0.1rem;
+            &:first-child {
+                .action-header {
+                    justify-content: start;
                 }
             }
 
-            .focus-pool {
-                cursor: pointer;
-                gap: 0.25em;
-                position: relative;
-
-                img.pool-size {
-                    border: none;
-                    height: 2rem;
-                    width: 2.125rem;
-                }
-
-                .pips {
-                    display: flex;
-                    font-size: var(--font-size-10);
-                    gap: var(--space-1);
-
-                    i {
-                        padding-bottom: 0.08rem;
+            .rollable {
+                .d20-svg {
+                    width: var(--font-size-14);
+                    height: var(--font-size-14);
+                    path {
+                        fill: var(--color-text-dark-1);
                     }
                 }
 
+                &:hover {
+                    text-shadow: none;
+                    svg {
+                        @include animations.die-spin;
+                    }
+                }
+            }
+
+            .spell-ability-data {
+                align-items: center;
+                display: flex;
+                flex: 1;
+                gap: 1rem;
+                margin: 0.5em var(--space-4);
+
+                section {
+                    display: flex;
+                    align-items: center;
+                }
+
+                .skill-score {
+                    font: 700 var(--font-size-16) / 1 var(--serif);
+                    letter-spacing: -1px;
+                    color: var(--secondary);
+                }
+
                 h4 {
+                    margin: 0;
+                }
+
+                button.prepare-spells {
+                    font-family: var(--serif);
+                    font-size: var(--font-size-14);
                     white-space: nowrap;
                 }
-            }
 
-            .spell-ability {
-                gap: 0.5em;
-                margin-left: auto;
+                .statistic-values {
+                    display: flex;
+                    gap: var(--space-8);
 
-                .spell-tradition {
-                    font-family: var(--body-serif);
-                    font-weight: 600;
+                    .skill-data {
+                        display: flex;
+                        gap: var(--space-4);
+                        white-space: nowrap;
+                    }
+
+                    h4 {
+                        white-space: nowrap;
+                    }
+
+                    .rollable {
+                        gap: 0.1rem;
+                    }
+                }
+
+                .focus-pool {
+                    cursor: pointer;
+                    gap: 0.25em;
+                    position: relative;
+
+                    img.pool-size {
+                        border: none;
+                        height: 2rem;
+                        width: 2.125rem;
+                    }
+
+                    .pips {
+                        display: flex;
+                        font-size: var(--font-size-10);
+                        gap: var(--space-1);
+
+                        i {
+                            padding-bottom: 0.08rem;
+                        }
+                    }
+
+                    h4 {
+                        white-space: nowrap;
+                    }
+                }
+
+                .spell-ability {
+                    gap: 0.5em;
+                    margin-left: auto;
+
+                    .spell-tradition {
+                        font-family: var(--body-serif);
+                        font-weight: 600;
+                    }
+                }
+
+                .pf-rank {
+                    margin-bottom: var(--space-2);
                 }
             }
-
-            .pf-rank {
-                margin-bottom: var(--space-2);
-            }
         }
-    }
 
-    .spellbook-empty {
-        margin: var(--space-8) 0;
-    }
+        .spellbook-empty {
+            margin: var(--space-8) 0;
+        }
 
-    button.create-entry {
-        font: 500 var(--font-size-14) var(--serif);
-        margin: 1rem 0 1.25rem;
-        width: 100%;
+        button.create-entry {
+            font: 500 var(--font-size-14) var(--serif);
+            margin: 1rem 0 1.25rem;
+            width: 100%;
+        }
     }
 }

--- a/src/styles/actor/familiar/_index.scss
+++ b/src/styles/actor/familiar/_index.scss
@@ -1,5 +1,9 @@
+@use "sass:meta";
+@use "../../mixins/effects-list";
+@use "../../mixins/layout";
+
 .sheet.familiar {
-    @import "../red-action-boxes";
+    @include meta.load-css("../red-action-boxes");
 
     form {
         background: url("/assets/sheet/background.webp") repeat-x local top/cover;
@@ -475,11 +479,11 @@
     }
 
     .effects-list {
-        @include p-reset;
-        @include effects-list;
+        @include layout.p-reset;
+        @include effects-list.effects-list;
 
         .item {
-            @include p-reset;
+            @include layout.p-reset;
             margin: 0.25em 0;
         }
     }

--- a/src/styles/actor/hazard/_header.scss
+++ b/src/styles/actor/hazard/_header.scss
@@ -1,3 +1,5 @@
+@use "../../mixins/frames";
+
 form > header {
     align-items: center;
     background: url("/assets/sheet/header-bw.webp"), url("/assets/sheet/background.webp");
@@ -28,7 +30,7 @@ form > header {
         }
 
         .actor-image {
-            @include brown-border;
+            @include frames.brown-border;
             border-radius: 0;
             border: none;
             max-height: 11.125rem;
@@ -38,7 +40,7 @@ form > header {
         }
 
         .edit-mode-button {
-            @include brown-border;
+            @include frames.brown-border;
             align-items: center;
             background-color: var(--color-text-light-0);
             border-radius: 10px;

--- a/src/styles/actor/hazard/_index.scss
+++ b/src/styles/actor/hazard/_index.scss
@@ -1,9 +1,13 @@
+@use "sass:meta";
+@use "../../mixins/forms";
+@use "../../mixins/layout";
+
 .sheet.hazard section.window-content {
-    @import "../red-action-boxes";
+    @include meta.load-css("../red-action-boxes");
 
     ul,
     ol {
-        @include p-reset;
+        @include layout.p-reset;
         list-style-type: none;
     }
 
@@ -11,12 +15,12 @@
     h2,
     h3,
     h4 {
-        @include p-reset;
+        @include layout.p-reset;
         border-bottom: none;
     }
 
     form {
-        @include p-reset;
+        @include layout.p-reset;
         display: flex;
         flex-direction: column;
         height: 100%;
@@ -36,16 +40,16 @@
     }
 
     .window-content {
-        @include p-reset;
+        @include layout.p-reset;
     }
 
     .window-content {
-        @include p-reset;
+        @include layout.p-reset;
     }
 
     input[type="text"],
     input[type="number"] {
-        @include p-reset;
+        @include layout.p-reset;
         background: none;
         border: 1px solid transparent;
 
@@ -69,7 +73,8 @@
         padding: 0 var(--space-5) 1.25rem;
     }
 
-    @import "header", "sidebar";
+    @include meta.load-css("header");
+    @include meta.load-css("sidebar");
 
     .toggles {
         .section-body {
@@ -172,7 +177,7 @@
             }
 
             .section-body {
-                @include publication-data;
+                @include forms.publication-data;
                 border-top: none;
                 padding: var(--space-4) var(--space-8);
 

--- a/src/styles/actor/hazard/_sidebar.scss
+++ b/src/styles/actor/hazard/_sidebar.scss
@@ -1,3 +1,5 @@
+@use "../../mixins/animations";
+
 .sidebar {
     border-right: 1px solid #888;
     box-shadow: 0 0 8px rgba(0, 0, 0, 0.2);
@@ -116,7 +118,7 @@
             text-shadow: none;
 
             i {
-                @include die-spin;
+                @include animations.die-spin;
             }
         }
     }

--- a/src/styles/actor/loot/_index.scss
+++ b/src/styles/actor/loot/_index.scss
@@ -1,3 +1,5 @@
+@use "../../mixins/buttons";
+
 .sheet.actor.loot form {
     display: flex;
     flex-direction: row;
@@ -45,7 +47,7 @@
                     background-color: var(--tertiary);
 
                     &:not(:hover) {
-                        @include button;
+                        @include buttons.button;
                     }
                 }
             }
@@ -220,7 +222,7 @@
     flex: unset;
 
     .confirm-button {
-        @include button;
+        @include buttons.button;
         width: calc(100% - 6px);
         height: 2.5em;
         margin-top: 1em;

--- a/src/styles/actor/npc/_effects.scss
+++ b/src/styles/actor/npc/_effects.scss
@@ -1,5 +1,4 @@
 @use "../../colors";
-
 @use "../../mixins/effects-list";
 
 @include effects-list.configure($alt-color: colors.$alt-color);

--- a/src/styles/actor/npc/_effects.scss
+++ b/src/styles/actor/npc/_effects.scss
@@ -1,11 +1,13 @@
+@use "../../colors";
+
 @use "../../mixins/effects-list";
 
-@include configure($alt-color: $alt-color);
+@include effects-list.configure($alt-color: colors.$alt-color);
 
 .effects {
     .section-body {
         .effects-list {
-            @include effects-list;
+            @include effects-list.effects-list;
             padding-left: 0px;
             padding-right: 5px;
         }

--- a/src/styles/actor/npc/_index.scss
+++ b/src/styles/actor/npc/_index.scss
@@ -1,7 +1,6 @@
 @use "sass:meta";
 @use "recall-knowledge";
 @use "skills-editor";
-@use "../../colors";
 @use "../../mixins/animations";
 @use "../../mixins/forms";
 
@@ -119,11 +118,11 @@
         text-align: right;
 
         &.adjusted-higher {
-            color: colors.$adjusted-higher;
+            color: var(--color-adjusted-higher);
         }
 
         &.adjusted-lower {
-            color: colors.$adjusted-lower;
+            color: var(--color-adjusted-lower);
         }
     }
 

--- a/src/styles/actor/npc/_index.scss
+++ b/src/styles/actor/npc/_index.scss
@@ -1,4 +1,9 @@
-@import "recall-knowledge", "skills-editor";
+@use "sass:meta";
+@use "recall-knowledge";
+@use "skills-editor";
+@use "../../colors";
+@use "../../mixins/animations";
+@use "../../mixins/forms";
 
 .actor.npc.sheet form {
     --faded-border-color: #7a7971;
@@ -6,7 +11,7 @@
     flex-direction: row;
     align-items: flex-start;
 
-    @import "../spell-collection";
+    @include meta.load-css("../spell-collection");
 
     > .npc-body > header {
         display: flex;
@@ -72,12 +77,12 @@
             text-shadow: none;
 
             .d20-svg {
-                @include die-spin;
+                @include animations.die-spin;
             }
         }
     }
 
-    @import "sidebar";
+    @include meta.load-css("sidebar");
 
     .sheet-body {
         flex: auto;
@@ -101,10 +106,10 @@
             }
         }
 
-        @import "inventory";
-        @import "spells";
-        @import "effects";
-        @import "../red-action-boxes";
+        @include meta.load-css("inventory");
+        @include meta.load-css("spells");
+        @include meta.load-css("effects");
+        @include meta.load-css("../red-action-boxes");
     }
 
     input.adjustable:not(:focus),
@@ -114,11 +119,11 @@
         text-align: right;
 
         &.adjusted-higher {
-            color: $adjusted-higher;
+            color: colors.$adjusted-higher;
         }
 
         &.adjusted-lower {
-            color: $adjusted-lower;
+            color: colors.$adjusted-lower;
         }
     }
 
@@ -415,7 +420,7 @@
                 margin-top: auto;
 
                 .notes-text {
-                    @include publication-data;
+                    @include forms.publication-data;
 
                     input[type="text"] {
                         background: rgba(black, 0.05);
@@ -452,4 +457,4 @@
     }
 }
 
-@import "simple";
+@include meta.load-css("simple");

--- a/src/styles/actor/party/_exploration.scss
+++ b/src/styles/actor/party/_exploration.scss
@@ -1,3 +1,5 @@
+@use "../../mixins/frames";
+
 .exploration-members {
     .actor-link {
         display: flex;
@@ -54,7 +56,7 @@
     gap: 0.5rem;
 
     .member-activity {
-        @include frame-elegant;
+        @include frames.frame-elegant;
         display: flex;
         align-items: center;
 

--- a/src/styles/actor/party/_index.scss
+++ b/src/styles/actor/party/_index.scss
@@ -1,3 +1,8 @@
+@use "sass:meta";
+@use "../../mixins/effects-list";
+@use "../../mixins/frames";
+@use "../../mixins/layout";
+
 .sheet.party {
     --color-border: rgba(0, 0, 0, 0.28);
 
@@ -51,7 +56,7 @@
                 border-radius: 0;
                 width: 100%;
                 cursor: pointer;
-                @include brown-border;
+                @include frames.brown-border;
             }
         }
 
@@ -110,7 +115,7 @@
         }
     }
 
-    @import "../nav";
+    @include meta.load-css("../nav");
 
     .actor-link {
         cursor: pointer;
@@ -140,8 +145,8 @@
     }
 
     .item-list.directory-list {
-        @include effects-list;
-        @include p-reset;
+        @include effects-list.effects-list;
+        @include layout.p-reset;
         display: flex;
         flex-direction: column;
         width: 100%;
@@ -202,7 +207,7 @@
         width: 13.5rem;
 
         .box-list {
-            @include p-reset;
+            @include layout.p-reset;
             display: flex;
             color: var(--alt-dark);
             flex-direction: column;
@@ -306,15 +311,15 @@
     }
 
     [data-tab="inventory"] {
-        @import "inventory";
+        @include meta.load-css("inventory");
     }
 
     [data-tab="overview"] {
-        @import "overview";
+        @include meta.load-css("overview");
     }
 
     [data-tab="exploration"] {
-        @import "exploration";
+        @include meta.load-css("exploration");
     }
 
     [data-tab="orphaned"] {
@@ -324,4 +329,4 @@
     }
 }
 
-@import "kingdom";
+@include meta.load-css("kingdom");

--- a/src/styles/actor/party/_overview.scss
+++ b/src/styles/actor/party/_overview.scss
@@ -1,10 +1,12 @@
+@use "../../mixins/frames";
+
 .content {
     padding-top: 0.5rem;
     padding-bottom: 0.25rem;
 }
 
 .summary {
-    @include frame-elegant;
+    @include frames.frame-elegant;
     display: flex;
     flex-direction: column;
     padding: 0.375rem 0.5rem;

--- a/src/styles/actor/party/kingdom/_activities.scss
+++ b/src/styles/actor/party/kingdom/_activities.scss
@@ -1,10 +1,3 @@
-& {
-    display: flex;
-    flex-direction: row;
-    padding: 0 1rem;
-    height: 100%;
-}
-
 .skills,
 .actions {
     display: flex;

--- a/src/styles/actor/party/kingdom/_builder.scss
+++ b/src/styles/actor/party/kingdom/_builder.scss
@@ -1,3 +1,5 @@
+@use "../../../mixins/animations";
+
 .sheet.kingdom-builder {
     .window-content {
         padding: 0;
@@ -294,7 +296,7 @@
                 text-align: center;
 
                 &.extra {
-                    @include requires-user-attention;
+                    @include animations.requires-user-attention;
                 }
             }
 

--- a/src/styles/actor/party/kingdom/_features.scss
+++ b/src/styles/actor/party/kingdom/_features.scss
@@ -1,3 +1,5 @@
+@use "../../../colors";
+
 .content {
     padding: 0.5rem 0.75rem 1rem 0.75rem;
     font-family: var(--body-serif);
@@ -23,7 +25,7 @@ ol.feats-list li.slot {
     row-gap: var(--space-2);
 
     &:nth-child(odd) {
-        background-color: rgba($alt-color, 0.1);
+        background-color: rgba(colors.$alt-color, 0.1);
     }
 
     .item-name,

--- a/src/styles/actor/party/kingdom/_index.scss
+++ b/src/styles/actor/party/kingdom/_index.scss
@@ -1,3 +1,8 @@
+@use "sass:meta";
+@use "../../../colors";
+@use "../../../mixins/frames";
+@use "../../../mixins/typography";
+
 @use "../../../mixins/effects-list";
 
 .sheet.kingdom {
@@ -55,7 +60,7 @@
                 width: 3.25rem;
                 height: 3.25rem;
                 cursor: pointer;
-                @include brown-border;
+                @include frames.brown-border;
             }
         }
 
@@ -170,7 +175,7 @@
                 padding-top: 2px;
                 label {
                     color: var(--sidebar-label);
-                    @include micro;
+                    @include typography.micro;
                     line-height: 1.5;
                 }
                 input {
@@ -239,7 +244,7 @@
         }
     }
 
-    @import "../../nav";
+    @include meta.load-css("../../nav");
 
     .container {
         height: 100%;
@@ -247,11 +252,11 @@
     }
 
     input.adjusted-higher {
-        color: $adjusted-higher;
+        color: colors.$adjusted-higher;
     }
 
     input.adjusted-lower {
-        color: $adjusted-lower;
+        color: colors.$adjusted-lower;
     }
 
     .content {
@@ -310,7 +315,7 @@
     }
 
     .effects .directory-list {
-        @include effects-list;
+        @include effects-list.effects-list;
         display: flex;
         flex-direction: column;
         width: 100%;
@@ -359,7 +364,7 @@
     button.small-button,
     select.proficiency,
     span.proficiency {
-        @include micro;
+        @include typography.micro;
         align-items: center;
         background: var(--color-proficiency-untrained);
         border: 1px solid rgba(black, 0.5);
@@ -413,26 +418,34 @@
 
     .tab.active {
         &[data-tab="main"] {
-            @import "main";
+            overflow: hidden scroll;
+            flex-direction: column;
+            @include meta.load-css("main");
         }
 
         &[data-tab="activities"] {
-            @import "activities";
+            display: flex;
+            flex-direction: row;
+            padding: 0 1rem;
+            height: 100%;
+            @include meta.load-css("activities");
         }
 
         &[data-tab="world"] {
-            @import "world";
+            @include meta.load-css("world");
         }
 
         &[data-tab="features"] {
-            @import "features";
+            @include meta.load-css("features");
         }
 
         &[data-tab="ongoing"] {
-            @import "ongoing";
+            padding: 0.75rem;
+            gap: 1rem;
+            @include meta.load-css("ongoing");
         }
     }
 }
 
-@import "builder";
-@import "chat";
+@include meta.load-css("builder");
+@include meta.load-css("chat");

--- a/src/styles/actor/party/kingdom/_index.scss
+++ b/src/styles/actor/party/kingdom/_index.scss
@@ -1,5 +1,4 @@
 @use "sass:meta";
-@use "../../../colors";
 @use "../../../mixins/frames";
 @use "../../../mixins/typography";
 
@@ -252,11 +251,11 @@
     }
 
     input.adjusted-higher {
-        color: colors.$adjusted-higher;
+        color: var(--color-adjusted-higher);
     }
 
     input.adjusted-lower {
-        color: colors.$adjusted-lower;
+        color: var(--color-adjusted-lower);
     }
 
     .content {

--- a/src/styles/actor/party/kingdom/_main.scss
+++ b/src/styles/actor/party/kingdom/_main.scss
@@ -1,7 +1,4 @@
-& {
-    overflow: hidden scroll;
-    flex-direction: column;
-}
+@use "../../../mixins/frames";
 
 input[type="text"],
 input[type="number"] {
@@ -34,7 +31,7 @@ input[type="number"] {
         }
 
         .image {
-            @include frame-icon;
+            @include frames.frame-icon;
             grid-area: img;
             width: 2.75rem;
             height: 2.75rem;

--- a/src/styles/actor/party/kingdom/_ongoing.scss
+++ b/src/styles/actor/party/kingdom/_ongoing.scss
@@ -1,7 +1,5 @@
-& {
-    padding: 0.75rem;
-    gap: 1rem;
-}
+@use "../../../mixins/effects-list";
+@use "../../../mixins/typography";
 
 .events {
     flex: 1;
@@ -49,7 +47,7 @@
         }
 
         .editor-content {
-            @include journal-styling;
+            @include typography.journal-styling;
         }
     }
 }
@@ -60,7 +58,7 @@ section.effects {
         margin-top: 0;
     }
     .effects-list {
-        @include effects-list;
+        @include effects-list.effects-list;
         .item {
             padding-left: 0;
         }

--- a/src/styles/actor/party/kingdom/_world.scss
+++ b/src/styles/actor/party/kingdom/_world.scss
@@ -1,3 +1,5 @@
+@use "../../../mixins/typography";
+
 input[type="text"],
 input[type="number"] {
     border: none;
@@ -176,7 +178,7 @@ input[type="number"] {
     .editor {
         min-height: 2rem;
         .editor-content {
-            @include journal-styling;
+            @include typography.journal-styling;
             padding: 0 var(--space-4);
         }
 

--- a/src/styles/actor/tabs/_actions.scss
+++ b/src/styles/actor/tabs/_actions.scss
@@ -1,8 +1,7 @@
+@use "sass:color";
 @use "../../colors";
 @use "../../mixins/frames";
 @use "../../mixins/layout";
-
-@use "sass:color";
 
 .actions-container {
     padding: var(--space-8) var(--space-4) 2rem;

--- a/src/styles/actor/tabs/_actions.scss
+++ b/src/styles/actor/tabs/_actions.scss
@@ -1,3 +1,7 @@
+@use "../../colors";
+@use "../../mixins/frames";
+@use "../../mixins/layout";
+
 @use "sass:color";
 
 .actions-container {
@@ -36,7 +40,7 @@ ol.actions-list {
 
         &.action,
         &.strike {
-            $border-color: color.adjust($alt-color, $lightness: 40%);
+            $border-color: color.adjust(colors.$alt-color, $lightness: 40%);
             border: solid transparent;
             border-image: linear-gradient(90deg, #f1edea, $border-color) 1 repeat;
             border-width: 0 0 var(--space-1);
@@ -48,7 +52,7 @@ ol.actions-list {
             }
 
             .item-image {
-                @include flex-center;
+                @include layout.flex-center;
                 background-repeat: no-repeat;
                 background-size: contain;
                 cursor: pointer;
@@ -93,7 +97,7 @@ ol.actions-list {
             }
 
             .item-summary {
-                @include frame-elegant;
+                @include frames.frame-elegant;
                 padding: 0.5rem 1rem 1rem;
                 margin: var(--space-8) 0;
 

--- a/src/styles/actor/vehicle/_effects.scss
+++ b/src/styles/actor/vehicle/_effects.scss
@@ -1,16 +1,17 @@
 @use "sass:color";
-@import "../../mixins/effects-list";
+@use "../../mixins/effects-list";
+@use "../../colors";
 
-&.effects {
-    @include configure($alt-color: $alt-color);
+.effects {
+    @include effects-list.configure($alt-color: colors.$alt-color);
 
     .effects-list {
-        @include effects-list;
+        @include effects-list.effects-list;
         padding-bottom: 1em;
 
         .item {
-            border-top: 1px solid color.adjust($-alt-color, $lightness: 40%);
-            $border-color: color.adjust($-alt-color, $lightness: 40%);
+            border-top: 1px solid color.adjust(effects-list.$alt-color, $lightness: 40%);
+            $border-color: color.adjust(effects-list.$alt-color, $lightness: 40%);
             border: solid transparent;
             border-width: 0 0 1px;
             border-image: linear-gradient(90deg, #f1edea, $border-color) 1 repeat;

--- a/src/styles/actor/vehicle/_index.scss
+++ b/src/styles/actor/vehicle/_index.scss
@@ -1,8 +1,13 @@
+@use "sass:meta";
+@use "../../colors";
+@use "../../mixins/forms";
+@use "../../mixins/layout";
+
 .sheet-navigation {
     min-width: 375px;
 }
 
-@import "sidebar";
+@include meta.load-css("sidebar");
 
 header.char-header {
     .tags select {
@@ -119,17 +124,17 @@ header.char-header {
     }
 
     &.effects {
-        @import "effects";
+        @include meta.load-css("effects");
 
         ol.directory-list {
-            @include p-reset;
+            @include layout.p-reset;
             display: flex;
             flex-direction: column;
             list-style: none;
             width: 100%;
 
             h4 {
-                @include p-reset;
+                @include layout.p-reset;
             }
 
             .item {
@@ -164,7 +169,7 @@ header.char-header {
             margin-top: auto;
 
             > .content {
-                @include publication-data;
+                @include forms.publication-data;
             }
         }
     }
@@ -173,11 +178,11 @@ header.char-header {
 input.adjustable:not(:focus),
 span.adjustable {
     &.adjusted-higher {
-        color: $adjusted-higher;
+        color: colors.$adjusted-higher;
     }
 
     &.adjusted-lower {
-        color: $adjusted-lower;
+        color: colors.$adjusted-lower;
     }
 }
 

--- a/src/styles/actor/vehicle/_sidebar.scss
+++ b/src/styles/actor/vehicle/_sidebar.scss
@@ -1,3 +1,8 @@
+@use "../../colors";
+@use "../../mixins/forms";
+@use "../../mixins/layout";
+@use "../../mixins/typography";
+
 @use "sass:color";
 
 aside {
@@ -39,7 +44,7 @@ aside {
             color: var(--tertiary-light);
         }
         &:hover {
-            @include input-glow;
+            @include forms.input-glow;
         }
     }
 
@@ -112,7 +117,7 @@ aside {
 
     .sidebar_label {
         color: var(--sidebar-label);
-        @include micro;
+        @include typography.micro;
         white-space: nowrap;
     }
 
@@ -154,7 +159,7 @@ aside {
                     background-image: linear-gradient(
                         90deg,
                         var(--color-pf-primary-dark) 0%,
-                        color.adjust($primary-color, $lightness: 8%) 50%,
+                        color.adjust(colors.$primary-color, $lightness: 8%) 50%,
                         var(--color-pf-primary-dark) 100%
                     );
                     background-color: var(--primary);
@@ -210,7 +215,7 @@ aside {
 
             h4,
             label {
-                @include micro;
+                @include typography.micro;
             }
 
             i.fa-regular,
@@ -266,7 +271,7 @@ aside {
     }
 
     ul.sidebar-saves {
-        @include p-reset;
+        @include layout.p-reset;
         display: flex;
 
         .roll-data {
@@ -290,7 +295,7 @@ aside {
             }
 
             .save-roll {
-                @include flex-center;
+                @include layout.flex-center;
                 margin: 4px 0;
 
                 h3 {

--- a/src/styles/gm/_index.scss
+++ b/src/styles/gm/_index.scss
@@ -1,2 +1,2 @@
-@import "check-prompt";
-@import "travel-speed";
+@use "check-prompt";
+@use "travel-speed";

--- a/src/styles/item/_ability-sheet.scss
+++ b/src/styles/item/_ability-sheet.scss
@@ -1,1 +1,1 @@
-@import "self-applied-effect";
+@use "self-applied-effect";

--- a/src/styles/item/_feat-sheet.scss
+++ b/src/styles/item/_feat-sheet.scss
@@ -1,4 +1,4 @@
-@import "self-applied-effect";
+@use "self-applied-effect";
 
 .sidebar {
     .prerequisites {

--- a/src/styles/item/_header.scss
+++ b/src/styles/item/_header.scss
@@ -1,66 +1,68 @@
-> header {
-    img {
-        border: none;
-        object-fit: contain;
-    }
-
-    .details {
-        align-items: baseline;
-        column-gap: 0.33rem;
-        display: flex;
-        flex-wrap: wrap;
-
-        input,
-        .level {
-            font: 700 var(--font-size-36) var(--serif-condensed);
+@mixin header {
+    > header {
+        img {
+            border: none;
+            object-fit: contain;
         }
 
+        .details {
+            align-items: baseline;
+            column-gap: 0.33rem;
+            display: flex;
+            flex-wrap: wrap;
+
+            input,
+            .level {
+                font: 700 var(--font-size-36) var(--serif-condensed);
+            }
+
+            tagify-tags {
+                height: auto;
+            }
+        }
+
+        input[type="text"],
+        input[type="number"],
         tagify-tags {
-            height: auto;
-        }
-    }
+            color: var(--color-text-dark-input);
+            border: none;
+            height: var(--font-size-34);
 
-    input[type="text"],
-    input[type="number"],
-    tagify-tags {
-        color: var(--color-text-dark-input);
-        border: none;
-        height: var(--font-size-34);
-
-        &:hover,
-        &:focus {
-            box-shadow: none;
-        }
-    }
-
-    input[name="name"] {
-        flex: 1;
-    }
-
-    .level {
-        flex: 0;
-        white-space: nowrap;
-        margin-left: auto;
-
-        i {
-            font-size: 0.6em;
-            vertical-align: middle;
+            &:hover,
+            &:focus {
+                box-shadow: none;
+            }
         }
 
-        input {
-            width: 40px;
-            text-align: center;
+        input[name="name"] {
+            flex: 1;
         }
-    }
 
-    .action-glyph {
-        font-size: 2.125rem;
-    }
+        .level {
+            flex: 0;
+            white-space: nowrap;
+            margin-left: auto;
 
-    .paizo-style {
-        border: none;
-        flex-basis: 100%;
-        margin-top: 0.125rem;
-        padding: 0;
+            i {
+                font-size: 0.6em;
+                vertical-align: middle;
+            }
+
+            input {
+                width: 40px;
+                text-align: center;
+            }
+        }
+
+        .action-glyph {
+            font-size: 2.125rem;
+        }
+
+        .paizo-style {
+            border: none;
+            flex-basis: 100%;
+            margin-top: 0.125rem;
+            padding: 0;
+        }
     }
 }

--- a/src/styles/item/_index.scss
+++ b/src/styles/item/_index.scss
@@ -1,5 +1,13 @@
+@use "sass:meta";
+@use "header" as *;
+@use "nav" as *;
+@use "../colors";
+@use "../mixins/forms";
+@use "../mixins/typography";
+@use "../reset" as *;
+
 .pf2e.item.sheet {
-    @import "../reset";
+    @include reset;
 
     .window-content {
         padding: var(--space-8);
@@ -24,8 +32,8 @@
             font-weight: 500;
         }
 
-        @import "header";
-        @import "nav";
+        @include header;
+        @include nav;
 
         .mce-panel span {
             display: inherit;
@@ -136,7 +144,7 @@
                 scrollbar-gutter: stable;
             }
 
-            @import "sidebar";
+            @include meta.load-css("sidebar");
         }
 
         .sheet-body {
@@ -262,7 +270,7 @@
             }
 
             .editor {
-                @include journal-styling;
+                @include typography.journal-styling;
             }
         }
 
@@ -296,7 +304,7 @@
                 padding: var(--space-4);
 
                 .data {
-                    @include publication-data;
+                    @include forms.publication-data;
                 }
             }
 
@@ -383,12 +391,12 @@
             input,
             select {
                 &.adjusted-higher:not(:focus) {
-                    color: $adjusted-higher;
+                    color: colors.$adjusted-higher;
                     font-weight: 700;
                 }
 
                 &.adjusted-lower:not(:focus) {
-                    color: $adjusted-lower;
+                    color: colors.$adjusted-lower;
                     font-weight: 700;
                 }
             }
@@ -498,7 +506,7 @@
         input {
             &.adjusted:not(:focus) {
                 font-weight: 700;
-                color: $adjusted-higher;
+                color: colors.$adjusted-higher;
             }
         }
 
@@ -520,10 +528,10 @@
             }
         }
 
-        @import "abc-sheet";
-        @import "activations";
-        @import "mystification";
-        @import "rules";
+        @include meta.load-css("abc-sheet");
+        @include meta.load-css("activations");
+        @include meta.load-css("mystification");
+        @include meta.load-css("rules");
     }
 
     a.disabled,
@@ -537,56 +545,57 @@
     }
 
     &.action form {
-        @import "ability-sheet";
+        @include meta.load-css("ability-sheet");
     }
 
     &.affliction form {
-        @import "affliction-sheet";
+        @include meta.load-css("affliction-sheet");
     }
 
     &.ancestry form {
-        @import "ancestry-sheet";
+        @include meta.load-css("ancestry-sheet");
     }
 
     &.consumable form {
-        @import "consumable-sheet";
+        @include meta.load-css("consumable-sheet");
     }
 
     &.deity form {
-        @import "deity-sheet";
+        @include meta.load-css("deity-sheet");
     }
 
     &.effect form {
-        @import "effect-sheet";
+        @include meta.load-css("effect-sheet");
     }
 
     &.feat form {
-        @import "feat-sheet";
+        @include meta.load-css("feat-sheet");
     }
 
     &.heritage form {
-        @import "heritage-sheet";
+        @include meta.load-css("heritage-sheet");
     }
 
     &.kit form {
-        @import "kit-sheet";
+        @include meta.load-css("kit-sheet");
     }
 
     &.melee form {
-        @import "melee-sheet";
+        @include meta.load-css("melee-sheet");
     }
 
     &.physical form .sidebar {
-        @import "physical-sidebar";
+        @include meta.load-css("physical-sidebar");
     }
 
     &.spell form {
-        @import "spell-sheet";
+        @include meta.load-css("spell-sheet");
     }
 
     &.weapon form {
-        @import "weapon-sheet";
+        @include meta.load-css("weapon-sheet");
     }
 }
 
-@import "item-attacher", "persistent-damage-dialog";
+@include meta.load-css("item-attacher");
+@include meta.load-css("persistent-damage-dialog");

--- a/src/styles/item/_item-attacher.scss
+++ b/src/styles/item/_item-attacher.scss
@@ -1,5 +1,8 @@
+@use "sass:meta";
+@use "../reset" as *;
+
 #item-attacher .content {
-    @import "../reset";
+    @include reset;
 
     > * {
         display: flex;

--- a/src/styles/item/_nav.scss
+++ b/src/styles/item/_nav.scss
@@ -1,41 +1,43 @@
-> nav {
-    align-items: baseline;
-    border-bottom: 1px solid var(--secondary-background);
-    border-top: 1px solid var(--secondary-background);
-    display: flex;
-    flex: 0 0 1.75rem;
-    line-height: 1.75rem;
-
-    a {
-        flex: 1 1 auto;
-    }
-
-    a.active {
-        text-decoration: underline;
-    }
-
-    .sidebar-summary {
-        flex: 0 0 13.75rem;
-        margin: 0;
-        text-align: center;
-    }
-
-    > .tabs {
-        font-weight: 500;
-        margin: 0;
-        flex: 1;
+@mixin nav {
+    > nav {
         align-items: baseline;
+        border-bottom: 1px solid var(--secondary-background);
+        border-top: 1px solid var(--secondary-background);
+        display: flex;
+        flex: 0 0 1.75rem;
+        line-height: 1.75rem;
 
-        > a {
-            font-size: var(--font-size-12);
+        a {
+            flex: 1 1 auto;
+        }
+
+        a.active {
+            text-decoration: underline;
+        }
+
+        .sidebar-summary {
+            flex: 0 0 13.75rem;
+            margin: 0;
             text-align: center;
+        }
 
-            &:last-of-type {
-                padding-right: 0.25rem;
-            }
+        > .tabs {
+            font-weight: 500;
+            margin: 0;
+            flex: 1;
+            align-items: baseline;
 
-            &.active {
-                font-weight: 600;
+            > a {
+                font-size: var(--font-size-12);
+                text-align: center;
+
+                &:last-of-type {
+                    padding-right: 0.25rem;
+                }
+
+                &.active {
+                    font-weight: 600;
+                }
             }
         }
     }

--- a/src/styles/item/_persistent-damage-dialog.scss
+++ b/src/styles/item/_persistent-damage-dialog.scss
@@ -1,3 +1,5 @@
+@use "../mixins/animations";
+
 .persistent-damage-dialog {
     /** Work around Font Awesome styling bug present as of version 6.2 */
     i.fa-fw {
@@ -12,7 +14,7 @@
             float: right;
             font-size: 0.8em;
             &:hover i {
-                @include die-spin;
+                @include animations.die-spin;
             }
         }
     }

--- a/src/styles/item/_physical-sidebar.scss
+++ b/src/styles/item/_physical-sidebar.scss
@@ -1,3 +1,5 @@
+@use "../colors";
+
 .inventory-details .form-group.subitems {
     align-items: start;
     flex-direction: column;
@@ -22,7 +24,7 @@
             padding: var(--space-4);
 
             &:nth-of-type(even) {
-                background: rgba($alt-color, 0.1);
+                background: rgba(colors.$alt-color, 0.1);
             }
 
             > * {

--- a/src/styles/item/_sidebar.scss
+++ b/src/styles/item/_sidebar.scss
@@ -1,3 +1,5 @@
+@use "../mixins/typography";
+
 section.sidebar {
     flex: 0 0 13.75rem;
     display: flex;
@@ -9,7 +11,7 @@ section.sidebar {
 
     .item-summary,
     .tags-title {
-        @include serif-condensed;
+        @include typography.serif-condensed;
         flex: 0 0 1.5em;
         line-height: 1.5em;
         text-align: center;

--- a/src/styles/legacy/_chat.scss
+++ b/src/styles/legacy/_chat.scss
@@ -1,3 +1,6 @@
+@use "../colors";
+@use "../mixins/frames";
+
 /* ----------------------------------------- */
 /* Item Card Structure                       */
 /* ----------------------------------------- */
@@ -82,8 +85,8 @@
     }
 
     .addendum {
-        @include frame-elegant;
-        background: rgba($alt-dark, 0.1);
+        @include frames.frame-elegant;
+        background: rgba(colors.$alt-dark, 0.1);
         border-radius: 2px;
         color: var(--color-pf-alternate-darker);
         padding: var(--space-4);

--- a/src/styles/legacy/_index.scss
+++ b/src/styles/legacy/_index.scss
@@ -11,4 +11,6 @@
 *
 */
 
-@import "chat", "pf2e", "tooltipster";
+@use "chat";
+@use "pf2e";
+@use "tooltipster";

--- a/src/styles/legacy/_pf2e.scss
+++ b/src/styles/legacy/_pf2e.scss
@@ -1,3 +1,5 @@
+@use "../mixins/typography";
+
 :root {
     --primary-background: #454a7c;
     --secondary-background: gray;
@@ -32,7 +34,7 @@
             border: none;
 
             > input {
-                @include serif-condensed;
+                @include typography.serif-condensed;
                 height: 2.5rem;
                 width: 100%;
                 margin: var(--space-2);

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,31 +1,16 @@
-@import "fonts",
-    // Color definitions
-    "colors",
-    // Useful Functions
-    "mixins",
-    // Old CSS files
-    "legacy",
-    // Global Settings
-    "globals",
-    // Foundry System stylings
-    "ui",
-    // General styling for system V2 Applications
-    "application",
-    // Character Sheets
-    "actor",
-    // Item Sheets
-    "item",
-    // Scene and scene-object sheets
-    "scene",
-    // PF2E Settings Applications
-    "settings",
-    // PF2E System Applications
-    "system",
-    // Trait, trait-like, and tagify styles
-    "tags",
-    // Foundry Tooltip API
-    "tooltip",
-    // GM tools
-    "gm",
-    // UserConfig
-    "user";
+@use "fonts";
+@use "colors";
+@use "mixins";
+@use "legacy";
+@use "globals";
+@use "ui";
+@use "application";
+@use "actor";
+@use "item";
+@use "scene";
+@use "settings";
+@use "system";
+@use "tags";
+@use "tooltip";
+@use "gm";
+@use "user";

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,5 +1,4 @@
 @use "fonts";
-@use "colors";
 @use "mixins";
 @use "legacy";
 @use "globals";

--- a/src/styles/mixins/_effects-list.scss
+++ b/src/styles/mixins/_effects-list.scss
@@ -1,4 +1,7 @@
-$-alt-color: #786452 !default;
+@use "buttons";
+@use "typography";
+
+$alt-color: #786452 !default;
 
 @mixin configure($alt-color: null) {
     @if $alt-color {
@@ -74,11 +77,11 @@ $-alt-color: #786452 !default;
                 margin: 0;
                 border: none;
                 cursor: pointer;
-                @include micro;
+                @include typography.micro;
                 padding: 5px;
                 color: var(--text-light);
                 width: 70px;
-                @include button;
+                @include buttons.button;
                 background: var(--secondary);
                 border-radius: 2px;
                 flex: 0;

--- a/src/styles/mixins/_index.scss
+++ b/src/styles/mixins/_index.scss
@@ -1,1 +1,7 @@
-@import "layout", "typography", "buttons", "forms", "animations", "frames", "effects-list";
+@use "layout";
+@use "typography";
+@use "buttons";
+@use "forms";
+@use "animations";
+@use "frames";
+@use "effects-list";

--- a/src/styles/scene/_index.scss
+++ b/src/styles/scene/_index.scss
@@ -1,5 +1,7 @@
 @use "sass:color";
-@import "darkness-adjuster", "sheet", "token-config";
+@use "darkness-adjuster";
+@use "sheet";
+@use "token-config";
 
 #controls ol.control-tools > li:has(> i.gm-vision) {
     $gm-vision: #d1ccff;

--- a/src/styles/settings/_index.scss
+++ b/src/styles/settings/_index.scss
@@ -1,4 +1,7 @@
-@import "homebrew", "variant-rules", "world-clock";
+@use "sass:meta";
+@use "homebrew";
+@use "variant-rules";
+@use "world-clock";
 
 // Settings sidebar
 #game-details {
@@ -50,5 +53,5 @@
 }
 
 #metagame-settings {
-    @import "metagame";
+    @include meta.load-css("metagame");
 }

--- a/src/styles/system/_compendium-browser-settings.scss
+++ b/src/styles/system/_compendium-browser-settings.scss
@@ -1,3 +1,5 @@
+@use "../mixins/frames";
+
 .compendium-browser-settings {
     height: 100%;
 
@@ -96,7 +98,7 @@
     }
 
     > nav {
-        @include corner-boxes;
+        @include frames.corner-boxes;
         flex: 0;
         width: 100%;
         display: inline-flex;

--- a/src/styles/system/_effects-panel.scss
+++ b/src/styles/system/_effects-panel.scss
@@ -1,3 +1,7 @@
+@use "../mixins/frames";
+@use "../mixins/layout";
+@use "../mixins/typography";
+
 #effects-panel {
     pointer-events: initial;
     position: absolute;
@@ -37,7 +41,7 @@
         }
 
         > .icon {
-            @include frame-silver;
+            @include frames.frame-silver;
             align-items: center;
             background-repeat: no-repeat;
             background-size: contain;
@@ -68,7 +72,7 @@
                 bottom: -1px;
                 width: 100%;
                 padding: 2px 1px;
-                @include micro;
+                @include typography.micro;
                 color: var(--text-light);
                 background-color: var(--primary);
             }
@@ -134,7 +138,7 @@ aside.effect-info {
     }
 
     h1 {
-        @include p-reset;
+        @include layout.p-reset;
         border: none;
         display: flex;
         font-size: var(--font-size-14);

--- a/src/styles/system/_index.scss
+++ b/src/styles/system/_index.scss
@@ -1,2 +1,10 @@
-@import "actions", "choice-set-prompt", "compendium-browser-settings", "compendium-migration-status", "effects-panel",
-    "journal", "license-viewer", "migration-summary", "upw-viewer", "world-clock";
+@use "actions";
+@use "choice-set-prompt";
+@use "compendium-browser-settings";
+@use "compendium-migration-status";
+@use "effects-panel";
+@use "journal";
+@use "license-viewer";
+@use "migration-summary";
+@use "upw-viewer";
+@use "world-clock";

--- a/src/styles/system/actions/_index.scss
+++ b/src/styles/system/actions/_index.scss
@@ -1,1 +1,2 @@
-@import "craft", "repair";
+@use "craft";
+@use "repair";

--- a/src/styles/system/journal/_index.scss
+++ b/src/styles/system/journal/_index.scss
@@ -1,6 +1,9 @@
+@use "sass:meta";
+@use "../../mixins/typography";
+
 .journal-entry-page {
     .journal-page-content {
-        @include journal-styling;
-        @import "critical-fumble-deck";
+        @include typography.journal-styling;
+        @include meta.load-css("critical-fumble-deck");
     }
 }

--- a/src/styles/system/license-viewer/_index.scss
+++ b/src/styles/system/license-viewer/_index.scss
@@ -1,3 +1,5 @@
+@use "../../mixins/frames";
+
 #license-viewer {
     > section.window-content > .content-box {
         flex: 1;
@@ -5,7 +7,7 @@
         height: inherit;
 
         > nav {
-            @include corner-boxes;
+            @include frames.corner-boxes;
             flex: 0;
             width: 100%;
             display: inline-flex;

--- a/src/styles/tooltip/_index.scss
+++ b/src/styles/tooltip/_index.scss
@@ -1,4 +1,4 @@
-@import "carry-type-menu";
+@use "carry-type-menu";
 
 aside.locked-tooltip .roll-options {
     padding-right: var(--space-8);

--- a/src/styles/ui/_hover.scss
+++ b/src/styles/ui/_hover.scss
@@ -1,10 +1,14 @@
+@use "../mixins/frames";
+@use "../mixins/layout";
+@use "../mixins/typography";
+
 .hover-content {
     display: none;
 }
 
 .crb-hover {
     .tooltipster-box {
-        @include corner-boxes;
+        @include frames.corner-boxes;
         background-color: rgba(black, 0.9);
         overflow: visible;
 
@@ -13,7 +17,7 @@
             padding: 0;
 
             .item-summary {
-                @include journal-styling;
+                @include typography.journal-styling;
                 a,
                 span[data-pf2-effect-area] {
                     color: var(--color-text-dark-primary);
@@ -49,7 +53,7 @@
 
                     h2,
                     a {
-                        @include micro;
+                        @include typography.micro;
                         border: none;
                         color: var(--sidebar-title);
                         line-height: 1.5;
@@ -190,8 +194,8 @@
                         }
 
                         .tag-legacy {
-                            @include micro;
-                            @include flex-center;
+                            @include typography.micro;
+                            @include layout.flex-center;
                             color: var(--color-pf-tertiary);
                             grid-area: type;
                             letter-spacing: 0.5px;
@@ -283,7 +287,7 @@
                         }
 
                         .add-modifier-submit {
-                            @include micro;
+                            @include typography.micro;
                             background-color: black;
                             color: var(--color-pf-tertiary);
                             grid-area: btn;

--- a/src/styles/ui/_index.scss
+++ b/src/styles/ui/_index.scss
@@ -1,1 +1,7 @@
-@import "windows", "sidebar", "hover", "icons", "roll-modifiers-dialog", "tag-selector", "token-hud";
+@use "windows";
+@use "sidebar";
+@use "hover";
+@use "icons";
+@use "roll-modifiers-dialog";
+@use "tag-selector";
+@use "token-hud";

--- a/src/styles/ui/_roll-modifiers-dialog.scss
+++ b/src/styles/ui/_roll-modifiers-dialog.scss
@@ -1,3 +1,7 @@
+@use "../mixins/buttons";
+@use "../mixins/frames";
+@use "../mixins/typography";
+
 @use "sass:color";
 
 .roll-modifiers-dialog {
@@ -5,7 +9,7 @@
     box-shadow: none;
 
     .window-header {
-        @include inset-gold-border;
+        @include frames.inset-gold-border;
         background: linear-gradient(
             90deg,
             var(--color-pf-secondary) 0%,
@@ -18,12 +22,12 @@
     }
 
     .window-content {
-        @include corner-boxes;
+        @include frames.corner-boxes;
         padding-top: 0;
     }
 
     button {
-        @include button;
+        @include buttons.button;
         background-color: var(--color-pf-alternate);
         border-radius: 2px;
         color: var(--text-light);
@@ -74,7 +78,7 @@
 
         &::after,
         &::before {
-            @include micro;
+            @include typography.micro;
             top: 4px;
         }
 

--- a/src/styles/ui/sidebar/_index.scss
+++ b/src/styles/ui/sidebar/_index.scss
@@ -1,8 +1,8 @@
-@import "actor-directory";
-@import "item-directory";
-@import "chat";
-@import "compendium-directory";
-@import "encounter-tracker";
+@use "actor-directory";
+@use "item-directory";
+@use "chat";
+@use "compendium-directory";
+@use "encounter-tracker";
 
 .sidebar-tab ol.subdirectory {
     border-left-width: 6px;

--- a/src/styles/ui/sidebar/chat/_action.scss
+++ b/src/styles/ui/sidebar/chat/_action.scss
@@ -1,116 +1,118 @@
-&.emote > .message-content {
-    font-style: italic;
+@mixin action {
+    &.emote > .message-content {
+        font-style: italic;
 
-    p.action-content {
-        display: flex;
-        align-items: center;
-        font-weight: normal;
-
-        a.content-link {
-            background: none;
-            border: none;
-            padding: 0;
-            text-decoration: underline;
-            white-space: unset;
-            word-break: normal;
-
-            > i {
-                margin-inline: 0.125rem;
-            }
-        }
-
-        img {
-            height: 2.33em;
-            width: 2.33em;
-            float: left;
-            margin-right: 0.5em;
-        }
-    }
-
-    hr.action-divider {
-        margin: 0;
-    }
-}
-
-> .message-header .flavor-text h4.action {
-    line-height: 1.5em;
-    margin: 0;
-
-    > strong {
-        font-weight: 600;
-    }
-
-    + .tags {
-        padding: var(--space-2) 0 0;
-    }
-}
-
-> .message-content {
-    > .description {
-        margin-bottom: 0rem;
-        position: relative;
-
-        a.preview {
-            height: 4.5ch;
-            display: block;
-            -webkit-mask-image: linear-gradient(to bottom, black, rgba(black, 0));
-            mask-image: linear-gradient(to bottom, black, rgba(black, 0));
-            overflow: hidden;
-            position: relative;
-            z-index: 2;
-
-            &:hover {
-                text-shadow: none;
-
-                + .shadow {
-                    box-shadow: 0 1px 6px var(--color-shadow-primary);
-                    clip-path: polygon(0 0, 100% 0, 100% 200%, 0 200%);
-                    width: 100%;
-                }
-            }
-        }
-
-        .shadow {
-            border-bottom: 1px solid rgba(black, 0.05);
-            height: 6px;
-            position: relative;
-            top: -6px;
-            z-index: 1;
-        }
-    }
-
-    .message-buttons {
-        display: flex;
-        margin: 0.35em 0 2px;
-
-        button {
-            align-items: center;
+        p.action-content {
             display: flex;
-            justify-content: center;
-            position: relative;
+            align-items: center;
+            font-weight: normal;
 
-            .cue {
-                position: absolute;
-                right: 0.5rem;
+            a.content-link {
+                background: none;
+                border: none;
+                padding: 0;
+                text-decoration: underline;
+                white-space: unset;
+                word-break: normal;
 
-                i {
-                    --fa-primary-color: var(--color-border-dark);
-                    --fa-secondary-color: var(--primary);
-                    --fa-secondary-opacity: 0.6;
+                > i {
+                    margin-inline: 0.125rem;
                 }
+            }
+
+            img {
+                height: 2.33em;
+                width: 2.33em;
+                float: left;
+                margin-right: 0.5em;
             }
         }
 
-        &:has(.effect-applied, .crafted-item) {
-            align-items: center;
-            color: var(--color-text-dark-secondary);
-            font-style: italic;
-            flex-direction: column;
-            gap: var(--space-8);
-            justify-content: center;
-            min-height: 2.1rem;
-            padding-bottom: 0.1rem;
-            text-align: center;
+        hr.action-divider {
+            margin: 0;
+        }
+    }
+
+    > .message-header .flavor-text h4.action {
+        line-height: 1.5em;
+        margin: 0;
+
+        > strong {
+            font-weight: 600;
+        }
+
+        + .tags {
+            padding: var(--space-2) 0 0;
+        }
+    }
+
+    > .message-content {
+        > .description {
+            margin-bottom: 0rem;
+            position: relative;
+
+            a.preview {
+                height: 4.5ch;
+                display: block;
+                -webkit-mask-image: linear-gradient(to bottom, black, rgba(black, 0));
+                mask-image: linear-gradient(to bottom, black, rgba(black, 0));
+                overflow: hidden;
+                position: relative;
+                z-index: 2;
+
+                &:hover {
+                    text-shadow: none;
+
+                    + .shadow {
+                        box-shadow: 0 1px 6px var(--color-shadow-primary);
+                        clip-path: polygon(0 0, 100% 0, 100% 200%, 0 200%);
+                        width: 100%;
+                    }
+                }
+            }
+
+            .shadow {
+                border-bottom: 1px solid rgba(black, 0.05);
+                height: 6px;
+                position: relative;
+                top: -6px;
+                z-index: 1;
+            }
+        }
+
+        .message-buttons {
+            display: flex;
+            margin: 0.35em 0 2px;
+
+            button {
+                align-items: center;
+                display: flex;
+                justify-content: center;
+                position: relative;
+
+                .cue {
+                    position: absolute;
+                    right: 0.5rem;
+
+                    i {
+                        --fa-primary-color: var(--color-border-dark);
+                        --fa-secondary-color: var(--primary);
+                        --fa-secondary-opacity: 0.6;
+                    }
+                }
+            }
+
+            &:has(.effect-applied, .crafted-item) {
+                align-items: center;
+                color: var(--color-text-dark-secondary);
+                font-style: italic;
+                flex-direction: column;
+                gap: var(--space-8);
+                justify-content: center;
+                min-height: 2.1rem;
+                padding-bottom: 0.1rem;
+                text-align: center;
+            }
         }
     }
 }

--- a/src/styles/ui/sidebar/chat/_check.scss
+++ b/src/styles/ui/sidebar/chat/_check.scss
@@ -1,73 +1,77 @@
-> .message-header {
-    .flavor-text {
-        .target-dc-result {
-            line-height: 0.75rem;
-            margin-bottom: var(--space-4);
+@use "../../../colors";
 
-            .target-dc,
-            .result {
-                display: block;
-                margin: var(--space-1) 0;
-                width: fit-content;
-            }
+@mixin check {
+    > .message-header {
+        .flavor-text {
+            .target-dc-result {
+                line-height: 0.75rem;
+                margin-bottom: var(--space-4);
 
-            .unadjusted {
-                text-decoration: line-through;
-            }
-
-            .adjusted {
-                text-decoration: underline dotted;
-                &.increased {
-                    color: $degree-success-critical;
+                .target-dc,
+                .result {
+                    display: block;
+                    margin: var(--space-1) 0;
+                    width: fit-content;
                 }
-                &.decreased {
-                    color: $degree-failure-critical;
+
+                .unadjusted {
+                    text-decoration: line-through;
+                }
+
+                .adjusted {
+                    text-decoration: underline dotted;
+                    &.increased {
+                        color: colors.$degree-success-critical;
+                    }
+                    &.decreased {
+                        color: colors.$degree-failure-critical;
+                    }
                 }
             }
-        }
 
-        .degree-of-success {
-            .criticalSuccess {
-                color: $degree-success-critical;
+            .degree-of-success {
+                .criticalSuccess {
+                    color: colors.$degree-success-critical;
+                }
+                .success {
+                    color: colors.$degree-success;
+                }
+                .failure {
+                    color: colors.$degree-failure;
+                }
+                .criticalFailure {
+                    color: colors.$degree-failure-critical;
+                }
             }
-            .success {
-                color: $degree-success;
-            }
-            .failure {
-                color: $degree-failure;
-            }
-            .criticalFailure {
-                color: $degree-failure-critical;
-            }
-        }
 
-        .effect {
-            align-items: center;
-            column-gap: var(--space-5);
-            display: flex;
+            .effect {
+                align-items: center;
+                column-gap: var(--space-5);
+                display: flex;
 
-            img {
-                height: 2rem;
-                width: 2rem;
+                img {
+                    height: 2rem;
+                    width: 2rem;
+                }
             }
         }
     }
-}
 
-> .message-content {
-    .dice-total button.set-as-initiative {
-        align-items: center;
-        display: flex;
-        font-size: var(--font-size-10);
-        height: 2.2em;
-        justify-content: center;
-        position: absolute;
-        right: 0;
-        top: 1px;
-        width: 2.2em;
+    > .message-content {
+        .dice-total button.set-as-initiative {
+            align-items: center;
+            display: flex;
+            font-size: var(--font-size-10);
+            height: 2.2em;
+            justify-content: center;
+            position: absolute;
+            right: 0;
+            top: 1px;
+            width: 2.2em;
 
-        > i {
-            margin-right: 0;
+            > i {
+                margin-right: 0;
+            }
         }
     }
 }

--- a/src/styles/ui/sidebar/chat/_index.scss
+++ b/src/styles/ui/sidebar/chat/_index.scss
@@ -1,7 +1,15 @@
-@import "roll-inspector";
+@use "sass:meta";
+@use "roll-inspector";
+@use "action" as *;
+@use "check" as *;
+@use "damage";
+@use "reroll";
 
 .chat-message {
-    @import "action", "check", "damage", "reroll";
+    @include action;
+    @include check;
+    @include meta.load-css("damage");
+    @include meta.load-css("reroll");
 
     .message-header.with-image {
         display: grid;
@@ -98,7 +106,7 @@
     }
 
     > .message-content {
-        @import "conditions";
+        @include meta.load-css("conditions");
 
         .dice-roll {
             .dice-result > [data-visibility="gm"] {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -197,7 +197,14 @@ const config = Vite.defineConfig(({ command, mode }): Vite.UserConfig => {
             },
         },
         plugins,
-        css: { devSourcemap: buildMode === "development" },
+        css: {
+            devSourcemap: buildMode === "development",
+            preprocessorOptions: {
+                scss: {
+                    api: "modern-compiler", // This will be the default in Vite v6
+                },
+            },
+        },
     };
 });
 


### PR DESCRIPTION
The changes are mostly auto generated by the migration client but there are some areas that needed adjustments. Everything _should_ still look the same but I'm sure there is some stuff that broke somewhere.

**Top level parent selectors (&)**
With `@use` it's no longer possbile to have `&` selectors at the top level of an `scss` file. To solve this I have wrapped most occurences in a `@mixin`. Some new mixins are `@use`d with `as *` to avoid creating a [namespace](https://sass-lang.com/documentation/at-rules/use/#choosing-a-namespace) for them where the file has the same name as the mixin, like for instance `reset.reset`.

**Top level child combinator (>)**
With `@use` a top level child combinator generates warnings about [bogus combinators](https://sass-lang.com/documentation/js-api/interfaces/deprecations/#bogus_combinators). I've wrapped those in `@mixin`s too.

**The `_colors.scss` file**
`@use`-ing the colors file for its variables instead of `@import`ing leads to the full file contents being appended to the css context that `@used` it. That lead to the generated .css file being 200KB larger than before.
Moving the `:root` part in a mixin and changing the comments to single line comments (multi line comments are not stripped by the sass compiler) solves this.
I've also added some new css variables for degree of success and adjustments to make it not as necessary to import `_colors` just for the sass variables. The `sass:color` functions don't work with plain css variables so it's not possbile to avoid it completly.