### PR TITLE
Use melee and ranged selectors instead of predicates where possible

### DIFF
--- a/packs/actions/vital-shot.json
+++ b/packs/actions/vital-shot.json
@@ -30,10 +30,9 @@
                 "key": "DamageDice",
                 "predicate": [
                     "vital-shot",
-                    "item:ranged",
                     "target:condition:off-guard"
                 ],
-                "selector": "strike-damage"
+                "selector": "ranged-strike-damage"
             },
             {
                 "damageType": "bleed",
@@ -42,10 +41,9 @@
                 "key": "DamageDice",
                 "predicate": [
                     "vital-shot",
-                    "item:ranged",
                     "target:condition:off-guard"
                 ],
-                "selector": "strike-damage"
+                "selector": "ranged-strike-damage"
             }
         ],
         "traits": {

--- a/packs/agents-of-edgewatch-bestiary/book-4-assault-on-hunting-lodge-seven/jonis-flakfatter.json
+++ b/packs/agents-of-edgewatch-bestiary/book-4-assault-on-hunting-lodge-seven/jonis-flakfatter.json
@@ -2960,10 +2960,9 @@
                         "dieSize": "d8",
                         "key": "DamageDice",
                         "predicate": [
-                            "call-toxins-active",
-                            "item:melee"
+                            "call-toxins-active"
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     },
                     {
                         "domain": "all",

--- a/packs/bestiary-effects/effect-adaptive-strike.json
+++ b/packs/bestiary-effects/effect-adaptive-strike.json
@@ -46,7 +46,6 @@
                 "key": "AdjustStrike",
                 "mode": "add",
                 "property": "materials",
-                "selector": "strike-damage",
                 "value": "{item|flags.pf2e.rulesSelections.material}"
             }
         ],

--- a/packs/bestiary-effects/effect-blade-barrage.json
+++ b/packs/bestiary-effects/effect-blade-barrage.json
@@ -27,10 +27,7 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "predicate": [
-                    "item:melee"
-                ],
-                "selector": "strike-damage",
+                "selector": "melee-strike-damage",
                 "type": "circumstance",
                 "value": "@item.system.badge.value * 2"
             }

--- a/packs/bestiary-effects/effect-harrowing-misfortune.json
+++ b/packs/bestiary-effects/effect-harrowing-misfortune.json
@@ -58,10 +58,9 @@
                 "keep": "lower",
                 "key": "RollTwice",
                 "predicate": [
-                    "harrow-doll:harrow-suit:hammers",
-                    "item:melee"
+                    "harrow-doll:harrow-suit:hammers"
                 ],
-                "selector": "attack"
+                "selector": "melee-attack-roll"
             },
             {
                 "keep": "lower",

--- a/packs/bestiary-family-ability-glossary/zombie-shock-arcing-strikes.json
+++ b/packs/bestiary-family-ability-glossary/zombie-shock-arcing-strikes.json
@@ -25,10 +25,7 @@
                     "criticalSuccess",
                     "success"
                 ],
-                "predicate": [
-                    "item:melee"
-                ],
-                "selector": "strike-attack-roll",
+                "selector": "melee-strike-attack-roll",
                 "text": "{item|system.description.value}",
                 "title": "{item|name}",
                 "visibility": "owner"

--- a/packs/classfeatures/curse-of-inclement-headwinds.json
+++ b/packs/classfeatures/curse-of-inclement-headwinds.json
@@ -36,7 +36,6 @@
             {
                 "key": "FlatModifier",
                 "predicate": [
-                    "item:ranged",
                     {
                         "gte": [
                             "self:condition:cursebound",
@@ -44,7 +43,7 @@
                         ]
                     }
                 ],
-                "selector": "attack-roll",
+                "selector": "ranged-attack-roll",
                 "type": "circumstance",
                 "value": -2
             },

--- a/packs/classfeatures/thief.json
+++ b/packs/classfeatures/thief.json
@@ -29,10 +29,9 @@
                 "ability": "dex",
                 "key": "FlatModifier",
                 "predicate": [
-                    "item:melee",
                     "item:trait:finesse"
                 ],
