### PR TITLE
Move Detective Readiness modifier RE into its feat

### DIFF
--- a/packs/actions/pursue-a-lead.json
+++ b/packs/actions/pursue-a-lead.json
@@ -33,10 +33,7 @@
             {
                 "key": "FlatModifier",
                 "predicate": [
-                    "pursue-a-lead",
-                    {
-                        "not": "check:type:saving-throw"
-                    }
+                    "pursue-a-lead"
                 ],
                 "selector": [
                     "perception",
@@ -48,7 +45,6 @@
             }
         ],
         "traits": {
-            "rarity": "common",
             "value": [
                 "concentrate",
                 "exploration",

--- a/packs/actions/pursue-a-lead.json
+++ b/packs/actions/pursue-a-lead.json
@@ -35,23 +35,12 @@
                 "predicate": [
                     "pursue-a-lead",
                     {
-                        "or": [
-                            {
-                                "not": "check:type:saving-throw"
-                            },
-                            {
-                                "and": [
-                                    "check:type:saving-throw",
-                                    "feat:detectives-readiness"
-                                ]
-                            }
-                        ]
+                        "not": "check:type:saving-throw"
                     }
                 ],
                 "selector": [
                     "perception",
-                    "skill-check",
-                    "saving-throw"
+                    "skill-check"
                 ],
                 "slug": "pursue-a-lead",
                 "type": "circumstance",

--- a/packs/feats/detectives-readiness.json
+++ b/packs/feats/detectives-readiness.json
@@ -49,6 +49,15 @@
                         "text": "PF2E.SpecificRule.Investigator.DetectivesReadiness.ClueInAddendum"
                     }
                 ]
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "check:type:saving-throw"
+                ],
+                "selector": "saving-throw",
+                "slug": "pursue-a-lead",
+                "value": 1
             }
         ],
         "traits": {

--- a/packs/feats/detectives-readiness.json
+++ b/packs/feats/detectives-readiness.json
@@ -57,6 +57,7 @@
                 ],
                 "selector": "saving-throw",
                 "slug": "pursue-a-lead",
+                "type": "circumstance",
                 "value": 1
             }
         ],


### PR DESCRIPTION
Should handle https://github.com/foundryvtt/pf2e/issues/17939 (at least the original issue). The Defensive Stratagem part might not be easily doable with REs.
- - -

Moves part of the RE responsible for the Pursue a Lead bonus for saving throws from Pursue a Lead action into Detective's Readiness.

Reasons: In the current implementation, investigators get an optional bonus to saving throws even without a feat, which is labeled Pursue a Lead. This might be confusing to players, especially if they don't intend to ever take Detective's Readiness.

Updated behavior: Shows the bonus when the character has the feat. This bonus is labeled Detective's Readiness, as expected.
Since the RE has slug property "pursue-a-lead", it still gets improved by Investigator Expertise.