### PR TITLE
Use more melee and ranged selectors instead of predicates where possible

### DIFF
--- a/packs/abomination-vaults-bestiary/abomination-vaults-hardcover-compilation/urthagul.json
+++ b/packs/abomination-vaults-bestiary/abomination-vaults-hardcover-compilation/urthagul.json
@@ -133,16 +133,18 @@
                     {
                         "key": "FlatModifier",
                         "selector": "melee-strike-damage",
+                        "slug": "crimson-fulcrum-lens",
                         "type": "item",
                         "value": 2
                     },
                     {
-                        "key": "FlatModifier",
+                        "key": "AdjustModifier",
+                        "mode": "upgrade",
                         "predicate": [
-                            "item:melee"
+                            "item:slug:jaws"
                         ],
-                        "selector": "jaws-damage",
-                        "type": "item",
+                        "selector": "melee-strike-damage",
+                        "slug": "crimson-fulcrum-lens",
                         "value": 4
                     }
                 ],

--- a/packs/abomination-vaults-bestiary/abomination-vaults-hardcover-compilation/urthagul.json
+++ b/packs/abomination-vaults-bestiary/abomination-vaults-hardcover-compilation/urthagul.json
@@ -132,17 +132,14 @@
                     },
                     {
                         "key": "FlatModifier",
-                        "predicate": [
-                            "melee"
-                        ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "type": "item",
                         "value": 2
                     },
                     {
                         "key": "FlatModifier",
                         "predicate": [
-                            "melee"
+                            "item:melee"
                         ],
                         "selector": "jaws-damage",
                         "type": "item",

--- a/packs/actions/elemental-blast.json
+++ b/packs/actions/elemental-blast.json
@@ -57,7 +57,7 @@
                 "key": "FlatModifier",
                 "predicate": [
                     "self:action:slug:elemental-blast",
-                    "melee"
+                    "item:melee"
                 ],
                 "selector": "elemental-blast-damage",
                 "slug": "melee-elemental-blast",

--- a/packs/age-of-ashes-bestiary/book-1-hellknight-hill/alak-stagram.json
+++ b/packs/age-of-ashes-bestiary/book-1-hellknight-hill/alak-stagram.json
@@ -438,10 +438,9 @@
                         "diceNumber": 1,
                         "key": "DamageDice",
                         "predicate": [
-                            "power-attack",
-                            "melee"
+                            "power-attack"
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     }
                 ],
                 "slug": null,

--- a/packs/age-of-ashes-bestiary/book-3-tomorrow-must-burn/scarlet-triad-poisoner.json
+++ b/packs/age-of-ashes-bestiary/book-3-tomorrow-must-burn/scarlet-triad-poisoner.json
@@ -878,10 +878,9 @@
                         "dieSize": "d6",
                         "key": "DamageDice",
                         "predicate": [
-                            "running-poison-strike",
-                            "melee"
+                            "running-poison-strike"
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     }
                 ],
                 "slug": null,

--- a/packs/agents-of-edgewatch-bestiary/book-1-devil-at-the-dreaming-palace/bolar-of-stonemoor.json
+++ b/packs/agents-of-edgewatch-bestiary/book-1-devil-at-the-dreaming-palace/bolar-of-stonemoor.json
@@ -229,10 +229,9 @@
                     {
                         "key": "FlatModifier",
                         "predicate": [
-                            "self:effect:rage",
-                            "melee"
+                            "self:effect:rage"
                         ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "value": 2
                     },
                     {

--- a/packs/agents-of-edgewatch-bestiary/book-2-sixty-feet-under/kolo-harvan.json
+++ b/packs/agents-of-edgewatch-bestiary/book-2-sixty-feet-under/kolo-harvan.json
@@ -387,7 +387,6 @@
                         "dieSize": "d6",
                         "key": "DamageDice",
                         "predicate": [
-                            "melee",
                             {
                                 "or": [
                                     "upward-stab",
@@ -400,7 +399,7 @@
                                 ]
                             }
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     },
                     {
                         "domain": "damage",

--- a/packs/agents-of-edgewatch-bestiary/book-4-assault-on-hunting-lodge-seven/norgorberite-poisoner.json
+++ b/packs/agents-of-edgewatch-bestiary/book-4-assault-on-hunting-lodge-seven/norgorberite-poisoner.json
@@ -698,10 +698,9 @@
                         "dieSize": "d8",
                         "key": "DamageDice",
                         "predicate": [
-                            "impromptu-toxin",
-                            "melee"
+                            "impromptu-toxin"
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     }
                 ],
                 "slug": null,

--- a/packs/bestiary-ability-glossary-srd/power-attack.json
+++ b/packs/bestiary-ability-glossary-srd/power-attack.json
@@ -29,10 +29,9 @@
                 "diceNumber": 1,
                 "key": "DamageDice",
                 "predicate": [
-                    "melee",
                     "power-attack"
                 ],
-                "selector": "strike-damage"
+                "selector": "melee-strike-damage"
             }
         ],
         "traits": {

--- a/packs/bestiary-effects/effect-drink-emotions.json
+++ b/packs/bestiary-effects/effect-drink-emotions.json
@@ -37,10 +37,7 @@
                 "diceNumber": 1,
                 "dieSize": "d4",
                 "key": "DamageDice",
-                "predicate": [
-                    "melee"
-                ],
-                "selector": "strike-damage"
+                "selector": "melee-strike-damage"
             }
         ],
         "start": {

--- a/packs/bestiary-family-ability-glossary/skeleton/skeleton-grave-eruption.json
+++ b/packs/bestiary-family-ability-glossary/skeleton/skeleton-grave-eruption.json
@@ -29,12 +29,11 @@
             {
                 "key": "EphemeralEffect",
                 "predicate": [
-                    "melee",
                     "grave-eruption"
                 ],
                 "selectors": [
-                    "strike-attack-roll",
-                    "strike-damage"
+                    "melee-strike-attack-roll",
+                    "melee-strike-damage"
                 ],
                 "uuid": "Compendium.pf2e.conditionitems.Item.Off-Guard"
             },
@@ -45,10 +44,9 @@
                     "success"
                 ],
                 "predicate": [
-                    "melee",
                     "grave-eruption"
                 ],
