### PR TITLE
Move trait Adjust Strike rule elements to Item Alteration

### DIFF
--- a/packs/bestiary-effects/effect-impersonated-ability.json
+++ b/packs/bestiary-effects/effect-impersonated-ability.json
@@ -236,12 +236,13 @@
                 "prompt": "PF2E.NPCAbility.NopperaBo.Impersonator.WeaponPerkPrompt"
             },
             {
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
                     "impersonated-ability:weapon-perk"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "{item|flags.pf2e.rulesSelections.perk}"
             }
         ],

--- a/packs/bestiary-effects/effect-invoke-rune.json
+++ b/packs/bestiary-effects/effect-invoke-rune.json
@@ -84,12 +84,13 @@
                         ]
                     }
                 ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
                     "invoke-rune:destruction"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "deadly-3d12"
             },
             {
@@ -97,12 +98,13 @@
                     "item:slug:{item|flags.pf2e.rulesSelections.weapon}",
                     "item:slug:longspear"
                 ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
                     "invoke-rune:destruction"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "deadly-3d8"
             },
             {

--- a/packs/blog-bestiary/mari-lwyd.json
+++ b/packs/blog-bestiary/mari-lwyd.json
@@ -121,12 +121,13 @@
                         "value": true
                     },
                     {
-                        "key": "AdjustStrike",
+                       "itemType": "melee",
+                       "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
                             "mostly-harmless"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "nonlethal"
                     }
                 ],

--- a/packs/boons-and-curses/erastil-moderate-boon.json
+++ b/packs/boons-and-curses/erastil-moderate-boon.json
@@ -26,12 +26,13 @@
         },
         "rules": [
             {
-                "definition": [
+                "itemType": "weapon",
+                "key": "ItemAlteration",
+                "mode": "remove",
+                "predicate": [
                     "item:base:longbow"
                 ],
-                "key": "AdjustStrike",
-                "mode": "remove",
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "volley-30"
             },
             {

--- a/packs/boons-and-curses/gorum-moderate-curse.json
+++ b/packs/boons-and-curses/gorum-moderate-curse.json
@@ -33,9 +33,10 @@
                 "selector": "strike-damage"
             },
             {
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "nonlethal"
             }
         ],

--- a/packs/classfeatures/mystic-strikes.json
+++ b/packs/classfeatures/mystic-strikes.json
@@ -36,15 +36,14 @@
                 "value": "magical"
             },
             {
-                "definition": [
-                    "item:trait:monk"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
+                    "item:trait:monk",
                     "feat:monastic-weaponry"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "magical"
             }
         ],

--- a/packs/classfeatures/twisting-tree.json
+++ b/packs/classfeatures/twisting-tree.json
@@ -38,43 +38,47 @@
                 "selector": "strike-damage"
             },
             {
-                "definition": [
+                "itemType": "weapon",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
                     "item:base:staff",
                     "item:hands-held:1"
                 ],
-                "key": "AdjustStrike",
-                "mode": "add",
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "agile"
             },
             {
-                "definition": [
+                "itemType": "weapon",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
                     "item:base:staff",
                     "item:hands-held:2"
                 ],
-                "key": "AdjustStrike",
-                "mode": "add",
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "parry"
             },
             {
-                "definition": [
+                "itemType": "weapon",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
                     "item:base:staff",
                     "item:hands-held:2"
                 ],
-                "key": "AdjustStrike",
-                "mode": "add",
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "reach"
             },
             {
-                "definition": [
+                "itemType": "weapon",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
                     "item:base:staff",
                     "item:hands-held:2"
                 ],
-                "key": "AdjustStrike",
-                "mode": "add",
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "trip"
             }
         ],

--- a/packs/equipment/fighters-fork.json
+++ b/packs/equipment/fighters-fork.json
@@ -60,27 +60,23 @@
                 "toggleable": true
             },
             {
-                "definition": [
-                    "item:id:{item|_id}"
-                ],
-                "key": "AdjustStrike",
+                "itemId": "{item|id}",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
                     "fighters-fork:fluid-length"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "reach"
             },
             {
-                "definition": [
-                    "item:id:{item|_id}"
-                ],
-                "key": "AdjustStrike",
+                "itemId": "{item|id}",
+                "key": "ItemAlteration",
                 "mode": "remove",
                 "predicate": [
                     "fighters-fork:fluid-length"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "thrown-20"
             }
         ],

