### PR TITLE
Fix damage of Spray of Stars

### DIFF
--- a/packs/spells/spray-of-stars.json
+++ b/packs/spells/spray-of-stars.json
@@ -15,7 +15,7 @@
             "0": {
                 "applyMod": false,
                 "category": null,
-                "formula": "1d4",
+                "formula": "2d4",
                 "kinds": [
                     "damage"
                 ],


### PR DESCRIPTION
Spray Of Stars deals 2d4 fire, not 1d4. It dealt 1d4 in legacy