### PR TITLE
Move several trait AdjustStrike rule elements to Item Alteration

### DIFF
--- a/packs/abomination-vaults-bestiary/book-2-hands-of-the-devil/siora-fallowglade.json
+++ b/packs/abomination-vaults-bestiary/book-2-hands-of-the-devil/siora-fallowglade.json
@@ -225,15 +225,14 @@
                         "value": 2
                     },
                     {
-                        "definition": [
-                            "item:slug:shadow-hand"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "mark-for-death"
+                            "mark-for-death",
+                            "item:slug:shadow-hand"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "deadly-d8"
                     }
                 ],

--- a/packs/age-of-ashes-bestiary/book-1-hellknight-hill/charau-ka.json
+++ b/packs/age-of-ashes-bestiary/book-1-hellknight-hill/charau-ka.json
@@ -451,12 +451,13 @@
                 },
                 "rules": [
                     {
-                        "definition": [
-                            "item:thrown"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "weapon",
+                        "key": "ItemAlteration",
                         "mode": "add",
-                        "property": "weapon-traits",
+                        "predicate": [
+                            "item:thrown"
+                        ],  
+                        "property": "traits",
                         "value": "deadly-d6"
                     }
                 ],

--- a/packs/age-of-ashes-bestiary/book-1-hellknight-hill/charau-ka.json
+++ b/packs/age-of-ashes-bestiary/book-1-hellknight-hill/charau-ka.json
@@ -456,7 +456,7 @@
                         "mode": "add",
                         "predicate": [
                             "item:thrown"
-                        ],  
+                        ],
                         "property": "traits",
                         "value": "deadly-d6"
                     }

--- a/packs/age-of-ashes-bestiary/book-1-hellknight-hill/malarunk.json
+++ b/packs/age-of-ashes-bestiary/book-1-hellknight-hill/malarunk.json
@@ -1946,12 +1946,13 @@
                 },
                 "rules": [
                     {
-                        "definition": [
-                            "item:thrown"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "weapon",
+                        "key": "ItemAlteration",
                         "mode": "add",
-                        "property": "weapon-traits",
+                        "predicate": [
+                            "item:thrown"
+                        ],  
+                        "property": "traits",
                         "value": "deadly-d6"
                     }
                 ],

--- a/packs/age-of-ashes-bestiary/book-1-hellknight-hill/malarunk.json
+++ b/packs/age-of-ashes-bestiary/book-1-hellknight-hill/malarunk.json
@@ -1951,7 +1951,7 @@
                         "mode": "add",
                         "predicate": [
                             "item:thrown"
-                        ],  
+                        ],
                         "property": "traits",
                         "value": "deadly-d6"
                     }

--- a/packs/age-of-ashes-bestiary/book-2-cult-of-cinders/charau-ka-dragon-priest.json
+++ b/packs/age-of-ashes-bestiary/book-2-cult-of-cinders/charau-ka-dragon-priest.json
@@ -1525,12 +1525,13 @@
                 },
                 "rules": [
                     {
-                        "definition": [
-                            "item:thrown"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "weapon",
+                        "key": "ItemAlteration",
                         "mode": "add",
-                        "property": "weapon-traits",
+                        "predicate": [
+                            "item:thrown"
+                        ],  
+                        "property": "traits",
                         "value": "deadly-d6"
                     }
                 ],

--- a/packs/age-of-ashes-bestiary/book-2-cult-of-cinders/charau-ka-dragon-priest.json
+++ b/packs/age-of-ashes-bestiary/book-2-cult-of-cinders/charau-ka-dragon-priest.json
@@ -1530,7 +1530,7 @@
                         "mode": "add",
                         "predicate": [
                             "item:thrown"
-                        ],  
+                        ],
                         "property": "traits",
                         "value": "deadly-d6"
                     }

--- a/packs/age-of-ashes-bestiary/book-2-cult-of-cinders/racharak.json
+++ b/packs/age-of-ashes-bestiary/book-2-cult-of-cinders/racharak.json
@@ -344,12 +344,13 @@
                 },
                 "rules": [
                     {
-                        "definition": [
-                            "item:thrown"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "weapon",
+                        "key": "ItemAlteration",
                         "mode": "add",
-                        "property": "weapon-traits",
+                        "predicate": [
+                            "item:thrown"
+                        ],  
+                        "property": "traits",
                         "value": "deadly-d6"
                     }
                 ],

--- a/packs/age-of-ashes-bestiary/book-2-cult-of-cinders/racharak.json
+++ b/packs/age-of-ashes-bestiary/book-2-cult-of-cinders/racharak.json
@@ -349,7 +349,7 @@
                         "mode": "add",
                         "predicate": [
                             "item:thrown"
-                        ],  
+                        ],
                         "property": "traits",
                         "value": "deadly-d6"
                     }

--- a/packs/age-of-ashes-bestiary/book-2-cult-of-cinders/spawn-of-dahak.json
+++ b/packs/age-of-ashes-bestiary/book-2-cult-of-cinders/spawn-of-dahak.json
@@ -320,7 +320,7 @@
                         "mode": "add",
                         "predicate": [
                             "item:thrown"
-                        ],  
+                        ],
                         "property": "traits",
                         "value": "deadly-d6"
                     }

--- a/packs/age-of-ashes-bestiary/book-2-cult-of-cinders/spawn-of-dahak.json
+++ b/packs/age-of-ashes-bestiary/book-2-cult-of-cinders/spawn-of-dahak.json
@@ -315,12 +315,13 @@
                 },
                 "rules": [
                     {
-                        "definition": [
-                            "item:thrown"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "weapon",
+                        "key": "ItemAlteration",
                         "mode": "add",
-                        "property": "weapon-traits",
+                        "predicate": [
+                            "item:thrown"
+                        ],  
+                        "property": "traits",
                         "value": "deadly-d6"
                     }
                 ],

--- a/packs/bestiary-effects/effect-absorb-shock.json
+++ b/packs/bestiary-effects/effect-absorb-shock.json
@@ -31,12 +31,13 @@
                 "uuid": "Compendium.pf2e.conditionitems.Item.Quickened"
             },
             {
-                "definition": [
-                    "item:slug:vine"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:slug:vine"
+                ],                     
+                "property": "traits",
                 "value": "reach-15"
             }
         ],

--- a/packs/bestiary-effects/effect-absorb-shock.json
+++ b/packs/bestiary-effects/effect-absorb-shock.json
@@ -36,7 +36,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:slug:vine"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "reach-15"
             }

--- a/packs/bestiary-effects/effect-metallify.json
+++ b/packs/bestiary-effects/effect-metallify.json
@@ -56,7 +56,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:slug:pseudopod"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "{item|flags.pf2e.rulesSelections.versatileTrait}"
             }

--- a/packs/bestiary-effects/effect-metallify.json
+++ b/packs/bestiary-effects/effect-metallify.json
@@ -51,12 +51,13 @@
                 "value": -5
             },
             {
-                "definition": [
-                    "item:slug:pseudopod"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:slug:pseudopod"
+                ],                     
+                "property": "traits",
                 "value": "{item|flags.pf2e.rulesSelections.versatileTrait}"
             }
         ],

--- a/packs/blog-bestiary/eleukas.json
+++ b/packs/blog-bestiary/eleukas.json
@@ -615,15 +615,14 @@
                         "toggleable": true
                     },
                     {
-                        "definition": [
-                            "item:melee"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "lunge"
+                            "lunge",
+                            "item:melee"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach"
                     }
                 ],

--- a/packs/book-of-the-dead-bestiary/gallowdead.json
+++ b/packs/book-of-the-dead-bestiary/gallowdead.json
@@ -520,15 +520,14 @@
                         "selector": "spiked-chain-damage"
                     },
                     {
-                        "definition": [
-                            "item:slug:spiked-chain"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "charge-chain:reach"
+                            "charge-chain:reach",
+                            "item:slug:spiked-chain"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach-120"
                     }
                 ],

--- a/packs/book-of-the-dead-bestiary/minister-of-tumult.json
+++ b/packs/book-of-the-dead-bestiary/minister-of-tumult.json
@@ -659,15 +659,14 @@
                         "value": 1
                     },
                     {
-                        "definition": [
-                            "item:slug:claw"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "stance-of-death:cloudless-void"
+                            "stance-of-death:cloudless-void",
+                            "item:slug:claw"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach"
                     },
                     {

--- a/packs/boons-and-curses/effect-rovagugs-destruction.json
+++ b/packs/boons-and-curses/effect-rovagugs-destruction.json
@@ -30,12 +30,13 @@
                 "prompt": "PF2E.SpecificRule.Prompt.WeaponOrUnarmed"
             },
             {
-                "definition": [
-                    "item:{item|flags.pf2e.rulesSelections.strike}"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:{item|flags.pf2e.rulesSelections.strike}"
+                ],                     
+                "property": "traits",
                 "value": "deadly-d12"
             }
         ],

--- a/packs/boons-and-curses/effect-rovagugs-destruction.json
+++ b/packs/boons-and-curses/effect-rovagugs-destruction.json
@@ -35,7 +35,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:{item|flags.pf2e.rulesSelections.strike}"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "deadly-d12"
             }

