### PR TITLE
Exclude rectangle templates from custom grid snapping

### DIFF
--- a/src/module/canvas/layer/template.ts
+++ b/src/module/canvas/layer/template.ts
@@ -38,7 +38,11 @@ class TemplateLayerPF2e<TObject extends MeasuredTemplatePF2e = MeasuredTemplateP
         }
 
         const { destination, preview: template, origin } = event.interactionData;
-        if (!template || template.destroyed) return;
+        if (!template || template.destroyed) {
+            return;
+        } else if (template.document.t === "rect") {
+            return super._onDragLeftMove(event);
+        }
 
         const dimensions = canvas.dimensions;
 


### PR DESCRIPTION
I don't think this will affect anything else.

- Closes #12815 

[snap.webm](https://github.com/user-attachments/assets/beeee0e3-ab94-41a9-bd0a-ad00f9e1c2af)
