### PR TITLE
Fix spell dc data of Dewey Daystar

### DIFF
--- a/packs/outlaws-of-alkenstar-bestiary/dewey-daystar.json
+++ b/packs/outlaws-of-alkenstar-bestiary/dewey-daystar.json
@@ -30,9 +30,9 @@
                 "slots": {},
                 "slug": null,
                 "spelldc": {
-                    "dc": "18",
+                    "dc": 18,
                     "mod": 0,
-                    "value": "10"
+                    "value": 10
                 },
                 "tradition": {
                     "value": "primal"


### PR DESCRIPTION
In all the other entities, in the spell dc fields (value, dc, mod) the values are written as int. This is the only case in which they are written as string.