--- a/packs/boons-and-curses/gorum-moderate-boon.json
+++ b/packs/boons-and-curses/gorum-moderate-boon.json
@@ -31,7 +31,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:base:greatsword"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "forceful"
             }

--- a/packs/boons-and-curses/gorum-moderate-boon.json
+++ b/packs/boons-and-curses/gorum-moderate-boon.json
@@ -26,12 +26,13 @@
         },
         "rules": [
             {
-                "definition": [
-                    "item:base:greatsword"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:base:greatsword"
+                ],                     
+                "property": "traits",
                 "value": "forceful"
             }
         ],

--- a/packs/classfeatures/dynamic-weighting.json
+++ b/packs/classfeatures/dynamic-weighting.json
@@ -34,7 +34,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:id:{actor|flags.pf2e.trackedItems.weaponInnovation}"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "versatile-b"
             },

--- a/packs/classfeatures/dynamic-weighting.json
+++ b/packs/classfeatures/dynamic-weighting.json
@@ -29,12 +29,13 @@
         },
         "rules": [
             {
-                "definition": [
-                    "item:id:{actor|flags.pf2e.trackedItems.weaponInnovation}"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:id:{actor|flags.pf2e.trackedItems.weaponInnovation}"
+                ],                     
+                "property": "traits",
                 "value": "versatile-b"
             },
             {

--- a/packs/classfeatures/dynamic-weighting.json
+++ b/packs/classfeatures/dynamic-weighting.json
@@ -29,12 +29,9 @@
         },
         "rules": [
             {
-                "itemType": "weapon",
+                "itemId": "{actor|flags.pf2e.trackedItems.weaponInnovation}",
                 "key": "ItemAlteration",
                 "mode": "add",
-                "predicate": [
-                    "item:id:{actor|flags.pf2e.trackedItems.weaponInnovation}"
-                ],
                 "property": "traits",
                 "value": "versatile-b"
             },

--- a/packs/classfeatures/mystic-strikes.json
+++ b/packs/classfeatures/mystic-strikes.json
@@ -26,12 +26,13 @@
         },
         "rules": [
             {
-                "definition": [
-                    "item:category:unarmed"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:category:unarmed"
+                ],                     
+                "property": "traits",
                 "value": "magical"
             },
             {

--- a/packs/classfeatures/mystic-strikes.json
+++ b/packs/classfeatures/mystic-strikes.json
@@ -31,7 +31,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:category:unarmed"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "magical"
             },

--- a/packs/equipment-effects/effect-clay-sphere-weapon.json
+++ b/packs/equipment-effects/effect-clay-sphere-weapon.json
@@ -34,32 +34,23 @@
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
             {
-                "itemType": "weapon",
+                "itemId": "{item|flags.pf2e.rulesSelections.weapon}",
                 "key": "ItemAlteration",
                 "mode": "add",
-                "predicate": [
-                    "item:id:{item|flags.pf2e.rulesSelections.weapon}"
-                ],
                 "property": "traits",
                 "value": "versatile-b"
             },
             {
-                "itemType": "weapon",
+                "itemId": "{item|flags.pf2e.rulesSelections.weapon}",
                 "key": "ItemAlteration",
                 "mode": "add",
-                "predicate": [
-                    "item:id:{item|flags.pf2e.rulesSelections.weapon}"
-                ],
                 "property": "traits",
                 "value": "versatile-p"
             },
             {
-                "itemType": "weapon",
+                "itemId": "{item|flags.pf2e.rulesSelections.weapon}",
                 "key": "ItemAlteration",
                 "mode": "add",
-                "predicate": [
-                    "item:id:{item|flags.pf2e.rulesSelections.weapon}"
-                ],
                 "property": "traits",
                 "value": "versatile-s"
             },

--- a/packs/equipment-effects/effect-clay-sphere-weapon.json
+++ b/packs/equipment-effects/effect-clay-sphere-weapon.json
@@ -34,30 +34,33 @@
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
             {
-                "definition": [
-                    "item:id:{item|flags.pf2e.rulesSelections.weapon}"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:id:{item|flags.pf2e.rulesSelections.weapon}"
+                ],                     
+                "property": "traits",
                 "value": "versatile-b"
             },
             {
-                "definition": [
-                    "item:id:{item|flags.pf2e.rulesSelections.weapon}"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:id:{item|flags.pf2e.rulesSelections.weapon}"
+                ],                     
+                "property": "traits",
                 "value": "versatile-p"
             },
             {
-                "definition": [
-                    "item:id:{item|flags.pf2e.rulesSelections.weapon}"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:id:{item|flags.pf2e.rulesSelections.weapon}"
+                ],                     
+                "property": "traits",
                 "value": "versatile-s"
             },
             {

--- a/packs/equipment-effects/effect-clay-sphere-weapon.json
+++ b/packs/equipment-effects/effect-clay-sphere-weapon.json
@@ -39,7 +39,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:id:{item|flags.pf2e.rulesSelections.weapon}"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "versatile-b"
             },
@@ -49,7 +49,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:id:{item|flags.pf2e.rulesSelections.weapon}"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "versatile-p"
             },
@@ -59,7 +59,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:id:{item|flags.pf2e.rulesSelections.weapon}"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "versatile-s"
             },

--- a/packs/equipment-effects/effect-malleable-clay.json
+++ b/packs/equipment-effects/effect-malleable-clay.json
@@ -39,7 +39,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:id:{item|flags.pf2e.rulesSelections.weapon}"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "versatile-b"
             },
@@ -49,7 +49,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:id:{item|flags.pf2e.rulesSelections.weapon}"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "versatile-p"
             },
@@ -59,7 +59,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:id:{item|flags.pf2e.rulesSelections.weapon}"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "versatile-s"
             }

--- a/packs/equipment-effects/effect-malleable-clay.json
+++ b/packs/equipment-effects/effect-malleable-clay.json
@@ -34,32 +34,23 @@
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
             {
-                "itemType": "weapon",
+                "itemId": "{item|flags.pf2e.rulesSelections.weapon}",
                 "key": "ItemAlteration",
                 "mode": "add",
-                "predicate": [
-                    "item:id:{item|flags.pf2e.rulesSelections.weapon}"
-                ],
                 "property": "traits",
                 "value": "versatile-b"
             },
             {
-                "itemType": "weapon",
+                "itemId": "{item|flags.pf2e.rulesSelections.weapon}",
                 "key": "ItemAlteration",
                 "mode": "add",
-                "predicate": [
-                    "item:id:{item|flags.pf2e.rulesSelections.weapon}"
-                ],
                 "property": "traits",
                 "value": "versatile-p"
             },
             {
-                "itemType": "weapon",
+                "itemId": "{item|flags.pf2e.rulesSelections.weapon}",
                 "key": "ItemAlteration",
                 "mode": "add",
-                "predicate": [
-                    "item:id:{item|flags.pf2e.rulesSelections.weapon}"
-                ],
                 "property": "traits",
                 "value": "versatile-s"
             }

--- a/packs/equipment-effects/effect-malleable-clay.json
+++ b/packs/equipment-effects/effect-malleable-clay.json
@@ -34,30 +34,33 @@
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
             {
-                "definition": [
-                    "item:id:{item|flags.pf2e.rulesSelections.weapon}"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:id:{item|flags.pf2e.rulesSelections.weapon}"
+                ],                     
+                "property": "traits",
                 "value": "versatile-b"
             },
             {
-                "definition": [
-                    "item:id:{item|flags.pf2e.rulesSelections.weapon}"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:id:{item|flags.pf2e.rulesSelections.weapon}"
+                ],                     
+                "property": "traits",
                 "value": "versatile-p"
             },
             {
-                "definition": [
-                    "item:id:{item|flags.pf2e.rulesSelections.weapon}"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:id:{item|flags.pf2e.rulesSelections.weapon}"
+                ],                     
+                "property": "traits",
                 "value": "versatile-s"
             }
         ],

--- a/packs/equipment-effects/effect-merciful-balm.json
+++ b/packs/equipment-effects/effect-merciful-balm.json
@@ -34,12 +34,13 @@
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
             {
-                "definition": [
-                    "item:id:{item|flags.pf2e.rulesSelections.effectMercifulBalmWeapon}"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:id:{item|flags.pf2e.rulesSelections.effectMercifulBalmWeapon}"
+                ],                     
+                "property": "traits",
                 "value": "nonlethal"
             }
         ],

--- a/packs/equipment-effects/effect-merciful-balm.json
+++ b/packs/equipment-effects/effect-merciful-balm.json
@@ -39,7 +39,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:id:{item|flags.pf2e.rulesSelections.effectMercifulBalmWeapon}"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "nonlethal"
             }

--- a/packs/equipment-effects/effect-merciful-balm.json
+++ b/packs/equipment-effects/effect-merciful-balm.json
@@ -34,12 +34,9 @@
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
             {
-                "itemType": "weapon",
+                "itemId": "{item|flags.pf2e.rulesSelections.effectMercifulBalmWeapon}",
                 "key": "ItemAlteration",
                 "mode": "add",
-                "predicate": [
-                    "item:id:{item|flags.pf2e.rulesSelections.effectMercifulBalmWeapon}"
-                ],
                 "property": "traits",
                 "value": "nonlethal"
             }

