### PR TITLE
Fix Kholo Weapon Familiarity

### DIFF
--- a/packs/feats/kholo-weapon-familiarity.json
+++ b/packs/feats/kholo-weapon-familiarity.json
@@ -31,7 +31,7 @@
                         "or": [
                             {
                                 "and": [
-                                    "item:trait:kholo",
+                                    "item:trait:gnoll",
                                     "item:category:martial"
                                 ]
                             },
@@ -49,7 +49,7 @@
             },
             {
                 "definition": [
-                    "item:trait:kholo",
+                    "item:trait:gnoll",
                     "item:category:advanced"
                 ],
                 "key": "MartialProficiency",
@@ -68,7 +68,7 @@
                     },
                     {
                         "or": [
-                            "item:trait:kholo",
+                            "item:trait:gnoll",
                             "item:base:flail",
                             "item:base:khopesh",
                             "item:base:mambele",


### PR DESCRIPTION
Also, there seems to be a "kholo" trait description in the translation data. Not sure if that's vestigial or the gnoll trait was actually meant to be renamed to kholo, as opposed to just having a different display value.

https://github.com/foundryvtt/pf2e/blob/376d59d743108cd77a3f44acf761b23c54a94e00/src/scripts/config/traits.ts#L1352