### PR TITLE
Reduce divider size in effects panel

### DIFF
--- a/src/styles/system/_effects-panel.scss
+++ b/src/styles/system/_effects-panel.scss
@@ -121,7 +121,7 @@
     }
 
     > hr {
-        margin-right: 0;
+        margin: 0;
         width: 48px;
     }
 }


### PR DESCRIPTION
The hr size in v12 is very small, but in v13 its currently taller than even a single icon.

After tweak:
![image](https://github.com/user-attachments/assets/df0afa6d-6830-49c3-9618-4b7b1e64da7e)