-                "selector": "strike-attack-roll",
+                "selector": "melee-strike-attack-roll",
                 "text": "{item|system.description.value}",
                 "title": "{item|name}",
                 "visibility": "owner"

--- a/packs/bestiary-family-ability-glossary/skeleton/skeleton-skeleton-of-roses.json
+++ b/packs/bestiary-family-ability-glossary/skeleton/skeleton-skeleton-of-roses.json
@@ -24,10 +24,9 @@
                 "damageType": "piercing",
                 "key": "FlatModifier",
                 "predicate": [
-                    "melee",
-                    "unarmed"
+                    "item:trait:unarmed"
                 ],
-                "selector": "strike-damage",
+                "selector": "melee-strike-damage",
                 "value": "max(1,floor(@actor.level/3))"
             }
         ],

--- a/packs/blog-bestiary/eleukas.json
+++ b/packs/blog-bestiary/eleukas.json
@@ -669,10 +669,9 @@
                         "diceNumber": 1,
                         "key": "DamageDice",
                         "predicate": [
-                            "melee",
                             "power-attack"
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     }
                 ],
                 "slug": "power-attack",

--- a/packs/blood-lords-bestiary/book-5-a-taste-of-ashes/facetbound-nullifier.json
+++ b/packs/blood-lords-bestiary/book-5-a-taste-of-ashes/facetbound-nullifier.json
@@ -800,10 +800,7 @@
                         "diceNumber": 2,
                         "dieSize": "d10",
                         "key": "DamageDice",
-                        "predicate": [
-                            "melee"
-                        ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     }
                 ],
                 "slug": null,

--- a/packs/extinction-curse-bestiary/book-1-the-show-must-go-on/corrupted-retainer.json
+++ b/packs/extinction-curse-bestiary/book-1-the-show-must-go-on/corrupted-retainer.json
@@ -471,10 +471,9 @@
                     {
                         "key": "FlatModifier",
                         "predicate": [
-                            "self:effect:rage",
-                            "melee"
+                            "self:effect:rage"
                         ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "value": 2
                     }
                 ],

--- a/packs/extinction-curse-bestiary/book-1-the-show-must-go-on/horba.json
+++ b/packs/extinction-curse-bestiary/book-1-the-show-must-go-on/horba.json
@@ -509,10 +509,9 @@
                     {
                         "key": "FlatModifier",
                         "predicate": [
-                            "self:effect:rage",
-                            "melee"
+                            "self:effect:rage"
                         ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "value": 2
                     }
                 ],

--- a/packs/extinction-curse-bestiary/book-2-legacy-of-the-lost-god/darricus-stallit.json
+++ b/packs/extinction-curse-bestiary/book-2-legacy-of-the-lost-god/darricus-stallit.json
@@ -641,10 +641,9 @@
                         "diceNumber": 1,
                         "key": "DamageDice",
                         "predicate": [
-                            "melee",
                             "power-attack"
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     }
                 ],
                 "slug": "power-attack",

