### PR TITLE
Add missing spell statistics to additional NPC Core Actors

### DIFF
--- a/packs/pathfinder-npc-core/ancestry-npcs/catfolk/catfolk-name-collector.json
+++ b/packs/pathfinder-npc-core/ancestry-npcs/catfolk/catfolk-name-collector.json
@@ -85,8 +85,8 @@
                 },
                 "slug": null,
                 "spelldc": {
-                    "dc": 0,
-                    "value": 0
+                    "dc": 24,
+                    "value": 16
                 },
                 "tradition": {
                     "value": "occult"

--- a/packs/pathfinder-npc-core/ancestry-npcs/elf/forlorn-artist.json
+++ b/packs/pathfinder-npc-core/ancestry-npcs/elf/forlorn-artist.json
@@ -30,7 +30,7 @@
                 "slots": {},
                 "slug": null,
                 "spelldc": {
-                    "dc": 0,
+                    "dc": 18,
                     "value": 0
                 },
                 "tradition": {

--- a/packs/pathfinder-npc-core/ancestry-npcs/elf/forlorn-artist.json
+++ b/packs/pathfinder-npc-core/ancestry-npcs/elf/forlorn-artist.json
@@ -31,7 +31,7 @@
                 "slug": null,
                 "spelldc": {
                     "dc": 18,
-                    "value": 0
+                    "value": 10
                 },
                 "tradition": {
                     "value": "arcane"

--- a/packs/pathfinder-npc-core/ancestry-npcs/halfling/halfling-yarnspinner.json
+++ b/packs/pathfinder-npc-core/ancestry-npcs/halfling/halfling-yarnspinner.json
@@ -47,8 +47,8 @@
                 },
                 "slug": null,
                 "spelldc": {
-                    "dc": 0,
-                    "value": 0
+                    "dc": 26,
+                    "value": 18
                 },
                 "tradition": {
                     "value": "occult"

--- a/packs/pathfinder-npc-core/official/watchmage-squadron.json
+++ b/packs/pathfinder-npc-core/official/watchmage-squadron.json
@@ -85,8 +85,8 @@
                 },
                 "slug": null,
                 "spelldc": {
-                    "dc": 0,
-                    "value": 0
+                    "dc": 26,
+                    "value": 18
                 },
                 "tradition": {
                     "value": "arcane"

--- a/packs/pathfinder-npc-core/scholar/departmental-chair.json
+++ b/packs/pathfinder-npc-core/scholar/departmental-chair.json
@@ -80,8 +80,8 @@
                 },
                 "slug": null,
                 "spelldc": {
-                    "dc": 0,
-                    "value": 0
+                    "dc": 25,
+                    "value": 17
                 },
                 "tradition": {
                     "value": "arcane"


### PR DESCRIPTION
Added missing Spell Statistics (Spell DC/Attack) to the following NPC Core actors:
Forlorn Artist
Catfolk Name Collector
Halfling Yarnspinner
Watchmage Squadron
Departmental Chair