### PR TITLE
Add support for Instinct Ability to Fury Instinct

### DIFF
--- a/packs/classfeatures/fury-instinct.json
+++ b/packs/classfeatures/fury-instinct.json
@@ -56,7 +56,12 @@
                 "key": "AdjustModifier",
                 "mode": "upgrade",
                 "predicate": [
-                    "class:barbarian"
+                    {
+                        "or": [
+                            "class:barbarian",
+                            "feat:instinct-ability"
+                        ]
+                    }
                 ],
                 "selector": "strike-damage",
                 "slug": "rage",
@@ -136,6 +141,11 @@
                 "value": 13
             }
         ],
+        "subfeatures": {
+            "proficiencies": {},
+            "senses": {},
+            "suppressedFeatures": []
+        },
         "traits": {
             "otherTags": [
                 "barbarian-instinct"

--- a/packs/feats/archetype/barbarian/instinct-ability.json
+++ b/packs/feats/archetype/barbarian/instinct-ability.json
@@ -35,8 +35,40 @@
                 "mode": "add",
                 "path": "flags.pf2e.barbarian.archetypeFeatCount",
                 "value": 1
+            },
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        "item:level:1",
+                        "item:category:class",
+                        "item:trait:barbarian",
+                        {
+                            "not": "item:draconic-arrogance"
+                        }
+                    ],
+                    "itemType": "feat"
+                },
+                "flag": "furyInstinct",
+                "key": "ChoiceSet",
+                "predicate": [
+                    "feature:fury-instinct"
+                ],
+                "prompt": "PF2E.SpecificRule.Prompt.LevelOneClassFeat"
+            },
+            {
+                "key": "GrantItem",
+                "predicate": [
+                    "feature:fury-instinct"
+                ],
+                "uuid": "{item|flags.pf2e.rulesSelections.furyInstinct}"
             }
         ],
+        "subfeatures": {
+            "proficiencies": {},
+            "senses": {},
+            "suppressedFeatures": []
+        },
         "traits": {
             "rarity": "common",
             "value": [


### PR DESCRIPTION
Closes #18348

Fury also provides a 1st Level Barbarian feat with the Instinct Ability - since ChoiceSets cannot be revaluated at this time, I added support for that selection directly to Instinct Ability itself.