### PR TITLE
Fix stacks of items being bulk adjusted on vehicle actors

### DIFF
--- a/src/module/item/container/document.ts
+++ b/src/module/item/container/document.ts
@@ -27,7 +27,7 @@ class ContainerPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends
 
     get capacity(): { value: Bulk; max: Bulk } {
         return {
-            value: InventoryBulk.computeTotalBulk(this.contents.contents, this.actor?.size ?? "med"),
+            value: InventoryBulk.computeTotalBulk(this.contents.contents, this.actor ?? null),
             max: new Bulk(this.system.bulk.capacity),
         };
     }


### PR DESCRIPTION
This check also exists in PhysicalItemPF2e#bulk, but was inconsistent in its application. Closes https://github.com/foundryvtt/pf2e/issues/18089.