### PR TITLE
Implement Wellspring Magic grant as class archetype choice and add brush up Elemental Magic and Flexible Spell Preparation choice grants

### DIFF
--- a/packs/classfeatures/elemental-magic.json
+++ b/packs/classfeatures/elemental-magic.json
@@ -48,7 +48,10 @@
                 "adjustName": false,
                 "choices": {
                     "filter": [
-                        "item:tag:druid-order"
+                        "item:tag:druid-order",
+                        {
+                            "not": "item:tag:class-archetype"
+                        }
                     ]
                 },
                 "flag": "druidicOrder",
@@ -69,7 +72,10 @@
                 "adjustName": false,
                 "choices": {
                     "filter": [
-                        "item:tag:witch-elementalist-patron"
+                        "item:tag:witch-elementalist-patron",
+                        {
+                            "not": "item:tag:class-archetype"
+                        }
                     ]
                 },
                 "flag": "patron",
@@ -90,7 +96,10 @@
                 "adjustName": false,
                 "choices": {
                     "filter": [
-                        "item:tag:sorcerer-bloodline"
+                        "item:tag:sorcerer-bloodline",
+                        {
+                            "not": "item:tag:class-archetype"
+                        }
                     ]
                 },
                 "flag": "bloodline",
@@ -111,7 +120,10 @@
                 "adjustName": false,
                 "choices": {
                     "filter": [
-                        "item:tag:magus-hybrid-study"
+                        "item:tag:magus-hybrid-study",
+                        {
+                            "not": "item:tag:class-archetype"
+                        }
                     ]
                 },
                 "flag": "hybridStudy",
@@ -132,7 +144,10 @@
                 "adjustName": false,
                 "choices": {
                     "filter": [
-                        "item:tag:wizard-elemental-school"
+                        "item:tag:wizard-elemental-school",
+                        {
+                            "not": "item:tag:class-archetype"
+                        }
                     ]
                 },
                 "flag": "arcaneSchool",

--- a/packs/classfeatures/flexible-spell-preparation.json
+++ b/packs/classfeatures/flexible-spell-preparation.json
@@ -33,7 +33,10 @@
                 "adjustName": false,
                 "choices": {
                     "filter": [
-                        "item:tag:cleric-doctrine"
+                        "item:tag:cleric-doctrine",
+                        {
+                            "not": "item:tag:class-archetype"
+                        }
                     ]
                 },
                 "flag": "doctrine",
@@ -54,7 +57,10 @@
                 "adjustName": false,
                 "choices": {
                     "filter": [
-                        "item:tag:druid-order"
+                        "item:tag:druid-order",
+                        {
+                            "not": "item:tag:class-archetype"
+                        }
                     ]
                 },
                 "flag": "druidicOrder",
@@ -75,7 +81,10 @@
                 "adjustName": false,
                 "choices": {
                     "filter": [
-                        "item:tag:witch-patron"
+                        "item:tag:witch-patron",
+                        {
+                            "not": "item:tag:class-archetype"
+                        }
                     ]
                 },
                 "flag": "patron",
@@ -96,7 +105,10 @@
                 "adjustName": false,
                 "choices": {
                     "filter": [
-                        "item:tag:wizard-arcane-school"
+                        "item:tag:wizard-arcane-school",
+                        {
+                            "not": "item:tag:class-archetype"
+                        }
                     ]
                 },
                 "flag": "arcaneSchool",