--- a/packs/equipment/shield-augmentation.json
+++ b/packs/equipment/shield-augmentation.json
@@ -148,16 +148,16 @@
                 "rollOption": "shield-augmentation"
             },
             {
-                "itemType": "weapon",
-                "key": "ItemAlteration",
-                "mode": "add",
-                "predicate": [
+                "definition": [
                     "item:group:shield"
                 ],
-                "property": "traits",
+                "key": "AdjustStrike",
+                "mode": "add",
+                "property": "weapon-traits",
                 "value": "{item|flags.pf2e.rulesSelections.traitOne}"
             },
             {
+                "itemType": "weapon",
                 "definition": [
                     "item:group:shield"
                 ],

--- a/packs/equipment/skysunder.json
+++ b/packs/equipment/skysunder.json
@@ -52,15 +52,13 @@
         },
         "rules": [
             {
-                "definition": [
-                    "item:id:{item|id}"
-                ],
-                "key": "AdjustStrike",
+                "itemId": "{item|id}",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
                     "divine-retribution"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "deadly-d4"
             }
         ],

--- a/packs/feat-effects/effect-bone-spikes.json
+++ b/packs/feat-effects/effect-bone-spikes.json
@@ -41,15 +41,14 @@
                 ]
             },
             {
-                "definition": [
-                    "item:slug:bone-spike"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
+                    "item:slug:bone-spike",
                     "awakening:bone-spikes:reach:active"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "reach"
             },
             {

--- a/packs/feat-effects/effect-castigating-weapon.json
+++ b/packs/feat-effects/effect-castigating-weapon.json
@@ -22,21 +22,23 @@
         },
         "rules": [
             {
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
                     "self:trait:holy"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "holy"
             },
             {
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
                     "self:trait:unholy"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "unholy"
             },
             {

--- a/packs/feat-effects/effect-elemental-assault.json
+++ b/packs/feat-effects/effect-elemental-assault.json
@@ -93,39 +93,43 @@
                 "selector": "strike-damage"
             },
             {
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
                     "elemental-assault:electricity"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "air"
             },
             {
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
                     "elemental-assault:bludgeoning"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "earth"
             },
             {
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
                     "elemental-assault:fire"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "fire"
             },
             {
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
                     "elemental-assault:water"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "cold"
             }
         ],

--- a/packs/feat-effects/effect-mutate-weapon.json
+++ b/packs/feat-effects/effect-mutate-weapon.json
@@ -88,15 +88,14 @@
                 "rollOption": "mutate-weapon-bonus"
             },
             {
-                "definition": [
-                    "item:{item|flags.pf2e.rulesSelections.mutateWeaponTarget}"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
+                    "item:{item|flags.pf2e.rulesSelections.mutateWeaponTarget}",
                     "mutate-weapon-bonus:reach"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "reach"
             },
             {

--- a/packs/feat-effects/stance-flood-stance.json
+++ b/packs/feat-effects/stance-flood-stance.json
@@ -45,15 +45,14 @@
                 ]
             },
             {
-                "definition": [
-                    "item:slug:flooded-river"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
+                    "item:slug:flooded-river",
                     "terrain:aquatic"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "forceful"
             }
         ],

--- a/packs/feat-effects/stance-waterfowl-stance.json
+++ b/packs/feat-effects/stance-waterfowl-stance.json
@@ -22,7 +22,10 @@
         },
         "rules": [
             {
-                "definition": [
+                "itemType": "weapon",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
                     {
                         "or": [
                             "item:base:dandpatta",
@@ -32,9 +35,7 @@
                         ]
                     }
                 ],
-                "key": "AdjustStrike",
-                "mode": "add",
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "monk"
             },
             {

--- a/packs/feat-effects/stance-wolf-stance.json
+++ b/packs/feat-effects/stance-wolf-stance.json
@@ -45,15 +45,14 @@
                 ]
             },
             {
-                "definition": [
-                    "item:wolf-jaws"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
+                    "item:wolf-jaws",
                     "self:flanking"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "trip"
             }
         ],

