### PR TITLE
Support delta inputs for health and shield hp in the character sheet

### DIFF
--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -531,14 +531,10 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
             });
 
             deltaInput.addEventListener("keydown", (event: KeyboardEvent) => {
-                const min = Number(deltaInput.dataset.min) || 0;
-                const max = Number(deltaInput.dataset.max) || 0;
-                const stepSize = Number(deltaInput.dataset.step) || 1;
-
                 if (event.key === "ArrowUp") {
-                    applyDeltaToInput(deltaInput, +stepSize, min, max);
+                    applyDeltaToInput(deltaInput, 1);
                 } else if (event.key === "ArrowDown") {
-                    applyDeltaToInput(deltaInput, -stepSize, min, max);
+                    applyDeltaToInput(deltaInput, -1);
                 }
             });
 
@@ -547,12 +543,8 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
                     event.preventDefault();
                     event.stopPropagation();
 
-                    const min = Number(deltaInput.dataset.min) || 0;
-                    const max = Number(deltaInput.dataset.max) || 0;
-                    const stepSize = Number(deltaInput.dataset.step) || 1;
-                    const step = stepSize * Math.sign(-1 * event.deltaY);
-
-                    applyDeltaToInput(deltaInput, step, min, max);
+                    const step = Math.sign(-1 * event.deltaY);
+                    applyDeltaToInput(deltaInput, step);
                 }
             });
         }

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -537,7 +537,7 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
 
                 if (event.key === "ArrowUp") {
                     applyDeltaToInput(deltaInput, +1, min, max);
-                } else if(event.key === "ArrowDown") {
+                } else if (event.key === "ArrowDown") {
                     applyDeltaToInput(deltaInput, -1, min, max);
                 }
             });

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -523,7 +523,7 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
 
         // Only allow digits & leading plus and minus signs for `data-allow-delta` inputs,
         // thus emulating input[type="number"]