--- a/packs/equipment-effects/effect-merciful-charm.json
+++ b/packs/equipment-effects/effect-merciful-charm.json
@@ -34,12 +34,13 @@
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
             {
-                "definition": [
-                    "item:id:{item|flags.pf2e.rulesSelections.effectMercifulCharm}"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:id:{item|flags.pf2e.rulesSelections.effectMercifulCharm}"
+                ],                     
+                "property": "traits",
                 "value": "nonlethal"
             }
         ],

--- a/packs/equipment-effects/effect-merciful-charm.json
+++ b/packs/equipment-effects/effect-merciful-charm.json
@@ -34,12 +34,9 @@
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
             {
-                "itemType": "weapon",
+                "itemId": "{item|flags.pf2e.rulesSelections.effectMercifulCharm}",
                 "key": "ItemAlteration",
                 "mode": "add",
-                "predicate": [
-                    "item:id:{item|flags.pf2e.rulesSelections.effectMercifulCharm}"
-                ],
                 "property": "traits",
                 "value": "nonlethal"
             }

--- a/packs/equipment-effects/effect-merciful-charm.json
+++ b/packs/equipment-effects/effect-merciful-charm.json
@@ -39,7 +39,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:id:{item|flags.pf2e.rulesSelections.effectMercifulCharm}"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "nonlethal"
             }

--- a/packs/equipment-effects/effect-thundering-fury-dadao.json
+++ b/packs/equipment-effects/effect-thundering-fury-dadao.json
@@ -27,7 +27,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:slug:thundering-fury-dadao"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "agile"
             },
@@ -37,7 +37,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:slug:thundering-fury-dadao"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "forceful"
             }

--- a/packs/equipment-effects/effect-thundering-fury-dadao.json
+++ b/packs/equipment-effects/effect-thundering-fury-dadao.json
@@ -22,21 +22,23 @@
         },
         "rules": [
             {
-                "definition": [
-                    "item:slug:thundering-fury-dadao"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:slug:thundering-fury-dadao"
+                ],                     
+                "property": "traits",
                 "value": "agile"
             },
             {
-                "definition": [
-                    "item:slug:thundering-fury-dadao"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:slug:thundering-fury-dadao"
+                ],                     
+                "property": "traits",
                 "value": "forceful"
             }
         ],

--- a/packs/equipment-effects/effect-tiger-menuki.json
+++ b/packs/equipment-effects/effect-tiger-menuki.json
@@ -39,7 +39,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:id:{item|flags.pf2e.rulesSelections.weapon}"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "forceful"
             },
@@ -49,7 +49,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:id:{item|flags.pf2e.rulesSelections.weapon}"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "sweep"
             }

--- a/packs/equipment-effects/effect-tiger-menuki.json
+++ b/packs/equipment-effects/effect-tiger-menuki.json
@@ -34,22 +34,16 @@
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
             {
-                "itemType": "weapon",
+                "itemId": "{item|flags.pf2e.rulesSelections.weapon}",
                 "key": "ItemAlteration",
                 "mode": "add",
-                "predicate": [
-                    "item:id:{item|flags.pf2e.rulesSelections.weapon}"
-                ],
                 "property": "traits",
                 "value": "forceful"
             },
             {
-                "itemType": "weapon",
+                "itemId": "{item|flags.pf2e.rulesSelections.weapon}",
                 "key": "ItemAlteration",
                 "mode": "add",
-                "predicate": [
-                    "item:id:{item|flags.pf2e.rulesSelections.weapon}"
-                ],
                 "property": "traits",
                 "value": "sweep"
             }

--- a/packs/equipment-effects/effect-tiger-menuki.json
+++ b/packs/equipment-effects/effect-tiger-menuki.json
@@ -34,21 +34,23 @@
                 "prompt": "PF2E.SpecificRule.Prompt.Weapon"
             },
             {
-                "definition": [
-                    "item:id:{item|flags.pf2e.rulesSelections.weapon}"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:id:{item|flags.pf2e.rulesSelections.weapon}"
+                ],                     
+                "property": "traits",
                 "value": "forceful"
             },
             {
-                "definition": [
-                    "item:id:{item|flags.pf2e.rulesSelections.weapon}"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:id:{item|flags.pf2e.rulesSelections.weapon}"
+                ],                     
+                "property": "traits",
                 "value": "sweep"
             }
         ],

--- a/packs/equipment-effects/effect-vashus-ninth-life.json
+++ b/packs/equipment-effects/effect-vashus-ninth-life.json
@@ -26,12 +26,13 @@
                 "uuid": "Compendium.pf2e.equipment-effects.Item.Effect: Parry"
             },
             {
-                "definition": [
-                    "item:slug:vashus-ninth-life"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:slug:vashus-ninth-life"
+                ],                     
+                "property": "traits",
                 "value": "parry"
             }
         ],

--- a/packs/equipment-effects/effect-vashus-ninth-life.json
+++ b/packs/equipment-effects/effect-vashus-ninth-life.json
@@ -31,7 +31,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:slug:vashus-ninth-life"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "parry"
             }

--- a/packs/equipment/amphisbaena-handwraps.json
+++ b/packs/equipment/amphisbaena-handwraps.json
@@ -58,7 +58,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:category:unarmed"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "versatile-p"
             },

--- a/packs/equipment/amphisbaena-handwraps.json
+++ b/packs/equipment/amphisbaena-handwraps.json
@@ -53,12 +53,13 @@
         },
         "rules": [
             {
-                "definition": [
-                    "item:category:unarmed"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:category:unarmed"
+                ],                     
+                "property": "traits",
                 "value": "versatile-p"
             },
             {

--- a/packs/equipment/magnetic-shot-greater.json
+++ b/packs/equipment/magnetic-shot-greater.json
@@ -43,7 +43,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:id:{item|_id}"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "deadly-d12"
             },

--- a/packs/equipment/magnetic-shot-greater.json
+++ b/packs/equipment/magnetic-shot-greater.json
@@ -38,12 +38,13 @@
         "quantity": 1,
         "rules": [
             {
-                "definition": [
-                    "item:id:{item|_id}"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:id:{item|_id}"
+                ],                     
+                "property": "traits",
                 "value": "deadly-d12"
             },
             {

--- a/packs/equipment/magnetic-shot-greater.json
+++ b/packs/equipment/magnetic-shot-greater.json
@@ -38,12 +38,9 @@
         "quantity": 1,
         "rules": [
             {
-                "itemType": "weapon",
+                "itemId": "{item|_id}",
                 "key": "ItemAlteration",
                 "mode": "add",
-                "predicate": [
-                    "item:id:{item|_id}"
-                ],
                 "property": "traits",
                 "value": "deadly-d12"
             },

--- a/packs/equipment/magnetic-shot-lesser.json
+++ b/packs/equipment/magnetic-shot-lesser.json
@@ -43,7 +43,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:id:{item|_id}"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "deadly-d8"
             },

--- a/packs/equipment/magnetic-shot-lesser.json
+++ b/packs/equipment/magnetic-shot-lesser.json
@@ -38,12 +38,13 @@
         "quantity": 1,
         "rules": [
             {
-                "definition": [
-                    "item:id:{item|_id}"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:id:{item|_id}"
+                ],                     
+                "property": "traits",
                 "value": "deadly-d8"
             },
             {

--- a/packs/equipment/magnetic-shot-lesser.json
+++ b/packs/equipment/magnetic-shot-lesser.json
@@ -38,12 +38,9 @@
         "quantity": 1,
         "rules": [
             {
-                "itemType": "weapon",
+                "itemId": "{item|_id}",
                 "key": "ItemAlteration",
                 "mode": "add",
-                "predicate": [
-                    "item:id:{item|_id}"
-                ],
                 "property": "traits",
                 "value": "deadly-d8"
             },

--- a/packs/equipment/magnetic-shot-moderate.json
+++ b/packs/equipment/magnetic-shot-moderate.json
@@ -38,12 +38,13 @@
         "quantity": 1,
         "rules": [
             {
-                "definition": [
-                    "item:id:{item|_id}"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:id:{item|_id}"
+                ],                     
+                "property": "traits",
                 "value": "deadly-d10"
             },
             {

--- a/packs/equipment/magnetic-shot-moderate.json
+++ b/packs/equipment/magnetic-shot-moderate.json
@@ -43,7 +43,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:id:{item|_id}"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "deadly-d10"
             },

--- a/packs/equipment/magnetic-shot-moderate.json
+++ b/packs/equipment/magnetic-shot-moderate.json
@@ -38,12 +38,9 @@
         "quantity": 1,
         "rules": [
             {
-                "itemType": "weapon",
+                "itemId": "{item|_id}",
                 "key": "ItemAlteration",
                 "mode": "add",
-                "predicate": [
-                    "item:id:{item|_id}"
-                ],
                 "property": "traits",
                 "value": "deadly-d10"
             },

--- a/packs/equipment/shield-augmentation.json
+++ b/packs/equipment/shield-augmentation.json
@@ -153,7 +153,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:group:shield"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "{item|flags.pf2e.rulesSelections.traitOne}"
             },

--- a/packs/equipment/shield-augmentation.json
+++ b/packs/equipment/shield-augmentation.json
@@ -148,12 +148,13 @@
                 "rollOption": "shield-augmentation"
             },
             {
-                "definition": [
-                    "item:group:shield"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:group:shield"
+                ],                     
+                "property": "traits",
                 "value": "{item|flags.pf2e.rulesSelections.traitOne}"
             },
             {

--- a/packs/extinction-curse-bestiary/book-1-the-show-must-go-on/corrupted-priest.json
+++ b/packs/extinction-curse-bestiary/book-1-the-show-must-go-on/corrupted-priest.json
@@ -1420,7 +1420,7 @@
                         "mode": "add",
                         "predicate": [
                             "item:base:trident"
-                        ],  
+                        ],
                         "property": "traits",
                         "value": "fatal-d10"
                     }

--- a/packs/extinction-curse-bestiary/book-1-the-show-must-go-on/corrupted-priest.json
+++ b/packs/extinction-curse-bestiary/book-1-the-show-must-go-on/corrupted-priest.json
@@ -1415,12 +1415,13 @@
                         "selector": "strike-damage"
                     },
                     {
-                        "definition": [
-                            "item:base:trident"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "weapon",
+                        "key": "ItemAlteration",
                         "mode": "add",
-                        "property": "weapon-traits",
+                        "predicate": [
+                            "item:base:trident"
+                        ],  
+                        "property": "traits",
                         "value": "fatal-d10"
                     }
                 ],

--- a/packs/extinction-curse-bestiary/book-1-the-show-must-go-on/corrupted-retainer.json
+++ b/packs/extinction-curse-bestiary/book-1-the-show-must-go-on/corrupted-retainer.json
@@ -425,7 +425,7 @@
                         "mode": "add",
                         "predicate": [
                             "item:base:trident"
-                        ],  
+                        ],
                         "property": "traits",
                         "value": "fatal-d10"
                     }

--- a/packs/extinction-curse-bestiary/book-1-the-show-must-go-on/corrupted-retainer.json
+++ b/packs/extinction-curse-bestiary/book-1-the-show-must-go-on/corrupted-retainer.json
@@ -420,12 +420,13 @@
                         "selector": "strike-damage"
                     },
                     {
-                        "definition": [
-                            "item:base:trident"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "weapon",
+                        "key": "ItemAlteration",
                         "mode": "add",
-                        "property": "weapon-traits",
+                        "predicate": [
+                            "item:base:trident"
+                        ],  
+                        "property": "traits",
                         "value": "fatal-d10"
                     }
                 ],

--- a/packs/extinction-curse-bestiary/book-1-the-show-must-go-on/horba.json
+++ b/packs/extinction-curse-bestiary/book-1-the-show-must-go-on/horba.json
@@ -463,7 +463,7 @@
                         "mode": "add",
                         "predicate": [
                             "item:base:trident"
-                        ],  
+                        ],
                         "property": "traits",
                         "value": "fatal-d10"
                     }

