### PR TITLE
Allow inline roll overrideTraits to be a list of traits itself

### DIFF
--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -549,10 +549,15 @@ class TextEditorPF2e extends TextEditor {
               ? "all"
               : "gm";
 
+        // Determine traits. If overrideTraits is given and looks like a list of traits, we use that as a trait list
         const basic = "basic" in rawParams;
         const overrideTraits = "overrideTraits" in rawParams;
         const rawTraits = splitListString(rawParams.traits ?? "");
+        if (rawParams.overrideTraits && rawParams.overrideTraits?.trim()?.toLowerCase() !== "true") {
+            rawTraits.push(...splitListString(rawParams.overrideTraits));
+        }
         const traits = R.unique(overrideTraits ? rawTraits : [rawTraits, item?.system.traits.value ?? []].flat());
+
         const rollerRole = tupleHasValue(["origin", "target"], rawParams.rollerRole)
             ? rawParams.rollerRole
             : tupleHasValue(SAVE_TYPES, type)


### PR DESCRIPTION
This should preserve backwards compatibility. `@Check[deception|traits:fire|overrideTraits]` and `@Check[deception|traits:fire|overrideTraits:true]` should be equivalent to `@Check[deception|overrideTraits:fire]`.

We can either go this route, or attempt to transition/migrate to overriding by default and using `@Check[deception|addTraits:fire]` to add new ones instead. Regardless of what we do, we should make https://github.com/foundryvtt/pf2e/pull/18422 behave accordingly.