### PR TITLE
Adding the missing trigger description to the "drop dead" spell.

### DIFF
--- a/packs/spells/5th-rank/drop-dead.json
+++ b/packs/spells/5th-rank/drop-dead.json
@@ -12,7 +12,7 @@
         "damage": {},
         "defense": null,
         "description": {
-            "value": "<p><strong>Trigger</strong> a creature within range is hit by an attack from an enemy.</p>\n<hr />\n<p>The target appears to fall down dead, though it actually turns @UUID[Compendium.pf2e.conditionitems.Item.Invisible]. Its illusory corpse remains where it fell, complete with a believable fatal wound. This illusion looks and feels like a dead body. If the target's death seems absurd—for instance, a barbarian at full health appears to be slain by 2 damage—the GM can grant the attacker an immediate Perception check to disbelieve the illusion. If the target uses hostile actions, the spell ends. This ends the entire spell, so the illusory corpse disappears too.</p><hr /><p><strong>Heightened (7th)</strong> The spell doesn't end if the target uses a hostile action.</p>"
+            "value": "<p><strong>Trigger</strong> A creature within range is hit by an attack from an enemy.</p>\n<hr />\n<p>The target appears to fall down dead, though it actually turns @UUID[Compendium.pf2e.conditionitems.Item.Invisible]. Its illusory corpse remains where it fell, complete with a believable fatal wound. This illusion looks and feels like a dead body. If the target's death seems absurd—for instance, a barbarian at full health appears to be slain by 2 damage—the GM can grant the attacker an immediate @Check[perception] check to disbelieve the illusion. If the target uses hostile actions, the spell ends. This ends the entire spell, so the illusory corpse disappears too.</p><hr /><p><strong>Heightened (7th)</strong> The spell doesn't end if the target uses a hostile action.</p>"
         },
         "duration": {
             "sustained": true,

--- a/packs/spells/5th-rank/drop-dead.json
+++ b/packs/spells/5th-rank/drop-dead.json
@@ -12,7 +12,7 @@
         "damage": {},
         "defense": null,
         "description": {
-            "value": "<p>The target appears to fall down dead, though it actually turns @UUID[Compendium.pf2e.conditionitems.Item.Invisible]. Its illusory corpse remains where it fell, complete with a believable fatal wound. This illusion looks and feels like a dead body. If the target's death seems absurd—for instance, a barbarian at full health appears to be slain by 2 damage—the GM can grant the attacker an immediate Perception check to disbelieve the illusion. If the target uses hostile actions, the spell ends. This ends the entire spell, so the illusory corpse disappears too.</p><hr /><p><strong>Heightened (7th)</strong> The spell doesn't end if the target uses a hostile action.</p>"
+            "value": "<p><strong>Trigger</strong> a creature within range is hit by an attack from an enemy.</p>\n<hr />\n<p>The target appears to fall down dead, though it actually turns @UUID[Compendium.pf2e.conditionitems.Item.Invisible]. Its illusory corpse remains where it fell, complete with a believable fatal wound. This illusion looks and feels like a dead body. If the target's death seems absurd—for instance, a barbarian at full health appears to be slain by 2 damage—the GM can grant the attacker an immediate Perception check to disbelieve the illusion. If the target uses hostile actions, the spell ends. This ends the entire spell, so the illusory corpse disappears too.</p><hr /><p><strong>Heightened (7th)</strong> The spell doesn't end if the target uses a hostile action.</p>"
         },
         "duration": {
             "sustained": true,


### PR DESCRIPTION
5th rank "Drop Dead" spell was missing it's trigger description.