### PR TITLE
Add effect for Blessed Coins

### DIFF
--- a/packs/campaign-effects/season-of-ghosts/effect-blessed-coins.json
+++ b/packs/campaign-effects/season-of-ghosts/effect-blessed-coins.json
@@ -1,0 +1,75 @@
+{
+    "_id": "A1VCJqeusccB7OOH",
+    "folder": "nYejRh5pL5dk5R7M",
+    "img": "icons/commodities/currency/coins-engraved-copper.webp",
+    "name": "Effect: Blessed Coins",
+    "system": {
+        "description": {
+            "value": "<p>You are granted a +1 item bonus to skill checks you attempt with the deities' divine skills.</p>"
+        },
+        "duration": {
+            "expiry": null,
+            "sustained": false,
+            "unit": "unlimited",
+            "value": -1
+        },
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder #196: The Summer That Never Was"
+        },
+        "rules": [
+            {
+                "adjustName": false,
+                "choices": {
+                    "config": "skills"
+                },
+                "flag": "skillOne",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.Skill"
+            },
+            {
+                "adjustName": false,
+                "choices": {
+                    "config": "skills"
+                },
+                "flag": "skillTwo",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.Skill"
+            },
+            {
+                "adjustName": false,
+                "choices": {
+                    "config": "skills"
+                },
+                "flag": "skillThree",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.Skill"
+            },
+            {
+                "key": "FlatModifier",
+                "selector": [
+                    "{item|flags.pf2e.rulesSelections.skillOne}",
+                    "{item|flags.pf2e.rulesSelections.skillTwo}",
+                    "{item|flags.pf2e.rulesSelections.skillThree}"
+                ],
+                "type": "item",
+                "value": 1
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/campaign-effects/season-of-ghosts/effect-spirit-power-passion.json
+++ b/packs/campaign-effects/season-of-ghosts/effect-spirit-power-passion.json
@@ -5,7 +5,7 @@
     "name": "Effect: Spirit Power (Passion)",
     "system": {
         "description": {
-            "value": "<p>your body is engulfed in fire of a color of your choice that sheds bright light in a 40-foot radius (and dim light to the next 40 feet). Your melee Strikes inflict an additional 1d6 points of fire damage, you gain resistance 10 to fire, and you gain the @UUID[Compendium.pf2e.adventure-specific-actions.Item.Reactive Scorch] reaction.</p>"
+            "value": "<p>Your body is engulfed in fire of a color of your choice that sheds bright light in a 40-foot radius (and dim light to the next 40 feet). Your melee Strikes inflict an additional 1d6 points of fire damage, you gain resistance 10 to fire, and you gain the @UUID[Compendium.pf2e.adventure-specific-actions.Item.Reactive Scorch] reaction.</p>"
         },
         "duration": {
             "expiry": "turn-start",


### PR DESCRIPTION
Didn't add a predicate to subsequent skill choices, as TSTNW p. 25 doesn't preclude it: "... there’s no advantage to using multiple blessed coins from the same shrine or from deities who share the same divine skill.