### PR TITLE
Add monk to trait to Ki Cutting Sight and add effect

### DIFF
--- a/packs/spell-effects/spell-effect-ki-cutting-sight.json
+++ b/packs/spell-effects/spell-effect-ki-cutting-sight.json
@@ -1,0 +1,64 @@
+{
+    "_id": "IFbDmy0HhKa8XaEU",
+    "img": "icons/magic/perception/third-eye-blue-red.webp",
+    "name": "Spell Effect: Ki Cutting Sight",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Ki Cutting Sight]</p>\n<p>The next time you deal damage to the target with a Strike or ki spell, you deal additional slashing damage.</p>"
+        },
+        "duration": {
+            "expiry": null,
+            "sustained": false,
+            "unit": "unlimited",
+            "value": -1
+        },
+        "level": {
+            "value": 3
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Wake the Dead #2"
+        },
+        "rules": [
+            {
+                "domain": "damage",
+                "key": "RollOption",
+                "option": "ki-cutting-sight",
+                "toggleable": true
+            },
+            {
+                "damageType": "slashing",
+                "diceNumber": "@item.level+1",
+                "dieSize": "d10",
+                "key": "DamageDice",
+                "predicate": [
+                    "ki-cutting-sight",
+                    {
+                        "or": [
+                            "action:strike",
+                            {
+                                "and": [
+                                    "item:trait:focus",
+                                    "item:trait:monk"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "selector": "damage"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/spell-effects/spell-effect-ki-cutting-sight.json
+++ b/packs/spell-effects/spell-effect-ki-cutting-sight.json
@@ -29,7 +29,7 @@
             },
             {
                 "damageType": "slashing",
-                "diceNumber": "@item.level+1",
+                "diceNumber": "@item.level + 1",
                 "dieSize": "d10",
                 "key": "DamageDice",
                 "predicate": [

--- a/packs/spells/focus/ki-cutting-sight.json
+++ b/packs/spells/focus/ki-cutting-sight.json
@@ -12,7 +12,7 @@
         "damage": {},
         "defense": null,
         "description": {
-            "value": "<p>Ki flows through everything in existence—animals and plants, living and dead, mortals and spirits. Strike at just the right place, in just the right way, and the flow is stopped, with dire consequences.</p>\n<p>When you Cast the Spell, make a @Check[perception|defense:fortitude] check against the target's Fortitude DC. If you succeed, the next time you deal damage to the target with a Strike or ki spell, you deal 4d10 additional slashing damage.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Ki Cutting Sight]</p><hr /><p><strong>Heightened (+1)</strong> The slashing damage increases by 1d10.</p>\n<p><em>Note: The source does not include the monk trait, and lists the heightened damage as precision. Both issues have been corrected here.</em></p>"
+            "value": "<p>Ki flows through everything in existence—animals and plants, living and dead, mortals and spirits. Strike at just the right place, in just the right way, and the flow is stopped, with dire consequences.</p>\n<p>When you Cast the Spell, make a @Check[perception|defense:fortitude] check against the target's Fortitude DC. If you succeed, the next time you deal damage to the target with a Strike or ki spell, you deal 4d10 additional slashing damage.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Ki Cutting Sight]</p><hr /><p><strong>Heightened (+1)</strong> The slashing damage increases by 1d10.</p>"
         },
         "duration": {
             "sustained": false,

--- a/packs/spells/focus/ki-cutting-sight.json
+++ b/packs/spells/focus/ki-cutting-sight.json
@@ -9,32 +9,14 @@
             "value": ""
         },
         "counteraction": false,
-        "damage": {
-            "BfIsx6L1o2ExZVwh": {
-                "applyMod": false,
-                "category": null,
-                "formula": "4d10",
-                "kinds": [
-                    "damage"
-                ],
-                "materials": [],
-                "type": "slashing"
-            }
-        },
+        "damage": {},
         "defense": null,
         "description": {
-            "value": "<p>Ki flows through everything in existence—animals and plants, living and dead, mortals and spirits. Strike at just the right place, in just the right way, and the flow is stopped, with dire consequences.</p>\n<p>When you Cast the Spell, make a @Check[perception|defense:fortitude] check against the target's Fortitude DC. If you succeed, the next time you deal damage to the target with a Strike or ki spell, you deal 4d10 additional slashing damage.</p>\n<hr />\n<p><strong>Heightened (+1)</strong> The precision damage increases by 1d10.</p>"
+            "value": "<p>Ki flows through everything in existence—animals and plants, living and dead, mortals and spirits. Strike at just the right place, in just the right way, and the flow is stopped, with dire consequences.</p>\n<p>When you Cast the Spell, make a @Check[perception|defense:fortitude] check against the target's Fortitude DC. If you succeed, the next time you deal damage to the target with a Strike or ki spell, you deal 4d10 additional slashing damage.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Ki Cutting Sight]</p><hr /><p><strong>Heightened (+1)</strong> The slashing damage increases by 1d10.</p>\n<p><em>Note: The source does not include the monk trait, and lists the heightened damage as precision. Both issues have been corrected here.</em></p>"
         },
         "duration": {
             "sustained": false,
             "value": ""
-        },
-        "heightening": {
-            "damage": {
-                "BfIsx6L1o2ExZVwh": "1d10"
-            },
-            "interval": 1,
-            "type": "interval"
         },
         "level": {
             "value": 3
@@ -60,7 +42,8 @@
             "traditions": [],
             "value": [
                 "focus",
-                "manipulate"
+                "manipulate",
+                "monk"
             ]
         }
     },


### PR DESCRIPTION
Used a RollOption rather than a TokenMark as save spells (such as Qi Blast) don't include target data.

Closes https://github.com/foundryvtt/pf2e/issues/18962