### PR TITLE
Set Mikazuki to reload 0

### DIFF
--- a/packs/equipment/mikazuki.json
+++ b/packs/equipment/mikazuki.json
@@ -62,7 +62,7 @@
         "quantity": 1,
         "range": 70,
         "reload": {
-            "value": "1"
+            "value": "0"
         },
         "rules": [],
         "runes": {


### PR DESCRIPTION
Missed this in Treasure Vault Remastered data entry. Mikazuki should have reload 0 now.