--- a/packs/extinction-curse-bestiary/book-1-the-show-must-go-on/horba.json
+++ b/packs/extinction-curse-bestiary/book-1-the-show-must-go-on/horba.json
@@ -458,12 +458,13 @@
                         "selector": "strike-damage"
                     },
                     {
-                        "definition": [
-                            "item:base:trident"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "weapon",
+                        "key": "ItemAlteration",
                         "mode": "add",
-                        "property": "weapon-traits",
+                        "predicate": [
+                            "item:base:trident"
+                        ],  
+                        "property": "traits",
                         "value": "fatal-d10"
                     }
                 ],

--- a/packs/extinction-curse-bestiary/book-4-siege-of-the-dinosaurs/xulgath-hardscale.json
+++ b/packs/extinction-curse-bestiary/book-4-siege-of-the-dinosaurs/xulgath-hardscale.json
@@ -929,12 +929,13 @@
                         "selector": "strike-damage"
                     },
                     {
-                        "definition": [
-                            "item:trait:shove"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "weapon",
+                        "key": "ItemAlteration",
                         "mode": "add",
-                        "property": "weapon-traits",
+                        "predicate": [
+                            "item:trait:shove"
+                        ],  
+                        "property": "traits",
                         "value": "deadly-2d8"
                     }
                 ],

--- a/packs/extinction-curse-bestiary/book-4-siege-of-the-dinosaurs/xulgath-hardscale.json
+++ b/packs/extinction-curse-bestiary/book-4-siege-of-the-dinosaurs/xulgath-hardscale.json
@@ -934,7 +934,7 @@
                         "mode": "add",
                         "predicate": [
                             "item:trait:shove"
-                        ],  
+                        ],
                         "property": "traits",
                         "value": "deadly-2d8"
                     }

--- a/packs/feat-effects/effect-giants-lunge.json
+++ b/packs/feat-effects/effect-giants-lunge.json
@@ -22,12 +22,13 @@
         },
         "rules": [
             {
-                "definition": [
-                    "item:melee"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:melee"
+                ],                     
+                "property": "traits",
                 "value": "reach"
             }
         ],

--- a/packs/feat-effects/effect-giants-lunge.json
+++ b/packs/feat-effects/effect-giants-lunge.json
@@ -27,7 +27,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:melee"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "reach"
             }

--- a/packs/feat-effects/effect-walking-the-cardinal-paths.json
+++ b/packs/feat-effects/effect-walking-the-cardinal-paths.json
@@ -60,12 +60,13 @@
                 "selector": "{item|flags.pf2e.rulesSelections.strike}-damage"
             },
             {
-                "definition": [
-                    "item:{item|flags.pf2e.rulesSelections.strike}"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:{item|flags.pf2e.rulesSelections.strike}"
+                ],                     
+                "property": "traits",
                 "value": "{item|flags.pf2e.rulesSelections.damage}"
             }
         ],

--- a/packs/feat-effects/effect-walking-the-cardinal-paths.json
+++ b/packs/feat-effects/effect-walking-the-cardinal-paths.json
@@ -65,7 +65,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:{item|flags.pf2e.rulesSelections.strike}"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "{item|flags.pf2e.rulesSelections.damage}"
             }

--- a/packs/feats/ancestry/conrasu/ceremony-of-strengthened-hand.json
+++ b/packs/feats/ancestry/conrasu/ceremony-of-strengthened-hand.json
@@ -31,30 +31,33 @@
         },
         "rules": [
             {
-                "definition": [
-                    "item:branch"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:branch"
+                ],                     
+                "property": "traits",
                 "value": "shove"
             },
             {
-                "definition": [
-                    "item:branch"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:branch"
+                ],                     
+                "property": "traits",
                 "value": "trip"
             },
             {
-                "definition": [
-                    "item:claw"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:claw"
+                ],                     
+                "property": "traits",
                 "value": "deadly-d8"
             }
         ],

--- a/packs/feats/ancestry/conrasu/ceremony-of-strengthened-hand.json
+++ b/packs/feats/ancestry/conrasu/ceremony-of-strengthened-hand.json
@@ -36,7 +36,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:branch"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "shove"
             },
@@ -46,7 +46,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:branch"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "trip"
             },
@@ -56,7 +56,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:claw"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "deadly-d8"
             }

--- a/packs/feats/ancestry/gnoll/crunch.json
+++ b/packs/feats/ancestry/gnoll/crunch.json
@@ -36,12 +36,13 @@
                 "value": 8
             },
             {
-                "definition": [
-                    "item:slug:jaws"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:slug:jaws"
+                ],                     
+                "property": "traits",
                 "value": "grapple"
             }
         ],

--- a/packs/feats/ancestry/gnoll/crunch.json
+++ b/packs/feats/ancestry/gnoll/crunch.json
@@ -41,7 +41,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:slug:jaws"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "grapple"
             }

--- a/packs/feats/ancestry/goloma/protective-claws.json
+++ b/packs/feats/ancestry/goloma/protective-claws.json
@@ -31,12 +31,13 @@
         },
         "rules": [
             {
-                "definition": [
-                    "item:claw"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:claw"
+                ],                     
+                "property": "traits",
                 "value": "parry"
             }
         ],

--- a/packs/feats/ancestry/goloma/protective-claws.json
+++ b/packs/feats/ancestry/goloma/protective-claws.json
@@ -36,7 +36,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:claw"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "parry"
             }

--- a/packs/feats/ancestry/kashrishi/fighting-horn.json
+++ b/packs/feats/ancestry/kashrishi/fighting-horn.json
@@ -127,7 +127,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:slug:horn"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "{item|flags.pf2e.rulesSelections.traitOne}"
             },
@@ -137,7 +137,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:slug:horn"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "{item|flags.pf2e.rulesSelections.traitTwo}"
             }

--- a/packs/feats/ancestry/kashrishi/fighting-horn.json
+++ b/packs/feats/ancestry/kashrishi/fighting-horn.json
@@ -122,21 +122,23 @@
                 "rollOption": "fighting-horn"
             },
             {
-                "definition": [
-                    "item:slug:horn"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:slug:horn"
+                ],                     
+                "property": "traits",
                 "value": "{item|flags.pf2e.rulesSelections.traitOne}"
             },
             {
-                "definition": [
-                    "item:slug:horn"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:slug:horn"
+                ],                     
+                "property": "traits",
                 "value": "{item|flags.pf2e.rulesSelections.traitTwo}"
             }
         ],