-                "selector": "strike-damage",
+                "selector": "melee-strike-damage",
                 "type": "ability"
             },
             {

--- a/packs/equipment-effects/effect-energy-mutagen-greater.json
+++ b/packs/equipment-effects/effect-energy-mutagen-greater.json
@@ -91,12 +91,11 @@
                 "dieSize": "d6",
                 "key": "DamageDice",
                 "predicate": [
-                    "item:melee",
                     {
-                        "not": "unarmed"
+                        "not": "item:trait:unarmed"
                     }
                 ],
-                "selector": "strike-damage"
+                "selector": "melee-strike-damage"
             },
             {
                 "key": "Resistance",

--- a/packs/equipment-effects/effect-energy-mutagen-lesser.json
+++ b/packs/equipment-effects/effect-energy-mutagen-lesser.json
@@ -89,12 +89,11 @@
                 "damageType": "{item|flags.pf2e.rulesSelections.energy}",
                 "key": "FlatModifier",
                 "predicate": [
-                    "item:melee",
                     {
-                        "not": "unarmed"
+                        "not": "item:trait:unarmed"
                     }
                 ],
-                "selector": "strike-damage",
+                "selector": "melee-strike-damage",
                 "value": 1
             },
             {

--- a/packs/equipment-effects/effect-energy-mutagen-major.json
+++ b/packs/equipment-effects/effect-energy-mutagen-major.json
@@ -91,12 +91,11 @@
                 "dieSize": "d6",
                 "key": "DamageDice",
                 "predicate": [
-                    "item:melee",
                     {
-                        "not": "unarmed"
+                        "not": "item:trait:unarmed"
                     }
                 ],
-                "selector": "strike-damage"
+                "selector": "melee-strike-damage"
             },
             {
                 "key": "Resistance",

--- a/packs/equipment-effects/effect-energy-mutagen-moderate.json
+++ b/packs/equipment-effects/effect-energy-mutagen-moderate.json
@@ -91,12 +91,11 @@
                 "dieSize": "d4",
                 "key": "DamageDice",
                 "predicate": [
-                    "item:melee",
                     {
-                        "not": "unarmed"
+                        "not": "item:trait:unarmed"
                     }
                 ],
-                "selector": "strike-damage"
+                "selector": "melee-strike-damage"
             },
             {
                 "key": "Resistance",

--- a/packs/equipment-effects/effect-fury-cocktail-greater.json
+++ b/packs/equipment-effects/effect-fury-cocktail-greater.json
@@ -64,10 +64,7 @@
             },
             {
                 "key": "FlatModifier",
-                "predicate": [
-                    "item:melee"
-                ],
-                "selector": "attack-roll",
+                "selector": "melee-attack-roll",
                 "type": "item",
                 "value": 4
             },

--- a/packs/equipment-effects/effect-fury-cocktail-lesser.json
+++ b/packs/equipment-effects/effect-fury-cocktail-lesser.json
@@ -64,10 +64,7 @@
             },
             {
                 "key": "FlatModifier",
-                "predicate": [
-                    "item:melee"
-                ],
-                "selector": "attack-roll",
+                "selector": "melee-attack-roll",
                 "type": "item",
                 "value": 2
             },

--- a/packs/equipment-effects/effect-fury-cocktail-moderate.json
+++ b/packs/equipment-effects/effect-fury-cocktail-moderate.json
@@ -64,10 +64,7 @@
             },
             {
                 "key": "FlatModifier",
-                "predicate": [
-                    "item:melee"
-                ],
-                "selector": "attack-roll",
+                "selector": "melee-attack-roll",
                 "type": "item",
                 "value": 3
             },

--- a/packs/extinction-curse-bestiary/book-5-lord-of-the-black-sands/raptor-guard-wight.json
+++ b/packs/extinction-curse-bestiary/book-5-lord-of-the-black-sands/raptor-guard-wight.json
@@ -564,10 +564,7 @@
                             "success",
                             "criticalSuccess"
                         ],