--- a/packs/feats/ancestry/ghoran/murderous-thorns.json
+++ b/packs/feats/ancestry/ghoran/murderous-thorns.json
@@ -31,15 +31,14 @@
         },
         "rules": [
             {
-                "definition": [
-                    "item:slug:thorns"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
+                    "item:slug:thorns",
                     "feat:hidden-thorn"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "deadly-d6"
             }
         ],

--- a/packs/feats/ancestry/goblin/fang-sharpener.json
+++ b/packs/feats/ancestry/goblin/fang-sharpener.json
@@ -49,15 +49,14 @@
                 "slug": "irongut-jaws"
             },
             {
-                "definition": [
-                    "item:slug:razortooth-jaws"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "remove",
                 "predicate": [
+                    "item:slug:razortooth-jaws",
                     "self:heritage:razortooth-goblin"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "finesse"
             },
             {

--- a/packs/feats/ancestry/halfling/toppling-dance.json
+++ b/packs/feats/ancestry/halfling/toppling-dance.json
@@ -37,15 +37,14 @@
                 "toggleable": true
             },
             {
-                "definition": [
-                    "item:melee"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
+                    "item:melee",
                     "toppling-dance"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "trip"
             }
         ],

--- a/packs/feats/ancestry/kobold/dragonblood-paragon.json
+++ b/packs/feats/ancestry/kobold/dragonblood-paragon.json
@@ -54,15 +54,14 @@
                 "rollOption": "dragonblood-paragon"
             },
             {
-                "definition": [
-                    "item:jaws"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
+                    "item:jaws",
                     "dragonblood-paragon:strongjaw-kobold"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "deadly-d6"
             },
             {

--- a/packs/feats/ancestry/lizardfolk/iruxi-armaments.json
+++ b/packs/feats/ancestry/lizardfolk/iruxi-armaments.json
@@ -73,15 +73,14 @@
                 "selector": "claw-damage"
             },
             {
-                "definition": [
-                    "item:claw"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
+                    "item:claw",
                     "iruxi-armaments:claw"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "versatile-p"
             },
             {

--- a/packs/feats/ancestry/versatile-heritages/nephilim/bestial-manifestation.json
+++ b/packs/feats/ancestry/versatile-heritages/nephilim/bestial-manifestation.json
@@ -145,15 +145,13 @@
                 ]
             },
             {
-                "definition": [
-                    "item:id:{item|id}"
-                ],
-                "key": "AdjustStrike",
+                "itemId": "{item|id}",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
                     "feat:bestial-brutality"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "deadly-d6"
             },
             {

--- a/packs/feats/archetype/ghost-eater/ghost-eater-dedication.json
+++ b/packs/feats/archetype/ghost-eater/ghost-eater-dedication.json
@@ -40,9 +40,10 @@
                 "value": "ghost-touch"
             },
             {
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "magical"
             }
         ],

--- a/packs/feats/archetype/lich/hand-of-the-lich.json
+++ b/packs/feats/archetype/lich/hand-of-the-lich.json
@@ -54,19 +54,18 @@
                 ]
             },
             {
-                "definition": [
+                "itemType": "weapon",
+                "key": "ItemAlteration",
+                "mode": "remove",
+                "predicate": [
                     "item:base:fist"
                 ],
-                "key": "AdjustStrike",
-                "mode": "remove",
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "nonlethal"
             },
             {
-                "definition": [
-                    "item:base:fist"
-                ],
-                "key": "AdjustStrike",
+                "itemId": "xxxxxxFISTxxxxxx",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "property": "traits",
                 "value": "magical"

--- a/packs/feats/archetype/verduran-shadow/death-from-above.json
+++ b/packs/feats/archetype/verduran-shadow/death-from-above.json
@@ -50,15 +50,14 @@
                 "toggleable": true
             },
             {
-                "definition": [
-                    "item:melee"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
+                    "item:melee",
                     "death-from-above"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "deadly-d8"
             },
             {

--- a/packs/feats/archetype/warrior-of-legend/warrior-of-legend-dedication.json
+++ b/packs/feats/archetype/warrior-of-legend/warrior-of-legend-dedication.json
@@ -28,17 +28,16 @@
         },
         "rules": [
             {
-                "definition": [
+                "itemType": "weapon",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
                     {
                         "or": [
                             "item:group:polearm",
                             "item:group:spear"
                         ]
-                    }
-                ],
-                "key": "AdjustStrike",
-                "mode": "add",
-                "predicate": [
+                    },
                     {
                         "nor": [
                             "armor:category:heavy",
@@ -46,7 +45,7 @@
                         ]
                     }
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "parry"
             },
             {

--- a/packs/feats/class/barbarian/follow-up-assault.json
+++ b/packs/feats/class/barbarian/follow-up-assault.json
@@ -33,27 +33,25 @@
                 "toggleable": true
             },
             {
-                "definition": [
-                    "item:melee"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
+                    "item:melee",
                     "follow-up-assault"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "backswing"
             },
             {
-                "definition": [
-                    "item:melee"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
+                    "item:melee",
                     "follow-up-assault"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "forceful"
             }
         ],

--- a/packs/feats/class/fighter/overwhelming-blow.json
+++ b/packs/feats/class/fighter/overwhelming-blow.json
@@ -34,12 +34,13 @@
                 "toggleable": true
             },
             {
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
                     "overwhelming-blow"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "deadly-d12"
             }
         ],

--- a/packs/feats/class/monk/wolf-drag.json
+++ b/packs/feats/class/monk/wolf-drag.json
@@ -43,15 +43,14 @@
                 "toggleable": true
             },
             {
-                "definition": [
-                    "item:slug:wolf-jaws"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
+                    "item:slug:wolf-jaws",
                     "wolf-drag"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "fatal-d12"
             },
             {

--- a/packs/feats/class/shared-class-feats/agile-shield-grip.json
+++ b/packs/feats/class/shared-class-feats/agile-shield-grip.json
@@ -54,12 +54,13 @@
                         ]
                     }
                 ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
                     "agile-shield-grip"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "agile"
             }
         ],

