### PR TITLE
Change grid check location to function that is actually grid dependant

### DIFF
--- a/src/module/canvas/token/aura/map.ts
+++ b/src/module/canvas/token/aura/map.ts
@@ -53,7 +53,7 @@ export class AuraRenderers extends Map<string, AuraRenderer> {
                 : this.token.combatant?.encounter.active);
 
         return (
-            canvas.scene?.grid.type === CONST.GRID_TYPES.SQUARE &&
+            canvas.scene !== null &&
             // Assume if token vision is disabled then the scene is not intended for play.
             canvas.scene.tokenVision &&
             // The scene must be active, or a GM must be the only user logged in.

--- a/src/module/canvas/token/aura/util.ts
+++ b/src/module/canvas/token/aura/util.ts
@@ -5,7 +5,7 @@ import { TokenDocumentPF2e } from "@scene";
 import type { TokenPF2e } from "../index.ts";
 
 export function getAreaSquares(data: GetAreaSquaresParams): EffectAreaSquare[] {
-    if (!canvas.ready) return [];
+    if (!canvas.ready || canvas.scene?.grid?.type !== CONST.GRID_TYPES.SQUARE) return [];
     const squareWidth = canvas.dimensions.size;
     const rowCount = Math.ceil(data.bounds.width / squareWidth);
     const emptyVector = Array<null>(rowCount - 1).fill(null);

--- a/src/module/scene/helpers.ts
+++ b/src/module/scene/helpers.ts
@@ -7,7 +7,7 @@ let auraCheckLock = Promise.resolve();
 
 /** Check for auras containing newly-placed or moved tokens */
 const checkAuras = fu.debounce(async function (this: ScenePF2e): Promise<void> {
-    if (!(canvas.ready && this.isInFocus && this.grid.type === CONST.GRID_TYPES.SQUARE)) {
+    if (!(canvas.ready && this.isInFocus)) {
         return;
     }
 


### PR DESCRIPTION
## Description
Moves a grid check to functions that actually contains grid dependent code. This is a sensible approach to limiting function behavior that assume a type of grid and improves readability in that regards. This limits `getAreaSquares` to square grid as that is the grid type the function is written for. The only downside of that is the `PartyClownCar` uses that function even on non square grids. In my opinion that function is deficient for use in `PartyClownCar` as it does not support Large, Huge, or Gargantuan creatures which will overlap other tokens. If the `PartyClownCar` support on non square grids is a deal breaker I can mark this MR as draft and implement a square/hex algorithm and a gridless algorithm for this purpose then unmark this MR as draft. 

#16543 - issue with MR was that system dev(s) did not want to expose Aura classes (I have worked around this)
#19066 - issue with MR was that system dev(s) mentioned the approach was not sensible

## Changes
- Remove grid type check from `#showBordersHighlights` and `checkAuras` functions
- Add grid type check to `getAreaSquares` function
## Effects
- Auras circle will render on non square grids
- Clown car deposit longer spreads tokens out on non square grids