### PR TITLE
Improve the interaction between Lingering Composition and Courageous Anthem

### DIFF
--- a/packs/spell-effects/spell-effect-courageous-anthem-3-rounds.json
+++ b/packs/spell-effects/spell-effect-courageous-anthem-3-rounds.json
@@ -1,0 +1,76 @@
+{
+    "_id": "rFKINZ3yQHYdkHbm",
+    "img": "systems/pf2e/icons/spells/inspire-courage.webp",
+    "name": "Spell Effect: Courageous Anthem (3 rounds)",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Courageous Anthem]</p>\n<p>You gain a +1 status bonus to attack rolls, damage rolls, and saves against fear effects.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 3
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "selector": [
+                    "attack-roll",
+                    "damage"
+                ],
+                "type": "status",
+                "value": 1
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "fear"
+                ],
+                "selector": "saving-throw",
+                "type": "status",
+                "value": 1
+            },
+            {
+                "damageType": "sonic",
+                "diceNumber": 1,
+                "dieSize": "d6",
+                "hideIfDisabled": true,
+                "key": "DamageDice",
+                "label": "PF2E.SpecificRule.Bard.DiscordantVoice.Label",
+                "predicate": [
+                    "parent:origin:discordant-voice",
+                    {
+                        "not": "parent:origin:signature:{item|parent.signature}"
+                    }
+                ],
+                "selector": "strike-damage"
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "option": "courageous-anthem:origin:signature:{item|origin.signature}"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/spell-effects/spell-effect-courageous-anthem-4-rounds.json
+++ b/packs/spell-effects/spell-effect-courageous-anthem-4-rounds.json
@@ -1,0 +1,76 @@
+{
+    "_id": "zot8JuAN0HXfWo3j",
+    "img": "systems/pf2e/icons/spells/inspire-courage.webp",
+    "name": "Spell Effect: Courageous Anthem (4 rounds)",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Courageous Anthem]</p>\n<p>You gain a +1 status bonus to attack rolls, damage rolls, and saves against fear effects.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 4
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "selector": [
+                    "attack-roll",
+                    "damage"
+                ],
+                "type": "status",
+                "value": 1
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "fear"
+                ],
+                "selector": "saving-throw",
+                "type": "status",
+                "value": 1
+            },
+            {
+                "damageType": "sonic",
+                "diceNumber": 1,
+                "dieSize": "d6",
+                "hideIfDisabled": true,
+                "key": "DamageDice",
+                "label": "PF2E.SpecificRule.Bard.DiscordantVoice.Label",
+                "predicate": [
+                    "parent:origin:discordant-voice",
+                    {
+                        "not": "parent:origin:signature:{item|parent.signature}"
+                    }
+                ],
+                "selector": "strike-damage"
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "option": "courageous-anthem:origin:signature:{item|origin.signature}"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/spell-effects/spell-effect-lingering-composition-critical-success.json
+++ b/packs/spell-effects/spell-effect-lingering-composition-critical-success.json
@@ -16,9 +16,9 @@
             "value": 1
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": ""
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
         },
         "rules": [
             {

--- a/packs/spell-effects/spell-effect-lingering-composition-critical-success.json
+++ b/packs/spell-effects/spell-effect-lingering-composition-critical-success.json
@@ -1,0 +1,62 @@
+{
+    "_id": "pGWlbo549LtsXGg4",
+    "img": "systems/pf2e/icons/spells/lingering-composition.webp",
+    "name": "Spell Effect: Lingering Composition (Critical Success)",
+    "system": {
+        "description": {
+            "value": "<p>The next composition lasts 4 rounds.</p>"
+        },
+        "duration": {
+            "expiry": "turn-end",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": ""
+        },
+        "rules": [
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "override",
+                "predicate": [
+                    "item:slug:courageous-anthem"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "60-foot emanation",
+                        "title": "Area"
+                    },
+                    {
+                        "text": "4 round",
+                        "title": "Duration"
+                    },
+                    {
+                        "text": "You inspire yourself and your allies with words or tunes of encouragement. You and all allies in the area gain a +1 status bonus to attack rolls, damage rolls, and saves against fear effects."
+                    },
+                    {
+                        "text": "@UUID[Compendium.pf2e.spell-effects.Item.zot8JuAN0HXfWo3j]{Spell Effect: Courageous Anthem}"
+                    }
+                ]
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/spell-effects/spell-effect-lingering-composition-critical-success.json
+++ b/packs/spell-effects/spell-effect-lingering-composition-critical-success.json
@@ -24,23 +24,12 @@
             {
                 "itemType": "spell",
                 "key": "ItemAlteration",
-                "mode": "override",
+                "mode": "add",
                 "predicate": [
                     "item:slug:courageous-anthem"
                 ],
                 "property": "description",
                 "value": [
-                    {
-                        "text": "60-foot emanation",
-                        "title": "Area"
-                    },
-                    {
-                        "text": "4 round",
-                        "title": "Duration"
-                    },
-                    {
-                        "text": "You inspire yourself and your allies with words or tunes of encouragement. You and all allies in the area gain a +1 status bonus to attack rolls, damage rolls, and saves against fear effects."
-                    },
                     {
                         "text": "@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Courageous Anthem (4 rounds)]"
                     }

--- a/packs/spell-effects/spell-effect-lingering-composition-critical-success.json
+++ b/packs/spell-effects/spell-effect-lingering-composition-critical-success.json
@@ -42,7 +42,7 @@
                         "text": "You inspire yourself and your allies with words or tunes of encouragement. You and all allies in the area gain a +1 status bonus to attack rolls, damage rolls, and saves against fear effects."
                     },
                     {
-                        "text": "@UUID[Compendium.pf2e.spell-effects.Item.zot8JuAN0HXfWo3j]{Spell Effect: Courageous Anthem}"
+                        "text": "@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Courageous Anthem (4 rounds)]"
                     }
                 ]
             }

--- a/packs/spell-effects/spell-effect-lingering-composition-success.json
+++ b/packs/spell-effects/spell-effect-lingering-composition-success.json
@@ -24,23 +24,12 @@
             {
                 "itemType": "spell",
                 "key": "ItemAlteration",
-                "mode": "override",
+                "mode": "add",
                 "predicate": [
                     "item:slug:courageous-anthem"
                 ],
                 "property": "description",
                 "value": [
-                    {
-                        "text": "60-foot emanation",
-                        "title": "Area"
-                    },
-                    {
-                        "text": "3 round",
-                        "title": "Duration"
-                    },
-                    {
-                        "text": "You inspire yourself and your allies with words or tunes of encouragement. You and all allies in the area gain a +1 status bonus to attack rolls, damage rolls, and saves against fear effects."
-                    },
                     {
                         "text": "@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Courageous Anthem (3 rounds)]"
                     }

--- a/packs/spell-effects/spell-effect-lingering-composition-success.json
+++ b/packs/spell-effects/spell-effect-lingering-composition-success.json
@@ -1,0 +1,62 @@
+{
+    "_id": "bCNXCyWlstxFkqGl",
+    "img": "systems/pf2e/icons/spells/lingering-composition.webp",
+    "name": "Spell Effect: Lingering Composition (Success)",
+    "system": {
+        "description": {
+            "value": "<p>The next composition spell lasts 3 rounds.</p>"
+        },
+        "duration": {
+            "expiry": "turn-end",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": ""
+        },
+        "rules": [
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "override",
+                "predicate": [
+                    "item:slug:courageous-anthem"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "60-foot emanation",
+                        "title": "Area"
+                    },
+                    {
+                        "text": "3 round",
+                        "title": "Duration"
+                    },
+                    {
+                        "text": "You inspire yourself and your allies with words or tunes of encouragement. You and all allies in the area gain a +1 status bonus to attack rolls, damage rolls, and saves against fear effects."
+                    },
+                    {
+                        "text": "@UUID[Compendium.pf2e.spell-effects.Item.rFKINZ3yQHYdkHbm]{Spell Effect: Courageous Anthem}"
+                    }
+                ]
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/spell-effects/spell-effect-lingering-composition-success.json
+++ b/packs/spell-effects/spell-effect-lingering-composition-success.json
@@ -42,7 +42,7 @@
                         "text": "You inspire yourself and your allies with words or tunes of encouragement. You and all allies in the area gain a +1 status bonus to attack rolls, damage rolls, and saves against fear effects."
                     },
                     {
-                        "text": "@UUID[Compendium.pf2e.spell-effects.Item.rFKINZ3yQHYdkHbm]{Spell Effect: Courageous Anthem}"
+                        "text": "@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Courageous Anthem (3 rounds)]"
                     }
                 ]
             }

--- a/packs/spells/lingering-composition.json
+++ b/packs/spells/lingering-composition.json
@@ -11,7 +11,7 @@
         "damage": {},
         "defense": null,
         "description": {
-            "value": "<p>You add a flourish to your composition to extend its benefits. If your next action is to cast a cantrip composition with a duration of 1 round, attempt a @Check[performance|options:spell-lingering-composition|dc:@self.level] check. The DC is usually a standard-difficulty DC of a level equal to the highest-level target of your composition, but the GM can assign a different DC based on the circumstances. The effect depends on the result of your check.</p><hr /><p><strong>Critical Success</strong> The composition lasts 4 rounds.</p>\n<p><strong>Success</strong> The composition lasts 3 rounds.</p>\n<p><strong>Failure</strong> The composition lasts 1 round, but you don't spend the Focus Point for casting this spell.</p>"
+            "value": "<p>You add a flourish to your composition to extend its benefits. If your next action is to cast a cantrip composition with a duration of 1 round, attempt a @Check[performance|options:spell-lingering-composition] check. The DC is usually a standard-difficulty DC of a level equal to the highest-level target of your composition, but the GM can assign a different DC based on the circumstances. The effect depends on the result of your check.</p><hr /><p><strong>Critical Success</strong> The composition lasts 4 rounds.</p>\n<p><strong>Success</strong> The composition lasts 3 rounds.</p>\n<p><strong>Failure</strong> The composition lasts 1 round, but you don't spend the Focus Point for casting this spell.</p>"
         },
         "duration": {
             "sustained": false,
@@ -33,57 +33,11 @@
             {
                 "key": "Note",
                 "predicate": [
-                    "spell-lingering-composition",
-                    {
-                        "lt": [
-                            "check:total:delta",
-                            0
-                        ]
-                    }
+                    "spell-lingering-composition"
                 ],
                 "selector": "performance-check",
-                "text": "The composition lasts 1 round, but you don't spend the Focus Point for casting this spell.",
-                "title": "Failure"
-            },
-            {
-                "key": "Note",
-                "predicate": [
-                    "spell-lingering-composition",
-                    {
-                        "and": [
-                            {
-                                "lt": [
-                                    "check:total:delta",
-                                    10
-                                ]
-                            },
-                            {
-                                "gte": [
-                                    "check:total:delta",
-                                    0
-                                ]
-                            }
-                        ]
-                    }
-                ],
-                "selector": "performance-check",
-                "text": "The next composition spell lasts 3 rounds. @UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Lingering Composition (Success)]",
-                "title": "Success"
-            },
-            {
-                "key": "Note",
-                "predicate": [
-                    "spell-lingering-composition",
-                    {
-                        "gte": [
-                            "check:total:delta",
-                            10
-                        ]
-                    }
-                ],
-                "selector": "performance-check",
-                "text": "The next composition lasts 4 rounds. @UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Lingering Composition (Critical Success)]",
-                "title": "Critical Success"
+                "text": "PF2E.SpecificRule.Feat.LingeringComposition.Note",
+                "title": "{item|name}"
             }
         ],
         "target": {

--- a/packs/spells/lingering-composition.json
+++ b/packs/spells/lingering-composition.json
@@ -67,7 +67,7 @@
                     }
                 ],
                 "selector": "performance-check",
-                "text": "The next composition spell lasts 3 rounds. @UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Lingering Composition (Success)]{Spell Effect: Lingering Composition}",
+                "text": "The next composition spell lasts 3 rounds. @UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Lingering Composition (Success)]",
                 "title": "Success"
             },
             {
@@ -82,7 +82,7 @@
                     }
                 ],
                 "selector": "performance-check",
-                "text": "The next composition lasts 4 rounds. @UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Lingering Composition (Success)]{Spell Effect: Lingering Composition}",
+                "text": "The next composition lasts 4 rounds. @UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Lingering Composition (Critical Success)]",
                 "title": "Critical Success"
             }
         ],

