### PR TITLE
Add Expert Spellcasting to Expert Red Mantis Magic Feat

### DIFF
--- a/packs/feats/archetype/red-mantis-assassin/expert-red-mantis-magic.json
+++ b/packs/feats/archetype/red-mantis-assassin/expert-red-mantis-magic.json
@@ -33,11 +33,16 @@
             "title": "Pathfinder Adventure: Prey for Death"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 2
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
-            "value": [
-                "archetype"
-            ]
+            "value": ["archetype"]
         }
     },
     "type": "feat"

--- a/packs/spells/focus/achaekeks-clutch.json
+++ b/packs/spells/focus/achaekeks-clutch.json
@@ -37,7 +37,7 @@
         "requirements": "",
         "rules": [],
         "target": {
-            "value": "1 Creature"
+            "value": "1 creature"
         },
         "time": {
             "value": "2"


### PR DESCRIPTION
Does what it says: gives expert spellcasting prof to the Expert Red Mantis Magic feat as needed.

Also fixes the case in one of the Red Mantis focus spell targets.