### PR TITLE
Fix affliction errors and import more types

### DIFF
--- a/src/module/item/abstract-effect/data.ts
+++ b/src/module/item/abstract-effect/data.ts
@@ -10,13 +10,13 @@ interface AbstractEffectSystemSource extends ItemSystemSource {
     traits: EffectTraits;
     /** Whether this effect originated from a spell */
     fromSpell?: boolean;
-    expired?: boolean;
 }
 
 interface AbstractEffectSystemData extends ItemSystemData {
     traits: EffectTraits;
     /** Whether this effect originated from a spell */
     fromSpell: boolean;
+    expired?: boolean;
 }
 
 interface EffectBadgeBaseSource {

--- a/src/module/item/armor/document.ts
+++ b/src/module/item/armor/document.ts
@@ -1,13 +1,15 @@
 import type { ActorPF2e } from "@actor";
 import { AutomaticBonusProgression as ABP } from "@actor/character/automatic-bonus-progression.ts";
-import { RawItemChatData } from "@item/base/data/index.ts";
+import type { DatabaseUpdateOperation } from "@common/abstract/_module.mjs";
+import type { RawItemChatData } from "@item/base/data/index.ts";
 import { PhysicalItemPF2e, getPropertyRuneSlots } from "@item/physical/index.ts";
 import { MAGIC_TRADITIONS } from "@item/spell/values.ts";
-import { UserPF2e } from "@module/user/index.ts";
+import type { UserPF2e } from "@module/user/index.ts";
+import type { EnrichmentOptionsPF2e } from "@system/text-editor.ts";
 import { ErrorPF2e, setHasElement, signedInteger, sluggify } from "@util";
 import * as R from "remeda";
 import { ArmorSource, ArmorSystemData } from "./data.ts";
-import { ArmorCategory, ArmorGroup, ArmorTrait, BaseArmorType } from "./types.ts";
+import type { ArmorCategory, ArmorGroup, ArmorTrait, BaseArmorType } from "./types.ts";
 
 class ArmorPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends PhysicalItemPF2e<TParent> {
     static override get validTraits(): Record<ArmorTrait, string> {
@@ -142,7 +144,7 @@ class ArmorPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Phy
 
     override async getChatData(
         this: ArmorPF2e<ActorPF2e>,
-        htmlOptions: EnrichmentOptions = {},
+        htmlOptions: EnrichmentOptionsPF2e = {},
     ): Promise<RawItemChatData> {
         const properties = [
             CONFIG.PF2E.armorCategories[this.category],

--- a/src/module/item/physical/data.ts
+++ b/src/module/item/physical/data.ts
@@ -1,4 +1,5 @@
 import { AttributeString } from "@actor/types.ts";
+import type { ImageFilePath } from "@common/constants.mjs";
 import { PhysicalItemSource } from "@item/base/data/index.ts";
 import { Size, TraitsWithRarity, ZeroToTwo } from "@module/data.ts";
 import { MaterialDamageEffect } from "@system/damage/types.ts";

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -1014,6 +1014,7 @@ async function augmentInlineDamageRoll(
 }
 
 interface EnrichmentOptionsPF2e extends EnrichmentOptions {
+    /** @todo as of v13 this should also support functions that produce roll data */
     rollData?: RollDataPF2e;
     /** Whether to run the enriched string through `UserVisibility.process` */
     processVisibility?: boolean;


### PR DESCRIPTION
Expired is only ever set programmatically, not persisted, so it shouldn't be part of the abstract effect source data.