### PR TITLE
Update various type imports

### DIFF
--- a/build/lib/compendium-pack.ts
+++ b/build/lib/compendium-pack.ts
@@ -1,6 +1,7 @@
 import type { ActorSourcePF2e } from "@actor/data/index.ts";
-import type { CompendiumActorUUID, CompendiumItemUUID, ItemUUID } from "@client/documents/abstract/_module.d.mts";
+import type { CompendiumActorUUID, CompendiumItemUUID, ItemUUID } from "@client/documents/_module.d.mts";
 import type { CompendiumDocumentType } from "@client/utils/_module.d.mts";
+import type { ImageFilePath } from "@common/constants.d.mts";
 import type { DocumentStatsData, DocumentStatsSchema, SourceFromSchema } from "@common/data/fields.d.mts";
 import type { ItemSourcePF2e, MeleeSource } from "@item/base/data/index.ts";
 import { FEAT_OR_FEATURE_CATEGORIES } from "@item/feat/values.ts";
@@ -12,8 +13,8 @@ import { recursiveReplaceString, setHasElement, sluggify, tupleHasValue } from "
 import fs from "fs";
 import path from "path";
 import * as R from "remeda";
-import systemJSON from "../../static/system.json";
-import coreIconsJSON from "../core-icons.json";
+import systemJSON from "../../static/system.json" with { type: "json" };
+import coreIconsJSON from "../core-icons.json" with { type: "json" };
 import "./foundry-utils.ts";
 import { PackError, getFilesRecursively } from "./helpers.ts";
 import { DBFolder, LevelDatabase } from "./level-database.ts";

--- a/build/lib/level-database.ts
+++ b/build/lib/level-database.ts
@@ -7,7 +7,7 @@ import { tupleHasValue } from "@util";
 import type { AbstractSublevel } from "abstract-level";
 import { ClassicLevel, type DatabaseOptions } from "classic-level";
 import * as R from "remeda";
-import systemJSON from "../../static/system.json" assert { type: "json" };
+import systemJSON from "../../static/system.json" with { type: "json" };
 import { PackError } from "./helpers.ts";
 import { PackEntry } from "./types.ts";
 

--- a/build/run-migration.ts
+++ b/build/run-migration.ts
@@ -1,6 +1,6 @@
 import type { ActorSourcePF2e } from "@actor/data/index.ts";
 import { CREATURE_ACTOR_TYPES } from "@actor/values.ts";
-import type { CompendiumDocument } from "@client/documents/collections/compendium-collection.d.mts";
+import type { CompendiumDocument } from "@client/documents/_module.d.mts";
 import type { ItemSourcePF2e } from "@item/base/data/index.ts";
 import { itemIsOfType } from "@item/helpers.ts";
 import { PHYSICAL_ITEM_TYPES } from "@item/physical/values.ts";

--- a/src/module/canvas/effect-area-square.ts
+++ b/src/module/canvas/effect-area-square.ts
@@ -1,4 +1,6 @@
 import type { AuraAppearanceData } from "@actor/types.ts";
