### PR TITLE
Fix `TemplateLayerPF2e#getSnappedPoint`

### DIFF
--- a/src/module/canvas/layer/template.ts
+++ b/src/module/canvas/layer/template.ts
@@ -17,7 +17,7 @@ class TemplateLayerPF2e<TObject extends MeasuredTemplatePF2e = MeasuredTemplateP
 
     /** Overriden to snap according to the dragged template's type */
     override getSnappedPoint(point: Point): Point {
-        const template = this.preview;
+        const template = this.preview?.children.at(0);
         if (!template || !canvas.grid.isSquare) {
             return super.getSnappedPoint(point);
         }

--- a/types/foundry/client/canvas/layers/base/placeables-layer.d.mts
+++ b/types/foundry/client/canvas/layers/base/placeables-layer.d.mts
@@ -24,7 +24,7 @@ export default class PlaceablesLayer<TObject extends PlaceableObject = Placeable
     objects: PIXI.Container | null;
 
     /** Preview Object Placement */
-    preview: TObject | null;
+    preview: PIXI.Container<TObject> | null;
 
     /** Keep track of history so that CTRL+Z can undo changes. */
     history: CanvasHistoryEvent<TObject>[];


### PR DESCRIPTION
This is included in #19045 but probably needs to go out sooner. I've accidentally bricked measured templates yesterday because the type of `PlaceablesLayer#preview` was wrong (also my fault).