-                        "predicate": [
-                            "item:melee"
-                        ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "text": "{item|system.description.value}",
                         "title": "{item|name}",
                         "visibility": "owner"
@@ -611,10 +608,7 @@
                             "success",
                             "criticalSuccess"
                         ],
-                        "predicate": [
-                            "item:ranged"
-                        ],
-                        "selector": "strike-damage",
+                        "selector": "ranged-strike-damage",
                         "text": "{item|system.description.value}",
                         "title": "{item|name}",
                         "visibility": "owner"

--- a/packs/feat-effects/effect-curse-of-the-perpetual-storm.json
+++ b/packs/feat-effects/effect-curse-of-the-perpetual-storm.json
@@ -113,7 +113,6 @@
                 "key": "FlatModifier",
                 "predicate": [
                     "class:oracle",
-                    "item:ranged",
                     {
                         "nor": [
                             "item:thrown",
@@ -127,7 +126,7 @@
                         ]
                     }
                 ],
-                "selector": "strike-attack-roll",
+                "selector": "ranged-strike-attack-roll",
                 "value": -2
             },
             {

--- a/packs/feat-effects/effect-metallic-skin.json
+++ b/packs/feat-effects/effect-metallic-skin.json
@@ -53,10 +53,9 @@
                 "key": "DamageDice",
                 "predicate": [
                     "item:category:unarmed",
-                    "item:melee",
                     "metallic-skin-fire"
                 ],
-                "selector": "strike-damage"
+                "selector": "melee-strike-damage"
             }
         ],
         "start": {

--- a/packs/feat-effects/stance-arcane-cascade.json
+++ b/packs/feat-effects/stance-arcane-cascade.json
@@ -113,10 +113,7 @@
             {
                 "damageType": "{item|flags.pf2e.rulesSelections.stanceArcaneCascade}",
                 "key": "FlatModifier",
-                "predicate": [
-                    "item:melee"
-                ],
-                "selector": "strike-damage",
+                "selector": "melee-strike-damage",
                 "slug": "arcane-cascade-extra-damage",
                 "value": 1
             },
@@ -124,10 +121,9 @@
                 "key": "AdjustModifier",
                 "mode": "upgrade",
                 "predicate": [
-                    "item:melee",
                     "feature:weapon-specialization"
                 ],
-                "selector": "strike-damage",
+                "selector": "melee-strike-damage",
                 "slug": "arcane-cascade-extra-damage",
                 "value": 2
             },
@@ -135,10 +131,9 @@
                 "key": "AdjustModifier",
                 "mode": "upgrade",
                 "predicate": [
-                    "item:melee",
                     "feature:greater-weapon-specialization"
                 ],
-                "selector": "strike-damage",
+                "selector": "melee-strike-damage",
                 "slug": "arcane-cascade-extra-damage",
                 "value": 3
             },

--- a/packs/feat-effects/stance-point-blank-stance.json
+++ b/packs/feat-effects/stance-point-blank-stance.json
@@ -30,7 +30,6 @@
                 "key": "FlatModifier",
                 "predicate": [
                     "target:range-increment:1",
-                    "item:ranged",
                     {
                         "nor": [
                             "item:trait:volley-20",
@@ -39,7 +38,7 @@
                         ]
                     }
                 ],
-                "selector": "strike-damage",
+                "selector": "ranged-strike-damage",
                 "type": "circumstance",
                 "value": 2
             }

--- a/packs/feats/class/gunslinger/snipers-aim.json
+++ b/packs/feats/class/gunslinger/snipers-aim.json
@@ -39,20 +39,18 @@
             {
                 "key": "FlatModifier",
                 "predicate": [
-                    "snipers-aim",
-                    "item:ranged"
+                    "snipers-aim"
                 ],
-                "selector": "attack",
+                "selector": "ranged-attack-roll",
                 "type": "circumstance",
                 "value": 2
             },
             {
                 "key": "Note",
                 "predicate": [
-                    "target:condition:concealed",
-                    "item:ranged"
+                    "target:condition:concealed"
                 ],
-                "selector": "attack",
+                "selector": "ranged-attack-roll",
                 "text": "PF2E.SpecificRule.SnipersAim.Note",
                 "title": "{item|name}"
             },