--- a/packs/feats/ancestry/ratfolk/vicious-incisors.json
+++ b/packs/feats/ancestry/ratfolk/vicious-incisors.json
@@ -34,12 +34,13 @@
                 "selector": "jaws-damage"
             },
             {
-                "definition": [
-                    "item:jaws"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:jaws"
+                ],                     
+                "property": "traits",
                 "value": "backstabber"
             }
         ],

--- a/packs/feats/ancestry/ratfolk/vicious-incisors.json
+++ b/packs/feats/ancestry/ratfolk/vicious-incisors.json
@@ -39,7 +39,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:jaws"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "backstabber"
             }

--- a/packs/feats/ancestry/sarangay/crown-of-bone.json
+++ b/packs/feats/ancestry/sarangay/crown-of-bone.json
@@ -27,12 +27,13 @@
         },
         "rules": [
             {
-                "definition": [
-                    "item:tag:sarangay-horns"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:tag:sarangay-horns"
+                ],                     
+                "property": "traits",
                 "value": "concussive"
             },
             {

--- a/packs/feats/ancestry/sarangay/crown-of-bone.json
+++ b/packs/feats/ancestry/sarangay/crown-of-bone.json
@@ -32,7 +32,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:tag:sarangay-horns"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "concussive"
             },

--- a/packs/feats/ancestry/sprite/elemental-spark.json
+++ b/packs/feats/ancestry/sprite/elemental-spark.json
@@ -79,12 +79,13 @@
                 "prompt": "PF2E.SpecificRule.Prompt.Element"
             },
             {
-                "definition": [
-                    "item:slug:sprites-spark"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:slug:sprites-spark"
+                ],                     
+                "property": "traits",
                 "value": "{item|flags.pf2e.rulesSelections.elementalSpark.trait}"
             },
             {

--- a/packs/feats/ancestry/sprite/elemental-spark.json
+++ b/packs/feats/ancestry/sprite/elemental-spark.json
@@ -84,7 +84,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:slug:sprites-spark"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "{item|flags.pf2e.rulesSelections.elementalSpark.trait}"
             },

--- a/packs/feats/ancestry/tengu/dogfang-bite.json
+++ b/packs/feats/ancestry/tengu/dogfang-bite.json
@@ -31,12 +31,13 @@
         },
         "rules": [
             {
-                "definition": [
-                    "item:beak"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:beak"
+                ],                     
+                "property": "traits",
                 "value": "versatile-s"
             }
         ],

--- a/packs/feats/ancestry/tengu/dogfang-bite.json
+++ b/packs/feats/ancestry/tengu/dogfang-bite.json
@@ -36,7 +36,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:beak"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "versatile-s"
             }

--- a/packs/feats/ancestry/versatile-heritages/nephilim/mischievous-tail.json
+++ b/packs/feats/ancestry/versatile-heritages/nephilim/mischievous-tail.json
@@ -36,7 +36,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:tail"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "trip"
             },
@@ -46,7 +46,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:tail"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "disarm"
             }

--- a/packs/feats/ancestry/versatile-heritages/nephilim/mischievous-tail.json
+++ b/packs/feats/ancestry/versatile-heritages/nephilim/mischievous-tail.json
@@ -31,21 +31,23 @@
         },
         "rules": [
             {
-                "definition": [
-                    "item:tail"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:tail"
+                ],                     
+                "property": "traits",
                 "value": "trip"
             },
             {
-                "definition": [
-                    "item:tail"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:tail"
+                ],                     
+                "property": "traits",
                 "value": "disarm"
             }
         ],

--- a/packs/feats/archetype/ghost/ghost-dedication.json
+++ b/packs/feats/archetype/ghost/ghost-dedication.json
@@ -50,7 +50,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:category:unarmed"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "magical"
             },

--- a/packs/feats/archetype/ghost/ghost-dedication.json
+++ b/packs/feats/archetype/ghost/ghost-dedication.json
@@ -45,12 +45,13 @@
                 "key": "ActorTraits"
             },
             {
-                "definition": [
-                    "item:category:unarmed"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:category:unarmed"
+                ],                     
+                "property": "traits",
                 "value": "magical"
             },
             {

--- a/packs/feats/archetype/hilt-hammer.json
+++ b/packs/feats/archetype/hilt-hammer.json
@@ -36,7 +36,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:melee"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "versatile-b"
             }

--- a/packs/feats/archetype/hilt-hammer.json
+++ b/packs/feats/archetype/hilt-hammer.json
@@ -31,12 +31,13 @@
         },
         "rules": [
             {
-                "definition": [
-                    "item:melee"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:melee"
+                ],                     
+                "property": "traits",
                 "value": "versatile-b"
             }
         ],

--- a/packs/feats/archetype/spirit-warrior/intercepting-hand.json
+++ b/packs/feats/archetype/spirit-warrior/intercepting-hand.json
@@ -41,7 +41,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:slug:fist"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "disarm"
             }

--- a/packs/feats/archetype/spirit-warrior/intercepting-hand.json
+++ b/packs/feats/archetype/spirit-warrior/intercepting-hand.json
@@ -36,12 +36,13 @@
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Disarming Interception"
             },
             {
-                "definition": [
-                    "item:slug:fist"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:slug:fist"
+                ],                     
+                "property": "traits",
                 "value": "disarm"
             }
         ],

--- a/packs/feats/archetype/spirit-warrior/spirit-warrior-dedication.json
+++ b/packs/feats/archetype/spirit-warrior/spirit-warrior-dedication.json
@@ -43,12 +43,13 @@
                 "property": "damage-dice-faces"
             },
             {
-                "definition": [
-                    "item:slug:fist"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:slug:fist"
+                ],                     
+                "property": "traits",
                 "value": "parry"
             }
         ],

--- a/packs/feats/archetype/spirit-warrior/spirit-warrior-dedication.json
+++ b/packs/feats/archetype/spirit-warrior/spirit-warrior-dedication.json
@@ -48,7 +48,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:slug:fist"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "parry"
             }

--- a/packs/feats/archetype/sterling-dynamo/construct-dynamo.json
+++ b/packs/feats/archetype/sterling-dynamo/construct-dynamo.json
@@ -45,7 +45,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:slug:sterling-dynamo"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "magical"
             }

--- a/packs/feats/archetype/sterling-dynamo/construct-dynamo.json
+++ b/packs/feats/archetype/sterling-dynamo/construct-dynamo.json
@@ -40,12 +40,13 @@
                 "value": 1
             },
             {
-                "definition": [
-                    "item:slug:sterling-dynamo"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:slug:sterling-dynamo"
+                ],                     
+                "property": "traits",
                 "value": "magical"
             }
         ],

--- a/packs/feats/archetype/thlipit-contestant/powerful-lash.json
+++ b/packs/feats/archetype/thlipit-contestant/powerful-lash.json
@@ -36,7 +36,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:slug:lash"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "sweep"
             },

--- a/packs/feats/archetype/thlipit-contestant/powerful-lash.json
+++ b/packs/feats/archetype/thlipit-contestant/powerful-lash.json
@@ -31,12 +31,13 @@
         },
         "rules": [
             {
-                "definition": [
-                    "item:slug:lash"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:slug:lash"
+                ],                     
+                "property": "traits",
                 "value": "sweep"
             },
             {

--- a/packs/feats/class/alchemist/mutant-physique.json
+++ b/packs/feats/class/alchemist/mutant-physique.json
@@ -36,12 +36,13 @@
                 "property": "damage-dice-faces"
             },
             {
-                "definition": [
-                    "item:tag:bestial-mutagen-strike"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:tag:bestial-mutagen-strike"
+                ],                     
+                "property": "traits",
                 "value": "deadly-d10"
             },
             {

--- a/packs/feats/class/alchemist/mutant-physique.json
+++ b/packs/feats/class/alchemist/mutant-physique.json
@@ -41,7 +41,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:tag:bestial-mutagen-strike"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "deadly-d10"
             },

--- a/packs/feats/class/monk/deadly-strikes.json
+++ b/packs/feats/class/monk/deadly-strikes.json
@@ -32,7 +32,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:category:unarmed"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "deadly-d10"
             }

--- a/packs/feats/class/monk/deadly-strikes.json
+++ b/packs/feats/class/monk/deadly-strikes.json
@@ -27,12 +27,13 @@
         },
         "rules": [
             {
-                "definition": [
-                    "item:category:unarmed"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:category:unarmed"
+                ],                     
+                "property": "traits",
                 "value": "deadly-d10"
             }
         ],

--- a/packs/feats/class/monk/golden-body.json
+++ b/packs/feats/class/monk/golden-body.json
@@ -32,7 +32,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:category:unarmed"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "deadly-d12"
             },

--- a/packs/feats/class/monk/golden-body.json
+++ b/packs/feats/class/monk/golden-body.json
@@ -27,12 +27,13 @@
         },
         "rules": [
             {
-                "definition": [
-                    "item:category:unarmed"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:category:unarmed"
+                ],                     
+                "property": "traits",
                 "value": "deadly-d12"
             },
             {

--- a/packs/feats/class/witch/syu-tak-nwas-deadly-hair.json
+++ b/packs/feats/class/witch/syu-tak-nwas-deadly-hair.json
@@ -39,12 +39,13 @@
                 "selector": "living-hair-damage"
             },
             {
-                "definition": [
-                    "item:slug:living-hair"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:slug:living-hair"
+                ],                     
+                "property": "traits",
                 "value": "grapple"
             }
         ],

