### PR TITLE
Remove `attack` trait from Elemental Counter cantrip

### DIFF
--- a/packs/spells/cantrip/elemental-counter.json
+++ b/packs/spells/cantrip/elemental-counter.json
@@ -44,7 +44,6 @@
                 "primal"
             ],
             "value": [
-                "attack",
                 "cantrip",
                 "concentrate"
             ]


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f04d3b3c-46f5-479b-87d4-6169d731c4c3)
