### PR TITLE
Remove `Concentrate` trait from Blood Vendetta spell

### DIFF
--- a/packs/spells/2nd-rank/blood-vendetta.json
+++ b/packs/spells/2nd-rank/blood-vendetta.json
@@ -68,7 +68,6 @@
                 "occult"
             ],
             "value": [
-                "concentrate",
                 "curse"
             ]
         }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f1297a3c-9a9e-4414-8872-7b86b18595df)