--- a/packs/feats/class/gunslinger/triggerbrand-salvo.json
+++ b/packs/feats/class/gunslinger/triggerbrand-salvo.json
@@ -40,10 +40,9 @@
                 "key": "FlatModifier",
                 "predicate": [
                     "triggerbrand-salvo",
-                    "item:trait:combination",
-                    "item:ranged"
+                    "item:trait:combination"
                 ],
-                "selector": "strike-attack-roll",
+                "selector": "ranged-strike-attack-roll",
                 "type": "circumstance",
                 "value": 2
             }

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-1-despair-on-danger-island/takatorra-level-9.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-1-despair-on-danger-island/takatorra-level-9.json
@@ -367,10 +367,9 @@
                     {
                         "key": "Note",
                         "predicate": [
-                            "blade-barrage",
-                            "item:melee"
+                            "blade-barrage"
                         ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "text": "{item|system.description.value}",
                         "title": "{item|name}",
                         "visibility": "owner"

--- a/packs/iconics/korakai-level-1.json
+++ b/packs/iconics/korakai-level-1.json
@@ -3160,7 +3160,6 @@
                     {
                         "key": "FlatModifier",
                         "predicate": [
-                            "item:ranged",
                             {
                                 "gte": [
                                     "self:condition:cursebound",
@@ -3168,7 +3167,7 @@
                                 ]
                             }
                         ],
-                        "selector": "attack-roll",
+                        "selector": "ranged-attack-roll",
                         "type": "circumstance",
                         "value": -2
                     },

--- a/packs/iconics/korakai-level-3.json
+++ b/packs/iconics/korakai-level-3.json
@@ -4006,7 +4006,6 @@
                     {
                         "key": "FlatModifier",
                         "predicate": [
-                            "item:ranged",
                             {
                                 "gte": [
                                     "self:condition:cursebound",
@@ -4014,7 +4013,7 @@
                                 ]
                             }
                         ],
-                        "selector": "attack-roll",
+                        "selector": "ranged-attack-roll",
                         "type": "circumstance",
                         "value": -2
                     },

--- a/packs/iconics/korakai-level-5.json
+++ b/packs/iconics/korakai-level-5.json
@@ -4633,7 +4633,6 @@
                     {
                         "key": "FlatModifier",
                         "predicate": [
-                            "item:ranged",
                             {
                                 "gte": [
                                     "self:condition:cursebound",
@@ -4641,7 +4640,7 @@
                                 ]
                             }
                         ],
-                        "selector": "attack-roll",
+                        "selector": "ranged-attack-roll",
                         "type": "circumstance",
                         "value": -2
                     },

--- a/packs/iconics/merisiel-level-1.json
+++ b/packs/iconics/merisiel-level-1.json
@@ -816,10 +816,9 @@
                         "ability": "dex",
                         "key": "FlatModifier",
                         "predicate": [
-                            "item:melee",
                             "item:trait:finesse"
                         ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "type": "ability"
                     },
                     {

--- a/packs/iconics/merisiel-level-3.json
+++ b/packs/iconics/merisiel-level-3.json
@@ -2292,10 +2292,9 @@
                         "ability": "dex",
                         "key": "FlatModifier",
                         "predicate": [
-                            "item:melee",
                             "item:trait:finesse"
                         ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "type": "ability"
                     },
                     {

--- a/packs/iconics/merisiel-level-5.json
+++ b/packs/iconics/merisiel-level-5.json
@@ -2315,10 +2315,9 @@
                         "ability": "dex",
                         "key": "FlatModifier",
                         "predicate": [
-                            "item:melee",
                             "item:trait:finesse"
                         ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "type": "ability"
                     },
                     {

--- a/packs/kingmaker-bestiary/akiros-ismort.json
+++ b/packs/kingmaker-bestiary/akiros-ismort.json
@@ -758,10 +758,9 @@
                     {
                         "key": "FlatModifier",
                         "predicate": [
-                            "self:effect:rage",
-                            "item:melee"
+                            "self:effect:rage"
                         ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "value": 2
                     }
                 ],

--- a/packs/kingmaker-bestiary/pavetta-stroon-drelev.json
+++ b/packs/kingmaker-bestiary/pavetta-stroon-drelev.json
@@ -475,10 +475,9 @@
                         "dieSize": "d6",
                         "key": "DamageDice",
                         "predicate": [
-                            "self:effect:rage",
-                            "item:melee"
+                            "self:effect:rage"
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     },
                     {
                         "key": "FlatModifier",

--- a/packs/other-effects/effect-aquatic-combat.json
+++ b/packs/other-effects/effect-aquatic-combat.json
@@ -84,12 +84,11 @@
             {
                 "key": "Note",
                 "predicate": [
-                    "item:ranged",
                     {
                         "not": "item:rune:property:underwater"
                     }
                 ],
-                "selector": "attack",
+                "selector": "ranged-attack-roll",
                 "text": "PF2E.SpecificRule.AquaticCombat.RangedNote"
             },
             {

--- a/packs/outlaws-of-alkenstar-bestiary/book-3-the-smoking-gun/anjelique-loveless.json
+++ b/packs/outlaws-of-alkenstar-bestiary/book-3-the-smoking-gun/anjelique-loveless.json
@@ -950,10 +950,9 @@
                         "dieSize": "d8",
                         "key": "DamageDice",
                         "predicate": [
-                            "item:ranged",
                             "tormenting-shot"
                         ],
-                        "selector": "strike-damage"
+                        "selector": "ranged-strike-damage"
                     },
                     {
                         "damageType": "bleed",
@@ -961,11 +960,10 @@
                         "dieSize": "d6",
                         "key": "DamageDice",
                         "predicate": [
-                            "item:ranged",
                             "target:condition:frightened",
                             "tormenting-shot"
                         ],
-                        "selector": "strike-damage"
+                        "selector": "ranged-strike-damage"
                     }
                 ],
                 "slug": null,

--- a/packs/outlaws-of-alkenstar-bestiary/book-3-the-smoking-gun/vewslog.json
+++ b/packs/outlaws-of-alkenstar-bestiary/book-3-the-smoking-gun/vewslog.json
@@ -539,10 +539,7 @@
                         "diceNumber": 4,
                         "dieSize": "d6",
                         "key": "DamageDice",
-                        "predicate": [
-                            "item:ranged"
-                        ],
-                        "selector": "strike-damage"
+                        "selector": "ranged-strike-damage"
                     }
                 ],
                 "slug": null,

--- a/packs/paizo-pregens/a-few-flowers-more/popcorn-level-4.json
+++ b/packs/paizo-pregens/a-few-flowers-more/popcorn-level-4.json
@@ -251,7 +251,6 @@
                             "downgrade": true
                         },
                         "predicate": [
-                            "item:melee",
                             "item:usage:hands:2",
                             "grasping-reach",
                             {
@@ -261,7 +260,7 @@
                                 ]
                             }
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     }
                 ],
                 "slug": "grasping-reach",

