### PR TITLE
Update `You're next` to use `/act` syntax on select NPC actors

### DIFF
--- a/packs/npc-gallery/prisoner.json
+++ b/packs/npc-gallery/prisoner.json
@@ -301,7 +301,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> The prisoner reduces a creature to 0 hit points.</p>\n<hr />\n<p><strong>Effect</strong> The prisoner attempts an Intimidation check with a +2 circumstance bonus to @UUID[Compendium.pf2e.actionspf2e.Item.Demoralize] a single creature it can see and that can see them.</p>"
+                    "value": "<p><strong>Trigger</strong> The prisoner reduces a creature to 0 hit points.</p><hr /><p><strong>Effect</strong> The prisoner attempts an Intimidation check with a +2 circumstance bonus to [[/act demoralize]] a single creature it can see and that can see them.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -309,12 +309,6 @@
                     "title": ""
                 },
                 "rules": [
-                    {
-                        "domain": "all",
-                        "key": "RollOption",
-                        "option": "youre-next",
-                        "toggleable": true
-                    },
                     {
                         "key": "FlatModifier",
                         "predicate": [

--- a/packs/npc-gallery/prisoner.json
+++ b/packs/npc-gallery/prisoner.json
@@ -301,7 +301,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> The prisoner reduces a creature to 0 hit points.</p><hr /><p><strong>Effect</strong> The prisoner attempts an Intimidation check with a +2 circumstance bonus to [[/act demoralize]] a single creature it can see and that can see them.</p>"
+                    "value": "<p><strong>Trigger</strong> The prisoner reduces a creature to 0 hit points.</p><hr /><p><strong>Effect</strong> The prisoner attempts an Intimidation check with a +2 circumstance bonus to [[/act demoralize options=youre-next]] a single creature it can see and that can see them.</p>"
                 },
                 "publication": {
                     "license": "OGL",

--- a/packs/pfs-season-1-bestiary/1-12/hungry-blade-apprentice.json
+++ b/packs/pfs-season-1-bestiary/1-12/hungry-blade-apprentice.json
@@ -296,7 +296,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> The Hungry Blade apprentice reduces a creature to 0 Hit Points</p><hr /><p><strong>Effect</strong> Hungry Blade apprentice prisoner attempts an Intimidation check with a +2 circumstance bonus to [[/act demoralize]] a single creature it can see and that can see them.</p>"
+                    "value": "<p><strong>Trigger</strong> The Hungry Blade apprentice reduces a creature to 0 Hit Points</p><hr /><p><strong>Effect</strong> Hungry Blade apprentice prisoner attempts an Intimidation check with a +2 circumstance bonus to [[/act demoralize options=youre-next]] a single creature it can see and that can see them.</p>"
                 },
                 "publication": {
                     "license": "OGL",

--- a/packs/pfs-season-1-bestiary/1-12/hungry-blade-apprentice.json
+++ b/packs/pfs-season-1-bestiary/1-12/hungry-blade-apprentice.json
@@ -296,7 +296,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> The Hungry Blade apprentice reduces a creature to 0 Hit Points</p>\n<hr />\n<p><strong>Effect</strong> Hungry Blade apprentice prisoner attempts an Intimidation check with a +2 circumstance bonus to @UUID[Compendium.pf2e.action-macros.Macro.Demoralize: Intimidation] a single creature it can see and that can see them.</p>"
+                    "value": "<p><strong>Trigger</strong> The Hungry Blade apprentice reduces a creature to 0 Hit Points</p><hr /><p><strong>Effect</strong> Hungry Blade apprentice prisoner attempts an Intimidation check with a +2 circumstance bonus to [[/act demoralize]] a single creature it can see and that can see them.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -313,13 +313,6 @@
                         "selector": "intimidation",
                         "type": "circumstance",
                         "value": 2
-                    },
-                    {
-                        "domain": "intimidation",
-                        "key": "RollOption",
-                        "option": "youre-next",
-                        "toggleable": true,
-                        "value": true
                     }
                 ],
                 "slug": null,

--- a/packs/pfs-season-1-bestiary/1-12/hungry-blade-recruit.json
+++ b/packs/pfs-season-1-bestiary/1-12/hungry-blade-recruit.json
@@ -296,7 +296,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> The Hungry Blade recruit reduces a creature to 0 Hit Points</p><hr /><p><strong>Effect</strong> Hungry Blade recruit prisoner attempts an Intimidation check with a +2 circumstance bonus to [[/act demoralize]] a single creature it can see and that can see them.</p>"
+                    "value": "<p><strong>Trigger</strong> The Hungry Blade recruit reduces a creature to 0 Hit Points</p><hr /><p><strong>Effect</strong> Hungry Blade recruit prisoner attempts an Intimidation check with a +2 circumstance bonus to [[/act demoralize options=youre-next]] a single creature it can see and that can see them.</p>"
                 },
                 "publication": {
                     "license": "OGL",

--- a/packs/pfs-season-1-bestiary/1-12/hungry-blade-recruit.json
+++ b/packs/pfs-season-1-bestiary/1-12/hungry-blade-recruit.json
@@ -296,7 +296,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> The Hungry Blade recruit reduces a creature to 0 Hit Points</p>\n<hr />\n<p><strong>Effect</strong> Hungry Blade recruit prisoner attempts an Intimidation check with a +2 circumstance bonus to @UUID[Compendium.pf2e.action-macros.Macro.Demoralize: Intimidation] a single creature it can see and that can see them.</p>"
+                    "value": "<p><strong>Trigger</strong> The Hungry Blade recruit reduces a creature to 0 Hit Points</p><hr /><p><strong>Effect</strong> Hungry Blade recruit prisoner attempts an Intimidation check with a +2 circumstance bonus to [[/act demoralize]] a single creature it can see and that can see them.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -313,13 +313,6 @@
                         "selector": "intimidation",
                         "type": "circumstance",
                         "value": 2
-                    },
-                    {
-                        "domain": "intimidation",
-                        "key": "RollOption",
-                        "option": "youre-next",
-                        "toggleable": true,
-                        "value": true
                     }
                 ],
                 "slug": null,

