### PR TITLE
Correct ternary syntax on Entreaty Spirit spell effect

### DIFF
--- a/packs/spell-effects/spell-effect-entreat-spirit.json
+++ b/packs/spell-effects/spell-effect-entreat-spirit.json
@@ -59,7 +59,7 @@
                     "{item|flags.pf2e.rulesSelections.attribute}-skill-check"
                 ],
                 "type": "status",
-                "value": "ternary(gte(@item.rank,8),3,ternary(gte(@item.rank,4),2,1))"
+                "value": "ternary(gte(@item.level,8),3,ternary(gte(@item.level,4),2,1))"
             }
         ],
         "start": {


### PR DESCRIPTION
Partially addresses #18336