### PR TITLE
Modify hold breath Air Remaining Effect duration to be upgradeable by feats

### DIFF
--- a/packs/feats/ancestry/android/internal-respirator.json
+++ b/packs/feats/ancestry/android/internal-respirator.json
@@ -25,7 +25,14 @@
             "remaster": false,
             "title": "Pathfinder Lost Omens Ancestry Guide"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "flags.pf2e.remainingAir.rounds",
+                "value": "600"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/ancestry/kashrishi/mental-sustenance.json
+++ b/packs/feats/ancestry/kashrishi/mental-sustenance.json
@@ -25,7 +25,14 @@
             "remaster": false,
             "title": "Pathfinder Lost Omens Impossible Lands"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.remainingAir.rounds",
+                "value": "5"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/ancestry/versatile-heritages/sylph/inner-breath.json
+++ b/packs/feats/ancestry/versatile-heritages/sylph/inner-breath.json
@@ -25,7 +25,14 @@
             "remaster": false,
             "title": "Pathfinder Lost Omens Ancestry Guide"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "flags.pf2e.remainingAir.rounds",
+                "value": "600"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/general/breath-control.json
+++ b/packs/feats/general/breath-control.json
@@ -44,6 +44,12 @@
                     "item:trait:inhaled"
                 ],
                 "selector": "saving-throw"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "flags.pf2e.remainingAir.rounds",
+                "value": "25 * (5 + @actor.abilities.con.mod)"
             }
         ],
         "traits": {

--- a/packs/heritages/awakened-animal/swimming-animal.json
+++ b/packs/heritages/awakened-animal/swimming-animal.json
@@ -80,6 +80,15 @@
             {
                 "key": "GrantItem",
                 "uuid": "Compendium.pf2e.ancestryfeatures.Item.Animal Attack"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "flags.pf2e.remainingAir.rounds",
+                "predicate": [
+                    "swimming-animal:water-dwelling"
+                ],
+                "value": "100"
             }
         ],
         "traits": {

--- a/packs/other-effects/effect-remaining-air.json
+++ b/packs/other-effects/effect-remaining-air.json
@@ -4,9 +4,9 @@
     "name": "Effect: Remaining Air",
     "system": {
         "badge": {
-            "max": 20,
+            "max": 600,
             "type": "counter",
-            "value": 20
+            "value": 600
         },
         "description": {
             "value": "<p>See @UUID[Compendium.pf2e.journals.JournalEntry.S55aqwWIzpQRFhcq.JournalEntryPage.OiRwxbfLNUniLg15#drowning-and-suffocating]{Drowning and Suffocating}</p>\n<p>You can hold your breath for a number of rounds equal to 5 + your Constitution modifier. Reduce your remaining air by 1 round at the end of each of your turns, or by 2 if you attacked or cast any spells that turn.</p>\n<p>You also lose 1 round worth of air each time you are critically hit or critically fail a save against a damaging effect. If you speak (including Casting a Spell) you lose all remaining air.</p>"
@@ -27,11 +27,17 @@
         },
         "rules": [
             {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.remainingAir.rounds",
+                "value": "5 + @actor.abilities.con.mod"
+            },
+            {
                 "itemId": "{item|id}",
                 "key": "ItemAlteration",
                 "mode": "override",
                 "property": "badge-max",
-                "value": "5 + @actor.abilities.con.mod"
+                "value": "@actor.flags.pf2e.remainingAir.rounds"
             },
             {
                 "key": "Note",


### PR DESCRIPTION
Made the Remaining Air effect max badge counter into an AE Like that gets upgraded by various feats like Breath Control.

Remade PR to rebase my fork and remove unnecessary extra merge commits