--- a/packs/paizo-pregens/a-few-flowers-more/reaching-rings-level-4.json
+++ b/packs/paizo-pregens/a-few-flowers-more/reaching-rings-level-4.json
@@ -2399,13 +2399,12 @@
                         "ability": "dex",
                         "key": "FlatModifier",
                         "predicate": [
-                            "item:melee",
                             "item:trait:finesse",
                             {
                                 "not": "item:category:unarmed"
                             }
                         ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "type": "ability"
                     },
                     {

--- a/packs/paizo-pregens/a-fistful-of-flowers/popcorn.json
+++ b/packs/paizo-pregens/a-fistful-of-flowers/popcorn.json
@@ -251,7 +251,6 @@
                             "downgrade": true
                         },
                         "predicate": [
-                            "item:melee",
                             "item:usage:hands:2",
                             "grasping-reach",
                             {
@@ -261,7 +260,7 @@
                                 ]
                             }
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     }
                 ],
                 "slug": "grasping-reach",

--- a/packs/paizo-pregens/a-fistful-of-flowers/reaching-rings.json
+++ b/packs/paizo-pregens/a-fistful-of-flowers/reaching-rings.json
@@ -2312,13 +2312,12 @@
                         "ability": "dex",
                         "key": "FlatModifier",
                         "predicate": [
-                            "item:melee",
                             "item:trait:finesse",
                             {
                                 "not": "item:category:unarmed"
                             }
                         ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "type": "ability"
                     },
                     {

--- a/packs/paizo-pregens/beginner-box/merisiel-beginner-box.json
+++ b/packs/paizo-pregens/beginner-box/merisiel-beginner-box.json
@@ -979,10 +979,9 @@
                         "ability": "dex",
                         "key": "FlatModifier",
                         "predicate": [
-                            "item:melee",
                             "item:trait:finesse"
                         ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "type": "ability"
                     },
                     {

--- a/packs/paizo-pregens/little-trouble-in-big-absalom/quizrel.json
+++ b/packs/paizo-pregens/little-trouble-in-big-absalom/quizrel.json
@@ -2559,13 +2559,12 @@
                         "ability": "dex",
                         "key": "FlatModifier",
                         "predicate": [
-                            "item:melee",
                             "item:trait:finesse",
                             {
                                 "not": "item:category:unarmed"
                             }
                         ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "type": "ability"
                     },
                     {

--- a/packs/paizo-pregens/mark-of-the-mantis/zeah.json
+++ b/packs/paizo-pregens/mark-of-the-mantis/zeah.json
@@ -4603,10 +4603,9 @@
                         "ability": "dex",
                         "key": "FlatModifier",
                         "predicate": [
-                            "item:melee",
                             "item:trait:finesse"
                         ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "type": "ability"
                     },
                     {

--- a/packs/paizo-pregens/sundered-waves/kaako-ashfeather.json
+++ b/packs/paizo-pregens/sundered-waves/kaako-ashfeather.json
@@ -3138,13 +3138,12 @@
                         "ability": "dex",
                         "key": "FlatModifier",
                         "predicate": [
-                            "item:melee",
                             "item:trait:finesse",
                             {
                                 "not": "item:category:unarmed"
                             }
                         ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "type": "ability"
                     },
                     {

--- a/packs/quest-for-the-frozen-flame-bestiary/book-3-burning-tundra/ivarsa.json
+++ b/packs/quest-for-the-frozen-flame-bestiary/book-3-burning-tundra/ivarsa.json
@@ -1584,20 +1584,18 @@
                         "damageType": "fire",
                         "key": "FlatModifier",
                         "predicate": [
-                            "arcane-cascade",
-                            "item:melee"
+                            "arcane-cascade"
                         ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "slug": "arcane-cascade",
                         "value": 2
                     },
                     {
                         "key": "Note",
                         "predicate": [
-                            "arcane-cascade",
-                            "item:melee"
+                            "arcane-cascade"
                         ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "text": "PF2E.NPCAbility.Ivarsa.ArcaneCascade.Note",
                         "title": "{item|name}",
                         "visibility": "owner"

--- a/packs/spell-effects/spell-effect-divine-vessel-9th-level.json
+++ b/packs/spell-effects/spell-effect-divine-vessel-9th-level.json
@@ -157,10 +157,7 @@
             },
             {
                 "key": "FlatModifier",
-                "predicate": [
-                    "item:melee"
-                ],
-                "selector": "strike-damage",
+                "selector": "melee-strike-damage",
                 "type": "status",
                 "value": 2
             },

--- a/packs/spell-effects/spell-effect-divine-vessel.json
+++ b/packs/spell-effects/spell-effect-divine-vessel.json
@@ -157,10 +157,7 @@
             },
             {
                 "key": "FlatModifier",
-                "predicate": [
-                    "item:melee"
-                ],
-                "selector": "strike-damage",
+                "selector": "melee-strike-damage",
                 "type": "status",
                 "value": 2
             },

--- a/packs/spell-effects/spell-effect-enlarge-companion.json
+++ b/packs/spell-effects/spell-effect-enlarge-companion.json
@@ -76,10 +76,7 @@
             },
             {
                 "key": "FlatModifier",
-                "predicate": [
-                    "item:melee"
-                ],
-                "selector": "strike-damage",
+                "selector": "melee-strike-damage",
                 "type": "status",
                 "value": "{item|flags.pf2e.rulesSelections.enlarge.damage}"
             }

--- a/packs/spell-effects/spell-effect-enlarge-heightened-4th.json
+++ b/packs/spell-effects/spell-effect-enlarge-heightened-4th.json
@@ -24,10 +24,7 @@
             {
                 "key": "FlatModifier",
                 "label": "Enlarge",
-                "predicate": [
-                    "item:melee"
-                ],
-                "selector": "strike-damage",
+                "selector": "melee-strike-damage",
                 "type": "status",
                 "value": 4
             },

--- a/packs/spell-effects/spell-effect-wrathful-storm.json
+++ b/packs/spell-effects/spell-effect-wrathful-storm.json
@@ -24,10 +24,7 @@
             {
                 "hideIfDisabled": true,
                 "key": "FlatModifier",
-                "predicate": [
-                    "item:ranged"
-                ],
-                "selector": "strike-attack-roll",
+                "selector": "ranged-strike-attack-roll",
                 "type": "circumstance",
                 "value": -4
             }

--- a/packs/stolen-fate-bestiary/book-1-the-choosing/blade-magus.json
+++ b/packs/stolen-fate-bestiary/book-1-the-choosing/blade-magus.json
@@ -1581,20 +1581,18 @@
                         "damageType": "force",
                         "key": "FlatModifier",
                         "predicate": [
-                            "arcane-cascade",
-                            "item:melee"
+                            "arcane-cascade"
                         ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "slug": "arcane-cascade",
                         "value": 2
                     },
                     {
                         "key": "Note",
                         "predicate": [
-                            "arcane-cascade",
-                            "item:melee"
+                            "arcane-cascade"
                         ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "text": "PF2E.NPCAbility.BladeMagus.ArcaneCascade.Note",
                         "title": "{item|name}",
                         "visibility": "owner"

--- a/packs/stolen-fate-bestiary/book-1-the-choosing/harpy-warbird.json
+++ b/packs/stolen-fate-bestiary/book-1-the-choosing/harpy-warbird.json
@@ -486,10 +486,9 @@
                         "dieSize": "d6",
                         "key": "DamageDice",
                         "predicate": [
-                            "item:melee",
                             "war-formation"
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     }
                 ],
                 "slug": null,

--- a/packs/stolen-fate-bestiary/book-1-the-choosing/queen-kawlinawk.json
+++ b/packs/stolen-fate-bestiary/book-1-the-choosing/queen-kawlinawk.json
@@ -571,10 +571,9 @@
                         "dieSize": "d6",
                         "key": "DamageDice",
                         "predicate": [
-                            "item:melee",
                             "war-formation"
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     }
                 ],
                 "slug": null,

--- a/packs/stolen-fate-bestiary/book-3-worst-of-all-possible-worlds/storied-harrowkin.json
+++ b/packs/stolen-fate-bestiary/book-3-worst-of-all-possible-worlds/storied-harrowkin.json
@@ -622,10 +622,9 @@
                         "dieSize": "d6",
                         "key": "DamageDice",
                         "predicate": [
-                            "item:melee",
                             "target:condition:prone"
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     }
                 ],
                 "slug": null,

--- a/packs/strength-of-thousands-bestiary/book-6-shadows-of-the-ancients/wereant-poisoner.json
+++ b/packs/strength-of-thousands-bestiary/book-6-shadows-of-the-ancients/wereant-poisoner.json
@@ -560,10 +560,7 @@
                         "outcome": [
                             "criticalSuccess"
                         ],
-                        "predicate": [
-                            "item:melee"
-                        ],
-                        "selector": "strike-attack-roll",
+                        "selector": "melee-strike-attack-roll",
                         "text": "{item|system.description.value}",
                         "title": "{item|name}",
                         "visibility": "owner"


### PR DESCRIPTION
Adjust to move `item:melee` and `item:ranged` out of predicates and use `melee-` and `ranged-` selectors where possible Also changes a few top level `unarmed` predicates to `item:trait:unarmed` in the items affected