### PR TITLE
Add Covenant support to Clerics and Champions

### DIFF
--- a/packs/classfeatures/deity-champion.json
+++ b/packs/classfeatures/deity-champion.json
@@ -32,7 +32,8 @@
                         {
                             "or": [
                                 "item:category:deity",
-                                "item:category:pantheon"
+                                "item:category:pantheon",
+                                "item:category:covenant"
                             ]
                         }
                     ],
@@ -146,6 +147,11 @@
                 "uuid": "Compendium.pf2e.classfeatures.Item.Champion's Aura"
             }
         ],
+        "subfeatures": {
+            "proficiencies": {},
+            "senses": {},
+            "suppressedFeatures": []
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/classfeatures/deity-cleric.json
+++ b/packs/classfeatures/deity-cleric.json
@@ -31,7 +31,8 @@
                         {
                             "or": [
                                 "item:category:deity",
-                                "item:category:pantheon"
+                                "item:category:pantheon",
+                                "item:category:covenant"
                             ]
                         }
                     ],
@@ -145,6 +146,11 @@
                 "value": 1
             }
         ],
+        "subfeatures": {
+            "proficiencies": {},
+            "senses": {},
+            "suppressedFeatures": []
+        },
         "traits": {
             "rarity": "common",
             "value": [


### PR DESCRIPTION
Closes #19234

Per Divine Mysteries pg. 171, clerics and champions may dedicate themselves to covenants, pantheons, or deities.