### PR TITLE
Exclude eidolons from ABC Picker

### DIFF
--- a/src/module/actor/character/apps/abc-picker/app.ts
+++ b/src/module/actor/character/apps/abc-picker/app.ts
@@ -78,7 +78,7 @@ class ABCPicker extends SvelteApplicationMixin<
             .filter((item): item is ABCItemPF2e<null> | HeritagePF2e<null> | DeityPF2e<null> => {
                 if (item.type !== itemType || item.parent) return false;
                 if (item.pack?.startsWith("pf2e-animal-companions.")) return false;
-                if (item.traits.has("eidolon")) return false;
+                if (item.system.traits.value?.includes("eidolon")) return false;
                 if (item.isOfType("heritage")) {
                     const ancestrySlug = actor.ancestry ? (actor.ancestry.slug ?? sluggify(actor.ancestry.name)) : null;
                     return item.system.ancestry?.slug === ancestrySlug || item.system.ancestry === null;

--- a/src/module/actor/character/apps/abc-picker/app.ts
+++ b/src/module/actor/character/apps/abc-picker/app.ts
@@ -78,6 +78,7 @@ class ABCPicker extends SvelteApplicationMixin<
             .filter((item): item is ABCItemPF2e<null> | HeritagePF2e<null> | DeityPF2e<null> => {
                 if (item.type !== itemType || item.parent) return false;
                 if (item.pack?.startsWith("pf2e-animal-companions.")) return false;
+                if (item.traits.has("eidolon")) return false;
                 if (item.isOfType("heritage")) {
                     const ancestrySlug = actor.ancestry ? (actor.ancestry.slug ?? sluggify(actor.ancestry.name)) : null;
                     return item.system.ancestry?.slug === ancestrySlug || item.system.ancestry === null;


### PR DESCRIPTION
The `pf2e-animal-companions` clause is insufficient when it comes to any other 3rd party eidolons. This should hopefully take care of it.