### PR TITLE
Add missing prerequisite to Empiricist's Eye

### DIFF
--- a/packs/feats/empiricists-eye.json
+++ b/packs/feats/empiricists-eye.json
@@ -11,20 +11,35 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>Sharp and piercing, your eyes see all and convey more. Your Point Out actions lose the auditory trait, and you don't need to be heard to convey the information to your allies. In addition, a creature you Point Out is @UUID[Compendium.pf2e.conditionitems.Item.Off-Guard] to your allies until the start of your next turn.</p><hr /><p><strong>Special</strong> If you have the Blind-Fight feat, your allies gain that feat's benefits against any creature that's off-guard due to Empiricist's Eye.</p>"
+            "value": "<p>Sharp and piercing, your eyes see all and convey more. Your Point Out actions lose the auditory trait, and you don't need to be heard to convey the information to your allies. In addition, a creature you Point Out is @UUID[Compendium.pf2e.conditionitems.Item.Off-Guard] to your allies until the start of your next turn.</p><hr /><p><strong>Special</strong> If you have the @UUID[Compendium.pf2e.feats-srd.Item.Blind-Fight] feat, your allies gain that feat's benefits against any creature that's off-guard due to Empiricist's Eye.</p>"
         },
         "level": {
             "value": 12
         },
         "prerequisites": {
-            "value": []
+            "value": [
+                {
+                    "value": "empiricism methodology"
+                }
+            ]
         },
         "publication": {
             "license": "ORC",
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "mode": "remove",
+                "predicate": [
+                    "item:slug:point-out"
+                ],
+                "property": "traits",
+                "value": "auditory"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [


### PR DESCRIPTION
and remove auditory trait from Point Out if it's on the actor's sheet