### PR TITLE
Enable `AdjustModifier` predication on derived values and pass more options to the `Statistic` created for `@Check`

### DIFF
--- a/src/module/rules/rule-element/adjust-modifier.ts
+++ b/src/module/rules/rule-element/adjust-modifier.ts
@@ -74,6 +74,7 @@ class AdjustModifierRuleElement extends RuleElementPF2e<AdjustModifierSchema> {
         const adjustment: ModifierAdjustment = {
             slug: this.slug,
             test: (options): boolean => {
+                // Lazy load the predicate and avoid constructing it again every time the adjustment is tested
                 predicate ??= new Predicate(this.resolveInjectedProperties(fu.deepClone([...this.predicate])));
                 return predicate.test([...options, ...this.item.getRollOptions("parent")]);
             },

--- a/src/module/rules/rule-element/adjust-modifier.ts
+++ b/src/module/rules/rule-element/adjust-modifier.ts
@@ -69,11 +69,12 @@ class AdjustModifierRuleElement extends RuleElementPF2e<AdjustModifierSchema> {
     override beforePrepareData(): void {
         if (this.ignored) return;
 
-        const predicate = new Predicate(this.resolveInjectedProperties(fu.deepClone([...this.predicate])));
+        let predicate: Predicate | null = null;
 
         const adjustment: ModifierAdjustment = {
             slug: this.slug,
             test: (options): boolean => {
+                predicate ??= new Predicate(this.resolveInjectedProperties(fu.deepClone([...this.predicate])));
                 return predicate.test([...options, ...this.item.getRollOptions("parent")]);
             },
             suppress: this.suppress,

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -875,20 +875,22 @@ function getCheckDC({
         const idDomain = item ? `${item.id}-inline-dc` : null;
         const slugDomain = `${sluggify(name)}-inline-dc`;
         const domains = [params.type !== "flat" ? "all" : null, "inline-dc", idDomain, slugDomain].filter(R.isTruthy);
-        const { synthetics } = actor;
         const modifier = new ModifierPF2e({
             slug: "base",
             label: "PF2E.ModifierTitle",
             modifier: base - 10,
-            adjustments: extractModifierAdjustments(synthetics.modifierAdjustments, domains, "base"),
+            adjustments: extractModifierAdjustments(actor.synthetics.modifierAdjustments, domains, "base"),
         });
-        const stat = new Statistic(actor, {
-            slug: params.type,
-            label: name,
-            domains,
-            modifiers: [modifier],
-        });
-
+        const stat = new Statistic(
+            actor,
+            {
+                slug: params.type,
+                label: name,
+                domains,
+                modifiers: [modifier],
+            },
+            { extraRollOptions: [`inline-dc:value:${base}`], item },
+        );
         return String(stat.dc.value);
     }
 


### PR DESCRIPTION
- As the predicate for `AdjustModifier` was immediately constructed in `beforePrepareData` it wasn't possible to resolve dervied values.
- Passing the item in `checkDC` makes it possible to predicate on item roll options.

This PR would enable automation for feats like `Powerful Alchemy`:
````
Alchemical items you infuse are particularly potent. When you create an infused alchemical item
that allows a saving throw, you can change its DC to your class DC.
````

```json
{
  "key": "AdjustModifier",
  "mode": "override",
  "value": "@actor.classDCs.alchemist.mod",
  "selector": "inline-dc",
  "predicate": [
    "item:trait:infused",
    {
      "gt": [
        "{actor|classDCs.alchemist.dc.value}",
        "inline-dc:value"
      ]
    }
  ]
}
```
(That should probably be a toggle but it's what I've tested with)