### PR TITLE
Update Effects Panel to AppV2 and fix inline rolls styling

### DIFF
--- a/src/scripts/hooks/canvas-ready.ts
+++ b/src/scripts/hooks/canvas-ready.ts
@@ -15,7 +15,7 @@ export const CanvasReady = {
 
         Hooks.on("canvasReady", () => {
             // Effect Panel singleton application
-            game.pf2e.effectPanel.render(true);
+            game.pf2e.effectPanel.render({ force: true });
             if (!canvas.scene) return;
 
             if (game.ready) canvas.scene.reset();

--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -37,7 +37,8 @@ $degree-failure-critical: rgb(255, 0, 0);
 /* ----------------------------------------- */
 
 body,
-.app {
+.app,
+.themed.theme-light {
     /* Global */
     --color-pf-primary: #{$primary-color};
     --color-pf-primary-dark: #{color.adjust($primary-color, $lightness: -5%)};
@@ -69,8 +70,6 @@ body,
     --color-disabled: var(--color-text-dark-4);
 
     // Inline links and user visibility
-    --inline-link-bg: #ddd;
-    --inline-repost-bg: #{color.adjust(#ddd, $lightness: 5%)};
     --visibility-gm-bg: #e8e8ef;
     --visibility-owner-bg: #ddebe1;
     --blind-roll: #f5eaf5;
@@ -377,6 +376,7 @@ body,
     }
 }
 
-.theme-dark .application {
+body.theme-dark .application,
+.themed.theme-dark {
     --visibility-gm-bg: var(--color-cool-4);
 }

--- a/src/styles/_globals.scss
+++ b/src/styles/_globals.scss
@@ -161,17 +161,17 @@ table.pf2-table {
 }
 
 @mixin inline-link {
-    background: var(--inline-link-bg);
+    background: var(--content-link-background);
     border-radius: 2px;
-    border: 1px solid var(--color-border-dark-tertiary);
+    border: 1px solid var(--content-link-border-color);
     box-sizing: border-box;
-    color: var(--color-text-dark-primary);
+    color: var(--content-link-text-color);
     padding: 0 var(--space-4);
     white-space: nowrap;
     word-break: break-all;
 
     > i.icon {
-        color: var(--color-text-dark-inactive);
+        color: var(var(--color-text-dark-inactive));
         margin-right: var(--space-4);
     }
 }
@@ -338,17 +338,15 @@ span[data-pf2-effect-area] {
 
 i[data-pf2-repost] {
     @include quick-transition;
-    background: var(--inline-repost-bg);
-    color: var(--color-text-dark-inactive);
-    border-left: 1px solid var(--color-border-dark-tertiary);
-    background: #fff9;
+    color: var(--color-text-subtle);
+    border-left: 1px solid var(--content-link-border-color);
     padding: var(--space-2);
     margin-left: var(--space-2);
     text-shadow: none;
 
     &:hover {
-        color: var(--text-light);
-        text-shadow: 0 0 2px var(--text-dark);
+        color: var(--color-text-selection);
+        text-shadow: 0 0 2px var(--color-text-emphatic);
     }
 }
 
@@ -445,6 +443,11 @@ aside.locked-tooltip.pf2e {
     font-size: var(--font-size-14);
     padding: var(--space-4) 0;
     text-align: left;
+
+    &.themed {
+        background: var(--background);
+        color: var(--color-text-primary);
+    }
 
     h1,
     h2,

--- a/src/styles/system/_effects-panel.scss
+++ b/src/styles/system/_effects-panel.scss
@@ -3,32 +3,34 @@
 }
 
 #effects-panel {
-    pointer-events: initial;
     position: absolute;
     top: 1rem;
     right: 0;
-    display: flex;
-    height: fit-content;
-    max-height: calc(100% - 150px);
 
-    .effects-list {
-        overflow: auto;
-        scrollbar-gutter: stable;
-        direction: rtl;
-    }
+    direction: rtl;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    height: fit-content;
+    max-height: calc(100% - 165px);
+    overflow: auto;
+    pointer-events: initial;
+    padding-left: 2px;
+    scrollbar-gutter: stable;
 
     .effect-item {
         display: flex;
         justify-content: end;
-        height: 52px;
+        border-radius: 4px;
 
         &[data-badge-type="formula"] .icon {
             cursor: pointer;
 
+            /* Show fa-dice-d20 */
             &:hover::before {
                 content: "\f6cf";
                 background: rgba(0, 0, 0, 0.5);
-                font-family: "Font Awesome 5 Free";
+                font-family: var(--font-awesome);
                 font-weight: 900;
                 font-size: var(--font-size-26);
                 color: var(--text-light);
@@ -43,21 +45,19 @@
         }
 
         > .icon {
-            @include frame-silver;
             align-items: center;
             background-repeat: no-repeat;
             background-size: contain;
-            box-shadow:
-                0 0 0 1px #c0c0c0,
-                0 0 0 2px #808080,
-                inset 0 0 4px rgba(0, 0, 0, 0.5);
+            box-shadow: inset 0 0 4px rgba(0, 0, 0, 0.5);
+            border: 1px solid var(--color-cool-4);
+            border-radius: 4px;
             color: transparent;
             display: flex;
             justify-content: center;
             position: relative;
-            margin: 2px;
-            height: 48px;
-            width: 48px;
+            height: 46px;
+            width: 46px;
+            overflow: hidden;
 
             &.aura {
                 border-radius: 50%;
@@ -71,7 +71,7 @@
             .expired {
                 position: absolute;
                 left: 0;
-                bottom: -1px;
+                bottom: 0;
                 width: 100%;
                 padding: 2px 1px;
                 @include micro;
@@ -82,8 +82,8 @@
             .linked {
                 position: absolute;
                 display: inline-block;
-                bottom: -1px;
-                right: -1px;
+                bottom: 0;
+                right: 0;
                 padding: 0px 2px;
                 color: var(--text-light);
                 background-color: rgba(0, 0, 0, 0.75);
@@ -91,8 +91,8 @@
 
             .value-wrapper {
                 position: absolute;
-                bottom: -1px;
-                left: -1px;
+                bottom: 0;
+                left: 0;
                 max-width: calc(100% + 2px);
                 padding: 0px 2px;
 
@@ -122,8 +122,6 @@
 }
 
 aside.effect-info {
-    background-color: rgba(0, 0, 0, 0.75);
-    color: var(--color-text-light-2);
     gap: 3px;
     height: min-content;
     margin-right: 0.5em;
@@ -140,10 +138,11 @@ aside.effect-info {
     }
 
     h1 {
-        @include p-reset;
         border: none;
         display: flex;
-        font-size: var(--font-size-14);
+        font: var(--font-size-14) var(--font-primary);
+        margin: 0;
+        padding: 0;
         padding-top: 0.25em;
         text-align: right;
 
@@ -187,16 +186,10 @@ aside.effect-info {
     }
 
     .description {
-        background: rgba(black, 0.7);
         max-height: 22em;
         overflow-y: auto;
         padding: 0 0.5em;
         text-align: left;
-
-        a,
-        span[data-pf2-effect-area] {
-            color: var(--color-text-dark-primary);
-        }
 
         hr {
             border: none;

--- a/static/templates/system/effects/panel.hbs
+++ b/static/templates/system/effects/panel.hbs
@@ -1,21 +1,19 @@
-<article id="effects-panel">
-    <div class="effects-list">
-        {{#each afflictions as |affliction|}}
-            {{> effect this=affliction}}
-        {{/each}}
+<article>
+    {{#each afflictions as |affliction|}}
+        {{> effect this=affliction}}
+    {{/each}}
 
-        {{#if (and afflictions.length conditions.length)}}<hr />{{/if}}
+    {{#if (and afflictions.length conditions.length)}}<hr />{{/if}}
 
-        {{#each conditions as |condition|}}
-            {{> effect this=condition}}
-        {{/each}}
+    {{#each conditions as |condition|}}
+        {{> effect this=condition}}
+    {{/each}}
 
-        {{#if (and conditions.length effects.length)}}<hr />{{/if}}
+    {{#if (and conditions.length effects.length)}}<hr />{{/if}}
 
-        {{#each effects as |effect|}}
-            {{> effect this=effect}}
-        {{/each}}
-    </div>
+    {{#each effects as |effect|}}
+        {{> effect this=effect}}
+    {{/each}}
 </article>
 
 {{#*inline "effect"}}


### PR DESCRIPTION
Since Foundry V13 reduces borders by quite a bit, the current effects panel stands out. I changed it and themed the tooltips. Addendums have not been handled since item alterations are currently non-functional.

![image](https://github.com/user-attachments/assets/6073cf66-d5aa-4620-a8bb-e595fd0e8b2e)

Also supports light mode interface

![image](https://github.com/user-attachments/assets/75b1cb58-7cf2-4c29-9016-d174124492e6)
