### PR TITLE
Add inline damage rolls and variants to Prismatic Spray

### DIFF
--- a/packs/spells/prismatic-spray.json
+++ b/packs/spells/prismatic-spray.json
@@ -14,7 +14,7 @@
         "damage": {},
         "defense": null,
         "description": {
-            "value": "<p>A spray of rainbow light beams cascades from your open hand. Each creature in the area must roll 1d8 on the table below to see which beam affects it, then attempt a saving throw of the indicated type. The table notes any additional traits that apply to each type of ray. If a creature is struck by multiple beams, it uses the same d20 result for all its saving throws. For all rays, a successful saving throw negates the effect for that creature.</p>\n<h3><strong>Prismatic Spray</strong></h3>\n<table class=\"pf2e\">\n<thead>\n<tr>\n<th>1d8</th>\n<th>Color</th>\n<th>Save</th>\n<th>Effects (Traits)</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>1</td>\n<td>Red</td>\n<td>Reflex</td>\n<td>50 fire damage (fire)</td>\n</tr>\n<tr>\n<td>2</td>\n<td>Orange</td>\n<td>Reflex</td>\n<td>60 acid damage (acid)</td>\n</tr>\n<tr>\n<td>3</td>\n<td>Yellow</td>\n<td>Reflex</td>\n<td>70 electricity damage (electricity)</td>\n</tr>\n<tr>\n<td>4</td>\n<td>Green</td>\n<td>Fortitude</td>\n<td>30 poison damage and @UUID[Compendium.pf2e.conditionitems.Item.Enfeebled]{Enfeebled 1} for 1 minute (poison)</td>\n</tr>\n<tr>\n<td>5</td>\n<td>Blue</td>\n<td>Fortitude</td>\n<td>Affected as if by @UUID[Compendium.pf2e.spells-srd.Item.Petrify]</td>\n</tr>\n<tr>\n<td>6</td>\n<td>Indigo</td>\n<td>Will</td>\n<td>Confused, as the @UUID[Compendium.pf2e.spells-srd.Item.Warp Mind] spell (mental)</td>\n</tr>\n<tr>\n<td>7</td>\n<td>Violet</td>\n<td>Will</td>\n<td>Slowed for 1 minute; if a critical failure, sent to another plane, as @UUID[Compendium.pf2e.spells-srd.Item.Interplanar Teleport] (teleportation)</td>\n</tr>\n<tr>\n<td>8</td>\n<td>Potent beam</td>\n<td>-</td>\n<td>Affected by two beams - roll twice, rerolling any duplicates or results of 8</td>\n</tr>\n</tbody>\n</table>\n<p>@Check[fortitude|against:spell] @Check[reflex|against:spell] @Check[will|against:spell]</p>"
+            "value": "<p>A spray of rainbow light beams cascades from your open hand. Each creature in the area must roll 1d8 on the table below to see which beam affects it, then attempt a saving throw of the indicated type. The table notes any additional traits that apply to each type of ray. If a creature is struck by multiple beams, it uses the same d20 result for all its saving throws. For all rays, a successful saving throw negates the effect for that creature.</p><h3><strong>Prismatic Spray</strong></h3><table class=\"pf2e\"><thead><tr><th>[[/r 1d8 #Prismatic Spray]]</th><th>Color</th><th>Save</th><th>Effects (Traits)</th></tr></thead><tbody><tr><td>1</td><td>Red</td><td>Reflex</td><td>@Damage[50[fire]] damage (fire)</td></tr><tr><td>2</td><td>Orange</td><td>Reflex</td><td>@Damage[60[acid]] damage (acid)</td></tr><tr><td>3</td><td>Yellow</td><td>Reflex</td><td>@Damage[70[electricity]] damage (electricity)</td></tr><tr><td>4</td><td>Green</td><td>Fortitude</td><td>@Damage[30[poison]] damage and @UUID[Compendium.pf2e.conditionitems.Item.Enfeebled]{Enfeebled 1} for 1 minute (poison)</td></tr><tr><td>5</td><td>Blue</td><td>Fortitude</td><td>Affected as if by @UUID[Compendium.pf2e.spells-srd.Item.Petrify]</td></tr><tr><td>6</td><td>Indigo</td><td>Will</td><td>@UUID[Compendium.pf2e.conditionitems.Item.Confused], as the @UUID[Compendium.pf2e.spells-srd.Item.Warp Mind] spell (mental)</td></tr><tr><td>7</td><td>Violet</td><td>Will</td><td>@UUID[Compendium.pf2e.conditionitems.Item.Slowed] for 1 minute; if a critical failure, sent to another plane, as @UUID[Compendium.pf2e.spells-srd.Item.Interplanar Teleport] (teleportation)</td></tr><tr><td>8</td><td>Potent beam</td><td>-</td><td>Affected by two beams - roll twice, rerolling any duplicates or results of 8</td></tr></tbody></table>"
         },
         "duration": {
             "sustained": false,
@@ -22,6 +22,47 @@
         },
         "level": {
             "value": 7
+        },
+        "overlays": {
+            "GuBnvdpox1BZWuix": {
+                "name": "Prismatic Spray (Reflex)",
+                "overlayType": "override",
+                "sort": 2,
+                "system": {
+                    "defense": {
+                        "save": {
+                            "basic": false,
+                            "statistic": "reflex"
+                        }
+                    }
+                }
+            },
+            "pNsq7lcVfx7Pekmw": {
+                "name": "Prismatic Spray (Fortitude)",
+                "overlayType": "override",
+                "sort": 1,
+                "system": {
+                    "defense": {
+                        "save": {
+                            "basic": false,
+                            "statistic": "fortitude"
+                        }
+                    }
+                }
+            },
+            "sjiSDFHqHzMT9tGW": {
+                "name": "Prismatic Spray (Will)",
+                "overlayType": "override",
+                "sort": 3,
+                "system": {
+                    "defense": {
+                        "save": {
+                            "basic": false,
+                            "statistic": "will"
+                        }
+                    }
+                }
+            }
         },
         "publication": {
             "license": "OGL",


### PR DESCRIPTION
Removed the saving throw inlines for the spell variants as the inlines would go for the highest values, not those from the origin spellcasting.

Closes #18246