### PR TITLE
Add rules to handle Armored Stealth penalty adjustment

### DIFF
--- a/packs/feats/armored-stealth.json
+++ b/packs/feats/armored-stealth.json
@@ -51,7 +51,7 @@
                 "mode": "downgrade",
                 "selector": "stealth-check",
                 "slug": "armor-check-penalty",
-                "value": "0"
+                "value": 0
             }
         ],
         "traits": {

--- a/packs/feats/armored-stealth.json
+++ b/packs/feats/armored-stealth.json
@@ -33,6 +33,25 @@
                 "domain": "stealth",
                 "key": "RollOption",
                 "option": "armor:ignore-noisy-penalty"
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "add",
+                "predicate": [
+                    {
+                        "not": "armor:trait:noisy"
+                    }
+                ],
+                "selector": "stealth-check",
+                "slug": "armor-check-penalty",
+                "value": "max(@actor.system.skills.stealth.rank - 1, 0)"
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "downgrade",
+                "selector": "stealth-check",
+                "slug": "armor-check-penalty",
+                "value": "0"
             }
         ],
         "traits": {


### PR DESCRIPTION
The second rule is needed to cap the resolved penalty to `0`. Otherwise, an actor with `master` stealth and studded leather armor, will make the penalty `-1 + 2 = +1`!

Note that the item is still not 100% supported with this change, as it doesn't check for proficiency. You could potentially account for this in the `value` calculation, but it really should be a `predicate` since the existing rule also needs to be disabled when not proficient. I tried with a `{"not":"defense:{actor|wornArmor.system.category}:rank:0"}` predicate, which technically works, but it throws an error when no armor is worn.