### PR TITLE
Remove kineticist trait from stance auras and show invalid traits in form

### DIFF
--- a/packs/feat-effects/stance-ghosts-in-the-storm.json
+++ b/packs/feat-effects/stance-ghosts-in-the-storm.json
@@ -38,7 +38,6 @@
                 "radius": "@actor.flags.pf2e.kineticist.auraRadius",
                 "slug": "kinetic-aura",
                 "traits": [
-                    "kineticist",
                     "primal",
                     "air",
                     "electricity"

--- a/packs/feat-effects/stance-kindle-inner-flames.json
+++ b/packs/feat-effects/stance-kindle-inner-flames.json
@@ -38,7 +38,6 @@
                 "radius": "@actor.flags.pf2e.kineticist.auraRadius",
                 "slug": "kinetic-aura",
                 "traits": [
-                    "kineticist",
                     "primal",
                     "fire"
                 ]

--- a/packs/feat-effects/stance-orchards-endurance.json
+++ b/packs/feat-effects/stance-orchards-endurance.json
@@ -38,7 +38,6 @@
                 "radius": "@actor.flags.pf2e.kineticist.auraRadius",
                 "slug": "kinetic-aura",
                 "traits": [
-                    "kineticist",
                     "primal",
                     "plant",
                     "wood"

--- a/packs/feat-effects/stance-sea-glass-guardians.json
+++ b/packs/feat-effects/stance-sea-glass-guardians.json
@@ -38,7 +38,6 @@
                 "radius": "@actor.flags.pf2e.kineticist.auraRadius",
                 "slug": "kinetic-aura",
                 "traits": [
-                    "kineticist",
                     "primal",
                     "water"
                 ]

--- a/packs/feat-effects/stance-shattershields.json
+++ b/packs/feat-effects/stance-shattershields.json
@@ -44,7 +44,6 @@
                 "radius": "@actor.flags.pf2e.kineticist.auraRadius",
                 "slug": "kinetic-aura",
                 "traits": [
-                    "kineticist",
                     "primal",
                     "metal"
                 ]

--- a/packs/feat-effects/stance-thermal-nimbus.json
+++ b/packs/feat-effects/stance-thermal-nimbus.json
@@ -56,7 +56,6 @@
                 "radius": "@actor.flags.pf2e.kineticist.auraRadius",
                 "slug": "kinetic-aura",
                 "traits": [
-                    "kineticist",
                     "primal",
                     "fire"
                 ]

--- a/static/templates/items/rules/aura.hbs
+++ b/static/templates/items/rules/aura.hbs
@@ -35,7 +35,7 @@
     <div class="stacked">
         <div class="grid-item">
             <label>{{localize fields.traits.label}}</label>
-            <tagify-tags class="pf2e-tagify tagify-traits" name="system.rules.{{index}}.traits" value="{{json object.traits}}" />
+            <tagify-tags class="pf2e-tagify tagify-traits" name="system.rules.{{index}}.traits" value="{{json rule.traits}}" />
         </div>
 
         <div class="grid-item long-label">


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/19176

Its exclusion from the form made it tricky for the layman to fix.