### PR TITLE
Extend Unstable note to actions that have the `unstable` trait and add notes RE to Inventor dedication

### DIFF
--- a/packs/classfeatures/explode.json
+++ b/packs/classfeatures/explode.json
@@ -46,6 +46,24 @@
                         "text": "PF2E.SpecificRule.Inventor.Unstable.Note"
                     }
                 ]
+            },
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "label": "PF2E.TraitUnstable",
+                "mode": "add",
+                "predicate": [
+                    "item:trait:unstable",
+                    {
+                        "not": "self:effect:unstable-check-failure"
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Inventor.Unstable.Note"
+                    }
+                ]
             }
         ],
         "traits": {

--- a/packs/feats/archetype/inventor/inventor-dedication.json
+++ b/packs/feats/archetype/inventor/inventor-dedication.json
@@ -91,6 +91,42 @@
                 ],
                 "text": "PF2E.SpecificRule.Inventor.Unstable.FlatCheck.CriticalFailure",
                 "title": "PF2E.Check.Result.Degree.Check.criticalFailure"
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "label": "PF2E.TraitUnstable",
+                "mode": "add",
+                "predicate": [
+                    "item:trait:unstable",
+                    {
+                        "not": "self:effect:unstable-check-failure"
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Inventor.Unstable.Note"
+                    }
+                ]
+            },
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "label": "PF2E.TraitUnstable",
+                "mode": "add",
+                "predicate": [
+                    "item:trait:unstable",
+                    {
+                        "not": "self:effect:unstable-check-failure"
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Inventor.Unstable.Note"
+                    }
+                ]
             }
         ],
         "subfeatures": {


### PR DESCRIPTION
Closes #18772
