### PR TITLE
Add reminder notes to deafened, grabbed, restrained and sickened conditions

### DIFF
--- a/packs/conditions/deafened.json
+++ b/packs/conditions/deafened.json
@@ -27,7 +27,15 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "selector": "perception-initiative",
+                "predicate": [
+                    {
+                        "or": [
+                            "check:statistic:initiative",
+                            "item:trait:auditory"
+                        ]
+                    }
+                ],
+                "selector": "skill-check",
                 "slug": "deafened",
                 "type": "status",
                 "value": -2
@@ -35,6 +43,60 @@
             {
                 "key": "Immunity",
                 "type": "auditory"
+            },
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:trait:auditory"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.condition.deafened.note"
+                    }
+                ]
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:trait:auditory"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.condition.deafened.note"
+                    }
+                ]
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    {
+                        "not": "item:trait:subtle"
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.condition.deafened.note"
+                    }
+                ]
+            },
+            {
+                "adjustment": {
+                    "all": "to-critical-failure"
+                },
+                "key": "AdjustDegreeOfSuccess",
+                "predicate": [
+                    "item:trait:auditory"
+                ],
+                "selector": "perception"
             }
         ],
         "traits": {

--- a/packs/conditions/deafened.json
+++ b/packs/conditions/deafened.json
@@ -30,12 +30,25 @@
                 "predicate": [
                     {
                         "or": [
-                            "check:statistic:initiative",
-                            "item:trait:auditory"
+                            {
+                                "and": [
+                                    "check:type:skill",
+                                    "item:trait:auditory"
+                                ]
+                            },
+                            {
+                                "and": [
+                                    "check:statistic:base:perception",
+                                    "check:statistic:initiative"
+                                ]
+                            }
                         ]
                     }
                 ],
-                "selector": "skill-check",
+                "selector": [
+                    "perception",
+                    "skill-check"
+                ],
                 "slug": "deafened",
                 "type": "status",
                 "value": -2

--- a/packs/conditions/encumbered.json
+++ b/packs/conditions/encumbered.json
@@ -27,7 +27,7 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "selector": "speed",
+                "selector": "all-speeds",
                 "slug": "encumbered",
                 "value": -10
             },

--- a/packs/conditions/grabbed.json
+++ b/packs/conditions/grabbed.json
@@ -34,6 +34,48 @@
                 "inMemoryOnly": true,
                 "key": "GrantItem",
                 "uuid": "Compendium.pf2e.conditionitems.Item.Immobilized"
