### PR TITLE
Fix minor typo in Far-Flung Fetch

### DIFF
--- a/packs/spells/far-flung-fetch.json
+++ b/packs/spells/far-flung-fetch.json
@@ -11,7 +11,7 @@
         "damage": {},
         "defense": null,
         "description": {
-            "value": "<p>You can pilfer an object even if it’s outside the reach of your fingers. You teleport the target into one of your open hand. If you don’t have a hand free, it falls to the ground at your feet.</p><hr /><p><strong>Heightened (3rd)</strong> The range increases to 120 feet.</p>\n<p><strong>Heightened (5th)</strong> The range increases to 120 feet, and you can target an unattended object with a Bulk of 1 or less.</p>\n<p><strong>Heightened (7th)</strong> As 5th rank, and when you Cast the Spell you can spend 3 actions instead of 1 to increase the range to planetary. If you do, you don't need line of sight to the target, but you must be extremely familiar with the target.</p>"
+            "value": "<p>You can pilfer an object even if it’s outside the reach of your fingers. You teleport the target into one of your open hands. If you don’t have a hand free, it falls to the ground at your feet.</p><hr /><p><strong>Heightened (3rd)</strong> The range increases to 120 feet.</p>\n<p><strong>Heightened (5th)</strong> The range increases to 120 feet, and you can target an unattended object with a Bulk of 1 or less.</p>\n<p><strong>Heightened (7th)</strong> As 5th rank, and when you Cast the Spell you can spend 3 actions instead of 1 to increase the range to planetary. If you do, you don't need line of sight to the target, but you must be extremely familiar with the target.</p>"
         },
         "duration": {
             "sustained": false,


### PR DESCRIPTION
Fixed the passage "...one of your open hand..." to "...one of your open hands..." as corroborated by [Demiplane's page for the spell](https://app.demiplane.com/nexus/pathfinder2e/spells/far-flung-fetch-rm).