### PR TITLE
Correct level for the Quick Recovery Yaoguai ancestry feat

### DIFF
--- a/packs/feats/quick-recovery.json
+++ b/packs/feats/quick-recovery.json
@@ -18,7 +18,7 @@
             "per": "day"
         },
         "level": {
-            "value": 1
+            "value": 9
         },
         "prerequisites": {
             "value": []


### PR DESCRIPTION
Should be level 9