### PR TITLE
Prevent having two sets of origin options for non-saves

### DIFF
--- a/src/module/system/statistic/statistic.ts
+++ b/src/module/system/statistic/statistic.ts
@@ -127,7 +127,8 @@ class Statistic<TActor extends ActorPF2e = ActorPF2e> extends BaseStatistic<TAct
     }
 
     override createRollOptions(domains = this.domains, args: RollOptionConfig = {}): Set<string> {
-        const { item, extraRollOptions, origin, target } = args;
+        const { item, extraRollOptions, target } = args;
+        const origin = args.origin ?? (item?.actor && item.actor.uuid !== this.actor.uuid ? item.actor : null);
 
         const rollOptions: string[] = [];
         if (domains.length > 0) {
@@ -144,9 +145,6 @@ class Statistic<TActor extends ActorPF2e = ActorPF2e> extends BaseStatistic<TAct
 
         if (item) {
             rollOptions.push(...item.getRollOptions("item"));
-            if (item.actor && item.actor.uuid !== this.actor.uuid) {
-                rollOptions.push(...item.actor.getSelfRollOptions("origin"));
-            }
 
             // Special cases, traits that modify the action itself universally
             // This might change once we've better decided how derivative traits will work


### PR DESCRIPTION
It seems the code we're removing predates the origin/target options. Currently if an NPC ability includes an inline perception check that is posted to chat, the origin is the roller and not the NPC. This conflicted with item.actor, creating two sets of origin options.

After this, it should only post the roller's options as the origin by default.

This bug looks ancient though, I wonder why now.