### PR TITLE
Add automation for return damage to Furnace form

### DIFF
--- a/packs/feat-effects/effect-furnace-form.json
+++ b/packs/feat-effects/effect-furnace-form.json
@@ -4,7 +4,7 @@
     "name": "Effect: Furnace Form",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Furnace Form]</p>\n<p>You gain fire immunity, resistance 10 to precision damage, and weakness 5 to cold and to water. Your unarmed attacks deal 1d4 additional fire damage, and your fire spells deal one additional die of fire damage (of the same damage die the spell uses). Your fire Elemental Blasts deal an additional die of damage. In fire form, you have a fly Speed of 40 feet.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Furnace Form]</p>\n<p>You gain fire immunity, resistance 10 to precision damage, weakness 5 to cold and to water, and a fly Speed of 40 feet. Any creature that touches you or damages you with an unarmed attack or non-reach melee weapon takes @Damage[3d6[fire]] damage.</p>\n<p>Your unarmed attacks deal 1d4 additional fire damage, and your fire spells deal one additional die of fire damage (of the same damage die the spell uses). Your fire Elemental Blasts deal an additional die of damage.</p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -69,6 +69,22 @@
                     "item:trait:fire"
                 ],
                 "selector": "elemental-blast-damage"
+            },
+            {
+                "key": "Note",
+                "predicate": [
+                    {
+                        "or": [
+                            "item:category:unarmed",
+                            {
+                                "not": "item:trait:reach"
+                            }
+                        ]
+                    }
+                ],
+                "selector": "damage-received",
+                "text": "PF2E.SpecificRule.SpellEffectFurnaceForm.Note",
+                "title": "{item|name}"
             }
         ],
         "start": {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -5530,6 +5530,9 @@
             "SpellEffectFieryBody": {
                 "Note": "The attacker takes @Damage[(ternary(gte(@item.level,9),4,3))d6[fire]] damage."
             },
+            "SpellEffectFurnaceBody": {
+                "Note": "The attacker takes @Damage[3d6[fire]] damage."
+            },
             "SpellEffectGluttonsJaw": {
                 "Text": "If you hit with your jaws and deal damage, you gain [[/r (ceil(@item.level/2))d6 #Temporary Hit Points]] temporary Hit Points."
             },


### PR DESCRIPTION
Furnace Form feat (https://2e.aonprd.com/Feats.aspx?ID=4247) states:
```
You gain the benefits of the fiery body spell (except the ability to cast ignition) until the end of your next turn
```
However, in the actual effect, there is no mention of return damage, which combined with the fact the feat is just refering to the fiery body and not actually listing the effects itself can create a confusion what actually should be applied.

This PR fixes this issue by introducing automation for return damage.