### PR TITLE
Update Reinforced Chassis physical armor to be unarmored

### DIFF
--- a/packs/equipment/reinforced-chassis.json
+++ b/packs/equipment/reinforced-chassis.json
@@ -8,11 +8,11 @@
         "bulk": {
             "value": 0
         },
-        "category": "medium",
+        "category": "unarmored",
         "checkPenalty": -2,
         "containerId": null,
         "description": {
-            "value": ""
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Reinforced Chassis]</p>\n<p>@Embed[Compendium.pf2e.feats-srd.Item.cilZUszwjSGB4p1W inline]</p>"
         },
         "dexCap": 1,
         "group": null,


### PR DESCRIPTION
This is the new language of Reinforced Chassis
> Your body is designed to be particularly resilient. Your chassis is made from reinforced armor plating that grants a +3 item bonus to AC with a Dexterity cap of +1. If you are at least 5th level, the item bonus increases to +4 and at 10th level it increases to +5. You can never wear other armor or remove your chassis; however, you still don't become fatigued from sleeping. You can etch armor runes onto your chassis.

Since it doesn't specify it being any category of armor, and the runes are etched into the chassis specifically (as opposed to onto explorer's clothing in Scaly Hide), I think this might be the best way to go about it. The Reinforced Chassis feat includes the scaling for this armor.