### PR TITLE
Refactor spell unprepare to be done by preparing a null spell

### DIFF
--- a/src/module/actor/creature/sheet.ts
+++ b/src/module/actor/creature/sheet.ts
@@ -197,7 +197,7 @@ abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends ActorSheet
             const slotIndex = Number(row?.dataset.slotId) || 0;
             const entryId = row?.dataset.entryId;
             const collection = actor.spellcasting.collections.get(entryId, { strict: true });
-            return collection.unprepareSpell(groupId, slotIndex);
+            return collection.prepareSpell(null, groupId, slotIndex);
         };
 
         // Set expended state of a spell slot

--- a/src/module/item/spellcasting-entry/document.ts
+++ b/src/module/item/spellcasting-entry/document.ts
@@ -356,15 +356,18 @@ class SpellcastingEntryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null>
     }
 
     /** Saves the prepared spell slot data to the spellcasting entry  */
-    async prepareSpell(spell: SpellPF2e, groupId: SpellSlotGroupId, spellSlot: number): Promise<Maybe<this>> {
+    async prepareSpell(spell: SpellPF2e | null, groupId: SpellSlotGroupId, spellSlot: number): Promise<Maybe<this>> {
         const result = this.spells?.prepareSpell(spell, groupId, spellSlot);
         return result ? this : null;
     }
 
-    /** Removes the spell slot and updates the spellcasting entry */
+    /** @deprecated Removes the spell slot and updates the spellcasting entry */
     async unprepareSpell(groupId: SpellSlotGroupId, slotId: number): Promise<Maybe<this>> {
-        const result = this.spells?.unprepareSpell(groupId, slotId);
-        return result ? this : null;
+        foundry.utils.logCompatibilityWarning(
+            "SpellcastingEntryPF2e#unprepareSpell() is deprecated. Use SpellcastingEntryPF2e#prepareSpell() with a null spell instead.",
+            { since: "6.11.2", until: "7.0.0" },
+        );
+        return this.prepareSpell(null, groupId, slotId);
     }
 
     /** Sets the expended state of a spell slot and updates the spellcasting entry */


### PR DESCRIPTION
I asked idle and these functions aren't used in his module. I suspect the next release will be a patch release since no major changes are occurring nor are in the docket.