### PR TITLE
Fix multiplying addendum notes on spells

### DIFF
--- a/src/module/item/base/sheet/sheet.ts
+++ b/src/module/item/base/sheet/sheet.ts
@@ -101,11 +101,12 @@ class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem, ItemSheetOp
         const rollData = { ...this.item.getRollData(), ...this.actor?.getRollData() };
 
         // Get the source description in case this is an unidentified physical item
-        enrichedContent.description = await TextEditor.enrichHTML(item._source.system.description.value, {
+        const description = await item.getDescription();
+        enrichedContent.description = await TextEditor.enrichHTML(description.value, {
             rollData,
             secrets: item.isOwner,
         });
-        enrichedContent.gmNotes = await TextEditor.enrichHTML(item.system.description.gm.trim(), { rollData });
+        enrichedContent.gmNotes = await TextEditor.enrichHTML(description.gm.trim(), { rollData });
 
         const validTraits = this.validTraits;
         const hasRarity = !item.isOfType("action", "condition", "deity", "effect", "lore", "melee");

--- a/src/module/item/consumable/document.ts
+++ b/src/module/item/consumable/document.ts
@@ -2,8 +2,8 @@ import type { ActorPF2e } from "@actor";
 import { TrickMagicItemPopup } from "@actor/sheet/trick-magic-item-popup.ts";
 import type { SpellPF2e, WeaponPF2e } from "@item";
 import { ItemProxyPF2e, PhysicalItemPF2e } from "@item";
-import { processSanctification } from "@item/ability/helpers.ts";
 import { RawItemChatData } from "@item/base/data/index.ts";
+import { performLatePreparation } from "@item/helpers.ts";
 import { TrickMagicItemEntry } from "@item/spellcasting-entry/trick.ts";
 import type { SpellcastingEntry } from "@item/spellcasting-entry/types.ts";
 import type { ValueAndMax } from "@module/data.ts";
@@ -43,13 +43,7 @@ class ConsumablePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extend
         const spellSource = fu.mergeObject(this.system.spell, { "system.location.value": null }, { inplace: false });
         const context = { parent: this.actor, parentItem: this };
         const spell = new ItemProxyPF2e(spellSource, context) as SpellPF2e<NonNullable<TParent>>;
-
-        for (const alteration of this.actor.synthetics.itemAlterations) {
-            alteration.applyAlteration({ singleItem: spell });
-        }
-
-        processSanctification(spell);
-
+        performLatePreparation(spell);
         return spell;
     }
 

--- a/src/module/item/spell/sheet.ts
+++ b/src/module/item/spell/sheet.ts
@@ -19,7 +19,7 @@ import {
 } from "@util";
 import { tagify } from "@util/tags.ts";
 import * as R from "remeda";
-import { createDescriptionPrepend, createSpellRankLabel } from "./helpers.ts";
+import { createSpellRankLabel } from "./helpers.ts";
 import type {
     EffectAreaShape,
     SpellDamageSource,
@@ -64,9 +64,6 @@ export class SpellSheetPF2e extends ItemSheetPF2e<SpellPF2e> {
     override async getData(options?: Partial<ItemSheetOptions>): Promise<SpellSheetData> {
         const sheetData = await super.getData(options);
         const spell = this.item;
-
-        const descriptionPrepend = await createDescriptionPrepend(spell, { includeTraditions: true });
-        sheetData.enrichedContent.description = `${descriptionPrepend}${sheetData.enrichedContent.description}`;
 
         const variants = spell.overlays.overrideVariants
             .map((variant) => ({

--- a/src/module/item/weapon/document.ts
+++ b/src/module/item/weapon/document.ts
@@ -7,6 +7,7 @@ import type { ConsumablePF2e, MeleePF2e, ShieldPF2e } from "@item";
 import { ItemProxyPF2e, PhysicalItemPF2e } from "@item";
 import { createActionRangeLabel } from "@item/ability/helpers.ts";
 import type { ItemSourcePF2e, MeleeSource, RawItemChatData } from "@item/base/data/index.ts";
+import { performLatePreparation } from "@item/helpers.ts";
 import type { NPCAttackDamage } from "@item/melee/data.ts";
 import type { NPCAttackTrait } from "@item/melee/types.ts";
 import type { PhysicalItemConstructionContext } from "@item/physical/document.ts";
@@ -483,11 +484,9 @@ class WeaponPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
             recurse ? (meleeUsage?.toThrownUsage() ?? []) : [],
         ].flat();
 
-        // Apply item alterations to all alt usages
-        for (const rule of this.actor?.synthetics.itemAlterations ?? []) {
-            for (const weapon of altUsages) {
-                rule.applyAlteration({ singleItem: weapon as WeaponPF2e<NonNullable<TParent>> });
-            }
+        // Apply late prep procedures to all alt usages
+        for (const weapon of altUsages) {
+            performLatePreparation(weapon as WeaponPF2e<NonNullable<TParent>>);
         }
 
         return altUsages;

--- a/src/module/rules/rule-element/item-alteration/rule-element.ts
+++ b/src/module/rules/rule-element/item-alteration/rule-element.ts
@@ -52,6 +52,11 @@ class ItemAlterationRuleElement extends RuleElementPF2e<ItemAlterationRuleSchema
     /** Alteration properties that should only be processed when requested directly */
     static #LAZY_PROPERTIES = ["description"];
 
+    /** If this item alteration is lazy and should be applied only when requested */
+    get isLazy(): boolean {
+        return this.constructor.#LAZY_PROPERTIES.includes(this.property);
+    }
+
     override async preCreate({ tempItems }: RuleElementPF2e.PreCreateParams): Promise<void> {
         if (this.ignored) return;
 
@@ -89,17 +94,15 @@ class ItemAlterationRuleElement extends RuleElementPF2e<ItemAlterationRuleSchema
 
     override onApplyActiveEffects(): void {
         this.actor.synthetics.itemAlterations.push(this);
-        const isLazy = this.constructor.#LAZY_PROPERTIES.includes(this.property);
         const isDelayed = this.constructor.#DELAYED_PROPERTIES.includes(this.property);
-        if (!isLazy && !isDelayed) {
+        if (!this.isLazy && !isDelayed) {
             this.applyAlteration();
         }
     }
 
     override afterPrepareData(): void {
-        const isLazy = this.constructor.#LAZY_PROPERTIES.includes(this.property);
         const isDelayed = this.constructor.#DELAYED_PROPERTIES.includes(this.property);
-        if (!isLazy && isDelayed) {
+        if (!this.isLazy && isDelayed) {
             this.applyAlteration();
         }
     }

--- a/src/module/rules/rule-element/strike.ts
+++ b/src/module/rules/rule-element/strike.ts
@@ -1,5 +1,6 @@
 import type { ActorPF2e, ActorType, CharacterPF2e, NPCPF2e } from "@actor";
 import { WeaponPF2e } from "@item";
+import { performLatePreparation } from "@item/helpers.ts";
 import type { NPCAttackTrait } from "@item/melee/types.ts";
 import { BaseShieldType } from "@item/shield/types.ts";
 import type { WeaponRuneSource, WeaponSource } from "@item/weapon/data.ts";
@@ -283,10 +284,7 @@ class StrikeRuleElement extends RuleElementPF2e<StrikeSchema> {
         const weapon = new WeaponPF2e(source, { parent: actor });
         weapon.rule = this;
         weapon.name = weapon._source.name; // Remove renaming by runes
-        for (const alteration of actor.synthetics.itemAlterations) {
-            alteration.applyAlteration({ singleItem: weapon });
-        }
-
+        performLatePreparation(weapon);
         return weapon;
     }
 


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/18018. Applies to both real spells and fake spells such as signature spells. I copied over some of the refactors of the staff PR regarding descriptions so that it works a bit more smoothly.

