### PR TITLE
Convert ContainerSystemData and EquipmentSystemData to TypeDataModel

### DIFF
--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -23,6 +23,7 @@ import type { ItemOriginFlag } from "@module/chat-message/data.ts";
 import { ChatMessagePF2e } from "@module/chat-message/document.ts";
 import { preImportJSON } from "@module/doc-helpers.ts";
 import { MigrationList, MigrationRunner } from "@module/migration/index.ts";
+import { Migration901ReorganizeBulkData } from "@module/migration/migrations/901-reorganize-bulk-data.ts";
 import { MigrationRunnerBase } from "@module/migration/runner/base.ts";
 import { RuleElement, RuleElementOptions, RuleElementSource, RuleElements } from "@module/rules/index.ts";
 import { processGrantDeletions } from "@module/rules/rule-element/grant-item/helpers.ts";
@@ -820,6 +821,34 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
         }
 
         return super.deleteDocuments(ids, operation);
+    }
+
+    /**
+     * Temporary migration to allow certain data models to work despite more recent migrations.
+     * It works by manually running specific non-async migrations and applying the special keys.
+     * @todo complete data models and create new migration framework
+     * @todo check if converting the -= to _del in migration 901 and such will cause this to have issues
+     */
+    static override migrateData<T extends foundry.abstract.DataModel>(
+        this: ConstructorOf<T>,
+        source: Record<string, unknown>,
+    ): Record<string, unknown> {
+        const itemType = String(source.type);
+        const hasTypeDataModel = itemType in CONFIG.Item.dataModels;
+        if (!hasTypeDataModel) return super.migrateData(source);
+
+        const itemSource = source as ItemSourcePF2e;
+        const legacyVersion = R.isPlainObject(itemSource.system.schema)
+            ? Number(itemSource.system.schema.version) || null
+            : null;
+        const version = Number(itemSource.system._migration?.version) || legacyVersion;
+        if (version && version < 0.901 && itemIsOfType(itemSource, "physical")) {
+            const migration = new Migration901ReorganizeBulkData();
+            migration.updateItem(itemSource);
+            source = fu.applySpecialKeys(source);
+        }
+
+        return super.migrateData(source);
     }
 
     /* -------------------------------------------- */

--- a/src/module/item/container/data.ts
+++ b/src/module/item/container/data.ts
@@ -1,50 +1,110 @@
-import { EquipmentTrait } from "@item/equipment/data.ts";
+import type { ModelPropsFromSchema } from "@common/data/fields.d.mts";
+import type { EquipmentTrait } from "@item/equipment/data.ts";
+import type { BasePhysicalItemSource, BulkData, PhysicalItemTraits } from "@item/physical/data.ts";
 import {
-    BasePhysicalItemSource,
-    BulkData,
-    Investable,
-    PhysicalItemTraits,
-    PhysicalSystemData,
-    PhysicalSystemSource,
-} from "@item/physical/data.ts";
+    ApexField,
+    PhysicalItemModelOmission,
+    PhysicalItemSystemModel,
+    PhysicalItemSystemSchema,
+    PhysicalItemSystemSource,
+    PhysicalItemTraitsSchema,
+} from "@item/physical/schema.ts";
+import { RarityField } from "@module/model.ts";
+import { LaxArrayField, SlugField } from "@system/schema-data-fields.ts";
+import type { ContainerPF2e } from "./document.ts";
+import fields = foundry.data.fields;
 
 type ContainerSource = BasePhysicalItemSource<"backpack", ContainerSystemSource>;
 
