### PR TITLE
Clean up Champion deity rule elements

### DIFF
--- a/packs/classfeatures/deity-champion.json
+++ b/packs/classfeatures/deity-champion.json
@@ -11,7 +11,7 @@
         },
         "category": "classfeature",
         "description": {
-            "value": "<p>As a champion, you are a warrior in the name of a deity you revere above all others. The most common deities in Pathfinder appear on pages 35–39 of Player Core, along with their edicts, areas of concern, and the benefits you get for being a devotee of that deity. Choose one deity.</p><h2>Skill</h2><p>You become trained in the divine skill listed for your deity. As normal, if you're already trained in that skill, you become trained in a different skill of your choice.</p><h2>Anathema</h2><p>Champions care deeply about the edicts and anathema they take from their deity, sanctification, and cause. As with any implementation of edicts and anathema in the rules, these are a tool for roleplaying between you, the GM, and the other players at the table—you're still playing a nuanced character, not strictly following a script.</p>\n<p>Acts fundamentally opposed to your deity's ideals are anathema to your faith. Learning or casting spells, committing acts, and using items that are anathema to your deity remove you from your deity's good graces.</p>\n<p>Similarly, using items, spells, or actions that are anathema to the tenets or goals of your faith could interfere with your connection to your deity. For example, assisting with a ritual that raises undead would be anathema to Pharasma, the goddess of death. Many actions that are anathema don't appear in any deity's formal list. For borderline cases, you and your GM determine which acts are anathema.</p>\n<p>If you perform enough acts that are anathema to your deity, you lose the magical abilities that come from your connection to your deity. The class features that you lose are determined by the GM, but they likely include your holy or unholy trait, your focus pool, and your blessing of the devoted. These abilities can be regained only if you repent by conducting an atone ritual. If your deity doesn't require the specific sanctification you had, your GM might let you retrain your sanctification and cause while still following the same deity.</p><h2>Sanctification</h2><p>Depending on your deity, their sanctification can make you holy or unholy. This commits you to one side of a struggle over souls. Whether you become holy, unholy, or neither will limit your choice of causes, devotion spells, and feats.</p>\n<p>If you \"can be\" holy or unholy according to your deity's sanctification entry, you make that choice, and if you \"must be\" holy or unholy, you gain the trait automatically. If the deity lists \"none,\" you can choose only options that don't require the holy or unholy trait. If you are holy or unholy and gain the opposing trait in some way, you lose the previous trait until you atone.</p>\n<p>Unholy sanctification for a champion can be extremely disruptive to a typical game and should be a player character option only in appropriate adventures or campaigns where the group collectively decides to embrace them. Unholy sanctification and causes are uncommon options.</p>\n<p><strong>Holy:</strong> You gain the holy trait and add that trait to any Strikes you make. You gain the edict, \"Do not knowingly harm innocents or fail to prevent harm to an innocent if your direct intervention could save them\" and the anathema \"Commit murder.\" Even if your game includes behavior outside the Pathfinder baseline, the acts listed there are anathema to you.</p>\n<p><strong>Unholy:</strong> You gain the unholy trait and add that trait to any Strikes you make. You gain the edict, \"Do not put another's needs before your own or those of your deity\" and the anathema \"Commit an entirely altruistic act, such as giving something away in charity\" and \"Put anyone's needs before those of your deity.\" None of these prevents you from performing acts others might consider helpful, but these acts must be done with the expectation that they ultimately further your own goals or those of your deity</p>"
+            "value": "<p>As a champion, you are a warrior in the name of a deity you revere above all others. Choose one deity.</p><h2>Skill</h2><p>You become trained in the divine skill listed for your deity. As normal, if you're already trained in that skill, you become trained in a different skill of your choice.</p><h2>Anathema</h2><p>Champions care deeply about the edicts and anathema they take from their deity, sanctification, and cause. As with any implementation of edicts and anathema in the rules, these are a tool for roleplaying between you, the GM, and the other players at the table—you're still playing a nuanced character, not strictly following a script.</p>\n<p>Acts fundamentally opposed to your deity's ideals are anathema to your faith. Learning or casting spells, committing acts, and using items that are anathema to your deity remove you from your deity's good graces.</p>\n<p>Similarly, using items, spells, or actions that are anathema to the tenets or goals of your faith could interfere with your connection to your deity. For example, assisting with a ritual that raises undead would be anathema to Pharasma, the goddess of death. Many actions that are anathema don't appear in any deity's formal list. For borderline cases, you and your GM determine which acts are anathema.</p>\n<p>If you perform enough acts that are anathema to your deity, you lose the magical abilities that come from your connection to your deity. The class features that you lose are determined by the GM, but they likely include your holy or unholy trait, your focus pool, and your blessing of the devoted. These abilities can be regained only if you repent by conducting an atone ritual. If your deity doesn't require the specific sanctification you had, your GM might let you retrain your sanctification and cause while still following the same deity.</p><h2>Sanctification</h2><p>Depending on your deity, their sanctification can make you holy or unholy. This commits you to one side of a struggle over souls. Whether you become holy, unholy, or neither will limit your choice of causes, devotion spells, and feats.</p>\n<p>If you \"can be\" holy or unholy according to your deity's sanctification entry, you make that choice, and if you \"must be\" holy or unholy, you gain the trait automatically. If the deity lists \"none,\" you can choose only options that don't require the holy or unholy trait. If you are holy or unholy and gain the opposing trait in some way, you lose the previous trait until you atone.</p>\n<p>Unholy sanctification for a champion can be extremely disruptive to a typical game and should be a player character option only in appropriate adventures or campaigns where the group collectively decides to embrace them. Unholy sanctification and causes are uncommon options.</p>\n<p><strong>Holy:</strong> You gain the holy trait and add that trait to any Strikes you make. You gain the edict, \"Do not knowingly harm innocents or fail to prevent harm to an innocent if your direct intervention could save them\" and the anathema \"Commit murder.\" Even if your game includes behavior outside the Pathfinder baseline, the acts listed there are anathema to you.</p>\n<p><strong>Unholy:</strong> You gain the unholy trait and add that trait to any Strikes you make. You gain the edict, \"Do not put another's needs before your own or those of your deity\" and the anathema \"Commit an entirely altruistic act, such as giving something away in charity\" and \"Put anyone's needs before those of your deity.\" None of these prevents you from performing acts others might consider helpful, but these acts must be done with the expectation that they ultimately further your own goals or those of your deity</p>"
         },
         "level": {
             "value": 1
@@ -114,39 +114,25 @@
             },
             {
                 "add": [
-                    "holy"
+                    "{item|flags.pf2e.rulesSelections.sanctification}"
                 ],
                 "key": "ActorTraits",
                 "predicate": [
-                    "sanctification:holy"
-                ]
-            },
-            {
-                "add": [
-                    "unholy"
-                ],
-                "key": "ActorTraits",
-                "predicate": [
-                    "sanctification:unholy"
+                    {
+                        "not": "sanctification:none"
+                    }
                 ]
             },
             {
                 "key": "AdjustStrike",
                 "mode": "add",
                 "predicate": [
-                    "sanctification:holy"
+                    {
+                        "not": "sanctification:none"
+                    }
                 ],
                 "property": "traits",
-                "value": "holy"
-            },
-            {
-                "key": "AdjustStrike",
-                "mode": "add",
-                "predicate": [
-                    "sanctification:unholy"
-                ],
-                "property": "traits",
-                "value": "unholy"
+                "value": "{item|flags.pf2e.rulesSelections.sanctification}"
             },
             {
                 "key": "GrantItem",


### PR DESCRIPTION
Remove the page reference from the description and reduce the number of rules needed to do the same thing