### PR TITLE
Update Tengu Fan Item usage, description text, publication source and add automation to feats.

### DIFF
--- a/packs/equipment/tengu-feather-fan.json
+++ b/packs/equipment/tengu-feather-fan.json
@@ -9,7 +9,7 @@
         },
         "containerId": null,
         "description": {
-            "value": "<p><strong>Activate</strong> Interact</p>\n<p><strong>Frequency</strong> once per day</p>\n<hr />\n<p><strong>Effect</strong> You cast one of the spells contained in your <em>tengu feather fan</em>. Activating the fan takes the spell's normal number of actions. You can also Activate the fan to cast a cantrip you've gained from a heritage or ancestry feat; this activation doesn't count against the fan's uses per day.</p>\n<p>The DC for spells you cast with your <em>tengu feather fan</em> is your class DC or spell DC, whichever is higher.</p>\n<p>You can cast the 1st-rank @UUID[Compendium.pf2e.spells-srd.Item.Gust of Wind] spell by activating your <em>tengu feather fan</em>. @Check[fortitude|against:class-spell|traits:air]{Fortitude saving throw}</p>"
+            "value": "<p><strong>Activate—Wave Fan</strong> (manipulate)</p>\n<p><strong>Frequency</strong> once per day</p><hr /><p><strong>Effect</strong> You cast one of the spells contained in your <em>tengu feather fan</em>. Activating the fan takes the spell's normal number of actions. You can also Activate the fan to cast a cantrip you've gained from a heritage or ancestry feat; this activation doesn't count against the fan's uses per day. The DC for spells you cast with your <em>tengu feather fan</em> is your class DC or spell DC, whichever is higher.</p>\n<p>You can cast the 1st-rank @UUID[Compendium.pf2e.spells-srd.Item.Gust of Wind] spell by activating your <em>tengu feather fan</em>. @Check[fortitude|against:class-spell|traits:air]{Fortitude saving throw}</p>"
         },
         "hardness": 0,
         "hp": {
@@ -27,9 +27,9 @@
             "value": {}
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": "Pathfinder Lost Omens Ancestry Guide"
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core 2"
         },
         "quantity": 1,
         "rules": [],
@@ -41,7 +41,7 @@
             ]
         },
         "usage": {
-            "value": "other"
+            "value": "held-in-one-hand"
         }
     },
     "type": "equipment"