--- a/packs/extinction-curse-bestiary/book-5-lord-of-the-black-sands/kharostan.json
+++ b/packs/extinction-curse-bestiary/book-5-lord-of-the-black-sands/kharostan.json
@@ -977,10 +977,7 @@
                 "rules": [
                     {
                         "key": "Note",
-                        "predicate": [
-                            "melee"
-                        ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "text": "{item|system.description.value}",
                         "title": "{item|name}",
                         "visibility": "owner"
@@ -1059,10 +1056,9 @@
                     {
                         "key": "FlatModifier",
                         "predicate": [
-                            "melee",
                             "self:effect:rage"
                         ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "value": 12
                     },
                     {

--- a/packs/extinction-curse-bestiary/book-5-lord-of-the-black-sands/urdefhan-hunter.json
+++ b/packs/extinction-curse-bestiary/book-5-lord-of-the-black-sands/urdefhan-hunter.json
@@ -784,10 +784,9 @@
                     {
                         "key": "FlatModifier",
                         "predicate": [
-                            "ranged",
                             "deadly-aim"
                         ],
-                        "selector": "strike-damage",
+                        "selector": "ranged-strike-damage",
                         "value": 4
                     },
                     {

--- a/packs/fall-of-plaguestone/hallod.json
+++ b/packs/fall-of-plaguestone/hallod.json
@@ -706,10 +706,7 @@
                         "outcome": [
                             "criticalSuccess"
                         ],
-                        "predicate": [
-                            "melee"
-                        ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "text": "<div class='compact-text' data-visibility='gm'><p><strong>{item|name}</strong> <span class=\"action-glyph\">F</span></p><p><strong>Trigger</strong> Hallod scores a critical hit with a melee attack.</p><p><strong>Effect</strong> Hallod can attempt an Athletics check to @UUID[Compendium.pf2e.actionspf2e.Item.Shove] or @UUID[Compendium.pf2e.actionspf2e.Item.Trip] the target of his attack. This uses the same multiple attack penalty as the attack, but it does not count as an additional attack for that penalty</p></div>"
                     }
                 ],

--- a/packs/feats/ancestry/dwarf/telluric-power.json
+++ b/packs/feats/ancestry/dwarf/telluric-power.json
@@ -29,10 +29,9 @@
             {
                 "key": "FlatModifier",
                 "predicate": [
-                    "telluric-power",
-                    "melee"
+                    "telluric-power"
                 ],
-                "selector": "strike-damage",
+                "selector": "melee-strike-damage",
                 "type": "circumstance",
                 "value": "@weapon.system.damage.dice"
             },

--- a/packs/feats/archetype/archer/archers-aim.json
+++ b/packs/feats/archetype/archer/archers-aim.json
@@ -39,7 +39,7 @@
                 "key": "FlatModifier",
                 "predicate": [
                     "archers-aim",
-                    "ranged"
+                    "item:ranged"
                 ],
                 "selector": [
                     "bow-group-attack-roll",

--- a/packs/feats/archetype/eldritch-archer/impossible-volley-eldritch-archer.json
+++ b/packs/feats/archetype/eldritch-archer/impossible-volley-eldritch-archer.json
@@ -30,12 +30,11 @@
                 "key": "FlatModifier",
                 "label": "Impossible Volley",
                 "predicate": [
-                    "ranged",
                     "impossible-volley",
                     "volley-30",
                     "reload-0"
                 ],
-                "selector": "attack",
+                "selector": "ranged-attack-roll",
                 "value": -2
             }
         ],

--- a/packs/feats/class/fighter/incredible-aim.json
+++ b/packs/feats/class/fighter/incredible-aim.json
@@ -35,10 +35,9 @@
             {
                 "key": "FlatModifier",
                 "predicate": [
-                    "ranged",
                     "incredible-aim"
                 ],
-                "selector": "attack",
+                "selector": "ranged-attack-roll",
                 "type": "circumstance",
                 "value": 2
             },

--- a/packs/feats/class/fighter/vicious-swing.json
+++ b/packs/feats/class/fighter/vicious-swing.json
@@ -29,33 +29,10 @@
             {
                 "key": "DamageDice",
                 "predicate": [
-                    "melee",
                     "vicious-swing"
                 ],
-                "selector": "strike-damage",
-                "value": {
-                    "brackets": [
-                        {
-                            "end": 9,
-                            "value": {
-                                "diceNumber": 1
-                            }
-                        },
-                        {
-                            "end": 17,
-                            "start": 10,
-                            "value": {
-                                "diceNumber": 2
-                            }
-                        },
-                        {
-                            "start": 18,
-                            "value": {
-                                "diceNumber": 3
-                            }
-                        }
-                    ]
-                }
+                "selector": "melee-strike-damage",
+                "diceNumber": "ternary(gte(@actor.level,18),3,ternary(gte(@actor.level,10),2,1))"
             },
             {
                 "domain": "damage",

--- a/packs/feats/class/monk/one-inch-punch.json
+++ b/packs/feats/class/monk/one-inch-punch.json
@@ -50,7 +50,6 @@
                 "diceNumber": "ternary(gte(@actor.level, 18), 3, ternary(gte(@actor.level, 10), 2, 1))",
                 "key": "DamageDice",
                 "predicate": [
-                    "melee",
                     {
                         "or": [
                             "unarmed",
@@ -64,13 +63,12 @@
                     },
                     "one-inch-punch:two"
                 ],
-                "selector": "strike-damage"
+                "selector": "melee-strike-damage"
             },
             {
                 "diceNumber": "ternary(gte(@actor.level, 18), 6, ternary(gte(@actor.level, 10), 4, 2))",
                 "key": "DamageDice",
                 "predicate": [
-                    "melee",
                     {
                         "or": [
                             "unarmed",
@@ -84,7 +82,7 @@
                     },
                     "one-inch-punch:three"
                 ],
-                "selector": "strike-damage"
+                "selector": "melee-strike-damage"
             }
         ],
         "traits": {

--- a/packs/feats/class/monk/one-millimeter-punch.json
+++ b/packs/feats/class/monk/one-millimeter-punch.json
@@ -33,7 +33,6 @@
             {
                 "key": "Note",
                 "predicate": [
-                    "melee",
                     {
                         "or": [
                             "unarmed",
@@ -52,7 +51,7 @@
                         ]
                     }
                 ],
-                "selector": "strike-damage",
+                "selector": "melee-strike-damage",
                 "text": "{item|system.description.value}",
                 "title": "{item|name}"
             }

--- a/packs/feats/class/monk/triangle-shot.json
+++ b/packs/feats/class/monk/triangle-shot.json
@@ -43,10 +43,9 @@
             {
                 "key": "FlatModifier",
                 "predicate": [
-                    "triangle-shot",
-                    "ranged"
+                    "triangle-shot"
                 ],
-                "selector": "attack",
+                "selector": "ranged-attack-roll",
                 "value": -2
             }
         ],

--- a/packs/feats/class/ranger/hunters-aim.json
+++ b/packs/feats/class/ranger/hunters-aim.json
@@ -36,10 +36,9 @@
                 "key": "FlatModifier",
                 "predicate": [
                     "hunters-aim",
-                    "target:mark:hunted-prey",
-                    "ranged"
+                    "target:mark:hunted-prey"
                 ],
-                "selector": "attack",
+                "selector": "ranged-attack-roll",
                 "type": "circumstance",
                 "value": 2
             },
@@ -48,10 +47,9 @@
                 "predicate": [
                     "hunters-aim",
                     "target:mark:hunted-prey",
-                    "ranged",
                     "target:condition:concealed"
                 ],
-                "selector": "attack",
+                "selector": "ranged-attack-roll",
                 "text": "Ignore your prey's concealed condition.",
                 "title": "{item|name}"
             }

--- a/packs/feats/class/shared-class-feats/impossible-volley.json
+++ b/packs/feats/class/shared-class-feats/impossible-volley.json
@@ -30,12 +30,11 @@
                 "key": "FlatModifier",
                 "label": "Impossible Volley",
                 "predicate": [
-                    "ranged",
                     "impossible-volley",
                     "volley-30",
                     "reload-0"
                 ],
-                "selector": "attack",
+                "selector": "ranged-attack-roll",
                 "value": -2
             }
         ],

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-1-despair-on-danger-island/tino-tung-level-9.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-1-despair-on-danger-island/tino-tung-level-9.json
@@ -660,10 +660,9 @@
                         "damageType": "spirit",
                         "key": "FlatModifier",
                         "predicate": [
-                            "melee",
                             "retributive-strike"
                         ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "value": 3
                     }
                 ],

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-1-despair-on-danger-island/weapon-master-under-the-pale-sun-dervishes.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-1-despair-on-danger-island/weapon-master-under-the-pale-sun-dervishes.json
@@ -450,12 +450,11 @@
                     {
                         "key": "EphemeralEffect",
                         "predicate": [
-                            "melee",
                             "swift-blow"
                         ],
                         "selectors": [
-                            "strike-attack-roll",
-                            "strike-damage"
+                            "melee-strike-attack-roll",
+                            "melee-strike-damage"
                         ],
                         "uuid": "Compendium.pf2e.conditionitems.Item.Off-Guard"
                     },
