### PR TITLE
Fix missing localized string for NPC Shield Max HP

### DIFF
--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3719,7 +3719,6 @@
         "SettingsQuickDamageNotes": "If disabled, dialogs to preview Damage rolls will appear only when a roll button is shift-clicked.",
         "SheetLabel": "{type} Sheet",
         "ShieldLabel": "Shield",
-        "ShieldMaxTitle": "Shield Max HP",
         "SidebarAppearanceLabel": "Appearance",
         "Size": "Size",
         "SizeLabel": "Size",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3719,6 +3719,7 @@
         "SettingsQuickDamageNotes": "If disabled, dialogs to preview Damage rolls will appear only when a roll button is shift-clicked.",
         "SheetLabel": "{type} Sheet",
         "ShieldLabel": "Shield",
+        "ShieldMaxTitle": "Shield Max HP",
         "SidebarAppearanceLabel": "Appearance",
         "Size": "Size",
         "SizeLabel": "Size",

--- a/static/templates/actors/npc/partials/sidebar.hbs
+++ b/static/templates/actors/npc/partials/sidebar.hbs
@@ -51,7 +51,7 @@
             <div class="hit-points">
                 <input type="number" name="system.attributes.shield.hp.value" value="{{data.attributes.shield.hp.value}}" class="current" placeholder="0" />
                 <span class="slash">/</span>
-                <label class="max" data-tooltip="PF2E.ShieldMaxTitle">{{data.attributes.shield.hp.max}}</label>
+                <label class="max" data-tooltip="PF2E.Actor.Creature.Shield.HitPoints.Max">{{data.attributes.shield.hp.max}}</label>
             </div>
         </header>
 


### PR DESCRIPTION
Before:
<img width="228" alt="Screen Shot 2025-04-25 at 10 33 21 PM" src="https://github.com/user-attachments/assets/0ea33197-6cbf-462d-9769-b2f99e9bb95e" />

After:
<img width="221" alt="Screen Shot 2025-04-25 at 10 35 10 PM" src="https://github.com/user-attachments/assets/c1299957-f0d5-4f36-bcc0-4fd222c3d994" />