### PR TITLE
Revert "Correct treatment of Aquatic Combat Penalty"

### DIFF
--- a/packs/other-effects/effect-aquatic-combat.json
+++ b/packs/other-effects/effect-aquatic-combat.json
@@ -49,7 +49,7 @@
                                     "self:trait:aquatic"
                                 ]
                             },
-                            "item:type:melee",
+                            "item:category:unarmed",
                             "self:type:npc"
                         ]
                     },


### PR DESCRIPTION
Reverts foundryvtt/pf2e#19064

Oops, the melee bit needs to go too.