### PR TITLE
Remove level 7 reach increment for Deer antler and Frog tongue from Animal Instinct class feature

### DIFF
--- a/packs/classfeatures/animal-instinct.json
+++ b/packs/classfeatures/animal-instinct.json
@@ -526,29 +526,6 @@
                 ]
             },
             {
-                "definition": [
-                    {
-                        "or": [
-                            "item:slug:instinct-antler",
-                            "item:slug:instinct-tongue"
-                        ]
-                    }
-                ],
-                "key": "AdjustStrike",
-                "mode": "add",
-                "predicate": [
-                    "class:barbarian",
-                    {
-                        "gte": [
-                            "self:level",
-                            7
-                        ]
-                    }
-                ],
-                "property": "weapon-traits",
-                "value": "reach"
-            },
-            {
                 "category": "unarmed",
                 "damage": {
                     "base": {


### PR DESCRIPTION
Closes #18137