--- a/packs/classfeatures/wellspring-magic.json
+++ b/packs/classfeatures/wellspring-magic.json
@@ -11,7 +11,7 @@
         },
         "category": "classfeature",
         "description": {
-            "value": "<p>You regain magic power quickly, but it can be difficult for you to control. You must select @UUID[Compendium.pf2e.feats-srd.Item.Wellspring Mage Dedication] as your 2nd-level class feat.</p>\n<p><strong>Prerequisites</strong> You must have a class that casts spells with a spell repertoire.</p>\n<p><strong>Wellspring Mage Adjustments</strong> You learn spells as normal for your class, but change your spontaneous spellcasting in the following ways.</p>\n<p>You can cast fewer spells each day unless you gain more spells thanks to your wellspring. Reduce your number of spell slots of each spell rank by 1. Reduce the number of cantrips you gain from your class by 1.</p>\n<p>A wellspring of magic fills you with power that's not fully under your control. When you roll initiative for a non-trivial combat encounter, as well as in other high-stress situations of the GM's choice, magic wells up within you. Attempt a @Check[flat|dc:6] check.</p><hr /><p><strong>Critical Success</strong> You temporarily recover an expended spell slot of any rank of your choice. The temporary spell slot lasts for 1 minute, and if you don't use it by then, you experience an immediate @UUID[Compendium.pf2e.rollable-tables.RollTable.Wellspring Surges].</p>\n<p><strong>Success</strong> As critical success, except you randomly determine the rank of spell slot from among your top three spell ranks (or all your ranks of spell slots if you have fewer than three). The slot lasts 3 rounds instead of 1 minute.</p>\n<p><strong>Failure</strong> You generate a <em>wellspring surge</em>, with a spell rank chosen randomly among your top three ranks of spell slots (or all your ranks if you have fewer than three).</p>\n<p>You can gain a temporary spell slot no more than twice per day. If you would gain a temporary spell slot for a rank that has no expended spell slots, there's no effect. If you use a temporary slot to cast a spell with a duration, the spell ends whenever you would have lost the slot if its duration hasn't yet elapsed. If you roll for <em>wellspring magic</em> while you currently have a temporary spell slot, you automatically fail the flat check.</p><hr /><h3>WELLSPRING SURGES</h3><p>When your wellspring magic goes out of control, it becomes a wellspring surge. Typically, this happens when you fail the flat check from wellspring magic, but other wellspring mage feats have effects that sometimes cause you to generate a wellspring surge, or might even cause your foes to do so.</p>\n<p>Roll [[/r 1d20]]{1d20} and use the <em>@UUID[Compendium.pf2e.rollable-tables.RollTable.Wellspring Surges]</em> rolltable to determine the surge's effect. If the effect calls for a damage type, the GM chooses the type based on the types of spells you know or your current location. The wellspring surge uses your spell DC. You have no control over the way your wellspring surge manifests. You are the point of origin for your wellspring surges, and you are not excluded from their effects. If you force a foe to generate a surge, they are the origin point of that surge instead.</p>\n<p>If your wellspring was granted by a being like a god or muse, the entity's intentions might sometimes alter the results of wellspring surges, or move the point of origin for an area to any point within 30 feet if the GM determines this fits the situation. For example, instead of uncontrolled damage, the entity might choose to damage only creatures opposing its plan, even if they are your allies.</p>\n<p>A wellspring surge always has the trait of your magical tradition, plus any traits that appear in parentheses at the end of the surge's effects.</p>"
+            "value": "<p>You regain magic power quickly, but it can be difficult for you to control. You must select @UUID[Compendium.pf2e.feats-srd.Item.Wellspring Mage Dedication] as your 2nd-level class feat.</p>\n<p><strong>Wellspring Mage Adjustments</strong> You learn spells as normal for your class, but change your spontaneous spellcasting in the following ways.</p>\n<p>You can cast fewer spells each day unless you gain more spells thanks to your wellspring. Reduce your number of spell slots of each spell rank by 1. Reduce the number of cantrips you gain from your class by 1.</p>\n<p>A wellspring of magic fills you with power that's not fully under your control. When you roll initiative for a non-trivial combat encounter, as well as in other high-stress situations of the GM's choice, magic wells up within you. Attempt a @Check[flat|dc:6] check.</p><hr /><p><strong>Critical Success</strong> You temporarily recover an expended spell slot of any rank of your choice. The temporary spell slot lasts for 1 minute, and if you don't use it by then, you experience an immediate @UUID[Compendium.pf2e.rollable-tables.RollTable.Wellspring Surges].</p>\n<p><strong>Success</strong> As critical success, except you randomly determine the rank of spell slot from among your top three spell ranks (or all your ranks of spell slots if you have fewer than three). The slot lasts 3 rounds instead of 1 minute.</p>\n<p><strong>Failure</strong> You generate a <em>wellspring surge</em>, with a spell rank chosen randomly among your top three ranks of spell slots (or all your ranks if you have fewer than three).</p>\n<p>You can gain a temporary spell slot no more than twice per day. If you would gain a temporary spell slot for a rank that has no expended spell slots, there's no effect. If you use a temporary slot to cast a spell with a duration, the spell ends whenever you would have lost the slot if its duration hasn't yet elapsed. If you roll for <em>wellspring magic</em> while you currently have a temporary spell slot, you automatically fail the flat check.</p><hr /><h3>WELLSPRING SURGES</h3><p>When your wellspring magic goes out of control, it becomes a wellspring surge. Typically, this happens when you fail the flat check from wellspring magic, but other wellspring mage feats have effects that sometimes cause you to generate a wellspring surge, or might even cause your foes to do so.</p>\n<p>Roll [[/r 1d20]]{1d20} and use the <em>@UUID[Compendium.pf2e.rollable-tables.RollTable.Wellspring Surges]</em> rolltable to determine the surge's effect. If the effect calls for a damage type, the GM chooses the type based on the types of spells you know or your current location. The wellspring surge uses your spell DC. You have no control over the way your wellspring surge manifests. You are the point of origin for your wellspring surges, and you are not excluded from their effects. If you force a foe to generate a surge, they are the origin point of that surge instead.</p>\n<p>If your wellspring was granted by a being like a god or muse, the entity's intentions might sometimes alter the results of wellspring surges, or move the point of origin for an area to any point within 30 feet if the GM determines this fits the situation. For example, instead of uncontrolled damage, the entity might choose to damage only creatures opposing its plan, even if they are your allies.</p>\n<p>A wellspring surge always has the trait of your magical tradition, plus any traits that appear in parentheses at the end of the surge's effects.</p>"
         },
         "level": {
             "value": 1
@@ -85,11 +85,86 @@
                 ],
                 "reevaluateOnUpdate": true,
                 "uuid": "Compendium.pf2e.feats-srd.Item.Wellspring Mage Dedication"
