### PR TITLE
Fix Versatile Vials having item bonus to attack rolls before level 4

### DIFF
--- a/packs/equipment/versatile-vial.json
+++ b/packs/equipment/versatile-vial.json
@@ -55,7 +55,15 @@
                 "key": "FlatModifier",
                 "selector": "{item|id}-attack",
                 "type": "item",
-                "value": "ternary(gte(@item.level,18),3,ternary(gte(@item.level,12),2,ternary(gte(@item.level,4),1)))"
+                "predicate": [
+                    {
+                        "gte": [
+                            "parent:level",
+                            4
+                        ]
+                    }
+                ],
+                "value": "ternary(gte(@item.level,18),3,ternary(gte(@item.level,12),2,1))"
             },
             {
                 "key": "DamageAlteration",

--- a/packs/equipment/versatile-vial.json
+++ b/packs/equipment/versatile-vial.json
@@ -55,7 +55,7 @@
                 "key": "FlatModifier",
                 "selector": "{item|id}-attack",
                 "type": "item",
-                "value": "ternary(gte(@item.level,18),3,ternary(gte(@item.level,12),2,1))"
+                "value": "ternary(gte(@item.level,18),3,ternary(gte(@item.level,12),2,ternary(gte(@item.level,4),1)))"
             },
             {
                 "key": "DamageAlteration",


### PR DESCRIPTION
Versatile Vials have a bug in automation that incorrectly applies item bonus to attack rolls from 4th level upgrade to lower level versions. As far as I can understand, the issue is in automation that scales them with actor level, the main problem lying in automation defaulting to +1 bonus for Versatile Vials below 12th level.