### PR TITLE
Implement Horn of Plenty's daily crafting

### DIFF
--- a/packs/classfeatures/horn-of-plenty.json
+++ b/packs/classfeatures/horn-of-plenty.json
@@ -11,7 +11,7 @@
         },
         "category": "classfeature",
         "description": {
-            "value": "<p><strong>Usage</strong> a wallet, bag, or similar container of 1 Bulk you can wear on your body</p><hr /><p>Whether a bag, gourd, wallet, cornucopia, or similar food receptacle, this ikon recalls the harvest and hearth. The receptacle can store up to 1 Bulk of potions and elixirs, but no other items. The receptacle can't be opened except by the ikon's immanence and transcendence abilities. Each day during your daily preparations, the ikon produces one temporary elixir of life. You can choose to have it make a different elixir or potion you know the formula for. The level of any elixir or potion created by the horn must be your level or lower. The number of elixirs the horn creates increases to two at 8th level and three at 16th level, and you can choose each item individually. These temporary items vanish the next time you make your daily preparations, and any remaining effects of the temporary items end. A temporary elixir or potion has no value.</p>\n<p><strong>Immanence</strong> The horn of plenty shimmers, allowing access to the stored consumables inside. You can Interact to draw a consumable and drink it in a single action while your divine spark rests within the horn. Other creatures can't access the contents unless you allow them to.</p>\n<p><strong>Transcendence—</strong>@UUID[Compendium.pf2e.actionspf2e.Item.Feed the Masses] <span class=\"action-glyph\">1</span> (transcendence)</p>\n<p>@Embed[Compendium.pf2e.actionspf2e.Item.PdEJEiPUP0FDaBki inline]</p>"
+            "value": "<p><strong>Usage</strong> a wallet, bag, or similar container of 1 Bulk you can wear on your body</p><hr /><p>Whether a bag, gourd, wallet, cornucopia, or similar food receptacle, this ikon recalls the harvest and hearth. The receptacle can store up to 1 Bulk of potions and elixirs, but no other items. The receptacle can't be opened except by the ikon's immanence and transcendence abilities. Each day during your daily preparations, the ikon produces one temporary @UUID[Compendium.pf2e.equipment-srd.Item.Elixir of Life (Minor)]{Elixir of Life}. You can choose to have it make a different elixir or potion you know the formula for. The level of any elixir or potion created by the horn must be your level or lower. The number of elixirs the horn creates increases to two at 8th level and three at 16th level, and you can choose each item individually. These temporary items vanish the next time you make your daily preparations, and any remaining effects of the temporary items end. A temporary elixir or potion has no value.</p>\n<p><strong>Immanence</strong> The horn of plenty shimmers, allowing access to the stored consumables inside. You can Interact to draw a consumable and drink it in a single action while your divine spark rests within the horn. Other creatures can't access the contents unless you allow them to.</p>\n<p><strong>Transcendence—</strong>@UUID[Compendium.pf2e.actionspf2e.Item.Feed the Masses] <span class=\"action-glyph\">1</span> (transcendence)</p>\n<p>@Embed[Compendium.pf2e.actionspf2e.Item.PdEJEiPUP0FDaBki inline]</p>"
         },
         "level": {
             "value": 1
@@ -169,6 +169,20 @@
                 "mode": "add",
                 "property": "traits",
                 "value": "divine"
+            },
+            {
+                "craftableItems": [
+                    {
+                        "or": [
+                            "item:trait:elixir",
+                            "item:trait:potion"
+                        ]
+                    }
+                ],
+                "isDailyPrep": true,
+                "key": "CraftingAbility",
+                "maxSlots": "ternary(gte(@actor.level,16),3,ternary(gte(@actor.level,8),2,1))",
+                "slug": "horn-of-plenty"
             }
         ],
         "traits": {


### PR DESCRIPTION
and add link to elixir of life in the description.

It seems the elixirs, which are alchemical items, are hardcoded to receive the infused trait when created via daily prep crafting, so that makes this implementation slightly innacurate.