### PR TITLE
Fix display of NPC Shield health when 3 digits long

### DIFF
--- a/src/styles/actor/npc/_sidebar.scss
+++ b/src/styles/actor/npc/_sidebar.scss
@@ -53,8 +53,10 @@
     .hit-points {
         display: flex;
         flex: 0;
+        align-items: center;
         justify-content: end;
         margin-left: auto;
+        font-size: var(--font-size-16);
 
         input.current {
             font-weight: normal;
@@ -66,12 +68,12 @@
         .slash {
             align-items: center;
             display: flex;
-            font-size: var(--font-size-16);
             padding: 0 var(--space-1);
         }
 
         .max {
-            text-align: center;
+            font-weight: 600;
+            text-align: end;
 
             &.lt10 {
                 width: 0.5rem;
@@ -86,12 +88,6 @@
     }
 
     &.shield {
-        .hit-points {
-            .max {
-                font-size: var(--font-size-16);
-            }
-        }
-
         .shield-details {
             align-items: baseline;
             display: flex;

--- a/static/templates/actors/npc/partials/sidebar.hbs
+++ b/static/templates/actors/npc/partials/sidebar.hbs
@@ -51,7 +51,7 @@
             <div class="hit-points">
                 <input type="number" name="system.attributes.shield.hp.value" value="{{data.attributes.shield.hp.value}}" class="current" placeholder="0" />
                 <span class="slash">/</span>
-                <label class="max" data-tooltip="PF2E.Actor.Creature.Shield.HitPoints.Max">{{data.attributes.shield.hp.max}}</label>
+                <div class="max" data-tooltip="PF2E.Actor.Creature.Shield.HitPoints.Max">{{data.attributes.shield.hp.max}}</div>
             </div>
         </header>
 


### PR DESCRIPTION
Color are still a bit off but I'd rather not mess with colors outside of the V13 branch if possible

![image](https://github.com/user-attachments/assets/dca192bd-8999-4465-acea-728d25d0d00d)
