### PR TITLE
Hide aura texture when token is GM hidden

### DIFF
--- a/src/module/canvas/token/aura/renderer.ts
+++ b/src/module/canvas/token/aura/renderer.ts
@@ -68,6 +68,11 @@ class AuraRenderer extends PIXI.Graphics implements TokenAuraData {
 
     /** Draw the aura's border and texture */
     async draw(showBorder: boolean): Promise<void> {
+        // If the token is GM hidden, don't render anything
+        if (this.token.document.hidden && !this.token.visible) {
+            return;
+        }
+
         // Auras draw at 0, 0. Shift it into the correct position here
         const { mechanicalBounds } = this.token;
         this.x = mechanicalBounds.width / 2;

--- a/src/module/canvas/token/object.ts
+++ b/src/module/canvas/token/object.ts
@@ -630,7 +630,7 @@ class TokenPF2e<TDocument extends TokenDocumentPF2e = TokenDocumentPF2e> extends
         }
     }
 
-    /** Reset aura renders when token size changes. */
+    /** Reset aura renders when token size or GM hidden changes. */
     override _onUpdate(
         changed: DeepPartial<TDocument["_source"]>,
         operation: TokenUpdateOperation<TDocument["parent"]>,
@@ -638,7 +638,7 @@ class TokenPF2e<TDocument extends TokenDocumentPF2e = TokenDocumentPF2e> extends
     ): void {
         super._onUpdate(changed, operation, userId);
 
-        if (changed.width) {
+        if (changed.width || "hidden" in changed) {
             if (this.animation) {
                 this.animation.then(() => {
                     this.auras.reset();


### PR DESCRIPTION
Continues to show for regular hidden

![image](https://github.com/user-attachments/assets/e0d9291d-927c-4d62-92c8-811711465b38)
