### PR TITLE
Include failing property path in `RuleElementPF2e#resolveInjectedProperties` warning

### DIFF
--- a/src/module/rules/rule-element/base.ts
+++ b/src/module/rules/rule-element/base.ts
@@ -268,7 +268,7 @@ abstract class RuleElementPF2e<TSchema extends RuleElementSchema = RuleElementSc
                 })();
                 if (value === undefined) {
                     this.ignored = true;
-                    if (warn) this.failValidation(`Failed to resolve injected property "${source}"`);
+                    if (warn) this.failValidation(`Failed to resolve injected property "${prop}" in "${source}"`);
                 }
                 return String(value);
             });


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b30bca0f-1a9e-4674-81e4-a71e3f642025)
