### PR TITLE
Add class predicate to Oracle Time mystery

### DIFF
--- a/packs/classfeatures/time.json
+++ b/packs/classfeatures/time.json
@@ -33,6 +33,9 @@
             },
             {
                 "key": "GrantItem",
+                "predicate": [
+                    "class:oracle"
+                ],
                 "uuid": "Compendium.pf2e.feats-srd.Item.Oracular Warning"
             },
             {


### PR DESCRIPTION
Added a class predicate to the Grant Item rule element that confers Oracular Warning to prevent incorrectly giving the class feat to characters who pick up the time mystery via the oracle dedication archetype feat.