### PR TITLE
Remove `TinyMCE` dependency and add stubbed `TinyMCE` types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,6 @@
                 "socket.io": "4.8.1",
                 "socket.io-client": "4.8.1",
                 "svelte-preprocess": "^6.0.3",
-                "tinymce": "6.8.5",
                 "tsx": "^4.19.3",
                 "typescript": "^5.8.3",
                 "typescript-eslint": "^8.31.0",
@@ -8529,13 +8528,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
-        },
-        "node_modules/tinymce": {
-            "version": "6.8.5",
-            "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.8.5.tgz",
-            "integrity": "sha512-qAL/FxL7cwZHj4BfaF818zeJJizK9jU5IQzTcSLL4Rj5MaJdiVblEj7aDr80VCV1w9h4Lak9hlnALhq/kVtN1g==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/tldts": {
             "version": "6.1.86",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
         "socket.io": "4.8.1",
         "socket.io-client": "4.8.1",
         "svelte-preprocess": "^6.0.3",
-        "tinymce": "6.8.5",
         "tsx": "^4.19.3",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.31.0",

--- a/src/module/item/base/sheet/sheet.ts
+++ b/src/module/item/base/sheet/sheet.ts
@@ -34,7 +34,6 @@ import {
 import { createSortable } from "@util/destroyables.ts";
 import { tagify } from "@util/tags.ts";
 import * as R from "remeda";
-import type * as TinyMCE from "tinymce";
 import { CodeMirror } from "./codemirror.ts";
 import { RULE_ELEMENT_FORMS, RuleElementForm } from "./rule-element-form/index.ts";
 

--- a/types/foundry/client/applications/ux/form-data-extended.d.mts
+++ b/types/foundry/client/applications/ux/form-data-extended.d.mts
@@ -1,4 +1,3 @@
-import * as TinyMCE from "tinymce";
 import { TinyMCEEditorData } from "../../appv1/api/form-application-v1.mjs";
 import ProseMirrorEditor from "./prosemirror-editor.mjs";
 

--- a/types/foundry/client/appv1/api/document-sheet-v1.d.mts
+++ b/types/foundry/client/appv1/api/document-sheet-v1.d.mts
@@ -1,6 +1,5 @@
 import User from "@client/documents/user.mjs";
 import Document from "@common/abstract/document.mjs";
-import * as TinyMCE from "tinymce";
 import HTMLSecret from "../../applications/html-secret.mjs";
 import { AppV1RenderOptions, ApplicationV1HeaderButton } from "./application-v1.mjs";
 import FormApplication, { FormApplicationOptions } from "./form-application-v1.mjs";

--- a/types/foundry/client/appv1/api/form-application-v1.d.mts
+++ b/types/foundry/client/appv1/api/form-application-v1.d.mts
@@ -1,4 +1,3 @@
-import type * as TinyMCE from "tinymce";
 import Application, { AppV1RenderOptions, ApplicationV1Options } from "./application-v1.mjs";
 
 /**

--- a/types/foundry/client/appv1/sheets/journal-page-sheet.d.mts
+++ b/types/foundry/client/appv1/sheets/journal-page-sheet.d.mts
@@ -1,4 +1,3 @@
-import type * as TinyMCE from "tinymce";
 import { AppV1RenderOptions } from "../api/application-v1.mjs";
 import DocumentSheet, { DocumentSheetData, DocumentSheetV1Options } from "../api/document-sheet-v1.mjs";
 

--- a/types/foundry/client/config.d.mts
+++ b/types/foundry/client/config.d.mts
@@ -1,6 +1,5 @@
 import { DataSchema, Document, TypeDataModel } from "@common/abstract/_module.mjs";
 import { AudioFilePath, ImageFilePath, RollMode } from "@common/constants.mjs";
-import type * as TinyMCE from "tinymce";
 import { DocumentConstructionContext } from "../common/_types.mjs";
 import { ActiveEffectSource } from "../common/documents/active-effect.mjs";
 import DocumentSheetV2 from "./applications/api/document-sheet.mjs";
@@ -774,9 +773,7 @@ export default interface Config<
 
     /** Default configuration options for TinyMCE editors */
     // See https://www.tiny.cloud/docs/configure/content-appearance/
-    TinyMCE: Omit<TinyMCE.EditorOptions, "style_formats"> & {
-        style_formats: NonNullable<TinyMCE.EditorOptions["style_formats"]>;
-    };
+    TinyMCE: TinyMCE.EditorOptions;
 
     ui: {
         actors: ConstructorOf<foundry.applications.sidebar.tabs.ActorDirectory<documents.Actor<null>>>;

--- a/types/foundry/client/global.d.mts
+++ b/types/foundry/client/global.d.mts
@@ -5,7 +5,7 @@ import clipperlib from "js-angusj-clipper";
 import PixiJS from "pixi.js";
 import * as Showdown from "showdown";
 import * as SocketIO from "socket.io-client";
-import * as tinymce from "tinymce";
+import { TinyMCE as tinymce } from "./../tinymce-stub.mjs";
 import * as globalFoundry from "./client.mjs";
 
 declare global {

--- a/types/foundry/tinymce-stub.d.mts
+++ b/types/foundry/tinymce-stub.d.mts
@@ -1,0 +1,122 @@
+/** Partial TinyMCE types to avoid having an old version of TinyMCE as a dev dependency.
+ *  Remove once TinyMCE is no longer in use.
+ */
+export namespace TinyMCE {
+    class Editor {}
+
+    interface EditorOptions {
+        content_css: string[];
+        extended_valid_elements?: string;
+        style_formats: AllowedFormat[];
+    }
+
+    type AllowedFormat = Separator | FormatReference | StyleFormat | NestedFormatting;
+
+    type StyleFormat = BlockStyleFormat | InlineStyleFormat | SelectorStyleFormat;
+
+    interface Separator {
+        title: string;
+    }
+
+    interface FormatReference {
+        title: string;
+        format: string;
+        icon?: string;
+    }
+
+    interface NestedFormatting {
+        title: string;
+        items: Array<FormatReference | StyleFormat>;
+    }
+
+    interface CommonStyleFormat {
+        name?: string;
+        title: string;
+        icon?: string;
+    }
+
+    interface BlockStyleFormat extends BlockFormat, CommonStyleFormat {}
+
+    interface InlineStyleFormat extends InlineFormat, CommonStyleFormat {}
+
+    interface SelectorStyleFormat extends SelectorFormat, CommonStyleFormat {}
+
+    type ApplyFormat = BlockFormat | InlineFormat | SelectorFormat;
+
+    type RemoveFormat = RemoveBlockFormat | RemoveInlineFormat | RemoveSelectorFormat;
+
+    type Format = ApplyFormat | RemoveFormat;
+
+    type Formats = Record<string, Format | Format[]>;
+
+    type FormatAttrOrStyleValue = string | ((vars?: FormatVars) => string | null);
+
+    type FormatVars = Record<string, string | null>;
+
+    interface BaseFormat<T> {
+        ceFalseOverride?: boolean;
+        classes?: string | string[];
+        collapsed?: boolean;
+        exact?: boolean;
+        expand?: boolean;
+        links?: boolean;
+        mixed?: boolean;
+        block_expand?: boolean;
+        onmatch?: (node: Element, fmt: T, itemName: string) => boolean;
+        remove?: "none" | "empty" | "all";
+        remove_similar?: boolean;
+        split?: boolean;
+        deep?: boolean;
+        preserve_attributes?: string[];
+    }
+
+    interface Block {
+        block: string;
+        list_block?: string;
+        wrapper?: boolean;
+    }
+
+    interface Inline {
+        inline: string;
+    }
+
+    interface Selector {
+        selector: string;
+        inherit?: boolean;
+    }
+
+    interface RangeLikeObject {
+        startContainer: Node;
+        startOffset: number;
+        endContainer: Node;
+        endOffset: number;
+    }
+
+    interface CommonFormat<T> extends BaseFormat<T> {
+        attributes?: Record<string, FormatAttrOrStyleValue>;
+        styles?: Record<string, FormatAttrOrStyleValue>;
+        toggle?: boolean;
+        preview?: string | false;
+        onformat?: (elm: Element, fmt: T, vars?: FormatVars, node?: Node | RangeLikeObject | null) => void;
+        clear_child_styles?: boolean;
+        merge_siblings?: boolean;
+        merge_with_parents?: boolean;
+    }
+
+    interface BlockFormat extends Block, CommonFormat<BlockFormat> {}
+
+    interface InlineFormat extends Inline, CommonFormat<InlineFormat> {}
+
+    interface SelectorFormat extends Selector, CommonFormat<SelectorFormat> {}
+
+    interface CommonRemoveFormat<T> extends BaseFormat<T> {
+        attributes?: string[] | Record<string, FormatAttrOrStyleValue>;
+        styles?: string[] | Record<string, FormatAttrOrStyleValue>;
+    }
+
+    interface RemoveBlockFormat extends Block, CommonRemoveFormat<RemoveBlockFormat> {}
+
+    interface RemoveInlineFormat extends Inline, CommonRemoveFormat<RemoveInlineFormat> {}
+
+    interface RemoveSelectorFormat extends Selector, CommonRemoveFormat<RemoveSelectorFormat> {}
+}


### PR DESCRIPTION
I used text search to find all `tinymce` imports as type checking is still a bit difficult in the dev branch. I think this covers all uses.
The format interfaces could probably be pared down some more if desired.