### PR TITLE
Remove `free hand` trait from Grasp of Droskar weapon

### DIFF
--- a/packs/equipment/grasp-of-droskar.json
+++ b/packs/equipment/grasp-of-droskar.json
@@ -83,7 +83,6 @@
             "value": [
                 "agile",
                 "cursed",
-                "free-hand",
                 "invested",
                 "magical"
             ]


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/527fac67-260b-4be5-9f5e-1eab756c8c8b)

Closes #18832