### PR TITLE
Avoid saving temporary modifications to weapon striking runes when editing the weapon

### DIFF
--- a/src/module/item/weapon/sheet.ts
+++ b/src/module/item/weapon/sheet.ts
@@ -178,8 +178,6 @@ export class WeaponSheetPF2e extends PhysicalItemSheetPF2e<WeaponPF2e> {
                 delete formData[`system.runes.property.${index}`];
             }
         }
-        formData["system.runes.potency"] ||= 0;
-        formData["system.runes.striking"] ||= 0;
 
         return super._updateObject(event, formData);
     }

--- a/static/templates/items/weapon-details.hbs
+++ b/static/templates/items/weapon-details.hbs
@@ -70,14 +70,14 @@
         {{#unless abpEnabled}}
             <div class="form-group">
                 <label for="{{fieldIdPrefix}}rune-potency">{{localize "PF2E.PotencyRuneLabel"}}</label>
-                <select name="system.runes.potency" id="{{fieldIdPrefix}}rune-potency" data-dtype="Number">
+                <select data-property="system.runes.potency" id="{{fieldIdPrefix}}rune-potency" data-dtype="Number">
                     <option value="0"></option>
                     {{selectOptions (omit runeTypes.potency 0) selected=data.runes.potency labelAttr="name" localize=true}}
                 </select>
             </div>
             <div class="form-group">
                 <label for="{{fieldIdPrefix}}rune-striking">{{localize "PF2E.StrikingRuneLabel"}}</label>
-                <select name="system.runes.striking" id="{{fieldIdPrefix}}rune-striking" data-dtype="Number">
+                <select data-property="system.runes.striking" id="{{fieldIdPrefix}}rune-striking" data-dtype="Number">
                     <option value="0"></option>
                     {{selectOptions (omit runeTypes.striking 0) selected=data.runes.striking labelAttr="name" localize=true}}
                 </select>


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/18025