@@ -465,10 +464,9 @@
                         "dieSize": "d8",
                         "key": "DamageDice",
                         "predicate": [
-                            "melee",
                             "swift-blow"
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     }
                 ],
                 "slug": null,

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-1-despair-on-danger-island/weapon-master.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-1-despair-on-danger-island/weapon-master.json
@@ -474,12 +474,11 @@
                     {
                         "key": "EphemeralEffect",
                         "predicate": [
-                            "melee",
                             "swift-blow"
                         ],
                         "selectors": [
-                            "strike-attack-roll",
-                            "strike-damage"
+                            "melee-strike-attack-roll",
+                            "melee-strike-damage"
                         ],
                         "uuid": "Compendium.pf2e.conditionitems.Item.Off-Guard"
                     },
@@ -489,10 +488,9 @@
                         "dieSize": "d8",
                         "key": "DamageDice",
                         "predicate": [
-                            "melee",
                             "swift-blow"
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     }
                 ],
                 "slug": null,

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-2-ready-fight/tino-tung-level-13.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-2-ready-fight/tino-tung-level-13.json
@@ -865,10 +865,9 @@
                         "damageType": "spirit",
                         "key": "FlatModifier",
                         "predicate": [
-                            "melee",
                             "retributive-strike"
                         ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "value": 3
                     }
                 ],

--- a/packs/iconics/yoon-level-1.json
+++ b/packs/iconics/yoon-level-1.json
@@ -1545,7 +1545,7 @@
                         "key": "FlatModifier",
                         "predicate": [
                             "self:action:slug:elemental-blast",
-                            "melee"
+                            "item:melee"
                         ],
                         "selector": "elemental-blast-damage",
                         "slug": "melee-elemental-blast",

--- a/packs/iconics/yoon-level-3.json
+++ b/packs/iconics/yoon-level-3.json
@@ -1545,7 +1545,7 @@
                         "key": "FlatModifier",
                         "predicate": [
                             "self:action:slug:elemental-blast",
-                            "melee"
+                            "item:melee"
                         ],
                         "selector": "elemental-blast-damage",
                         "slug": "melee-elemental-blast",

--- a/packs/iconics/yoon-level-5.json
+++ b/packs/iconics/yoon-level-5.json
@@ -1545,7 +1545,7 @@
                         "key": "FlatModifier",
                         "predicate": [
                             "self:action:slug:elemental-blast",
-                            "melee"
+                            "item:melee"
                         ],
                         "selector": "elemental-blast-damage",
                         "slug": "melee-elemental-blast",

--- a/packs/kingmaker-bestiary/agai.json
+++ b/packs/kingmaker-bestiary/agai.json
@@ -1084,12 +1084,11 @@
                     {
                         "key": "FlatModifier",
                         "predicate": [
-                            "enraged-growth",
-                            "melee"
+                            "enraged-growth"
                         ],
                         "selector": [
-                            "strike-attack-roll",
-                            "strike-damage"
+                            "melee-strike-attack-roll",
+                            "melee-strike-damage"
                         ],
                         "type": "status",
                         "value": 2

--- a/packs/kingmaker-bestiary/false-priestess.json
+++ b/packs/kingmaker-bestiary/false-priestess.json
@@ -2671,10 +2671,9 @@
                         "dieSize": "d6",
                         "key": "DamageDice",
                         "predicate": [
-                            "melee",
                             "primal-weapon"
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     }
                 ],
                 "slug": null,

--- a/packs/kingmaker-bestiary/ntavi.json
+++ b/packs/kingmaker-bestiary/ntavi.json
@@ -605,10 +605,9 @@
                         "diceNumber": 1,
                         "key": "DamageDice",
                         "predicate": [
-                            "melee",
                             "power-attack"
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     }
                 ],
                 "slug": null,

