### PR TITLE
Update `EnrichmentOptionsPF2e` to accept a function as `rollData`

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -60,7 +60,7 @@ import type {
     Statistic,
     StatisticDifficultyClass,
 } from "@system/statistic/index.ts";
-import { EnrichmentOptionsPF2e, TextEditorPF2e } from "@system/text-editor.ts";
+import { type RollDataPF2e, TextEditorPF2e } from "@system/text-editor.ts";
 import { ErrorPF2e, localizer, objectHasKey, setHasElement, signedInteger, sluggify, tupleHasValue } from "@util";
 import { Duration } from "luxon";
 import * as R from "remeda";
@@ -1654,7 +1654,7 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
     }
 
     /** This allows @actor.level and such to work for macros and inline rolls */
-    override getRollData(): NonNullable<EnrichmentOptionsPF2e["rollData"]> {
+    override getRollData(): RollDataPF2e {
         return { actor: this };
     }
 

--- a/src/module/actor/loot/sheet.ts
+++ b/src/module/actor/loot/sheet.ts
@@ -1,6 +1,7 @@
 import type { LootPF2e } from "@actor";
 import { transferItemsBetweenActors } from "@actor/helpers.ts";
 import type { ActorSheetDataPF2e, InventoryItem, SheetInventory } from "@actor/sheet/data-types.ts";
+import type { FormSelectOption } from "@client/applications/forms/fields.d.mts";
 import type { ActorSheetOptions } from "@client/appv1/sheets/actor-sheet.d.mts";
 import type { PhysicalItemPF2e } from "@item";
 import { TextEditorPF2e } from "@system/text-editor.ts";

--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -24,7 +24,7 @@ import { RuleElementOptions, RuleElementPF2e, RuleElementSource, RuleElements } 
 import { processGrantDeletions } from "@module/rules/rule-element/grant-item/helpers.ts";
 import { eventToRollMode } from "@module/sheet/helpers.ts";
 import type { UserPF2e } from "@module/user/document.ts";
-import { EnrichmentOptionsPF2e, TextEditorPF2e } from "@system/text-editor.ts";
+import { type EnrichmentOptionsPF2e, type RollDataPF2e, TextEditorPF2e } from "@system/text-editor.ts";
 import {
     ErrorPF2e,
     createHTMLElement,
@@ -204,7 +204,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
         return rollOptions;
     }
 
-    override getRollData(): NonNullable<EnrichmentOptionsPF2e["rollData"]> {
+    override getRollData(): RollDataPF2e {
         const actorRollData = this.actor?.getRollData() ?? { actor: null };
         return { ...actorRollData, item: this };
     }

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -47,7 +47,7 @@ import {
 } from "@system/damage/types.ts";
 import { DEGREE_OF_SUCCESS_STRINGS } from "@system/degree-of-success.ts";
 import { StatisticRollParameters } from "@system/statistic/index.ts";
-import { EnrichmentOptionsPF2e, TextEditorPF2e } from "@system/text-editor.ts";
+import { type EnrichmentOptionsPF2e, type RollDataPF2e, TextEditorPF2e } from "@system/text-editor.ts";
 import {
     ErrorPF2e,
     createHTMLElement,
@@ -255,9 +255,7 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
         return Math.max(this.baseRank, slotNumber ?? this.rank) as OneToTen;
     }
 
-    override getRollData(
-        rollOptions: { castRank?: number | string } = {},
-    ): NonNullable<EnrichmentOptionsPF2e["rollData"]> {
+    override getRollData(rollOptions: { castRank?: number | string } = {}): RollDataPF2e {
         const spellRank = Number(rollOptions?.castRank) || null;
         const castRank = Math.max(this.baseRank, spellRank || this.rank);
 

--- a/src/module/system/check/roll.ts
+++ b/src/module/system/check/roll.ts
@@ -1,7 +1,7 @@
 import { ZeroToThree } from "@module/data.ts";
 import { UserPF2e } from "@module/user/index.ts";
 import { DegreeOfSuccessIndex } from "@system/degree-of-success.ts";
-import { RollDataPF2e } from "@system/rolls.ts";
+import { BaseRollDataPF2e } from "@system/rolls.ts";
 import { CheckType } from "./types.ts";
 import dice = foundry.dice;
 
@@ -76,7 +76,7 @@ interface CheckRoll extends Roll {
 /** A legacy class kept to allow chat messages to reconstruct rolls */
 class StrikeAttackRoll extends CheckRoll {}
 
-interface CheckRollDataPF2e extends RollDataPF2e {
+interface CheckRollDataPF2e extends BaseRollDataPF2e {
     type?: CheckType;
     /** A string of some kind to help system API identify the roll */
     identifier?: Maybe<string>;

--- a/src/module/system/check/roll.ts
+++ b/src/module/system/check/roll.ts
@@ -1,7 +1,7 @@
 import { ZeroToThree } from "@module/data.ts";
 import { UserPF2e } from "@module/user/index.ts";
 import { DegreeOfSuccessIndex } from "@system/degree-of-success.ts";
-import { BaseRollDataPF2e } from "@system/rolls.ts";
+import { DiceRollOptionsPF2e } from "@system/rolls.ts";
 import { CheckType } from "./types.ts";
 import dice = foundry.dice;
 
@@ -76,7 +76,7 @@ interface CheckRoll extends Roll {
 /** A legacy class kept to allow chat messages to reconstruct rolls */
 class StrikeAttackRoll extends CheckRoll {}
 
-interface CheckRollDataPF2e extends BaseRollDataPF2e {
+interface CheckRollDataPF2e extends DiceRollOptionsPF2e {
     type?: CheckType;
     /** A string of some kind to help system API identify the roll */
     identifier?: Maybe<string>;

--- a/src/module/system/damage/roll.ts
+++ b/src/module/system/damage/roll.ts
@@ -11,7 +11,7 @@ import type { DiceTerm, NumericTermData, PoolTermData, RollTerm, RollTermData } 
 import { DamageRollFlag } from "@module/chat-message/index.ts";
 import type { UserPF2e } from "@module/user/index.ts";
 import { DegreeOfSuccessIndex } from "@system/degree-of-success.ts";
-import { BaseRollDataPF2e } from "@system/rolls.ts";
+import { DiceRollOptionsPF2e } from "@system/rolls.ts";
 import { ErrorPF2e, fontAwesomeIcon, tupleHasValue } from "@util";
 import type Peggy from "peggy";
 import * as R from "remeda";
@@ -652,7 +652,7 @@ interface AbstractDamageRollData extends RollOptions {
     evaluatePersistent?: boolean;
 }
 
-interface DamageRollData extends BaseRollDataPF2e, AbstractDamageRollData {
+interface DamageRollData extends DiceRollOptionsPF2e, AbstractDamageRollData {
     /** Whether to double dice or total on critical hits */
     critRule?: Maybe<CriticalDoublingRule>;
     /** Data used to construct the damage formula and options */

--- a/src/module/system/damage/roll.ts
+++ b/src/module/system/damage/roll.ts
@@ -11,7 +11,7 @@ import type { DiceTerm, NumericTermData, PoolTermData, RollTerm, RollTermData } 
 import { DamageRollFlag } from "@module/chat-message/index.ts";
 import type { UserPF2e } from "@module/user/index.ts";
 import { DegreeOfSuccessIndex } from "@system/degree-of-success.ts";
-import { RollDataPF2e } from "@system/rolls.ts";
+import { BaseRollDataPF2e } from "@system/rolls.ts";
 import { ErrorPF2e, fontAwesomeIcon, tupleHasValue } from "@util";
 import type Peggy from "peggy";
 import * as R from "remeda";
@@ -652,7 +652,7 @@ interface AbstractDamageRollData extends RollOptions {
     evaluatePersistent?: boolean;
 }
 
-interface DamageRollData extends RollDataPF2e, AbstractDamageRollData {
+interface DamageRollData extends BaseRollDataPF2e, AbstractDamageRollData {
     /** Whether to double dice or total on critical hits */
     critRule?: Maybe<CriticalDoublingRule>;
     /** Data used to construct the damage formula and options */

--- a/src/module/system/rolls.ts
+++ b/src/module/system/rolls.ts
@@ -10,7 +10,7 @@ import type { RollTwiceOption } from "./check/index.ts";
 import type { CheckDC, DEGREE_OF_SUCCESS_STRINGS } from "./degree-of-success.ts";
 import dice = foundry.dice;
 
-interface RollDataPF2e extends dice.RollOptions {
+interface BaseRollDataPF2e extends dice.RollOptions {
     rollerId?: string;
     totalModifier?: number;
     /** Whether to show roll formula and tooltip to players */
@@ -74,4 +74,4 @@ interface BaseRollContext {
     skipDialog?: boolean;
 }
 
-export type { AttackRollParams, BaseRollContext, DamageRollParams, RollDataPF2e, RollParameters, RollTwiceOption };
+export type { AttackRollParams, BaseRollContext, BaseRollDataPF2e, DamageRollParams, RollParameters, RollTwiceOption };

--- a/src/module/system/rolls.ts
+++ b/src/module/system/rolls.ts
@@ -10,7 +10,7 @@ import type { RollTwiceOption } from "./check/index.ts";
 import type { CheckDC, DEGREE_OF_SUCCESS_STRINGS } from "./degree-of-success.ts";
 import dice = foundry.dice;
 
-interface BaseRollDataPF2e extends dice.RollOptions {
+interface DiceRollOptionsPF2e extends dice.RollOptions {
     rollerId?: string;
     totalModifier?: number;
     /** Whether to show roll formula and tooltip to players */
@@ -74,4 +74,11 @@ interface BaseRollContext {
     skipDialog?: boolean;
 }
 
-export type { AttackRollParams, BaseRollContext, BaseRollDataPF2e, DamageRollParams, RollParameters, RollTwiceOption };
+export type {
+    AttackRollParams,
+    BaseRollContext,
+    DamageRollParams,
+    DiceRollOptionsPF2e,
+    RollParameters,
+    RollTwiceOption,
+};

--- a/types/foundry/client/applications/ux/text-editor.d.mts
+++ b/types/foundry/client/applications/ux/text-editor.d.mts
@@ -24,7 +24,7 @@ interface EnrichmentOptions {
     custom?: boolean;
 
     /** The data object providing context for inline rolls, or a function that produces it. */
-    rollData?: object | Function;
+    rollData?: Record<string, unknown> | (() => Record<string, unknown>);
 
     /** A document to resolve relative UUIDs against. */
     relativeTo?: ClientDocument;


### PR DESCRIPTION
I've renamed the `RollDataPF2e` interface in `text-editor.ts` to `RollDataContextPF2e` because of a collision with `RollDataPF2e` in `system/rolls.ts`.