### PR TITLE
Hide Token Name based on metagame settings when transferring items

### DIFF
--- a/src/module/actor/item-transfer.ts
+++ b/src/module/actor/item-transfer.ts
@@ -120,8 +120,17 @@ export class ItemTransfer implements ItemTransferData {
         if ("items" in document) {
             // Use a special moniker for party actors
             if (document.isOfType("party")) return game.i18n.localize("PF2E.loot.PartyStash");
+
+            // check to see if the token name can be seen
+            const tokenSetsNameVisibility = game.pf2e.settings.tokens.nameVisibility;
+            const canSeeName = !tokenSetsNameVisibility || !document.token || document.token.playersCanSeeName;
+
             // Synthetic actor: use its token name or, failing that, actor name
-            if (document.token) return document.token.name;
+            // hide name if the token's name is not visible and the token is an NPC
+            if (document.token)
+                return !canSeeName && document.isOfType("npc")
+                    ? game.i18n.localize("PF2E.loot.LootUnknownNPCMessage")
+                    : document.token.name;
 
             // Linked actor: use its token prototype name
             return document.prototypeToken?.name ?? document.name;

--- a/src/module/actor/item-transfer.ts
+++ b/src/module/actor/item-transfer.ts
@@ -127,10 +127,11 @@ export class ItemTransfer implements ItemTransferData {
 
             // Synthetic actor: use its token name or, failing that, actor name
             // hide name if the token's name is not visible and the token is an NPC
-            if (document.token)
+            if (document.token) {
                 return !canSeeName && document.isOfType("npc")
                     ? game.i18n.localize("PF2E.loot.LootUnknownNPCMessage")
                     : document.token.name;
+            }
 
             // Linked actor: use its token prototype name
             return document.prototypeToken?.name ?? document.name;

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -6375,6 +6375,7 @@
             "LootDescription": "Allows for distribution of coins across players",
             "LootLabel": "Loot",
             "LootMessage": "{looter} loots {quantity} × {item} off {corpse}.",
+            "LootUnknownNPCMessage": "an unidentified creature",
             "LootNPCsLabel": "Loot Selected Tokens",
             "LootNPCsPopupHeader": "Choose tokens to loot from",
             "LootNamePlaceholder": "Loot",


### PR DESCRIPTION
Closes #16618

This applies solely to NPCs - this changes the message from showing the token name to "an unidentified creature" when an NPC is looted or transferred to, based on metagame settings.