### PR TITLE
Show spell traditions in description for unowned actors

### DIFF
--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -835,7 +835,7 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
 
     override async getDescription(): Promise<ItemDescriptionData> {
         const description = await super.getDescription();
-        const prepend = await createDescriptionPrepend(this, { includeTraditions: false });
+        const prepend = await createDescriptionPrepend(this, { includeTraditions: !this.actor });
         description.value = `${prepend}\n${description.value}`;
         return description;
     }


### PR DESCRIPTION
This probably broke when I was refactoring this to support other kinds of prepends/appends.