### PR TITLE
Support multiple token marks instead of overriding them

### DIFF
--- a/src/module/actor/roll-context/base.ts
+++ b/src/module/actor/roll-context/base.ts
@@ -235,13 +235,13 @@ abstract class RollContext<
             const targetActor = unresolved.target?.actor;
             const targetUuid = unresolved.target?.token?.uuid;
 
-            const originMark = originUuid ? targetActor?.synthetics.tokenMarks.get(originUuid) : null;
-            const targetMark = targetUuid ? originActor?.synthetics.tokenMarks.get(targetUuid) : null;
+            const originMark = originUuid ? (targetActor?.synthetics.tokenMarks.get(originUuid) ?? []) : [];
+            const targetMark = targetUuid ? (originActor?.synthetics.tokenMarks.get(targetUuid) ?? []) : [];
 
             return [
-                originMark ? `origin:mark:${originMark}` : null,
-                targetMark ? `target:mark:${targetMark}` : null,
-            ].filter(R.isTruthy);
+                ...originMark.map((mark) => `origin:mark:${mark}`),
+                ...targetMark.map((mark) => `target:mark:${mark}`),
+            ];
         })();
 
         // Get ephemeral effects from the target that affect this actor while attacking

--- a/src/module/rules/rule-element/token-mark/rule-element.ts
+++ b/src/module/rules/rule-element/token-mark/rule-element.ts
@@ -44,7 +44,10 @@ class TokenMarkRuleElement extends RuleElementPF2e<TokenMarkSchema> {
 
     override beforePrepareData(): void {
         if (UUIDUtils.isTokenUUID(this.uuid) && this.test()) {
-            this.actor.synthetics.tokenMarks.set(this.uuid, this.slug);
+            const tokenMarks = this.actor.synthetics.tokenMarks;
+            const slugs = tokenMarks.get(this.uuid) ?? [];
+            slugs.push(this.slug);
+            tokenMarks.set(this.uuid, slugs);
         }
     }
 

--- a/src/module/rules/synthetics.ts
+++ b/src/module/rules/synthetics.ts
@@ -57,7 +57,7 @@ interface RuleElementSynthetics<TActor extends ActorPF2e = ActorPF2e> {
     striking: Record<string, StrikingSynthetic[]>;
     toggles: Record<string, Record<string, RollOptionToggle>>;
     tokenEffectIcons: ActiveEffectPF2e<TActor>[];
-    tokenMarks: Map<TokenDocumentUUID, string>;
+    tokenMarks: Map<TokenDocumentUUID, string[]>;
     tokenOverrides: DeepPartial<Pick<TokenSource, "light" | "name">> & {
         alpha?: number | null;
         texture?:


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/18807. While the original issue is a feature request, token marks disabling the automation of other token marks smells more like a bug.