### PR TITLE
Support description item alteration addendums in expandable self effect actions

### DIFF
--- a/src/module/chat-message/listeners/cards.ts
+++ b/src/module/chat-message/listeners/cards.ts
@@ -177,12 +177,9 @@ class ChatCards {
                     return;
                 }
                 case "expand-description": {
-                    const { description } = item;
                     const element = htmlClosest(button, ".description");
                     if (element) {
-                        element.innerHTML = await TextEditor.enrichHTML(description, {
-                            rollData: item.getRollData(),
-                        });
+                        element.innerHTML = (await item.getDescription()).value;
                         element.scrollIntoView({ behavior: "smooth", block: "center" });
                     }
                     break;

--- a/src/module/item/base/sheet/sheet.ts
+++ b/src/module/item/base/sheet/sheet.ts
@@ -98,15 +98,11 @@ class ItemSheetPF2e<TItem extends ItemPF2e> extends ItemSheet<TItem, ItemSheetOp
 
         // Enrich content
         const enrichedContent: Record<string, string> = {};
-        const rollData = { ...this.item.getRollData(), ...this.actor?.getRollData() };
 
         // Get the source description in case this is an unidentified physical item
-        const description = await item.getDescription();
-        enrichedContent.description = await TextEditor.enrichHTML(description.value, {
-            rollData,
-            secrets: item.isOwner,
-        });
-        enrichedContent.gmNotes = await TextEditor.enrichHTML(description.gm.trim(), { rollData });
+        const description = await item.getDescription({ includeAddendum: false, secrets: item.isOwner });
+        enrichedContent.description = description.value;
+        enrichedContent.gmNotes = description.gm;
 
         const validTraits = this.validTraits;
         const hasRarity = !item.isOfType("action", "condition", "deity", "effect", "lore", "melee");

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -833,8 +833,8 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
         return ChatMessagePF2e.create(messageSource, { renderSheet: false });
     }
 
-    override async getDescription(): Promise<ItemDescriptionData> {
-        const description = await super.getDescription();
+    override async getDescriptionData(): Promise<ItemDescriptionData> {
+        const description = await super.getDescriptionData();
         const prepend = await createDescriptionPrepend(this, { includeTraditions: !this.actor });
         description.value = `${prepend}\n${description.value}`;
         return description;

--- a/src/styles/legacy/_chat.scss
+++ b/src/styles/legacy/_chat.scss
@@ -81,19 +81,6 @@
         }
     }
 
-    .addendum {
-        @include frame-elegant;
-        background: rgba($alt-dark, 0.1);
-        border-radius: 2px;
-        color: var(--color-pf-alternate-darker);
-        padding: var(--space-4);
-
-        h4 {
-            margin: 0 0 var(--space-4) 0;
-            text-align: center;
-        }
-    }
-
     .card-buttons {
         display: flex;
         flex-basis: 100%;

--- a/src/styles/ui/sidebar/chat/_index.scss
+++ b/src/styles/ui/sidebar/chat/_index.scss
@@ -100,6 +100,20 @@
     > .message-content {
         @import "conditions";
 
+        .addendum {
+            @include frame-elegant;
+            background: rgba($alt-dark, 0.1);
+            border-radius: 2px;
+            color: var(--color-pf-alternate-darker);
+            padding: var(--space-4);
+
+            h4 {
+                font-weight: 600;
+                margin: 0 0 var(--space-4) 0;
+                text-align: center;
+            }
+        }
+
         .dice-roll {
             .dice-result > [data-visibility="gm"] {
                 background: var(--visibility-gm-bg);


### PR DESCRIPTION
In the process of removing our dependency of the description getter, I saw a use case where we might want the full description.

![image](https://github.com/user-attachments/assets/9b7e164a-0fe4-4656-9c57-0c592177f8aa)