--- a/packs/kingmaker-bestiary/pitax-warden.json
+++ b/packs/kingmaker-bestiary/pitax-warden.json
@@ -1023,10 +1023,9 @@
                         "diceNumber": 1,
                         "key": "DamageDice",
                         "predicate": [
-                            "melee",
                             "power-attack"
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     }
                 ],
                 "slug": "power-attack",

--- a/packs/kingmaker-bestiary/the-stag-lord.json
+++ b/packs/kingmaker-bestiary/the-stag-lord.json
@@ -939,12 +939,11 @@
                         "key": "EphemeralEffect",
                         "predicate": [
                             "hunted-prey",
-                            "ranged",
                             "unfair-aim"
                         ],
                         "selectors": [
-                            "strike-attack-roll",
-                            "strike-damage"
+                            "ranged-strike-attack-roll",
+                            "ranged-strike-damage"
                         ],
                         "uuid": "Compendium.pf2e.conditionitems.Item.Off-Guard"
                     }

--- a/packs/kingmaker-bestiary/thresholder-hermeticist.json
+++ b/packs/kingmaker-bestiary/thresholder-hermeticist.json
@@ -962,10 +962,7 @@
                         "diceNumber": 2,
                         "dieSize": "d8",
                         "key": "DamageDice",
-                        "predicate": [
-                            "melee"
-                        ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     }
                 ],
                 "slug": null,

