### PR TITLE
Add class predicate to Oracle Ashes mystery

### DIFF
--- a/packs/classfeatures/ashes.json
+++ b/packs/classfeatures/ashes.json
@@ -33,6 +33,9 @@
             },
             {
                 "key": "GrantItem",
+                "predicate": [
+                    "class:oracle"
+                ],
                 "uuid": "Compendium.pf2e.feats-srd.Item.Whispers of Weakness"
             },
             {


### PR DESCRIPTION
Added a class predicate to the Grant Item rule element that confers Whispers of Weakness to prevent incorrectly giving this class feat to characters who pick up the ashes mystery via the oracle dedication archetype feat.