### PR TITLE
Add roll options for SingleCheckAction previews

### DIFF
--- a/src/module/actor/actions/single-check.ts
+++ b/src/module/actor/actions/single-check.ts
@@ -199,7 +199,11 @@ class SingleCheckActionVariant extends BaseActionVariant {
                     ...statistic.modifiers,
                     ...this.modifiers.map((modifier) => new ModifierPF2e(modifier)),
                 ];
-                const modifier = new StatisticModifier(args.slug, modifiers, args.rollOptions);
+                const modifier = new StatisticModifier(
+                    args.slug,
+                    modifiers,
+                    new Set(args.rollOptions).union(statistic.dc.options),
+                );
                 return { label: statistic.label, modifier: modifier.totalModifier, slug: args.slug };
             }
         } else {


### PR DESCRIPTION
When it generates the previews is only uses the roll option(s) that are specific to the action, e.g. only "action:escape".  This doesn't match what will be used for the actual roll.  For instance, it won't include "armor:strength-requirement-met" and that results in the value being incorrect for nearly every str or dex based action.