--- a/packs/feats/class/witch/syu-tak-nwas-deadly-hair.json
+++ b/packs/feats/class/witch/syu-tak-nwas-deadly-hair.json
@@ -44,7 +44,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:slug:living-hair"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "grapple"
             }

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-1-despair-on-danger-island/takatorra-level-9.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-1-despair-on-danger-island/takatorra-level-9.json
@@ -348,15 +348,14 @@
                 },
                 "rules": [
                     {
-                        "definition": [
-                            "item:melee"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "blade-barrage"
+                            "blade-barrage",
+                            "item:melee"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "forceful"
                     },
                     {

--- a/packs/heritages/anadi/snaring-anadi.json
+++ b/packs/heritages/anadi/snaring-anadi.json
@@ -19,21 +19,23 @@
         },
         "rules": [
             {
-                "definition": [
-                    "item:slug:fangs"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:slug:fangs"
+                ],                     
+                "property": "traits",
                 "value": "grapple"
             },
             {
-                "definition": [
-                    "item:slug:fangs"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:slug:fangs"
+                ],                     
+                "property": "traits",
                 "value": "trip"
             }
         ],

--- a/packs/heritages/anadi/snaring-anadi.json
+++ b/packs/heritages/anadi/snaring-anadi.json
@@ -24,7 +24,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:slug:fangs"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "grapple"
             },
@@ -34,7 +34,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:slug:fangs"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "trip"
             }

--- a/packs/heritages/minotaur/littlehorn-minotaur.json
+++ b/packs/heritages/minotaur/littlehorn-minotaur.json
@@ -26,12 +26,13 @@
                 "selector": "horns-damage"
             },
             {
-                "definition": [
-                    "item:slug:horns"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:slug:horns"
+                ],                     
+                "property": "traits",
                 "value": "agile"
             },
             {

--- a/packs/heritages/minotaur/littlehorn-minotaur.json
+++ b/packs/heritages/minotaur/littlehorn-minotaur.json
@@ -31,7 +31,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:slug:horns"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "agile"
             },

--- a/packs/heritages/tengu/dogtooth-tengu.json
+++ b/packs/heritages/tengu/dogtooth-tengu.json
@@ -24,7 +24,7 @@
                 "mode": "add",
                 "predicate": [
                     "item:slug:beak"
-                ],                     
+                ],
                 "property": "traits",
                 "value": "deadly-d8"
             }

--- a/packs/heritages/tengu/dogtooth-tengu.json
+++ b/packs/heritages/tengu/dogtooth-tengu.json
@@ -19,12 +19,13 @@
         },
         "rules": [
             {
-                "definition": [
-                    "item:slug:beak"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "predicate": [
+                    "item:slug:beak"
+                ],                     
+                "property": "traits",
                 "value": "deadly-d8"
             }
         ],

--- a/packs/howl-of-the-wild-bestiary/goblin-shark.json
+++ b/packs/howl-of-the-wild-bestiary/goblin-shark.json
@@ -189,15 +189,14 @@
                         "toggleable": true
                     },
                     {
-                        "definition": [
-                            "item:slug:jaws"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "lunging-bite"
+                            "lunging-bite",
+                            "item:slug:jaws"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach-10"
                     }
                 ],

--- a/packs/howl-of-the-wild-bestiary/plated-python.json
+++ b/packs/howl-of-the-wild-bestiary/plated-python.json
@@ -279,15 +279,14 @@
                         "toggleable": true
                     },
                     {
-                        "definition": [
-                            "item:slug:jaws"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "towering-bite"
+                            "towering-bite",
+                            "item:slug:jaws"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach-60"
                     }
                 ],

--- a/packs/howl-of-the-wild-bestiary/warden-of-oceans-and-rivers.json
+++ b/packs/howl-of-the-wild-bestiary/warden-of-oceans-and-rivers.json
@@ -99,27 +99,25 @@
                         "value": "reach-60"
                     },
                     {
-                        "definition": [
-                            "item:slug:tentacle"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "all-are-one:2"
+                            "all-are-one:2",
+                            "item:slug:tentacle"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach-50"
                     },
                     {
-                        "definition": [
-                            "item:slug:tentacle"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "all-are-one:1"
+                            "all-are-one:1",
+                            "item:slug:tentacle"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach-40"
                     },
                     {

--- a/packs/iconics/sajan-level-3.json
+++ b/packs/iconics/sajan-level-3.json
@@ -2153,24 +2153,23 @@
                 },
                 "rules": [
                     {
-                        "definition": [
-                            "item:category:unarmed"
-                        ],
-                        "key": "AdjustStrike",
-                        "mode": "add",
-                        "property": "weapon-traits",
-                        "value": "magical"
-                    },
-                    {
-                        "definition": [
-                            "item:trait:monk"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "weapon",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "feat:monastic-weaponry"
+                            {
+                                "or": [
+                                    "item:category:unarmed",
+                                    {
+                                        "and": [
+                                            "item:trait:monk",
+                                            "feat:monastic-weaponry"
+                                        ]
+                                    }
+                                ]
+                            }
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "magical"
                     }
                 ],

--- a/packs/iconics/sajan-level-5.json
+++ b/packs/iconics/sajan-level-5.json
@@ -2372,24 +2372,23 @@
                 },
                 "rules": [
                     {
-                        "definition": [
-                            "item:category:unarmed"
-                        ],
-                        "key": "AdjustStrike",
-                        "mode": "add",
-                        "property": "weapon-traits",
-                        "value": "magical"
-                    },
-                    {
-                        "definition": [
-                            "item:trait:monk"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "weapon",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "feat:monastic-weaponry"
+                            {
+                                "or": [
+                                    "item:category:unarmed",
+                                    {
+                                        "and": [
+                                            "item:trait:monk",
+                                            "feat:monastic-weaponry"
+                                        ]
+                                    }
+                                ]
+                            }
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "magical"
                     }
                 ],

--- a/packs/impossible-lands-bestiary/cursed-king.json
+++ b/packs/impossible-lands-bestiary/cursed-king.json
@@ -285,15 +285,14 @@
                         "type": "mental"
                     },
                     {
-                        "definition": [
-                            "item:category:unarmed"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "berserk"
+                            "berserk",
+                            "item:category:unarmed"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "deadly-d8"
                     }
                 ],

--- a/packs/kingmaker-bestiary/agai.json
+++ b/packs/kingmaker-bestiary/agai.json
@@ -1071,15 +1071,14 @@
                         "value": "large"
                     },
                     {
-                        "definition": [
-                            "item:melee"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "enraged-growth"
+                            "enraged-growth",
+                            "item:melee"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach"
                     },
                     {
@@ -1145,15 +1144,14 @@
                         "value": 2
                     },
                     {
-                        "definition": [
-                            "item:slug:morningstar"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "bullys-bludgeon"
+                            "bullys-bludgeon",
+                            "item:slug:morningstar"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "nonlethal"
                     }
                 ],

--- a/packs/kingmaker-bestiary/corax.json
+++ b/packs/kingmaker-bestiary/corax.json
@@ -601,15 +601,14 @@
                         "toggleable": true
                     },
                     {
-                        "definition": [
-                            "item:slug:greataxe"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "felling-blow"
+                            "felling-blow",
+                            "item:slug:greataxe"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach"
                     },
                     {

--- a/packs/kingmaker-bestiary/hannis-drelev.json
+++ b/packs/kingmaker-bestiary/hannis-drelev.json
@@ -784,17 +784,18 @@
                 },
                 "rules": [
                     {
-                        "definition": [
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "predicate": [
                             {
                                 "or": [
-                                    "item:longsword",
-                                    "item:shortsword"
+                                    "item:slug:longsword",
+                                    "item:slug:shortsword"
                                 ]
                             }
                         ],
-                        "key": "AdjustStrike",
-                        "mode": "add",
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "disarm"
                     }
                 ],

--- a/packs/mwangi-expanse-bestiary/charau-ka-acolyte-of-angazhan.json
+++ b/packs/mwangi-expanse-bestiary/charau-ka-acolyte-of-angazhan.json
@@ -1326,12 +1326,13 @@
                 },
                 "rules": [
                     {
-                        "definition": [
-                            "item:thrown"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "weapon",
+                        "key": "ItemAlteration",
                         "mode": "add",
-                        "property": "weapon-traits",
+                        "predicate": [
+                            "item:thrown"
+                        ],  
+                        "property": "traits",
                         "value": "deadly-d6"
                     }
                 ],

--- a/packs/mwangi-expanse-bestiary/charau-ka-acolyte-of-angazhan.json
+++ b/packs/mwangi-expanse-bestiary/charau-ka-acolyte-of-angazhan.json
@@ -1331,7 +1331,7 @@
                         "mode": "add",
                         "predicate": [
                             "item:thrown"
-                        ],  
+                        ],
                         "property": "traits",
                         "value": "deadly-d6"
                     }

--- a/packs/mwangi-expanse-bestiary/charau-ka-butcher.json
+++ b/packs/mwangi-expanse-bestiary/charau-ka-butcher.json
@@ -548,7 +548,7 @@
                         "mode": "add",
                         "predicate": [
                             "item:thrown"
-                        ],  
+                        ],
                         "property": "traits",
                         "value": "deadly-d6"
                     }

