### PR TITLE
Move Tome Implement's Recall Knowledge improvement from Adept to Paragon benefit

### DIFF
--- a/packs/classfeatures/adept-benefit-tome.json
+++ b/packs/classfeatures/adept-benefit-tome.json
@@ -34,13 +34,6 @@
                     "label": "PF2E.SpecificRule.Thaumaturge.Implement.Tome.Label",
                     "value": "Compendium.pf2e.classfeatures.Item.Paragon Benefit (Tome)"
                 }
-            },
-            {
-                "key": "AdjustModifier",
-                "mode": "upgrade",
-                "selector": "skill-check",
-                "slug": "tome-recall-knowledge",
-                "value": 2
             }
         ],
         "traits": {

--- a/packs/classfeatures/paragon-benefit-tome.json
+++ b/packs/classfeatures/paragon-benefit-tome.json
@@ -47,6 +47,13 @@
                 "selector": "initiative",
                 "type": "circumstance",
                 "value": 3
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "upgrade",
+                "selector": "skill-check",
+                "slug": "tome-recall-knowledge",
+                "value": 2
             }
         ],
         "traits": {

--- a/packs/feat-effects/effect-tome-adept-benefit.json
+++ b/packs/feat-effects/effect-tome-adept-benefit.json
@@ -27,9 +27,12 @@
             },
             {
                 "key": "FlatModifier",
+                "predicate": [
+                    "target:mark:tome-adept-benefit"
+                ],
                 "removeAfterRoll": [
                     {
-                        "not": "implement-adept:tome"
+                        "not": "feature:paragon-benefit-tome"
                     }
                 ],
                 "selector": "strike-attack-roll",


### PR DESCRIPTION
And fix adept benefit's effect by adding a missing predicate and using the right roll option in its `removeAfterRoll` condition. Closes #18570