### PR TITLE
Extend `bulk` ItemAlteration to allow for further `mode`s

### DIFF
--- a/src/module/rules/rule-element/item-alteration/alteration.ts
+++ b/src/module/rules/rule-element/item-alteration/alteration.ts
@@ -157,7 +157,7 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
                     data.item.system.bulk.value,
                     data.alteration.value,
                 );
-                data.item.system.bulk.value = Math.round(newValue * 10) / 10;
+                data.item.system.bulk.value = Math.round(Math.max(newValue, 0) * 10) / 10;
                 if (data.item instanceof foundry.abstract.DataModel) {
                     data.item.system.bulk = prepareBulkData(data.item);
                 }

--- a/src/module/rules/rule-element/item-alteration/alteration.ts
+++ b/src/module/rules/rule-element/item-alteration/alteration.ts
@@ -36,7 +36,6 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
         "frequency-per",
         "hardness",
         "hp-max",
-        "level",
         "material-type",
         "other-tags",
         "pd-recovery-dc",
@@ -288,20 +287,6 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
                         hp.brokenThreshold = Math.floor(hp.max / 2);
                     }
                     this.#adjustCreatureShieldData(data.item);
-                }
-                return;
-            }
-            case "level": {
-                const validator = ITEM_ALTERATION_VALIDATORS[this.property];
-                if (
-                    validator.isValid(data) &&
-                    "level" in data.item.system &&
-                    typeof data.item.system.level !== "undefined"
-                ) {
-                    const level = data.item.system.level;
-                    const value = data.alteration.value;
-                    const newValue = AELikeRuleElement.getNewValue(this.mode, level.value, value);
-                    level.value = Math.clamp(Math.trunc(newValue), -1, 100);
                 }
                 return;
             }

--- a/src/module/rules/rule-element/item-alteration/alteration.ts
+++ b/src/module/rules/rule-element/item-alteration/alteration.ts
@@ -152,7 +152,12 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
                 const validator = ITEM_ALTERATION_VALIDATORS[this.property];
                 data.alteration.value = Number(data.alteration.value) || 0;
                 if (!validator.isValid(data)) return;
-                data.item.system.bulk.value = data.alteration.value;
+                const newValue = AELikeRuleElement.getNewValue(
+                    this.mode,
+                    data.item.system.bulk.value,
+                    data.alteration.value,
+                );
+                data.item.system.bulk.value = Math.round(newValue * 10) / 10;
                 if (data.item instanceof foundry.abstract.DataModel) {
                     data.item.system.bulk = prepareBulkData(data.item);
                 }

--- a/src/module/rules/rule-element/item-alteration/alteration.ts
+++ b/src/module/rules/rule-element/item-alteration/alteration.ts
@@ -31,6 +31,7 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
         "defense-passive",
         "description",
         "dex-cap",
+        "flags",
         "focus-point-cost",
         "frequency-max",
         "frequency-per",
@@ -252,6 +253,24 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
                     data.alteration.value,
                 );
                 data.item.system.dexCap = Math.max(newValue, 0);
+                return;
+            }
+            case "flags": {
+                const validator = ITEM_ALTERATION_VALIDATORS[this.property];
+                if (!validator.isValid(data)) return;
+                if (!("getFlag" in data.item) || typeof data.item.getFlag !== "function") return;
+
+                const flatValue = foundry.utils.flattenObject(data.alteration.value);
+                for (const [key, value] of Object.entries(flatValue)) {
+                    const flag = data.item.getFlag("pf2e", key);
+                    const newValue = AELikeRuleElement.getNewValue(this.mode, flag, value);
+                    if (newValue instanceof DataModelValidationFailure) {
+                        throw newValue.asError();
+                    }
+                    foundry.utils.mergeObject(data.item.flags.pf2e, {
+                        [`${key}`]: newValue,
+                    });
+                }
                 return;
             }
             case "focus-point-cost": {

--- a/src/module/rules/rule-element/item-alteration/alteration.ts
+++ b/src/module/rules/rule-element/item-alteration/alteration.ts
@@ -36,6 +36,7 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
         "frequency-per",
         "hardness",
         "hp-max",
+        "level",
         "material-type",
         "other-tags",
         "pd-recovery-dc",
@@ -287,6 +288,20 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
                         hp.brokenThreshold = Math.floor(hp.max / 2);
                     }
                     this.#adjustCreatureShieldData(data.item);
