### PR TITLE
Correct Sivanah's primary domain selection

### DIFF
--- a/packs/deities/other-gods/sivanah.json
+++ b/packs/deities/other-gods/sivanah.json
@@ -17,7 +17,7 @@
                 "glyph"
             ],
             "primary": [
-                "disorientation",
+                "delirium",
                 "magic",
                 "secrecy",
                 "trickery"


### PR DESCRIPTION
I reverted this to `delirium`, but this needs a migration.

Closes #18697