### PR TITLE
Fix rarity for Armored Coat

### DIFF
--- a/packs/equipment/armored-coat.json
+++ b/packs/equipment/armored-coat.json
@@ -49,7 +49,7 @@
         "speedPenalty": 0,
         "strength": 2,
         "traits": {
-            "rarity": "common",
+            "rarity": "uncommon",
             "value": [
                 "comfort",
                 "flexible"


### PR DESCRIPTION
LO: KoL p. 86: "All the gear, armor, shields, and weapons in this section are uncommon, and Knights of Lastwall have access to all of them."