### PR TITLE
Update Bands of Force's Flat Modifier slug

### DIFF
--- a/packs/equipment/assassins-bracers-type-i.json
+++ b/packs/equipment/assassins-bracers-type-i.json
@@ -41,7 +41,6 @@
                     "ac",
                     "saving-throw"
                 ],
-                "slug": "bracers-of-armor",
                 "type": "item",
                 "value": 1
             },

--- a/packs/equipment/assassins-bracers-type-ii.json
+++ b/packs/equipment/assassins-bracers-type-ii.json
@@ -41,7 +41,6 @@
                     "ac",
                     "saving-throw"
                 ],
-                "slug": "bracers-of-armor",
                 "type": "item",
                 "value": 2
             },

--- a/packs/equipment/assassins-bracers-type-iii.json
+++ b/packs/equipment/assassins-bracers-type-iii.json
@@ -41,7 +41,6 @@
                     "ac",
                     "saving-throw"
                 ],
-                "slug": "bracers-of-armor",
                 "type": "item",
                 "value": 3
             },

--- a/packs/equipment/bands-of-force-greater.json
+++ b/packs/equipment/bands-of-force-greater.json
@@ -41,7 +41,7 @@
                     "ac",
                     "saving-throw"
                 ],
-                "slug": "bracers-of-armor",
+                "slug": "bands-of-force",
                 "type": "item",
                 "value": 2
             },

--- a/packs/equipment/bands-of-force-major.json
+++ b/packs/equipment/bands-of-force-major.json
@@ -41,7 +41,7 @@
                     "ac",
                     "saving-throw"
                 ],
-                "slug": "bracers-of-armor",
+                "slug": "bands-of-force",
                 "type": "item",
                 "value": 3
             },

--- a/packs/equipment/bands-of-force.json
+++ b/packs/equipment/bands-of-force.json
@@ -41,7 +41,7 @@
                     "ac",
                     "saving-throw"
                 ],
-                "slug": "bracers-of-armor",
+                "slug": "bands-of-force",
                 "type": "item",
                 "value": 1
             },


### PR DESCRIPTION
Closes #18479
and remove `bracers-of-armor` slug from Assassin's Bracers, which are seemingly the result of copy pasting rule elements from the Bands of Force.