### PR TITLE
Grant persistent damage with Ooze Ammunition depending on its variety

### DIFF
--- a/packs/equipment-effects/effect-ooze-ammunition.json
+++ b/packs/equipment-effects/effect-ooze-ammunition.json
@@ -117,15 +117,38 @@
                 "value": -15
             },
             {
-                "adjustment": {
-                    "criticalSuccess": "to-failure",
-                    "success": "to-failure"
-                },
-                "key": "AdjustDegreeOfSuccess",
-                "predicate": [
-                    "item:damage:type:acid"
+                "alterations": [
+                    {
+                        "mode": "override",
+                        "property": "persistent-damage",
+                        "value": {
+                            "damageType": "acid",
+                            "formula": "1d4"
+                        }
+                    }
                 ],
-                "selector": "pd-recovery-check"
+                "key": "GrantItem",
+                "predicate": [
+                    "ooze-ammunition:ooze-ammunition-lesser"
+                ],
+                "uuid": "Compendium.pf2e.conditionitems.Item.Persistent Damage"
+            },
+            {
+                "alterations": [
+                    {
+                        "mode": "override",
+                        "property": "persistent-damage",
+                        "value": {
+                            "damageType": "acid",
+                            "formula": "2d4"
+                        }
+                    }
+                ],
+                "key": "GrantItem",
+                "predicate": [
+                    "ooze-ammunition:ooze-ammunition-moderate"
+                ],
+                "uuid": "Compendium.pf2e.conditionitems.Item.Persistent Damage"
             },
             {
                 "alterations": [
@@ -139,6 +162,26 @@
                     }
                 ],
                 "key": "GrantItem",
+                "predicate": [
+                    "ooze-ammunition:ooze-ammunition-greater"
+                ],
+                "uuid": "Compendium.pf2e.conditionitems.Item.Persistent Damage"
+            },
+            {
+                "alterations": [
+                    {
+                        "mode": "override",
+                        "property": "persistent-damage",
+                        "value": {
+                            "damageType": "acid",
+                            "formula": "4d4"
+                        }
+                    }
+                ],
+                "key": "GrantItem",
+                "predicate": [
+                    "ooze-ammunition:ooze-ammunition-major"
+                ],
                 "uuid": "Compendium.pf2e.conditionitems.Item.Persistent Damage"
             }
         ],


### PR DESCRIPTION
Before it was granting 3d4 for all varieties.

Also remove degree of success adjustment. It seems ambiguous to me whether the persistent damage can be ended independently of the other effects via a flat check, but groups that rule that it can't can simply skip rolling the flat check.