### PR TITLE
Fix level of Moderate Chromatic Jellyfish Oil

### DIFF
--- a/packs/equipment/chromatic-jellyfish-oil-moderate.json
+++ b/packs/equipment/chromatic-jellyfish-oil-moderate.json
@@ -19,7 +19,7 @@
             "value": 0
         },
         "level": {
-            "value": 11
+            "value": 14
         },
         "material": {
             "grade": null,


### PR DESCRIPTION
Moderate Chromatic Jellyfish Oil was set to Level 11; the actual level is 14 (see https://2e.aonprd.com/Equipment.aspx?ID=1959 )

I opened a previous Issue about this, #18047 .