### PR TITLE
Custom Inline Check/Action Titles

### DIFF
--- a/src/module/actor/actions/single-check.ts
+++ b/src/module/actor/actions/single-check.ts
@@ -140,10 +140,11 @@ class SingleCheckActionVariant extends BaseActionVariant {
             .map((note) => new RollNotePF2e(note));
         const rollOptions = this.rollOptions.concat(options.rollOptions ?? []);
         const slug = options.statistic?.trim() || (Array.isArray(this.statistic) ? this.statistic[0] : this.statistic);
-        const title = options.title ?? 
-        (
-            this.name ? `${game.i18n.localize(this.#action.name)} - ${game.i18n.localize(this.name)}` : game.i18n.localize(this.#action.name)
-        );
+        const title =
+            options.title ??
+            (this.name
+                ? `${game.i18n.localize(this.#action.name)} - ${game.i18n.localize(this.name)}`
+                : game.i18n.localize(this.#action.name));
         const difficultyClass = Number.isNumeric(options.difficultyClass)
             ? { value: Number(options.difficultyClass) }
             : isValidDifficultyClass(options.difficultyClass)

--- a/src/module/actor/actions/single-check.ts
+++ b/src/module/actor/actions/single-check.ts
@@ -140,9 +140,10 @@ class SingleCheckActionVariant extends BaseActionVariant {
             .map((note) => new RollNotePF2e(note));
         const rollOptions = this.rollOptions.concat(options.rollOptions ?? []);
         const slug = options.statistic?.trim() || (Array.isArray(this.statistic) ? this.statistic[0] : this.statistic);
-        const title = this.name
-            ? `${game.i18n.localize(this.#action.name)} - ${game.i18n.localize(this.name)}`
-            : game.i18n.localize(this.#action.name);
+        const title = options.title ?? 
+        (
+            this.name ? `${game.i18n.localize(this.#action.name)} - ${game.i18n.localize(this.name)}` : game.i18n.localize(this.#action.name)
+        );
         const difficultyClass = Number.isNumeric(options.difficultyClass)
             ? { value: Number(options.difficultyClass) }
             : isValidDifficultyClass(options.difficultyClass)
@@ -153,6 +154,7 @@ class SingleCheckActionVariant extends BaseActionVariant {
         await ActionMacroHelpers.simpleRollActionCheck({
             actors: options.actors,
             title,
+            simpleTitle: options.simpleTitle,
             actionGlyph: getActionGlyph(this.cost ?? null) as ActionGlyph,
             callback: (result) => results.push(result),
             checkContext: (opts) => this.checkContext(opts, { modifiers, rollOptions, slug }),

--- a/src/module/actor/actions/types.ts
+++ b/src/module/actor/actions/types.ts
@@ -36,6 +36,8 @@ interface ActionVariant {
 
 interface ActionUseOptions extends ActionVariantUseOptions {
     variant: string;
+    title?: string;
+    simpleTitle?: boolean;
 }
 
 interface Action {

--- a/src/module/system/action-macros/helpers.ts
+++ b/src/module/system/action-macros/helpers.ts
@@ -181,6 +181,7 @@ class ActionMacroHelpers {
                     glyph: options.actionGlyph,
                     subtitle,
                     title: options.title,
+                    simpleTitle: options.simpleTitle,
                 });
 
                 const actionTraits = (options.traits ?? []).filter(

--- a/src/module/system/action-macros/types.ts
+++ b/src/module/system/action-macros/types.ts
@@ -60,6 +60,7 @@ interface SimpleRollActionCheckOptions<TItem extends ItemPF2e<ActorPF2e>> {
     actors: ActorPF2e | ActorPF2e[] | undefined;
     actionGlyph: ActionGlyph | undefined;
     title: string;
+    simpleTitle?: boolean;
     checkContext: (
         context: CheckContextOptions<TItem>,
     ) => Promise<CheckMacroContext<TItem>> | CheckMacroContext<TItem> | undefined;

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -643,6 +643,7 @@ class TextEditorPF2e extends TextEditor {
         icon.classList.add("icon");
 
         const name = game.i18n.localize(params.name ?? item?.name ?? params.type);
+        const title = params.title ? game.i18n.localize(params.title) : undefined;
         const localize = localizer("PF2E.InlineCheck");
 
         // Get the label
@@ -677,6 +678,7 @@ class TextEditorPF2e extends TextEditor {
                 pf2RepostFlavor: name,
                 pf2ShowDc: params.showDC === "all" ? null : params.showDC,
                 pf2Label: localize("DCWithName", { name }),
+                pf2ActionLabel: title,
                 pf2Adjustment: Number(params.adjustment) || null,
                 pf2Roller: params.roller || null,
                 targetOwner: params.targetOwner,
@@ -1067,6 +1069,7 @@ interface CheckLinkParams {
     overrideTraits: boolean;
     extraRollOptions: string[];
     name?: string;
+    title?: string;
     showDC: UserVisibility;
     /** Refrain from adding domains to the check. */
     immutable: boolean;

--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -131,7 +131,7 @@ export class InlineRollLinks {
     }
 
     static async #onClickInlineCheck(event: MouseEvent, link: HTMLAnchorElement | HTMLSpanElement): Promise<void> {
-        const { pf2Check, pf2Dc, pf2Traits, pf2Label, pf2Adjustment, pf2Roller, pf2RollOptions } = link.dataset;
+        const { pf2Check, pf2Dc, pf2Traits, pf2Label, pf2ActionLabel, pf2Adjustment, pf2Roller, pf2RollOptions } = link.dataset;
         const against = link.dataset.against || link.dataset.pf2Defense; // pf2Defense is only checked for backwards compat
         const overrideTraits = "overrideTraits" in link.dataset;
         const targetOwner = "targetOwner" in link.dataset;
@@ -286,6 +286,7 @@ export class InlineRollLinks {
                 target: dc?.statistic ? targetActor : null,
                 item,
                 traits: abilityTraits,
+                title: pf2ActionLabel,
             };
 
             // Use a special header for checks against defenses

--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -95,9 +95,20 @@ export class InlineRollLinks {
     }
 
     static #onClickInlineAction(event: MouseEvent, link: HTMLAnchorElement | HTMLSpanElement): void {
-        const { pf2Action, pf2Glyph, pf2Variant, pf2Dc, pf2ShowDc, pf2Skill, pf2Options, pf2Traits, pf2Title, pf2SimpleTitle } = link.dataset;
+        const {
+            pf2Action,
+            pf2Glyph,
+            pf2Variant,
+            pf2Dc,
+            pf2ShowDc,
+            pf2Skill,
+            pf2Options,
+            pf2Traits,
+            pf2Title,
+            pf2SimpleTitle,
+        } = link.dataset;
 
-        const title = pf2Title?.replaceAll('-', ' ') ?? undefined;
+        const title = pf2Title?.replaceAll("-", " ") ?? undefined;
         const slug = sluggify(pf2Action ?? "");
         const visibility = pf2ShowDc ?? "all";
         const difficultyClass = Number.isNumeric(pf2Dc)
@@ -111,7 +122,16 @@ export class InlineRollLinks {
         if (slug && game.pf2e.actions.has(slug)) {
             game.pf2e.actions
                 .get(slug)
-                ?.use({ event, variant: pf2Variant, title, simpleTitle: Boolean(pf2SimpleTitle), difficultyClass, rollOptions, statistic: pf2Skill, traits })
+                ?.use({
+                    event,
+                    variant: pf2Variant,
+                    title,
+                    simpleTitle: Boolean(pf2SimpleTitle),
+                    difficultyClass,
+                    rollOptions,
+                    statistic: pf2Skill,
+                    traits,
+                })
                 .catch((reason: string) => ui.notifications.warn(reason));
         } else {
             const action = game.pf2e.actions[pf2Action ? sluggify(pf2Action, { camel: "dromedary" }) : ""];
@@ -125,7 +145,7 @@ export class InlineRollLinks {
                     skill: pf2Skill,
                     traits,
                     title,
-                    simpleTitle: Boolean(pf2SimpleTitle)
+                    simpleTitle: Boolean(pf2SimpleTitle),
                 });
             } else {
                 console.warn(`PF2e System | Skip executing unknown action '${pf2Action}'`);
@@ -134,7 +154,8 @@ export class InlineRollLinks {
     }
 
     static async #onClickInlineCheck(event: MouseEvent, link: HTMLAnchorElement | HTMLSpanElement): Promise<void> {
-        const { pf2Check, pf2Dc, pf2Traits, pf2Label, pf2ActionLabel, pf2Adjustment, pf2Roller, pf2RollOptions } = link.dataset;
+        const { pf2Check, pf2Dc, pf2Traits, pf2Label, pf2ActionLabel, pf2Adjustment, pf2Roller, pf2RollOptions } =
+            link.dataset;
         const against = link.dataset.against || link.dataset.pf2Defense; // pf2Defense is only checked for backwards compat
         const overrideTraits = "overrideTraits" in link.dataset;
         const targetOwner = "targetOwner" in link.dataset;

--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -97,6 +97,7 @@ export class InlineRollLinks {
     static #onClickInlineAction(event: MouseEvent, link: HTMLAnchorElement | HTMLSpanElement): void {
         const { pf2Action, pf2Glyph, pf2Variant, pf2Dc, pf2ShowDc, pf2Skill, pf2Options, pf2Traits, pf2Title, pf2SimpleTitle } = link.dataset;
 
+        const title = pf2Title?.replaceAll('-', ' ') ?? undefined;
         const slug = sluggify(pf2Action ?? "");
         const visibility = pf2ShowDc ?? "all";
         const difficultyClass = Number.isNumeric(pf2Dc)
@@ -110,7 +111,7 @@ export class InlineRollLinks {
         if (slug && game.pf2e.actions.has(slug)) {
             game.pf2e.actions
                 .get(slug)
-                ?.use({ event, variant: pf2Variant, title: pf2Title, simpleTitle: Boolean(pf2SimpleTitle), difficultyClass, rollOptions, statistic: pf2Skill, traits })
+                ?.use({ event, variant: pf2Variant, title, simpleTitle: Boolean(pf2SimpleTitle), difficultyClass, rollOptions, statistic: pf2Skill, traits })
                 .catch((reason: string) => ui.notifications.warn(reason));
         } else {
             const action = game.pf2e.actions[pf2Action ? sluggify(pf2Action, { camel: "dromedary" }) : ""];
@@ -123,7 +124,7 @@ export class InlineRollLinks {
                     rollOptions,
                     skill: pf2Skill,
                     traits,
-                    title: pf2Title,
+                    title,
                     simpleTitle: Boolean(pf2SimpleTitle)
                 });
             } else {

--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -95,7 +95,7 @@ export class InlineRollLinks {
     }
 
     static #onClickInlineAction(event: MouseEvent, link: HTMLAnchorElement | HTMLSpanElement): void {
-        const { pf2Action, pf2Glyph, pf2Variant, pf2Dc, pf2ShowDc, pf2Skill, pf2Options, pf2Traits } = link.dataset;
+        const { pf2Action, pf2Glyph, pf2Variant, pf2Dc, pf2ShowDc, pf2Skill, pf2Options, pf2Traits, pf2Title, pf2SimpleTitle } = link.dataset;
 
         const slug = sluggify(pf2Action ?? "");
         const visibility = pf2ShowDc ?? "all";
@@ -110,7 +110,7 @@ export class InlineRollLinks {
         if (slug && game.pf2e.actions.has(slug)) {
             game.pf2e.actions
                 .get(slug)
-                ?.use({ event, variant: pf2Variant, difficultyClass, rollOptions, statistic: pf2Skill, traits })
+                ?.use({ event, variant: pf2Variant, title: pf2Title, simpleTitle: Boolean(pf2SimpleTitle), difficultyClass, rollOptions, statistic: pf2Skill, traits })
                 .catch((reason: string) => ui.notifications.warn(reason));
         } else {
             const action = game.pf2e.actions[pf2Action ? sluggify(pf2Action, { camel: "dromedary" }) : ""];
@@ -123,6 +123,8 @@ export class InlineRollLinks {
                     rollOptions,
                     skill: pf2Skill,
                     traits,
+                    title: pf2Title,
+                    simpleTitle: Boolean(pf2SimpleTitle)
                 });
             } else {
                 console.warn(`PF2e System | Skip executing unknown action '${pf2Action}'`);

--- a/static/templates/chat/action/header.hbs
+++ b/static/templates/chat/action/header.hbs
@@ -1,9 +1,13 @@
 <h4 class="action">
-    <strong>{{localize title}}</strong>
-    {{#if glyph}}<span class="action-glyph">{{glyph}}</span>{{/if}}
-    {{#if subtitle}}
-        <span class="subtitle degree-of-success">
-            (<span{{#if outcome}} class="{{outcome}}"{{/if}}>{{localize subtitle}}</span>)
-        </span>
+    {{#if simpleTitle}}
+        <strong>{{localize title}}</strong>
+    {{else}}
+        <strong>{{localize title}}</strong>
+        {{#if glyph}}<span class="action-glyph">{{glyph}}</span>{{/if}}
+        {{#if subtitle}}
+            <span class="subtitle degree-of-success">
+                (<span{{#if outcome}} class="{{outcome}}"{{/if}}>{{localize subtitle}}</span>)
+            </span>
+        {{/if}}
     {{/if}}
 </h4>


### PR DESCRIPTION
Heya, I wanted to add a little bit of extra customization to inline Checks and Actions, specifically in altering the Action title.

--------
What I've done for inline checks is to parse and use this type of signature: 
`@Check[type:athletics|dc:10|title:Infiltration: Armwrestling]`
![image](https://github.com/user-attachments/assets/9e8dfefc-a4a3-448e-b1f9-247d88a224a2)
It completly overwrites the standard Action title.

--------
For inline actions I parsed and utilized these two signatures:
`[[/act administer-first-aid variant=stabilize dc=10 title=Soothe]]`
![image](https://github.com/user-attachments/assets/48780084-d8c4-4756-a9f0-e46dc125f8ab)

`[[/act administer-first-aid variant=stabilize dc=10 title=Soothe simpleTitle]]`
![image](https://github.com/user-attachments/assets/2ba9e422-0086-416f-9476-b2e2778531bd)

I added the simpleTitle boolean because I felt it might be annoying to try to reconstruct the action glyphs and skill check naming if a user wanted to keep that.