### PR TITLE
Add missing bow group note for Grievous rune

### DIFF
--- a/src/module/item/physical/runes.ts
+++ b/src/module/item/physical/runes.ts
@@ -1787,6 +1787,12 @@ const WEAPON_PROPERTY_RUNES: { [T in WeaponPropertyRuneType]: WeaponPropertyRune
                 },
                 {
                     outcome: ["criticalSuccess"],
+                    predicate: ["item:group:bow"],
+                    title: "PF2E.WeaponPropertyRune.grievous.Name",
+                    text: "PF2E.WeaponPropertyRune.grievous.Note.Bow",
+                },
+                {
+                    outcome: ["criticalSuccess"],
                     predicate: [{ or: ["item:group:brawling", "item:group:firearm"] }],
                     title: "PF2E.WeaponPropertyRune.grievous.Name",
                     text: "PF2E.WeaponPropertyRune.grievous.Note.Brawling",


### PR DESCRIPTION
The localization key already existed, the note just wasn't added yet