### PR TITLE
Fix show/hide of Roll Options in Generate Check Prompt

### DIFF
--- a/static/templates/gm/check-prompt.hbs
+++ b/static/templates/gm/check-prompt.hbs
@@ -70,7 +70,7 @@
                         <input id="check-prompt-secret" name="secret" type="checkbox" />
                     </div>
                 </div>
-                <div class="roll-options hidden">
+                <div class="roll-options">
                     <div class="form-group">
                         <input id="check-prompt-actions" placeholder="{{localize "PF2E.ActionActionsLabel"}}" />
                     </div>


### PR DESCRIPTION
Addresses #19314

`.roll-options` is already `display: none;` by default. `.hidden` superseded `.show-roll-options`.