### PR TITLE
Change Dragon Instinct pre-remaster dragons to arcane tradition

### DIFF
--- a/packs/classfeatures/dragon-instinct.json
+++ b/packs/classfeatures/dragon-instinct.json
@@ -176,7 +176,7 @@
                         "value": {
                             "damageType": "acid",
                             "dragonType": "black",
-                            "tradition": "chromatic"
+                            "tradition": "arcane"
                         }
                     },
                     {
@@ -184,7 +184,7 @@
                         "value": {
                             "damageType": "electricity",
                             "dragonType": "blue",
-                            "tradition": "chromatic"
+                            "tradition": "arcane"
                         }
                     },
                     {
@@ -192,7 +192,7 @@
                         "value": {
                             "damageType": "fire",
                             "dragonType": "brass",
-                            "tradition": "metallic"
+                            "tradition": "arcane"
                         }
                     },
                     {
@@ -200,7 +200,7 @@
                         "value": {
                             "damageType": "electricity",
                             "dragonType": "bronze",
-                            "tradition": "metallic"
+                            "tradition": "arcane"
                         }
                     },
                     {
@@ -208,7 +208,7 @@
                         "value": {
                             "damageType": "acid",
                             "dragonType": "copper",
-                            "tradition": "metallic"
+                            "tradition": "arcane"
                         }
                     },
                     {
@@ -216,7 +216,7 @@
                         "value": {
                             "damageType": "fire",
                             "dragonType": "gold",
-                            "tradition": "metallic"
+                            "tradition": "arcane"
                         }
                     },
                     {
@@ -224,7 +224,7 @@
                         "value": {
                             "damageType": "poison",
                             "dragonType": "green",
-                            "tradition": "chromatic"
+                            "tradition": "arcane"
                         }
                     },
                     {
@@ -232,7 +232,7 @@
                         "value": {
                             "damageType": "cold",
                             "dragonType": "silver",
-                            "tradition": "metallic"
+                            "tradition": "arcane"
                         }
                     },
                     {
@@ -240,7 +240,7 @@
                         "value": {
                             "damageType": "fire",
                             "dragonType": "red",
-                            "tradition": "chromatic"
+                            "tradition": "arcane"
                         }
                     },
                     {
@@ -248,7 +248,7 @@
                         "value": {
                             "damageType": "cold",
                             "dragonType": "white",
-                            "tradition": "chromatic"
+                            "tradition": "arcane"
                         }
                     }
                 ],


### PR DESCRIPTION
Currently the ItemAlteration RE breaks due to chromatic/metallic not being real traits.

Alternatively if this interpretation is not something the system wants to use, we should change the table to say N/A instead of Arcane. 