--- a/packs/spells/lingering-composition.json
+++ b/packs/spells/lingering-composition.json
@@ -11,7 +11,7 @@
         "damage": {},
         "defense": null,
         "description": {
-            "value": "<p>You add a flourish to your composition to extend its benefits. If your next action is to cast a cantrip composition with a duration of 1 round, attempt a @Check[performance] check. The DC is usually a standard-difficulty DC of a level equal to the highest-level target of your composition, but the GM can assign a different DC based on the circumstances. The effect depends on the result of your check.</p>\n<hr />\n<p><strong>Critical Success</strong> The composition lasts 4 rounds.</p>\n<p><strong>Success</strong> The composition lasts 3 rounds.</p>\n<p><strong>Failure</strong> The composition lasts 1 round, but you don't spend the Focus Point for casting this spell.</p>"
+            "value": "<p>You add a flourish to your composition to extend its benefits. If your next action is to cast a cantrip composition with a duration of 1 round, attempt a @Check[performance|options:spell-lingering-composition|dc:@self.level] check. The DC is usually a standard-difficulty DC of a level equal to the highest-level target of your composition, but the GM can assign a different DC based on the circumstances. The effect depends on the result of your check.</p><hr /><p><strong>Critical Success</strong> The composition lasts 4 rounds.</p>\n<p><strong>Success</strong> The composition lasts 3 rounds.</p>\n<p><strong>Failure</strong> The composition lasts 1 round, but you don't spend the Focus Point for casting this spell.</p>"
         },
         "duration": {
             "sustained": false,
@@ -29,7 +29,63 @@
             "value": ""
         },
         "requirements": "",
