### PR TITLE
Fix malformed Promises in `processPreUpdateActorHooks` helper

### DIFF
--- a/src/module/rules/helpers.ts
+++ b/src/module/rules/helpers.ts
@@ -196,7 +196,7 @@ async function processPreUpdateActorHooks(
         await Promise.all(
             rules.map(
                 (r): Promise<{ create: ItemSourcePF2e[]; delete: string[] }> =>
-                    actor.items.has(r.item.id) ? r.preUpdateActor() : new Promise(() => ({ create: [], delete: [] })),
+                    actor.items.has(r.item.id) ? r.preUpdateActor() : Promise.resolve({ create: [], delete: [] }),
             ),
         )
     ).reduce(


### PR DESCRIPTION
The `new Promise(() => ({ create: [], delete: [] }))` resolved to `undefined` and that somehow prevented any new actor updates without throwing an error.

https://github.com/user-attachments/assets/46a3752c-a1e0-4b29-aa3a-babadef61087

https://github.com/user-attachments/assets/56b1522c-0e37-4199-90b4-32bf00a4eea0


Fixes #18250