### PR TITLE
Remove Improved Grab from Fungal Flytrap's Focused Assault

### DIFF
--- a/packs/spore-war-bestiary/book-1-whispers-in-the-dirt/fungal-flytrap.json
+++ b/packs/spore-war-bestiary/book-1-whispers-in-the-dirt/fungal-flytrap.json
@@ -123,7 +123,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The flytrap attacks a single target with all four of its leaves. The flytrap makes one leaf Strike. On a success, the flytrap deals the damage from one leaf Strike plus an additional [[/r {1d8}]]{1d8 damage} for every leaf beyond the first. On a failure, the flytrap deals the damage from one leaf Strike, but it can't use Improved Grab. It deals no damage on a critical failure. This counts toward the flytrap's multiple attack penalty as a number of attacks equal to the number of leaves the flytrap has.</p>"
+                    "value": "<p>The flytrap attacks a single target with all four of its leaves. The flytrap makes one leaf Strike. On a success, the flytrap deals the damage from one leaf Strike plus an additional [[/r {1d8}]]{1d8 damage} for every leaf beyond the first. On a failure, the flytrap deals the damage from one leaf Strike. It deals no damage on a critical failure. This counts toward the flytrap's multiple attack penalty as a number of attacks equal to the number of leaves the flytrap has.</p>"
                 },
                 "publication": {
                     "license": "ORC",


### PR DESCRIPTION
This variant Giant Flytrap doesn't have Improved Grab
![image](https://github.com/user-attachments/assets/0aee59da-ed66-451a-a665-50624335cc43)