-type ContainerTraits = PhysicalItemTraits<EquipmentTrait>;
+class ContainerSystemData extends PhysicalItemSystemModel<ContainerPF2e, ContainerSystemSchema> {
+    declare traits: PhysicalItemTraits<EquipmentTrait>;
 
-interface ContainerSystemSource extends Investable<PhysicalSystemSource> {
-    traits: ContainerTraits;
-    stowing: boolean;
-    bulk: ContainerBulkSource;
-    collapsed: boolean;
-    usage: { value: string };
-    subitems?: never;
-}
+    declare bulk: ContainerBulkData;
 
-interface ContainerBulkSource {
-    value: number;
-    heldOrStowed: number;
-    capacity: number;
-    ignored: number;
+    static override defineSchema(): ContainerSystemSchema {
+        const traits: Record<EquipmentTrait, string> = CONFIG.PF2E.equipmentTraits;
+
+        return {
+            ...super.defineSchema(),
+            apex: new ApexField(),
+            traits: new fields.SchemaField({
+                otherTags: new fields.ArrayField(
+                    new SlugField({ required: true, nullable: false, initial: undefined }),
+                ),
+                value: new LaxArrayField(
+                    new fields.StringField({
+                        required: true,
+                        nullable: false,
+                        choices: traits,
+                        initial: undefined,
+                    }),
+                ),
+                rarity: new RarityField(),
+            }),
+            bulk: new fields.SchemaField({
+                value: new fields.NumberField({ required: true, nullable: false, min: 0, initial: 0 }),
+                heldOrStowed: new fields.NumberField({ required: true, nullable: false, min: 0, initial: 0.1 }),
+                capacity: new fields.NumberField({ required: true, nullable: false, min: 0, initial: 10 }),
+                ignored: new fields.NumberField({ required: true, nullable: false, min: 0, initial: 0 }),
+            }),
+            usage: new fields.SchemaField({
+                value: new fields.StringField({ required: true, nullable: false, initial: "worn" }),
+            }),
+            collapsed: new fields.BooleanField({ required: true, nullable: false, initial: false }),
+            stowing: new fields.BooleanField({ required: true, nullable: false, initial: false }),
+        };
+    }
+
+    override prepareBaseData(): void {
+        this.temporary = false;
+
+        // Simple measure to avoid self-recursive containers
+        if (this.containerId === this.parent.id) {
+            this.containerId = null;
+        }
+    }
+
+    protected override async _preUpdate(
+        changes: DeepPartial<ContainerSystemSource>,
+        options: object,
+        user: User,
+    ): Promise<boolean | void> {
+        if ((await super._preUpdate(changes, options, user)) === false) return;
+        const isApex = (changes.traits?.value ?? this.traits.value).includes("apex");
+        if (!isApex) this.apex = null;
+    }
 }
 
 interface ContainerSystemData
-    extends Omit<ContainerSystemSource, SourceOmission>, Omit<Investable<PhysicalSystemData>, "subitems" | "traits"> {
-    bulk: ContainerBulkData;
-    stackGroup: null;
+    extends
+        PhysicalItemSystemModel<ContainerPF2e, ContainerSystemSchema>,
+        Omit<ModelPropsFromSchema<ContainerSystemSchema>, PhysicalItemModelOmission> {
+    temporary: false;
 }
 
-type SourceOmission =
-    | "apex"
-    | "bulk"
-    | "description"
-    | "hp"
-    | "identification"
-    | "material"
-    | "price"
-    | "temporary"
-    | "usage";
+type ContainerSystemSchema = Omit<PhysicalItemSystemSchema, "traits" | "bulk"> & {
+    apex: ApexField;
+    traits: fields.SchemaField<PhysicalItemTraitsSchema<EquipmentTrait>>;
+    bulk: fields.SchemaField<ContainerBulkSchema>;
+    usage: fields.SchemaField<{
+        value: fields.StringField<string, string, true, false>;
+    }>;
+    collapsed: fields.BooleanField<boolean, boolean, true, false, true>;
+    stowing: fields.BooleanField<boolean, boolean, true, false, true>;
+};
 
-interface ContainerBulkData extends ContainerBulkSource, BulkData {}
+type ContainerBulkSchema = {
+    value: fields.NumberField<number, number, true, false, true>;
+    heldOrStowed: fields.NumberField<number, number, true, false, true>;
+    capacity: fields.NumberField<number, number, true, false, true>;
+    ignored: fields.NumberField<number, number, true, false, true>;
+};
 
-export type { ContainerBulkData, ContainerSource, ContainerSystemData };
+type ContainerSystemSource = PhysicalItemSystemSource<ContainerSystemSchema> & {
+    subitems?: never;
+};
+
+interface ContainerBulkData extends ModelPropsFromSchema<ContainerBulkSchema>, BulkData {}
+
+export { ContainerSystemData };
+export type { ContainerBulkData, ContainerSource };

--- a/src/module/item/container/document.ts
+++ b/src/module/item/container/document.ts
@@ -1,11 +1,11 @@
 import type { ActorPF2e } from "@actor";
 import { InventoryBulk } from "@actor/inventory/index.ts";
-import type { EnrichmentOptions } from "@client/applications/ux/text-editor.d.mts";
 import type { DatabaseUpdateCallbackOptions } from "@common/abstract/_module.d.mts";
 import type { RawItemChatData } from "@item/base/data/index.ts";
 import type { EquipmentTrait } from "@item/equipment/data.ts";
 import { Bulk } from "@item/physical/bulk.ts";
 import { PhysicalItemPF2e } from "@item/physical/document.ts";
+import type { EnrichmentOptionsPF2e } from "@system/text-editor.ts";
 import type { ContainerSource, ContainerSystemData } from "./data.ts";
 import { hasExtraDimensionalParent } from "./helpers.ts";
 
@@ -52,15 +52,6 @@ class ContainerPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends
         return super.bulk.plus(this.capacity.value.minus(this.bulkIgnored));
     }
 
-    override prepareBaseData(): void {
-        super.prepareBaseData();
-
-        // Simple measure to avoid self-recursive containers
-        if (this.system.containerId === this.id) {
-            this.system.containerId = null;
-        }
-    }
-
     /** Reload this container's contents following Actor embedded-document preparation */
     override prepareSiblingData(this: ContainerPF2e<ActorPF2e>): void {
         super.prepareSiblingData();
@@ -85,7 +76,7 @@ class ContainerPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends
 
     override async getChatData(
         this: ContainerPF2e<TParent>,
-        htmlOptions: EnrichmentOptions = {},
+        htmlOptions: EnrichmentOptionsPF2e = {},
     ): Promise<RawItemChatData> {
         return this.processChatData(htmlOptions, {
             ...(await super.getChatData()),

--- a/src/module/item/equipment/data.ts
+++ b/src/module/item/equipment/data.ts
@@ -1,38 +1,81 @@
+import type { ModelPropsFromSchema } from "@common/data/fields.d.mts";
 import type { PhysicalItemSource } from "@item/base/data/index.ts";
-import type {
-    BasePhysicalItemSource,
-    Investable,
-    PhysicalItemTraits,
-    PhysicalSystemData,
-    PhysicalSystemSource,
-} from "@item/physical/data.ts";
+import type { BasePhysicalItemSource, PhysicalItemTraits } from "@item/physical/data.ts";
+import {
+    ApexField,
+    type PhysicalItemModelOmission,
+    PhysicalItemSystemModel,
+    PhysicalItemSystemSchema,
+    PhysicalItemSystemSource,
+    PhysicalItemTraitsSchema,
+} from "@item/physical/schema.ts";
+import { RarityField } from "@module/model.ts";
+import { LaxArrayField, SlugField } from "@system/schema-data-fields.ts";
+import type { EquipmentPF2e } from "./document.ts";
 import type { EquipmentTrait } from "./types.ts";
+import fields = foundry.data.fields;
 
 type EquipmentSource = BasePhysicalItemSource<"equipment", EquipmentSystemSource>;
 
-interface EquipmentSystemSource extends Investable<PhysicalSystemSource> {
-    traits: EquipmentTraits;
-    usage: { value: string };
-    /** Doubly-embedded adjustments, attachments, talismans etc. */
-    subitems: PhysicalItemSource[];
+class EquipmentSystemData extends PhysicalItemSystemModel<EquipmentPF2e, EquipmentSystemSchema> {
+    declare traits: PhysicalItemTraits<EquipmentTrait>;
+
+    static override defineSchema(): EquipmentSystemSchema {
+        const traits: Record<EquipmentTrait, string> = CONFIG.PF2E.equipmentTraits;
+
+        return {
+            ...super.defineSchema(),
+            apex: new ApexField(),
+            traits: new fields.SchemaField({
+                otherTags: new fields.ArrayField(
+                    new SlugField({ required: true, nullable: false, initial: undefined }),
+                ),
+                value: new LaxArrayField(
+                    new fields.StringField({
+                        required: true,
+                        nullable: false,
+                        choices: traits,
+                        initial: undefined,
+                    }),
+                ),
+                rarity: new RarityField(),
+            }),
+            usage: new fields.SchemaField({
+                value: new fields.StringField({ required: true, nullable: false, initial: "held-in-one-hand" }),
+            }),
+            subitems: new fields.ArrayField(new fields.ObjectField({ required: true, nullable: false })),
+        };
+    }
+
+    override prepareBaseData(): void {
+        this.subitems ??= [];
+    }
+
+    protected override async _preUpdate(
+        changes: DeepPartial<EquipmentSystemSource>,
+        options: object,
+        user: User,
+    ): Promise<boolean | void> {
+        if ((await super._preUpdate(changes, options, user)) === false) return;
+        const isApex = (changes.traits?.value ?? this.traits.value).includes("apex");
+        if (!isApex) this.apex = null;
+    }
 }
-
-interface EquipmentTraits extends PhysicalItemTraits<EquipmentTrait> {}
-
 interface EquipmentSystemData
-    extends Omit<EquipmentSystemSource, SourceOmission>, Omit<Investable<PhysicalSystemData>, "subitems" | "traits"> {
-    stackGroup: null;
-}
+    extends
+        PhysicalItemSystemModel<EquipmentPF2e, EquipmentSystemSchema>,
+        Omit<ModelPropsFromSchema<EquipmentSystemSchema>, PhysicalItemModelOmission> {}
 
-type SourceOmission =
-    | "apex"
-    | "bulk"
-    | "description"
-    | "hp"
-    | "identification"
-    | "material"
-    | "price"
-    | "temporary"
-    | "usage";
+type EquipmentSystemSchema = Omit<PhysicalItemSystemSchema, "traits"> & {
+    apex: ApexField;
+    traits: fields.SchemaField<PhysicalItemTraitsSchema<EquipmentTrait>>;
+    usage: fields.SchemaField<{
+        value: fields.StringField<string, string, true, false>;
+    }>;
+    subitems: fields.ArrayField<fields.ObjectField<PhysicalItemSource, PhysicalItemSource, true, false>>;
+};
 
-export type { EquipmentSource, EquipmentSystemData, EquipmentSystemSource, EquipmentTrait };
+type EquipmentSystemSource = PhysicalItemSystemSource<EquipmentSystemSchema>;
+
+export { EquipmentSystemData };
+export type { EquipmentSource, EquipmentSystemSource, EquipmentTrait };

--- a/src/module/item/physical/data.ts
+++ b/src/module/item/physical/data.ts
@@ -41,7 +41,7 @@ interface PhysicalSystemSource extends ItemSystemSource {
     apex?: {
         attribute: AttributeString;
         selected?: boolean;
-    };
+    } | null;
 }
 
 interface IdentificationSource {
@@ -58,7 +58,7 @@ interface PhysicalSystemData extends Omit<PhysicalSystemSource, "description">, 
     apex?: {
         attribute: AttributeString;
         selected: boolean;
-    };
+    } | null;
     equipped: EquippedData;
     hp: PhysicalItemHitPoints;
     price: Price;
@@ -68,7 +68,7 @@ interface PhysicalSystemData extends Omit<PhysicalSystemSource, "description">, 
     temporary: boolean;
     identification: IdentificationData;
     usage: UsageDetails;
-    stackGroup: string | null;
+    stackGroup?: string | null;
 }
 
 type Investable<TData extends PhysicalSystemData | PhysicalSystemSource> = TData & {
@@ -106,7 +106,7 @@ interface ItemMaterialData extends ItemMaterialSource {
 type IdentifiedData = DeepPartial<MystifiedData>;
 
 interface IdentificationData extends IdentificationSource {
-    identified: MystifiedData;
+    identified: MystifiedData & { img: ImageFilePath | null };
 }
 
 type EquippedData = {

--- a/src/module/item/physical/schema.ts
+++ b/src/module/item/physical/schema.ts
@@ -1,8 +1,33 @@
-import { PrunedSchemaField } from "@system/schema-data-fields.ts";
+import type { AttributeString } from "@actor/types.ts";
+import { ATTRIBUTE_ABBREVIATIONS } from "@actor/values.ts";
+import type { ImageFilePath } from "@common/constants.d.mts";
+import { ModelPropsFromSchema, SourceFromSchema } from "@common/data/fields.mjs";
+import { ItemSystemModel, type ItemSystemSchema } from "@item/base/data/model.ts";
+import type { ItemDescriptionData, ItemSystemSource } from "@item/base/data/system.ts";
+import { ITEM_CARRY_TYPES } from "@item/base/data/values.ts";
+import { ItemSize } from "@item/types.ts";
+import { type ZeroToTwo } from "@module/data.ts";
+import { RarityField } from "@module/model.ts";
+import { PrunedSchemaField, SlugField } from "@system/schema-data-fields.ts";
 import * as R from "remeda";
-import { Coins } from "./coins.ts";
-import type { Price } from "./index.ts";
-import { COIN_DENOMINATIONS } from "./values.ts";
+import {
+    Coins,
+    EquippedData,
+    type BulkData,
+    type IdentificationData,
+    type IdentificationStatus,
+    type ItemCarryType,
+    type ItemMaterialData,
+    type PhysicalItemHitPoints,
+    type PhysicalItemPF2e,
+    type PhysicalItemTrait,
+    type PhysicalItemTraits,
+    type PreciousMaterialGrade,
+    type PreciousMaterialType,
+    type Price,
+    type UsageDetails,
+} from "./index.ts";
+import { COIN_DENOMINATIONS, PRECIOUS_MATERIAL_TYPES } from "./values.ts";
 import fields = foundry.data.fields;
 
 class PriceField extends fields.SchemaField<PriceSchema, fields.SourceFromSchema<PriceSchema>, Price> {
@@ -33,6 +58,150 @@ class PriceField extends fields.SchemaField<PriceSchema, fields.SourceFromSchema
     }
 }
 
+class ApexField extends fields.SchemaField<
+    ApexSchema,
+    fields.SourceFromSchema<ApexSchema>,
+    fields.ModelPropsFromSchema<ApexSchema>,
+    true,
+    true,
+    true
+> {
+    constructor() {
+        super(
+            {
+                attribute: new fields.StringField({
+                    choices: [...ATTRIBUTE_ABBREVIATIONS],
+                    required: true,
+                    nullable: false,
+                    initial: "str",
+                }),
+                selected: new fields.BooleanField({ required: true, nullable: false, initial: false }),
+            },
+            { required: true, nullable: true, initial: null },
+        );
+    }
+}
+
+/** Base system model for physical items. */
+abstract class PhysicalItemSystemModel<
+    TItem extends PhysicalItemPF2e,
+    TSchema extends PhysicalItemSystemSchema,
+> extends ItemSystemModel<TItem, TSchema> {
+    declare traits: PhysicalItemTraits<PhysicalItemTrait>;
+
+    declare usage: UsageDetails;
+
+    static override defineSchema(): PhysicalItemSystemSchema {
+        const unidentifiedImg: ImageFilePath = `systems/${SYSTEM_ID}/icons/unidentified_item_icons/adventuring_gear.webp`;
+        return {
+            ...super.defineSchema(),
+            baseItem: new fields.StringField({ required: true, nullable: true, initial: null }),
+            bulk: new fields.SchemaField({
+                value: new fields.NumberField({
+                    required: true,
+                    nullable: false,
+                    min: 0,
+                    max: 1000,
+                    initial: 0.1,
+                    validate: (v) => typeof v === "number" && (v === 0.1 || Number.isInteger(v)),
+                }),
+            }),
+            containerId: new fields.StringField({
+                required: true,
+                nullable: true,
+                blank: false,
+                validate: (v) => typeof v === "string" && foundry.data.validators.isValidId(v),
+            }),
+            equipped: new fields.SchemaField({
+                carryType: new fields.StringField({
+                    required: true,
+                    nullable: false,
+                    choices: ITEM_CARRY_TYPES,
+                    initial: "worn",
+                }),
+                // todo: check if the below are required, treasure didn't have it
+                inSlot: new fields.BooleanField({ required: false, nullable: false }),
+                handsHeld: new fields.NumberField({ required: false, nullable: false, min: 0, max: 2, integer: true }),
+                invested: new fields.BooleanField({ required: false, nullable: true, initial: null }),
+            }),
+            hardness: new fields.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 0 }),
+            hp: new fields.SchemaField({
+                max: new fields.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 0 }),
+                value: new fields.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 0 }),
+            }),
+            identification: new fields.SchemaField({
+                status: new fields.StringField({
+                    required: true,
+                    nullable: false,
+                    choices: ["identified", "unidentified"],
+                    initial: "identified",
+                }),
+                unidentified: new fields.SchemaField(
+                    {
+                        img: new fields.FilePathField({
+                            required: true,
+                            categories: ["IMAGE"],
+                            nullable: false,
+                            initial: unidentifiedImg,
+                        }),
+                        name: new fields.StringField({ required: true, nullable: false }),
+                        data: new fields.SchemaField({
+                            description: new fields.SchemaField({ value: new fields.HTMLField() }),
+                        }),
+                    },
+                    { required: true, nullable: true },
+                ),
+            }),
+            level: new fields.SchemaField({
+                value: new fields.NumberField({
+                    required: true,
+                    nullable: false,
+                    integer: true,
+                    min: 0,
+                    max: 30,
+                    initial: 0,
+                }),
+            }),
+            material: new fields.SchemaField({
+                type: new fields.StringField({
+                    required: true,
+                    nullable: true,
+                    choices: PRECIOUS_MATERIAL_TYPES.values().toArray(),
+                }),
+                grade: new fields.StringField({ required: true, nullable: true, choices: ["low", "standard", "high"] }),
+            }),
+            price: new PriceField(),
+            quantity: new fields.NumberField({
+                required: true,
+                nullable: false,
+                integer: true,
+                min: 0,
+                initial: 1,
+            }),
+            size: new fields.StringField({
+                required: true,
+                choices: ["tiny", "med", "lg", "huge", "grg"],
+                initial: "med",
+            }),
+            temporary: new fields.BooleanField({ required: false }),
+        };
+    }
+}
+
+interface PhysicalItemSystemModel<TItem extends PhysicalItemPF2e, TSchema extends PhysicalItemSystemSchema>
+    extends
+        ItemSystemModel<TItem, TSchema>,
+        Omit<ModelPropsFromSchema<PhysicalItemSystemSchema>, "description" | "equipped"> {
+    bulk: BulkData;
+    description: ItemDescriptionData;
+    equipped: EquippedData;
+    hp: PhysicalItemHitPoints;
+    identification: IdentificationData;
+    material: ItemMaterialData;
+    price: Price;
+    temporary: boolean;
+}
+
 type CoinsSchema = {
     cp: fields.NumberField<number, number, false, false, false>;
     sp: fields.NumberField<number, number, false, false, false>;
@@ -46,4 +215,81 @@ type PriceSchema = {
     sizeSensitive: fields.BooleanField<boolean, boolean, false, false, false>;
 };
 
-export { PriceField };
+type EquippedDataSchema = {
+    carryType: fields.StringField<ItemCarryType, ItemCarryType, true, false>;
+    inSlot: fields.BooleanField<boolean, boolean, false, false, false>;
+    handsHeld: fields.NumberField<ZeroToTwo, ZeroToTwo, false, false>;
+    invested: fields.BooleanField<boolean, boolean, false, true>;
+};
+
+type ApexSchema = {
+    attribute: fields.StringField<AttributeString, AttributeString, true, false>;
+    selected: fields.BooleanField<boolean, boolean, true, false, true>;
+};
+
+type PhysicalItemTraitsSchema<T extends PhysicalItemTrait> = {
+    value: fields.ArrayField<fields.StringField<T, T, true, false, false>>;
+    rarity: RarityField;
+    otherTags: fields.ArrayField<SlugField<true, false, false>, string[], string[], true, false, true>;
+};
+
+type PhysicalItemSystemSchema = ItemSystemSchema & {
+    baseItem: fields.StringField<string, string, true, true, true>;
+    bulk: fields.SchemaField<{ value: fields.NumberField<number, number, true, false, true> }>;
+    containerId: fields.StringField<string, string, true, true, true>;
+    hardness: fields.NumberField<number, number, true, false, true>;
+    hp: fields.SchemaField<{
+        value: fields.NumberField<number, number, true, false, true>;
+        max: fields.NumberField<number, number, true, false, true>;
+    }>;
+    equipped: fields.SchemaField<EquippedDataSchema>;
+    level: fields.SchemaField<{ value: fields.NumberField<number, number, true, false, true> }>;
+    identification: fields.SchemaField<{
+        status: fields.StringField<IdentificationStatus, IdentificationStatus, true, false, true>;
+        unidentified: fields.SchemaField<
+            UnidentifiedSchema,
+            fields.SourceFromSchema<UnidentifiedSchema>,
+            fields.ModelPropsFromSchema<UnidentifiedSchema>,
+            true,
+            true,
+            true
+        >;
+    }>;
+    material: fields.SchemaField<{
+        grade: fields.StringField<PreciousMaterialGrade, PreciousMaterialGrade, true, true, true>;
+        type: fields.StringField<PreciousMaterialType, PreciousMaterialType, true, true, true>;
+    }>;
+    price: PriceField;
+    quantity: fields.NumberField<number, number, true, false, true>;
+    size: fields.StringField<ItemSize, ItemSize, true, false, true>;
+    temporary: fields.BooleanField<boolean, boolean, false, false, false>;
+};
+
+type UnidentifiedSchema = {
+    name: fields.StringField<string, string, true, false, true>;
+    img: fields.FilePathField<ImageFilePath, ImageFilePath, true, false, true>;
+    data: fields.SchemaField<{
+        description: fields.SchemaField<{
+            value: fields.StringField<string, string, true, false, true>;
+        }>;
+    }>;
+};
+
+type PhysicalItemModelOmission =
+    | "bulk"
+    | "description"
+    | "equipped"
+    | "hp"
+    | "identification"
+    | "material"
+    | "temporary"
+    | "traits"
+    | "usage";
+
+type PhysicalItemSystemSource<T extends PhysicalItemSystemSchema = PhysicalItemSystemSchema> = SourceFromSchema<T> & {
+    schema?: ItemSystemSource["schema"];
+    usage?: { value: string };
+};
+
+export { ApexField, PhysicalItemSystemModel, PriceField };
+export type { PhysicalItemModelOmission, PhysicalItemSystemSchema, PhysicalItemSystemSource, PhysicalItemTraitsSchema };

--- a/src/module/item/treasure/data.ts
+++ b/src/module/item/treasure/data.ts
@@ -1,23 +1,6 @@
-import type { ImageFilePath } from "@common/constants.d.mts";
-import { ItemSystemModel, ItemSystemSchema } from "@item/base/data/model.ts";
-import type { ItemDescriptionData } from "@item/base/data/system.ts";
-import { ITEM_CARRY_TYPES } from "@item/base/data/values.ts";
-import type {
-    BasePhysicalItemSource,
-    BulkData,
-    EquippedData,
-    IdentificationData,
-    IdentificationStatus,
-    ItemCarryType,
-    ItemMaterialData,
-    PhysicalItemHitPoints,
-    Price,
-} from "@item/physical/data.ts";
-import { PriceField } from "@item/physical/schema.ts";
-import type { PreciousMaterialGrade, PreciousMaterialType } from "@item/physical/types.ts";
+import type { BasePhysicalItemSource, EquippedData } from "@item/physical/data.ts";
+import { PhysicalItemModelOmission, PhysicalItemSystemModel, PhysicalItemSystemSchema } from "@item/physical/schema.ts";
 import type { CarriedUsage } from "@item/physical/usage.ts";
-import { PRECIOUS_MATERIAL_TYPES } from "@item/physical/values.ts";
-import { ItemSize } from "@item/types.ts";
 import { RarityField } from "@module/model.ts";
 import { LaxArrayField, SlugField } from "@system/schema-data-fields.ts";
 import type { TreasurePF2e } from "./document.ts";
@@ -25,99 +8,13 @@ import { TreasureCategory } from "./types.ts";
 import { TREASURE_CATEGORIES } from "./values.ts";
 import fields = foundry.data.fields;
 
-class TreasureSystemData extends ItemSystemModel<TreasurePF2e, TreasureSystemSchema> {
+class TreasureSystemData extends PhysicalItemSystemModel<TreasurePF2e, TreasureSystemSchema> {
     static override LOCALIZATION_PREFIXES = [...super.LOCALIZATION_PREFIXES, "PF2E.Item.Treasure"];
 
     static override defineSchema(): TreasureSystemSchema {
-        const unidentifiedImg: ImageFilePath = `systems/${SYSTEM_ID}/icons/unidentified_item_icons/adventuring_gear.webp`;
         return {
             ...super.defineSchema(),
-            baseItem: new fields.StringField({ required: true, nullable: true, blank: false }),
-            bulk: new fields.SchemaField({
-                value: new fields.NumberField({
-                    required: true,
-                    nullable: false,
-                    min: 0,
-                    max: 1000,
-                    initial: 0.1,
-                    validate: (v) => typeof v === "number" && (v === 0.1 || Number.isInteger(v)),
-                }),
-            }),
             category: new fields.StringField({ required: true, nullable: true, choices: TREASURE_CATEGORIES }),
-            containerId: new fields.StringField({
-                required: true,
-                nullable: true,
-                blank: false,
-                validate: (v) => typeof v === "string" && foundry.data.validators.isValidId(v),
-            }),
-            equipped: new fields.SchemaField({
-                carryType: new fields.StringField({
-                    required: true,
-                    nullable: false,
-                    choices: ITEM_CARRY_TYPES,
-                    initial: "worn",
-                }),
-            }),
-            hardness: new fields.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 0 }),
-            hp: new fields.SchemaField({
-                max: new fields.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 0 }),
-                value: new fields.NumberField({ required: true, nullable: false, integer: true, min: 0, initial: 0 }),
-            }),
-            identification: new fields.SchemaField({
-                status: new fields.StringField({
-                    required: true,
-                    nullable: false,
-                    choices: ["identified", "unidentified"],
-                    initial: "identified",
-                }),
-                unidentified: new fields.SchemaField(
-                    {
-                        img: new fields.FilePathField({
-                            required: true,
-                            categories: ["IMAGE"],
-                            nullable: false,
-                            initial: unidentifiedImg,
-                        }),
-                        name: new fields.StringField({ required: true, nullable: false }),
-                        data: new fields.SchemaField({
-                            description: new fields.SchemaField({ value: new fields.HTMLField() }),
-                        }),
-                    },
-                    { required: true, nullable: true },
-                ),
-            }),
-            level: new fields.SchemaField({
-                value: new fields.NumberField({
-                    required: true,
-                    nullable: false,
-                    integer: true,
-                    min: 0,
-                    max: 30,
-                    initial: 0,
-                }),
-            }),
-            material: new fields.SchemaField({
-                type: new fields.StringField({
-                    required: true,
-                    nullable: true,
-                    choices: PRECIOUS_MATERIAL_TYPES.values().toArray(),
-                }),
-                grade: new fields.StringField({ required: true, nullable: true, choices: ["low", "standard", "high"] }),
-            }),
-            price: new PriceField(),
-            quantity: new fields.NumberField({
-                required: true,
-                nullable: false,
-                integer: true,
-                min: 0,
-                initial: 1,
-            }),
-            size: new fields.StringField({
-                required: true,
-                choices: ["tiny", "med", "lg", "huge", "grg"],
-                initial: "med",
-            }),
-            temporary: new fields.BooleanField({ required: false }),
             traits: new fields.SchemaField({
                 value: new LaxArrayField(new fields.StringField({ required: true, choices: ["precious"] } as const)),
                 rarity: new RarityField(),
@@ -158,78 +55,27 @@ class TreasureSystemData extends ItemSystemModel<TreasurePF2e, TreasureSystemSch
 }
 
 interface TreasureSystemData
-    extends ItemSystemModel<TreasurePF2e, TreasureSystemSchema>, fields.ModelPropsFromSchema<TreasureSystemSchema> {
-    bulk: BulkData;
-    description: ItemDescriptionData;
-    equipped: TreasureEquippedData;
-    hp: PhysicalItemHitPoints;
-    identification: IdentificationData;
-    material: ItemMaterialData;
-    price: Price;
-    temporary: boolean;
-
+    extends
+        PhysicalItemSystemModel<TreasurePF2e, TreasureSystemSchema>,
+        Omit<fields.ModelPropsFromSchema<TreasureSystemSchema>, PhysicalItemModelOmission> {
     apex?: never;
+    equipped: TreasureEquippedData;
     subitems?: never;
 }
 
 interface TreasureSystemSource extends fields.SourceFromSchema<TreasureSystemSchema> {
-    equipped: {
-        carryType: ItemCarryType;
-        invested?: never;
-    };
     apex?: never;
     schema?: never;
     subitems?: never;
     usage?: never;
 }
 
-type TreasureSystemSchema = Omit<ItemSystemSchema, "traits"> & {
-    baseItem: fields.StringField<string, string, true, true>;
+type TreasureSystemSchema = Omit<PhysicalItemSystemSchema, "traits"> & {
     category: fields.StringField<TreasureCategory, TreasureCategory, true, true, true>;
-    bulk: fields.SchemaField<{ value: fields.NumberField<number, number, true, false, true> }>;
-    containerId: fields.StringField<string, string, true, true>;
-    hardness: fields.NumberField<number, number, true, false, true>;
-    hp: fields.SchemaField<{
-        max: fields.NumberField<number, number, true, false, true>;
-        value: fields.NumberField<number, number, true, false, true>;
-    }>;
-    equipped: fields.SchemaField<{
-        carryType: fields.StringField<ItemCarryType, ItemCarryType, true, false, true>;
-    }>;
-    identification: fields.SchemaField<{
-        status: fields.StringField<IdentificationStatus, IdentificationStatus, true, false, true>;
-        unidentified: fields.SchemaField<
-            UnidentifiedSchema,
-            fields.SourceFromSchema<UnidentifiedSchema>,
-            fields.ModelPropsFromSchema<UnidentifiedSchema>,
-            true,
-            true,
-            true
-        >;
-    }>;
-    level: fields.SchemaField<{ value: fields.NumberField<number, number, true, false, true> }>;
-    material: fields.SchemaField<{
-        type: fields.StringField<PreciousMaterialType, PreciousMaterialType, true, true>;
-        grade: fields.StringField<PreciousMaterialGrade, PreciousMaterialGrade, true, true>;
-    }>;
-    price: PriceField;
-    quantity: fields.NumberField<number, number, true, false, true>;
-    size: fields.StringField<ItemSize, ItemSize, true, false, true>;
-    temporary: fields.BooleanField<boolean, boolean, false, false, false>;
     traits: fields.SchemaField<{
         value: fields.ArrayField<fields.StringField<"precious", "precious", true, false, false>>;
         rarity: RarityField;
         otherTags: fields.ArrayField<SlugField<true, false, false>>;
-    }>;
-};
-
-type UnidentifiedSchema = {
-    name: fields.StringField<string, string, true, false, true>;
-    img: fields.FilePathField<ImageFilePath, ImageFilePath, true, false, true>;
-    data: fields.SchemaField<{
-        description: fields.SchemaField<{
-            value: fields.StringField<string, string, true, false, true>;
-        }>;
     }>;
 };
 

--- a/src/module/migration/base.ts
+++ b/src/module/migration/base.ts
@@ -50,7 +50,7 @@ interface MigrationBase {
      * @param source Item to update. This should be an `ItemData` from the previous version.
      * @param actorSource If the item is part of an actor, this is set to the actor. For instance
      */
-    updateItem?(source: ItemSourcePF2e, actorSource?: ActorSourcePF2e): Promise<void>;
+    updateItem?(source: ItemSourcePF2e, actorSource?: ActorSourcePF2e): Promise<void> | void;
 
     /**
      * Update the macro to the latest schema version.

--- a/src/module/migration/migrations/855-apex-equipment-system-data.ts
+++ b/src/module/migration/migrations/855-apex-equipment-system-data.ts
@@ -21,7 +21,7 @@ export class Migration855ApexEquipmentSystemData extends MigrationBase {
             .shift();
 
         if (setHasElement(ATTRIBUTE_ABBREVIATIONS, apexAttribute)) {
-            source.system.apex ??= { attribute: apexAttribute };
+            source.system.apex ??= { attribute: apexAttribute, selected: false };
             source.system.rules = source.system.rules.filter((r) => !isApexRE(r));
         }
     }

--- a/src/module/migration/migrations/901-reorganize-bulk-data.ts
+++ b/src/module/migration/migrations/901-reorganize-bulk-data.ts
@@ -9,7 +9,7 @@ import { MigrationBase } from "../base.ts";
 export class Migration901ReorganizeBulkData extends MigrationBase {
     static override version = 0.901;
 
-    override async updateItem(source: ItemSourcePF2e): Promise<void> {
+    override updateItem(source: ItemSourcePF2e): void {
         this.#migrateRules(source);
         if (!itemIsOfType(source, "physical")) return;
 

--- a/src/scripts/hooks/load.ts
+++ b/src/scripts/hooks/load.ts
@@ -14,7 +14,9 @@ import { AfflictionSystemData } from "@item/affliction/data.ts";
 import { CampaignFeatureSystemData } from "@item/campaign-feature/data.ts";
 import { ClassSystemData } from "@item/class/data.ts";
 import { ConditionSystemData } from "@item/condition/data.ts";
+import { ContainerSystemData } from "@item/container/data.ts";
 import { EffectSystemData } from "@item/effect/data.ts";
+import { EquipmentSystemData } from "@item/equipment/data.ts";
 import { FeatSystemData } from "@item/feat/data.ts";
 import { HeritageSystemData } from "@item/heritage/data.ts";
 import { KitSystemData } from "@item/kit/data.ts";
@@ -117,10 +119,12 @@ export class Load {
             CONFIG.Item.dataModels.affliction = AfflictionSystemData;
         }
         CONFIG.Item.dataModels.action = AbilitySystemData;
+        CONFIG.Item.dataModels.backpack = ContainerSystemData;
         CONFIG.Item.dataModels.campaignFeature = CampaignFeatureSystemData;
         CONFIG.Item.dataModels.class = ClassSystemData;
         CONFIG.Item.dataModels.condition = ConditionSystemData;
         CONFIG.Item.dataModels.effect = EffectSystemData;
+        CONFIG.Item.dataModels.equipment = EquipmentSystemData;
         CONFIG.Item.dataModels.feat = FeatSystemData;
         CONFIG.Item.dataModels.heritage = HeritageSystemData;
         CONFIG.Item.dataModels.kit = KitSystemData;

--- a/static/template.json
+++ b/static/template.json
@@ -323,24 +323,6 @@
                 }
             }
         },
-        "backpack": {
-            "templates": [
-                "common",
-                "physical",
-                "investable"
-            ],
-            "bulk": {
-                "value": 0,
-                "heldOrStowed": 0.1,
-                "capacity": 10,
-                "ignored": 0
-            },
-            "collapsed": false,
-            "stowing": false,
-            "usage": {
-                "value": "worn"
-            }
-        },
         "book": {
             "templates": [
                 "common",
@@ -450,17 +432,6 @@
                     "consumable"
                 ]
             }
-        },
-        "equipment": {
-            "templates": [
-                "common",
-                "physical",
-                "investable"
-            ],
-            "usage": {
-                "value": "held-in-one-hand"
-            },
-            "subitems": []
         },
         "ancestry": {
             "templates": [


### PR DESCRIPTION
I tested with an old actor from the discord and the temporary source migration seems to be converting them correctly. This should allow us to start converting the less touched physical items, though weapons/armor/shields are still off limits right now.