### PR TITLE
Fix incorrect casting time on Trade Death for Life

### DIFF
--- a/packs/spells/trade-death-for-life.json
+++ b/packs/spells/trade-death-for-life.json
@@ -57,7 +57,7 @@
             "value": "1 creature"
         },
         "time": {
-            "value": "2"
+            "value": "1"
         },
         "traits": {
             "rarity": "uncommon",


### PR DESCRIPTION
Trade Death for Life hex cantrip is incorrectly stated to have casting time of 2 actions instead of 1.