--- a/packs/kingmaker-bestiary/valerie-level-9.json
+++ b/packs/kingmaker-bestiary/valerie-level-9.json
@@ -1599,10 +1599,9 @@
                     {
                         "key": "DamageDice",
                         "predicate": [
-                            "melee",
                             "power-attack"
                         ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "value": {
                             "brackets": [
                                 {

--- a/packs/monsters-of-myth-bestiary/kothogaz-dance-of-disharmony.json
+++ b/packs/monsters-of-myth-bestiary/kothogaz-dance-of-disharmony.json
@@ -455,10 +455,9 @@
                         "dieSize": "d12",
                         "key": "DamageDice",
                         "predicate": [
-                            "disharmonic-door",
-                            "melee"
+                            "disharmonic-door"
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     }
                 ],
                 "slug": null,

--- a/packs/monsters-of-myth-bestiary/somnalu.json
+++ b/packs/monsters-of-myth-bestiary/somnalu.json
@@ -851,10 +851,9 @@
                         "dieSize": "d8",
                         "key": "DamageDice",
                         "predicate": [
-                            "digestive-secretions",
-                            "melee"
+                            "digestive-secretions"
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     }
                 ],
                 "slug": null,

--- a/packs/mwangi-expanse-bestiary/charau-ka-butcher.json
+++ b/packs/mwangi-expanse-bestiary/charau-ka-butcher.json
@@ -453,7 +453,7 @@
                             {
                                 "nor": [
                                     "agile",
-                                    "ranged"
+                                    "item:ranged"
                                 ]
                             }
                         ],

--- a/packs/other-effects/effect-2-circumstance-penalty-to-ranged-attacks.json
+++ b/packs/other-effects/effect-2-circumstance-penalty-to-ranged-attacks.json
@@ -24,10 +24,7 @@
             {
                 "key": "FlatModifier",
                 "label": "PF2E.SpecificRule.CriticalDeck.Effect.Label",
-                "predicate": [
-                    "ranged"
-                ],
-                "selector": "attack",
+                "selector": "ranged-attack-roll",
                 "slug": "critical-effect-penalty-to-ranged-attacks",
                 "type": "circumstance",
                 "value": -2

--- a/packs/outlaws-of-alkenstar-bestiary/book-1-punks-in-a-powder-keg/shoma-lyzerius.json
+++ b/packs/outlaws-of-alkenstar-bestiary/book-1-punks-in-a-powder-keg/shoma-lyzerius.json
@@ -1226,10 +1226,7 @@
                         "diceNumber": 1,
                         "dieSize": "d6",
                         "key": "DamageDice",
-                        "predicate": [
-                            "melee"
-                        ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     }
                 ],
                 "slug": null,

--- a/packs/paizo-pregens/little-trouble-in-big-absalom/simeek.json
+++ b/packs/paizo-pregens/little-trouble-in-big-absalom/simeek.json
@@ -295,33 +295,10 @@
                     {
                         "key": "DamageDice",
                         "predicate": [
-                            "melee",
                             "power-attack"
                         ],
-                        "selector": "strike-damage",
-                        "value": {
-                            "brackets": [
-                                {
-                                    "end": 9,
-                                    "value": {
-                                        "diceNumber": 1
-                                    }
-                                },
-                                {
-                                    "end": 17,
-                                    "start": 10,
-                                    "value": {
-                                        "diceNumber": 2
-                                    }
-                                },
-                                {
-                                    "start": 18,
-                                    "value": {
-                                        "diceNumber": 3
-                                    }
-                                }
-                            ]
-                        }
+                        "selector": "melee-strike-damage",
+                        "diceNumber": "ternary(gte(@actor.level,18),3,ternary(gte(@actor.level,10),2,1))"
                     },
                     {
                         "domain": "damage",

--- a/packs/pathfinder-bestiary-2/oread-guard.json
+++ b/packs/pathfinder-bestiary-2/oread-guard.json
@@ -522,10 +522,9 @@
                         "diceNumber": 1,
                         "key": "DamageDice",
                         "predicate": [
-                            "melee",
                             "power-attack"
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     }
                 ],
                 "slug": null,

--- a/packs/pathfinder-bestiary-2/spriggan-bully.json
+++ b/packs/pathfinder-bestiary-2/spriggan-bully.json
@@ -631,12 +631,11 @@
                     {
                         "key": "FlatModifier",
                         "predicate": [
-                            "enraged-growth",
-                            "melee"
+                            "enraged-growth"
                         ],
                         "selector": [
-                            "strike-attack-roll",
-                            "strike-damage"
+                            "melee-strike-attack-roll",
+                            "melee-strike-damage"
                         ],
                         "type": "status",
                         "value": 2

--- a/packs/pathfinder-bestiary-2/spriggan-warlord.json
+++ b/packs/pathfinder-bestiary-2/spriggan-warlord.json
@@ -818,12 +818,11 @@
                     {
                         "key": "FlatModifier",
                         "predicate": [
-                            "enraged-growth",
-                            "melee"
+                            "enraged-growth"
                         ],
                         "selector": [
-                            "strike-attack-roll",
-                            "strike-damage"
+                            "melee-strike-attack-roll",
+                            "melee-strike-damage"
                         ],
                         "type": "status",
                         "value": 2

--- a/packs/pathfinder-bestiary-2/suli-dune-dancer.json
+++ b/packs/pathfinder-bestiary-2/suli-dune-dancer.json
@@ -985,10 +985,9 @@
                         "dieSize": "d4",
                         "key": "DamageDice",
                         "predicate": [
-                            "elemental-assault:air",
-                            "melee"
+                            "elemental-assault:air"
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     },
                     {
                         "damageType": "bludgeoning",
@@ -996,10 +995,9 @@
                         "dieSize": "d4",
                         "key": "DamageDice",
                         "predicate": [
-                            "elemental-assault:earth",
-                            "melee"
+                            "elemental-assault:earth"
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     },
                     {
                         "damageType": "fire",
@@ -1007,10 +1005,9 @@
                         "dieSize": "d4",
                         "key": "DamageDice",
                         "predicate": [
-                            "elemental-assault:fire",
-                            "melee"
+                            "elemental-assault:fire"
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     },
                     {
                         "damageType": "cold",
@@ -1018,10 +1015,9 @@
                         "dieSize": "d4",
                         "key": "DamageDice",
                         "predicate": [
-                            "elemental-assault:water",
-                            "melee"
+                            "elemental-assault:water"
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     }
                 ],
                 "slug": null,

--- a/packs/pathfinder-bestiary-3/levaloch.json
+++ b/packs/pathfinder-bestiary-3/levaloch.json
@@ -502,7 +502,7 @@
                         "dieSize": "d6",
                         "key": "DamageDice",
                         "predicate": [
-                            "melee",
+                            "item:melee",
                             {
                                 "or": [
                                     "target:condition:clumsy",

--- a/packs/pathfinder-bestiary-3/munagola.json
+++ b/packs/pathfinder-bestiary-3/munagola.json
@@ -829,10 +829,7 @@
                             "criticalSuccess",
                             "success"
                         ],
-                        "predicate": [
-                            "melee"
-                        ],
-                        "selector": "attack",
+                        "selector": "melee-attack-roll",
                         "text": "{item|system.description.value}",
                         "title": "{item|name}",
                         "visibility": "gm"
@@ -950,10 +947,9 @@
                     {
                         "key": "FlatModifier",
                         "predicate": [
-                            "sudden-dive",
-                            "melee"
+                            "sudden-dive"
                         ],
-                        "selector": "attack",
+                        "selector": "melee-attack-roll",
                         "type": "circumstance",
                         "value": 1
                     }

--- a/packs/pathfinder-monster-core/shuln.json
+++ b/packs/pathfinder-monster-core/shuln.json
@@ -155,10 +155,7 @@
                         "outcome": [
                             "criticalSuccess"
                         ],
-                        "predicate": [
-                            "melee"
-                        ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "text": "{item|system.description.value}",
                         "title": "{item|name}",
                         "visibility": "owner"

--- a/packs/pfs-season-1-bestiary/1-08/veteran-guard-captain.json
+++ b/packs/pfs-season-1-bestiary/1-08/veteran-guard-captain.json
@@ -272,10 +272,9 @@
                         "diceNumber": 1,
                         "key": "DamageDice",
                         "predicate": [
-                            "melee",
                             "power-attack"
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     }
                 ],
                 "slug": "power-attack",

--- a/packs/pfs-season-1-bestiary/1-24/blue-streak-sentry.json
+++ b/packs/pfs-season-1-bestiary/1-24/blue-streak-sentry.json
@@ -428,10 +428,9 @@
                     {
                         "key": "FlatModifier",
                         "predicate": [
-                            "sentrys-aim",
-                            "ranged"
+                            "sentrys-aim"
                         ],
-                        "selector": "attack",
+                        "selector": "ranged-attack-roll",
                         "type": "circumstance",
                         "value": 1
                     }

--- a/packs/pfs-season-3-bestiary/3-15/sparkles-11-12.json
+++ b/packs/pfs-season-3-bestiary/3-15/sparkles-11-12.json
@@ -156,10 +156,7 @@
                         "outcome": [
                             "criticalSuccess"
                         ],
-                        "predicate": [
-                            "melee"
-                        ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "text": "{item|system.description.value}",
                         "title": "{item|name}",
                         "visibility": "owner"

--- a/packs/pfs-season-3-bestiary/3-15/sparkles-9-10.json
+++ b/packs/pfs-season-3-bestiary/3-15/sparkles-9-10.json
@@ -123,10 +123,7 @@
                         "outcome": [
                             "criticalSuccess"
                         ],
-                        "predicate": [
-                            "melee"
-                        ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "text": "{item|system.description.value}",
                         "title": "{item|name}",
                         "visibility": "owner"

--- a/packs/pfs-season-4-bestiary/4-99/recon-scout.json
+++ b/packs/pfs-season-4-bestiary/4-99/recon-scout.json
@@ -477,10 +477,9 @@
                         "key": "FlatModifier",
                         "label": "PF2E.TraitRage",
                         "predicate": [
-                            "self:effect:rage",
-                            "melee"
+                            "self:effect:rage"
                         ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "value": 8
                     },
                     {

--- a/packs/pfs-season-5-bestiary/quests/arisen-shadow-pixie.json
+++ b/packs/pfs-season-5-bestiary/quests/arisen-shadow-pixie.json
@@ -293,10 +293,9 @@
                         "damageType": "cold",
                         "key": "FlatModifier",
                         "predicate": [
-                            "melee",
                             "shadowed-illumination"
                         ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "value": 3
                     }
                 ],

--- a/packs/pfs-season-5-bestiary/quests/arisen-umbral-pixie.json
+++ b/packs/pfs-season-5-bestiary/quests/arisen-umbral-pixie.json
@@ -293,10 +293,9 @@
                         "damageType": "cold",
                         "key": "FlatModifier",
                         "predicate": [
-                            "melee",
                             "shadowed-illumination"
                         ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "value": 5
                     }
                 ],

--- a/packs/pfs-season-5-bestiary/quests/elite-arisen-shadow-pixie.json
+++ b/packs/pfs-season-5-bestiary/quests/elite-arisen-shadow-pixie.json
@@ -293,10 +293,9 @@
                         "damageType": "cold",
                         "key": "FlatModifier",
                         "predicate": [
-                            "melee",
                             "shadowed-illumination"
                         ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "value": 3
                     }
                 ],

--- a/packs/pfs-season-5-bestiary/quests/elite-arisen-umbral-pixie.json
+++ b/packs/pfs-season-5-bestiary/quests/elite-arisen-umbral-pixie.json
@@ -293,10 +293,9 @@
                         "damageType": "cold",
                         "key": "FlatModifier",
                         "predicate": [
-                            "melee",
                             "shadowed-illumination"
                         ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "value": 5
                     }
                 ],

--- a/packs/quest-for-the-frozen-flame-bestiary/book-3-burning-tundra/lomok.json
+++ b/packs/quest-for-the-frozen-flame-bestiary/book-3-burning-tundra/lomok.json
@@ -941,10 +941,7 @@
                         "diceNumber": 1,
                         "dieSize": "d10",
                         "key": "DamageDice",
-                        "predicate": [
-                            "melee"
-                        ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     }
                 ],
                 "slug": null,

--- a/packs/rage-of-elements-bestiary/faydhaan-shuyookh.json
+++ b/packs/rage-of-elements-bestiary/faydhaan-shuyookh.json
@@ -1827,7 +1827,7 @@
                         "dieSize": "d6",
                         "key": "DamageDice",
                         "predicate": [
-                            "melee",
+                            "item:melee",
                             "to-the-hilt"
                         ],
                         "selector": "jambiya-damage"

--- a/packs/season-of-ghosts-bestiary/book-4-to-bloom-below-the-web/silkwasp-bandit.json
+++ b/packs/season-of-ghosts-bestiary/book-4-to-bloom-below-the-web/silkwasp-bandit.json
@@ -555,10 +555,9 @@
                         "key": "FlatModifier",
                         "label": "PF2E.TraitRage",
                         "predicate": [
-                            "self:effect:rage",
-                            "melee"
+                            "self:effect:rage"
                         ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "value": 8
                     },
                     {

--- a/packs/sky-kings-tomb-bestiary/book-3-heavy-is-the-crown/dwarven-monster-hunter.json
+++ b/packs/sky-kings-tomb-bestiary/book-3-heavy-is-the-crown/dwarven-monster-hunter.json
@@ -477,10 +477,9 @@
                         "key": "FlatModifier",
                         "label": "PF2E.TraitRage",
                         "predicate": [
-                            "self:effect:rage",
-                            "melee"
+                            "self:effect:rage"
                         ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "value": 8
                     },
                     {

--- a/packs/sky-kings-tomb-bestiary/book-3-heavy-is-the-crown/hryngar-rager.json
+++ b/packs/sky-kings-tomb-bestiary/book-3-heavy-is-the-crown/hryngar-rager.json
@@ -774,10 +774,9 @@
                         "key": "FlatModifier",
                         "label": "PF2E.TraitRage",
                         "predicate": [
-                            "self:effect:rage",
-                            "melee"
+                            "self:effect:rage"
                         ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "value": 8
                     },
                     {

--- a/packs/spell-effects/spell-effect-elemental-gift.json
+++ b/packs/spell-effects/spell-effect-elemental-gift.json
@@ -106,10 +106,9 @@
                 "dieSize": "d6",
                 "key": "DamageDice",
                 "predicate": [
-                    "elemental-gift:fire",
-                    "melee"
+                    "elemental-gift:fire"
                 ],
-                "selector": "strike-damage"
+                "selector": "melee-strike-damage"
             },
             {
                 "domain": "all",

--- a/packs/spell-effects/spell-effect-mantle-of-the-magma-heart.json
+++ b/packs/spell-effects/spell-effect-mantle-of-the-magma-heart.json
@@ -96,7 +96,6 @@
             {
                 "key": "FlatModifier",
                 "predicate": [
-                    "melee",
                     {
                         "or": [
                             "magma-heart-first:enlarging-eruption",
@@ -104,7 +103,7 @@
                         ]
                     }
                 ],
-                "selector": "strike-damage",
+                "selector": "melee-strike-damage",
                 "type": "status",
                 "value": 2
             },

--- a/packs/spell-effects/spell-effect-primal-summons.json
+++ b/packs/spell-effects/spell-effect-primal-summons.json
@@ -149,10 +149,9 @@
             {
                 "key": "Note",
                 "predicate": [
-                    "melee",
                     "primal-summons:water"
                 ],
-                "selector": "strike-damage",
+                "selector": "melee-strike-damage",
                 "text": "PF2E.BattleForm.Note.Shove",
                 "title": "{item|name}"
             },

--- a/packs/stolen-fate-bestiary/book-1-the-choosing/blade-mercenary.json
+++ b/packs/stolen-fate-bestiary/book-1-the-choosing/blade-mercenary.json
@@ -768,10 +768,9 @@
                         "diceNumber": 1,
                         "key": "DamageDice",
                         "predicate": [
-                            "melee",
                             "power-attack"
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     }
                 ],
                 "slug": "power-attack",

--- a/packs/stolen-fate-bestiary/book-2-the-destiny-war/derhii.json
+++ b/packs/stolen-fate-bestiary/book-2-the-destiny-war/derhii.json
@@ -439,10 +439,7 @@
                         "outcome": [
                             "criticalSuccess"
                         ],
-                        "predicate": [
-                            "melee"
-                        ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "text": "{item|system.description.value}",
                         "title": "{item|name}"
                     }
@@ -486,10 +483,9 @@
                         "diceNumber": 1,
                         "key": "DamageDice",
                         "predicate": [
-                            "melee",
                             "power-attack"
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     }
                 ],
                 "slug": null,

--- a/packs/stolen-fate-bestiary/book-2-the-destiny-war/katpaskir.json
+++ b/packs/stolen-fate-bestiary/book-2-the-destiny-war/katpaskir.json
@@ -1213,10 +1213,9 @@
                         "diceNumber": 3,
                         "key": "DamageDice",
                         "predicate": [
-                            "melee",
                             "power-attack"
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     }
                 ],
                 "slug": null,

--- a/packs/strength-of-thousands-bestiary/book-1-kindled-magic/kurshkin.json
+++ b/packs/strength-of-thousands-bestiary/book-1-kindled-magic/kurshkin.json
@@ -800,10 +800,9 @@
                         "dieSize": "d6",
                         "key": "DamageDice",
                         "predicate": [
-                            "melee",
                             "target:effect:unluck-aura"
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     }
                 ],
                 "slug": null,

--- a/packs/strength-of-thousands-bestiary/book-1-kindled-magic/urbel.json
+++ b/packs/strength-of-thousands-bestiary/book-1-kindled-magic/urbel.json
@@ -736,10 +736,9 @@
                         "dieSize": "d6",
                         "key": "DamageDice",
                         "predicate": [
-                            "melee",
                             "target:condition:prone"
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     }
                 ],
                 "slug": null,

--- a/packs/strength-of-thousands-bestiary/book-2-spoken-on-the-song-wind/reth.json
+++ b/packs/strength-of-thousands-bestiary/book-2-spoken-on-the-song-wind/reth.json
@@ -495,7 +495,7 @@
                         "dieSize": "d8",
                         "key": "DamageDice",
                         "predicate": [
-                            "ranged",
+                            "item:ranged",
                             "deadly-bolts"
                         ],
                         "selector": "hand-crossbow-damage"

--- a/packs/strength-of-thousands-bestiary/book-3-hurricanes-howl/cyclops-bully.json
+++ b/packs/strength-of-thousands-bestiary/book-3-hurricanes-howl/cyclops-bully.json
@@ -351,11 +351,10 @@
                         "dieSize": "d10",
                         "key": "DamageDice",
                         "predicate": [
-                            "melee",
                             "target:condition:frightened",
                             "terrorizing-swing"
                         ],
-                        "selector": "strike-damage"
+                        "selector": "melee-strike-damage"
                     },
                     {
                         "domain": "all",
@@ -366,11 +365,10 @@
                     {
                         "key": "Note",
                         "predicate": [
-                            "melee",
                             "target:condition:frightened",
                             "terrorizing-swing"
                         ],
-                        "selector": "strike-damage",
+                        "selector": "melee-strike-damage",
                         "text": "PF2E.NPCAbility.CyclopsBully.TerrorizingSwing",
                         "title": "{item|name}"
                     }

--- a/packs/strength-of-thousands-bestiary/book-3-hurricanes-howl/norgorberite-spy.json
+++ b/packs/strength-of-thousands-bestiary/book-3-hurricanes-howl/norgorberite-spy.json
@@ -621,7 +621,7 @@
                                 "or": [
                                     "finesse",
                                     "agile",
-                                    "ranged"
+                                    "item:ranged"
                                 ]
                             },
                             {


### PR DESCRIPTION
Adjust to move `melee` and `ranged` out of predicates and use melee- and ranged- selectors where possible Changes some `melee` and `ranged` predicates that can't be moved into `item:melee` and `item:ranged`.

Change value on Vicious Swing feat to use a ternary instead of brackets while editing the feat. Same change made to Power Attack ability on NPC Simeek.