### PR TITLE
Extend ItemAlteration to be able to change base damage dice number

### DIFF
--- a/src/module/rules/rule-element/item-alteration/alteration.ts
+++ b/src/module/rules/rule-element/item-alteration/alteration.ts
@@ -25,6 +25,7 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
         "category",
         "check-penalty",
         "damage-dice-faces",
+        "damage-dice-number",
         "damage-type",
         "defense-passive",
         "description",
@@ -191,6 +192,23 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
                     }
                     item.system.damage.die = `d${data.alteration.value}`;
                 }
+
+                return;
+            }
+            case "damage-dice-number": {
+                const validator = ITEM_ALTERATION_VALIDATORS[this.property];
+                if (!validator.isValid(data) || !(data.item instanceof ItemPF2e)) {
+                    return;
+                }
+
+                const item = data.item;
+                if (!item.system.damage.dice) return;
+                const newValue = AELikeRuleElement.getNewValue(
+                    this.mode,
+                    item.system.damage.dice,
+                    data.alteration.value,
+                );
+                item.system.damage.dice = newValue;
 
                 return;
             }

--- a/src/module/rules/rule-element/item-alteration/alteration.ts
+++ b/src/module/rules/rule-element/item-alteration/alteration.ts
@@ -197,10 +197,7 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
             }
             case "damage-dice-number": {
                 const validator = ITEM_ALTERATION_VALIDATORS[this.property];
-                if (!validator.isValid(data) || !(data.item instanceof ItemPF2e)) {
-                    return;
-                }
-
+                if (!validator.isValid(data)) return;
                 const item = data.item;
                 if (!item.system.damage.dice) return;
                 const newValue = AELikeRuleElement.getNewValue(
@@ -209,7 +206,6 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
                     data.alteration.value,
                 );
                 item.system.damage.dice = newValue;
-
                 return;
             }
             case "damage-type": {

--- a/src/module/rules/rule-element/item-alteration/schemas.ts
+++ b/src/module/rules/rule-element/item-alteration/schemas.ts
@@ -217,6 +217,20 @@ const ITEM_ALTERATION_VALIDATORS = {
             },
         },
     ),
+    "damage-dice-number": new ItemAlterationValidator({
+        itemType: new fields.StringField({ required: true, choices: ["weapon"] }),
+        mode: new fields.StringField({
+            required: true,
+            choices: ["add", "downgrade", "override", "remove", "subtract", "upgrade"],
+        }),
+        value: new fields.NumberField({
+            required: true,
+            nullable: false,
+            integer: true,
+            positive: true,
+            initial: undefined,
+        } as const),
+    }),
     "damage-type": new ItemAlterationValidator({
         itemType: new fields.StringField({ required: true, choices: ["weapon"] }),
         mode: new fields.StringField({ required: true, choices: ["override"] }),


### PR DESCRIPTION
Sort of fixes #18054, #18032 and #16714?

While looking for DamageAlteration info, I noticed that in #18032, Shark mentioned that increasing the damage of weapons should be done in ItemAlteration. I suspect he meant damage faces, but I was curious if you could really do base weapon damage dice number increases that way, and turns out, yeah?

Additionally, I think having the base weapon damage dice number increased for weapons in ItemAlteration makes more sense than having it in DamageAlteration. This solution also "fixes" the problem that Gravity Weapon and the like have, where by referring to `@weapon.system.damage.dice`, they don't benefit from DamageAlteration increases.