### PR TITLE
Set message sender name and portrait cursor type on chat messages to pointer

### DIFF
--- a/src/styles/ui/sidebar/chat/_index.scss
+++ b/src/styles/ui/sidebar/chat/_index.scss
@@ -19,6 +19,7 @@
         .portrait {
             grid-area: img;
             padding: 0.125rem 0.125rem 0.125rem 0;
+            cursor: pointer;
             img {
                 border: none;
                 height: 2.25rem;
@@ -44,6 +45,7 @@
             margin-top: auto;
             overflow: hidden;
             text-overflow: ellipsis;
+            cursor: pointer;
         }
 
         .user {


### PR DESCRIPTION
Since they both have a click listener to control/pan to the token, their cursor type should both be pointer.