### PR TITLE
Update Extra Alchemy's rule element to execute after Advanced Alchemy slot upgrades

### DIFF
--- a/packs/feat-effects/effect-extra-alchemy.json
+++ b/packs/feat-effects/effect-extra-alchemy.json
@@ -25,6 +25,7 @@
                 "key": "ActiveEffectLike",
                 "mode": "add",
                 "path": "system.crafting.entries.advancedAlchemy.maxSlots",
+                "priority": 41,
                 "value": 1
             }
         ],


### PR DESCRIPTION
Closes #17893
I was sure I had accounted for this, but clearly I didn't. My bad!