### PR TITLE
Include "Black Powder (Dose)" in Munitions Crafter's Crafting Ability

### DIFF
--- a/packs/equipment/black-powder-dose.json
+++ b/packs/equipment/black-powder-dose.json
@@ -1,7 +1,7 @@
 {
     "_id": "AOOQJfSkTPiSzfB9",
     "img": "systems/pf2e/icons/equipment/consumables/other-consumables/black-powder-dose.webp",
-    "name": "Black Powder (Dose or Round)",
+    "name": "Black Powder (Dose)",
     "system": {
         "baseItem": null,
         "bulk": {

--- a/packs/feats/munitions-crafter.json
+++ b/packs/feats/munitions-crafter.json
@@ -43,7 +43,7 @@
                                 {
                                     "or": [
                                         "item:category:ammo",
-                                        "item:slug:black-powder-dose-or-round"
+                                        "item:slug:black-powder-dose"
                                     ]
                                 }
                             ],
@@ -57,7 +57,7 @@
                         "or": [
                             "item:category:ammo",
                             "item:group:bomb",
-                            "item:slug:black-powder-dose-or-round"
+                            "item:slug:black-powder-dose"
                         ]
                     }
                 ],

--- a/packs/feats/munitions-crafter.json
+++ b/packs/feats/munitions-crafter.json
@@ -40,7 +40,12 @@
                     "other": [
                         {
                             "definition": [
-                                "item:category:ammo"
+                                {
+                                    "or": [
+                                        "item:category:ammo",
+                                        "item:slug:black-powder-dose-or-round"
+                                    ]
+                                }
                             ],
                             "quantity": 4
                         }
@@ -50,8 +55,9 @@
                     "item:trait:alchemical",
                     {
                         "or": [
+                            "item:category:ammo",
                             "item:group:bomb",
-                            "item:category:ammo"
+                            "item:slug:black-powder-dose-or-round"
                         ]
                     }
                 ],


### PR DESCRIPTION
Closes #18251
For the sake of completion I suppose. Also shorten `Black Powder (Dose or Round)` to `Black Powder (Dose)`, since rounds have weapon-specific items.