### PR TITLE
Restore erroneously removed `buttons` property in xp macro dialog

### DIFF
--- a/src/scripts/macros/xp/dialog.ts
+++ b/src/scripts/macros/xp/dialog.ts
@@ -148,6 +148,7 @@ function showXP(partyLevel: number, partySize: number, npcLevels: number[], haza
     new foundry.appv1.api.Dialog({
         title: "XP",
         content: dialogTemplate(xp),
+        buttons: {},
     }).render(true);
 }
 

--- a/types/foundry/client/appv1/api/dialog-v1.d.mts
+++ b/types/foundry/client/appv1/api/dialog-v1.d.mts
@@ -180,7 +180,7 @@ export interface DialogData {
     title?: string;
     content?: string | HTMLElement | (() => string | HTMLElement);
     close?: (html: HTMLElement | JQuery) => void;
-    buttons?: Record<string, DialogButton>;
+    buttons: Record<string, DialogButton>;
     default?: string;
     render?: (html: HTMLElement | JQuery) => void;
 }


### PR DESCRIPTION
This was removed in https://github.com/foundryvtt/pf2e/commit/3b8ce882ac255863dde12fb5d18272b02b5f9216 but is required to render the dialog.

Closes #18934 