### PR TITLE
Don't set Dark Mode colors on windows with `theme-light` override

### DIFF
--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -374,7 +374,7 @@ body,
     }
 }
 
-body.theme-dark .application,
+body.theme-dark .application:not(.themed),
 .themed.theme-dark {
     --color-text-tertiary: var(--color-light-4);
     --visibility-gm-bg: var(--color-cool-4);


### PR DESCRIPTION
I've only found chat popouts to be affected by this. If you know of any other AppV2's that might have this override, let me know and I'll take a look!

<img width="354" alt="Screenshot 2025-06-09 at 8 16 18 PM" src="https://github.com/user-attachments/assets/e5f4ebba-4040-41eb-a533-dd9c98937e6e" />
<img width="344" alt="Screenshot 2025-06-09 at 8 16 29 PM" src="https://github.com/user-attachments/assets/777b1455-6441-46d8-9522-8259c6b3af3e" />