--- a/packs/mwangi-expanse-bestiary/charau-ka-butcher.json
+++ b/packs/mwangi-expanse-bestiary/charau-ka-butcher.json
@@ -543,12 +543,13 @@
                 },
                 "rules": [
                     {
-                        "definition": [
-                            "item:thrown"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "weapon",
+                        "key": "ItemAlteration",
                         "mode": "add",
-                        "property": "weapon-traits",
+                        "predicate": [
+                            "item:thrown"
+                        ],  
+                        "property": "traits",
                         "value": "deadly-d6"
                     }
                 ],

--- a/packs/mwangi-expanse-bestiary/charau-ka-warrior.json
+++ b/packs/mwangi-expanse-bestiary/charau-ka-warrior.json
@@ -589,12 +589,13 @@
                 },
                 "rules": [
                     {
-                        "definition": [
-                            "item:thrown"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "weapon",
+                        "key": "ItemAlteration",
                         "mode": "add",
-                        "property": "weapon-traits",
+                        "predicate": [
+                            "item:thrown"
+                        ],  
+                        "property": "traits",
                         "value": "deadly-d6"
                     }
                 ],

--- a/packs/mwangi-expanse-bestiary/charau-ka-warrior.json
+++ b/packs/mwangi-expanse-bestiary/charau-ka-warrior.json
@@ -594,7 +594,7 @@
                         "mode": "add",
                         "predicate": [
                             "item:thrown"
-                        ],  
+                        ],
                         "property": "traits",
                         "value": "deadly-d6"
                     }

--- a/packs/one-shot-bestiary/a-fistful-of-flowers/meliosas-leshy-golden-bamboo-leshy.json
+++ b/packs/one-shot-bestiary/a-fistful-of-flowers/meliosas-leshy-golden-bamboo-leshy.json
@@ -208,15 +208,14 @@
                         "toggleable": true
                     },
                     {
-                        "definition": [
-                            "item:slug:fist"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "bend-back"
+                            "bend-back",
+                            "item:slug:fist"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach-10"
                     }
                 ],

--- a/packs/paizo-pregens/mark-of-the-mantis/yacob.json
+++ b/packs/paizo-pregens/mark-of-the-mantis/yacob.json
@@ -3139,24 +3139,23 @@
                 },
                 "rules": [
                     {
-                        "definition": [
-                            "item:category:unarmed"
-                        ],
-                        "key": "AdjustStrike",
-                        "mode": "add",
-                        "property": "weapon-traits",
-                        "value": "magical"
-                    },
-                    {
-                        "definition": [
-                            "item:trait:monk"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "weapon",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "feat:monastic-weaponry"
+                            {
+                                "or": [
+                                    "item:category:unarmed",
+                                    {
+                                        "and": [
+                                            "item:trait:monk",
+                                            "feat:monastic-weaponry"
+                                        ]
+                                    }
+                                ]
+                            }
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "magical"
                     }
                 ],

--- a/packs/pathfinder-bestiary-2/spriggan-bully.json
+++ b/packs/pathfinder-bestiary-2/spriggan-bully.json
@@ -618,15 +618,14 @@
                         "value": "large"
                     },
                     {
-                        "definition": [
-                            "item:melee"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "enraged-growth"
+                            "enraged-growth",
+                            "item:melee"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach"
                     },
                     {
@@ -692,15 +691,14 @@
                         "value": 2
                     },
                     {
-                        "definition": [
-                            "item:slug:morningstar"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "bullys-bludgeon"
+                            "bullys-bludgeon",
+                            "item:slug:morningstar"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "nonlethal"
                     }
                 ],

--- a/packs/pathfinder-bestiary-2/spriggan-warlord.json
+++ b/packs/pathfinder-bestiary-2/spriggan-warlord.json
@@ -805,15 +805,14 @@
                         "value": "large"
                     },
                     {
-                        "definition": [
-                            "item:melee"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "enraged-growth"
+                            "enraged-growth",
+                            "item:melee"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach"
                     },
                     {
@@ -879,15 +878,14 @@
                         "value": 2
                     },
                     {
-                        "definition": [
-                            "item:slug:morningstar"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "bullys-bludgeon"
+                            "bullys-bludgeon",
+                            "item:slug:morningstar"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "nonlethal"
                     }
                 ],

--- a/packs/pathfinder-bestiary-2/suli-dune-dancer.json
+++ b/packs/pathfinder-bestiary-2/suli-dune-dancer.json
@@ -969,15 +969,14 @@
                         "toggleable": true
                     },
                     {
-                        "definition": [
-                            "item:melee"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "elemental-assault"
+                            "elemental-assault",
+                            "item:melee"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "{item|flags.pf2e.rulesSelections.elementalAssault}"
                     },
                     {

--- a/packs/pathfinder-bestiary-2/yellow-musk-brute.json
+++ b/packs/pathfinder-bestiary-2/yellow-musk-brute.json
@@ -147,15 +147,14 @@
                         "toggleable": true
                     },
                     {
-                        "definition": [
-                            "item:melee"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "limb-extension"
+                            "limb-extension",
+                            "item:melee"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach-15"
                     }
                 ],

--- a/packs/pathfinder-bestiary-2/yellow-musk-thrall.json
+++ b/packs/pathfinder-bestiary-2/yellow-musk-thrall.json
@@ -145,15 +145,14 @@
                         "toggleable": true
                     },
                     {
-                        "definition": [
-                            "item:melee"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "limb-extension"
+                            "limb-extension",
+                            "item:melee"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach"
                     }
                 ],

--- a/packs/pathfinder-bestiary-3/hadrinnex.json
+++ b/packs/pathfinder-bestiary-3/hadrinnex.json
@@ -248,39 +248,36 @@
                         "selector": "weapon-arm-damage"
                     },
                     {
-                        "definition": [
-                            "item:slug:weapon-arm"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "rapid-evolution-husk:bludgeoning"
+                            "rapid-evolution-husk:bludgeoning",
+                            "item:slug:weapon-arm"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "shove"
                     },
                     {
-                        "definition": [
-                            "item:slug:weapon-arm"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "rapid-evolution-husk:piercing"
+                            "rapid-evolution-husk:piercing",
+                            "item:slug:weapon-arm"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "deadly-d8"
                     },
                     {
-                        "definition": [
-                            "item:slug:weapon-arm"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "rapid-evolution-husk:slashing"
+                            "rapid-evolution-husk:slashing",
+                            "item:slug:weapon-arm"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "sweep"
                     }
                 ],
@@ -324,15 +321,14 @@
                         "toggleable": true
                     },
                     {
-                        "definition": [
-                            "item:slug:weapon-arm"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "extend-limbs"
+                            "extend-limbs",
+                            "item:slug:weapon-arm"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach-20"
                     }
                 ],

--- a/packs/pathfinder-bestiary/bunyip.json
+++ b/packs/pathfinder-bestiary/bunyip.json
@@ -306,15 +306,14 @@
                         "value": 20
                     },
                     {
-                        "definition": [
-                            "item:slug:tail"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "shift-form:snake-tail"
+                            "shift-form:snake-tail",
+                            "item:slug:tail"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach"
                     },
                     {

--- a/packs/pathfinder-monster-core/mirage-dragon-adult-spellcaster.json
+++ b/packs/pathfinder-monster-core/mirage-dragon-adult-spellcaster.json
@@ -2646,15 +2646,14 @@
                         "toggleable": true
                     },
                     {
-                        "definition": [
-                            "item:slug:jaws"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "lunging-bite"
+                            "lunging-bite",
+                            "item:slug:jaws"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach-25"
                     }
                 ],

--- a/packs/pathfinder-monster-core/mirage-dragon-adult.json
+++ b/packs/pathfinder-monster-core/mirage-dragon-adult.json
@@ -1067,15 +1067,14 @@
                         "toggleable": true
                     },
                     {
-                        "definition": [
-                            "item:slug:jaws"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "lunging-bite"
+                            "lunging-bite",
+                            "item:slug:jaws"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach-25"
                     }
                 ],

--- a/packs/pathfinder-monster-core/mirage-dragon-ancient-spellcaster.json
+++ b/packs/pathfinder-monster-core/mirage-dragon-ancient-spellcaster.json
@@ -3074,15 +3074,14 @@
                         "toggleable": true
                     },
                     {
-                        "definition": [
-                            "item:slug:jaws"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "lunging-bite"
+                            "lunging-bite",
+                            "item:slug:jaws"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach-25"
                     }
                 ],

--- a/packs/pathfinder-monster-core/mirage-dragon-ancient.json
+++ b/packs/pathfinder-monster-core/mirage-dragon-ancient.json
@@ -1005,15 +1005,14 @@
                         "toggleable": true
                     },
                     {
-                        "definition": [
-                            "item:slug:jaws"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "lunging-bite"
+                            "lunging-bite",
+                            "item:slug:jaws"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach-25"
                     }
                 ],

