### PR TITLE
Fix update mechanic on RollOptions with merged suboptions

### DIFF
--- a/src/module/rules/rule-element/roll-option/rule-element.ts
+++ b/src/module/rules/rule-element/roll-option/rule-element.ts
@@ -197,18 +197,14 @@ class RollOptionRuleElement extends RuleElementPF2e<RollOptionSchema> {
      * Filter rules, including those with suboptions among the same merge family.
      * Includes ignored rules and those with failed predications. */
     #resolveSuboptionRules(): RuleElementPF2e[] {
-        const rules = this.mergeable
-            ? this.actor.rules.filter(
-                  (r) =>
-                      r instanceof RollOptionRuleElement &&
-                      r.toggleable &&
-                      r.mergeable &&
-                      r.domain === this.domain &&
-                      r.option === this.option,
-              )
-            : [];
-
-        return rules;
+        return this.actor.rules.filter(
+              (r) =>
+                  r instanceof RollOptionRuleElement &&
+                  r.toggleable &&
+                  r.mergeable &&
+                  r.domain === this.domain &&
+                  r.option === this.option,
+          );
     }
 
     #resolveOption({ withSuboption = false } = {}): string {

--- a/src/module/rules/rule-element/roll-option/rule-element.ts
+++ b/src/module/rules/rule-element/roll-option/rule-element.ts
@@ -198,13 +198,13 @@ class RollOptionRuleElement extends RuleElementPF2e<RollOptionSchema> {
      * Includes ignored rules and those with failed predications. */
     #resolveSuboptionRules(): RuleElementPF2e[] {
         return this.actor.rules.filter(
-              (r) =>
-                  r instanceof RollOptionRuleElement &&
-                  r.toggleable &&
-                  r.mergeable &&
-                  r.domain === this.domain &&
-                  r.option === this.option,
-          );
+            (r) =>
+                r instanceof RollOptionRuleElement &&
+                r.toggleable &&
+                r.mergeable &&
+                r.domain === this.domain &&
+                r.option === this.option,
+        );
     }
 
     #resolveOption({ withSuboption = false } = {}): string {

--- a/src/module/rules/rule-element/roll-option/rule-element.ts
+++ b/src/module/rules/rule-element/roll-option/rule-element.ts
@@ -193,6 +193,24 @@ class RollOptionRuleElement extends RuleElementPF2e<RollOptionSchema> {
         return suboptions;
     }
 
+    /**
+     * Filter rules, including those with suboptions among the same merge family.
+     * Includes ignored rules and those with failed predications. */
+    #resolveSuboptionRules(): RuleElementPF2e[] {
+        const rules = this.mergeable
+            ? this.actor.rules.filter(
+                  (r) =>
+                      r instanceof RollOptionRuleElement &&
+                      r.toggleable &&
+                      r.mergeable &&
+                      r.domain === this.domain &&
+                      r.option === this.option,
+              )
+            : [];
+
+        return rules;
+    }
+
     #resolveOption({ withSuboption = false } = {}): string {
         const baseOption = this.resolveInjectedProperties(this._source.option)
             .replace(/[^-:\w]/g, "")
@@ -335,7 +353,7 @@ class RollOptionRuleElement extends RuleElementPF2e<RollOptionSchema> {
 
         if (this.mergeable && selection) {
             // Update the items containing rule elements in the merge family
-            const rulesByItem = R.groupBy(R.unique(this.#resolveSuboptions().map((s) => s.rule)), (r) => r.item.id);
+            const rulesByItem = R.groupBy(this.#resolveSuboptionRules(), (r) => r.item.id);
             for (const [itemId, rules] of Object.entries(rulesByItem)) {
                 const item = actor.items.get(itemId, { strict: true });
                 const ruleSources = item.toObject().system.rules;


### PR DESCRIPTION
Closes #17015
Closes #17857
Closes #17932

If a new suboption is selected, all related `RollOptions` are updated. However, `#resolveSuboptions` is used to select the affected rules, which first filters out duplicates. This can result in individual `RuleElements` not being passed and therefore not being updated. During subsequent processing, these `RuleElements` then overwrite the new selection with the old value.

This PR adds a separate method `#resolveSuboptionRules` to find all `RollOptions` of the same family, replacing `#resolveSuboptions` in the update process.