### PR TITLE
Add missing predicate to initiate benefit Grant Item in Thaumaturge implements

### DIFF
--- a/packs/classfeatures/bell.json
+++ b/packs/classfeatures/bell.json
@@ -41,6 +41,9 @@
             },
             {
                 "key": "GrantItem",
+                "predicate": [
+                    "class:thaumaturge"
+                ],
                 "uuid": "Compendium.pf2e.classfeatures.Item.Initiate Benefit (Bell)"
             },
             {

--- a/packs/classfeatures/lantern.json
+++ b/packs/classfeatures/lantern.json
@@ -41,6 +41,9 @@
             },
             {
                 "key": "GrantItem",
+                "predicate": [
+                    "class:thaumaturge"
+                ],
                 "uuid": "Compendium.pf2e.classfeatures.Item.Initiate Benefit (Lantern)"
             },
             {

--- a/packs/classfeatures/mirror.json
+++ b/packs/classfeatures/mirror.json
@@ -41,6 +41,9 @@
             },
             {
                 "key": "GrantItem",
+                "predicate": [
+                    "class:thaumaturge"
+                ],
                 "uuid": "Compendium.pf2e.classfeatures.Item.Initiate Benefit (Mirror)"
             },
             {

--- a/packs/classfeatures/regalia.json
+++ b/packs/classfeatures/regalia.json
@@ -41,6 +41,9 @@
             },
             {
                 "key": "GrantItem",
+                "predicate": [
+                    "class:thaumaturge"
+                ],
                 "uuid": "Compendium.pf2e.classfeatures.Item.Initiate Benefit (Regalia)"
             },
             {

--- a/packs/classfeatures/wand.json
+++ b/packs/classfeatures/wand.json
@@ -41,6 +41,9 @@
             },
             {
                 "key": "GrantItem",
+                "predicate": [
+                    "class:thaumaturge"
+                ],
                 "uuid": "Compendium.pf2e.classfeatures.Item.Initiate Benefit (Wand)"
             },
             {

--- a/packs/classfeatures/weapon.json
+++ b/packs/classfeatures/weapon.json
@@ -102,6 +102,9 @@
             },
             {
                 "key": "GrantItem",
+                "predicate": [
+                    "class:thaumaturge"
+                ],
                 "uuid": "Compendium.pf2e.classfeatures.Item.Initiate Benefit (Weapon)"
             },
             {


### PR DESCRIPTION
The Implement Initiate feat takes care of granting the benefit to archetype thaums