### PR TITLE
Update types for multiple document source flags

### DIFF
--- a/src/module/actor/data/base.ts
+++ b/src/module/actor/data/base.ts
@@ -5,7 +5,7 @@ import type { InitiativeTraceData } from "@actor/initiative.ts";
 import type { StatisticModifier } from "@actor/modifiers.ts";
 import type { ActorAlliance, AttributeString, SkillSlug } from "@actor/types.ts";
 import type { Rolled } from "@client/dice/roll.d.mts";
-import type { DocumentFlags } from "@common/data/_module.d.mts";
+import type { DocumentFlags, DocumentFlagsSource } from "@common/data/_module.d.mts";
 import type { MeleePF2e, WeaponPF2e } from "@item";
 import type { ItemSourcePF2e } from "@item/base/data/index.ts";
 import type { MigrationRecord, Rarity, Size, ValueAndMaybeMax, ZeroToTwo } from "@module/data.ts";
@@ -22,19 +22,20 @@ type BaseActorSourcePF2e<
     TType extends ActorType,
     TSystemSource extends ActorSystemSource = ActorSystemSource,
 > = foundry.documents.ActorSource<TType, TSystemSource, ItemSourcePF2e> & {
-    flags: DeepPartial<ActorFlagsPF2e>;
+    flags: ActorSourceFlagsPF2e;
     prototypeToken: PrototypeTokenSourcePF2e;
 };
 
-type ActorFlagsPF2e = DocumentFlags & {
-    pf2e: {
-        rollOptions: RollOptionFlags;
-        /** IDs of granted items that are tracked */
-        trackedItems: Record<string, string>;
-        hideStowed?: boolean;
-        [key: string]: unknown;
-    };
-};
+type ActorSourceFlagsPF2e = DocumentFlagsSource & { pf2e?: Partial<ActorFlagsPF2eSystemProps> };
+type ActorFlagsPF2e = DocumentFlags & { pf2e: ActorFlagsPF2eSystemProps };
+
+interface ActorFlagsPF2eSystemProps {
+    rollOptions: RollOptionFlags;
+    /** IDs of granted items that are tracked */
+    trackedItems: Record<string, string>;
+    hideStowed?: boolean;
+    [key: string]: unknown;
+}
 
 type ActorSystemSource = {
     details?: ActorDetailsSource;

--- a/src/module/item/base/data/system.ts
+++ b/src/module/item/base/data/system.ts
@@ -1,4 +1,4 @@
-import type { DocumentFlags } from "@common/data/_types.d.mts";
+import type { DocumentFlags, DocumentFlagsSource } from "@common/data/_types.d.mts";
 import type * as fields from "@common/data/fields.d.mts";
 import type { MigrationRecord, OneToThree, PublicationData, Rarity } from "@module/data.ts";
 import type { RuleElementSource } from "@module/rules/index.ts";
@@ -51,7 +51,7 @@ type ItemFlagsPF2e = DocumentFlags & {
     };
 };
 
-type ItemSourceFlagsPF2e = DocumentFlags & {
+type ItemSourceFlagsPF2e = DocumentFlagsSource & {
     pf2e?: {
         rulesSelections?: Record<string, string | number | object>;
         itemGrants?: Record<string, ItemGranterSource>;

--- a/src/module/user/data.ts
+++ b/src/module/user/data.ts
@@ -1,14 +1,21 @@
-import type { DocumentFlags } from "@common/data/_module.d.mts";
-import { UserSettingsPF2e } from "./document.ts";
+import type { DocumentFlags, DocumentFlagsSource } from "@common/data/_module.d.mts";
 
-type UserSourcePF2e = Omit<foundry.documents.UserSource, "flags"> & {
-    flags: DeepPartial<UserFlagsPF2e>;
+interface UserSettingsPF2e {
+    showEffectPanel: boolean;
+    showCheckDialogs: boolean;
+    showDamageDialogs: boolean;
+    monochromeDarkvision: boolean;
+    searchPackContents: boolean;
+}
+
+type UserSourcePF2e = foundry.documents.UserSource & {
+    flags: UserSourceFlagsPF2e;
 };
+
+type UserSourceFlagsPF2e = DocumentFlagsSource & { pf2e?: { settings?: Partial<UserSettingsPF2e> } };
 
 type UserFlagsPF2e = DocumentFlags & {
-    pf2e: {
-        settings: UserSettingsPF2e;
-    };
+    pf2e: { settings: UserSettingsPF2e };
 };
 
-export type { UserFlagsPF2e, UserSourcePF2e };
+export type { UserFlagsPF2e, UserSettingsPF2e, UserSourcePF2e };

--- a/src/module/user/document.ts
+++ b/src/module/user/document.ts
@@ -4,7 +4,7 @@ import type { DatabaseUpdateCallbackOptions } from "@common/abstract/_types.d.mt
 import type { TokenPF2e } from "@module/canvas/index.ts";
 import type { ScenePF2e, TokenDocumentPF2e } from "@scene";
 import * as R from "remeda";
-import type { UserFlagsPF2e, UserSourcePF2e } from "./data.ts";
+import type { UserFlagsPF2e, UserSettingsPF2e, UserSourcePF2e } from "./data.ts";
 
 class UserPF2e extends User {
     override prepareData(): void {
@@ -76,12 +76,4 @@ interface UserPF2e extends User {
     readonly _source: UserSourcePF2e;
 }
 
-interface UserSettingsPF2e {
-    showEffectPanel: boolean;
-    showCheckDialogs: boolean;
-    showDamageDialogs: boolean;
-    monochromeDarkvision: boolean;
-    searchPackContents: boolean;
-}
-
-export { UserPF2e, type UserSettingsPF2e };
+export { UserPF2e };

--- a/types/foundry/common/data/_types.d.mts
+++ b/types/foundry/common/data/_types.d.mts
@@ -7,6 +7,7 @@ import {
     DocumentStatsData,
     MaybeSchemaProp,
     ModelPropFromDataField,
+    SourceFromDataField,
 } from "./fields.mjs";
 import { DataModelValidationFailure } from "./validation-failure.mjs";
 
@@ -321,6 +322,7 @@ interface FilePathFieldOptions<
     wildcard?: boolean;
 }
 
+export type DocumentFlagsSource = SourceFromDataField<DocumentFlagsField>;
 export type DocumentFlags = ModelPropFromDataField<DocumentFlagsField>;
 
 export interface DocumentStats extends DocumentStatsData {}

--- a/types/foundry/common/documents/user.d.mts
+++ b/types/foundry/common/documents/user.d.mts
@@ -90,4 +90,4 @@ type UserSchema<TActor extends BaseActor<null>> = {
     _stats: fields.DocumentStatsField;
 };
 
-export interface UserSource extends fields.SourceFromSchema<UserSchema<BaseActor<null>>> {}
+export type UserSource = fields.SourceFromSchema<UserSchema<BaseActor<null>>>;


### PR DESCRIPTION
The actor/item ones are supplementary for correctness but this seems to resolve the UserPF2e not assignable to User thing. `DeepPartial<ModelPropFromDataField<DocumentFlagsField>>` isn't the same as `SourceFromDataField<DocumentFlagsField>`.

Feel free to suggest an alternative to WithPF2eFlags