### PR TITLE
added splash damage as resistance source

### DIFF
--- a/src/module/system/damage/iwr.ts
+++ b/src/module/system/damage/iwr.ts
@@ -178,6 +178,19 @@ function applyIWR(actor: ActorPF2e, roll: Rolled<DamageRoll>, rollOptions: Set<s
             );
             const applicableResistances = workingResistanceData.filter((r) => r.applicable);
             const criticalResistance = resistances.find((r) => r.type === "critical-hits");
+
+            const splashResistance = splashDamage
+                ? (resistances.find((r) => r.type === "splash-damage") ?? null)
+                : null;
+            if (splashResistance) {
+                applicableResistances.push(
+                    new WorkingResistanceData(splashResistance, {
+                        value: splashResistance.getDoubledValue(formalDescription),
+                        ignored: ignoredResistances.some((ir) => ir.test(formalDescription)),
+                    }),
+                );
+            }
+
             if (criticalResistance && isCriticalSuccess) {
                 const maxResistable = instanceTotal - critImmuneTotal;
                 if (maxResistable > 0) {

--- a/src/scripts/config/iwr.ts
+++ b/src/scripts/config/iwr.ts
@@ -211,6 +211,7 @@ const resistanceTypes = {
     slashing: "PF2E.Damage.RollFlavor.slashing",
     sonic: "PF2E.Damage.RollFlavor.sonic",
     spells: "PF2E.Damage.IWR.Type.spells",
+    "splash-damage": "PF2E.Damage.IWR.Type.splash-damage",
     spirit: "PF2E.Damage.RollFlavor.spirit",
     "unarmed-attacks": "PF2E.Damage.IWR.Type.unarmed-attacks",
     vitality: "PF2E.Damage.RollFlavor.vitality",


### PR DESCRIPTION
Added splash damage as a resistance source.

Manual tests done:
- Checked if untyped splash damage is reduced
- Checked if typed splash damage is reduced
- Checked that resistance against typed splash is correct if there is a resistance for both
- Checked double resistance
- ~~Checked exception~~ still working on that

Closes #17157