### PR TITLE
Fix `CompendiumDirectoryPF2e` drag selector

### DIFF
--- a/src/module/apps/sidebar/compendium-directory.ts
+++ b/src/module/apps/sidebar/compendium-directory.ts
@@ -98,8 +98,7 @@ class CompendiumDirectoryPF2e extends tabs.CompendiumDirectory {
             });
             html.querySelector(":scope > footer")?.append(browserButton);
             this.matchDragDrop = new fa.ux.DragDrop({
-                dragSelector: ".directory-item",
-                dropSelector: ".directory-list",
+                dragSelector: "li.match",
                 permissions: {
                     dragstart: this._canDragStart.bind(this),
                     drop: this._canDragDrop.bind(this),


### PR DESCRIPTION
It's either this or adding `.directory-item` to the search result template. Sorting packs inside a folder is also broken but that doesn't work in 5e either so it's probably an upstream bug.

- Closes #18929 