+            },
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:trait:manipulate"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.condition.grabbed.note"
+                    }
+                ]
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:trait:manipulate"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.condition.grabbed.note"
+                    }
+                ]
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:trait:manipulate"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.condition.grabbed.note"
+                    }
+                ]
             }
         ],
         "traits": {

--- a/packs/conditions/restrained.json
+++ b/packs/conditions/restrained.json
@@ -42,6 +42,65 @@
                 "inMemoryOnly": true,
                 "key": "GrantItem",
                 "uuid": "Compendium.pf2e.conditionitems.Item.Immobilized"
+            },
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:trait:manipulate"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.condition.restrained.note"
+                    }
+                ]
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:trait:manipulate"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.condition.restrained.note"
+                    }
+                ]
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:trait:manipulate"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.condition.restrained.note"
+                    }
+                ]
+            },
+            {
+                "key": "Note",
+                "predicate": [
+                    {
+                        "nor": [
+                            "action:escape",
+                            "action:force-open"
+                        ]
+                    }
+                ],
+                "selector": [
+                    "attack",
+                    "skill-check"
+                ],
+                "text": "PF2E.condition.restrained.note",
+                "title": "{item|name}"
             }
         ],
         "traits": {

--- a/packs/conditions/sickened.json
+++ b/packs/conditions/sickened.json
@@ -4,7 +4,7 @@
     "name": "Sickened",
     "system": {
         "description": {
-            "value": "<p>You feel ill. Sickened always includes a value. You take a status penalty equal to this value on all your checks and DCs. You can't willingly ingest anything—including elixirs and potions—while sickened.</p>\n<p>You can spend a single action retching in an attempt to recover, which lets you immediately attempt a Fortitude save against the DC of the effect that made you sickened. On a success, you reduce your sickened value by 1 (or by 2 on a critical success).</p>"
+            "value": "<p>You feel ill. Sickened always includes a value. You take a status penalty equal to this value on all your checks and DCs. You can't willingly ingest anything—including elixirs and potions—while sickened.</p>\n<p>You can spend a single action retching in an attempt to recover, which lets you immediately attempt a @Check[fortitude] save against the DC of the effect that made you sickened. On a success, you reduce your sickened value by 1 (or by 2 on a critical success).</p>"
         },
         "duration": {
             "expiry": null,
@@ -31,6 +31,27 @@
                 "slug": "sickened",
                 "type": "status",
                 "value": "-@item.badge.value"
+            },
+            {
+                "itemType": "consumable",
+                "key": "ItemAlteration",
+                "label": "PF2E.condition.sickened.name",
+                "mode": "add",
+                "predicate": [
+                    {
+                        "or": [
+                            "item:tag:alchemical-food",
+                            "item:trait:elixir",
+                            "item:trait:potion"
+                        ]
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.condition.sickened.note"
+                    }
+                ]
             }
         ],
         "traits": {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -6047,6 +6047,7 @@
             },
             "deafened": {
                 "name": "Deafened",
+                "note": "If you perform an action that has the auditory trait, you must succeed at a @Check[flat|dc:5|showDC:all] or the action is lost.",
                 "rules": "<p>You can't hear. You automatically critically fail Perception checks that require you to be able to hear. You take a -2 status penalty to Perception checks for initiative and checks that involve sound but also rely on other senses. If you perform an action with the auditory trait, you must succeed at a @Check[flat|dc:5] or the action is lost; attempt the check after spending the action but before any effects are applied. You are immune to auditory effects.</p>",
                 "summary": "You're unable to hear."
             },
@@ -6107,6 +6108,7 @@
             },
             "grabbed": {
                 "name": "Grabbed",
+                "note": "If you attempt a manipulate action while grabbed, you must succeed at a @Check[flat|dc:5|showDC:all] or it is lost.",
                 "rules": "<p>You're held in place by another creature, giving you the off-guard and immobilized conditions. If you attempt a manipulate action while grabbed, you must succeed at a @Check[flat|dc:5] or it is lost; roll the check after spending the action, but before any effects are applied.</p>",
                 "summary": "A creature, object, or magic holds you in place."
             },
@@ -6178,11 +6180,13 @@
             },
             "restrained": {
                 "name": "Restrained",
+                "note": "You can't use any attack or manipulate actions except to attempt to Escape or Force Open your bonds.",
                 "rules": "<p>You're tied up and can barely move, or a creature has you pinned. You have the off-guard and immobilized conditions, and you can't use any actions with the attack or manipulate traits except to attempt to Escape or Force Open your bonds. Restrained overrides grabbed.</p>",
                 "summary": "You're tied up and can't move, or a grappling creature has you pinned."
             },
             "sickened": {
                 "name": "Sickened",
+                "note": "You can't willingly ingest anything—including elixirs and potions—while sickened.",
                 "rules": "<p>You feel ill. Sickened always includes a value. You take a status penalty equal to this value on all your checks and DCs. You can't willingly ingest anything-including elixirs and potions-while sickened.</p>\n<p>You can spend a single action retching in an attempt to recover, which lets you immediately attempt a Fortitude save against the DC of the effect that made you sickened. On a success, you reduce your sickened value by 1 (or by 2 on a critical success).</p>",
                 "summary": "You're sick to your stomach."
             },

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -5871,7 +5871,6 @@
             },
             "SwallowWhole": {
                 "InvalidAttack": "A swallowed creature can attack the monster that has swallowed it, but only with unarmed attacks or with weapons of light Bulk or less.",
-                "Label": "Swallow Whole",
                 "RuptureDamage": "If the monster takes piercing or slashing damage equaling or exceeding the listed Rupture value from a single attack or spell, the swallowed creature cuts itself free."
             },
             "Swashbuckler": {


### PR DESCRIPTION
Few points of interest
- Deafened
  - `item:trait:auditory` doesn't necessarily represent all skill checks involving sound and involve other senses, but seems preferable to adding a toggle on the character sheet, and instead allowing it to be enabled in the roll dialog.
  - All spells are affected by deafened's description alteration. That is based on the rules stating "being unable to speak prevents spellcasting for most casters", and that "all speech has the auditory trait". I know this is a bit of a hot topic of discussion, so let me know if we'd rather not have the note in that case.
- Sickened
  - Added a DC-less fortitude save to its description.
  - Included alchemical foods as items that are affected by its Item Alteration aside from potions and elixirs. Hopefully it's a reasonable enough assumption, but it can be removed if needed.

Merging this will also
- Correct selector on encumbered speed penalty.
- Remove an unused localization key that was added recently.