### PR TITLE
Convert 'dc' field string values to integers

### DIFF
--- a/packs/agents-of-edgewatch-bestiary/baatamidar.json
+++ b/packs/agents-of-edgewatch-bestiary/baatamidar.json
@@ -42,7 +42,7 @@
                 },
                 "slug": null,
                 "spelldc": {
-                    "dc": "44",
+                    "dc": 44,
                     "mod": 0,
                     "value": 36
                 },

--- a/packs/agents-of-edgewatch-bestiary/blune-bandersworth.json
+++ b/packs/agents-of-edgewatch-bestiary/blune-bandersworth.json
@@ -180,7 +180,7 @@
                 },
                 "slug": null,
                 "spelldc": {
-                    "dc": "42",
+                    "dc": 42,
                     "mod": 0,
                     "value": 38
                 },

--- a/packs/agents-of-edgewatch-bestiary/blunes-illusory-toady.json
+++ b/packs/agents-of-edgewatch-bestiary/blunes-illusory-toady.json
@@ -42,7 +42,7 @@
                 },
                 "slug": null,
                 "spelldc": {
-                    "dc": "36",
+                    "dc": 36,
                     "mod": 0,
                     "value": 28
                 },

--- a/packs/agents-of-edgewatch-bestiary/camarach.json
+++ b/packs/agents-of-edgewatch-bestiary/camarach.json
@@ -46,7 +46,7 @@
                 },
                 "slug": null,
                 "spelldc": {
-                    "dc": "43",
+                    "dc": 43,
                     "mod": 0,
                     "value": 35
                 },

--- a/packs/agents-of-edgewatch-bestiary/daemonic-infector.json
+++ b/packs/agents-of-edgewatch-bestiary/daemonic-infector.json
@@ -202,7 +202,7 @@
                 },
                 "slug": null,
                 "spelldc": {
-                    "dc": "46",
+                    "dc": 46,
                     "mod": 0,
                     "value": 38
                 },
@@ -248,7 +248,7 @@
                 },
                 "slug": null,
                 "spelldc": {
-                    "dc": "46",
+                    "dc": 46,
                     "mod": 0,
                     "value": 38
                 },

--- a/packs/agents-of-edgewatch-bestiary/daemonic-rumormonger.json
+++ b/packs/agents-of-edgewatch-bestiary/daemonic-rumormonger.json
@@ -46,7 +46,7 @@
                 },
                 "slug": null,
                 "spelldc": {
-                    "dc": "45",
+                    "dc": 45,
                     "mod": 0,
                     "value": 37
                 },

--- a/packs/agents-of-edgewatch-bestiary/daemonic-skinner.json
+++ b/packs/agents-of-edgewatch-bestiary/daemonic-skinner.json
@@ -42,7 +42,7 @@
                 },
                 "slug": null,
                 "spelldc": {
-                    "dc": "38",
+                    "dc": 38,
                     "mod": 0,
                     "value": 30
                 },

--- a/packs/agents-of-edgewatch-bestiary/ghaele-of-kharnas.json
+++ b/packs/agents-of-edgewatch-bestiary/ghaele-of-kharnas.json
@@ -66,7 +66,7 @@
                 },
                 "slug": null,
                 "spelldc": {
-                    "dc": "38",
+                    "dc": 38,
                     "mod": 0,
                     "value": 30
                 },
@@ -103,7 +103,7 @@
                 "slots": {},
                 "slug": null,
                 "spelldc": {
-                    "dc": "38",
+                    "dc": 38,
                     "mod": 0,
                     "value": 30
                 },

--- a/packs/agents-of-edgewatch-bestiary/hundun-chaos-mage.json
+++ b/packs/agents-of-edgewatch-bestiary/hundun-chaos-mage.json
@@ -50,7 +50,7 @@
                 },
                 "slug": null,
                 "spelldc": {
-                    "dc": "40",
+                    "dc": 40,
                     "mod": 0,
                     "value": 35
                 },