--- a/packs/equipment/tengu-feather-fan.json
+++ b/packs/equipment/tengu-feather-fan.json
@@ -9,7 +9,7 @@
         },
         "containerId": null,
         "description": {
-            "value": "<p><strong>Activate—Wave Fan</strong> (manipulate)</p>\n<p><strong>Frequency</strong> once per day</p><hr /><p><strong>Effect</strong> You cast your choice of one spell contained in your tengu feather fan. You can instead cast a cantrip you've gained from a heritage or an ancestry feat; this doesn't use up one of the fan's daily activations. This activation takes the spell's normal number of actions.</p>\n<p>The spell's DC is your class DC or spell DC, whichever is higher.</p>"
+            "value": "<p><strong>Activate—Wave Fan</strong> (manipulate)</p>\n<p><strong>Frequency</strong> once per day</p><hr /><p><strong>Effect</strong> You cast your choice of one spell contained in your <em>tengu feather fan</em>. You can instead cast a cantrip you've gained from a heritage or an ancestry feat; this doesn't use up one of the fan's daily activations. This activation takes the spell's normal number of actions.</p>\n<p>The spell's DC is your class DC or spell DC, whichever is higher.</p>"
         },
         "hardness": 0,
         "hp": {

--- a/packs/equipment/tengu-feather-fan.json
+++ b/packs/equipment/tengu-feather-fan.json
@@ -9,7 +9,7 @@
         },
         "containerId": null,
         "description": {
-            "value": "<p><strong>Activate—Wave Fan</strong> (manipulate)</p>\n<p><strong>Frequency</strong> once per day</p><hr /><p><strong>Effect</strong> You cast one of the spells contained in your <em>tengu feather fan</em>. Activating the fan takes the spell's normal number of actions. You can also Activate the fan to cast a cantrip you've gained from a heritage or ancestry feat; this activation doesn't count against the fan's uses per day. The DC for spells you cast with your <em>tengu feather fan</em> is your class DC or spell DC, whichever is higher.</p>\n<p>You can cast the 1st-rank @UUID[Compendium.pf2e.spells-srd.Item.Gust of Wind] spell by activating your <em>tengu feather fan</em>. @Check[fortitude|against:class-spell|traits:air]{Fortitude saving throw}</p>"
+            "value": "<p><strong>Activate—Wave Fan</strong> (manipulate)</p>\n<p><strong>Frequency</strong> once per day</p><hr /><p><strong>Effect</strong> You cast your choice of one spell contained in your tengu feather fan. You can instead cast a cantrip you've gained from a heritage or an ancestry feat; this doesn't use up one of the fan's daily activations. This activation takes the spell's normal number of actions.</p>\n<p>The spell's DC is your class DC or spell DC, whichever is higher.</p>"
         },
         "hardness": 0,
         "hp": {

--- a/packs/feats/ancestry/tengu/tengu-feather-fan.json
+++ b/packs/feats/ancestry/tengu/tengu-feather-fan.json
@@ -29,6 +29,43 @@
             {
                 "key": "GrantItem",
                 "uuid": "Compendium.pf2e.equipment-srd.Item.Tengu Feather Fan"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:gust-of-wind",
+                    "spellcasting:innate"
+                ],
+                "property": "other-tags",
+                "value": "tengu-fan"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:gust-of-wind",
+                    "spellcasting:innate"
+                ],
+                "property": "other-tags",
+                "value": "ancestral-spell:tengu"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:tag:tengu-fan",
+                    "item:slug:gust-of-wind"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Tengu.TenguFan.GustOfWind"
+                    }
+                ]
             }
         ],
         "traits": {

--- a/packs/feats/ancestry/tengu/thunder-gods-fan.json
+++ b/packs/feats/ancestry/tengu/thunder-gods-fan.json
@@ -29,7 +29,46 @@
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:lightning-bolt",
+                    "spellcasting:innate"
+                ],
+                "property": "other-tags",
+                "value": "tengu-fan"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:lightning-bolt",
+                    "spellcasting:innate"
+                ],
+                "property": "other-tags",
+                "value": "ancestral-spell:tengu"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:rank:5",
+                    "item:tag:tengu-fan",
+                    "item:slug:lightning-bolt"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Tengu.TenguFan.LightningBolt"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/ancestry/tengu/wind-gods-fan.json
+++ b/packs/feats/ancestry/tengu/wind-gods-fan.json
@@ -29,7 +29,45 @@
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:wall-of-wind",
+                    "spellcasting:innate"
+                ],
+                "property": "other-tags",
+                "value": "tengu-fan"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:wall-of-wind",
+                    "spellcasting:innate"
+                ],
+                "property": "other-tags",
+                "value": "ancestral-spell:tengu"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:tag:tengu-fan",
+                    "item:slug:wall-of-wind"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Tengu.TenguFan.WallOfWind"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -6023,6 +6023,11 @@
                 "Water": "Water"
             },
             "Tengu": {
+                "TenguFan": {
+                    "GustOfWind": "You can cast the 1st-rank @UUID[Compendium.pf2e.spells-srd.Item.g8QqHpv2CWDwmIm1]{Gust of Wind} spell by activating your tengu feather fan. @Check[fortitude|against:class-spell|traits:air] save.",
+                    "LightningBolt": "You cast the 5th-rank @UUID[Compendium.pf2e.spells-srd.Item.9AAkVUCwF6WVNNY2]{Lightning Bolt} spell by activating your tengu feather fan. @Check[reflex|against:class-spell|basic|traits:electricity] save.",
+                    "WallOfWind": "You cast the 3rd-rank @UUID[Compendium.pf2e.spells-srd.Item.it4ZsAi6XgvGcodc]{Wall of Wind} spell by activating your tengu feather fan. @Check[fortitude|against:class-spell|traits:air]{Fortitude saving throw} save."
+                },
                 "WeaponFamiliarity": {
                     "Prompt1": "Select a weapon from the sword group.",
                     "Prompt2": "Select a second weapon from the sword group."

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -6025,8 +6025,8 @@
             "Tengu": {
                 "TenguFan": {
                     "GustOfWind": "You can cast the 1st-rank @UUID[Compendium.pf2e.spells-srd.Item.g8QqHpv2CWDwmIm1]{Gust of Wind} spell by activating your tengu feather fan. @Check[fortitude|against:class-spell|traits:air] save.",
-                    "LightningBolt": "You cast the 5th-rank @UUID[Compendium.pf2e.spells-srd.Item.9AAkVUCwF6WVNNY2]{Lightning Bolt} spell by activating your tengu feather fan. @Check[reflex|against:class-spell|basic|traits:electricity] save.",
-                    "WallOfWind": "You cast the 3rd-rank @UUID[Compendium.pf2e.spells-srd.Item.it4ZsAi6XgvGcodc]{Wall of Wind} spell by activating your tengu feather fan. @Check[fortitude|against:class-spell|traits:air]{Fortitude saving throw} save."
+                    "LightningBolt": "You can cast the 5th-rank @UUID[Compendium.pf2e.spells-srd.Item.9AAkVUCwF6WVNNY2]{Lightning Bolt} spell by activating your tengu feather fan. @Check[reflex|against:class-spell|basic|traits:electricity] save.",
+                    "WallOfWind": "You can cast the 3rd-rank @UUID[Compendium.pf2e.spells-srd.Item.it4ZsAi6XgvGcodc]{Wall of Wind} spell by activating your tengu feather fan. @Check[fortitude|against:class-spell|traits:air]{Fortitude saving throw} save."
                 },
                 "WeaponFamiliarity": {
                     "Prompt1": "Select a weapon from the sword group.",


### PR DESCRIPTION
- Updated item to one-hand-held usage per PFS Clarification.
- Updated item text and publication source to Pathfinder Player Core 2
- Added item alteration REs to add the respective class or spell DCs