+                }
+                return;
+            }
+            case "level": {
+                const validator = ITEM_ALTERATION_VALIDATORS[this.property];
+                if (
+                    validator.isValid(data) &&
+                    "level" in data.item.system &&
+                    typeof data.item.system.level !== "undefined"
+                ) {
+                    const level = data.item.system.level;
+                    const value = data.alteration.value;
+                    const newValue = AELikeRuleElement.getNewValue(this.mode, level.value, value);
+                    level.value = Math.clamp(Math.trunc(newValue), -1, 100);
                 }
                 return;
             }

--- a/src/module/rules/rule-element/item-alteration/alteration.ts
+++ b/src/module/rules/rule-element/item-alteration/alteration.ts
@@ -31,7 +31,6 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
         "defense-passive",
         "description",
         "dex-cap",
-        "flags",
         "focus-point-cost",
         "frequency-max",
         "frequency-per",
@@ -253,24 +252,6 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
                     data.alteration.value,
                 );
                 data.item.system.dexCap = Math.max(newValue, 0);
-                return;
-            }
-            case "flags": {
-                const validator = ITEM_ALTERATION_VALIDATORS[this.property];
-                if (!validator.isValid(data)) return;
-                if (!("getFlag" in data.item) || typeof data.item.getFlag !== "function") return;
-
-                const flatValue = foundry.utils.flattenObject(data.alteration.value);
-                for (const [key, value] of Object.entries(flatValue)) {
-                    const flag = data.item.getFlag("pf2e", key);
-                    const newValue = AELikeRuleElement.getNewValue(this.mode, flag, value);
-                    if (newValue instanceof DataModelValidationFailure) {
-                        throw newValue.asError();
-                    }
-                    foundry.utils.mergeObject(data.item.flags.pf2e, {
-                        [`${key}`]: newValue,
-                    });
-                }
                 return;
             }
             case "focus-point-cost": {

--- a/src/module/rules/rule-element/item-alteration/alteration.ts
+++ b/src/module/rules/rule-element/item-alteration/alteration.ts
@@ -261,16 +261,16 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
                 if (!("getFlag" in data.item) || typeof data.item.getFlag !== "function") return;
 
                 const flatValue = foundry.utils.flattenObject(data.alteration.value);
-                const resolvedValue = {};
                 for (const [key, value] of Object.entries(flatValue)) {
                     const flag = data.item.getFlag("pf2e", key);
                     const newValue = AELikeRuleElement.getNewValue(this.mode, flag, value);
                     if (newValue instanceof DataModelValidationFailure) {
                         throw newValue.asError();
                     }
-                    foundry.utils.mergeObject(resolvedValue, { [`${key}`]: newValue });
+                    foundry.utils.mergeObject(data.item.flags.pf2e, {
+                        [`${key}`]: newValue,
+                    });
                 }
-                foundry.utils.mergeObject(data.item.flags.pf2e, resolvedValue);
                 return;
             }
             case "focus-point-cost": {

--- a/src/module/rules/rule-element/item-alteration/alteration.ts
+++ b/src/module/rules/rule-element/item-alteration/alteration.ts
@@ -261,16 +261,16 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
                 if (!("getFlag" in data.item) || typeof data.item.getFlag !== "function") return;
 
                 const flatValue = foundry.utils.flattenObject(data.alteration.value);
+                const resolvedValue = {};
                 for (const [key, value] of Object.entries(flatValue)) {
                     const flag = data.item.getFlag("pf2e", key);
                     const newValue = AELikeRuleElement.getNewValue(this.mode, flag, value);
                     if (newValue instanceof DataModelValidationFailure) {
                         throw newValue.asError();
                     }
-                    foundry.utils.mergeObject(data.item.flags.pf2e, {
-                        [`${key}`]: newValue,
-                    });
+                    foundry.utils.mergeObject(resolvedValue, { [`${key}`]: newValue });
                 }
+                foundry.utils.mergeObject(data.item.flags.pf2e, resolvedValue);
                 return;
             }
             case "focus-point-cost": {

--- a/src/module/rules/rule-element/item-alteration/schemas.ts
+++ b/src/module/rules/rule-element/item-alteration/schemas.ts
@@ -307,6 +307,28 @@ const ITEM_ALTERATION_VALIDATORS = {
             initial: undefined,
         } as const),
     }),
