### PR TITLE
Allow custom non-damage weaknesses, fix Blessed Counterstrike weakness

### DIFF
--- a/packs/feat-effects/effect-blessed-counterstrike.json
+++ b/packs/feat-effects/effect-blessed-counterstrike.json
@@ -28,6 +28,7 @@
                 ],
                 "key": "Weakness",
                 "label": "PF2E.IWR.Custom.EnemyStrikes",
+                "applyOnce": true,
                 "type": "custom",
                 "value": "floor(@item.origin.level / 2)"
             }

--- a/src/module/actor/data/iwr.ts
+++ b/src/module/actor/data/iwr.ts
@@ -305,9 +305,12 @@ class Weakness extends IWR<WeaknessType> implements WeaknessSource {
 
     override value: number;
 
-    constructor(data: IWRConstructorData<WeaknessType> & { value: number }) {
+    readonly applyOnce: boolean;
+
+    constructor(data: IWRConstructorData<WeaknessType> & { value: number; applyOnce?: boolean }) {
         super(data);
         this.value = data.value;
+        this.applyOnce = data.applyOnce ?? APPLY_ONCE_WEAKNESSES.has(this.type);
     }
 
     override toObject(): Readonly<WeaknessDisplayData> {
@@ -322,6 +325,7 @@ type WeaknessDisplayData = IWRDisplayData<WeaknessType> & Pick<Weakness, "value"
 
 interface WeaknessSource extends IWRSource<WeaknessType> {
     value: number;
+    applyOnce?: boolean;
 }
 
 class Resistance extends IWR<ResistanceType> implements ResistanceSource {
@@ -371,7 +375,7 @@ interface ResistanceSource extends IWRSource<ResistanceType> {
 }
 
 /** Weaknesses to things that "[don't] normally deal damage, such as water": applied separately as untyped damage */
-const NON_DAMAGE_WEAKNESSES: Set<WeaknessType> = new Set([
+const APPLY_ONCE_WEAKNESSES: Set<WeaknessType> = new Set([
     ...MAGIC_TRADITIONS,
     "air",
     "earth",
@@ -388,5 +392,5 @@ const NON_DAMAGE_WEAKNESSES: Set<WeaknessType> = new Set([
     "wood",
 ]);
 
-export { Immunity, NON_DAMAGE_WEAKNESSES, Resistance, Weakness };
+export { Immunity, APPLY_ONCE_WEAKNESSES, Resistance, Weakness };
 export type { ImmunitySource, IWRSource, ResistanceSource, WeaknessSource };

--- a/src/module/rules/rule-element/iwr/weakness.ts
+++ b/src/module/rules/rule-element/iwr/weakness.ts
@@ -17,10 +17,9 @@ class WeaknessRuleElement extends IWRRuleElement<WeaknessRuleSchema> {
         };
     }
 
-    static override validateJoint(source: SourceFromSchema<WeaknessRuleSchema>): void {
+    static override validateJoint(source: fields.SourceFromSchema<WeaknessRuleSchema>): void {
         super.validateJoint(source);
-
-        if (typeof source.applyOnce === "boolean" && !source.type.some((t) => t === "custom")) {
+        if (typeof source.applyOnce === "boolean" && !source.type.every((t) => t === "custom")) {
             throw new foundry.data.validation.DataModelValidationError(
                 "applyOnce can only be specified for custom weakness types",
             );
@@ -67,7 +66,7 @@ class WeaknessRuleElement extends IWRRuleElement<WeaknessRuleSchema> {
                     value,
                     exceptions: this.exceptions,
                     source: this.item.name,
-                    applyOnce: this.applyOnce, // maybe be undefined
+                    applyOnce: this.applyOnce,
                 }),
         );
     }

--- a/src/module/system/damage/iwr.ts
+++ b/src/module/system/damage/iwr.ts
@@ -1,5 +1,5 @@
 import type { ActorPF2e } from "@actor";
-import { Immunity, NON_DAMAGE_WEAKNESSES, Resistance, Weakness } from "@actor/data/iwr.ts";
+import { Immunity, Resistance, Weakness } from "@actor/data/iwr.ts";
 import { ResistanceType } from "@actor/types.ts";
 import type { Rolled } from "@client/dice/_module.d.mts";
 import { DEGREE_OF_SUCCESS } from "@system/degree-of-success.ts";
@@ -37,12 +37,10 @@ function applyIWR(actor: ActorPF2e, roll: Rolled<DamageRoll>, rollOptions: Set<s
         resistances: roll.options.bypass?.resistance.redirect ?? [],
     };
 
-    const nonDamageWeaknesses = weaknesses.filter(
-        (w) =>
-            NON_DAMAGE_WEAKNESSES.has(w.type) &&
-            instances.some((i) => w.test([...i.formalDescription, ...rollOptions])),
+    const applyOnceWeaknesses = weaknesses.filter(
+        (w) => w.applyOnce && instances.some((i) => w.test([...i.formalDescription, ...rollOptions])),
     );
-    const damageWeaknesses = weaknesses.filter((w) => !nonDamageWeaknesses.includes(w));
+    const damageWeaknesses = weaknesses.filter((w) => !applyOnceWeaknesses.includes(w));
 
     const applications = instances
         .flatMap((instance): IWRApplication[] => {
@@ -263,7 +261,7 @@ function applyIWR(actor: ActorPF2e, roll: Rolled<DamageRoll>, rollOptions: Set<s
             return instanceApplications;
         })
         .concat(
-            ...nonDamageWeaknesses.map(
+            ...applyOnceWeaknesses.map(
                 (w): IWRApplication => ({ category: "weakness", type: w.typeLabel, adjustment: w.value }),
             ),
         )


### PR DESCRIPTION
Currently non-damage weaknesses are limited to a fixed set hard-coded in the
system with NON_DAMAGE_WEAKNESSES.

Add an optional field so the non-damage weakness type can be set.  If the field
is omitted, it will default to true if the weakness type is in
NON_DAMAGE_WEAKNESSES, false otherwise.

Address issue #16190

This allows creating custom non-damage weaknesses.  E.g., a definition of
"origin:signature:{item|origin.signature}" would create a weakness to strikes
from a specific player who is the origin of the effect with the weakness.  By
setting nonDamage to true, the weakness will only trigger once for a damage
roll, rather than triggering on every damage instance in the roll.

It also makes it possible to create weakness to spells/items with a trait or
traits that do not trigger multiple times on spells with multiple damage types.
This already exists for the magic traditions and a few other traits, which are
in the NON_DAMAGE_WEAKNESSES set, but not arbitrary traits.  E.g., there's no
way to make a weakness to fear spells that does not trigger twice on damage from
Invoke Spirits, which deals both mental and void damage.