### PR TITLE
Remove player facing links to All-Around Vision glossary item

### DIFF
--- a/packs/feat-effects/effect-watchful-gaze.json
+++ b/packs/feat-effects/effect-watchful-gaze.json
@@ -4,7 +4,7 @@
     "name": "Effect: Watchful Gaze",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Watchful Gaze]</p>\n<p>You gain @UUID[Compendium.pf2e.bestiary-ability-glossary-srd.Item.All-Around Vision] until the start of your next turn. This lets you see in all directions and prevents you from being flanked.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Watchful Gaze]</p>\n<p>You gain All-Around Vision until the start of your next turn. This lets you see in all directions and prevents you from being flanked.</p>"
         },
         "duration": {
             "expiry": "turn-start",

--- a/packs/feats/ancestry/goloma/watchful-gaze.json
+++ b/packs/feats/ancestry/goloma/watchful-gaze.json
@@ -12,7 +12,7 @@
         },
         "category": "ancestry",
         "description": {
-            "value": "<p>You use your many eyes to look in all directions at once, making you extremely observant for a short period of time. You gain @UUID[Compendium.pf2e.bestiary-ability-glossary-srd.Item.All-Around Vision] until the start of your next turn. This lets you see in all directions and prevents you from being flanked.</p>"
+            "value": "<p>You use your many eyes to look in all directions at once, making you extremely observant for a short period of time. You gain All-Around Vision until the start of your next turn. This lets you see in all directions and prevents you from being flanked.</p>"
         },
         "level": {
             "value": 1

--- a/packs/feats/archetype/chronoskimmer/superimpose-time-duplicates.json
+++ b/packs/feats/archetype/chronoskimmer/superimpose-time-duplicates.json
@@ -12,7 +12,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p><strong>Frequency</strong> once per hour</p>\n<hr />\n<p>You call alternate versions of yourself, either from a different timeline or perhaps yourself from a different point in your current timeline, to aid you in combat. Until the start of your next turn, these alternate selves flicker in and out in your vicinity, providing flanking for you against all enemies within your reach. Flanking with your time duplicates is the same as flanking with an ally and so is subject to effects like @UUID[Compendium.pf2e.bestiary-ability-glossary-srd.Item.All-Around Vision] or the @UUID[Compendium.pf2e.classfeatures.Item.Deny Advantage] class feature.</p>"
+            "value": "<p><strong>Frequency</strong> once per hour</p>\n<hr />\n<p>You call alternate versions of yourself, either from a different timeline or perhaps yourself from a different point in your current timeline, to aid you in combat. Until the start of your next turn, these alternate selves flicker in and out in your vicinity, providing flanking for you against all enemies within your reach. Flanking with your time duplicates is the same as flanking with an ally and so is subject to effects like All-Around Vision or the @UUID[Compendium.pf2e.classfeatures.Item.Deny Advantage] class feature.</p>"
         },
         "frequency": {
             "max": 1,


### PR DESCRIPTION
To prevent players from thinking they should drag the glossary item to themselves