### PR TITLE
Make `SpellOverlayOverride` type more shallow and remove cyclical reference

### DIFF
--- a/src/module/item/spell/data.ts
+++ b/src/module/item/spell/data.ts
@@ -94,7 +94,7 @@ interface SpellHeightenLayer {
 }
 
 interface SpellOverlayOverride {
-    system?: DeepPartial<SpellSystemSource>;
+    system?: Partial<Omit<SpellSystemSource, "overlays">>;
     name?: string;
     overlayType: "override";
     sort: number;
@@ -135,8 +135,8 @@ export type {
     SpellArea,
     SpellDamage,
     SpellDamageSource,
-    SpellHeightenLayer,
     SpellHeighteningInterval,
+    SpellHeightenLayer,
     SpellOverlay,
     SpellOverlayOverride,
     SpellOverlayType,

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -869,7 +869,9 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
             )
             .sort((a, b) => a.sort - b.sort);
 
-        const rollData = htmlOptions.rollData ?? this.getRollData({ castRank });
+        const rollData =
+            (htmlOptions.rollData instanceof Function ? htmlOptions.rollData() : htmlOptions.rollData) ??
+            this.getRollData({ castRank });
         rollData.item ??= this;
 
         const systemData: SpellSystemData = this.system;
@@ -1123,7 +1125,7 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
     }
 
     protected override async _preUpdate(
-        changed: DeepPartial<SpellSource>,
+        changed: DeepPartial<this["_source"]>,
         operation: DatabaseUpdateOperation<TParent>,
         user: UserPF2e,
     ): Promise<boolean | void> {


### PR DESCRIPTION
Also fixes an instance of `rollData` that slipped through the cracks.

The `DeepPartial` type isn't needed anywhere so it should be safe to use a `Partial` there.