### PR TITLE
Correct monster warden circumstance bonus

### DIFF
--- a/packs/feat-effects/effect-monster-warden.json
+++ b/packs/feat-effects/effect-monster-warden.json
@@ -4,7 +4,7 @@
     "name": "Effect: Monster Warden",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Monster Warden]</p>\n<p>You gain a +2 circumstance bonus to your next attack roll against that prey.</p>\n<p>You gain a +2 circumstance bonus to your next saving throw against that particular creature and to your AC against that creature's next attack against you.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Monster Warden]</p>\n<p>You gain a +1 circumstance bonus to your next attack roll against that prey.</p>\n<p>You gain a +2 circumstance bonus either to your AC the next time the creature attacks you or to your next saving throw against an effect from that particular creature (whichever comes first.)</p>"
         },
         "duration": {
             "expiry": null,
@@ -35,11 +35,19 @@
                 ],
                 "selector": [
                     "ac",
-                    "attack",
                     "saving-throw"
                 ],
                 "type": "circumstance",
                 "value": 2
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "monster-hunter"
+                ],
+                "selector": "attack",
+                "type": "circumstance",
+                "value": 1
             }
         ],
         "start": {


### PR DESCRIPTION
Closes #18079

Separate the FlatModifier RE on the `Effect: Monster Warden` to only provide a +1 to attacks.