### PR TITLE
Remove Shields of the Spirit effect if shield is no longer raised

### DIFF
--- a/packs/spell-effects/spell-effect-shields-of-the-spirit.json
+++ b/packs/spell-effects/spell-effect-shields-of-the-spirit.json
@@ -57,6 +57,10 @@
             {
                 "allowDuplicate": false,
                 "key": "GrantItem",
+                "onDeleteActions": {
+                    "grantee": "cascade",
+                    "granter": "detach"
+                },
                 "predicate": [
                     "self:signature:{item|origin.signature}"
                 ],


### PR DESCRIPTION
Also added `"granter": "detach"` to not lower shield, in case the effect is removed prematurely, or some ability that increases the duration of raise shield is introduced. 