-        "rules": [],
+        "rules": [
+            {
+                "key": "Note",
+                "predicate": [
+                    "spell-lingering-composition",
+                    {
+                        "lt": [
+                            "check:total:delta",
+                            0
+                        ]
+                    }
+                ],
+                "selector": "performance-check",
+                "text": "The composition lasts 1 round, but you don't spend the Focus Point for casting this spell.",
+                "title": "Failure"
+            },
+            {
+                "key": "Note",
+                "predicate": [
+                    "spell-lingering-composition",
+                    {
+                        "and": [
+                            {
+                                "lt": [
+                                    "check:total:delta",
+                                    10
+                                ]
+                            },
+                            {
+                                "gte": [
+                                    "check:total:delta",
+                                    0
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "selector": "performance-check",
+                "text": "The next composition spell lasts 3 rounds. @UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Lingering Composition (Success)]{Spell Effect: Lingering Composition}",
+                "title": "Success"
+            },
+            {
+                "key": "Note",
+                "predicate": [
+                    "spell-lingering-composition",
+                    {
+                        "gte": [
+                            "check:total:delta",
+                            10
+                        ]
+                    }
+                ],
+                "selector": "performance-check",
+                "text": "The next composition lasts 4 rounds. @UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Lingering Composition (Success)]{Spell Effect: Lingering Composition}",
+                "title": "Critical Success"
+            }
+        ],
         "target": {
             "value": ""
         },

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -3789,6 +3789,9 @@
                     "Exemplar": "You have practiced quickly switching between combat styles and the equipment needed for them, especially if you wield more than one weapon ikon. You Interact to stow any number of items from your hands, then draw up to two weapons or a shield and a weapon.",
                     "Fighter": "You have practiced quickly switching between combat styles and the equipment needed for them. You Interact to stow any number of items from your hands, then draw up to two weapons or a shield and a weapon."
                 },
+                "LingeringComposition": {
+                    "Note": "<p><strong>Critical Success</strong> The next composition lasts 4 rounds. @UUID[Compendium.pf2e.spell-effects.Item.pGWlbo549LtsXGg4]{Spell Effect: Lingering Composition (Critical Success)}</p>\n<p><strong>Success</strong> The next composition spell lasts 3 rounds. @UUID[Compendium.pf2e.spell-effects.Item.bCNXCyWlstxFkqGl]{Spell Effect: Lingering Composition (Success)}</p>\n<p><strong>Failure</strong> The composition lasts 1 round, but you don't spend the Focus Point for casting this spell.</p>"
+                },
                 "PeerBeyond": {
                     "Note": "You can roll a Spirit Lore or Haunt Lore check for initiative if you know that an incorporeal undead or a haunt is present."
                 },


### PR DESCRIPTION
The "Lingering Composition" _spell_ Performance skill check now carries a new traits. This one is used to trigger a Note specific to the result of said Performance check. In case of Success or Critical success,  a new _spell-effect_ is provided. Once applied to the bard, it will use an ItemAlteration targeting the _spell_ "Courageous Anthem" so that this one now provide a new "Courageous Anthem" _spell-effect_ with an updated duration (3 for a success and 4 for a critical success).

The Performance skill check DC is also defaulted to Level DC based on the bard level. This is not exactly RAW. In theory the spell DC is based on the highest level character targeted by the bard. I could not find a way to use the target level and this seems like a correct approximation, assuming most character in a party will have a similar level.