### PR TITLE
Remove prepared data inadvertently added to strikes

### DIFF
--- a/packs/pathfinder-monster-core/adamantine-dragon-adult-spellcaster.json
+++ b/packs/pathfinder-monster-core/adamantine-dragon-adult-spellcaster.json
@@ -1675,7 +1675,6 @@
                 "slug": null,
                 "traits": {
                     "value": [
-                        "adamantine",
                         "magical",
                         "reach-15",
                         "unarmed"
@@ -1722,7 +1721,6 @@
                 "slug": null,
                 "traits": {
                     "value": [
-                        "adamantine",
                         "agile",
                         "magical",
                         "reach-10",

--- a/packs/pathfinder-monster-core/adamantine-dragon-adult.json
+++ b/packs/pathfinder-monster-core/adamantine-dragon-adult.json
@@ -37,7 +37,6 @@
                 "slug": null,
                 "traits": {
                     "value": [
-                        "adamantine",
                         "magical",
                         "reach-15",
                         "unarmed"
@@ -84,7 +83,6 @@
                 "slug": null,
                 "traits": {
                     "value": [
-                        "adamantine",
                         "agile",
                         "magical",
                         "reach-10",

--- a/packs/pathfinder-monster-core/adamantine-dragon-ancient-spellcaster.json
+++ b/packs/pathfinder-monster-core/adamantine-dragon-ancient-spellcaster.json
@@ -2268,7 +2268,6 @@
                 "slug": null,
                 "traits": {
                     "value": [
-                        "adamantine",
                         "magical",
                         "reach-20",
                         "unarmed"
@@ -2315,7 +2314,6 @@
                 "slug": null,
                 "traits": {
                     "value": [
-                        "adamantine",
                         "agile",
                         "magical",
                         "reach-15",

--- a/packs/pathfinder-monster-core/adamantine-dragon-ancient.json
+++ b/packs/pathfinder-monster-core/adamantine-dragon-ancient.json
@@ -37,7 +37,6 @@
                 "slug": null,
                 "traits": {
                     "value": [
-                        "adamantine",
                         "magical",
                         "reach-20",
                         "unarmed"
@@ -84,7 +83,6 @@
                 "slug": null,
                 "traits": {
                     "value": [
-                        "adamantine",
                         "agile",
                         "magical",
                         "reach-15",

--- a/packs/pathfinder-monster-core/adamantine-dragon-young-spellcaster.json
+++ b/packs/pathfinder-monster-core/adamantine-dragon-young-spellcaster.json
@@ -1244,7 +1244,6 @@
                 "slug": null,
                 "traits": {
                     "value": [
-                        "adamantine",
                         "magical",
                         "reach-10",
                         "unarmed"
@@ -1291,7 +1290,6 @@
                 "slug": null,
                 "traits": {
                     "value": [
-                        "adamantine",
                         "agile",
                         "magical",
                         "unarmed"

--- a/packs/pathfinder-monster-core/adamantine-dragon-young.json
+++ b/packs/pathfinder-monster-core/adamantine-dragon-young.json
@@ -37,7 +37,6 @@
                 "slug": null,
                 "traits": {
                     "value": [
-                        "adamantine",
                         "magical",
                         "reach-10",
                         "unarmed"
@@ -84,7 +83,6 @@
                 "slug": null,
                 "traits": {
                     "value": [
-                        "adamantine",
                         "agile",
                         "magical",
                         "unarmed"


### PR DESCRIPTION
I went through the first PR and these were the only ones who got hit by the script