### PR TITLE
Add Stunning Appearance Note automation for Startling Appearance (Vigilante)

### DIFF
--- a/packs/feats/archetype/vigilante/stunning-appearance.json
+++ b/packs/feats/archetype/vigilante/stunning-appearance.json
@@ -12,7 +12,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>Your sudden appearance leaves your foe unable to respond. When you use Startling Appearance, if your foe's level is equal to or lower than yours, they are also @UUID[Compendium.pf2e.conditionitems.Item.Stunned]{Stunned 1} on a hit, or stunned 2 on a critical hit.</p>"
+            "value": "<p>Your sudden appearance leaves your foe unable to respond. When you use Startling Appearance, if your foe's level is equal to or lower than yours, they are also @UUID[Compendium.pf2e.conditionitems.Item.Stunned]{Stunned 1} on a hit, or @UUID[Compendium.pf2e.conditionitems.Item.Stunned]{Stunned 2} on a critical hit.</p>"
         },
         "level": {
             "value": 16

--- a/packs/feats/archetype/vigilante/stunning-appearance.json
+++ b/packs/feats/archetype/vigilante/stunning-appearance.json
@@ -29,7 +29,22 @@
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:startling-appearance-vigilante"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "{item|description}"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [


### PR DESCRIPTION
Adds the Stunning Appearance Information to Startling Appearance if the former feat is taken.