### PR TITLE
Fix embedding items in journal sheets failing with a max depth warning

### DIFF
--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -1056,7 +1056,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
     ): Promise<HTMLCollection> {
         options.relativeTo = this;
         const container = document.createElement("div");
-        container.innerHTML = await TextEditorPF2e.enrichHTML(this.embedHTMLString(config, options), options);
+        container.innerHTML = await TextEditorPF2e.enrichHTML(this.embedHTMLString(config, options), { ...options });
         return container.children;
     }
 }

--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -1056,7 +1056,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
     ): Promise<HTMLCollection> {
         options.relativeTo = this;
         const container = document.createElement("div");
-        container.innerHTML = await TextEditorPF2e.enrichHTML(this.embedHTMLString(config, options), { ...options });
+        container.innerHTML = await TextEditorPF2e.enrichHTML(this.embedHTMLString(config, options), options);
         return container.children;
     }
 }

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -196,6 +196,15 @@ class TextEditorPF2e extends foundry.applications.ux.TextEditor {
         return roll.toMessage({ speaker, flavor }, { rollMode });
     }
 
+    /** Remove once https://github.com/foundryvtt/foundryvtt/issues/12933 is fixed */
+    protected static override async _embedContent(
+        match: RegExpMatchArray,
+        options: EnrichmentOptionsPF2e = {},
+    ): Promise<HTMLElement | null> {
+        options = { ...options };
+        return super._embedContent(match, options);
+    }
+
     static processUserVisibility(content: string, options: EnrichmentOptionsPF2e): string {
         const html = createHTMLElement("div", { innerHTML: content });
         const rollData = resolveRollData(options.rollData);


### PR DESCRIPTION
Passing the value instead of a reference avoids the recursion depth warning. Credit to `ChaosOS` from the Foundry discord.