--- a/packs/heritages/surki/breaker-surki.json
+++ b/packs/heritages/surki/breaker-surki.json
@@ -75,51 +75,47 @@
                 "toggleable": true
             },
             {
-                "definition": [
-                    "item:slug:claw"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
+                    "item:slug:claw",
                     "digging-wedge-active"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "magical"
             },
             {
-                "definition": [
-                    "item:slug:claw"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
+                    "item:slug:claw",
                     "digging-wedge-active"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "razing"
             },
             {
-                "definition": [
-                    "item:slug:claw"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
+                    "item:slug:claw",
                     "digging-wedge-active"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "versatile-force"
             },
             {
-                "definition": [
-                    "item:slug:claw"
-                ],
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "remove",
                 "predicate": [
+                    "item:slug:claw",
                     "digging-wedge-active"
                 ],
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "agile"
             },
             {

--- a/packs/howl-of-the-wild-bestiary/warden-of-oceans-and-rivers.json
+++ b/packs/howl-of-the-wild-bestiary/warden-of-oceans-and-rivers.json
@@ -82,12 +82,11 @@
                 },
                 "rules": [
                     {
-                        "definition": [
-                            "item:slug:tentacle"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
+                            "item:slug:tentacle",
                             {
                                 "gte": [
                                     "all-are-one",
@@ -95,7 +94,7 @@
                                 ]
                             }
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach-60"
                     },
                     {
@@ -121,17 +120,16 @@
                         "value": "reach-40"
                     },
                     {
-                        "definition": [
-                            "item:slug:tentacle"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
+                            "item:slug:tentacle",
                             {
                                 "not": "all-are-one"
                             }
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach-30"
                     }
                 ],

--- a/packs/kingmaker-bestiary/gromog.json
+++ b/packs/kingmaker-bestiary/gromog.json
@@ -321,17 +321,16 @@
                 },
                 "rules": [
                     {
-                        "definition": [
-                            "item:slug:ogre-hook"
-                        ],
-                        "key": "AdjustStrike",
+                        "itemType": "melee",
+                        "key": "ItemAlterations",
                         "mode": "add",
                         "predicate": [
+                            "item:slug:ogre-hook",
                             {
                                 "not": "self:armored"
                             }
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "deadly-d10"
                     }
                 ],

--- a/packs/night-of-the-gray-death-bestiary/gray-gardener-assassin.json
+++ b/packs/night-of-the-gray-death-bestiary/gray-gardener-assassin.json
@@ -689,12 +689,13 @@
                         "value": 2
                     },
                     {
-                        "key": "AdjustStrike",
+                       "itemType": "melee",
+                       "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
                             "mark-for-death"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "deadly-d8"
                     }
                 ],

--- a/packs/night-of-the-gray-death-bestiary/zintaya-calbieste.json
+++ b/packs/night-of-the-gray-death-bestiary/zintaya-calbieste.json
@@ -689,12 +689,13 @@
                         "value": 2
                     },
                     {
-                        "key": "AdjustStrike",
+                       "itemType": "melee",
+                       "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
                             "mark-for-death"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "deadly-d8"
                     }
                 ],

--- a/packs/outlaws-of-alkenstar-bestiary/book-1-punks-in-a-powder-keg/clockwork-hunter.json
+++ b/packs/outlaws-of-alkenstar-bestiary/book-1-punks-in-a-powder-keg/clockwork-hunter.json
@@ -287,12 +287,13 @@
                         "value": 1
                     },
                     {
-                        "key": "AdjustStrike",
+                       "itemType": "melee",
+                       "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
                             "target-weakness"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "deadly-d4"
                     }
                 ],

