### PR TITLE
Correct `Effect: Renewed Vigor` choice set prompt

### DIFF
--- a/packs/feat-effects/effect-renewed-vigor.json
+++ b/packs/feat-effects/effect-renewed-vigor.json
@@ -29,7 +29,7 @@
                         "value": 1
                     },
                     {
-                        "label": "No",
+                        "label": "PF2E.UI.RuleElements.ChoiceSet.NoLabel",
                         "value": 2
                     }
                 ],

--- a/packs/feat-effects/effect-renewed-vigor.json
+++ b/packs/feat-effects/effect-renewed-vigor.json
@@ -25,17 +25,17 @@
                 "adjustName": false,
                 "choices": [
                     {
-                        "label": "PF2E.Check.Result.Degree.Attack.success",
-                        "value": 2
+                        "label": "Yes",
+                        "value": 1
                     },
                     {
-                        "label": "PF2E.Check.Result.Degree.Attack.criticalSuccess",
-                        "value": 1
+                        "label": "No",
+                        "value": 2
                     }
                 ],
                 "flag": "outcome",
                 "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.Prompt.DegreeOfSuccess"
+                "prompt": "PF2E.SpecificRule.Barbarian.RenewedVigor.Prompt"
             },
             {
                 "key": "TempHP",

--- a/packs/feat-effects/effect-renewed-vigor.json
+++ b/packs/feat-effects/effect-renewed-vigor.json
@@ -25,7 +25,7 @@
                 "adjustName": false,
                 "choices": [
                     {
-                        "label": "Yes",
+                        "label": "PF2E.UI.RuleElements.ChoiceSet.YesLabel",
                         "value": 1
                     },
                     {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -2365,6 +2365,9 @@
                 "Ligneous": {
                     "ToggleLabel": "Wooden Rage"
                 },
+                "RenewedVigor": {
+                    "Prompt": "Did you make an attack action this turn?"
+                },
                 "Spirit": {
                     "NegativeDamage": "Void Damage",
                     "PositiveDamage": "Vitality Damage",


### PR DESCRIPTION
> Through the haze of battle, you quickly recover your raging vigor. You gain temporary Hit Points equal to half your level plus your Constitution modifier. If you made an attack action this turn, increase the number of temporary Hit Points to your level plus your Constitution modifier. These temporary Hit Points last until the end of your rage.