### PR TITLE
Add Mythic as an effect-only proficiency

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -183,7 +183,7 @@ interface GamePF2e
                 pwol: {
                     enabled: boolean;
                     /** Modifiers for each proficiency rank */
-                    modifiers: [number, number, number, number, number];
+                    modifiers: [number, number, number, number, number, number];
                 };
                 /** Stamina */
                 stamina: boolean;
@@ -284,6 +284,7 @@ declare global {
         get(module: "pf2e", setting: "proficiencyExpertModifier"): number;
         get(module: "pf2e", setting: "proficiencyMasterModifier"): number;
         get(module: "pf2e", setting: "proficiencyLegendaryModifier"): number;
+        get(module: "pf2e", setting: "proficiencyMythicModifier"): number;
 
         get(module: "pf2e", setting: "metagame_partyVision"): boolean;
         get(module: "pf2e", setting: "metagame_secretCondition"): boolean;

--- a/src/module/actor/actions/base.ts
+++ b/src/module/actor/actions/base.ts
@@ -1,7 +1,6 @@
 import type { AbilityTrait } from "@item/ability/index.ts";
-import type { ProficiencyRank } from "@item/base/data/index.ts";
 import { ChatMessagePF2e } from "@module/chat-message/document.ts";
-import { PROFICIENCY_RANKS } from "@module/data.ts";
+import { getIndexedProficiencyOptions, ProficiencyRankString } from "@module/data.ts";
 import { getActionGlyph, sluggify } from "@util";
 import {
     Action,
@@ -26,20 +25,23 @@ interface BaseActionData<ActionVariantDataType extends BaseActionVariantData = B
     description: string;
     img?: string;
     name: string;
-    sampleTasks?: Partial<Record<ProficiencyRank, string>>;
+    sampleTasks?: Partial<Record<ProficiencyRankString, string>>;
     section?: ActionSection;
     slug?: string | null;
     traits?: AbilityTrait[];
     variants?: ActionVariantDataType | ActionVariantDataType[];
 }
 
-function labelSampleTasks(sampleTasks: Partial<Record<ProficiencyRank, string>>): { label: string; text: string }[] {
-    const unlabeled: { rank: ProficiencyRank; text: string }[] = [];
+function labelSampleTasks(
+    sampleTasks: Partial<Record<ProficiencyRankString, string>>,
+): { label: string; text: string }[] {
+    const unlabeled: { rank: ProficiencyRankString; text: string }[] = [];
     let rank: keyof typeof sampleTasks;
     for (rank in sampleTasks) {
         unlabeled.push({ rank, text: sampleTasks[rank]! });
     }
-    unlabeled.sort((t1, t2) => PROFICIENCY_RANKS.indexOf(t1.rank) - PROFICIENCY_RANKS.indexOf(t2.rank));
+    const indexedProficiencies = getIndexedProficiencyOptions();
+    unlabeled.sort((t1, t2) => indexedProficiencies[t1.rank]?.rank - indexedProficiencies[t2.rank]?.rank);
     return unlabeled.map((task) => ({ label: CONFIG.PF2E.proficiencyRanks[task.rank], text: task.text }));
 }
 
@@ -117,7 +119,7 @@ abstract class BaseAction<TData extends BaseActionVariantData, TAction extends B
     readonly description?: string;
     readonly img?: string;
     readonly name: string;
-    readonly sampleTasks?: Partial<Record<ProficiencyRank, string>>;
+    readonly sampleTasks?: Partial<Record<ProficiencyRankString, string>>;
     readonly section?: ActionSection;
     readonly slug: string;
     readonly traits: AbilityTrait[];

--- a/src/module/actor/actions/types.ts
+++ b/src/module/actor/actions/types.ts
@@ -1,8 +1,8 @@
 import type { ActorPF2e } from "@actor";
 import type { AbilityTrait } from "@item/ability/index.ts";
-import type { ProficiencyRank } from "@item/base/data/index.ts";
 import type { TokenPF2e } from "@module/canvas/index.ts";
 import type { ChatMessagePF2e } from "@module/chat-message/document.ts";
+import { ProficiencyRankString } from "@module/data.ts";
 
 type ActionCost = "free" | "reaction" | 0 | 1 | 2 | 3;
 type ActionSection = "basic" | "skill" | "specialty-basic";
@@ -44,7 +44,7 @@ interface Action {
     glyph?: string;
     img?: string;
     name: string;
-    sampleTasks?: Partial<Record<ProficiencyRank, string>>;
+    sampleTasks?: Partial<Record<ProficiencyRankString, string>>;
     section?: ActionSection;
     slug: string;
     traits: AbilityTrait[];

--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -318,6 +318,13 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
         return game.combat?.combatants.find((c) => c.actor?.uuid === this.uuid) ?? null;
     }
 
+    get isMythic(): boolean {
+        return Boolean(
+            game.pf2e.settings.campaign.mythic !== "disabled" &&
+                this.itemTypes.feat.some((f) => f.category === "calling"),
+        );
+    }
+
     /** Add effect icons from effect items and rule elements */
     override get temporaryEffects(): ActiveEffectPF2e<this>[] {
         const fromConditions = this.conditions.map((c) => ActiveEffectPF2e.fromEffect(c));

--- a/src/module/actor/character/data.ts
+++ b/src/module/actor/character/data.ts
@@ -27,11 +27,10 @@ import {
 import { AttributeString, MovementType, SaveType, SkillSlug } from "@actor/types.ts";
 import type { WeaponPF2e } from "@item";
 import { ArmorCategory } from "@item/armor/types.ts";
-import { ProficiencyRank } from "@item/base/data/index.ts";
 import { DeitySystemData } from "@item/deity/data.ts";
 import { DeityDomain } from "@item/deity/types.ts";
 import { BaseWeaponType, WeaponCategory, WeaponGroup } from "@item/weapon/types.ts";
-import { ValueAndMax, ZeroToFour } from "@module/data.ts";
+import { ProficiencyRankNumber, ProficiencyRankString, ValueAndMax } from "@module/data.ts";
 import { DamageType } from "@system/damage/types.ts";
 import type { Predicate } from "@system/predication.ts";
 import type { CharacterPF2e } from "./document.ts";
@@ -73,7 +72,7 @@ interface CharacterSystemSource extends CreatureSystemSource {
     proficiencies?: {
         attacks?: Record<string, MartialProficiencySource | undefined>;
     };
-    skills: Partial<Record<SkillSlug, { rank: ZeroToFour }>>;
+    skills: Partial<Record<SkillSlug, { rank: ProficiencyRankNumber }>>;
     resources: CharacterResourcesSource;
     initiative: CreatureInitiativeSource;
     crafting?: { formulas: CraftingFormulaData[] };
@@ -87,7 +86,7 @@ interface CharacterSystemSource extends CreatureSystemSource {
 }
 
 interface MartialProficiencySource {
-    rank: ZeroToFour;
+    rank: ProficiencyRankNumber;
     custom?: boolean;
 }
 
@@ -278,7 +277,7 @@ type SourceOmission = "customModifiers" | "perception" | "resources" | "saves" |
 interface CharacterSkillData extends SkillData {
     attribute: AttributeString;
     /** The proficiency rank ("TEML") */
-    rank: ZeroToFour;
+    rank: ProficiencyRankNumber;
     /** Whether this skill is subject to an armor check penalty */
     armor: boolean;
     /** Is this skill a Lore skill? */
@@ -341,7 +340,7 @@ type CharacterAbilities = Record<AttributeString, CharacterAbilityData>;
 
 interface CharacterSaveData extends SaveData {
     /** The proficiency rank ("TEML") */
-    rank: ZeroToFour;
+    rank: ProficiencyRankNumber;
 }
 type CharacterSaves = Record<SaveType, CharacterSaveData>;
 
@@ -352,7 +351,7 @@ interface CharacterProficiency {
     /** Describes how the value was computed. */
     breakdown: string;
     /** The proficiency rank (0 untrained - 4 legendary). */
-    rank: ZeroToFour;
+    rank: ProficiencyRankNumber;
 }
 
 /** A proficiency with a rank that depends on another proficiency */
@@ -363,7 +362,7 @@ interface MartialProficiency extends CharacterProficiency {
     /** The category to which this proficiency is linked */
     sameAs?: WeaponCategory | ArmorCategory;
     /** The maximum rank this proficiency can reach */
-    maxRank?: Exclude<ProficiencyRank, "untrained">;
+    maxRank?: Exclude<ProficiencyRankString, "untrained">;
     /** Whether the proficiency was manually added by the user */
     custom?: boolean;
 }
@@ -377,7 +376,7 @@ type WeaponGroupProficiencyKey = `weapon-group-${WeaponGroup}`;
 /** The full data for the class DC; similar to SkillData, but is not rollable. */
 interface ClassDCData extends Required<AttributeBasedTraceData> {
     label: string;
-    rank: ZeroToFour;
+    rank: ProficiencyRankNumber;
     primary: boolean;
 }
 
@@ -423,7 +422,7 @@ type CharacterResources = CreatureResources & {
 };
 
 interface CharacterPerceptionData extends CreaturePerceptionData {
-    rank: ZeroToFour;
+    rank: ProficiencyRankNumber;
 }
 
 interface CharacterDetails extends Omit<CharacterDetailsSource, "alliance">, CreatureDetails {

--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -27,7 +27,7 @@ import { BaseWeaponType, WeaponGroup } from "@item/weapon/types.ts";
 import { WEAPON_CATEGORIES } from "@item/weapon/values.ts";
 import { DropCanvasItemDataPF2e } from "@module/canvas/drop-canvas-data.ts";
 import { ChatMessagePF2e } from "@module/chat-message/document.ts";
-import { LabeledValueAndMax, ZeroToFour } from "@module/data.ts";
+import { LabeledValueAndMax, ProficiencyRankNumber } from "@module/data.ts";
 import { eventToRollParams } from "@module/sheet/helpers.ts";
 import { craft } from "@system/action-macros/crafting/craft.ts";
 import { DamageType } from "@system/damage/types.ts";
@@ -116,7 +116,7 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
             if (tab) tab.initial = "biography";
         }
 
-        sheetData.numberToRank = R.mapToObj([0, 1, 2, 3, 4] as const, (n) => [
+        sheetData.numberToRank = R.mapToObj([0, 1, 2, 3, 4, 5] as const, (n) => [
             n,
             game.i18n.localize(`PF2E.ProficiencyLevel${n}`),
         ]);
@@ -1551,7 +1551,7 @@ interface CharacterSheetData<TActor extends CharacterPF2e = CharacterPF2e> exten
     attributeBoostsAllocated: boolean;
     biography: CharacterBiography;
     class: ClassPF2e<CharacterPF2e> | null;
-    numberToRank: Record<ZeroToFour, string>;
+    numberToRank: Record<ProficiencyRankNumber, string>;
     classDCs: {
         dcs: ClassDCSheetData[];
         /** The slug of the character's primary class DC */

--- a/src/module/actor/character/types.ts
+++ b/src/module/actor/character/types.ts
@@ -1,7 +1,7 @@
 import type { HitPointsSummary } from "@actor/base.ts";
 import type { SaveType, SkillSlug } from "@actor/types.ts";
 import type { MagicTradition } from "@item/spell/types.ts";
-import type { ZeroToFour } from "@module/data.ts";
+import type { ProficiencyRankNumber } from "@module/data.ts";
 import type { Statistic } from "@system/statistic/index.ts";
 import type { CharacterPF2e } from "./document.ts";
 
@@ -10,7 +10,7 @@ interface CharacterHitPointsSummary extends HitPointsSummary {
     recoveryAddend: number;
 }
 
-type CharacterSkill<TActor extends CharacterPF2e> = Statistic<TActor> & { rank: ZeroToFour };
+type CharacterSkill<TActor extends CharacterPF2e> = Statistic<TActor> & { rank: ProficiencyRankNumber };
 
 type CharacterSkills<TActor extends CharacterPF2e> = Record<string, CharacterSkill<TActor>>;
 

--- a/src/module/actor/creature/document.ts
+++ b/src/module/actor/creature/document.ts
@@ -16,7 +16,7 @@ import { RitualSpellcasting } from "@item/spellcasting-entry/rituals.ts";
 import { SpellcastingEntry } from "@item/spellcasting-entry/types.ts";
 import type { ActiveEffectPF2e } from "@module/active-effect.ts";
 import { ItemAttacher } from "@module/apps/item-attacher.ts";
-import { Rarity, SIZES, SIZE_SLUGS, ZeroToFour, ZeroToTwo } from "@module/data.ts";
+import { ProficiencyRankNumber, Rarity, SIZES, SIZE_SLUGS, ZeroToTwo } from "@module/data.ts";
 import { RollNotePF2e } from "@module/notes.ts";
 import { extractModifiers } from "@module/rules/helpers.ts";
 import { BaseSpeedSynthetic } from "@module/rules/synthetics.ts";
@@ -374,7 +374,7 @@ abstract class CreaturePF2e<
             // and spell DC statistics. At 12th level, these proficiencies increase to expert.
             const actualSpellcasting = this.spellcasting.filter((e) => e.system && !e.system?.proficiency.slug);
             if (actualSpellcasting.some((e) => e.category === "innate")) {
-                spellcasting.rank = Math.max(spellcasting.rank, this.level >= 12 ? 2 : 1) as ZeroToFour;
+                spellcasting.rank = Math.max(spellcasting.rank, this.level >= 12 ? 2 : 1) as ProficiencyRankNumber;
             } else if (actualSpellcasting.length) {
                 // If you can cast spells using spellcasting prof, you logically need to be at least trained
                 spellcasting.rank ||= 1;

--- a/src/module/actor/creature/sheet.ts
+++ b/src/module/actor/creature/sheet.ts
@@ -7,7 +7,7 @@ import { ITEM_CARRY_TYPES } from "@item/base/data/values.ts";
 import { coerceToSpellGroupId, spellSlotGroupIdToNumber } from "@item/spellcasting-entry/helpers.ts";
 import { SpellcastingSheetData } from "@item/spellcasting-entry/index.ts";
 import { DropCanvasItemDataPF2e } from "@module/canvas/drop-canvas-data.ts";
-import { OneToTen, ZeroToFour, goesToEleven } from "@module/data.ts";
+import { OneToTen, ProficiencyRankNumber, goesToEleven } from "@module/data.ts";
 import { eventToRollParams } from "@module/sheet/helpers.ts";
 import { ErrorPF2e, createHTMLElement, fontAwesomeIcon, htmlClosest, htmlQueryAll, tupleHasValue } from "@util";
 import * as R from "remeda";
@@ -79,7 +79,7 @@ abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends ActorSheet
     }
 
     /** Get the font-awesome icon used to display a certain level of skill proficiency */
-    protected getProficiencyIcon(level: ZeroToFour): string {
+    protected getProficiencyIcon(level: ProficiencyRankNumber): string {
         return [...Array(level)].map(() => fontAwesomeIcon("check-circle").outerHTML).join("");
     }
 

--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -2,7 +2,7 @@ import { ActorProxyPF2e, type ActorPF2e } from "@actor";
 import type { ItemPF2e, MeleePF2e, PhysicalItemPF2e, WeaponPF2e } from "@item";
 import { AbilityTrait } from "@item/ability/types.ts";
 import { getPropertyRuneStrikeAdjustments } from "@item/physical/runes.ts";
-import { ZeroToFour, ZeroToTwo } from "@module/data.ts";
+import { getProficiencyOptionByRank, ProficiencyRankNumber, ZeroToTwo } from "@module/data.ts";
 import { MigrationList, MigrationRunner } from "@module/migration/index.ts";
 import { MigrationRunnerBase } from "@module/migration/runner/base.ts";
 import {
@@ -336,7 +336,7 @@ function isOffGuardFromFlanking(target: ActorPF2e, origin: ActorPF2e): boolean {
 
 function getStrikeAttackDomains(
     weapon: WeaponPF2e<ActorPF2e> | MeleePF2e<ActorPF2e>,
-    proficiencyRank: ZeroToFour | null,
+    proficiencyRank: ProficiencyRankNumber | null,
     baseRollOptions: string[] | Set<string>,
 ): string[] {
     const unarmedOrWeapon = weapon.category === "unarmed" ? "unarmed" : "weapon";
@@ -361,8 +361,10 @@ function getStrikeAttackDomains(
     ].flat();
 
     if (typeof proficiencyRank === "number") {
-        const proficiencies = ["untrained", "trained", "expert", "master", "legendary"] as const;
-        domains.push(`${proficiencies[proficiencyRank]}-attack`);
+        const proficiencyOption = getProficiencyOptionByRank(proficiencyRank);
+        if (proficiencyOption) {
+            domains.push(`${proficiencyOption.slug}-attack`);
+        }
     }
 
     const actor = weapon.actor;
@@ -399,7 +401,7 @@ function getStrikeAttackDomains(
 
 function getStrikeDamageDomains(
     weapon: WeaponPF2e<ActorPF2e> | MeleePF2e<ActorPF2e>,
-    proficiencyRank: ZeroToFour | null,
+    proficiencyRank: ProficiencyRankNumber | null,
 ): string[] {
     const meleeOrRanged = weapon.isMelee ? "melee" : "ranged";
     const slug = weapon.slug ?? sluggify(weapon.name);
@@ -425,8 +427,10 @@ function getStrikeDamageDomains(
     }
 
     if (typeof proficiencyRank === "number") {
-        const proficiencies = ["untrained", "trained", "expert", "master", "legendary"] as const;
-        domains.push(`${proficiencies[proficiencyRank]}-damage`);
+        const proficiencyOption = getProficiencyOptionByRank(proficiencyRank);
+        if (proficiencyOption) {
+            domains.push(`${proficiencyOption.slug}-damage`);
+        }
     }
 
     // Include selectors for "equivalent weapons": longbow for composite longbow, etc.

--- a/src/module/actor/npc/types.ts
+++ b/src/module/actor/npc/types.ts
@@ -4,11 +4,11 @@ import type { AbilityViewData } from "@actor/sheet/data-types.ts";
 import type { MovementType, SaveType, SkillSlug } from "@actor/types.ts";
 import type { ItemPF2e } from "@item";
 import type { SpellcastingSheetData } from "@item/spellcasting-entry/index.ts";
-import type { ZeroToFour } from "@module/data.ts";
 import type { TagifyEntry } from "@module/sheet/helpers.ts";
 import type { ArmorClassTraceData } from "@system/statistic/index.ts";
 import type { NPCAttributes, NPCPerceptionData, NPCSaveData, NPCSkillData, NPCSystemData } from "./data.ts";
 import type { NPCPF2e, NPCStrike } from "./index.ts";
+import { ProficiencyRankNumber } from "@module/data.ts";
 
 interface ActionsDetails {
     label: string;
@@ -37,7 +37,7 @@ interface VariantCloneParams {
     keepId?: boolean;
 }
 
-type WithRank = { icon?: string; hover?: string; rank: ZeroToFour };
+type WithRank = { icon?: string; hover?: string; rank: ProficiencyRankNumber };
 type NPCSkillSheetData = NPCSkillData & WithAdjustments & WithRank;
 
 interface NPCSystemSheetData extends NPCSystemData {

--- a/src/module/actor/party/kingdom/model.ts
+++ b/src/module/actor/party/kingdom/model.ts
@@ -4,7 +4,7 @@ import { MODIFIER_TYPES, ModifierPF2e, RawModifier, createProficiencyModifier } 
 import { CampaignFeaturePF2e, ItemPF2e } from "@item";
 import type { ItemType } from "@item/base/data/index.ts";
 import { ChatMessagePF2e } from "@module/chat-message/document.ts";
-import type { ZeroToFour } from "@module/data.ts";
+import type { ProficiencyRankNumber } from "@module/data.ts";
 import { extractModifierAdjustments } from "@module/rules/helpers.ts";
 import { Statistic } from "@system/statistic/index.ts";
 import { ErrorPF2e, createHTMLElement, fontAwesomeIcon, objectHasKey, setHasElement } from "@util";
@@ -243,7 +243,7 @@ class Kingdom extends DataModel<PartySystemData, KingdomSchema> implements Party
         // Government skills
         if (build.government && build.government.skills.length > 0) {
             for (const skill of build.government.skills) {
-                build.skills[skill].rank = Math.max(1, build.skills[skill].rank) as ZeroToFour;
+                build.skills[skill].rank = Math.max(1, build.skills[skill].rank) as ProficiencyRankNumber;
             }
         }
 

--- a/src/module/actor/party/kingdom/schema.ts
+++ b/src/module/actor/party/kingdom/schema.ts
@@ -1,5 +1,5 @@
 import { RawModifier } from "@actor/modifiers.ts";
-import { ZeroToFour } from "@module/data.ts";
+import { ProficiencyRankNumber } from "@module/data.ts";
 import { DataUnionField, RecordField, StrictBooleanField, StrictStringField } from "@system/schema-data-fields.ts";
 import * as R from "remeda";
 import type {
@@ -59,10 +59,10 @@ function defineKingdomSchema(): KingdomSchema {
         skills: new fields.SchemaField(
             R.mapToObj(KINGDOM_SKILLS, (skill) => {
                 const schema = new fields.SchemaField({
-                    rank: new fields.NumberField<ZeroToFour, ZeroToFour, true, false>({
+                    rank: new fields.NumberField<ProficiencyRankNumber, ProficiencyRankNumber, true, false>({
                         initial: 0,
                         min: 0,
-                        max: 4,
+                        max: 5,
                         required: true,
                         nullable: false,
                     }),
@@ -390,7 +390,7 @@ type BuildSchema = {
         Record<
             KingdomSkill,
             fields.SchemaField<{
-                rank: fields.NumberField<ZeroToFour, ZeroToFour, true, false, true>;
+                rank: fields.NumberField<ProficiencyRankNumber, ProficiencyRankNumber, true, false, true>;
             }>
         >
     >;

--- a/src/module/actor/party/sheet.ts
+++ b/src/module/actor/party/sheet.ts
@@ -11,7 +11,6 @@ import { ItemSourcePF2e } from "@item/base/data/index.ts";
 import { Bulk } from "@item/physical/index.ts";
 import { PHYSICAL_ITEM_TYPES } from "@item/physical/values.ts";
 import { DropCanvasItemDataPF2e } from "@module/canvas/drop-canvas-data.ts";
-import { ZeroToFour } from "@module/data.ts";
 import { SheetOptions, createSheetTags, eventToRollParams } from "@module/sheet/helpers.ts";
 import { SocketMessage } from "@scripts/socket.ts";
 import { SettingsMenuOptions } from "@system/settings/menu.ts";
@@ -19,6 +18,7 @@ import { createHTMLElement, htmlClosest, htmlQuery, htmlQueryAll, signedInteger 
 import { createTooltipster } from "@util/destroyables.ts";
 import * as R from "remeda";
 import { PartyPF2e } from "./document.ts";
+import { getProficiencyOptionByRank, ProficiencyRankNumber } from "@module/data.ts";
 
 interface PartySheetRenderOptions extends ActorSheetRenderOptionsPF2e {
     actors?: boolean;
@@ -369,7 +369,8 @@ class PartySheetPF2e extends ActorSheetPF2e<PartyPF2e> {
             const statistics = this.actor.members.map((m) => m.skills[slug]).filter(R.isTruthy);
             const labels = R.sortBy(statistics, (s) => s.mod).map((statistic) => {
                 const rank = statistic.rank ?? (statistic.proficient ? 1 : 0);
-                const prof = game.i18n.localize(CONFIG.PF2E.proficiencyLevels[rank]);
+                const proficiencyOption = getProficiencyOptionByRank(rank);
+                const prof = proficiencyOption?.label;
                 const label = `${statistic.actor.name} (${prof}) ${signedInteger(statistic.mod)}`;
                 const row = createHTMLElement("div", { children: [label] });
                 row.style.textAlign = "right";
@@ -550,7 +551,7 @@ interface SkillData {
     slug: string;
     label: string;
     mod: number;
-    rank?: ZeroToFour | null;
+    rank?: ProficiencyRankNumber | null;
 }
 
 interface MemberBreakdown {

--- a/src/module/data.ts
+++ b/src/module/data.ts
@@ -96,7 +96,78 @@ interface PublicationData {
     remaster: boolean;
 }
 
-export const PROFICIENCY_RANKS = ["untrained", "trained", "expert", "master", "legendary"] as const;
+export const PROFICIENCY_RANKS = ["untrained", "trained", "expert", "master", "legendary", "mythic"] as const;
+export type ProficiencyRankNumber = ZeroToFive;
+export type ProficiencyRankString = (typeof PROFICIENCY_RANKS)[ProficiencyRankNumber];
+
+export interface ProficiencyOption {
+    defaultModifier: number; // The default modifier to add before level
+    label: string; // The user-readable string representing the proficiency
+    rankOption: string; // The string used for proficiency rule elements (e.g. `proficiency:trained`)
+    slug: ProficiencyRankString; // The string used in rule elements to refer to this proficiency option (e.g. `trained`)
+    rank: ProficiencyRankNumber; // Numeric "rank" of the proficiency
+}
+
+const buildProficiencyOption = (
+    proficiencyBase: Pick<ProficiencyOption, "defaultModifier" | "label" | "slug" | "rank">,
+): ProficiencyOption => ({
+    get rankOption() {
+        return `proficiency:${this.slug}`;
+    },
+    ...proficiencyBase,
+});
+
+export function getAllProficiencyOptions(): ProficiencyOption[] {
+    return [
+        buildProficiencyOption({
+            defaultModifier: 0,
+            label: game.i18n.localize("PF2E.ProficiencyLevel0"),
+            slug: "untrained",
+            rank: 0,
+        }),
+        buildProficiencyOption({
+            defaultModifier: 2,
+            label: game.i18n.localize("PF2E.ProficiencyLevel1"),
+            slug: "trained",
+            rank: 1,
+        }),
+        buildProficiencyOption({
+            defaultModifier: 4,
+            label: game.i18n.localize("PF2E.ProficiencyLevel2"),
+            slug: "expert",
+            rank: 2,
+        }),
+        buildProficiencyOption({
+            defaultModifier: 6,
+            label: game.i18n.localize("PF2E.ProficiencyLevel3"),
+            slug: "master",
+            rank: 3,
+        }),
+        buildProficiencyOption({
+            defaultModifier: 6,
+            label: game.i18n.localize("PF2E.ProficiencyLevel4"),
+            slug: "legendary",
+            rank: 4,
+        }),
+        buildProficiencyOption({
+            defaultModifier: 10,
+            label: game.i18n.localize("PF2E.ProficiencyLevel5"),
+            slug: "mythic",
+            rank: 5,
+        }),
+    ];
+}
+
+export function getProficiencyOptionByRank(rank: ProficiencyRankNumber): ProficiencyOption | undefined {
+    return getAllProficiencyOptions()[rank];
+}
+
+export function getIndexedProficiencyOptions(): Record<ProficiencyRankString, ProficiencyOption> {
+    return Object.fromEntries(getAllProficiencyOptions().map((option) => [option.slug, option])) as Record<
+        ProficiencyRankString,
+        ProficiencyOption
+    >;
+}
 
 export const MATH_FUNCTION_NAMES: Set<MathFunctionName> = new Set([
     "abs",

--- a/src/module/dc.ts
+++ b/src/module/dc.ts
@@ -1,5 +1,4 @@
-import { ProficiencyRank } from "@item/base/data/index.ts";
-import { Rarity } from "./data.ts";
+import { ProficiencyRankString, Rarity } from "./data.ts";
 
 /**
  * Implementation of Difficulty Classes https://2e.aonprd.com/Rules.aspx?ID=552
@@ -62,7 +61,7 @@ const dcByLevel = new Map([
     [25, 50],
 ]);
 
-const simpleDCs = new Map<ProficiencyRank, number>([
+const simpleDCs = new Map<ProficiencyRankString, number>([
     ["untrained", 10],
     ["trained", 15],
     ["expert", 20],
@@ -70,7 +69,7 @@ const simpleDCs = new Map<ProficiencyRank, number>([
     ["legendary", 40],
 ]);
 
-const simpleDCsWithoutLevel = new Map<ProficiencyRank, number>([
+const simpleDCsWithoutLevel = new Map<ProficiencyRankString, number>([
     ["untrained", 10],
     ["trained", 15],
     ["expert", 20],
@@ -120,7 +119,15 @@ function calculateDC(level: number, { pwol, rarity = "common" }: DCOptions = {})
     }
 }
 
-function calculateSimpleDC(rank: ProficiencyRank, { pwol = false }: DCOptions = {}): number {
+function getDCByLevelOptions({ pwol = false }: DCOptions = {}): [ProficiencyRankString, number][] {
+    if (pwol) {
+        return Array.from(simpleDCsWithoutLevel.entries()) as [ProficiencyRankString, number][];
+    } else {
+        return Array.from(simpleDCs.entries()) as [ProficiencyRankString, number][];
+    }
+}
+
+function calculateSimpleDC(rank: ProficiencyRankString, { pwol = false }: DCOptions = {}): number {
     if (pwol) {
         return simpleDCsWithoutLevel.get(rank) ?? 10;
     } else {
@@ -167,6 +174,7 @@ export {
     calculateSpellDC,
     combineDCAdjustments,
     createDifficultyScale,
+    getDCByLevelOptions,
     rarityToDCAdjustment,
 };
 export type { DCAdjustment, DCOptions, NegativeDCAdjustment, PositiveDCAdjustment };

--- a/src/module/item/base/data/index.ts
+++ b/src/module/item/base/data/index.ts
@@ -23,10 +23,8 @@ import type { SpellSource } from "@item/spell/data.ts";
 import type { SpellcastingEntrySource } from "@item/spellcasting-entry/data.ts";
 import type { TreasureSource } from "@item/treasure/data.ts";
 import type { WeaponSource } from "@item/weapon/data.ts";
-import type { PROFICIENCY_RANKS, Rarity } from "@module/data.ts";
+import type { Rarity } from "@module/data.ts";
 import { ItemDescriptionData } from "./system.ts";
-
-type ProficiencyRank = (typeof PROFICIENCY_RANKS)[number];
 
 type NonPhysicalItemType =
     | "action"
@@ -131,7 +129,6 @@ export type {
     MeleeSource,
     NonPhysicalItemType,
     PhysicalItemSource,
-    ProficiencyRank,
     RawItemChatData,
     ShieldSource,
     SpellcastingEntrySource,

--- a/src/module/item/class/data.ts
+++ b/src/module/item/class/data.ts
@@ -1,7 +1,7 @@
 import { AttributeString, SaveType, SkillSlug } from "@actor/types.ts";
 import { ABCSystemData, ABCSystemSource } from "@item/abc/data.ts";
 import { BaseItemSourcePF2e, RarityTraitAndOtherTags } from "@item/base/data/system.ts";
-import { ZeroToFour } from "@module/data.ts";
+import { ProficiencyRankNumber } from "@module/data.ts";
 
 type ClassSource = BaseItemSourcePF2e<"class", ClassSystemSource>;
 
@@ -9,12 +9,12 @@ interface ClassSystemSource extends ABCSystemSource {
     traits: RarityTraitAndOtherTags;
     keyAbility: { value: AttributeString[]; selected: AttributeString | null };
     hp: number;
-    perception: ZeroToFour;
-    savingThrows: Record<SaveType, ZeroToFour>;
+    perception: ProficiencyRankNumber;
+    savingThrows: Record<SaveType, ProficiencyRankNumber>;
     attacks: ClassAttackProficiencies;
     defenses: ClassDefenseProficiencies;
     /** Starting proficiency in "spell attack rolls and DCs" */
-    spellcasting: ZeroToFour;
+    spellcasting: ProficiencyRankNumber;
     trainedSkills: {
         value: SkillSlug[];
         additional: number;
@@ -30,18 +30,18 @@ interface ClassSystemSource extends ABCSystemSource {
 interface ClassSystemData extends Omit<ClassSystemSource, "description">, Omit<ABCSystemData, "level" | "traits"> {}
 
 interface ClassAttackProficiencies {
-    simple: ZeroToFour;
-    martial: ZeroToFour;
-    advanced: ZeroToFour;
-    unarmed: ZeroToFour;
-    other: { name: string; rank: ZeroToFour };
+    simple: ProficiencyRankNumber;
+    martial: ProficiencyRankNumber;
+    advanced: ProficiencyRankNumber;
+    unarmed: ProficiencyRankNumber;
+    other: { name: string; rank: ProficiencyRankNumber };
 }
 
 interface ClassDefenseProficiencies {
-    unarmored: ZeroToFour;
-    light: ZeroToFour;
-    medium: ZeroToFour;
-    heavy: ZeroToFour;
+    unarmored: ProficiencyRankNumber;
+    light: ProficiencyRankNumber;
+    medium: ProficiencyRankNumber;
+    heavy: ProficiencyRankNumber;
 }
 
 export type { ClassAttackProficiencies, ClassDefenseProficiencies, ClassSource, ClassSystemData, ClassSystemSource };

--- a/src/module/item/class/document.ts
+++ b/src/module/item/class/document.ts
@@ -7,11 +7,11 @@ import { ABCItemPF2e, FeatPF2e } from "@item";
 import { ArmorCategory } from "@item/armor/index.ts";
 import { ARMOR_CATEGORIES } from "@item/armor/values.ts";
 import { WEAPON_CATEGORIES } from "@item/weapon/values.ts";
-import { ZeroToFour } from "@module/data.ts";
 import { objectHasKey, sluggify } from "@util";
 import * as R from "remeda";
 import { ClassAttackProficiencies, ClassDefenseProficiencies, ClassSource, ClassSystemData } from "./data.ts";
 import { ClassTrait } from "./types.ts";
+import { ProficiencyRankNumber } from "@module/data.ts";
 
 class ClassPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends ABCItemPF2e<TParent> {
     get attacks(): ClassAttackProficiencies {
@@ -26,11 +26,11 @@ class ClassPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends ABC
         return this.system.hp;
     }
 
-    get perception(): ZeroToFour {
+    get perception(): ProficiencyRankNumber {
         return this.system.perception;
     }
 
-    get savingThrows(): Record<SaveType, ZeroToFour> {
+    get savingThrows(): Record<SaveType, ProficiencyRankNumber> {
         return this.system.savingThrows;
     }
 
@@ -93,7 +93,7 @@ class ClassPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends ABC
 
         attributes.classhp = this.hpPerLevel;
 
-        actor.system.perception.rank = Math.max(actor.system.perception.rank, this.perception) as ZeroToFour;
+        actor.system.perception.rank = Math.max(actor.system.perception.rank, this.perception) as ProficiencyRankNumber;
         this.logAutoChange("system.perception.rank", this.perception);
 
         // Override the actor's key ability score if it's set
@@ -115,7 +115,7 @@ class ClassPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends ABC
         const { attacks, defenses } = proficiencies;
 
         for (const category of WEAPON_CATEGORIES) {
-            attacks[category].rank = Math.max(attacks[category].rank, this.attacks[category]) as ZeroToFour;
+            attacks[category].rank = Math.max(attacks[category].rank, this.attacks[category]) as ProficiencyRankNumber;
             this.logAutoChange(`system.proficiencies.attacks.${category}.rank`, this.attacks[category]);
         }
 
@@ -124,25 +124,28 @@ class ClassPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends ABC
                 !["light-barding", "heavy-barding"].includes(c),
         );
         for (const category of nonBarding) {
-            defenses[category].rank = Math.max(defenses[category].rank, this.defenses[category]) as ZeroToFour;
+            defenses[category].rank = Math.max(
+                defenses[category].rank,
+                this.defenses[category],
+            ) as ProficiencyRankNumber;
             this.logAutoChange(`system.proficiencies.defenses.${category}.rank`, this.defenses[category]);
         }
 
         for (const saveType of SAVE_TYPES) {
-            saves[saveType].rank = Math.max(saves[saveType].rank, this.savingThrows[saveType]) as ZeroToFour;
+            saves[saveType].rank = Math.max(saves[saveType].rank, this.savingThrows[saveType]) as ProficiencyRankNumber;
             this.logAutoChange(`system.saves.${saveType}.rank`, this.savingThrows[saveType]);
         }
 
         for (const trainedSkill of this.system.trainedSkills.value) {
             if (objectHasKey(skills, trainedSkill)) {
-                skills[trainedSkill].rank = Math.max(skills[trainedSkill].rank, 1) as ZeroToFour;
+                skills[trainedSkill].rank = Math.max(skills[trainedSkill].rank, 1) as ProficiencyRankNumber;
             }
         }
 
         proficiencies.spellcasting.rank = Math.max(
             proficiencies.spellcasting.rank,
             this.system.spellcasting,
-        ) as ZeroToFour;
+        ) as ProficiencyRankNumber;
         this.logAutoChange("system.proficiencies.spellcasting.rank", this.system.spellcasting);
 
         details.class = { name: this.name, trait: slug };

--- a/src/module/item/deity/document.ts
+++ b/src/module/item/deity/document.ts
@@ -2,7 +2,7 @@ import type { ActorPF2e, CharacterPF2e } from "@actor";
 import { MartialProficiency } from "@actor/character/data.ts";
 import { ItemPF2e } from "@item";
 import { BaseWeaponType } from "@item/weapon/types.ts";
-import { ZeroToFour } from "@module/data.ts";
+import { ProficiencyRankNumber } from "@module/data.ts";
 import { objectHasKey, sluggify } from "@util";
 import { DeityCategory, DeitySource, DeitySystemData } from "./data.ts";
 
@@ -94,7 +94,7 @@ class DeityPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
                     rank: Math.max(
                         Number(attacks[`weapon-base-${baseType}`]?.rank) || 0,
                         favoredWeaponRank,
-                    ) as ZeroToFour,
+                    ) as ProficiencyRankNumber,
                 };
             }
         }

--- a/src/module/item/lore.ts
+++ b/src/module/item/lore.ts
@@ -1,7 +1,7 @@
 import type { ActorPF2e } from "@actor";
 import { ItemPF2e, ItemSheetPF2e } from "@item";
 import { BaseItemSourcePF2e, ItemSystemData, ItemSystemSource, OtherTagsOnly } from "@item/base/data/system.ts";
-import { ZeroToFour } from "@module/data.ts";
+import { ProficiencyRankNumber } from "@module/data.ts";
 
 class LorePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends ItemPF2e<TParent> {}
 
@@ -15,7 +15,7 @@ type LoreSource = BaseItemSourcePF2e<"lore", LoreSystemSource>;
 interface LoreSystemSource extends ItemSystemSource {
     traits: OtherTagsOnly;
     mod: { value: number };
-    proficient: { value: ZeroToFour };
+    proficient: { value: ProficiencyRankNumber };
     variants?: Record<string, { label: string; options: string }>;
     level?: never;
 }

--- a/src/module/item/spellcasting-entry/data.ts
+++ b/src/module/item/spellcasting-entry/data.ts
@@ -1,7 +1,7 @@
 import { AttributeString } from "@actor/types.ts";
 import { BaseItemSourcePF2e, ItemSystemData, ItemSystemSource, OtherTagsOnly } from "@item/base/data/system.ts";
 import { MagicTradition } from "@item/spell/types.ts";
-import { OneToTen, ZeroToFour, ZeroToTen } from "@module/data.ts";
+import { OneToTen, ProficiencyRankNumber, ZeroToTen } from "@module/data.ts";
 import type { RollNotePF2e } from "@module/notes.ts";
 import { SpellcastingCategory } from "./types.ts";
 
@@ -41,7 +41,7 @@ interface SpellcastingEntrySystemSource extends ItemSystemSource {
     };
     proficiency: {
         slug: string;
-        value: ZeroToFour;
+        value: ProficiencyRankNumber;
     };
     slots: SpellcastingEntrySlots;
     autoHeightenLevel: {

--- a/src/module/item/spellcasting-entry/document.ts
+++ b/src/module/item/spellcasting-entry/document.ts
@@ -4,7 +4,7 @@ import { AttributeString } from "@actor/types.ts";
 import { ItemPF2e, PhysicalItemPF2e, type SpellPF2e } from "@item";
 import { MagicTradition } from "@item/spell/types.ts";
 import { MAGIC_TRADITIONS } from "@item/spell/values.ts";
-import { OneToTen, ZeroToFour, ZeroToTen } from "@module/data.ts";
+import { OneToTen, ProficiencyRankNumber, ZeroToTen } from "@module/data.ts";
 import type { UserPF2e } from "@module/user/index.ts";
 import { Statistic } from "@system/statistic/index.ts";
 import { ErrorPF2e, ordinalString, setHasElement, sluggify } from "@util";
@@ -47,7 +47,7 @@ class SpellcastingEntryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null>
      * Returns the proficiency used for calculations.
      * For innate spells, this is the highest spell proficiency (min trained)
      */
-    get rank(): ZeroToFour {
+    get rank(): ProficiencyRankNumber {
         return this.system.proficiency.value ?? 0;
     }
 
@@ -168,7 +168,7 @@ class SpellcastingEntryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null>
             if (!baseStat) return;
 
             this.system.ability.value = baseStat.attribute ?? this.system.ability.value;
-            this.system.proficiency.value = Math.max(this.rank, baseStat.rank ?? 0) as ZeroToFour;
+            this.system.proficiency.value = Math.max(this.rank, baseStat.rank ?? 0) as ProficiencyRankNumber;
             this.statistic = baseStat.extend({
                 slug,
                 label:

--- a/src/module/migration/migrations/900-class-spellcasting-proficiency.ts
+++ b/src/module/migration/migrations/900-class-spellcasting-proficiency.ts
@@ -1,6 +1,6 @@
 import { ActorSourcePF2e } from "@actor/data/index.ts";
 import { ItemSourcePF2e } from "@item/base/data/index.ts";
-import { ZeroToFour } from "@module/data.ts";
+import { ProficiencyRankNumber } from "@module/data.ts";
 import type { AELikeSource } from "@module/rules/rule-element/ae-like.ts";
 import { MigrationBase } from "../base.ts";
 
@@ -24,12 +24,12 @@ export class Migration900ClassSpellcastingProficiency extends MigrationBase {
                 (r: MaybeAELike) => r.key === "ActiveEffectLike" && r.path === "system.proficiencies.spellcasting.rank",
             );
             if (aeLikeIncrease) {
-                source.system.spellcasting = Math.max(1, source.system.spellcasting ?? 0) as ZeroToFour;
+                source.system.spellcasting = Math.max(1, source.system.spellcasting ?? 0) as ProficiencyRankNumber;
                 source.system.rules.splice(source.system.rules.indexOf(aeLikeIncrease), 1);
             } else if (["sorcerer", "summoner", "witch"].includes(source.system.slug ?? "")) {
                 source.system.spellcasting = 1;
             } else {
-                source.system.spellcasting = Math.max(0, source.system.spellcasting ?? 0) as ZeroToFour;
+                source.system.spellcasting = Math.max(0, source.system.spellcasting ?? 0) as ProficiencyRankNumber;
             }
         }
 

--- a/src/module/migration/migrations/928-character-skills-longform.ts
+++ b/src/module/migration/migrations/928-character-skills-longform.ts
@@ -2,7 +2,7 @@ import { CharacterSystemSource } from "@actor/character/data.ts";
 import { ActorSourcePF2e } from "@actor/data/index.ts";
 import { SkillSlug } from "@actor/types.ts";
 import { ItemSourcePF2e } from "@item/base/data/index.ts";
-import { ZeroToFour } from "@module/data.ts";
+import { ProficiencyRankNumber } from "@module/data.ts";
 import { objectHasKey, recursiveReplaceString } from "@util";
 import { MigrationBase } from "../base.ts";
 import { SKILL_ABBREVIATIONS, SKILL_DICTIONARY, SkillAbbreviation } from "./927-class-background-skill-longform.ts";
@@ -60,6 +60,6 @@ export class Migration928CharacterSkillsLongform extends MigrationBase {
 }
 
 interface CharacterSystemSourceMaybeOld extends CharacterSystemSource {
-    skills: Partial<Record<SkillSlug | SkillAbbreviation, { rank: ZeroToFour }>> &
+    skills: Partial<Record<SkillSlug | SkillAbbreviation, { rank: ProficiencyRankNumber }>> &
         Partial<Record<`-=${SkillAbbreviation}`, null>>;
 }

--- a/src/module/rules/rule-element/martial-proficiency.ts
+++ b/src/module/rules/rule-element/martial-proficiency.ts
@@ -1,10 +1,9 @@
 import type { ActorType, CharacterPF2e } from "@actor";
 import { ArmorCategory } from "@item/armor/types.ts";
 import { ARMOR_CATEGORIES } from "@item/armor/values.ts";
-import { ProficiencyRank } from "@item/base/data/index.ts";
 import { WeaponCategory } from "@item/weapon/types.ts";
 import { WEAPON_CATEGORIES } from "@item/weapon/values.ts";
-import { OneToFour } from "@module/data.ts";
+import { OneToFour, ProficiencyRankString } from "@module/data.ts";
 import { PredicateField } from "@system/schema-data-fields.ts";
 import { sluggify } from "@util";
 import { RuleElementOptions, RuleElementPF2e } from "./base.ts";
@@ -79,8 +78,8 @@ type MartialProficiencySchema = RuleElementSchema & {
     sameAs: fields.StringField<WeaponCategory | ArmorCategory, WeaponCategory | ArmorCategory, false, false, false>;
     /** The maximum rank this proficiency can reach, if any */
     maxRank: fields.StringField<
-        Exclude<ProficiencyRank, "untrained">,
-        Exclude<ProficiencyRank, "untrained">,
+        Exclude<ProficiencyRankString, "untrained">,
+        Exclude<ProficiencyRankString, "untrained">,
         false,
         false,
         false

--- a/src/module/system/action-macros/helpers.ts
+++ b/src/module/system/action-macros/helpers.ts
@@ -209,7 +209,7 @@ class ActionMacroHelpers {
                         fully: true,
                     });
                     const finalOptions = new Set(combinedOptions);
-                    ensureProficiencyOption(finalOptions, statistic.rank ?? -1);
+                    ensureProficiencyOption(finalOptions, statistic.rank ?? 0);
                     check.calculateTotal(finalOptions);
                     const selfActor = actor.getContextualClone(combinedOptions.filter((o) => o.startsWith("self:")));
 

--- a/src/module/system/action-macros/types.ts
+++ b/src/module/system/action-macros/types.ts
@@ -4,6 +4,7 @@ import type { ModifierPF2e } from "@actor/modifiers.ts";
 import type { DCSlug } from "@actor/types.ts";
 import type { ItemPF2e } from "@item";
 import type { WeaponTrait } from "@item/weapon/types.ts";
+import { ProficiencyRankNumber } from "@module/data.ts";
 import type { RollNotePF2e } from "@module/notes.ts";
 import type { TokenDocumentPF2e } from "@scene";
 import type { CheckRoll, CheckType } from "@system/check/index.ts";
@@ -45,7 +46,7 @@ interface CheckMacroContext<TItem extends ItemPF2e<ActorPF2e>> {
     modifiers?: ModifierPF2e[];
     rollOptions: string[];
     slug: string;
-    statistic: Statistic | (StrikeData & { rank?: number });
+    statistic: Statistic | (StrikeData & { rank?: ProficiencyRankNumber });
     subtitle: string;
 }
 

--- a/src/module/system/settings/variant-rules.ts
+++ b/src/module/system/settings/variant-rules.ts
@@ -120,6 +120,15 @@ const SETTINGS: Record<string, SettingRegistration> = {
             game.pf2e.settings.variants.pwol.modifiers[4] = Number(value) || 0;
         },
     },
+    proficiencyMythicModifier: {
+        name: "PF2E.SETTINGS.Variant.MythicModifier.Name",
+        hint: "PF2E.SETTINGS.Variant.MythicModifier.Hint",
+        default: 10,
+        type: Number,
+        onChange: (value) => {
+            game.pf2e.settings.variants.pwol.modifiers[5] = Number(value) || 0;
+        },
+    },
 };
 
 export class VariantRulesSettings extends FormApplication {

--- a/src/module/system/statistic/armor-class.ts
+++ b/src/module/system/statistic/armor-class.ts
@@ -3,7 +3,7 @@ import { createShoddyPenalty } from "@actor/character/helpers.ts";
 import { ModifierPF2e, StatisticModifier } from "@actor/modifiers.ts";
 import { AttributeString } from "@actor/types.ts";
 import type { ArmorPF2e } from "@item";
-import { ZeroToFour } from "@module/data.ts";
+import { ProficiencyRankNumber } from "@module/data.ts";
 import { extractModifierAdjustments } from "@module/rules/helpers.ts";
 import { sluggify } from "@util";
 import * as R from "remeda";
@@ -97,7 +97,7 @@ class ArmorStatistic<TActor extends ActorPF2e = ActorPF2e> extends Statistic<TAc
 }
 
 interface ArmorStatisticData extends StatisticData {
-    rank?: ZeroToFour;
+    rank?: ProficiencyRankNumber;
     details?: string;
 }
 

--- a/src/module/system/statistic/data.ts
+++ b/src/module/system/statistic/data.ts
@@ -1,6 +1,6 @@
 import type { ModifierPF2e, RawModifier } from "@actor/modifiers.ts";
 import { AttributeString } from "@actor/types.ts";
-import { ZeroToFour } from "@module/data.ts";
+import { ProficiencyRankNumber } from "@module/data.ts";
 import { CheckType } from "@system/check/index.ts";
 
 interface BaseStatisticData {
@@ -16,7 +16,7 @@ interface BaseStatisticData {
 /** Used to build the actual statistic object */
 interface StatisticData extends BaseStatisticData {
     attribute?: AttributeString | null;
-    rank?: ZeroToFour;
+    rank?: ProficiencyRankNumber;
     /** If the actor is proficient with this statistic (rather than deriving from rank) */
     proficient?: boolean;
     lore?: boolean;

--- a/src/module/system/statistic/statistic.ts
+++ b/src/module/system/statistic/statistic.ts
@@ -4,7 +4,6 @@ import { calculateMAPs } from "@actor/helpers.ts";
 import {
     CheckModifier,
     ModifierPF2e,
-    PROFICIENCY_RANK_OPTION,
     StatisticModifier,
     createAttributeModifier,
     createProficiencyModifier,
@@ -13,7 +12,7 @@ import { CheckContext } from "@actor/roll-context/check.ts";
 import { AttributeString } from "@actor/types.ts";
 import type { ItemPF2e } from "@item";
 import { AbilityTrait } from "@item/ability/types.ts";
-import { ZeroToFour, ZeroToTwo } from "@module/data.ts";
+import { getProficiencyOptionByRank, ProficiencyRankNumber, ZeroToTwo } from "@module/data.ts";
 import { RollNotePF2e, RollNoteSource } from "@module/notes.ts";
 import {
     extractDegreeOfSuccessAdjustments,
@@ -44,7 +43,7 @@ import {
 class Statistic<TActor extends ActorPF2e = ActorPF2e> extends BaseStatistic<TActor> {
     attribute: AttributeString | null = null;
 
-    rank: ZeroToFour | null = null;
+    rank: ProficiencyRankNumber | null = null;
 
     proficient = true;
 
@@ -136,7 +135,10 @@ class Statistic<TActor extends ActorPF2e = ActorPF2e> extends BaseStatistic<TAct
         }
 
         if (typeof this.rank === "number") {
-            rollOptions.push(PROFICIENCY_RANK_OPTION[this.rank]);
+            const proficiencyOption = getProficiencyOptionByRank(this.rank);
+            if (proficiencyOption) {
+                rollOptions.push(proficiencyOption.rankOption);
+            }
         }
 
         if (this.data.rollOptions) {

--- a/src/scripts/config/index.ts
+++ b/src/scripts/config/index.ts
@@ -736,6 +736,7 @@ export const PF2ECONFIG = {
         "PF2E.ProficiencyLevel2", // expert
         "PF2E.ProficiencyLevel3", // master
         "PF2E.ProficiencyLevel4", // legendary
+        "PF2E.ProficiencyLevel5", // mythic
     ] as const,
 
     proficiencyRanks: {
@@ -744,6 +745,7 @@ export const PF2ECONFIG = {
         expert: "PF2E.ProficiencyLevel2",
         master: "PF2E.ProficiencyLevel3",
         legendary: "PF2E.ProficiencyLevel4",
+        mythic: "PF2E.ProficiencyLevel5",
     } as const,
 
     actorSizes: sizeTypes,

--- a/src/scripts/macros/earn-income/calculate.ts
+++ b/src/scripts/macros/earn-income/calculate.ts
@@ -1,6 +1,6 @@
 import { CoinsPF2e } from "@item/physical/coins.ts";
 import { Coins } from "@item/physical/data.ts";
-import { OneToFour } from "@module/data.ts";
+import { OneToFive, OneToFour } from "@module/data.ts";
 import { calculateDC } from "@module/dc.ts";
 import { DegreeOfSuccess, DegreeOfSuccessIndex, RollBrief } from "@system/degree-of-success.ts";
 
@@ -9,7 +9,7 @@ import { DegreeOfSuccess, DegreeOfSuccessIndex, RollBrief } from "@system/degree
  */
 
 // you have to be at least trained to earn income
-type Rewards = Record<OneToFour, CoinsPF2e>;
+type Rewards = Record<OneToFive, CoinsPF2e>;
 
 /**
  * There is a cap at each level for a certain proficiency
@@ -23,6 +23,7 @@ function buildRewards(...rewards: Coins[]): Rewards {
         2: new CoinsPF2e(expert ?? trained),
         3: new CoinsPF2e(master ?? expert ?? trained),
         4: new CoinsPF2e(legendary ?? master ?? expert ?? trained),
+        5: new CoinsPF2e(legendary ?? master ?? expert ?? trained),
     };
 }
 
@@ -90,7 +91,7 @@ interface ApplyIncomeOptionsParams {
     result: PerDayEarnIncomeResult;
     options: EarnIncomeOptions;
     level: number;
-    proficiency: OneToFour;
+    proficiency: OneToFive;
 }
 
 /**

--- a/src/scripts/set-game-pf2e.ts
+++ b/src/scripts/set-game-pf2e.ts
@@ -154,6 +154,7 @@ export const SetGamePF2e = {
                         game.settings.get("pf2e", "proficiencyExpertModifier"),
                         game.settings.get("pf2e", "proficiencyMasterModifier"),
                         game.settings.get("pf2e", "proficiencyLegendaryModifier"),
+                        game.settings.get("pf2e", "proficiencyMythicModifier"),
                     ],
                 },
                 stamina: game.settings.get("pf2e", "staminaVariant"),

--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -122,6 +122,7 @@ $adjusted-lower: #cc3311;
     --color-proficiency-expert: #3c005e;
     --color-proficiency-master: #664400;
     --color-proficiency-legendary: #{$primary-color};
+    --color-proficiency-mythic: #990033;
 
     /* Damage colors */
     .damage {

--- a/src/styles/actor/character/_proficiency-ranks.scss
+++ b/src/styles/actor/character/_proficiency-ranks.scss
@@ -44,6 +44,11 @@
     option[value="4"] {
         background: var(--color-proficiency-legendary);
     }
+
+    &[data-rank="5"],
+    option[value="5"] {
+        background: var(--color-proficiency-mythic);
+    }
 }
 
 select.pf-rank {

--- a/src/styles/actor/party/_overview.scss
+++ b/src/styles/actor/party/_overview.scss
@@ -60,6 +60,9 @@
         &[data-rank="4"] {
             --tag-color: var(--color-proficiency-legendary);
         }
+        &[data-rank="5"] {
+            --tag-color: var(--color-proficiency-mythic);
+        }
     }
 
     .perception {

--- a/src/styles/settings/_variant-rules.scss
+++ b/src/styles/settings/_variant-rules.scss
@@ -9,8 +9,8 @@
         column-gap: 0.5em;
         display: grid;
         grid-template:
-            "untrained trained expert master legendary" auto "hint hint hint hint hint" auto
-            / 1fr 1fr 1fr 1fr 1fr;
+            "untrained trained expert master legendary mythic" auto "hint hint hint hint hint hint" auto
+            / 1fr 1fr 1fr 1fr 1fr 1fr;
 
         .hint {
             grid-area: hint;

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3158,6 +3158,7 @@
         "ProficiencyLevel2": "Expert",
         "ProficiencyLevel3": "Master",
         "ProficiencyLevel4": "Legendary",
+        "ProficiencyLevel5": "Mythic",
         "ProficiencyRankLabel": "Prof",
         "ProgressBar": {
             "LoadingComplete": "Loading complete",

--- a/static/templates/actors/character/partials/proficiencylevels-dropdown.hbs
+++ b/static/templates/actors/character/partials/proficiencylevels-dropdown.hbs
@@ -3,3 +3,4 @@
 <option value="2" {{#if (eq proflevel 2)}}selected{{/if}}>{{localize "PF2E.ProficiencyLevel2"}}</option>
 <option value="3" {{#if (eq proflevel 3)}}selected{{/if}}>{{localize "PF2E.ProficiencyLevel3"}}</option>
 <option value="4" {{#if (eq proflevel 4)}}selected{{/if}}>{{localize "PF2E.ProficiencyLevel4"}}</option>
+{{#if (eq proflevel 5)}}<option value="5" selected>{{localize "PF2E.ProficiencyLevel5"}}</option>{{/if}}

--- a/static/templates/system/settings/variant-rules.hbs
+++ b/static/templates/system/settings/variant-rules.hbs
@@ -66,6 +66,16 @@
                 />
             </div>
         </div>
+        <div class="modifier">
+            <label>{{localize "PF2E.ProficiencyLevel5"}}</label>
+            <div class="form-fields">
+                <input
+                    type="number"
+                    name="proficiencyMythicModifier"
+                    value="{{proficiencyMythicModifier.value}}"
+                />
+            </div>
+        </div>
         <p class="hint">{{localize "PF2E.SETTINGS.Variant.Proficiency.ModifiersHint"}}</p>
     </div>
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -20,6 +20,8 @@ global.game = Object.freeze({
                     return 6;
                 case "proficiencyLegendaryModifier":
                     return 8;
+                case "proficiencyMythicModifier":
+                    return 10;
 
                 /* Variant rules */
                 case "proficiencyVariant":


### PR DESCRIPTION
## Context

Right now, the system does not have support for Mythic proficiency.

As a consequence of this, there is basically no automation surrounding Mythic abilities such as Rewrite Fate and Mythic Strike, which makes those abilities time-intensive to use due to needing to manually calculate the relevant bonuses and apply them individually.

## Changes

This PR adds Mythic as an effect-only proficiency, which means that players cannot select it from the dropdown of proficiencies, but instead they must be granted [temporary] Mythic proficiency with an effect (e.g. from Mythic Strike)

![image](https://github.com/user-attachments/assets/cb598d8c-aaf8-4a9f-bd2b-c6516d53e299)

As for how this was accomplished, there were a few major points of implementation:
- First, a lot of proficiency details were centralized into `data.ts`; this enabled a bit of string de-duplication by centralizing the source of proficiencies
- Many usages of `ZeroToFour` were replaced with a new `ProficiencyRankNumber` to no longer assume the number of available proficiencies (and similarly, `ProficiencyRankString` has been created to cover `trained`/etc.)

If you could like to test this easily, I applied this to a random ability to grant Mythic Acrobatics

```json
{
  "key": "ActiveEffectLike",
  "mode": "upgrade",
  "path": "system.skills.acrobatics.rank",
  "value": 5
}
```

## Complications

The obvious complication is that a lot of things assumed the core game proficiencies of `U`/`T`/`E`/`M`/`L` would be the only five options. The less-obvious complication of this is that the static type-checking system of TS doesn't like the idea that Mythic can be enabled or disabled; a run-time configuration like that isn't well-liked by compile-time type-checking

Because of these factors, Mythic proficiency is always technically enabled/achievable through effects, though nothing that gives Mythic proficiency should really be in play unless Mythic rules are enabled (or someone makes a custom effect to get Mythic proficiency, but at that point they're doing whatever they want anyway)

This PR also does not concern itself with data entry; this is mostly to enable data entry later, though it could be worth implementing a system to spend resources like Mythic Points when such actions are performed (also not a part of this PR, though I would like to add that)
