### PR TITLE
Add optional start data to AbstractEffectSystemData

### DIFF
--- a/src/module/item/abstract-effect/data.ts
+++ b/src/module/item/abstract-effect/data.ts
@@ -34,6 +34,7 @@ interface AbstractEffectSystemData extends Omit<ModelPropsFromSchema<AbstractEff
     duration: DurationData;
     expired?: boolean;
     context?: EffectContextData | null;
+    start?: { value: number; initiative: number | null };
 }
 
 interface EffectContextData {

--- a/src/module/item/abstract-effect/helpers.ts
+++ b/src/module/item/abstract-effect/helpers.ts
@@ -9,7 +9,7 @@ export function calculateRemainingDuration(
     if (durationData.unit === "encounter") {
         const isExpired = effect.system.expired;
         return { expired: !!isExpired, remaining: isExpired ? 0 : Infinity };
-    } else if (durationData.unit === "unlimited" || !("start" in effect.system)) {
+    } else if (durationData.unit === "unlimited" || !effect.system.start) {
         return { expired: false, remaining: Infinity };
     }
 

--- a/src/module/item/spellcasting-entry/types.ts
+++ b/src/module/item/spellcasting-entry/types.ts
@@ -1,12 +1,13 @@
-import { ActorPF2e } from "@actor";
-import { AttributeString } from "@actor/types.ts";
-import { PhysicalItemPF2e } from "@item/physical/index.ts";
-import { SpellPF2e } from "@item/spell/document.ts";
-import { MagicTradition } from "@item/spell/types.ts";
-import { OneToTen } from "@module/data.ts";
-import { Statistic, StatisticChatData } from "@system/statistic/index.ts";
-import { SpellCollection, SpellCollectionData, SpellSlotGroupId } from "./collection.ts";
-import { SpellcastingEntrySystemData } from "./data.ts";
+import type { ActorPF2e } from "@actor";
+import type { AttributeString } from "@actor/types.ts";
+import type { RollMode } from "@common/constants.d.mts";
+import type { PhysicalItemPF2e } from "@item/physical/index.ts";
+import type { SpellPF2e } from "@item/spell/document.ts";
+import type { MagicTradition } from "@item/spell/types.ts";
+import type { OneToTen } from "@module/data.ts";
+import type { Statistic, StatisticChatData } from "@system/statistic/index.ts";
+import type { SpellCollection, SpellCollectionData, SpellSlotGroupId } from "./collection.ts";
+import type { SpellcastingEntrySystemData } from "./data.ts";
 
 interface BaseSpellcastingEntry<TActor extends ActorPF2e | null = ActorPF2e | null> {
     id: string;
@@ -122,9 +123,9 @@ export type {
     ActiveSpell,
     BaseSpellcastingEntry,
     CastOptions,
-    SpellPrepEntry,
     SpellcastingCategory,
     SpellcastingEntry,
     SpellcastingSheetData,
     SpellcastingSlotGroup,
+    SpellPrepEntry,
 };


### PR DESCRIPTION
...and import RollData into spellcasting types.

Now that abstract effect's isn't using the union, the types were failing in the helper.