### PR TITLE
Disable whitespace sensitivity for svelte files

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -20,7 +20,8 @@
                 "*.svelte"
             ],
             "options": {
-                "parser": "svelte"
+                "parser": "svelte",
+                "htmlWhitespaceSensitivity": "ignore"
             }
         },
         {

--- a/src/module/actor/character/apps/abc-picker/app.svelte
+++ b/src/module/actor/character/apps/abc-picker/app.svelte
@@ -66,8 +66,10 @@
                 class="confirm"
                 aria-labelledby="tooltip"
                 data-tooltip="PF2E.Actor.Character.ABCPicker.Tooltip.ConfirmSelection"
-                onclick={saveSelection}><i class="fa-solid fa-check"></i></button
+                onclick={saveSelection}
             >
+                <i class="fa-solid fa-check"></i>
+            </button>
         </li>
     {/each}
 </ul>


### PR DESCRIPTION
Svelte collapses whitespace by default, so the setting is unnecessary and only leads to ugly html