### PR TITLE
Fix spell category filter in Compendium Browser

### DIFF
--- a/src/module/apps/compendium-browser/tabs/spell.ts
+++ b/src/module/apps/compendium-browser/tabs/spell.ts
@@ -168,7 +168,7 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
         // Categories
         if (
             checkboxes.category.selected.length > 0 &&
-            !R.isDeepEqual(checkboxes.category.selected.sort(), indexData.categories.sort())
+            !R.isShallowEqual([...checkboxes.category.selected].sort(), indexData.categories.sort())
         ) {
             return false;
         }


### PR DESCRIPTION
`isShallowEqual` makes more sense for string arrays.

Closes #18483 