--- a/packs/agents-of-edgewatch-bestiary/overdrive-imentesh.json
+++ b/packs/agents-of-edgewatch-bestiary/overdrive-imentesh.json
@@ -58,7 +58,7 @@
                 },
                 "slug": null,
                 "spelldc": {
-                    "dc": "38",
+                    "dc": 38,
                     "mod": 0,
                     "value": 30
                 },

--- a/packs/agents-of-edgewatch-bestiary/sordesdaemon.json
+++ b/packs/agents-of-edgewatch-bestiary/sordesdaemon.json
@@ -46,7 +46,7 @@
                 },
                 "slug": null,
                 "spelldc": {
-                    "dc": "38",
+                    "dc": 38,
                     "mod": 0,
                     "value": 28
                 },

--- a/packs/agents-of-edgewatch-bestiary/ulressia-the-blessed.json
+++ b/packs/agents-of-edgewatch-bestiary/ulressia-the-blessed.json
@@ -58,7 +58,7 @@
                 },
                 "slug": null,
                 "spelldc": {
-                    "dc": "39",
+                    "dc": 39,
                     "mod": 0,
                     "value": 33
                 },

--- a/packs/agents-of-edgewatch-bestiary/veksciralenix.json
+++ b/packs/agents-of-edgewatch-bestiary/veksciralenix.json
@@ -50,7 +50,7 @@
                 },
                 "slug": null,
                 "spelldc": {
-                    "dc": "42",
+                    "dc": 42,
                     "mod": 0,
                     "value": 34
                 },
@@ -1062,7 +1062,7 @@
         },
         "spellcasting": {
             "rituals": {
-                "dc": "42"
+                "dc": 42
             }
         },
         "traits": {

--- a/packs/outlaws-of-alkenstar-bestiary/follower-of-shumfallow.json
+++ b/packs/outlaws-of-alkenstar-bestiary/follower-of-shumfallow.json
@@ -33,7 +33,7 @@
                 "slots": {},
                 "slug": null,
                 "spelldc": {
-                    "dc": "14",
+                    "dc": 14,
                     "mod": 0,
                     "value": 6
                 },

--- a/packs/pfs-season-2-bestiary/2-16/burned-out-efreet.json
+++ b/packs/pfs-season-2-bestiary/2-16/burned-out-efreet.json
@@ -39,7 +39,7 @@
                 },
                 "slug": null,
                 "spelldc": {
-                    "dc": "20",
+                    "dc": 20,
                     "mod": 0,
                     "value": 12
                 },

--- a/packs/pfs-season-2-bestiary/2-16/corvius-vayn-5-6.json
+++ b/packs/pfs-season-2-bestiary/2-16/corvius-vayn-5-6.json
@@ -51,7 +51,7 @@
                 },
                 "slug": null,
                 "spelldc": {
-                    "dc": "21",
+                    "dc": 21,
                     "mod": 0,
                     "value": 13
                 },

--- a/packs/pfs-season-2-bestiary/2-16/perizia-5-6.json
+++ b/packs/pfs-season-2-bestiary/2-16/perizia-5-6.json
@@ -38,7 +38,7 @@
                 },
                 "slug": null,
                 "spelldc": {
-                    "dc": "24",
+                    "dc": 24,
                     "mod": 0,
                     "value": 16
                 },

--- a/packs/pfs-season-2-bestiary/2-16/planar-nixie.json
+++ b/packs/pfs-season-2-bestiary/2-16/planar-nixie.json
@@ -39,7 +39,7 @@
                 },
                 "slug": null,
                 "spelldc": {
-                    "dc": "20",
+                    "dc": 20,
                     "mod": 0,
                     "value": 12
                 },

--- a/packs/pfs-season-2-bestiary/2-18/vermlek-centaur-3-4.json
+++ b/packs/pfs-season-2-bestiary/2-18/vermlek-centaur-3-4.json
@@ -35,7 +35,7 @@
                 },
                 "slug": null,
                 "spelldc": {
-                    "dc": "20",
+                    "dc": 20,
                     "mod": 0,
                     "value": 12
                 },


### PR DESCRIPTION
I've noticed that most of the creatures (NPC/Monsters) have their spell casting entry set as a int value (since the value is always numerical). I've changed every creature that had a string dc value to int to be more coherent with the rest of the data.