### PR TITLE
Fix switching color theme for `EffectsPanel` tooltips

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -84,6 +84,7 @@ interface ClientSettingsPF2e extends fh.ClientSettings {
     get(module: "core", key: "fontSize"): number;
     get(module: "core", key: "noCanvas"): boolean;
     get(module: "core", key: "rollMode"): RollMode;
+    get(module: "core", key: "uiConfig"): { colorScheme: { applications: string; interface: string } };
     get(module: "pf2e", setting: "automation.actorsDeadAtZero"): "neither" | "npcsOnly" | "pcsOnly" | "both";
     get(module: "pf2e", setting: "automation.encumbrance"): boolean;
     get(module: "pf2e", setting: "automation.flankingDetection"): boolean;

--- a/src/module/apps/effects-panel.ts
+++ b/src/module/apps/effects-panel.ts
@@ -147,16 +147,12 @@ export class EffectsPanel extends fa.api.HandlebarsApplicationMixin(fa.api.Appli
         options: HandlebarsRenderOptions,
     ): Promise<void> {
         // Add tooltip listener for effects panel entries
-        // The uiConfig setting doesn't handle browser default, so we poach the interface theme from the DOM
-        // If we don't include the application class, theme-dark has errors
-        const interfaceElement = document.querySelector("#interface");
-        const themeClass =
-            [...(interfaceElement?.classList.values() ?? [])].find((c) => c.startsWith("theme-")) ?? "theme-dark";
         createTooltipListener(this.element, {
             selector: ".effect-item[data-item-id]",
             locked: true,
             direction: "LEFT",
-            cssClass: `pf2e effect-info application themed ${themeClass}`,
+            cssClass: `pf2e effect-info application themed`,
+            themeGroup: "interface",
             align: "top",
             render: async (effectEl) => {
                 const actor = this.#actor;

--- a/src/module/sheet/helpers.ts
+++ b/src/module/sheet/helpers.ts
@@ -177,7 +177,7 @@ function createTooltipListener(
         render: (element: HTMLElement) => Promise<HTMLElement | null>;
     },
 ): void {
-    const tooltipOptions = R.pick(options, ["cssClass", "direction", "locked"]);
+    const tooltipOptions = R.pick(options, ["direction", "locked"]);
 
     element.addEventListener(
         "pointerenter",
@@ -190,14 +190,13 @@ function createTooltipListener(
             if (options.locked) {
                 game.tooltip.dismissLockedTooltips();
             }
-            if (options.themeGroup) {
-                const parts = tooltipOptions.cssClass?.split(" ") ?? [];
-                // Remove current theme if present
-                parts.findSplice((c) => c === "theme-dark" || c === "theme-light");
-                parts.push(getCurrentTheme(options.themeGroup));
-                tooltipOptions.cssClass = parts.join(" ");
-            }
-            game.tooltip.activate(target, { html, ...tooltipOptions });
+            game.tooltip.activate(target, {
+                html,
+                ...tooltipOptions,
+                cssClass: options.themeGroup
+                    ? `${(options.cssClass ?? "").trim()} ${getCurrentTheme(options.themeGroup)}`.trim()
+                    : options.cssClass,
+            });
 
             // A very crude implementation only designed for align top. Make it more flexible if we need to later
             if (options.align === "top") {

--- a/src/module/sheet/helpers.ts
+++ b/src/module/sheet/helpers.ts
@@ -171,6 +171,7 @@ function createTooltipListener(
         /** If given, the tooltip will spawn on elements that match this selector */
         selector?: string;
         locked?: boolean;
+        themeGroup?: "applications" | "interface";
         direction?: TooltipDirection;
         cssClass?: string;
         render: (element: HTMLElement) => Promise<HTMLElement | null>;
@@ -189,6 +190,13 @@ function createTooltipListener(
             if (options.locked) {
                 game.tooltip.dismissLockedTooltips();
             }
+            if (options.themeGroup) {
+                const parts = tooltipOptions.cssClass?.split(" ") ?? [];
+                // Remove current theme if present
+                parts.findSplice((c) => c === "theme-dark" || c === "theme-light");
+                parts.push(getCurrentTheme(options.themeGroup));
+                tooltipOptions.cssClass = parts.join(" ");
+            }
             game.tooltip.activate(target, { html, ...tooltipOptions });
 
             // A very crude implementation only designed for align top. Make it more flexible if we need to later
@@ -204,6 +212,13 @@ function createTooltipListener(
         },
         true,
     );
+}
+
+/** Returns the currently active color scheme as `theme-dark` or `theme-light` */
+function getCurrentTheme(group: "applications" | "interface"): string {
+    const setting = game.settings.get("core", "uiConfig").colorScheme[group];
+    const browserDefault = window.matchMedia("(prefers-color-scheme: dark)").matches ? "theme-dark" : "theme-light";
+    return setting ? `theme-${setting}` : browserDefault;
 }
 
 interface SheetOption {

--- a/types/foundry/client/helpers/client-settings.d.mts
+++ b/types/foundry/client/helpers/client-settings.d.mts
@@ -113,6 +113,7 @@ export default class ClientSettings {
     get(module: "core", key: "fontSize"): number;
     get(module: "core", key: "noCanvas"): boolean;
     get(module: "core", key: "rollMode"): RollMode;
+    get(module: "core", key: "uiConfig"): { colorScheme: { applications: string; interface: string } };
     get(module: string, key: string): unknown;
 
     /**


### PR DESCRIPTION
Retrieving the setting on every tooltip render isn't great but caching it doesn't really work there. I've only added the setting type as needed but can fill it out if you want.