### PR TITLE
Fix formula picker styling

### DIFF
--- a/src/module/actor/character/apps/formula-picker/app.svelte
+++ b/src/module/actor/character/apps/formula-picker/app.svelte
@@ -201,17 +201,20 @@
                     margin: 0;
                 }
                 .tag {
-                    padding: 0.15em 0.3em 0.1em 0.3em;
+                    /** Roboto has some inherit padding that makes sizing this small cause misalignment w/o line-height */
+                    height: var(--space-17);
+                    line-height: 95%;
                 }
             }
         }
 
         > .quantity {
+            --input-height: 1.375rem;
+
             display: flex;
             margin-top: var(--space-6);
             button {
                 width: 1.375rem;
-                height: 1.375rem;
                 i {
                     margin: 0;
                 }
@@ -219,7 +222,6 @@
             input {
                 border: none;
                 width: 3ch;
-                height: 1.375rem;
                 padding-left: 0;
                 padding-right: 0;
                 text-align: center;
@@ -232,8 +234,8 @@
         }
 
         > button.select {
+            --button-size: 1.75rem;
             width: 1.75rem;
-            height: 1.75rem;
             margin-top: var(--space-4);
             transition: all 0.25s ease-in-out;
 

--- a/src/module/actor/character/apps/formula-picker/app.ts
+++ b/src/module/actor/character/apps/formula-picker/app.ts
@@ -68,7 +68,7 @@ class FormulaPicker extends SvelteApplicationMixin<
         this.options.actor.apps[this.id] = this;
     }
 
-    override _onClose(options: ApplicationRenderOptions): void {
+    protected override _onClose(options: fa.ApplicationClosingOptions): void {
         delete this.options.actor.apps[this.id];
         super._onClose(options);
         this.#resolve?.(this.selection);

--- a/src/styles/_globals.scss
+++ b/src/styles/_globals.scss
@@ -20,6 +20,7 @@
     --space-13: 0.8125rem;
     --space-14: 0.875rem;
     --space-15: 0.9375rem;
+    --space-17: var(--font-size-17);
     --space-21: var(--font-size-21);
 }
 


### PR DESCRIPTION
Before

![image](https://github.com/user-attachments/assets/ca95c41a-15a6-41e9-8fd2-897dd8b8fbe3)
![image](https://github.com/user-attachments/assets/9e213a9d-241b-4c8e-ad61-adf411d403e2)

After

![image](https://github.com/user-attachments/assets/2d400014-7b0a-44b7-b05c-304dc5c33aa5)
![image](https://github.com/user-attachments/assets/8952f4b1-cc10-4c38-bd61-ea5ad03435fb)

There was a misalignment issue in the traits during dev, but when I went back to master it seems to have not occured, so it might be inconsistent sub-pixel rendering related (the height of the element was 17.5)