+            },
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        "item:tag:bard-muse",
+                        {
+                            "not": "item:tag:class-archetype"
+                        }
+                    ]
+                },
+                "flag": "muses",
+                "key": "ChoiceSet",
+                "predicate": [
+                    "class:bard"
+                ],
+                "prompt": "PF2E.SpecificRule.Bard.Muse.Prompt"
+            },
+            {
+                "key": "GrantItem",
+                "predicate": [
+                    "class:bard"
+                ],
+                "uuid": "{item|flags.pf2e.rulesSelections.muses}"
+            },
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        "item:tag:oracle-mystery",
+                        {
+                            "not": "item:tag:class-archetype"
+                        }
+                    ]
+                },
+                "flag": "muses",
+                "key": "ChoiceSet",
+                "predicate": [
+                    "class:oracle"
+                ],
+                "prompt": "PF2E.SpecificRule.Oracle.Mystery.Prompt"
+            },
+            {
+                "key": "GrantItem",
+                "predicate": [
+                    "class:oracle"
+                ],
+                "uuid": "{item|flags.pf2e.rulesSelections.mystery}"
+            },
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        "item:tag:sorcerer-bloodline",
+                        {
+                            "not": "item:tag:class-archetype"
+                        }
+                    ]
+                },
+                "flag": "bloodline",
+                "key": "ChoiceSet",
+                "predicate": [
+                    "class:sorcerer"
+                ],
+                "prompt": "PF2E.SpecificRule.Sorcerer.Bloodline.Prompt"
+            },
+            {
+                "key": "GrantItem",
+                "predicate": [
+                    "class:sorcerer"
+                ],
+                "uuid": "{item|flags.pf2e.rulesSelections.bloodline}"
             }
         ],
         "traits": {
             "otherTags": [
-                "class-archetype"
+                "bard-muse",
+                "class-archetype",
+                "oracle-mystery",
+                "sorcerer-bloodline"
             ],
             "rarity": "common",
             "value": []


### PR DESCRIPTION
I did another round of testing and noticed that I needed to fine-tune the filters for Elemental Magic and Flexible Spell Preparation.

Did not add Summoner and Psychic to the options for Wellspring Magic. Summoner has no grant choices for their subclasses and Psychic has two choices. Will leave those out for the moment.