### PR TITLE
Bring "Anima Invocation" spell effect in line with Remaster changes

### DIFF
--- a/packs/spell-effects/spell-effect-anima-invocation.json
+++ b/packs/spell-effects/spell-effect-anima-invocation.json
@@ -45,10 +45,16 @@
                 "value": "ghost-touch"
             },
             {
+                "key": "AdjustStrike",
+                "mode": "add",
+                "property": "weapon-traits",
+                "value": "holy"
+            },
+            {
                 "key": "FlatModifier",
                 "predicate": [
                     "anima-invocation:critical-success",
-                    "origin:trait:evil"
+                    "origin:trait:unholy"
                 ],
                 "selector": "saving-throw",
                 "slug": "anima-invocation-save-critical",
@@ -77,7 +83,7 @@
                 "key": "FlatModifier",
                 "predicate": [
                     "anima-invocation:success",
-                    "origin:trait:evil"
+                    "origin:trait:unholy"
                 ],
                 "selector": "saving-throw",
                 "slug": "anima-invocation-save-success",


### PR DESCRIPTION
Added an Adjust-Strike weapon-trait holy.
Changed the save modifier rule elements predicates to unholy instead of evil.
Closes #18195