### PR TITLE
Add support for spell rank alterations

### DIFF
--- a/src/module/chat-message/data.ts
+++ b/src/module/chat-message/data.ts
@@ -36,7 +36,7 @@ type ChatMessageFlagsPF2e = ChatMessageFlags & {
         journalEntry?: DocumentUUID;
         appliedDamage?: AppliedDamageFlag | null;
         treatWoundsMacroFlag?: { bonus: number };
-        [key: string]: unknown;
+        [key: string]: JSONValue;
     };
     core: NonNullable<ChatMessageFlags["core"]>;
 };

--- a/src/module/chat-message/listeners/cards.ts
+++ b/src/module/chat-message/listeners/cards.ts
@@ -115,23 +115,17 @@ class ChatCards {
                 case "spell-variant": {
                     const castRank = Number(htmlQuery(html, "div.chat-card")?.dataset.castRank) || 1;
                     const overlayIds = button.dataset.overlayIds?.split(",").map((id) => id.trim());
-                    if (overlayIds) {
-                        const variantSpell = spell?.loadVariant({ overlayIds, castRank });
-                        if (variantSpell) {
-                            const data = { castRank };
-                            const variantMessage = await variantSpell.toMessage(null, { data, create: false });
-                            if (variantMessage) {
-                                const whisper = message._source.whisper;
-                                const changes = variantMessage.clone({ whisper }).toObject();
-                                await message.update(changes);
-                            }
-                        }
-                    } else if (spell) {
-                        const originalSpell = spell.loadBaseVariant();
-                        const restoredMessage = await originalSpell.toMessage(null, { create: false });
-                        if (restoredMessage) {
+                    const variantOrOriginal = overlayIds
+                        ? spell?.loadVariant({ overlayIds })
+                        : spell?.loadBaseVariant();
+                    if (variantOrOriginal) {
+                        const newMessage = await variantOrOriginal.toMessage(null, {
+                            data: { castRank },
+                            create: false,
+                        });
+                        if (newMessage) {
                             const whisper = message._source.whisper;
-                            const changes = restoredMessage.clone({ whisper }).toObject();
+                            const changes = newMessage.clone({ whisper }).toObject();
                             await message.update(changes);
                         }
                     }

--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -226,12 +226,12 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
         const template = `systems/pf2e/templates/chat/${sluggify(this.type)}-card.hbs`;
         const token = this.actor.token;
         const nearestItem = htmlClosest(event?.target, ".item");
-        const rollOptions = options.data ?? { ...(nearestItem?.dataset ?? {}) };
+        const data = options.data ?? { ...(nearestItem?.dataset ?? {}) };
         const templateData = {
             actor: this.actor,
             tokenId: token ? `${token.parent?.id}.${token.id}` : null,
             item: this,
-            data: await this.getChatData(undefined, rollOptions),
+            data: await this.getChatData(undefined, data),
         };
 
         // Basic chat message data

--- a/src/module/item/spell/data.ts
+++ b/src/module/item/spell/data.ts
@@ -1,6 +1,7 @@
 import type { SaveType } from "@actor/types.ts";
 import type { BaseItemSourcePF2e, ItemSystemData, ItemSystemSource, ItemTraits } from "@item/base/data/system.ts";
 import type { OneToTen, ValueAndMax, ZeroToThree } from "@module/data.ts";
+import type { AELikeChangeMode } from "@module/rules/rule-element/ae-like.ts";
 import type { DamageCategoryUnique, DamageKind, DamageType, MaterialDamageEffect } from "@system/damage/index.ts";
 import type { EffectAreaShape, MagicTradition, SpellTrait } from "./types.ts";
 
@@ -103,6 +104,11 @@ interface SpellOverlayOverride {
 interface SpellSystemData
     extends Omit<SpellSystemSource, "damage" | "description">,
         Omit<ItemSystemData, "level" | "traits"> {
+    level: {
+        value: OneToTen;
+        /** Alterations performed on the rank when casting the spell */
+        alterations: { mode: AELikeChangeMode; value: number }[];
+    };
     /** Time and resources consumed in the casting of this spell */
     cast: SpellCastData;
     damage: Record<string, SpellDamage>;

--- a/src/module/item/spellcasting-entry/document.ts
+++ b/src/module/item/spellcasting-entry/document.ts
@@ -259,12 +259,11 @@ class SpellcastingEntryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null>
     async cast(spell: SpellPF2e<ActorPF2e>, options: CastOptions = {}): Promise<void> {
         const consume = options.consume ?? true;
         const message = options.message ?? true;
-        const rank = options.rank ?? spell.rank;
-        const valid = !consume || spell.atWill || (await this.consume(spell, rank, options.slotId));
+        const slotRank = options.rank ?? spell.rank;
+        const valid = !consume || spell.atWill || (await this.consume(spell, slotRank, options.slotId));
         if (message && valid) {
             spell.system.location.value ??= this.id;
-            const castRank = spell.computeCastRank(rank);
-            await spell.toMessage(null, { rollMode: options.rollMode, data: { castRank } });
+            await spell.toMessage(null, { rollMode: options.rollMode, data: { slotRank } });
         }
     }
 

--- a/src/module/item/spellcasting-entry/item-spellcasting.ts
+++ b/src/module/item/spellcasting-entry/item-spellcasting.ts
@@ -90,7 +90,8 @@ class ItemSpellcasting<TActor extends CreaturePF2e = CreaturePF2e> implements Sp
         const message = options.message ?? true;
         if (message && this.canCast(spell, { origin: spell.parentItem })) {
             spell.system.location.value = this.id;
-            await spell.toMessage(null, { rollMode: options.rollMode, data: { castRank: spell.rank } });
+            const slotRank = options.rank ?? spell.rank;
+            await spell.toMessage(null, { rollMode: options.rollMode, data: { slotRank } });
         }
     }
 

--- a/src/module/item/spellcasting-entry/trick.ts
+++ b/src/module/item/spellcasting-entry/trick.ts
@@ -138,12 +138,8 @@ class TrickMagicItemEntry<TActor extends ActorPF2e = ActorPF2e> implements Spell
     }
 
     async cast(spell: SpellPF2e, options: CastOptions = {}): Promise<void> {
-        const { rollMode, message } = options;
-        const castRank = spell.computeCastRank(spell.rank);
-        if (message === false) return;
-
-        spell = spell.loadVariant({ entryId: this.id }) ?? spell;
-        await spell.toMessage(null, { rollMode, data: { castRank } });
+        if (options.message === false) return;
+        await spell.toMessage(null, { rollMode: options.rollMode, data: { slotRank: options.rank } });
     }
 
     async getSheetData(): Promise<SpellcastingSheetData> {
@@ -163,5 +159,5 @@ class TrickMagicItemEntry<TActor extends ActorPF2e = ActorPF2e> implements Spell
     }
 }
 
-export { TRICK_MAGIC_SKILLS, TrickMagicItemEntry, traditionSkills };
+export { traditionSkills, TRICK_MAGIC_SKILLS, TrickMagicItemEntry };
 export type { TrickMagicItemSkill };

--- a/src/module/item/spellcasting-entry/types.ts
+++ b/src/module/item/spellcasting-entry/types.ts
@@ -55,7 +55,7 @@ type SpellcastingCategory = keyof ConfigPF2e["PF2E"]["preparationType"];
 
 interface CastOptions {
     slotId?: number;
-    /** The rank at which to cast the spell */
+    /** The slot rank at which to cast the spell */
     rank?: OneToTen;
     consume?: boolean;
     message?: boolean;

--- a/src/module/rules/rule-element/item-alteration/alteration.ts
+++ b/src/module/rules/rule-element/item-alteration/alteration.ts
@@ -42,6 +42,7 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
         "persistent-damage",
         "range-increment",
         "range-max",
+        "rank",
         "rarity",
         "speed-penalty",
         "strength",
@@ -419,6 +420,15 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
                 const maxRange = data.item.system.maxRange;
                 const newValue = AELikeRuleElement.getNewValue(this.mode, maxRange, data.alteration.value);
                 data.item.system.maxRange = newValue;
+                return;
+            }
+            case "rank": {
+                const validator = ITEM_ALTERATION_VALIDATORS[this.property];
+                if (!validator.isValid(data) || !(data.item instanceof ItemPF2e)) {
+                    return;
+                }
+
+                data.item.system.level.alterations.push({ mode: this.mode, value: data.alteration.value });
                 return;
             }
         }

--- a/src/module/rules/rule-element/item-alteration/schemas.ts
+++ b/src/module/rules/rule-element/item-alteration/schemas.ts
@@ -429,6 +429,18 @@ const ITEM_ALTERATION_VALIDATORS = {
             initial: undefined,
         } as const),
     }),
+    rank: new ItemAlterationValidator({
+        itemType: new fields.StringField({ required: true, choices: ["spell"] }),
+        mode: new fields.StringField({
+            required: true,
+            choices: ["add", "downgrade", "multiply", "override", "remove", "subtract", "upgrade"],
+        }),
+        value: new fields.NumberField({
+            required: true,
+            nullable: false,
+            initial: undefined,
+        } as const),
+    }),
     "frequency-max": new ItemAlterationValidator({
         itemType: new fields.StringField({ required: true, choices: ["action", "feat"] }),
         mode: new fields.StringField({


### PR DESCRIPTION
This attempts to solve it by adding a further divide between slot rank and cast rank, with slot rank being the slot rank. It gets a bit weird for spell.cast() on items though, but we can interpret those as some sort of source rank. If neither cast nor slot rank are provided, we assume the spell item's rank is a slot rank and apply alterations (if available). We could relax this, but then it means that ability.cast(fireball) would not apply rank alterations.