### PR TITLE
Add description addenda for Irongut Goblin and Virtuous Tanuki when sickened

### DIFF
--- a/packs/conditions/sickened.json
+++ b/packs/conditions/sickened.json
@@ -42,6 +42,7 @@
                         "or": [
                             "item:tag:alchemical-food",
                             "item:trait:elixir",
+                            "item:trait:ingested",
                             "item:trait:potion"
                         ]
                     }

--- a/packs/heritages/goblin/irongut-goblin.json
+++ b/packs/heritages/goblin/irongut-goblin.json
@@ -19,15 +19,15 @@
         },
         "rules": [
             {
-                "key": "RollOption",
-                "label": "PF2E.SpecificRule.Goblin.IrongutGoblin.BonusToggle",
-                "option": "irongut-goblin-ingested",
-                "toggleable": true
-            },
-            {
                 "key": "FlatModifier",
                 "predicate": [
-                    "irongut-goblin-ingested"
+                    "item:trait:ingested",
+                    {
+                        "or": [
+                            "inflicts:sickened",
+                            "item:type:affliction"
+                        ]
+                    }
                 ],
                 "selector": "saving-throw",
                 "slug": "irongut-save-bonus",
@@ -40,7 +40,13 @@
                 },
                 "key": "AdjustDegreeOfSuccess",
                 "predicate": [
-                    "irongut-goblin-ingested"
+                    "item:trait:ingested",
+                    {
+                        "or": [
+                            "inflicts:sickened",
+                            "item:type:affliction"
+                        ]
+                    }
                 ],
                 "selector": "saving-throw"
             },

--- a/packs/heritages/goblin/irongut-goblin.json
+++ b/packs/heritages/goblin/irongut-goblin.json
@@ -19,16 +19,15 @@
         },
         "rules": [
             {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Goblin.IrongutGoblin.BonusToggle",
+                "option": "irongut-goblin-ingested",
+                "toggleable": true
+            },
+            {
                 "key": "FlatModifier",
-                "label": "Irongut Goblin (vs. afflictions & sickened)",
                 "predicate": [
-                    "ingested",
-                    {
-                        "or": [
-                            "affliction",
-                            "inflicts:sickened"
-                        ]
-                    }
+                    "irongut-goblin-ingested"
                 ],
                 "selector": "saving-throw",
                 "slug": "irongut-save-bonus",
@@ -36,19 +35,37 @@
                 "value": 2
             },
             {
-                "key": "Note",
+                "adjustment": {
+                    "success": "to-critical-success"
+                },
+                "key": "AdjustDegreeOfSuccess",
                 "predicate": [
-                    "ingested",
+                    "irongut-goblin-ingested"
+                ],
+                "selector": "saving-throw"
+            },
+            {
+                "itemType": "consumable",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "self:condition:sickened",
                     {
                         "or": [
-                            "affliction",
-                            "sickened"
+                            "item:tag:alchemical-food",
+                            "item:trait:elixir",
+                            "item:trait:ingested",
+                            "item:trait:potion"
                         ]
                     }
                 ],
-                "selector": "fortitude",
-                "text": "If you roll a success on a save against an ingested affliction or to avoid gaining the sickened condition, treat it as a critical success",
-                "title": "{item|name}"
+                "priority": 121,
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Conditions.Sickened.AllowEatOrDrink"
+                    }
+                ]
             }
         ],
         "traits": {

--- a/packs/heritages/tanuki/virtuous-tanuki.json
+++ b/packs/heritages/tanuki/virtuous-tanuki.json
@@ -22,6 +22,29 @@
                 "key": "Resistance",
                 "type": "poison",
                 "value": "max(1,floor(@actor.level/2))"
+            },
+            {
+                "itemType": "consumable",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "self:condition:sickened",
+                    {
+                        "or": [
+                            "item:tag:alchemical-food",
+                            "item:trait:elixir",
+                            "item:trait:ingested",
+                            "item:trait:potion"
+                        ]
+                    }
+                ],
+                "priority": 121,
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Conditions.Sickened.AllowEatOrDrink"
+                    }
+                ]
             }
         ],
         "traits": {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -4045,9 +4045,6 @@
                 "ExtraSquishy": {
                     "Note": "If you roll a success to Squeeze, you get a critical success instead."
                 },
-                "IrongutGoblin": {
-                    "BonusToggle": "Irongut Goblin — Saving against ingested affliction or sickened"
-                },
                 "RecklessAbandon": {
                     "Note": "If you roll a failure or critical failure on a saving throw against a harmful effect, you get a success instead."
                 },

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -3001,6 +3001,7 @@
             },
             "Conditions": {
                 "Sickened": {
+                    "AllowEatOrDrink": "You can eat and drink things when you're sickened.",
                     "Reduce": {
                         "criticalSuccess": "When you critically succeed at a Fortitude save to reduce your @UUID[Compendium.pf2e.conditionitems.Item.fesd1n5eVhpCSS18]{Sickened} value, you reduce it by 3.",
                         "success": "When you succeed at a Fortitude save to reduce your @UUID[Compendium.pf2e.conditionitems.Item.fesd1n5eVhpCSS18]{Sickened} value, you reduce it by 2."
@@ -4043,6 +4044,9 @@
                 },
                 "ExtraSquishy": {
                     "Note": "If you roll a success to Squeeze, you get a critical success instead."
+                },
+                "IrongutGoblin": {
+                    "BonusToggle": "Irongut Goblin — Saving against ingested affliction or sickened"
                 },
                 "RecklessAbandon": {
                     "Note": "If you roll a failure or critical failure on a saving throw against a harmful effect, you get a success instead."


### PR DESCRIPTION
Merging this will also
- Account for consumables with the ingested traits in sickened's Item Alteration (most of these are poisons, but a few are drugs with beneficial benefits that a character could conceivably be for a character's own use)