--- a/packs/paizo-pregens/a-few-flowers-more/popcorn-level-4.json
+++ b/packs/paizo-pregens/a-few-flowers-more/popcorn-level-4.json
@@ -236,12 +236,13 @@
                                 ]
                             }
                         ],
-                        "key": "AdjustStrike",
+                       "itemType": "melee",
+                       "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
                             "grasping-reach"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach"
                     },
                     {

--- a/packs/paizo-pregens/a-fistful-of-flowers/popcorn.json
+++ b/packs/paizo-pregens/a-fistful-of-flowers/popcorn.json
@@ -236,12 +236,13 @@
                                 ]
                             }
                         ],
-                        "key": "AdjustStrike",
+                       "itemType": "weapon",
+                       "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
                             "grasping-reach"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach"
                     },
                     {

--- a/packs/pathfinder-bestiary-2/shocker-lizard.json
+++ b/packs/pathfinder-bestiary-2/shocker-lizard.json
@@ -151,15 +151,14 @@
                         "toggleable": true
                     },
                     {
-                        "definition": [
-                            "item:slug:shock"
-                        ],
-                        "key": "AdjustStrike",
+                        "definition": "melee",
+                        "key": "ItemAlteration",
                         "mode": "remove",
                         "predicate": [
+                            "item:slug:shock",
                             "amplify-voltage"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "nonlethal"
                     },
                     {

--- a/packs/pathfinder-bestiary-3/fossil-golem.json
+++ b/packs/pathfinder-bestiary-3/fossil-golem.json
@@ -204,12 +204,13 @@
                         "value": -10
                     },
                     {
-                        "key": "AdjustStrike",
+                       "itemType": "melee",
+                       "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
                             "reassemble"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach-25"
                     }
                 ],

