### PR TITLE
Remove most category getters from non-document spellcasting entries

### DIFF
--- a/src/module/actor/creature/document.ts
+++ b/src/module/actor/creature/document.ts
@@ -373,7 +373,7 @@ abstract class CreaturePF2e<
             // PC1 p.298, When you gain an innate spell, you become trained in the spell attack modifier
             // and spell DC statistics. At 12th level, these proficiencies increase to expert.
             const actualSpellcasting = this.spellcasting.filter((e) => e.system && !e.system?.proficiency.slug);
-            if (actualSpellcasting.some((e) => e.isInnate)) {
+            if (actualSpellcasting.some((e) => e.category === "innate")) {
                 spellcasting.rank = Math.max(spellcasting.rank, this.level >= 12 ? 2 : 1) as ZeroToFour;
             } else if (actualSpellcasting.length) {
                 // If you can cast spells using spellcasting prof, you logically need to be at least trained
@@ -392,10 +392,8 @@ abstract class CreaturePF2e<
     }
 
     protected override prepareDataFromItems(): void {
-        this.spellcasting = new ActorSpellcasting(this, [
-            ...this.itemTypes.spellcastingEntry,
-            new RitualSpellcasting(this),
-        ]);
+        this.spellcasting ??= new ActorSpellcasting(this);
+        this.spellcasting.initialize([...this.itemTypes.spellcastingEntry, new RitualSpellcasting(this)]);
 
         super.prepareDataFromItems();
     }

--- a/src/module/actor/creature/sheet.ts
+++ b/src/module/actor/creature/sheet.ts
@@ -323,7 +323,7 @@ abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends ActorSheet
             // Confirm whether this is a swap and execute if so
             const { collectionId, groupId, slotIndex } = spellFrom;
             const collection = this.actor.spellcasting.collections.get(spellFrom.collectionId, { strict: true });
-            const isPrepared = collection.entry.isPrepared;
+            const isPrepared = collection.entry.category === "prepared";
             const collectionEl = htmlClosest(event.target, "[data-container-id]");
             const sameCollectionId = collectionId === collectionEl?.dataset.containerId;
 

--- a/src/module/actor/spellcasting.ts
+++ b/src/module/actor/spellcasting.ts
@@ -22,10 +22,19 @@ export class ActorSpellcasting<TActor extends ActorPF2e> extends DelegatedCollec
     /** Cache of trick magic item entries */
     #trickEntries: Record<string, BaseSpellcastingEntry<TActor> | undefined> = {};
 
-    constructor(actor: TActor, entries: BaseSpellcastingEntry<TActor>[]) {
-        super(entries.map((entry) => [entry.id, entry]));
+    constructor(actor: TActor) {
+        super();
         this.actor = actor;
+    }
 
+    /** Initializes spellcasting data. Must be called every data preparation */
+    initialize(entries: BaseSpellcastingEntry<TActor>[]): void {
+        this.clear();
+        for (const entry of entries) {
+            this.set(entry.id, entry);
+        }
+
+        this.collections.clear();
         for (const entry of entries) {
             if (entry.spells) this.collections.set(entry.spells.id, entry.spells);
         }

--- a/src/module/apps/compendium-browser/browser.ts
+++ b/src/module/apps/compendium-browser/browser.ts
@@ -236,7 +236,7 @@ class CompendiumBrowser extends SvelteApplicationMixin(foundry.applications.api.
             filter.checkboxes.category.selected.push(category);
         }
 
-        if (entry.isRitual || entry.isFocusPool) {
+        if (entry.category === "ritual" || entry.isFocusPool) {
             filter.checkboxes.category.options[entry.category].selected = true;
             filter.checkboxes.category.selected.push(entry.category);
         }
@@ -247,13 +247,13 @@ class CompendiumBrowser extends SvelteApplicationMixin(foundry.applications.api.
                 filter.checkboxes.rank.options[rank].selected = true;
                 filter.checkboxes.rank.selected.push(rank);
             }
-            if ((entry.isPrepared || entry.isSpontaneous || entry.isInnate) && !category) {
+            if (["prepared", "spontaneous", "innate"].includes(entry.category) && !category) {
                 filter.checkboxes.category.options["spell"].selected = true;
                 filter.checkboxes.category.selected.push("spell");
             }
         }
 
-        if (entry.tradition && !entry.isFocusPool && !entry.isRitual) {
+        if (entry.tradition && !entry.isFocusPool && entry.category !== "ritual") {
             traditions.options[entry.tradition].selected = true;
             traditions.selected.push(entry.tradition);
         }

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -675,7 +675,7 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
     }
 
     override prepareSiblingData(this: SpellPF2e<ActorPF2e>): void {
-        if (this.spellcasting?.isInnate) {
+        if (this.spellcasting?.category === "innate") {
             fu.mergeObject(this.system.location, { uses: { value: 1, max: 1 } }, { overwrite: false });
         }
     }
@@ -706,7 +706,7 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
             spellOptions.add(`${prefix}:trait:${spellcasting.tradition}`);
         }
 
-        const entryHasSlots = !!(spellcasting?.isPrepared || spellcasting?.isSpontaneous);
+        const entryHasSlots = ["prepared", "spontaneous"].includes(spellcasting?.category ?? "");
         if (entryHasSlots && !this.isCantrip && !this.parentItem) {
             spellOptions.add(`${prefix}:spell-slot`);
         }
@@ -725,7 +725,7 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
             spellOptions.add(`${prefix}:frequency:limited`);
         }
 
-        if (spellcasting?.isSpontaneous && this.system.location.signature) {
+        if (spellcasting?.category === "spontaneous" && this.system.location.signature) {
             spellOptions.add(`${prefix}:signature`);
         }
 

--- a/src/module/item/spellcasting-entry/item-spellcasting.ts
+++ b/src/module/item/spellcasting-entry/item-spellcasting.ts
@@ -61,22 +61,6 @@ class ItemSpellcasting<TActor extends CreaturePF2e = CreaturePF2e> implements Sp
         return false;
     }
 
-    get isInnate(): false {
-        return false;
-    }
-
-    get isPrepared(): false {
-        return false;
-    }
-
-    get isSpontaneous(): false {
-        return false;
-    }
-
-    get isRitual(): false {
-        return false;
-    }
-
     get isEphemeral(): true {
         return true;
     }
@@ -103,18 +87,7 @@ class ItemSpellcasting<TActor extends CreaturePF2e = CreaturePF2e> implements Sp
         const collectionData: SpellCollectionData = (await spells?.getSpellData()) ?? { groups: [], prepList: null };
 
         return {
-            ...R.pick(this, [
-                "category",
-                "tradition",
-                "sort",
-                "isFlexible",
-                "isFocusPool",
-                "isInnate",
-                "isPrepared",
-                "isRitual",
-                "isSpontaneous",
-                "isEphemeral",
-            ]),
+            ...R.pick(this, ["category", "tradition", "sort", "isFlexible", "isFocusPool", "isEphemeral"]),
             ...collectionData,
             id: spells?.id ?? this.id,
             name: spells?.name ?? this.name,

--- a/src/module/item/spellcasting-entry/rituals.ts
+++ b/src/module/item/spellcasting-entry/rituals.ts
@@ -46,20 +46,8 @@ export class RitualSpellcasting<TActor extends ActorPF2e> implements BaseSpellca
         return false;
     }
 
-    get isInnate(): false {
-        return false;
-    }
-
-    get isPrepared(): false {
-        return false;
-    }
-
     get isRitual(): true {
         return true;
-    }
-
-    get isSpontaneous(): false {
-        return false;
     }
 
     get isEphemeral(): true {

--- a/src/module/item/spellcasting-entry/trick.ts
+++ b/src/module/item/spellcasting-entry/trick.ts
@@ -128,22 +128,6 @@ class TrickMagicItemEntry<TActor extends ActorPF2e = ActorPF2e> implements Spell
         return false;
     }
 
-    get isInnate(): false {
-        return false;
-    }
-
-    get isPrepared(): false {
-        return false;
-    }
-
-    get isRitual(): false {
-        return false;
-    }
-
-    get isSpontaneous(): false {
-        return false;
-    }
-
     get isEphemeral(): true {
         return true;
     }

--- a/src/module/item/spellcasting-entry/types.ts
+++ b/src/module/item/spellcasting-entry/types.ts
@@ -17,10 +17,6 @@ interface BaseSpellcastingEntry<TActor extends ActorPF2e | null = ActorPF2e | nu
     attribute?: Maybe<AttributeString>;
     isFlexible: boolean;
     isFocusPool: boolean;
-    isInnate: boolean;
-    isPrepared: boolean;
-    isRitual: boolean;
-    isSpontaneous: boolean;
     isEphemeral: boolean;
     statistic?: Statistic | null;
     /** A related but more-limited statistic for making counteract checks */


### PR DESCRIPTION
Adding these getters to each new spellcasting type is silliness. The ones that can return true still exist because they're easy to keep around, but they're on the chopping block.