### PR TITLE
Add `preDelete` callback and add the `grantOnDelete` option to control when the granted item is created to `GrantItemRuleElement`

### DIFF
--- a/src/module/rules/rule-element/grant-item/schema.ts
+++ b/src/module/rules/rule-element/grant-item/schema.ts
@@ -26,6 +26,8 @@ type GrantItemSchema = RuleElementSchema & {
      * options, which are added to the `all` domain.
      */
     track: fields.BooleanField<boolean, boolean, false, false, false>;
+    /** Whether to grant the item on deletion of the grantee instead of on creation. */
+    grantOnDelete: fields.BooleanField<boolean, boolean, false, false, true>;
 };
 
 export type { GrantItemSchema };


### PR DESCRIPTION
This adds a new option for `GrantItemRuleElement`s called `grantOnDelete` that controls whether the granted item should be created when the parent item is deleted instead.

Example rule element for `Effect: Rage` that creates the `Effect: Rage Temporary Hit Points Immunity` when the rage effect expires or is deleted:
```json
{
  "key": "GrantItem",
  "uuid": "Compendium.pf2e.feat-effects.Item.MaepXeSHiMoWDm7u",
  "allowDuplicate": false,
  "grantOnDelete": true
}
```