+import type { GridHighlight } from "@client/canvas/containers/_module.d.mts";
+import type { Point } from "@common/_types.d.mts";
 
 /** A square (`PIXI.Rectangle`) with additional information about an effect area it's part of */
 export class EffectAreaSquare extends PIXI.Rectangle {

--- a/src/module/canvas/layer/token.ts
+++ b/src/module/canvas/layer/token.ts
@@ -1,3 +1,4 @@
+import type { PlaceablesLayerPointerEvent } from "@client/canvas/layers/base/placeables-layer.d.mts";
 import type { TokenPF2e } from "../index.ts";
 
 class TokenLayerPF2e<TObject extends TokenPF2e> extends fc.layers.TokenLayer<TObject> {

--- a/src/module/canvas/perception/point-vision-source.ts
+++ b/src/module/canvas/perception/point-vision-source.ts
@@ -1,3 +1,4 @@
+import type { PointSourcePolygon } from "@client/canvas/geometry/_module.d.mts";
 import type { TokenPF2e } from "../token/index.ts";
 
 /** Subclassed to include hearing detection */

--- a/src/module/canvas/region.ts
+++ b/src/module/canvas/region.ts
@@ -1,3 +1,5 @@
+import type { PlaceablesLayerPointerEvent } from "@client/canvas/layers/base/placeables-layer.d.mts";
+import type { Point } from "@common/_types.d.mts";
 import type { RegionSource } from "@common/documents/region.d.mts";
 import type { RegionDocumentPF2e } from "@scene/region-document/document.ts";
 

--- a/src/module/canvas/token/aura/renderer.ts
+++ b/src/module/canvas/token/aura/renderer.ts
@@ -1,4 +1,5 @@
 import { AuraAppearanceData, AuraData } from "@actor/types.ts";
+import type { GridHighlight } from "@client/canvas/containers/_module.d.mts";
 import { ItemTrait } from "@item/base/data/system.ts";
 import { TokenAuraData } from "@scene/token-document/aura/index.ts";
 import { isVideoFilePath } from "@util";

--- a/src/module/item/ability/helpers.ts
+++ b/src/module/item/ability/helpers.ts
@@ -1,3 +1,5 @@
+import type { ClientDocument } from "@client/documents/abstract/_module.d.mts";
+import type { CompendiumIndexData } from "@client/documents/collections/compendium-collection.d.mts";
 import type { AbilityItemPF2e, FeatPF2e, SpellPF2e } from "@item";
 import { ItemPF2e } from "@item";
 import { ActionCost, FrequencySource } from "@item/base/data/system.ts";
@@ -73,9 +75,12 @@ function createSelfEffectSheetData(data: Maybe<SelfEffectReference>): SelfEffect
     }
     const parsedUUID = fu.parseUuid(data.uuid);
     const linkData = {
-        id: parsedUUID.documentId ?? null,
-        type: parsedUUID.documentType ?? null,
-        pack: parsedUUID.collection instanceof CompendiumCollection ? parsedUUID.collection.metadata.id : null,
+        id: parsedUUID?.documentId ?? null,
+        type: parsedUUID?.documentType ?? null,
+        pack:
+            parsedUUID?.collection instanceof fd.collections.CompendiumCollection
+                ? parsedUUID.collection.metadata.id
+                : null,
     };
 
     return { ...data, ...linkData };

--- a/src/module/item/ancestry/sheet.ts
+++ b/src/module/item/ancestry/sheet.ts
@@ -1,3 +1,4 @@
+import type { FormSelectOption } from "@client/applications/forms/fields.d.mts";
 import { ABCSheetData, ABCSheetPF2e } from "@item/abc/sheet.ts";
 import type { AncestryPF2e } from "@item/ancestry/index.ts";
 import { ItemSheetOptions } from "@item/base/sheet/sheet.ts";

--- a/src/module/item/base/sheet/rule-element-form/flat-modifier.ts
+++ b/src/module/item/base/sheet/rule-element-form/flat-modifier.ts
@@ -1,5 +1,6 @@
 import { AutomaticBonusProgression as ABP } from "@actor/character/automatic-bonus-progression.ts";
 import { MODIFIER_TYPES, ModifierType } from "@actor/modifiers.ts";
+import type { FormSelectOption } from "@client/applications/forms/fields.d.mts";
 import type { FlatModifierRuleElement, FlatModifierSource } from "@module/rules/rule-element/flat-modifier.ts";
 import type { DamageCategoryUnique } from "@system/damage/types.ts";
 import { DAMAGE_CATEGORIES_UNIQUE } from "@system/damage/values.ts";

--- a/src/module/item/base/sheet/rule-element-form/grant-item.ts
+++ b/src/module/item/base/sheet/rule-element-form/grant-item.ts
@@ -1,3 +1,4 @@
+import type { ClientDocument } from "@client/documents/abstract/_module.d.mts";
 import type { GrantItemRuleElement, GrantItemSource } from "@module/rules/rule-element/grant-item/rule-element.ts";
 import { UUIDUtils } from "@util/uuid.ts";
 import { RuleElementForm, RuleElementFormSheetData } from "./base.ts";

--- a/src/module/item/consumable/document.ts
+++ b/src/module/item/consumable/document.ts
@@ -9,6 +9,7 @@ import { TrickMagicItemEntry } from "@item/spellcasting-entry/trick.ts";
 import type { SpellcastingEntry } from "@item/spellcasting-entry/types.ts";
 import type { ValueAndMax } from "@module/data.ts";
 import { DamageRoll } from "@system/damage/roll.ts";
+import type { EnrichmentOptionsPF2e } from "@system/text-editor.ts";
 import { ErrorPF2e, setHasElement } from "@util";
 import * as R from "remeda";
 import type { ConsumableSource, ConsumableSystemData } from "./data.ts";
@@ -90,7 +91,7 @@ class ConsumablePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extend
 
     override async getChatData(
         this: ConsumablePF2e<ActorPF2e>,
-        htmlOptions: EnrichmentOptions = {},
+        htmlOptions: EnrichmentOptionsPF2e = {},
         rollOptions: Record<string, unknown> = {},
     ): Promise<RawItemChatData> {
         const traits = this.traitChatData(CONFIG.PF2E.consumableTraits);

--- a/src/module/item/consumable/sheet.ts
+++ b/src/module/item/consumable/sheet.ts
@@ -1,3 +1,4 @@
+import type { FormSelectOption } from "@client/applications/forms/fields.d.mts";
 import { ItemSheetOptions } from "@item/base/sheet/sheet.ts";
 import { PhysicalItemSheetData, PhysicalItemSheetPF2e } from "@item/physical/index.ts";
 import { SheetOptions, createSheetTags } from "@module/sheet/helpers.ts";

--- a/src/module/item/helpers.ts
+++ b/src/module/item/helpers.ts
@@ -1,5 +1,6 @@
 import type { ActorPF2e } from "@actor";
 import { createHTMLElement, setHasElement } from "@util";
+import type { Converter } from "showdown";
 import { processSanctification } from "./ability/helpers.ts";
 import type { ItemSourcePF2e, ItemType } from "./base/data/index.ts";
 import type { ItemPF2e } from "./base/document.ts";
@@ -55,7 +56,7 @@ function performLatePreparation(item: ItemPF2e): void {
     }
 }
 
-let mdConverter: showdown.Converter | null = null;
+let mdConverter: Converter | null = null;
 
 function markdownToHTML(markdown: string): string {
     const converter = (mdConverter ??= new showdown.Converter());

--- a/src/module/item/physical/sheet.ts
+++ b/src/module/item/physical/sheet.ts
@@ -1,4 +1,5 @@
 import { AutomaticBonusProgression as ABP } from "@actor/character/automatic-bonus-progression.ts";
+import type { FormSelectOption } from "@client/applications/forms/fields.d.mts";
 import type { AppV1RenderOptions } from "@client/appv1/api/application-v1.d.mts";
 import type { PhysicalItemPF2e } from "@item";
 import { ItemSheetDataPF2e, ItemSheetOptions, ItemSheetPF2e } from "@item/base/sheet/sheet.ts";

--- a/src/module/item/spell/sheet.ts
+++ b/src/module/item/spell/sheet.ts
@@ -1,4 +1,5 @@
 import type { ActorPF2e } from "@actor";
+import type { FormSelectOption } from "@client/applications/forms/fields.d.mts";
 import { ItemSheetDataPF2e, ItemSheetOptions, ItemSheetPF2e } from "@item/base/sheet/sheet.ts";
 import { OneToTen } from "@module/data.ts";
 import { TagifyEntry, createTagifyTraits } from "@module/sheet/helpers.ts";

--- a/src/module/migration/migrations/745-effect-target-to-choice-set.ts
+++ b/src/module/migration/migrations/745-effect-target-to-choice-set.ts
@@ -75,7 +75,8 @@ interface EffectTargetSource extends RuleElementSource {
     targetId?: string;
 }
 
-interface OwnedWeaponChoiceSetSource extends Pick<SourceFromSchema<ChoiceSetSchema>, "key" | "prompt"> {
+interface OwnedWeaponChoiceSetSource
+    extends Pick<foundry.data.fields.SourceFromSchema<ChoiceSetSchema>, "key" | "prompt"> {
     selection?: string;
     choices: {
         ownedItems: true;

--- a/src/module/migration/migrations/825-khakkhara-feng-huo-lun.ts
+++ b/src/module/migration/migrations/825-khakkhara-feng-huo-lun.ts
@@ -1,3 +1,4 @@
+import type { ImageFilePath } from "@common/constants.d.mts";
 import { ItemSourcePF2e } from "@item/base/data/index.ts";
 import { BaseWeaponType } from "@item/weapon/types.ts";
 import { MigrationBase } from "../base.ts";

--- a/src/module/migration/migrations/850-flat-footed-to-off-guard.ts
+++ b/src/module/migration/migrations/850-flat-footed-to-off-guard.ts
@@ -1,8 +1,9 @@
 import { ActorSourcePF2e } from "@actor/data/index.ts";
+import type { ImageFilePath } from "@common/constants.d.mts";
+import type { JournalEntrySource } from "@common/documents/_module.d.mts";
 import { ItemSourcePF2e } from "@item/base/data/index.ts";
 import { recursiveReplaceString } from "@util";
 import * as R from "remeda";
-import type { JournalEntrySource } from "types/foundry/common/documents/journal-entry.d.ts";
 import { MigrationBase } from "../base.ts";
 
 /** Rename all uses and mentions of "flat-footed" to "off-guard"  */

--- a/src/module/migration/migrations/851-just-innovation-id.ts
+++ b/src/module/migration/migrations/851-just-innovation-id.ts
@@ -3,6 +3,7 @@ import { RuleElementSource } from "@module/rules/index.ts";
 import { AELikeSchema } from "@module/rules/rule-element/ae-like.ts";
 import { recursiveReplaceString } from "@util";
 import { MigrationBase } from "../base.ts";
+import fields = foundry.data.fields;
 
 /** Set the same flag ("pf2e.innovationId") from all innovation class features  */
 export class Migration851JustInnovationId extends MigrationBase {
@@ -19,7 +20,7 @@ export class Migration851JustInnovationId extends MigrationBase {
             (r: MaybeAELikeSource) => r.key === "ActiveEffectLike" && r.path === "flags.pf2e.innovationId",
         );
         if (source.system.slug === "weapon-innovation" && !hasAELike) {
-            const reSource: Pick<SourceFromSchema<AELikeSchema>, "key" | "mode" | "path" | "value"> = {
+            const reSource: Pick<fields.SourceFromSchema<AELikeSchema>, "key" | "mode" | "path" | "value"> = {
                 key: "ActiveEffectLike",
                 mode: "override",
                 path: "flags.pf2e.innovationId",
@@ -27,7 +28,7 @@ export class Migration851JustInnovationId extends MigrationBase {
             };
             source.system.rules.push(reSource);
         } else if (source.system.slug === "construct-innovation" && !hasAELike) {
-            const reSource: Pick<SourceFromSchema<AELikeSchema>, "key" | "mode" | "path" | "value"> = {
+            const reSource: Pick<fields.SourceFromSchema<AELikeSchema>, "key" | "mode" | "path" | "value"> = {
                 key: "ActiveEffectLike",
                 mode: "override",
                 path: "flags.pf2e.innovationId",

--- a/src/module/migration/migrations/871-migrate-rollactionmacro-params.ts
+++ b/src/module/migration/migrations/871-migrate-rollactionmacro-params.ts
@@ -1,4 +1,4 @@
-import type { MacroSource } from "types/foundry/common/documents/macro.d.ts";
+import type { MacroSource } from "@common/documents/_module.d.mts";
 import { MigrationBase } from "../base.ts";
 
 /** Migrate rollActionMacro function parameters to an object */

--- a/src/module/migration/migrations/878-take-a-breather.ts
+++ b/src/module/migration/migrations/878-take-a-breather.ts
@@ -1,4 +1,4 @@
-import type { MacroSource } from "types/foundry/common/documents/macro.d.ts";
+import type { MacroSource } from "@common/documents/_module.d.mts";
 import { MigrationBase } from "../base.ts";
 
 /** Migrate "Take a Breather" macro to use function exposed at `game.pf2e.actions` */

--- a/src/module/migration/migrations/887-redirect-spell-links.ts
+++ b/src/module/migration/migrations/887-redirect-spell-links.ts
@@ -1,6 +1,6 @@
+import type { JournalEntrySource } from "@client/documents/_module.d.mts";
 import { ItemSourcePF2e } from "@item/base/data/index.ts";
 import { recursiveReplaceString } from "@util";
-import type { JournalEntrySource } from "types/foundry/common/documents/journal-entry.d.ts";
 import { MigrationBase } from "../base.ts";
 
 /** Redirect links some to-be-deleted spells to replacements */

--- a/src/module/migration/migrations/896-healing-domains.ts
+++ b/src/module/migration/migrations/896-healing-domains.ts
@@ -22,7 +22,7 @@ export class Migration896HealingDomains extends MigrationBase {
             }
             case "effect-curse-of-outpouring-life": {
                 const rule = source.system.rules.find(
-                    (r): r is { key?: JSONValue; selector?: unknown } => r.key === "DamageDice",
+                    (r): r is { key: string; selector?: unknown } => r.key === "DamageDice",
                 );
                 if (rule) rule.selector = "spell-healing";
             }

--- a/src/module/migration/migrations/899-armor-shields-to-shield-shields.ts
+++ b/src/module/migration/migrations/899-armor-shields-to-shield-shields.ts
@@ -1,3 +1,4 @@
+import type { ImageFilePath } from "@common/constants.d.mts";
 import { ArmorSystemSource } from "@item/armor/data.ts";
 import { ItemSourcePF2e } from "@item/base/data/index.ts";
 import { itemIsOfType } from "@item/helpers.ts";

--- a/src/module/migration/migrations/915-move-languages.ts
+++ b/src/module/migration/migrations/915-move-languages.ts
@@ -1,7 +1,7 @@
 import { LANGUAGES } from "@actor/creature/values.ts";
 import { ActorSourcePF2e, CharacterSource } from "@actor/data/index.ts";
 import { FeatSource, ItemSourcePF2e } from "@item/base/data/index.ts";
-import { AELikeSchema, AELikeSource } from "@module/rules/rule-element/ae-like.ts";
+import { AELikeSource } from "@module/rules/rule-element/ae-like.ts";
 import * as R from "remeda";
 import { Migration914MovePerceptionSenses } from "./914-move-perception-senses.ts";
 
@@ -41,7 +41,7 @@ export class Migration915MoveLanguages extends Migration914MovePerceptionSenses 
 
     override async updateItem(source: ItemSourcePF2e): Promise<void> {
         const languageAELikes = source.system.rules.filter(
-            (r: AELikeSource): r is Partial<SourceFromSchema<AELikeSchema>> =>
+            (r: AELikeSource): r is AELikeSource =>
                 r.key === "ActiveEffectLike" &&
                 r.path === "system.traits.languages.value" &&
                 typeof r.value === "string",

--- a/src/module/system/action-macros/types.ts
+++ b/src/module/system/action-macros/types.ts
@@ -2,6 +2,7 @@ import type { ActorPF2e } from "@actor";
 import { StrikeData } from "@actor/data/base.ts";
 import type { ModifierPF2e } from "@actor/modifiers.ts";
 import type { DCSlug } from "@actor/types.ts";
+import type { Rolled } from "@client/dice/_module.d.mts";
 import type { ItemPF2e } from "@item";
 import type { WeaponTrait } from "@item/weapon/types.ts";
 import type { RollNotePF2e } from "@module/notes.ts";

--- a/src/module/system/module-art.ts
+++ b/src/module/system/module-art.ts
@@ -1,4 +1,4 @@
-import type { CompendiumDocument } from "@client/documents/collections/compendium-collection.d.mts";
+import type { CompendiumDocument } from "@client/documents/_module.d.mts";
 import type { CompendiumUUID } from "@client/utils/_module.d.mts";
 import type { ImageFilePath, VideoFilePath } from "@common/constants.d.mts";
 import { isImageFilePath, isImageOrVideoPath } from "@util";

--- a/src/scripts/dice.ts
+++ b/src/scripts/dice.ts
@@ -1,6 +1,7 @@
 import type { ActorPF2e } from "@actor";
 import type { ApplicationV1Options } from "@client/appv1/api/_module.d.mts";
 import type { Rolled } from "@client/dice/roll.d.mts";
+import type { RollMode } from "@common/constants.d.mts";
 import type { ItemPF2e } from "@item";
 import { createSimpleFormula, parseTermsFromSimpleFormula } from "@system/damage/formula.ts";
 import { ErrorPF2e } from "@util";

--- a/src/scripts/🐵🩹.ts
+++ b/src/scripts/🐵🩹.ts
@@ -1,4 +1,5 @@
-import type { ProseMirrorMenu } from "@common/prosemirror/menu.d.mts";
+import type { ProseMirrorMenu } from "@common/prosemirror/_module.d.mts";
+import type { Mark, NodeType, ResolvedPos } from "prosemirror-model";
 import * as R from "remeda";
 
 function monkeyPatchFoundry(): void {
@@ -18,7 +19,7 @@ function isMarkActive(this: ProseMirrorMenu, item: ProseMirrorMenuItem): boolean
     // is not removed from marks
     const state = this.view.state;
     const { from, $from, to, empty } = state.selection;
-    const markCompare = (mark: ProseMirror.Mark) => {
+    const markCompare = (mark: Mark) => {
         if (mark.type !== item.mark) return false;
         // R.isDeepEqual returns false here so we use the foundry helper
         if (item.attrs) return fu.objectsEqual(mark.attrs, item.attrs);
@@ -46,7 +47,7 @@ function isNodeActive(this: ProseMirrorMenu, item: ProseMirrorMenuItem): boolean
 
 function toggleTextBlock(
     this: ProseMirrorMenu,
-    node: ProseMirror.NodeType,
+    node: NodeType,
     options?: {
         attrs?: Record<string, unknown> | null;
     },
@@ -71,11 +72,7 @@ function toggleTextBlock(
  * A reimplementation of Foundry's `ResolvedPos.prototype.hasAncestor` extension that keeps the
  * `attrs._preserve` property when comparing nodes
  */
-function hasAncestor(
-    pos: ProseMirror.ResolvedPos,
-    other?: ProseMirror.NodeType,
-    attrs?: Record<string, unknown> | null,
-): boolean {
+function hasAncestor(pos: ResolvedPos, other?: NodeType, attrs?: Record<string, unknown> | null): boolean {
     if (!pos.depth || !other) return false;
     for (let i = pos.depth; i > 0; i--) {
         // Depth 0 is the root document, so we don't need to test that.

--- a/tests/mocks/item.ts
+++ b/tests/mocks/item.ts
@@ -1,4 +1,6 @@
 import type { ActorPF2e } from "@actor/index.ts";
+import type { DocumentConstructionContext } from "@common/_types.d.mts";
+import type { DatabaseUpdateOperation } from "@common/abstract/_types.d.mts";
 import { ItemSourcePF2e } from "@item/base/data/index.ts";
 import { ItemSystemSource } from "@item/base/data/system.ts";
 import type { ItemPF2e } from "@item/index.ts";

--- a/tests/mocks/scene.ts
+++ b/tests/mocks/scene.ts
@@ -1,3 +1,5 @@
+import type { VideoFilePath } from "@common/constants.d.mts";
+
 export class MockScene {
     _source: foundry.documents.SceneSource;
 

--- a/tests/mocks/token.ts
+++ b/tests/mocks/token.ts
@@ -1,4 +1,5 @@
 import type { ActorPF2e } from "@actor";
+import type { DatabaseUpdateOperation } from "@common/abstract/_module.d.mts";
 import type { ScenePF2e } from "@scene";
 
 export class MockToken {

--- a/tests/module/lang/en.test.ts
+++ b/tests/module/lang/en.test.ts
@@ -1,4 +1,4 @@
-import json from "../../../static/lang/en.json";
+import json from "../../../static/lang/en.json" with { type: "json" };
 
 describe("Load json file", () => {
     test("it should be a valid JSON object", async () => {


### PR DESCRIPTION
This started out as a type update PR but then I noticed the browser's `RollTable` methods stopped working.
The rest is all type fixes except for one typo in `src/module/system/action-macros/crafting/repair.ts`.