### PR TITLE
Add `system` CSS layer to Vite HMR

### DIFF
--- a/src/styles/vite-hmr.scss
+++ b/src/styles/vite-hmr.scss
@@ -1,0 +1,4 @@
+// Wrap in the system layer for Vite HMR
+@layer system {
+    @import "main.scss";
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -66,13 +66,17 @@ const config = Vite.defineConfig(({ command, mode }): Vite.UserConfig => {
               })()
             : { foundryPort: 30000, serverPort: 30001 };
 
+    // Add system layer to svelte CSS in HMR
+    const hmrPreprocess = {
+        name: "svelte-hmr-layer",
+        style: ({ content }: { content: string }) => ({ code: `@layer system { ${content} }` }),
+    };
+
     const plugins = [
         checker({ typescript: false }),
         tsconfigPaths({ loose: true }),
         sveltePlugin({
-            preprocess: [
-                { name: "svelte-css-layer", style: ({ content }) => ({ code: `@layer system { ${content} }` }) },
-            ],
+            preprocess: command === "serve" ? hmrPreprocess : undefined,
         }),
     ];
     // Handle minification after build to allow for tree-shaking and whitespace minification

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -96,6 +96,17 @@ const config = Vite.defineConfig(({ command, mode }): Vite.UserConfig => {
                 ],
             }),
         );
+    } else if (command === "serve") {
+        const file = path.resolve(__dirname, "src/pf2e.ts").replaceAll("\\", "/");
+        plugins.push({
+            name: "hmr-layers",
+            transform: (code, id) => {
+                if (id === file) {
+                    return code.replace("styles/main.scss", "styles/vite-hmr.scss");
+                }
+                return;
+            },
+        });
     } else {
         plugins.push(
             // Foundry expects all esm files listed in system.json to exist: create empty vendor module when in dev mode

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -66,7 +66,15 @@ const config = Vite.defineConfig(({ command, mode }): Vite.UserConfig => {
               })()
             : { foundryPort: 30000, serverPort: 30001 };
 
-    const plugins = [checker({ typescript: false }), tsconfigPaths({ loose: true }), sveltePlugin()];
+    const plugins = [
+        checker({ typescript: false }),
+        tsconfigPaths({ loose: true }),
+        sveltePlugin({
+            preprocess: [
+                { name: "svelte-css-layer", style: ({ content }) => ({ code: `@layer system { ${content} }` }) },
+            ],
+        }),
+    ];
     // Handle minification after build to allow for tree-shaking and whitespace minification
     // "Note the build.minify option does not minify whitespaces when using the 'es' format in lib mode, as it removes
     // pure annotations and breaks tree-shaking."


### PR DESCRIPTION
I've looked for a while and this seems to be the best way to do it.

![image](https://github.com/user-attachments/assets/39c78ccd-9071-4658-8313-5956b8e56712)
