### PR TITLE
Add description addendum to Flash of Grandeur with the effects of Revealing Light

### DIFF
--- a/packs/actions/flash-of-grandeur.json
+++ b/packs/actions/flash-of-grandeur.json
@@ -11,14 +11,27 @@
         },
         "category": "defensive",
         "description": {
-            "value": "<p><strong>Trigger</strong> An enemy damages your ally, and both are in your champion's aura</p><hr /><p><strong>Effect</strong> Imperious divine light flashes out from you to surround your foe. The ally gains resistance to all damage against the triggering damage equal to 2 + your level. For 1 round, the attacker is affected by @UUID[Compendium.pf2e.spells-srd.Item.Revealing Light].</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Champion's Resistance]</p><hr /><p><em>Note:</em> A creature affected by <em>revealing light</em> is @UUID[Compendium.pf2e.conditionitems.Item.Dazzled]. If the creature was @UUID[Compendium.pf2e.conditionitems.Item.Invisible], it becomes @UUID[Compendium.pf2e.conditionitems.Item.Concealed] instead. If the creature was already concealed for any other reason, it is no longer concealed.</p>"
+            "value": "<p><strong>Trigger</strong> An enemy damages your ally, and both are in your champion's aura</p><hr /><p><strong>Effect</strong> Imperious divine light flashes out from you to surround your foe. The ally gains resistance to all damage against the triggering damage equal to 2 + your level. For 1 round, the attacker is affected by @UUID[Compendium.pf2e.spells-srd.Item.Revealing Light].</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Champion's Resistance]</p>"
         },
         "publication": {
             "license": "ORC",
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemId": "{item|id}",
+                "key": "ItemAlteration",
+                "label": "PF2E.SpecificRule.RevealingLight.Label",
+                "mode": "add",
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.RevealingLight.Description"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "value": [
                 "champion",

--- a/packs/actions/flash-of-grandeur.json
+++ b/packs/actions/flash-of-grandeur.json
@@ -11,7 +11,7 @@
         },
         "category": "defensive",
         "description": {
-            "value": "<p><strong>Trigger</strong> An enemy damages your ally, and both are in your champion's aura</p><hr /><p><strong>Effect</strong> Imperious divine light flashes out from you to surround your foe. The ally gains resistance to all damage against the triggering damage equal to 2 + your level. For 1 round, the attacker is affected by @UUID[Compendium.pf2e.spells-srd.Item.Revealing Light].</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Champion's Resistance]</p>"
+            "value": "<p><strong>Trigger</strong> An enemy damages your ally, and both are in your champion's aura</p><hr /><p><strong>Effect</strong> Imperious divine light flashes out from you to surround your foe. The ally gains resistance to all damage against the triggering damage equal to 2 + your level. For 1 round, the attacker is affected by @UUID[Compendium.pf2e.spells-srd.Item.Revealing Light].</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Champion's Resistance]</p><hr /><p><em>Note:</em> A creature affected by <em>revealing light</em> is @UUID[Compendium.pf2e.conditionitems.Item.Dazzled]. If the creature was @UUID[Compendium.pf2e.conditionitems.Item.Invisible], it becomes @UUID[Compendium.pf2e.conditionitems.Item.Concealed] instead. If the creature was already concealed for any other reason, it is no longer concealed.</p>"
         },
         "publication": {
             "license": "ORC",

--- a/packs/classfeatures/exalted-reaction.json
+++ b/packs/classfeatures/exalted-reaction.json
@@ -35,7 +35,6 @@
                 "property": "description",
                 "value": [
                     {
-                        "divider": true,
                         "text": "PF2E.SpecificRule.Champion.ExaltedReaction.Desecration"
                     }
                 ]
@@ -50,7 +49,6 @@
                 "property": "description",
                 "value": [
                     {
-                        "divider": true,
                         "text": "PF2E.SpecificRule.Champion.ExaltedReaction.Iniquity"
                     },
                     {
@@ -72,7 +70,6 @@
                 "property": "description",
                 "value": [
                     {
-                        "divider": true,
                         "text": "PF2E.SpecificRule.Champion.ExaltedReaction.Grandeur"
                     },
                     {
@@ -94,7 +91,6 @@
                 "property": "description",
                 "value": [
                     {
-                        "divider": true,
                         "text": "PF2E.SpecificRule.Champion.ExaltedReaction.Justice"
                     },
                     {
@@ -116,7 +112,6 @@
                 "property": "description",
                 "value": [
                     {
-                        "divider": true,
                         "text": "PF2E.SpecificRule.Champion.ExaltedReaction.Liberation"
                     },
                     {
@@ -138,7 +133,6 @@
                 "property": "description",
                 "value": [
                     {
-                        "divider": true,
                         "text": "PF2E.SpecificRule.Champion.ExaltedReaction.Obedience"
                     },
                     {
@@ -160,7 +154,6 @@
                 "property": "description",
                 "value": [
                     {
-                        "divider": true,
                         "text": "PF2E.SpecificRule.Champion.ExaltedReaction.Redemption"
                     },
                     {

--- a/packs/feats/class/champion/brilliant-flash.json
+++ b/packs/feats/class/champion/brilliant-flash.json
@@ -29,7 +29,22 @@
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:flash-of-grandeur"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "{item|description}"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2633,7 +2633,7 @@
                 },
                 "ExaltedReaction": {
                     "Desecration": "Each enemy in your champion's aura takes a –1 status penalty to attack rolls against you until the start of your next turn. @UUID[Compendium.pf2e.feat-effects.Item.Ef63SlxSKlZmHosM]{Effect: Exalted Reaction (Desecrator)}",
-                    "Grandeur": "In addition to the enemy affected by Flash of Grandeur, each other enemy in your champion's aura is affected by the revealing light spell for 1 round.",
+                    "Grandeur": "In addition to the enemy affected by Flash of Grandeur, each other enemy in your champion's aura is affected by the _revealing light_ spell for 1 round.",
                     "Iniquity": "Each enemy in your champion's aura other than the triggering creature takes half the damage you deal to the triggering enemy.",
                     "Justice": "Each ally in your champion's aura with the target in their melee reach can spend a reaction to Strike the target with a –5 penalty.",
                     "Liberation": "In addition to the ally affected by Liberating Step, you and all other allies in your champion's aura can Step as a free action. You and your allies gain the benefit even if the ally who benefited from Liberating Step can't move",
@@ -2673,7 +2673,7 @@
                     "Description": "You can use a ranged weapon to make a ranged Strike instead of a melee Strike for Retributive Strike. The enemy needs to be in range, but not in reach, and it must still be in your champion's aura. You can also make melee Strikes against enemies a bit farther away. If the enemy that triggered your reaction is outside your reach but is within 5 feet of your reach, as part of your reaction you can Step to put the enemy in your reach before making a melee Retributive Strike."
                 },
                 "RelentlessReaction": {
-                    "Grandeur": "The enemy also takes @Damage[(@actor.abilities.cha.mod)[persistent,spirit]|traits:holy] damage, and it can't recover from this persistent damage while affected by the revealing light from your Flash of Grandeur.",
+                    "Grandeur": "The enemy also takes @Damage[(@actor.abilities.cha.mod)[persistent,spirit]|traits:holy] damage, and it can't recover from this persistent damage while affected by the _revealing light_ from your Flash of Grandeur.",
                     "Iniquity": "An enemy damaged by the initial reaction's damage also takes @Damage[(@actor.abilities.cha.mod)[persistent,spirit]|traits:unholy] damage.",
                     "Liberation": "You punish those who ensnare your allies. If the triggering enemy was using any effects to make your ally grabbed, restrained, immobilized, or paralyzed when you used Liberating Step, that enemy takes @Damage[(@actor.abilities.cha.mod)[persistent,spirit]] damage",
                     "LiberationHoly": "You punish those who ensnare your allies. If the triggering enemy was using any effects to make your ally grabbed, restrained, immobilized, or paralyzed when you used Liberating Step, that enemy takes @Damage[(@actor.abilities.cha.mod)[persistent,spirit]|traits:holy] damage",
@@ -5174,6 +5174,10 @@
                     "Description": "You cast @UUID[Compendium.pf2e.spells-srd.Item.zfn5RqAdF63neqpP]{Control Water} as a 5th-rank innate divine spell. The area of water you control increases by 10 feet in length and width for every 2 levels you have beyond 10th level.",
                     "Title": "Reflection of Water"
                 }
+            },
+            "RevealingLight": {
+                "Description": "A creature affected by _revealing light_ is @UUID[Compendium.pf2e.conditionitems.Item.TkIyaNPgTZFBCCuh]{Dazzled}. If the creature was @UUID[Compendium.pf2e.conditionitems.Item.zJxUflt9np0q4yML]{Invisible}, it becomes @UUID[Compendium.pf2e.conditionitems.Item.DmAIPqOBomZ7H95W]{Concealed} instead. If the creature was already concealed for any other reason, it is no longer concealed.",
+                "Label": "Revealing Light"
             },
             "RivethunInvoker": {
                 "InvokeOffense": {


### PR DESCRIPTION
Merging this will also
- Remove dividers from Exalted Reaction addenda (it was inconsistent with other addenda, and I think saving space is useful for such an addendum heavy action)
- Emphasize some spell mentions of revealing light
- Add description alteration for Brilliant Flash