-        // Also enable delta adjustment by arrow key
+        // Also enable delta adjustment by arrow key and mousewheel
         for (const deltaInput of htmlQueryAll<HTMLInputElement>(html, "input[data-allow-delta]")) {
             deltaInput.addEventListener("input", () => {
                 const match = /[+-]?\d*/.exec(deltaInput.value)?.at(0);
@@ -533,11 +533,26 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
             deltaInput.addEventListener("keydown", (event: KeyboardEvent) => {
                 const min = Number(deltaInput.dataset.min) || 0;
                 const max = Number(deltaInput.dataset.max) || 0;
+                const stepSize = Number(deltaInput.dataset.step) || 1;
 
                 if (event.key === "ArrowUp") {
-                    applyDeltaToInput(deltaInput, +1, min, max);
+                    applyDeltaToInput(deltaInput, +stepSize, min, max);
                 } else if (event.key === "ArrowDown") {
-                    applyDeltaToInput(deltaInput, -1, min, max);
+                    applyDeltaToInput(deltaInput, -stepSize, min, max);
+                }
+            });
+
+            deltaInput.addEventListener("wheel", (event: WheelEvent) => {
+                if (deltaInput === document.activeElement) {
+                    event.preventDefault();
+                    event.stopPropagation();
+
+                    const min = Number(deltaInput.dataset.min) || 0;
+                    const max = Number(deltaInput.dataset.max) || 0;
+                    const stepSize = Number(deltaInput.dataset.step) || 1;
+                    const step = stepSize * Math.sign(-1 * event.deltaY);
+
+                    applyDeltaToInput(deltaInput, step, min, max);
                 }
             });
         }

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -34,7 +34,6 @@ import {
 import {
     ErrorPF2e,
     SORTABLE_BASE_OPTIONS,
-    applyDeltaToInput,
     fontAwesomeIcon,
     htmlClosest,
     htmlQuery,
@@ -56,7 +55,7 @@ import type {
     InventoryItem,
     SheetInventory,
 } from "./data-types.ts";
-import { createBulkPerLabel, onClickCreateSpell } from "./helpers.ts";
+import { applyDeltaToInput, createBulkPerLabel, onClickCreateSpell } from "./helpers.ts";
 import { ItemSummaryRenderer } from "./item-summary-renderer.ts";
 import { AddCoinsPopup } from "./popups/add-coins-popup.ts";
 import { CastingItemCreateDialog } from "./popups/casting-item-create-dialog.ts";

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -34,6 +34,7 @@ import {
 import {
     ErrorPF2e,
     SORTABLE_BASE_OPTIONS,
+    applyDeltaToInput,
     fontAwesomeIcon,
     htmlClosest,
     htmlQuery,
@@ -523,10 +524,22 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends ActorSheet<TActo
 
         // Only allow digits & leading plus and minus signs for `data-allow-delta` inputs,
         // thus emulating input[type="number"]
+        // Also enable delta adjustment by arrow key
         for (const deltaInput of htmlQueryAll<HTMLInputElement>(html, "input[data-allow-delta]")) {
             deltaInput.addEventListener("input", () => {
                 const match = /[+-]?\d*/.exec(deltaInput.value)?.at(0);
                 deltaInput.value = match ?? deltaInput.value;
+            });
+
+            deltaInput.addEventListener("keydown", (event: KeyboardEvent) => {
+                const min = Number(deltaInput.dataset.min) || 0;
+                const max = Number(deltaInput.dataset.max) || 0;
+
+                if (event.key === "ArrowUp") {
+                    applyDeltaToInput(deltaInput, +1, min, max);
+                } else if(event.key === "ArrowDown") {
+                    applyDeltaToInput(deltaInput, -1, min, max);
+                }
             });
         }
 

--- a/src/module/actor/sheet/helpers.ts
+++ b/src/module/actor/sheet/helpers.ts
@@ -83,10 +83,11 @@ function createAbilityViewData(item: AbilityItemPF2e | FeatPF2e): AbilityViewDat
 /**
  * Applies a delta change to the value of an input element
  *
- * @param input
- * @param delta
- * @param min
- * @param max
+ * @param input reference to the input field
+ * @param delta the amount of change to apply to the input's current value
+ * @param [min] minimum input value
+ * @param [max] maximum input value; if "0", do not limit the value
+ * @param [triggerChange] if true, dispatches a change event after this operation is complete
  * @returns the new value of the input field
  */
 function applyDeltaToInput(

--- a/src/module/actor/sheet/helpers.ts
+++ b/src/module/actor/sheet/helpers.ts
@@ -85,18 +85,11 @@ function createAbilityViewData(item: AbilityItemPF2e | FeatPF2e): AbilityViewDat
  *
  * @param input reference to the input field
  * @param delta the amount of change to apply to the input's current value
- * @param [min] minimum input value
- * @param [max] maximum input value; if "0", do not limit the value
- * @param [triggerChange] if true, dispatches a change event after this operation is complete
  * @returns the new value of the input field
  */
-function applyDeltaToInput(
-    input: HTMLInputElement,
-    delta: number,
-    min: number = 0,
-    max: number = 0,
-    triggerChange: boolean = true,
-): string {
+function applyDeltaToInput(input: HTMLInputElement, delta: number): string {
+    const min = Number(input.dataset.min) || 0;
+    const max = Number(input.dataset.max) || 0;
     const oldValue = Number(input.value) || min;
 
     if (max > 0) {
@@ -105,9 +98,7 @@ function applyDeltaToInput(
         input.value = String(Math.max(oldValue + delta, min));
     }
 
-    if (triggerChange) {
-        fu.debounce((el: HTMLInputElement) => el.dispatchEvent(new Event("change", { bubbles: true })), 0)(input);
-    }
+    fu.debounce((el: HTMLInputElement) => el.dispatchEvent(new Event("change", { bubbles: true })), 0)(input);
 
     return input.value;
 }

--- a/src/module/actor/sheet/helpers.ts
+++ b/src/module/actor/sheet/helpers.ts
@@ -81,13 +81,13 @@ function createAbilityViewData(item: AbilityItemPF2e | FeatPF2e): AbilityViewDat
 }
 
 /**
- * Applies a delta change to the value of an input element
+ * Applies a delta change to the numeric value of an input element. If the input field has a min or max data property,
+ * the delta change is limited to those values.
  *
  * @param input reference to the input field
  * @param delta the amount of change to apply to the input's current value
- * @returns the new value of the input field
  */
-function applyDeltaToInput(input: HTMLInputElement, delta: number): string {
+function applyDeltaToInput(input: HTMLInputElement, delta: number): void {
     const min = Number(input.dataset.min) || 0;
     const max = Number(input.dataset.max) || 0;
     const oldValue = Number(input.value) || min;
@@ -99,8 +99,6 @@ function applyDeltaToInput(input: HTMLInputElement, delta: number): string {
     }
 
     fu.debounce((el: HTMLInputElement) => el.dispatchEvent(new Event("change", { bubbles: true })), 0)(input);
-
-    return input.value;
 }
 
 export { applyDeltaToInput, condenseSenses, createAbilityViewData, createBulkPerLabel, onClickCreateSpell };

--- a/src/module/actor/sheet/helpers.ts
+++ b/src/module/actor/sheet/helpers.ts
@@ -105,7 +105,7 @@ function applyDeltaToInput(
     }
 
     if (triggerChange) {
-        fu.debounce((el: HTMLInputElement) => el.dispatchEvent(new Event('change', { bubbles: true })), 0)(input);
+        fu.debounce((el: HTMLInputElement) => el.dispatchEvent(new Event("change", { bubbles: true })), 0)(input);
     }
 
     return input.value;

--- a/src/module/actor/sheet/helpers.ts
+++ b/src/module/actor/sheet/helpers.ts
@@ -80,4 +80,35 @@ function createAbilityViewData(item: AbilityItemPF2e | FeatPF2e): AbilityViewDat
     };
 }
 
-export { condenseSenses, createAbilityViewData, createBulkPerLabel, onClickCreateSpell };
+/**
+ * Applies a delta change to the value of an input element
+ *
+ * @param input
+ * @param delta
+ * @param min
+ * @param max
+ * @returns the new value of the input field
+ */
+function applyDeltaToInput(
+    input: HTMLInputElement,
+    delta: number,
+    min: number = 0,
+    max: number = 0,
+    triggerChange: boolean = true,
+): string {
+    const oldValue = Number(input.value) || min;
+
+    if (max > 0) {
+        input.value = String(Math.clamp(oldValue + delta, min, max));
+    } else {
+        input.value = String(Math.max(oldValue + delta, min));
+    }
+
+    if (triggerChange) {
+        fu.debounce((el: HTMLInputElement) => el.dispatchEvent(new Event('change', { bubbles: true })), 0)(input);
+    }
+
+    return input.value;
+}
+
+export { applyDeltaToInput, condenseSenses, createAbilityViewData, createBulkPerLabel, onClickCreateSpell };

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -40,6 +40,29 @@ function applyNTimes<T>(func: (val: T) => T, times: number, start: T): T {
 }
 
 /**
+ * Applies a delta change to the value of an input element
+ *
+ * @param input
+ * @param delta
+ * @returns the new value of the input field
+ */
+function applyDeltaToInput(input: HTMLInputElement, delta: number, min: number = 0, max: number = 0, triggerChange: boolean = true): string {
+    const oldValue = Number(input.value) || min;
+
+    if(max > 0) {
+        input.value = String(Math.clamp(oldValue + delta, min, max));
+    } else {
+        input.value = String(Math.min(oldValue + delta, min));
+    }
+
+    if (triggerChange) {
+        $(input).trigger('change');
+    }
+
+    return input.value;
+}
+
+/**
  * Check if a key is present in a given object in a type safe way
  *
  * @param obj The object to check
@@ -403,6 +426,7 @@ export {
     ErrorPF2e,
     SORTABLE_BASE_OPTIONS,
     applyNTimes,
+    applyDeltaToInput,
     configFromLocalization,
     fontAwesomeIcon,
     getActionGlyph,

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -40,35 +40,6 @@ function applyNTimes<T>(func: (val: T) => T, times: number, start: T): T {
 }
 
 /**
- * Applies a delta change to the value of an input element
- *
- * @param input
- * @param delta
- * @returns the new value of the input field
- */
-function applyDeltaToInput(
-    input: HTMLInputElement,
-    delta: number,
-    min: number = 0,
-    max: number = 0,
-    triggerChange: boolean = true,
-): string {
-    const oldValue = Number(input.value) || min;
-
-    if (max > 0) {
-        input.value = String(Math.clamp(oldValue + delta, min, max));
-    } else {
-        input.value = String(Math.min(oldValue + delta, min));
-    }
-
-    if (triggerChange) {
-        $(input).trigger("change");
-    }
-
-    return input.value;
-}
-
-/**
  * Check if a key is present in a given object in a type safe way
  *
  * @param obj The object to check
@@ -432,7 +403,6 @@ export {
     ErrorPF2e,
     SORTABLE_BASE_OPTIONS,
     applyNTimes,
-    applyDeltaToInput,
     configFromLocalization,
     fontAwesomeIcon,
     getActionGlyph,

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -46,17 +46,23 @@ function applyNTimes<T>(func: (val: T) => T, times: number, start: T): T {
  * @param delta
  * @returns the new value of the input field
  */
-function applyDeltaToInput(input: HTMLInputElement, delta: number, min: number = 0, max: number = 0, triggerChange: boolean = true): string {
+function applyDeltaToInput(
+    input: HTMLInputElement,
+    delta: number,
+    min: number = 0,
+    max: number = 0,
+    triggerChange: boolean = true,
+): string {
     const oldValue = Number(input.value) || min;
 
-    if(max > 0) {
+    if (max > 0) {
         input.value = String(Math.clamp(oldValue + delta, min, max));
     } else {
         input.value = String(Math.min(oldValue + delta, min));
     }
 
     if (triggerChange) {
-        $(input).trigger('change');
+        $(input).trigger("change");
     }
 
     return input.value;

--- a/static/templates/actors/character/partials/header.hbs
+++ b/static/templates/actors/character/partials/header.hbs
@@ -34,7 +34,7 @@
         </div>
         <div class="exp-data">
             <div class="exp-input">
-                <input name="system.details.xp.value" type="text" value="{{data.details.xp.value}}" data-dtype="Number" data-allow-delta data-min="0" data-max="{{data.details.xp.max}}" placeholder="0" size="4" />
+                <input name="system.details.xp.value" type="text" value="{{data.details.xp.value}}" data-dtype="Number" data-allow-delta data-min="0" placeholder="0" size="4" />
                 <span class="max"> / </span>
                 <input name="system.details.xp.max" type="text" value="{{data.details.xp.max}}" data-dtype="Number" placeholder="1000" size="4" />
             </div>

--- a/static/templates/actors/character/partials/header.hbs
+++ b/static/templates/actors/character/partials/header.hbs
@@ -34,7 +34,7 @@
         </div>
         <div class="exp-data">
             <div class="exp-input">
-                <input name="system.details.xp.value" type="text" value="{{data.details.xp.value}}" data-dtype="Number" data-allow-delta placeholder="0" size="4" />
+                <input name="system.details.xp.value" type="text" value="{{data.details.xp.value}}" data-dtype="Number" data-allow-delta data-min="0" data-max="{{data.details.xp.max}}" placeholder="0" size="4" />
                 <span class="max"> / </span>
                 <input name="system.details.xp.max" type="text" value="{{data.details.xp.max}}" data-dtype="Number" placeholder="1000" size="4" />
             </div>

--- a/static/templates/actors/character/partials/sidebar.hbs
+++ b/static/templates/actors/character/partials/sidebar.hbs
@@ -121,10 +121,11 @@
             {{#if data.attributes.shield.hp.max}}
                 <input
                     id="{{@root.options.id}}-shield-hp"
-                    type="number"
+                    type="text"
                     placeholder="0"
                     name="system.attributes.shield.hp.value"
                     value="{{data.attributes.shield.hp.value}}"
+                    data-dtype="Number" data-allow-delta data-max="{{data.attributes.shield.hp.max}}"
                     {{disabled (not data.attributes.shield.hp.max)}}
                 />
             {{else}}

--- a/static/templates/actors/character/partials/sidebar.hbs
+++ b/static/templates/actors/character/partials/sidebar.hbs
@@ -11,13 +11,13 @@
         <div class="container temp-hp">
             <label for="{{options.id}}-pc-hp-temp" class="sidebar_label">{{localize "PF2E.TempHitPointsShortLabel"}}</label>
             <div class="data-value">
-                <input name="system.attributes.hp.temp" id="{{options.id}}-pc-hp-temp" type="number" value="{{data.attributes.hp.temp}}" placeholder="0" />
+                <input name="system.attributes.hp.temp" id="{{options.id}}-pc-hp-temp" type="text" value="{{data.attributes.hp.temp}}" placeholder="0" data-dtype="Number" data-allow-delta data-min="0" />
             </div>
         </div>
         <div class="container current-hp">
             <label for="{{options.id}}-pc-hp" class="sidebar_label">{{localize "PF2E.CurrentHitPointsShortLabel"}}</label>
             <div class="data-value">
-                <input name="system.attributes.hp.value" id="{{options.id}}-pc-hp" type="number" value="{{data.attributes.hp.value}}" placeholder="10" />
+                <input name="system.attributes.hp.value" id="{{options.id}}-pc-hp" type="text" value="{{data.attributes.hp.value}}" placeholder="10" data-dtype="Number" data-allow-delta data-min="0" data-max="{{data.attributes.hp.max}}" />
             </div>
         </div>
         <div class="container max-hp">

--- a/static/templates/actors/character/partials/sidebar.hbs
+++ b/static/templates/actors/character/partials/sidebar.hbs
@@ -203,7 +203,7 @@
         {{#each specialResources as |resource|}}
             <li class="special-resource">
                 <span class="label">{{resource.label}}</span>
-                <input type="text" data-resource="{{resource.slug}}" value="{{resource.value}}" />
+                <input type="text" data-dtype="Number" data-allow-delta data-min="0" data-max="{{resource.max}}" data-resource="{{resource.slug}}" value="{{resource.value}}" />
                 / {{resource.max}}
             </li>
         {{/each}}


### PR DESCRIPTION
Expands on the existing `input[data-allow-delta]` to support keyboard delta (ArrowUp/Down) and (eventually) mousewheel support, specifically for editable character sheet fields such as XP, special resources, and HP.