### PR TITLE
Fix toggling of modifiers in `DamageModifierDialog` and `CheckModifiersDialog`

### DIFF
--- a/src/module/apps/compendium-browser/components/filters/traits.svelte
+++ b/src/module/apps/compendium-browser/components/filters/traits.svelte
@@ -57,7 +57,7 @@
     value={traits.selected.map((s) => s.value)}
 />
 <div class="filter-conjunction">
-    <label>
+    <label class="checkbox">
         <input
             type="radio"
             name="filter-conjunction-and"
@@ -67,7 +67,7 @@
         />
         {game.i18n.localize("PF2E.CompendiumBrowser.Filter.Conjunction.AndLabel")}
     </label>
-    <label>
+    <label class="checkbox">
         <input
             type="radio"
             name="filter-conjunction-or"
@@ -135,7 +135,6 @@
         display: flex;
 
         input[type="radio"] {
-            --checkbox-size: var(--font-size-15);
             margin: 0 5px 0 3px;
         }
     }

--- a/src/module/apps/compendium-browser/components/filters/traits.svelte
+++ b/src/module/apps/compendium-browser/components/filters/traits.svelte
@@ -135,7 +135,7 @@
         display: flex;
 
         input[type="radio"] {
-            margin: 0 5px 0 3px;
+            margin-top: 0;
         }
     }
 </style>

--- a/src/styles/ui/_roll-modifiers-dialog.scss
+++ b/src/styles/ui/_roll-modifiers-dialog.scss
@@ -139,7 +139,7 @@
             }
         }
 
-        &.disabled {
+        &.off {
             text-decoration: line-through;
 
             & > * {
@@ -155,7 +155,7 @@
             }
         }
 
-        .exclude.disabled {
+        .exclude.off {
             filter: opacity(0.5);
 
             .toggle,

--- a/static/templates/chat/check-modifiers-dialog.hbs
+++ b/static/templates/chat/check-modifiers-dialog.hbs
@@ -7,10 +7,10 @@
         </div>
         <div class="substitutions">
             {{#each substitutions as |sub index|}}
-                <div class="dialog-row{{#if (and (not sub.toggleable) (not sub.selected))}} disabled{{/if}}">
+                <div class="dialog-row{{#if (and (not sub.toggleable) (not sub.selected))}} off{{/if}}">
                     <span class="mod">{{sub.label}}</span>
                     <span class="type">{{sub.value}}</span>
-                    <div class="exclude{{#if (and (not sub.toggleable) sub.selected)}} disabled{{/if}}">
+                    <div class="exclude{{#if (and (not sub.toggleable) sub.selected)}} off{{/if}}">
                         <label class="toggle">
                             <input type="checkbox" {{disabled (not sub.toggleable)}} data-sub-index="{{index}}" {{checked sub.selected}} />
                             <span class="widget"></span>
@@ -29,7 +29,7 @@
     </div>
     <div class="modifier-container">
         {{#each modifiers as |modifier idx|}}
-            <div class="dialog-row{{#unless modifier.enabled}} disabled{{#if modifier.hideIfDisabled}} hidden{{/if}}{{/unless}}">
+            <div class="dialog-row{{#unless modifier.enabled}} off{{#if modifier.hideIfDisabled}} hidden{{/if}}{{/unless}}">
                 <span class="mod">{{modifier.label}}</span>
                 <span class="type"><span class="tag">{{localize (concat "PF2E.ModifierType." modifier.type)}}</span></span>
                 <span class="value">{{numberFormat modifier.modifier decimals=0 sign=true}}</span>

--- a/static/templates/chat/damage/damage-modifier-dialog.hbs
+++ b/static/templates/chat/damage/damage-modifier-dialog.hbs
@@ -107,7 +107,7 @@
 </form>
 
 {{#*inline "modifier-row"}}
-    <div class="dialog-row{{#unless modifier.enabled}} disabled{{#if modifier.hideIfDisabled}} hidden{{/if}}{{/unless}}">
+    <div class="dialog-row{{#unless modifier.enabled}} off{{#if modifier.hideIfDisabled}} hidden{{/if}}{{/unless}}">
         <span class="mod">{{modifier.label}}</span>
         <span class="type"><span class="tag">{{localize (concat "PF2E.ModifierType." modifier.type)}}</span></span>
         <div class="value" data-tooltip="{{modifier.typeLabel}}">
@@ -125,7 +125,7 @@
 {{/inline}}
 
 {{#*inline "dice-row"}}
-    <div class="dialog-row{{#unless dice.enabled}} disabled{{#if dice.hideIfDisabled}} hidden{{/if}}{{/unless}}">
+    <div class="dialog-row{{#unless dice.enabled}} off{{#if dice.hideIfDisabled}} hidden{{/if}}{{/unless}}">
         <span class="mod">{{dice.label}}</span>
         <div class="value" data-tooltip="{{dice.typeLabel}}">
             <span class="dice-type damage color{{#if dice.damageType}} {{dice.damageType}}{{/if}}">


### PR DESCRIPTION
Looks like upstream is eating click events for elements with a `disabled` class.