### PR TITLE
Update Necklace of Knives and Druidic orders

### DIFF
--- a/packs/classfeatures/flame-order.json
+++ b/packs/classfeatures/flame-order.json
@@ -11,7 +11,7 @@
         },
         "category": "classfeature",
         "description": {
-            "value": "<p>You feel a kinship with flames and can use them for succor and destruction. You're trained in Acrobatics. You also gain the @UUID[Compendium.pf2e.feats-srd.Item.Fire Lung] druid feat. You gain the @UUID[Compendium.pf2e.spells-srd.Item.Wildfire] order spell. Allowing unnatural fires to spread or preventing natural fires from occurring in a way that harms the environment are anathema to your order (this doesn't prevent you from using fire destructively or force you to combat a controlled or natural fire).</p>"
+            "value": "<p>You feel a kinship with flames and can use them for succor and destruction.<br /><br /><strong>Order Skill</strong> Acrobatics</p>\n<p><strong>Druid Feat</strong> @UUID[Compendium.pf2e.feats-srd.Item.Fire Lung]</p>\n<p><strong>Order Spell</strong> @UUID[Compendium.pf2e.spells-srd.Item.Wildfire]</p>\n<p><strong>Anathema</strong> Allowing unnatural fires to spread or preventing natural fires from occurring in a way that harms the environment. (this doesn't prevent you from using fire destructively or force you to combat a controlled or natural fire).</p>"
         },
         "level": {
             "value": 1

--- a/packs/classfeatures/stone-order.json
+++ b/packs/classfeatures/stone-order.json
@@ -11,7 +11,7 @@
         },
         "category": "classfeature",
         "description": {
-            "value": "<p>You're as enduring as stone, and you take comfort in its steadfast presence, both natural and worked. You're trained in Crafting. You also gain the @UUID[Compendium.pf2e.feats-srd.Item.Steadying Stone] druid feat. You gain the @UUID[Compendium.pf2e.spells-srd.Item.Crushing Ground] order spell. Poisoning or polluting the land and heedlessly carving the earth to plunder its natural resources are anathema to your order (this doesn't prevent you from responsibly digging or mining).</p>"
+            "value": "<p>You're as enduring as stone, and you take comfort in its steadfast presence, both natural and worked.<br /> <br /><strong>Order Skill</strong> Crafting</p>\n<p><strong>Druid Feat</strong> @UUID[Compendium.pf2e.feats-srd.Item.Steadying Stone]</p>\n<p><strong>Order Spell</strong> @UUID[Compendium.pf2e.spells-srd.Item.Crushing Ground]</p>\n<p><strong>Anathema</strong> Poisoning or polluting the land and heedlessly carving the earth to plunder its natural resources. (this doesn't prevent you from responsibly digging or mining).</p>"
         },
         "level": {
             "value": 1

--- a/packs/classfeatures/wave-order.json
+++ b/packs/classfeatures/wave-order.json
@@ -11,7 +11,7 @@
         },
         "category": "classfeature",
         "description": {
-            "value": "<p>Water is the source of life, and you've learned to shape how it flows. You're trained in Medicine. You also gain the @UUID[Compendium.pf2e.feats-srd.Item.Shore Step] druid feat. You gain the @UUID[Compendium.pf2e.spells-srd.Item.Rising Surf] order spell. Polluting water or allowing those who pollute water sources to go unpunished is anathema to your order (this doesn't force you to take action against potential water pollution or to sacrifice yourself against an obviously superior foe).</p>"
+            "value": "<p>Water is the source of life, and you've learned to shape how it flows. <br /><br /><strong>Order Skill</strong> Medicine</p>\n<p><strong>Druid Feat</strong> @UUID[Compendium.pf2e.feats-srd.Item.Shore Step]</p>\n<p><strong>Order Spell</strong> @UUID[Compendium.pf2e.spells-srd.Item.Rising Surf]</p>\n<p><strong>Anathema</strong> Polluting water or allowing those who pollute water sources to go unpunished. (this doesn't force you to take action against potential water pollution or to sacrifice yourself against an obviously superior foe).</p>"
         },
         "level": {
             "value": 1

--- a/packs/equipment/necklace-of-knives.json
+++ b/packs/equipment/necklace-of-knives.json
@@ -9,7 +9,7 @@
         },
         "containerId": null,
         "description": {
-            "value": "<p>This necklace strung with miniature stone throwing knives. As long as you wear it, you are never without a weapon, a crude surgical tool, or stake for a vampire, if necessary in following Pharasma's teachings.</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> Interact</p><hr /><p><strong>Effect</strong> You pluck a miniature knife from the necklace, and it grows into a normal stone, steel, or wooden @UUID[Compendium.pf2e.equipment-srd.Item.Dagger] for as long as you hold it, fading away 1 round after it leaves your hand. No matter how many knives you pull from the necklace, you never seem to deplete them. Wooden daggers from the necklace are as effective as ordinary steel daggers and can be useful to stake vampires.</p>"
+            "value": "<p>This necklace strung with miniature stone throwing knives. As long as you wear it, you are never without a weapon, a crude surgical tool, or stake for a vampire, if necessary in following Pharasma's teachings.</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> Interact</p><hr /><p><strong>Effect</strong> You pluck a miniature knife from the necklace, and it grows into a normal stone, steel, or wooden dagger for as long as you hold it, fading away 1 round after it leaves your hand. No matter how many knives you pull from the necklace, you never seem to deplete them. Wooden daggers from the necklace are as effective as ordinary steel daggers and can be useful to stake vampires.</p>"
         },
         "hardness": 0,
         "hp": {

--- a/packs/equipment/necklace-of-knives.json
+++ b/packs/equipment/necklace-of-knives.json
@@ -9,7 +9,7 @@
         },
         "containerId": null,
         "description": {
-            "value": "<p>This necklace strung with miniature stone throwing knives. As long as you wear it, you are never without a weapon, a crude surgical tool, or stake for a vampire, if necessary in following Pharasma's teachings.</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> Interact</p>\n<hr />\n<p><strong>Effect</strong> You pluck a miniature knife from the necklace, and it grows into a normal stone, steel, or wooden dagger for as long as you hold it, fading away 1 round after it leaves your hand. No matter how many knives you pull from the necklace, you never seem to deplete them. Wooden daggers from the necklace are as effective as ordinary steel daggers and can be useful to stake vampires.</p>"
+            "value": "<p>This necklace strung with miniature stone throwing knives. As long as you wear it, you are never without a weapon, a crude surgical tool, or stake for a vampire, if necessary in following Pharasma's teachings.</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> Interact</p><hr /><p><strong>Effect</strong> You pluck a miniature knife from the necklace, and it grows into a normal stone, steel, or wooden @UUID[Compendium.pf2e.equipment-srd.Item.Dagger] for as long as you hold it, fading away 1 round after it leaves your hand. No matter how many knives you pull from the necklace, you never seem to deplete them. Wooden daggers from the necklace are as effective as ordinary steel daggers and can be useful to stake vampires.</p>"
         },
         "hardness": 0,
         "hp": {
@@ -36,18 +36,16 @@
         "quantity": 1,
         "rules": [
             {
+                "baseType": "dagger",
                 "category": "simple",
                 "damage": {
                     "base": {
-                        "damageType": "piercing",
-                        "dice": 1,
-                        "die": "d4"
+                        "damageType": "piercing"
                     }
                 },
-                "group": "brawling",
+                "group": "knife",
                 "key": "Strike",
                 "label": "PF2E.Weapon.Base.dagger",
-                "range": null,
                 "traits": [
                     "agile",
                     "finesse",


### PR DESCRIPTION
Updated the RE so it correctly interacts with Deadly simplicity and the description so it has a link to the dagger item.

Updated the descriptions of orders; Flame, Stone, Wave so they match up with the other orders style.

This closes issue #18285