### PR TITLE
Avoid persisting automated weapon property runes when closing the item sheet

### DIFF
--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -32,10 +32,6 @@ $degree-success: rgb(0, 0, 255);
 $degree-failure: rgb(255, 69, 0);
 $degree-failure-critical: rgb(255, 0, 0);
 
-/* Value adjustments (e.g. weak/elite) */
-$adjusted-higher: #009988;
-$adjusted-lower: #cc3311;
-
 /* ----------------------------------------- */
 /* CSS Custom Properties                     */
 /* ----------------------------------------- */
@@ -122,6 +118,10 @@ $adjusted-lower: #cc3311;
     --color-proficiency-expert: #3c005e;
     --color-proficiency-master: #664400;
     --color-proficiency-legendary: #{$primary-color};
+
+    /* Value adjustments (e.g. weak/elite) */
+    --color-pf-text-adjusted-higher: #009988;
+    --color-pf-text-adjusted-lower: #cc3311;
 
     /* Damage colors */
     .damage {

--- a/src/styles/actor/_index.scss
+++ b/src/styles/actor/_index.scss
@@ -429,7 +429,7 @@
 
         input.adjusted:not(:focus) {
             font-weight: 700;
-            color: $adjusted-higher;
+            color: var(--color-pf-text-adjusted-higher);
         }
 
         button.tag:disabled {

--- a/src/styles/actor/army/_index.scss
+++ b/src/styles/actor/army/_index.scss
@@ -26,11 +26,11 @@
 
     input {
         &.adjusted-higher {
-            color: $adjusted-higher;
+            color: var(--color-pf-text-adjusted-higher);
         }
 
         &.adjusted-lower {
-            color: $adjusted-lower;
+            color: var(--color-pf-text-adjusted-lower);
         }
     }
 

--- a/src/styles/actor/npc/_index.scss
+++ b/src/styles/actor/npc/_index.scss
@@ -114,11 +114,11 @@
         text-align: right;
 
         &.adjusted-higher {
-            color: $adjusted-higher;
+            color: var(--color-pf-text-adjusted-higher);
         }
 
         &.adjusted-lower {
-            color: $adjusted-lower;
+            color: var(--color-pf-text-adjusted-lower);
         }
     }
 

--- a/src/styles/actor/party/kingdom/_index.scss
+++ b/src/styles/actor/party/kingdom/_index.scss
@@ -247,11 +247,11 @@
     }
 
     input.adjusted-higher {
-        color: $adjusted-higher;
+        color: var(--color-pf-text-adjusted-higher);
     }
 
     input.adjusted-lower {
-        color: $adjusted-lower;
+        color: var(--color-pf-text-adjusted-lower);
     }
 
     .content {

--- a/src/styles/actor/vehicle/_index.scss
+++ b/src/styles/actor/vehicle/_index.scss
@@ -173,11 +173,11 @@ header.char-header {
 input.adjustable:not(:focus),
 span.adjustable {
     &.adjusted-higher {
-        color: $adjusted-higher;
+        color: var(--color-pf-text-adjusted-higher);
     }
 
     &.adjusted-lower {
-        color: $adjusted-lower;
+        color: var(--color-pf-text-adjusted-lower);
     }
 }
 

--- a/src/styles/item/_index.scss
+++ b/src/styles/item/_index.scss
@@ -386,19 +386,6 @@
                 flex: 0 1 auto;
             }
 
-            input,
-            select {
-                &.adjusted-higher:not(:focus) {
-                    color: $adjusted-higher;
-                    font-weight: 700;
-                }
-
-                &.adjusted-lower:not(:focus) {
-                    color: $adjusted-lower;
-                    font-weight: 700;
-                }
-            }
-
             select.readonly {
                 opacity: 0.7;
                 pointer-events: none;
@@ -501,10 +488,29 @@
             }
         }
 
-        input {
-            &.adjusted:not(:focus) {
+        input:not(:focus),
+        select {
+            &.adjusted-higher,
+            &.adjusted {
+                color: var(--color-pf-text-adjusted-higher);
+            }
+
+            &.adjusted-lower {
+                color: var(--color-pf-text-adjusted-lower);
+            }
+
+            &.adjusted-higher,
+            &.adjusted-lower,
+            &.adjusted {
                 font-weight: 700;
-                color: $adjusted-higher;
+
+                option:not(:checked) {
+                    color: var(--input-text-color);
+                }
+
+                option:checked {
+                    font-weight: 700;
+                }
             }
         }
 

--- a/static/templates/items/weapon-details.hbs
+++ b/static/templates/items/weapon-details.hbs
@@ -96,7 +96,7 @@
                     name="system.runes.property.{{index}}"
                     id="{{../fieldIdPrefix}}runes-property-{{index}}"
                     {{disabled slot.disabled}}
-                    {{#if @root.item.isSpecific}}class="readonly"{{/if}}
+                    class="{{#if @root.item.isSpecific}}readonly{{/if}}{{#if slot.adjusted}} adjusted{{/if}}"
                 >
                     {{selectOptions
                         @root.runeTypes.property


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/18587

I also did some UI/UX stuff to make the adjusted colors behave more predictably with select, and made it themeable.

![image](https://github.com/user-attachments/assets/28a34baa-c715-4662-b192-6f54e59b7821)

There is only one bug remaining: if you set it to empty input, the sheet will not re-render since there were no changes. This bug is a general problem with all of our handlebars sheets though, so I'm not really planning on fixing it here.