--- a/packs/pfs-season-4-bestiary/4-12/witchs-wing.json
+++ b/packs/pfs-season-4-bestiary/4-12/witchs-wing.json
@@ -216,7 +216,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> The witch's wing reduces a creature to 0 Hit Points</p>\n<hr />\n<p><strong>Effect</strong> The witch's wing attempt an Intimidation check with a +2 circumstance bonus to @UUID[Compendium.pf2e.actionspf2e.Item.Demoralize] a single creature they can see and that can see them.</p>"
+                    "value": "<p><strong>Trigger</strong> The witch's wing reduces a creature to 0 Hit Points</p><hr /><p><strong>Effect</strong> The witch's wing attempt an Intimidation check with a +2 circumstance bonus to [[/act demoralize]] a single creature they can see and that can see them.</p>"
                 },
                 "publication": {
                     "license": "OGL",

--- a/packs/pfs-season-4-bestiary/4-12/witchs-wing.json
+++ b/packs/pfs-season-4-bestiary/4-12/witchs-wing.json
@@ -216,7 +216,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> The witch's wing reduces a creature to 0 Hit Points</p><hr /><p><strong>Effect</strong> The witch's wing attempt an Intimidation check with a +2 circumstance bonus to [[/act demoralize]] a single creature they can see and that can see them.</p>"
+                    "value": "<p><strong>Trigger</strong> The witch's wing reduces a creature to 0 Hit Points</p><hr /><p><strong>Effect</strong> The witch's wing attempt an Intimidation check with a +2 circumstance bonus to [[/act demoralize options=youre-next]] a single creature they can see and that can see them.</p>"
                 },
                 "publication": {
                     "license": "OGL",

--- a/packs/pfs-season-5-bestiary/5-03/krosovahn-mendesil-7-8.json
+++ b/packs/pfs-season-5-bestiary/5-03/krosovahn-mendesil-7-8.json
@@ -1074,7 +1074,7 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> Krosovahn Mendesil reduces an enemy to 0 Hit Points</p>\n<hr />\n<p><strong>Effect</strong> After downing the foe, Krosovahn Mendesil menacingly reminds another foe that he's coming after them next. Krosovahn Mendesil attempts an Intimidation check with a +2 circumstance bonus to @UUID[Compendium.pf2e.actionspf2e.Item.Demoralize] a single creature that he can see and that can see him.</p>"
+                    "value": "<p><strong>Trigger</strong> Krosovahn Mendesil reduces an enemy to 0 Hit Points</p><hr /><p><strong>Effect</strong> After downing the foe, Krosovahn Mendesil menacingly reminds another foe that he's coming after them next. Krosovahn Mendesil attempts an Intimidation check with a +2 circumstance bonus to [[/act demoralize]] a single creature that he can see and that can see him.</p>"
                 },
                 "publication": {
                     "license": "OGL",

--- a/packs/pfs-season-5-bestiary/5-03/krosovahn-mendesil-7-8.json
+++ b/packs/pfs-season-5-bestiary/5-03/krosovahn-mendesil-7-8.json
@@ -1074,7 +1074,7 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> Krosovahn Mendesil reduces an enemy to 0 Hit Points</p><hr /><p><strong>Effect</strong> After downing the foe, Krosovahn Mendesil menacingly reminds another foe that he's coming after them next. Krosovahn Mendesil attempts an Intimidation check with a +2 circumstance bonus to [[/act demoralize]] a single creature that he can see and that can see him.</p>"
+                    "value": "<p><strong>Trigger</strong> Krosovahn Mendesil reduces an enemy to 0 Hit Points</p><hr /><p><strong>Effect</strong> After downing the foe, Krosovahn Mendesil menacingly reminds another foe that he's coming after them next. Krosovahn Mendesil attempts an Intimidation check with a +2 circumstance bonus to [[/act demoralize options=youre-next]] a single creature that he can see and that can see him.</p>"
                 },
                 "publication": {
                     "license": "OGL",

--- a/packs/pfs-season-5-bestiary/5-03/krosovahn-mendesil.json
+++ b/packs/pfs-season-5-bestiary/5-03/krosovahn-mendesil.json
@@ -1029,7 +1029,7 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> Krosovahn Mendesil reduces an enemy to 0 Hit Points</p>\n<hr />\n<p><strong>Effect</strong> After downing the foe, Krosovahn Mendesil menacingly reminds another foe that he's coming after them next. Krosovahn Mendesil attempts an Intimidation check with a +2 circumstance bonus to @UUID[Compendium.pf2e.actionspf2e.Item.Demoralize] a single creature that he can see and that can see him.</p>"
+                    "value": "<p><strong>Trigger</strong> Krosovahn Mendesil reduces an enemy to 0 Hit Points</p><hr /><p><strong>Effect</strong> After downing the foe, Krosovahn Mendesil menacingly reminds another foe that he's coming after them next. Krosovahn Mendesil attempts an Intimidation check with a +2 circumstance bonus to [[/act demoralize]] a single creature that he can see and that can see him.</p>"
                 },
                 "publication": {
                     "license": "OGL",

--- a/packs/pfs-season-5-bestiary/5-03/krosovahn-mendesil.json
+++ b/packs/pfs-season-5-bestiary/5-03/krosovahn-mendesil.json
@@ -1029,7 +1029,7 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> Krosovahn Mendesil reduces an enemy to 0 Hit Points</p><hr /><p><strong>Effect</strong> After downing the foe, Krosovahn Mendesil menacingly reminds another foe that he's coming after them next. Krosovahn Mendesil attempts an Intimidation check with a +2 circumstance bonus to [[/act demoralize]] a single creature that he can see and that can see him.</p>"
+                    "value": "<p><strong>Trigger</strong> Krosovahn Mendesil reduces an enemy to 0 Hit Points</p><hr /><p><strong>Effect</strong> After downing the foe, Krosovahn Mendesil menacingly reminds another foe that he's coming after them next. Krosovahn Mendesil attempts an Intimidation check with a +2 circumstance bonus to [[/act demoralize options=youre-next]] a single creature that he can see and that can see him.</p>"
                 },
                 "publication": {
                     "license": "OGL",

--- a/packs/pfs-season-6-bestiary/6-00/sharkskin.json
+++ b/packs/pfs-season-6-bestiary/6-00/sharkskin.json
@@ -1002,7 +1002,17 @@
                     "remaster": true,
                     "title": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "key": "FlatModifier",
+                        "predicate": [
+                            "action:demoralize",
+                            "youre-next"
+                        ],
+                        "selector": "intimidation",
+                        "value": 2
+                    }
+                ],
                 "slug": null,
                 "traits": {
                     "value": [

--- a/packs/pfs-season-6-bestiary/6-00/sharkskin.json
+++ b/packs/pfs-season-6-bestiary/6-00/sharkskin.json
@@ -995,7 +995,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> Sharkskin reduces an enemy to 0 hit points</p><hr /><p><strong>Effect</strong> Sharkskin attempts an Intimidation check to @UUID[Compendium.pf2e.actionspf2e.Item.Demoralize] a single creature xe can see with a +2 circumstance bonus.</p>"
+                    "value": "<p><strong>Trigger</strong> Sharkskin reduces an enemy to 0 hit points</p><hr /><p><strong>Effect</strong> Sharkskin attempts an Intimidation check to [[/act demoralize]] a single creature xe can see with a +2 circumstance bonus.</p>"
                 },
                 "publication": {
                     "license": "ORC",

--- a/packs/pfs-season-6-bestiary/6-00/sharkskin.json
+++ b/packs/pfs-season-6-bestiary/6-00/sharkskin.json
@@ -995,7 +995,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> Sharkskin reduces an enemy to 0 hit points</p><hr /><p><strong>Effect</strong> Sharkskin attempts an Intimidation check to [[/act demoralize]] a single creature xe can see with a +2 circumstance bonus.</p>"
+                    "value": "<p><strong>Trigger</strong> Sharkskin reduces an enemy to 0 hit points</p><hr /><p><strong>Effect</strong> Sharkskin attempts an Intimidation check to [[/act demoralize options=youre-next]] a single creature xe can see with a +2 circumstance bonus.</p>"
                 },
                 "publication": {
                     "license": "ORC",

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -3788,8 +3788,8 @@
                     "Lash": "Lash"
                 },
                 "YoureNext": {
-                    "Rogue": "After downing a foe, you menace another. Attempt to [[/act demoralize]] a creature within 60 feet, with a +2 circumstance bonus. If you have legendary proficiency in Intimidation, you can use this as a free action with the same trigger.",
-                    "Swashbuckler": "After downing a foe, you promise another that you're coming after them next. Attempt an Intimidation check with a +2 circumstance bonus to [[/act demoralize]] a single creature that you can see and that can see you. If you're legendary in Intimidation, you can use this as a free action with the same trigger.",
+                    "Rogue": "After downing a foe, you menace another. Attempt to [[/act demoralize options=youre-next]] a creature within 60 feet, with a +2 circumstance bonus. If you have legendary proficiency in Intimidation, you can use this as a free action with the same trigger.",
+                    "Swashbuckler": "After downing a foe, you promise another that you're coming after them next. Attempt an Intimidation check with a +2 circumstance bonus to [[/act demoralize options=youre-next]] a single creature that you can see and that can see you. If you're legendary in Intimidation, you can use this as a free action with the same trigger.",
                     "Trigger": "You reduce an enemy to 0 Hit Points."
                 }
             },

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -3788,8 +3788,8 @@
                     "Lash": "Lash"
                 },
                 "YoureNext": {
-                    "Rogue": "After downing a foe, you menace another. Attempt to @UUID[Compendium.pf2e.actionspf2e.Item.2u915NdUyQan6uKF]{Demoralize} a creature within 60 feet, with a +2 circumstance bonus. If you have legendary proficiency in Intimidation, you can use this as a free action with the same trigger.",
-                    "Swashbuckler": "After downing a foe, you promise another that you're coming after them next. Attempt an Intimidation check with a +2 circumstance bonus to @UUID[Compendium.pf2e.actionspf2e.Item.2u915NdUyQan6uKF]{Demoralize} a single creature that you can see and that can see you. If you're legendary in Intimidation, you can use this as a free action with the same trigger.",
+                    "Rogue": "After downing a foe, you menace another. Attempt to [[/act demoralize]] a creature within 60 feet, with a +2 circumstance bonus. If you have legendary proficiency in Intimidation, you can use this as a free action with the same trigger.",
+                    "Swashbuckler": "After downing a foe, you promise another that you're coming after them next. Attempt an Intimidation check with a +2 circumstance bonus to [[/act demoralize]] a single creature that you can see and that can see you. If you're legendary in Intimidation, you can use this as a free action with the same trigger.",
                     "Trigger": "You reduce an enemy to 0 Hit Points."
                 }
             },


### PR DESCRIPTION
Also removes the roll options from older actors as these are not in use