### PR TITLE
Fix regression with crit and crit fail result color

### DIFF
--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -23,16 +23,6 @@ $sub-color: #605856;
 $text-dark-color: #1c1c1c !default;
 
 /* ----------------------------------------- */
-/* Color schemes                             */
-/* ----------------------------------------- */
-
-/* Degrees of success */
-$degree-success-critical: rgb(0, 128, 0);
-$degree-success: rgb(0, 0, 255);
-$degree-failure: rgb(255, 69, 0);
-$degree-failure-critical: rgb(255, 0, 0);
-
-/* ----------------------------------------- */
 /* CSS Custom Properties                     */
 /* ----------------------------------------- */
 
@@ -88,6 +78,12 @@ body,
     --text-light-disabled: #a6a092;
     --color-text-dark-input: #333;
     --color-text-dark-improved: #006644;
+
+    /* Degrees of success */
+    --color-pf-text-critical-success: rgb(0, 128, 0);
+    --color-pf-text-success: rgb(0, 0, 255);
+    --color-pf-text-failure: rgb(255, 69, 0);
+    --color-pf-text-critical-failure: rgb(255, 0, 0);
 
     /* Borders */
     --color-border-divider: #baa991;

--- a/src/styles/ui/sidebar/chat/_check.scss
+++ b/src/styles/ui/sidebar/chat/_check.scss
@@ -18,26 +18,26 @@
             .adjusted {
                 text-decoration: underline dotted;
                 &.increased {
-                    color: $degree-success-critical;
+                    color: var(--color-pf-text-critical-success);
                 }
                 &.decreased {
-                    color: $degree-failure-critical;
+                    color: var(--color-pf-text-critical-failure);
                 }
             }
         }
 
         .degree-of-success {
             .criticalSuccess {
-                color: $degree-success-critical;
+                color: var(--color-pf-text-critical-success);
             }
             .success {
-                color: $degree-success;
+                color: var(--color-pf-text-success);
             }
             .failure {
-                color: $degree-failure;
+                color: var(--color-pf-text-failure);
             }
             .criticalFailure {
-                color: $degree-failure-critical;
+                color: var(--color-pf-text-critical-failure);
             }
         }
 
@@ -55,6 +55,15 @@
 }
 
 > .message-content {
+    h4.dice-total {
+        &.success {
+            color: var(--color-pf-text-critical-success);
+        }
+        &.failure {
+            color: var(--color-pf-text-critical-failure);
+        }
+    }
+
     .dice-total button.set-as-initiative {
         --button-size: 2em;
         height: var(--button-size);


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/19134

The core `.dice-roll .dice-total.success` style is being overwrtten by the core `.chat-message h4` style due to the layer system. I suspect foundry is more likely to remove the style than to fix it given core doesn't seem to actually use and 5e no longer uses it.