--- a/packs/pathfinder-monster-core/cacodaemon.json
+++ b/packs/pathfinder-monster-core/cacodaemon.json
@@ -667,51 +667,47 @@
                         "selector": "stinger-damage"
                     },
                     {
-                        "definition": [
-                            "item:slug:jaws"
-                        ],
-                        "key": "AdjustStrike",
+                        "definition": "melee",
+                        "key": "ItemAlteration",
                         "mode": "remove",
                         "predicate": [
+                            "item:slug:jaws",
                             "change-shape:lizard"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "disease"
                     },
                     {
-                        "definition": [
-                            "item:slug:jaws"
-                        ],
-                        "key": "AdjustStrike",
+                        "definition": "melee",
+                        "key": "ItemAlteration",
                         "mode": "remove",
                         "predicate": [
+                            "item:slug:jaws",
                             "change-shape:lizard"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "magical"
                     },
                     {
-                        "definition": [
-                            "item:slug:jaws"
-                        ],
-                        "key": "AdjustStrike",
+                        "definition": "melee",
+                        "key": "ItemAlteration",
                         "mode": "remove",
                         "predicate": [
+                            "item:slug:jaws",
                             "change-shape:lizard"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach-0"
                     },
                     {
-                        "definition": [
-                            "item:slug:jaws"
-                        ],
-                        "key": "AdjustStrike",
+                        "definition": "melee",
+                        "key": "ItemAlteration",
                         "mode": "remove",
                         "predicate": [
+                            "item:slug:jaws",
                             "change-shape:lizard"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "unholy"
                     },
                     {

--- a/packs/pathfinder-monster-core/cassisian.json
+++ b/packs/pathfinder-monster-core/cassisian.json
@@ -721,15 +721,14 @@
                         "value": "small"
                     },
                     {
-                        "definition": [
-                            "item:slug:headbutt"
-                        ],
-                        "key": "AdjustStrike",
+                        "definition": "melee",
+                        "key": "ItemAlteration",
                         "mode": "remove",
                         "predicate": [
+                            "item:slug:headbutt",
                             "change-shape:dog"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach-0"
                     }
                 ],

--- a/packs/pathfinder-monster-core/venedaemon.json
+++ b/packs/pathfinder-monster-core/venedaemon.json
@@ -1573,15 +1573,14 @@
                         "toggleable": true
                     },
                     {
-                        "definition": [
-                            "item:slug:tentacle"
-                        ],
-                        "key": "AdjustStrike",
+                        "definition": "melee",
+                        "key": "ItemAlteration",
                         "mode": "remove",
                         "predicate": [
+                            "item:slug:tentacle",
                             "residual-force"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach-10"
                     },
                     {

--- a/packs/pathfinder-monster-core/vordine.json
+++ b/packs/pathfinder-monster-core/vordine.json
@@ -843,12 +843,13 @@
                                 "not": "item:ranged"
                             }
                         ],
-                        "key": "AdjustStrike",
+                       "itemType": "melee",
+                       "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
                             "trident-of-dis"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach-10"
                     },
                     {

--- a/packs/pathfinder-npc-core/laborer/innkeeper.json
+++ b/packs/pathfinder-npc-core/laborer/innkeeper.json
@@ -508,12 +508,13 @@
                         "value": 1
                     },
                     {
-                        "key": "AdjustStrike",
+                       "itemType": "melee",
+                       "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
                             "home-base-brawler"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "nonlethal"
                     },
                     {

--- a/packs/pfs-season-5-bestiary/5-12/topiary-beast.json
+++ b/packs/pfs-season-5-bestiary/5-12/topiary-beast.json
@@ -155,21 +155,23 @@
                         "value": true
                     },
                     {
-                        "key": "AdjustStrike",
+                       "itemType": "melee",
+                       "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
                             "functional-form:ape"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "agile"
                     },
                     {
-                        "key": "AdjustStrike",
+                       "itemType": "melee",
+                       "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
                             "functional-form:ape"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach-10"
                     },
                     {

--- a/packs/pfs-season-5-bestiary/5-12/topiary-monster.json
+++ b/packs/pfs-season-5-bestiary/5-12/topiary-monster.json
@@ -88,21 +88,23 @@
                         "value": true
                     },
                     {
-                        "key": "AdjustStrike",
+                       "itemType": "melee",
+                       "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
                             "functional-form:mantis"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "agile"
                     },
                     {
-                        "key": "AdjustStrike",
+                       "itemType": "melee",
+                       "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
                             "functional-form:mantis"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach-10"
                     },
                     {
@@ -126,12 +128,13 @@
                         "uuid": "Compendium.pf2e.conditionitems.Item.Off-Guard"
                     },
                     {
-                        "key": "AdjustStrike",
+                       "itemType": "melee",
+                       "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
                             "functional-form:unicorn"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "deadly-d6"
                     }
                 ],

--- a/packs/quest-for-the-frozen-flame-bestiary/book-3-burning-tundra/burning-mammoth-commando.json
+++ b/packs/quest-for-the-frozen-flame-bestiary/book-3-burning-tundra/burning-mammoth-commando.json
@@ -512,13 +512,14 @@
                         "selector": "strike-damage"
                     },
                     {
-                        "definition": [
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "predicate": [
                             "item:group:axe",
                             "item:melee"
                         ],
-                        "key": "AdjustStrike",
-                        "mode": "add",
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach"
                     }
                 ],

--- a/packs/spell-effects/spell-effect-apex-companion.json
+++ b/packs/spell-effects/spell-effect-apex-companion.json
@@ -47,9 +47,10 @@
                 "selector": "strike-damage"
             },
             {
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "deadly-d12"
             }
         ],

--- a/packs/spell-effects/spell-effect-qi-form.json
+++ b/packs/spell-effects/spell-effect-qi-form.json
@@ -106,9 +106,10 @@
                 "value": "{item|flags.pf2e.rulesSelections.kiFormDamage}"
             },
             {
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "remove",
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "nonlethal"
             }
         ],

