### PR TITLE
Correct size of Arrester Squadron and Watchmage Squadron to gargantuan

### DIFF
--- a/packs/pathfinder-npc-core/official/arrester-squadron.json
+++ b/packs/pathfinder-npc-core/official/arrester-squadron.json
@@ -319,7 +319,7 @@
         "traits": {
             "rarity": "common",
             "size": {
-                "value": "med"
+                "value": "grg"
             },
             "value": [
                 "human",

--- a/packs/pathfinder-npc-core/official/watchmage-squadron.json
+++ b/packs/pathfinder-npc-core/official/watchmage-squadron.json
@@ -1184,7 +1184,7 @@
         "traits": {
             "rarity": "common",
             "size": {
-                "value": "med"
+                "value": "grg"
             },
             "value": [
                 "human",


### PR DESCRIPTION
There are two other troops from FotRP Book 1 that are also medium size, but those are "technically correct"