### PR TITLE
Change grid check location for aura

### DIFF
--- a/src/module/scene/helpers.ts
+++ b/src/module/scene/helpers.ts
@@ -7,7 +7,7 @@ let auraCheckLock = Promise.resolve();
 
 /** Check for auras containing newly-placed or moved tokens */
 const checkAuras = fu.debounce(async function (this: ScenePF2e): Promise<void> {
-    if (!(canvas.ready && this.isInFocus && this.grid.type === CONST.GRID_TYPES.SQUARE)) {
+    if (!(canvas.ready && this.isInFocus)) {
         return;
     }
 

--- a/src/module/scene/token-document/aura/index.ts
+++ b/src/module/scene/token-document/aura/index.ts
@@ -70,7 +70,13 @@ class TokenAura implements TokenAuraData {
     /** Does this aura overlap with (at least part of) a token? */
     containsToken(token: TokenDocumentPF2e): boolean {
         // If either token is hidden or not rendered, return false early
-        if (this.token.hidden || token.hidden || !this.token.object || !token.object) {
+        if (
+            this.token.hidden ||
+            token.hidden ||
+            !this.token.object ||
+            !token.object ||
+            this.scene.grid.type !== CONST.GRID_TYPES.SQUARE
+        ) {
             return false;
         }
 


### PR DESCRIPTION
## Description
I think I have found a work around for aura support on other grids (hex and gridless) however to avoid duplicating large sections of existing code I would still like to see the small change proposed in #16543 that moves the grid check from `checkAuras` to `containsToken`. I have not seen any adverse effect from this change in months of using my previous patch.
## Changes
- Move grid type check from `checkAuras` function to `containsToken`. 