### PR TITLE
Implement Slinger's Precision proficiency increase for some combination weapons

### DIFF
--- a/packs/classfeatures/gunslinger-weapon-mastery.json
+++ b/packs/classfeatures/gunslinger-weapon-mastery.json
@@ -53,6 +53,24 @@
                         ]
                     }
                 ]
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "system.proficiencies.attacks.slingers-precision-combination-advanced.rank",
+                "value": 2
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "system.proficiencies.attacks.slingers-precision-combination-martial.rank",
+                "value": 3
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "system.proficiencies.attacks.slingers-precision-combination-simple.rank",
+                "value": 3
             }
         ],
         "subfeatures": {

--- a/packs/classfeatures/gunslinging-legend.json
+++ b/packs/classfeatures/gunslinging-legend.json
@@ -42,6 +42,24 @@
                 "mode": "upgrade",
                 "path": "system.proficiencies.attacks.martial-firearms-crossbows.rank",
                 "value": 4
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "system.proficiencies.attacks.slingers-precision-combination-advanced.rank",
+                "value": 3
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "system.proficiencies.attacks.slingers-precision-combination-martial.rank",
+                "value": 4
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "system.proficiencies.attacks.slingers-precision-combination-simple.rank",
+                "value": 4
             }
         ],
         "subfeatures": {

--- a/packs/classfeatures/slingers-precision.json
+++ b/packs/classfeatures/slingers-precision.json
@@ -73,6 +73,36 @@
                 "selectors": [
                     "firearm-weapon-group-damage"
                 ]
+            },
+            {
+                "definition": [
+                    "item:category:advanced",
+                    "item:trait:slingers-precision"
+                ],
+                "key": "MartialProficiency",
+                "label": "PF2E.SpecificRule.MartialProficiency.AdvancedCombinationSP",
+                "slug": "slingers-precision-combination-advanced",
+                "value": "1"
+            },
+            {
+                "definition": [
+                    "item:category:martial",
+                    "item:trait:slingers-precision"
+                ],
+                "key": "MartialProficiency",
+                "label": "PF2E.SpecificRule.MartialProficiency.martialCombinationSP",
+                "slug": "slingers-precision-combination-martial",
+                "value": "2"
+            },
+            {
+                "definition": [
+                    "item:category:simple",
+                    "item:trait:slingers-precision"
+                ],
+                "key": "MartialProficiency",
+                "label": "PF2E.SpecificRule.MartialProficiency.SimpleCombinationSP",
+                "slug": "slingers-precision-combination-simple",
+                "value": "2"
             }
         ],
         "traits": {

--- a/packs/classfeatures/slingers-precision.json
+++ b/packs/classfeatures/slingers-precision.json
@@ -77,7 +77,12 @@
             {
                 "definition": [
                     "item:category:advanced",
-                    "item:trait:slingers-precision"
+                    {
+                        "or": [
+                            "item:rangedGroup:crossbow",
+                            "item:rangedGroup:firearm"
+                        ]
+                    }
                 ],
                 "key": "MartialProficiency",
                 "label": "PF2E.SpecificRule.MartialProficiency.AdvancedCombinationSP",
@@ -87,17 +92,27 @@
             {
                 "definition": [
                     "item:category:martial",
-                    "item:trait:slingers-precision"
+                    {
+                        "or": [
+                            "item:rangedGroup:crossbow",
+                            "item:rangedGroup:firearm"
+                        ]
+                    }
                 ],
                 "key": "MartialProficiency",
-                "label": "PF2E.SpecificRule.MartialProficiency.martialCombinationSP",
+                "label": "PF2E.SpecificRule.MartialProficiency.MartialCombinationSP",
                 "slug": "slingers-precision-combination-martial",
                 "value": "2"
             },
             {
                 "definition": [
                     "item:category:simple",
-                    "item:trait:slingers-precision"
+                    {
+                        "or": [
+                            "item:rangedGroup:crossbow",
+                            "item:rangedGroup:firearm"
+                        ]
+                    }
                 ],
                 "key": "MartialProficiency",
                 "label": "PF2E.SpecificRule.MartialProficiency.SimpleCombinationSP",

--- a/packs/equipment/axe-musket.json
+++ b/packs/equipment/axe-musket.json
@@ -42,6 +42,7 @@
                 "type": "slashing"
             },
             "group": "axe",
+            "rangedGroup": "firearm",
             "traits": [
                 "critical-fusion",
                 "forceful",

--- a/packs/equipment/black-powder-knuckle-dusters.json
+++ b/packs/equipment/black-powder-knuckle-dusters.json
@@ -42,6 +42,7 @@
                 "type": "bludgeoning"
             },
             "group": "brawling",
+            "rangedGroup": "firearm",
             "traits": [
                 "agile",
                 "critical-fusion",

--- a/packs/equipment/blade-of-fallen-stars.json
+++ b/packs/equipment/blade-of-fallen-stars.json
@@ -42,6 +42,7 @@
                 "type": "slashing"
             },
             "group": "sword",
+            "rangedGroup": "firearm",
             "traits": [
                 "critical-fusion",
                 "versatile-p"

--- a/packs/equipment/bow-staff.json
+++ b/packs/equipment/bow-staff.json
@@ -42,6 +42,7 @@
                 "type": "bludgeoning"
             },
             "group": "club",
+            "rangedGroup": "bow",
             "traits": [
                 "finesse",
                 "monk",

--- a/packs/equipment/cane-pistol.json
+++ b/packs/equipment/cane-pistol.json
@@ -42,6 +42,7 @@
                 "type": "bludgeoning"
             },
             "group": "club",
+            "rangedGroup": "firearm",
             "traits": [
                 "concealable",
                 "critical-fusion",

--- a/packs/equipment/crescent-cross.json
+++ b/packs/equipment/crescent-cross.json
@@ -42,6 +42,7 @@
                 "type": "slashing"
             },
             "group": "knife",
+            "rangedGroup": "crossbow",
             "traits": [
                 "critical-fusion",
                 "parry"

--- a/packs/equipment/dagger-pistol.json
+++ b/packs/equipment/dagger-pistol.json
@@ -42,6 +42,7 @@
                 "type": "piercing"
             },
             "group": "knife",
+            "rangedGroup": "firearm",
             "traits": [
                 "agile",
                 "critical-fusion",

--- a/packs/equipment/explosive-dogslicer.json
+++ b/packs/equipment/explosive-dogslicer.json
@@ -42,6 +42,7 @@
                 "type": "slashing"
             },
             "group": "sword",
+            "rangedGroup": "firearm",
             "traits": [
                 "agile",
                 "backstabber",

--- a/packs/equipment/fulmination-fang.json
+++ b/packs/equipment/fulmination-fang.json
@@ -41,7 +41,8 @@
                 "die": "d4",
                 "type": "piercing"
             },
-            "group": "knife"
+            "group": "knife",
+            "rangedGroup": "firearm"
         },
         "price": {
             "value": {

--- a/packs/equipment/gnome-amalgam-musket.json
+++ b/packs/equipment/gnome-amalgam-musket.json
@@ -42,6 +42,7 @@
                 "type": "bludgeoning"
             },
             "group": "hammer",
+            "rangedGroup": "firearm",
             "traits": [
                 "backswing",
                 "critical-fusion",

--- a/packs/equipment/gun-sword.json
+++ b/packs/equipment/gun-sword.json
@@ -42,6 +42,7 @@
                 "type": "slashing"
             },
             "group": "sword",
+            "rangedGroup": "firearm",
             "traits": [
                 "critical-fusion",
                 "versatile-p"

--- a/packs/equipment/hammer-gun.json
+++ b/packs/equipment/hammer-gun.json
@@ -42,6 +42,7 @@
                 "type": "bludgeoning"
             },
             "group": "hammer",
+            "rangedGroup": "firearm",
             "traits": [
                 "critical-fusion",
                 "shove"

--- a/packs/equipment/jax.json
+++ b/packs/equipment/jax.json
@@ -42,6 +42,7 @@
                 "type": "slashing"
             },
             "group": "sword",
+            "rangedGroup": "firearm",
             "traits": [
                 "critical-fusion",
                 "finesse",

--- a/packs/equipment/lancer.json
+++ b/packs/equipment/lancer.json
@@ -42,6 +42,7 @@
                 "type": "piercing"
             },
             "group": "spear",
+            "rangedGroup": "crossbow",
             "traits": [
                 "critical-fusion",
                 "reach"

--- a/packs/equipment/mace-multipistol.json
+++ b/packs/equipment/mace-multipistol.json
@@ -42,6 +42,7 @@
                 "type": "bludgeoning"
             },
             "group": "club",
+            "rangedGroup": "firearm",
             "traits": [
                 "critical-fusion",
                 "finesse",

--- a/packs/equipment/mikazuki.json
+++ b/packs/equipment/mikazuki.json
@@ -42,6 +42,7 @@
                 "type": "bludgeoning"
             },
             "group": "flail",
+            "rangedGroup": "bow",
             "traits": [
                 "backswing",
                 "disarm",

--- a/packs/equipment/nightmares-lament.json
+++ b/packs/equipment/nightmares-lament.json
@@ -41,7 +41,8 @@
                 "die": "d4",
                 "type": "piercing"
             },
-            "group": "knife"
+            "group": "knife",
+            "rangedGroup": "firearm"
         },
         "price": {
             "value": {

--- a/packs/equipment/obsidian-edge-greater.json
+++ b/packs/equipment/obsidian-edge-greater.json
@@ -42,6 +42,7 @@
                 "type": "slashing"
             },
             "group": "sword",
+            "rangedGroup": "firearm",
             "traits": [
                 "critical-fusion",
                 "versatile-p"

--- a/packs/equipment/obsidian-edge-major.json
+++ b/packs/equipment/obsidian-edge-major.json
@@ -42,6 +42,7 @@
                 "type": "slashing"
             },
             "group": "sword",
+            "rangedGroup": "firearm",
             "traits": [
                 "critical-fusion",
                 "versatile-p"

--- a/packs/equipment/obsidian-edge-true.json
+++ b/packs/equipment/obsidian-edge-true.json
@@ -42,6 +42,7 @@
                 "type": "slashing"
             },
             "group": "sword",
+            "rangedGroup": "firearm",
             "traits": [
                 "critical-fusion",
                 "versatile-p"

--- a/packs/equipment/obsidian-edge.json
+++ b/packs/equipment/obsidian-edge.json
@@ -42,6 +42,7 @@
                 "type": "slashing"
             },
             "group": "sword",
+            "rangedGroup": "firearm",
             "traits": [
                 "critical-fusion",
                 "versatile-p"

--- a/packs/equipment/piercing-wind.json
+++ b/packs/equipment/piercing-wind.json
@@ -42,6 +42,7 @@
                 "type": "slashing"
             },
             "group": "sword",
+            "rangedGroup": "firearm",
             "traits": [
                 "critical-fusion",
                 "finesse",

--- a/packs/equipment/rapier-pistol.json
+++ b/packs/equipment/rapier-pistol.json
@@ -42,6 +42,7 @@
                 "type": "piercing"
             },
             "group": "sword",
+            "rangedGroup": "firearm",
             "traits": [
                 "critical-fusion",
                 "deadly-d8",

--- a/packs/equipment/scarlet-queen.json
+++ b/packs/equipment/scarlet-queen.json
@@ -42,6 +42,7 @@
                 "type": "bludgeoning"
             },
             "group": "hammer",
+            "rangedGroup": "firearm",
             "traits": [
                 "critical-fusion",
                 "shove"

--- a/packs/equipment/three-peaked-tree.json
+++ b/packs/equipment/three-peaked-tree.json
@@ -42,6 +42,7 @@
                 "type": "piercing"
             },
             "group": "spear",
+            "rangedGroup": "firearm",
             "traits": [
                 "critical-fusion",
                 "elf",

--- a/packs/equipment/triggerbrand.json
+++ b/packs/equipment/triggerbrand.json
@@ -42,6 +42,7 @@
                 "type": "piercing"
             },
             "group": "sword",
+            "rangedGroup": "firearm",
             "traits": [
                 "critical-fusion",
                 "finesse",

--- a/packs/equipment/wrecker.json
+++ b/packs/equipment/wrecker.json
@@ -42,6 +42,7 @@
                 "type": "bludgeoning"
             },
             "group": "flail",
+            "rangedGroup": "sling",
             "traits": [
                 "dwarf",
                 "razing",

--- a/src/module/item/weapon/data.ts
+++ b/src/module/item/weapon/data.ts
@@ -54,6 +54,7 @@ interface WeaponSystemSource extends Investable<PhysicalSystemSource> {
     material: WeaponMaterialSource;
     category: WeaponCategory;
     group: WeaponGroup | null;
+    rangedGroup: WeaponGroup | null
     /** A base shield type can be used for attacks generated from shields */
     baseItem: BaseWeaponType | null;
     bonus: {
@@ -189,6 +190,7 @@ interface WeaponRuneData extends WeaponRuneSource {
 interface ComboWeaponMeleeUsage {
     damage: { type: DamageType; die: DamageDieSize };
     group: MeleeWeaponGroup;
+    rangedGroup?: WeaponGroup
     traits?: WeaponTrait[];
     traitToggles?: { modular: DamageType | null; versatile: DamageType | null };
 }

--- a/src/module/item/weapon/data.ts
+++ b/src/module/item/weapon/data.ts
@@ -190,7 +190,7 @@ interface WeaponRuneData extends WeaponRuneSource {
 interface ComboWeaponMeleeUsage {
     damage: { type: DamageType; die: DamageDieSize };
     group: MeleeWeaponGroup;
-    rangedGroup?: WeaponGroup;
+    rangedGroup: WeaponGroup;
     traits?: WeaponTrait[];
     traitToggles?: { modular: DamageType | null; versatile: DamageType | null };
 }

--- a/src/module/item/weapon/data.ts
+++ b/src/module/item/weapon/data.ts
@@ -54,7 +54,7 @@ interface WeaponSystemSource extends Investable<PhysicalSystemSource> {
     material: WeaponMaterialSource;
     category: WeaponCategory;
     group: WeaponGroup | null;
-    rangedGroup: WeaponGroup | null
+    rangedGroup: WeaponGroup | null;
     /** A base shield type can be used for attacks generated from shields */
     baseItem: BaseWeaponType | null;
     bonus: {
@@ -190,7 +190,7 @@ interface WeaponRuneData extends WeaponRuneSource {
 interface ComboWeaponMeleeUsage {
     damage: { type: DamageType; die: DamageDieSize };
     group: MeleeWeaponGroup;
-    rangedGroup?: WeaponGroup
+    rangedGroup?: WeaponGroup;
     traits?: WeaponTrait[];
     traitToggles?: { modular: DamageType | null; versatile: DamageType | null };
 }

--- a/src/module/item/weapon/document.ts
+++ b/src/module/item/weapon/document.ts
@@ -546,6 +546,7 @@ class WeaponPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
                 damage: { damageType: meleeUsage.damage.type, dice: 1, die: meleeUsage.damage.die },
                 group: meleeUsage.group,
                 range: null,
+                rangedGroup: meleeUsage.rangedGroup,
                 reload: { value: null },
                 traits: { value: [...meleeUsage.traits], toggles: traitToggles },
                 selectedAmmoId: null,

--- a/src/module/item/weapon/document.ts
+++ b/src/module/item/weapon/document.ts
@@ -78,6 +78,10 @@ class WeaponPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
         return this.system.group;
     }
 
+    get rangedGroup(): WeaponGroup | null {
+        return this.system.rangedGroup;
+    }
+
     get category(): WeaponCategory {
         return this.system.category;
     }
@@ -280,6 +284,7 @@ class WeaponPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
                 [`bulk:${bulk}`]: true,
                 [`usage:hands:${this.hands}`]: this.hands !== "0",
                 [`range-increment:${rangeIncrement}`]: !!rangeIncrement,
+                [`rangedGroup:${this.rangedGroup}`]: !!this.rangedGroup,
                 [`reload:${this.reload}`]: !!this.reload,
                 [`damage:type:${damage.type}`]: true,
                 [`damage:category:${damage.category}`]: !!damage.category,

--- a/src/module/item/weapon/sheet.ts
+++ b/src/module/item/weapon/sheet.ts
@@ -77,6 +77,7 @@ export class WeaponSheetPF2e extends PhysicalItemSheetPF2e<WeaponPF2e> {
 
         const meleeUsage = sheetData.data.meleeUsage ?? {
             group: "knife",
+            rangedGroup: "bow",
             damage: { type: "piercing", die: "d4" },
             traits: [],
         };

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -5919,6 +5919,7 @@
         "WeaponRange70": "70 ft.",
         "WeaponRange80": "80 ft.",
         "WeaponRange90": "90 ft.",
+        "WeaponRangedGroupLabel": "Ranged Group",
         "WeaponRangeMelee": "Melee",
         "WeaponRangeN": "{range} ft.",
         "WeaponRangeReach": "Reach",

--- a/static/templates/items/weapon-details.hbs
+++ b/static/templates/items/weapon-details.hbs
@@ -267,6 +267,12 @@
             </select>
         </div>
         <div class="form-group">
+            <label>{{localize "PF2E.WeaponRangedGroupLabel"}}</label>
+            <select name="system.meleeUsage.rangedGroup">
+                {{selectOptions groups selected=meleeUsage.rangedGroup}}
+            </select>
+        </div>
+        <div class="form-group">
             <label>{{localize "PF2E.WeaponDamageLabel"}}</label>
             <div class="details-container-three-columns">
                 <select name="system.meleeUsage.damage.die">


### PR DESCRIPTION
An attempt of implementing 3rd paragraph of Slinger's Precision.
Should resolve #18244

I don't know much about TypeScript and coding, so this probably contains some programminghorror material.

If I understand what I've done, this shoud add `item:rangedGroup` property to the `meleeUsage` of combination weapons, then if the character has **Slinger's Precision** feature it will bump proficiency for weapons that have `item:rangedGroup:firearm` or `item:rangedGroup:crossbow`.

### Known Issues:
- `rangedGroup` is manually assigned and not related to the actual weapon group of ranged usage
- ~~`rangedGroup` can't be assigned from GUI, only through editing packs directly~~
- `rangedGroup` assignment from GUI is not restricted to ranged weapon groups
- ~~Does not work with specific magic weapons, only base variants~~