### PR TITLE
Set up automation for `Unleash Yaoguai Might` and `Legendary Monster`

### DIFF
--- a/packs/feat-effects/effect-legendary-monster.json
+++ b/packs/feat-effects/effect-legendary-monster.json
@@ -1,6 +1,6 @@
 {
     "_id": "ELCODoiGDBEqRAtT",
-    "img": "systems/pf2e/icons/spells/monstrosity-form.webp",
+    "img": "icons/creatures/magical/humanoid-horned-rider.webp",
     "name": "Effect: Legendary Monster",
     "system": {
         "description": {
@@ -22,18 +22,43 @@
         },
         "rules": [
             {
-                "key": "GrantItem",
-                "uuid": "Compendium.pf2e.spell-effects.Item.Spell Effect: Enlarge (Heightened 4th)"
+                "choices": [
+                    {
+                        "label": "PF2E.SpecificRule.Yaoguai.LegendaryMonster.Options.Enlarge",
+                        "value": "enlarge"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Yaoguai.LegendaryMonster.Options.Damage",
+                        "value": "damage"
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.Yaoguai.LegendaryMonster.Options.Fly",
+                        "value": "fly"
+                    }
+                ],
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.Yaoguai.LegendaryMonster.Prompt",
+                "rollOption": "legendary-monster-boost"
             },
             {
-                "key": "GrantItem",
-                "uuid": "Compendium.pf2e.spell-effects.Item.Spell Effect: Fly"
+                "key": "BaseSpeed",
+                "predicate": [
+                    "change-shape:yaoguai",
+                    "legendary-monster-boost:fly"
+                ],
+                "selector": "fly",
+                "value": "max(20,@actor.attributes.speed.total)"
             },
             {
                 "damageType": "spirit",
                 "diceNumber": 1,
                 "dieSize": "d4",
+                "hideIfDisabled": true,
                 "key": "DamageDice",
+                "predicate": [
+                    "change-shape:yaoguai",
+                    "legendary-monster-boost:damage"
+                ],
                 "selector": [
                     "strike-damage",
                     "spell-damage"

--- a/packs/feat-effects/effect-unleash-yaoguai-might.json
+++ b/packs/feat-effects/effect-unleash-yaoguai-might.json
@@ -1,10 +1,10 @@
 {
     "_id": "OBsItGQScxHyUcmR",
-    "img": "icons/magic/unholy/silhouette-evil-horned-giant.webp",
+    "img": "icons/magic/symbols/rune-sigil-green-purple.webp",
     "name": "Effect: Unleash Yaoguai Might",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Unleash Yaoguai Might]</p>\n<p><strong>Frequency</strong> once per day</p>\n<p>As you enter your yaoguai form, you draw upon your internal magic to assume an even greater form. When you Change Shape to enter your yaoguai form, you can spend an additional action to gain the effects of @UUID[Compendium.pf2e.spells-srd.Item.Enlarge] and an additional effect based on your heritage. This effect persists for 1 minute or until you Change Shape again.</p><ul><li><strong>Animal</strong> Your hide thickens, granting a +1 circumstance bonus to AC.</li><li><strong>Celestial</strong> You recover some of your celestial perfection, granting you and all allies within 15 feet a +1 status bonus to attack rolls.</li><li><strong>Elements</strong> You're surrounded in wind and dust, granting concealment each round that you spend at least 1 action that has the move trait. You can't use this concealment to Hide or @UUID[Compendium.pf2e.actionspf2e.Item.Sneak], as normal for sources of obvious concealment.</li><li><strong>Object</strong> Your skin transmutes partially into an inorganic substance, granting resistance 5 to your choice of bludgeoning, piercing, or slashing.</li><li><strong>Vegetation</strong> You trigger an accelerated growth, gaining fast healing 5.</li></ul>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Unleash Yaoguai Might]</p>\n<p>When you Change Shape to enter your yaoguai form, you can spend an additional action to gain the effects of <em>enlarge</em> and an additional effect based on your heritage.</p><ul><li><strong>Animal</strong> Your hide thickens, granting a +1 circumstance bonus to AC.</li><li><strong>Celestial</strong> You recover some of your celestial perfection, granting you and all allies within 15 feet a +1 status bonus to attack rolls.</li><li><strong>Elements</strong> You're surrounded in wind and dust, granting concealment each round that you spend at least 1 action that has the move trait. You can't use this concealment to Hide or Sneak, as normal for sources of obvious concealment.</li><li><strong>Object</strong> Your skin transmutes partially into an inorganic substance, granting resistance 5 to your choice of bludgeoning, piercing, or slashing.</li><li><strong>Vegetation</strong> You trigger an accelerated growth, gaining fast healing 5.</li></ul>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -24,6 +24,7 @@
             {
                 "key": "FlatModifier",
                 "predicate": [
+                    "change-shape:yaoguai",
                     "self:heritage:born-of-animal"
                 ],
                 "selector": "ac",
@@ -39,9 +40,28 @@
                 ],
                 "key": "Aura",
                 "predicate": [
+                    "change-shape:yaoguai",
                     "self:heritage:born-of-celestial"
                 ],
                 "radius": 15
+            },
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Yaoguai.UnleashYaoguaiMight.UsedMoveAction",
+                "option": "unleash-elements-concealed",
+                "predicate": [
+                    "self:heritage:born-of-elements"
+                ],
+                "toggleable": true
+            },
+            {
+                "inMemoryOnly": true,
+                "key": "GrantItem",
+                "predicate": [
+                    "unleash-elements-concealed"
+                ],
+                "uuid": "Compendium.pf2e.conditionitems.Item.Concealed"
             },
             {
                 "choices": [
@@ -61,6 +81,7 @@
                 "flag": "objectResistanceType",
                 "key": "ChoiceSet",
                 "predicate": [
+                    "change-shape:yaoguai",
                     "self:heritage:born-of-item"
                 ],
                 "prompt": "PF2E.SpecificRule.Prompt.DamageType"
@@ -68,6 +89,7 @@
             {
                 "key": "Resistance",
                 "predicate": [
+                    "change-shape:yaoguai",
                     "self:heritage:born-of-item"
                 ],
                 "type": "{item|flags.pf2e.rulesSelections.objectResistanceType}",
@@ -76,13 +98,65 @@
             {
                 "key": "FastHealing",
                 "predicate": [
+                    "change-shape:yaoguai",
                     "self:heritage:born-of-vegetation"
                 ],
                 "value": 5
             },
             {
+                "key": "CreatureSize",
+                "predicate": [
+                    "change-shape:yaoguai",
+                    {
+                        "not": "legendary-monster-boost:enlarge"
+                    }
+                ],
+                "reach": {
+                    "override": "10"
+                },
+                "resizeEquipment": true,
+                "value": "large"
+            },
+            {
+                "key": "CreatureSize",
+                "predicate": [
+                    "change-shape:yaoguai",
+                    "legendary-monster-boost:enlarge"
+                ],
+                "reach": {
+                    "override": "15"
+                },
+                "resizeEquipment": true,
+                "value": "huge"
+            },
+            {
+                "inMemoryOnly": true,
                 "key": "GrantItem",
-                "uuid": "Compendium.pf2e.spell-effects.Item.Spell Effect: Enlarge"
+                "predicate": [
+                    "change-shape:yaoguai"
+                ],
+                "uuid": "Compendium.pf2e.conditionitems.Item.Clumsy"
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "change-shape:yaoguai"
+                ],
+                "selector": "melee-strike-damage",
+                "slug": "unleash-yaoguai-bonus",
+                "type": "status",
+                "value": 2
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "upgrade",
+                "predicate": [
+                    "change-shape:yaoguai",
+                    "legendary-monster-boost:enlarge"
+                ],
+                "selector": "melee-strike-damage",
+                "slug": "unleash-yaoguai-bonus",
+                "value": 4
             }
         ],
         "start": {

--- a/packs/feats/ancestry/yaoguai/legendary-monster.json
+++ b/packs/feats/ancestry/yaoguai/legendary-monster.json
@@ -12,7 +12,7 @@
         },
         "category": "ancestry",
         "description": {
-            "value": "<p>Your yaoguai form has reached its pinnacle, allowing you to assume (or perhaps, return to) the form of a monster of legend. You can @UUID[Compendium.pf2e.feats-srd.Item.Unleash Yaoguai Might] any number of times per day.</p>\n<p>Once per day when you Unleash Yaoguai Might, you can gain one of the following additional benefits, which persists for 1 minute or until you Change Shape again.</p><ul><li>Your body grows to impossible heights. Your @UUID[Compendium.pf2e.spells-srd.Item.Enlarge] effect is heightened to 4th rank.</li><li>Your spiritual power erupts to punish your enemies. You deal an additional 1d4 spirit damage with all Strikes and attack spells, and your Strikes and attack spells gain the spirit trait.</li><li>You can leap off the air itself. You gain the effects of the @UUID[Compendium.pf2e.spells-srd.Item.Fly] spell.</li></ul>"
+            "value": "<p>Your yaoguai form has reached its pinnacle, allowing you to assume (or perhaps, return to) the form of a monster of legend. You can @UUID[Compendium.pf2e.feats-srd.Item.Unleash Yaoguai Might] any number of times per day.</p>\n<p>Once per day when you Unleash Yaoguai Might, you can gain one of the following additional benefits, which persists for 1 minute or until you Change Shape again.</p><ul><li>Your body grows to impossible heights. Your @UUID[Compendium.pf2e.spells-srd.Item.Enlarge] effect is heightened to 4th rank.</li><li>Your spiritual power erupts to punish your enemies. You deal an additional 1d4 spirit damage with all Strikes and attack spells, and your Strikes and attack spells gain the spirit trait.</li><li>You can leap off the air itself. You gain the effects of the @UUID[Compendium.pf2e.spells-srd.Item.Fly] spell.</li></ul><p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Legendary Monster]</p>"
         },
         "level": {
             "value": 17
@@ -33,7 +33,9 @@
             {
                 "domain": "all",
                 "key": "RollOption",
-                "option": "legendary-monster"
+                "label": "PF2E.SpecificRule.Yaoguai.LegendaryMonster.RollOptionLabel",
+                "option": "legendary-monster",
+                "toggleable": true
             }
         ],
         "traits": {

--- a/packs/feats/ancestry/yaoguai/unleash-yaoguai-might.json
+++ b/packs/feats/ancestry/yaoguai/unleash-yaoguai-might.json
@@ -12,7 +12,7 @@
         },
         "category": "ancestry",
         "description": {
-            "value": "<p><strong>Frequency</strong> once per day</p>\n<p>As you enter your yaoguai form, you draw upon your internal magic to assume an even greater form. When you Change Shape to enter your yaoguai form, you can spend an additional action to gain the effects of @UUID[Compendium.pf2e.spells-srd.Item.Enlarge] and an additional effect based on your heritage. This effect persists for 1 minute or until you Change Shape again.</p><ul><li><strong>Animal</strong> Your hide thickens, granting a +1 circumstance bonus to AC.</li><li><strong>Celestial</strong> You recover some of your celestial perfection, granting you and all allies within 15 feet a +1 status bonus to attack rolls.</li><li><strong>Elements</strong> You're surrounded in wind and dust, granting concealment each round that you spend at least 1 action that has the move trait. You can't use this concealment to Hide or @UUID[Compendium.pf2e.actionspf2e.Item.Sneak], as normal for sources of obvious concealment.</li><li><strong>Object</strong> Your skin transmutes partially into an inorganic substance, granting resistance 5 to your choice of bludgeoning, piercing, or slashing.</li><li><strong>Vegetation</strong> You trigger an accelerated growth, gaining fast healing 5.</li></ul>"
+            "value": "<p><strong>Frequency</strong> once per day</p>\n<p>As you enter your yaoguai form, you draw upon your internal magic to assume an even greater form. When you Change Shape to enter your yaoguai form, you can spend an additional action to gain the effects of @UUID[Compendium.pf2e.spells-srd.Item.Enlarge] and an additional effect based on your heritage. This effect persists for 1 minute or until you Change Shape again.</p><ul><li><strong>Animal</strong> Your hide thickens, granting a +1 circumstance bonus to AC.</li><li><strong>Celestial</strong> You recover some of your celestial perfection, granting you and all allies within 15 feet a +1 status bonus to attack rolls.</li><li><strong>Elements</strong> You're surrounded in wind and dust, granting concealment each round that you spend at least 1 action that has the move trait. You can't use this concealment to Hide or @UUID[Compendium.pf2e.actionspf2e.Item.Sneak], as normal for sources of obvious concealment.</li><li><strong>Object</strong> Your skin transmutes partially into an inorganic substance, granting resistance 5 to your choice of bludgeoning, piercing, or slashing.</li><li><strong>Vegetation</strong> You trigger an accelerated growth, gaining fast healing 5.</li></ul><p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Unleash Yaoguai Might]</p>"
         },
         "frequency": {
             "max": 1,
@@ -29,7 +29,126 @@
             "remaster": true,
             "title": "Pathfinder Lost Omens Tian Xia Character Guide"
         },
-        "rules": [],
+        "rules": [
+            {
+                "domain": "all",
+                "key": "RollOption",
+                "option": "unleash-yaoguai-might",
+                "toggleable": true
+            },
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "unleash-yaoguai-might",
+                    "item:slug:change-shape"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "predicate": [
+                            {
+                                "not": "feat:legendary-monster"
+                            }
+                        ],
+                        "text": "PF2E.SpecificRule.Yaoguai.UnleashYaoguaiMight.Frequency"
+                    },
+                    {
+                        "text": "PF2E.SpecificRule.Yaoguai.UnleashYaoguaiMight.Description"
+                    },
+                    {
+                        "predicate": [
+                            "self:heritage:born-of-animal"
+                        ],
+                        "text": "PF2E.SpecificRule.Yaoguai.UnleashYaoguaiMight.BornOfAnimal"
+                    },
+                    {
+                        "predicate": [
+                            "self:heritage:born-of-celestial"
+                        ],
+                        "text": "PF2E.SpecificRule.Yaoguai.UnleashYaoguaiMight.BornOfCelestial"
+                    },
+                    {
+                        "predicate": [
+                            "self:heritage:born-of-elements"
+                        ],
+                        "text": "PF2E.SpecificRule.Yaoguai.UnleashYaoguaiMight.BornOfElements"
+                    },
+                    {
+                        "predicate": [
+                            "heritage:born-of-item"
+                        ],
+                        "text": "PF2E.SpecificRule.Yaoguai.UnleashYaoguaiMight.BornOfItem"
+                    },
+                    {
+                        "predicate": [
+                            "self:heritage:born-of-vegetation"
+                        ],
+                        "text": "PF2E.SpecificRule.Yaoguai.UnleashYaoguaiMight.BornOfVegetation"
+                    },
+                    {
+                        "divider": true,
+                        "predicate": [
+                            "feat:legendary-monster"
+                        ],
+                        "text": "PF2E.SpecificRule.Yaoguai.LegendaryMonster.Text.Title"
+                    },
+                    {
+                        "predicate": [
+                            "feat:legendary-monster"
+                        ],
+                        "text": "PF2E.SpecificRule.Yaoguai.LegendaryMonster.Text.Frequency"
+                    },
+                    {
+                        "predicate": [
+                            "legendary-monster",
+                            "feat:legendary-monster"
+                        ],
+                        "text": "PF2E.SpecificRule.Yaoguai.LegendaryMonster.Text.Description"
+                    },
+                    {
+                        "predicate": [
+                            "legendary-monster",
+                            "feat:legendary-monster"
+                        ],
+                        "text": "PF2E.SpecificRule.Yaoguai.LegendaryMonster.Text.Enlarge",
+                        "title": "-"
+                    },
+                    {
+                        "predicate": [
+                            "legendary-monster",
+                            "feat:legendary-monster"
+                        ],
+                        "text": "PF2E.SpecificRule.Yaoguai.LegendaryMonster.Text.Damage",
+                        "title": "-"
+                    },
+                    {
+                        "predicate": [
+                            "legendary-monster",
+                            "feat:legendary-monster"
+                        ],
+                        "text": "PF2E.SpecificRule.Yaoguai.LegendaryMonster.Text.Fly",
+                        "title": "-"
+                    },
+                    {
+                        "predicate": [
+                            {
+                                "not": "legendary-monster"
+                            }
+                        ],
+                        "text": "PF2E.SpecificRule.Yaoguai.UnleashYaoguaiMight.Effect"
+                    },
+                    {
+                        "predicate": [
+                            "legendary-monster",
+                            "feat:legendary-monster"
+                        ],
+                        "text": "PF2E.SpecificRule.Yaoguai.UnleashYaoguaiMight.Effect"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -6410,6 +6410,35 @@
             "Yaoguai": {
                 "AwakenedYaoguai": {
                     "Prompt": "Select a yaoguai heritage."
+                },
+                "LegendaryMonster": {
+                    "Effect": "@UUID[Compendium.pf2e.feat-effects.Item.ELCODoiGDBEqRAtT]{Effect: Legendary Monster}",
+                    "Options": {
+                        "Damage": "Additional spirit damage",
+                        "Enlarge": "4th rank Enlarge",
+                        "Fly": "Fly Speed"
+                    },
+                    "Prompt": "Choose an additional benefit",
+                    "RollOptionLabel": "Use Legendary Monster",
+                    "Text": {
+                        "Damage": "Your spiritual power erupts to punish your enemies. You deal an additional 1d4 spirit damage with all Strikes and attack spells, and your Strikes and attack spells gain the spirit trait.",
+                        "Description": "Once per day when you Unleash Yaoguai Might, you can gain one of the following additional benefits, which persists for 1 minute or until you Change Shape again.",
+                        "Enlarge": "Your body grows to impossible heights. Your Enlarge effect is heightened to 4th rank.",
+                        "Fly": "You can leap off the air itself. You gain the effects of the *fly* spell.",
+                        "Frequency": "You can Unleash Yaoguai Might any number of times per day.",
+                        "Title": "**Legendary Monster**"
+                    }
+                },
+                "UnleashYaoguaiMight": {
+                    "BornOfAnimal": "**Animal** Your hide thickens, granting a +1 circumstance bonus to AC.",
+                    "BornOfCelestial": "**Celestial** You recover some of your celestial perfection, granting you and all allies within 15 feet a +1 status bonus to attack rolls.",
+                    "BornOfElements": "**Elements** You're surrounded in wind and dust, granting concealment each round that you spend at least 1 action that has the move trait. You can't use this concealment to Hide or Sneak, as normal for sources of obvious concealment.",
+                    "BornOfItem": "**Object ** Your skin transmutes partially into an inorganic substance, granting resistance 5 to your choice of bludgeoning, piercing, or slashing.",
+                    "BornOfVegetation": "**Vegetation** You trigger an accelerated growth, gaining fast healing 5.",
+                    "Description": "As you enter your yaoguai form, you draw upon your internal magic to assume an even greater form. When you Change Shape to enter your yaoguai form, you can spend an additional action to gain the effects of Enlarge and an additional effect based on your heritage. This effect persists for 1 minute or until you Change Shape again.",
+                    "Effect": "@UUID[Compendium.pf2e.feat-effects.Item.OBsItGQScxHyUcmR]{Effect: Unleash Yaoguai Might}",
+                    "Frequency": "**Frequency** once per day",
+                    "UsedMoveAction": "Used action that has the move trait."
                 }
             },
             "Zombie": {


### PR DESCRIPTION
Turns out there were effects in the system, but neither was added to their respective feats. Things I did:

- Localize any instances of spell effects, such as Enlarge and Fly, to now use dedicated RE to do these effects.
- I added "change-shape:yaoguai" as a predicate for all effects (per the ability description, these effects can only happen in Yaoguai form).
- Added a Choice Set to Legendary Monster (can only have one benefit active) with RollOptions so they can better integrate with the Unleash Yaoguai Might effect.
- Added Localized text.
- Added a toggle and Item Alteration Description to add flavor text to Change Shape when either ability is used.
- Changed the icons on both effects.