### PR TITLE
Remove check and speed penalty, and strength requirement from Reinforced Chassis

### DIFF
--- a/packs/equipment/reinforced-chassis.json
+++ b/packs/equipment/reinforced-chassis.json
@@ -9,7 +9,7 @@
             "value": 0
         },
         "category": "unarmored",
-        "checkPenalty": -2,
+        "checkPenalty": 0,
         "containerId": null,
         "description": {
             "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Reinforced Chassis]</p>\n<p>@Embed[Compendium.pf2e.feats-srd.Item.cilZUszwjSGB4p1W inline]</p>"
@@ -44,8 +44,8 @@
             "resilient": 0
         },
         "size": "med",
-        "speedPenalty": -5,
-        "strength": 3,
+        "speedPenalty": 0,
+        "strength": null,
         "traits": {
             "rarity": "rare",
             "value": [


### PR DESCRIPTION
Closes #18612
I guess we could get away with not even having the physical item now, but it's still useful for property runes