### PR TITLE
Remove Cooperative Soul's prerequisite per Player Core update

### DIFF
--- a/packs/feats/ancestry/human/cooperative-soul.json
+++ b/packs/feats/ancestry/human/cooperative-soul.json
@@ -18,11 +18,7 @@
             "value": 9
         },
         "prerequisites": {
-            "value": [
-                {
-                    "value": "Cooperative Nature"
-                }
-            ]
+            "value": []
         },
         "publication": {
             "license": "ORC",


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/e10438f0-f72b-40c5-951d-3aa3ca28fb18)

Also checked the errata page - nothing.

Closes #18783