--- a/packs/spell-effects/spell-effect-untwisting-iron-augmentation.json
+++ b/packs/spell-effects/spell-effect-untwisting-iron-augmentation.json
@@ -42,9 +42,10 @@
                 "value": "silver"
             },
             {
-                "key": "AdjustStrike",
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
-                "property": "weapon-traits",
+                "property": "traits",
                 "value": "earth"
             },
             {

--- a/packs/stolen-fate-bestiary/book-1-the-choosing/arodeth.json
+++ b/packs/stolen-fate-bestiary/book-1-the-choosing/arodeth.json
@@ -1733,36 +1733,39 @@
                         "definition": [
                             "item:slug:staff"
                         ],
-                        "key": "AdjustStrike",
+                       "itemType": "melee",
+                       "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
                             "two-handed"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "trip"
                     },
                     {
                         "definition": [
                             "item:slug:staff"
                         ],
-                        "key": "AdjustStrike",
+                       "itemType": "melee",
+                       "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
                             "two-handed"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "parry"
                     },
                     {
                         "definition": [
                             "item:slug:staff"
                         ],
-                        "key": "AdjustStrike",
+                       "itemType": "melee",
+                       "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
                             "two-handed"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "reach"
                     }
                 ],

--- a/packs/strength-of-thousands-bestiary/book-1-kindled-magic/urbel.json
+++ b/packs/strength-of-thousands-bestiary/book-1-kindled-magic/urbel.json
@@ -670,15 +670,16 @@
                 },
                 "rules": [
                     {
-                        "definition": [
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "predicate": [
                             "item:melee",
                             {
                                 "not": "item:category:unarmed"
                             }
                         ],
-                        "key": "AdjustStrike",
-                        "mode": "add",
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "shove"
                     },
                     {

--- a/packs/strength-of-thousands-bestiary/book-3-hurricanes-howl/abendego-brute.json
+++ b/packs/strength-of-thousands-bestiary/book-3-hurricanes-howl/abendego-brute.json
@@ -433,13 +433,14 @@
                         "selector": "strike-damage"
                     },
                     {
-                        "definition": [
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "predicate": [
                             "item:base:trident",
                             "item:melee"
                         ],
-                        "key": "AdjustStrike",
-                        "mode": "add",
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "shove"
                     }
                 ],

--- a/packs/strength-of-thousands-bestiary/book-3-hurricanes-howl/ajbal-kimon.json
+++ b/packs/strength-of-thousands-bestiary/book-3-hurricanes-howl/ajbal-kimon.json
@@ -758,13 +758,14 @@
                 },
                 "rules": [
                     {
-                        "definition": [
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "predicate": [
                             "item:base:trident",
                             "item:melee"
                         ],
-                        "key": "AdjustStrike",
-                        "mode": "add",
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "shove"
                     },
                     {

--- a/packs/strength-of-thousands-bestiary/book-3-hurricanes-howl/bharlen-sajor.json
+++ b/packs/strength-of-thousands-bestiary/book-3-hurricanes-howl/bharlen-sajor.json
@@ -763,13 +763,14 @@
                         "selector": "strike-damage"
                     },
                     {
-                        "definition": [
+                        "itemType": "melee",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "predicate": [
                             "item:base:trident",
                             "item:melee"
                         ],
-                        "key": "AdjustStrike",
-                        "mode": "add",
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "shove"
                     }
                 ],

--- a/packs/triumph-of-the-tusk-bestiary/book-3-destroyers-doom/orc-raider.json
+++ b/packs/triumph-of-the-tusk-bestiary/book-3-destroyers-doom/orc-raider.json
@@ -386,12 +386,13 @@
                 },
                 "rules": [
                     {
-                        "key": "AdjustStrike",
+                       "itemType": "weapon",
+                       "key": "ItemAlteration",
                         "mode": "add",
                         "predicate": [
                             "self:effect:rage"
                         ],
-                        "property": "weapon-traits",
+                        "property": "traits",
                         "value": "versatile-fire"
                     }
                 ],


### PR DESCRIPTION
This takes care of the majority of the remaining instances of AdjustStrike for traits. Things I left out:
- Rule elements that rely on target data, which ItemAlteration doesn't have access to.
- Inner Upheaval effect, which PCs and NPCs currently share, and thus can't be easily converted without losing functionality on one of them.
- Some other instances that rely in priority timing, and should be looked at more carefully.

I also restored Shield Augmentation's Adjust Strike which I modified in my previous PR, as it appears weapon Item Alteration doesn't add traits to shields.