+    flags: new ItemAlterationValidator(
+        {
+            itemType: new fields.StringField({
+                required: true,
+                choices: () => R.keys(CONFIG.PF2E.Item.documentClasses),
+            }),
+            mode: new fields.StringField({
+                required: true,
+                choices: ["add", "downgrade", "multiply", "override", "remove", "subtract", "upgrade"],
+            }),
+            value: new fields.ObjectField({ required: true, nullable: false, initial: undefined } as const),
+        },
+        {
+            validateForItem(item): DataModelValidationFailure | void {
+                if (!("getFlag" in item) || typeof item.getFlag !== "function") {
+                    return new validation.DataModelValidationFailure({
+                        message: "item must be able to accept flags",
+                    });
+                }
+            },
+        },
+    ),
     "focus-point-cost": new ItemAlterationValidator({
         itemType: new fields.StringField({ required: true, choices: ["spell"] } as const),
         mode: new fields.StringField({

--- a/src/module/rules/rule-element/item-alteration/schemas.ts
+++ b/src/module/rules/rule-element/item-alteration/schemas.ts
@@ -307,28 +307,6 @@ const ITEM_ALTERATION_VALIDATORS = {
             initial: undefined,
         } as const),
     }),
-    flags: new ItemAlterationValidator(
-        {
-            itemType: new fields.StringField({
-                required: true,
-                choices: () => R.keys(CONFIG.PF2E.Item.documentClasses),
-            }),
-            mode: new fields.StringField({
-                required: true,
-                choices: ["add", "downgrade", "multiply", "override", "remove", "subtract", "upgrade"],
-            }),
-            value: new fields.ObjectField({ required: true, nullable: false, initial: undefined } as const),
-        },
-        {
-            validateForItem(item): DataModelValidationFailure | void {
-                if (!("getFlag" in item) || typeof item.getFlag !== "function") {
-                    return new validation.DataModelValidationFailure({
-                        message: "item must be able to accept flags",
-                    });
-                }
-            },
-        },
-    ),
     "focus-point-cost": new ItemAlterationValidator({
         itemType: new fields.StringField({ required: true, choices: ["spell"] } as const),
         mode: new fields.StringField({

--- a/src/module/rules/rule-element/item-alteration/schemas.ts
+++ b/src/module/rules/rule-element/item-alteration/schemas.ts
@@ -336,6 +336,33 @@ const ITEM_ALTERATION_VALIDATORS = {
             initial: undefined,
         } as const),
     }),
+    level: new ItemAlterationValidator(
+        {
+            itemType: new fields.StringField({
+                required: true,
+                choices: () => R.keys(CONFIG.PF2E.Item.documentClasses),
+            }),
+            mode: new fields.StringField({
+                required: true,
+                choices: ["add", "downgrade", "multiply", "override", "remove", "subtract", "upgrade"],
+            }),
+            value: new fields.NumberField({
+                required: true,
+                nullable: false,
+                positive: false,
+                initial: undefined,
+            } as const),
+        },
+        {
+            validateForItem(item): DataModelValidationFailure | void {
+                if (item.system.level === undefined || item.system.level.value === undefined) {
+                    return new validation.DataModelValidationFailure({
+                        message: "item must have a level",
+                    });
+                }
+            },
+        },
+    ),
     "material-type": new ItemAlterationValidator({
         itemType: new fields.StringField({ required: true, choices: Array.from(PHYSICAL_ITEM_TYPES) }),
         mode: new fields.StringField({ required: true, choices: ["override"] }),

--- a/src/module/rules/rule-element/item-alteration/schemas.ts
+++ b/src/module/rules/rule-element/item-alteration/schemas.ts
@@ -157,6 +157,7 @@ const ITEM_ALTERATION_VALIDATORS = {
         value: new StrictNumberField({
             required: true,
             nullable: false,
+            min: 0,
             integer: false,
             initial: undefined,
         } as const),

--- a/src/module/rules/rule-element/item-alteration/schemas.ts
+++ b/src/module/rules/rule-element/item-alteration/schemas.ts
@@ -336,33 +336,6 @@ const ITEM_ALTERATION_VALIDATORS = {
             initial: undefined,
         } as const),
     }),
-    level: new ItemAlterationValidator(
-        {
-            itemType: new fields.StringField({
-                required: true,
-                choices: () => R.keys(CONFIG.PF2E.Item.documentClasses),
-            }),
-            mode: new fields.StringField({
-                required: true,
-                choices: ["add", "downgrade", "multiply", "override", "remove", "subtract", "upgrade"],
-            }),
-            value: new fields.NumberField({
-                required: true,
-                nullable: false,
-                positive: false,
-                initial: undefined,
-            } as const),
-        },
-        {
-            validateForItem(item): DataModelValidationFailure | void {
-                if (item.system.level === undefined || item.system.level.value === undefined) {
-                    return new validation.DataModelValidationFailure({
-                        message: "item must have a level",
-                    });
-                }
-            },
-        },
-    ),
     "material-type": new ItemAlterationValidator({
         itemType: new fields.StringField({ required: true, choices: Array.from(PHYSICAL_ITEM_TYPES) }),
         mode: new fields.StringField({ required: true, choices: ["override"] }),

--- a/src/module/rules/rule-element/item-alteration/schemas.ts
+++ b/src/module/rules/rule-element/item-alteration/schemas.ts
@@ -150,11 +150,14 @@ const ITEM_ALTERATION_VALIDATORS = {
     ),
     bulk: new ItemAlterationValidator({
         itemType: new fields.StringField({ required: true, choices: Array.from(PHYSICAL_ITEM_TYPES) }),
-        mode: new fields.StringField({ required: true, choices: ["override"] }),
-        value: new StrictNumberField<number, number, true, false, false>({
+        mode: new fields.StringField({
+            required: true,
+            choices: () => ["add", "downgrade", "multiply", "override", "remove", "subtract", "upgrade"],
+        }),
+        value: new StrictNumberField({
             required: true,
             nullable: false,
-            choices: [0, 0.1, ...Array.fromRange(100, 1)],
+            integer: false,
             initial: undefined,
         } as const),
     }),


### PR DESCRIPTION
This is a reworked / extended version of PR #18126.

This PR adds or changes the following ItemAlterations:
- `bulk` is changed to be able to accept most of the modes. It's `add` and `subtract` that's especially noteworthy -- SF2's Soldier can subtract from an armour's Bulk, and PF2 has a few things that add to an item's bulk, like [Eyecatcher](https://2e.aonprd.com/Equipment.aspx?ID=2452), [Subtle Armour](https://2e.aonprd.com/Equipment.aspx?ID=2453), and the [Fortification](https://2e.aonprd.com/Equipment.aspx?ID=2789) rune.
- ~~`level` has been added to change an item's level. This will prove more useful as part of GrantItem, I believe, especially for effects that grant other effects. I personally ran into a use case with the [Wand of Hawthorn](https://2e.aonprd.com/Equipment.aspx?ID=2279), where I wanted to make an effect that grant Oaken Resilience at a given rank, and adds a note about the thorns on being struck with an unarmed attack.~~
- ~~`flags` would just be useful for homebrewing and there is no real justification for it from the system's standpoint (because the system is the system, and the system can just implement shit in code that it needs). The format for the value here is that it must be an object, for example:~~
   ```json
   "value": {
     "a": 1,
     "b": {
       "c": 2,
       "d": "whatever"
     }
   ```
   ~~With a mode of `override`, this would make the ItemAlteration add these flags to the item(s), unless of course the types of the values mismatch (for example, if `"a" = "test"`, it couldn't be overwritten by a number). The default location of these flags is `flags.pf2e`. With a mode of `add`, and the `b.d` removed, we could add 1 to `a`, and 2 to `b.c` at the same time.~~

Ultimately, I separate the three into their own commits, so if one is not accepted, so be it, I can revert it.