### PR TITLE
Fix OutlineOverlayFilter for v13.344

### DIFF
--- a/src/module/canvas/perception/modes.ts
+++ b/src/module/canvas/perception/modes.ts
@@ -73,7 +73,6 @@ class HearingDetectionMode extends fc.perception.DetectionMode {
     static override getDetectionFilter(): fc.rendering.filters.OutlineOverlayFilter {
         const filter = (this._detectionFilter ??= fc.rendering.filters.OutlineOverlayFilter.create({
             wave: true,
-            knockout: true,
         }));
         filter.thickness = 1;
         return filter;

--- a/src/module/canvas/perception/modes.ts
+++ b/src/module/canvas/perception/modes.ts
@@ -73,7 +73,7 @@ class HearingDetectionMode extends fc.perception.DetectionMode {
     static override getDetectionFilter(): fc.rendering.filters.OutlineOverlayFilter {
         const filter = (this._detectionFilter ??= fc.rendering.filters.OutlineOverlayFilter.create({
             wave: true,
-            knockout: false,
+            knockout: true,
         }));
         filter.thickness = 1;
         return filter;


### PR DESCRIPTION
13.344 fixes OutlineOverlayFilter ignoring `knockout` and always showing only the outline (foundryvtt/foundryvtt#12721). Because of that, out-of-sight tokens now look like this: 
![image](https://github.com/user-attachments/assets/dfa72d67-985e-4d78-b99a-d7fd4a53c730)

Setting knockout to true restore the previous appearance.