--- a/packs/pathfinder-monster-core/mirage-dragon-young-spellcaster.json
+++ b/packs/pathfinder-monster-core/mirage-dragon-young-spellcaster.json
@@ -2027,15 +2027,14 @@
                         "toggleable": true
                     },
                     {
-                        "definition": [
-                            "item:slug:jaws"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "lunging-bite"
+                            "lunging-bite",
+                            "item:slug:jaws"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach-20"
                     }
                 ],

--- a/packs/pathfinder-monster-core/mirage-dragon-young.json
+++ b/packs/pathfinder-monster-core/mirage-dragon-young.json
@@ -871,15 +871,14 @@
                         "toggleable": true
                     },
                     {
-                        "definition": [
-                            "item:slug:jaws"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "lunging-bite"
+                            "lunging-bite",
+                            "item:slug:jaws"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach-20"
                     }
                 ],

--- a/packs/pathfinder-monster-core/paleohemoth.json
+++ b/packs/pathfinder-monster-core/paleohemoth.json
@@ -120,15 +120,14 @@
                         "value": -10
                     },
                     {
-                        "definition": [
-                            "item:slug:jaws"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "reassemble"
+                            "reassemble",
+                            "item:slug:jaws"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach-25"
                     }
                 ],

--- a/packs/pathfinder-monster-core/shadow-giant.json
+++ b/packs/pathfinder-monster-core/shadow-giant.json
@@ -353,15 +353,14 @@
                         "toggleable": true
                     },
                     {
-                        "definition": [
-                            "item:slug:spiked-chain"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "shadow-chain"
+                            "shadow-chain",
+                            "item:slug:spiked-chain"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach-60"
                     }
                 ],

--- a/packs/pathfinder-monster-core/venedaemon.json
+++ b/packs/pathfinder-monster-core/venedaemon.json
@@ -1585,15 +1585,14 @@
                         "value": "reach-10"
                     },
                     {
-                        "definition": [
-                            "item:slug:tentacle"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "residual-force"
+                            "residual-force",
+                            "item:slug:tentacle"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach-20"
                     },
                     {

--- a/packs/pfs-season-2-bestiary/2-06/saddleback-bunyip.json
+++ b/packs/pfs-season-2-bestiary/2-06/saddleback-bunyip.json
@@ -302,15 +302,14 @@
                         "value": 20
                     },
                     {
-                        "definition": [
-                            "item:slug:tail"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "shift-form:snake-tail"
+                            "shift-form:snake-tail",
+                            "item:slug:tail"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach"
                     },
                     {

--- a/packs/pfs-season-5-bestiary/5-19/hardened-locust-knight.json
+++ b/packs/pfs-season-5-bestiary/5-19/hardened-locust-knight.json
@@ -425,15 +425,14 @@
                         "toggleable": true
                     },
                     {
-                        "definition": [
-                            "item:slug:rotcarver-scythe"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "lunge"
+                            "lunge",
+                            "item:slug:rotcarver-scythe"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach"
                     }
                 ],

--- a/packs/pfs-season-5-bestiary/5-19/locust-knight.json
+++ b/packs/pfs-season-5-bestiary/5-19/locust-knight.json
@@ -396,15 +396,14 @@
                         "toggleable": true
                     },
                     {
-                        "definition": [
-                            "item:slug:rotcarver-scythe"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "lunge"
+                            "lunge",
+                            "item:slug:rotcarver-scythe"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach"
                     }
                 ],

--- a/packs/pfs-season-6-bestiary/6-09/gruasha.json
+++ b/packs/pfs-season-6-bestiary/6-09/gruasha.json
@@ -336,15 +336,14 @@
                         "toggleable": true
                     },
                     {
-                        "definition": [
-                            "item:slug:spiked-chain"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "shadow-chain"
+                            "shadow-chain",
+                            "item:slug:spiked-chain"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach-60"
                     }
                 ],

--- a/packs/quest-for-the-frozen-flame-bestiary/book-3-burning-tundra/ivarsa.json
+++ b/packs/quest-for-the-frozen-flame-bestiary/book-3-burning-tundra/ivarsa.json
@@ -1570,15 +1570,14 @@
                         "value": 6
                     },
                     {
-                        "definition": [
-                            "item:melee"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "arcane-cascade"
+                            "arcane-cascade",
+                            "item:melee"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "arcane"
                     },
                     {

--- a/packs/seven-dooms-for-sandpoint-bestiary/chertus-jheed.json
+++ b/packs/seven-dooms-for-sandpoint-bestiary/chertus-jheed.json
@@ -465,15 +465,14 @@
                         "toggleable": true
                     },
                     {
-                        "definition": [
-                            "item:slug:fist"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "lunge"
+                            "lunge",
+                            "item:slug:fist"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach"
                     }
                 ],

--- a/packs/sky-kings-tomb-bestiary/book-1-mantle-of-gold/hhrulkaz.json
+++ b/packs/sky-kings-tomb-bestiary/book-1-mantle-of-gold/hhrulkaz.json
@@ -575,15 +575,14 @@
                         "toggleable": true
                     },
                     {
-                        "definition": [
-                            "item:slug:clan-dagger"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "sacrificial-takedown"
+                            "sacrificial-takedown",
+                            "item:slug:clan-dagger"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "fatal-d10"
                     }
                 ],

--- a/packs/stolen-fate-bestiary/book-1-the-choosing/blade-magus.json
+++ b/packs/stolen-fate-bestiary/book-1-the-choosing/blade-magus.json
@@ -1567,15 +1567,14 @@
                         "value": 5
                     },
                     {
-                        "definition": [
-                            "item:melee"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "arcane-cascade"
+                            "arcane-cascade",
+                            "item:melee"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "arcane"
                     },
                     {

--- a/packs/strength-of-thousands-bestiary/book-2-spoken-on-the-song-wind/froglegs.json
+++ b/packs/strength-of-thousands-bestiary/book-2-spoken-on-the-song-wind/froglegs.json
@@ -559,7 +559,7 @@
                         "mode": "add",
                         "predicate": [
                             "item:group:knife"
-                        ],  
+                        ],
                         "property": "traits",
                         "value": "deadly-d10"
                     }

--- a/packs/strength-of-thousands-bestiary/book-2-spoken-on-the-song-wind/froglegs.json
+++ b/packs/strength-of-thousands-bestiary/book-2-spoken-on-the-song-wind/froglegs.json
@@ -554,12 +554,13 @@
                         "selector": "strike-damage"
                     },
                     {
-                        "definition": [
-                            "item:group:knife"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "weapon",
+                        "key": "ItemAlteration",
                         "mode": "add",
-                        "property": "weapon-traits",
+                        "predicate": [
+                            "item:group:knife"
+                        ],  
+                        "property": "traits",
                         "value": "deadly-d10"
                     }
                 ],

--- a/packs/the-slithering-bestiary/angazhani-cultist.json
+++ b/packs/the-slithering-bestiary/angazhani-cultist.json
@@ -1605,12 +1605,13 @@
                         "selector": "strike-damage"
                     },
                     {
-                        "definition": [
-                            "item:base:spear"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "weapon",
+                        "key": "ItemAlteration",
                         "mode": "add",
-                        "property": "weapon-traits",
+                        "predicate": [
+                            "item:base:spear"
+                        ],  
+                        "property": "traits",
                         "value": "fatal-d10"
                     }
                 ],

--- a/packs/the-slithering-bestiary/angazhani-cultist.json
+++ b/packs/the-slithering-bestiary/angazhani-cultist.json
@@ -1610,7 +1610,7 @@
                         "mode": "add",
                         "predicate": [
                             "item:base:spear"
-                        ],  
+                        ],
                         "property": "traits",
                         "value": "fatal-d10"
                     }

--- a/packs/the-slithering-bestiary/nyamat-mshwe.json
+++ b/packs/the-slithering-bestiary/nyamat-mshwe.json
@@ -2133,7 +2133,7 @@
                         "mode": "add",
                         "predicate": [
                             "item:base:spear"
-                        ],  
+                        ],
                         "property": "traits",
                         "value": "fatal-d10"
                     }

--- a/packs/the-slithering-bestiary/nyamat-mshwe.json
+++ b/packs/the-slithering-bestiary/nyamat-mshwe.json
@@ -2128,12 +2128,13 @@
                         "selector": "strike-damage"
                     },
                     {
-                        "definition": [
-                            "item:base:spear"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "weapon",
+                        "key": "ItemAlteration",
                         "mode": "add",
-                        "property": "weapon-traits",
+                        "predicate": [
+                            "item:base:spear"
+                        ],  
+                        "property": "traits",
                         "value": "fatal-d10"
                     }
                 ],

--- a/packs/tian-xia-world-guide-bestiary/kun.json
+++ b/packs/tian-xia-world-guide-bestiary/kun.json
@@ -586,15 +586,14 @@
                         "selector": "jaws-damage"
                     },
                     {
-                        "definition": [
-                            "item:slug:jaws"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
-                            "heart-of-darkness"
+                            "heart-of-darkness",
+                            "item:slug:jaws"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "unholy"
                     }
                 ],


### PR DESCRIPTION
It's not all of them, but it's a bunch.

~~There are some that could use `itemId` over `itemType` that could've been done with a more clever find and replace, but no functionality is lost.~~ This has been dealt with

~~It could *maybe* conflict with #18548, but I'll deal with those if/when they come.~~ It didn't!