### PR TITLE
Remove unused adept and paragon implement tags

### DIFF
--- a/packs/classfeatures/implement-adept.json
+++ b/packs/classfeatures/implement-adept.json
@@ -39,13 +39,6 @@
                 "key": "ChoiceSet"
             },
             {
-                "itemId": "{item|flags.pf2e.rulesSelections.implementAdept}",
-                "key": "ItemAlteration",
-                "mode": "add",
-                "property": "other-tags",
-                "value": "thaumaturge-implement-adept"
-            },
-            {
                 "key": "GrantItem",
                 "uuid": "{item|flags.pf2e.rulesSelections.implementAdept}"
             }

--- a/packs/classfeatures/implement-paragon.json
+++ b/packs/classfeatures/implement-paragon.json
@@ -32,13 +32,6 @@
                 "key": "ChoiceSet"
             },
             {
-                "itemId": "{item|flags.pf2e.rulesSelections.implementParagon}",
-                "key": "ItemAlteration",
-                "mode": "add",
-                "property": "other-tags",
-                "value": "thaumaturge-implement-paragon"
-            },
-            {
                 "key": "GrantItem",
                 "uuid": "{item|flags.pf2e.rulesSelections.implementParagon}"
             }

--- a/packs/classfeatures/second-adept.json
+++ b/packs/classfeatures/second-adept.json
@@ -32,13 +32,6 @@
                 "key": "ChoiceSet"
             },
             {
-                "itemId": "{item|flags.pf2e.rulesSelections.secondAdept}",
-                "key": "ItemAlteration",
-                "mode": "add",
-                "property": "other-tags",
-                "value": "thaumaturge-implement-adept"
-            },
-            {
                 "key": "GrantItem",
                 "uuid": "{item|flags.pf2e.rulesSelections.secondAdept}"
             }

--- a/packs/feats/intense-implement.json
+++ b/packs/feats/intense-implement.json
@@ -32,13 +32,6 @@
                 "key": "ChoiceSet"
             },
             {
-                "itemId": "{item|flags.pf2e.rulesSelections.thirdAdept}",
-                "key": "ItemAlteration",
-                "mode": "add",
-                "property": "other-tags",
-                "value": "thaumaturge-implement-adept"
-            },
-            {
                 "key": "GrantItem",
                 "uuid": "{item|flags.pf2e.rulesSelections.thirdAdept}"
             }


### PR DESCRIPTION
These are not being used by anything anymore after the restructuring of the class.