### PR TITLE
Add creature identification skills for dream, shade, and time

### DIFF
--- a/src/module/recall-knowledge.ts
+++ b/src/module/recall-knowledge.ts
@@ -29,6 +29,7 @@ const identifySkills = new Map<CreatureTrait, SkillSlug[]>([
     ["celestial", ["religion"]],
     ["construct", ["arcana", "crafting"]],
     ["dragon", ["arcana"]],
+    ["dream", ["occultism"]],
     ["elemental", ["arcana", "nature"]],
     ["ethereal", ["occultism"]],
     ["fey", ["nature"]],
@@ -37,8 +38,10 @@ const identifySkills = new Map<CreatureTrait, SkillSlug[]>([
     ["humanoid", ["society"]],
     ["monitor", ["religion"]],
     ["ooze", ["occultism"]],
+    ["shade", ["religion"]],
     ["plant", ["nature"]],
     ["spirit", ["occultism"]],
+    ["time", ["occultism"]],
     ["undead", ["religion"]],
 ]);
 

--- a/src/scripts/config/traits.ts
+++ b/src/scripts/config/traits.ts
@@ -231,6 +231,7 @@ const creatureTraits = {
     serpentfolk: "PF2E.TraitSerpentfolk",
     seugathi: "PF2E.TraitSeugathi",
     shabti: "PF2E.TraitShabti",
+    shade: "PF2E.TraitShade",
     shadow: "PF2E.TraitShadow",
     shobhad: "PF2E.TraitShobhad",
     siktempora: "PF2E.TraitSiktempora",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -4916,6 +4916,7 @@
         "TraitSeugathi": "Seugathi",
         "TraitSewnIntoClothing": "Sewn Into Clothing",
         "TraitShabti": "Shabti",
+        "TraitShade": "Shade",
         "TraitShadow": "Shadow",
         "TraitShieldThrow20": "Shield Throw 20 ft",
         "TraitShieldThrow30": "Shield Throw 30 ft",


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/18458

Also adds the Shade trait, which isn't in use yet, but has been claimed by Player Core.