### PR TITLE
Avoid prosemirror menu wrapping in item and hazard sheets

### DIFF
--- a/src/module/actor/hazard/sheet.ts
+++ b/src/module/actor/hazard/sheet.ts
@@ -16,7 +16,7 @@ export class HazardSheetPF2e extends ActorSheetPF2e<HazardPF2e> {
             ...options,
             classes: [...options.classes, "hazard"],
             scrollY: ["section.content"],
-            width: 700,
+            width: 710,
             height: 680,
             template: "systems/pf2e/templates/actors/hazard/sheet.hbs",
         };

--- a/src/module/item/base/sheet/sheet.ts
+++ b/src/module/item/base/sheet/sheet.ts
@@ -56,7 +56,7 @@ class ItemSheetPF2e<TItem extends ItemPF2e> extends fav1.sheets.ItemSheet<TItem,
 
         return {
             ...options,
-            width: 695,
+            width: 700,
             height: 460,
             template: "systems/pf2e/templates/items/sheet.hbs",
             scrollY: [".tab.active", ".inventory-details", "div[data-rule-tab]"],

--- a/src/styles/_globals.scss
+++ b/src/styles/_globals.scss
@@ -438,8 +438,12 @@ a[href]:hover {
     }
 }
 
+// Ever so slightly more compact prosemirror menu
 .prosemirror menu {
-    gap: 3px;
+    gap: 2px;
+    button {
+        padding: 1px 5px;
+    }
 }
 
 // System theme Foundry tooltips

--- a/src/styles/actor/character/_biography.scss
+++ b/src/styles/actor/character/_biography.scss
@@ -175,9 +175,6 @@
 
             &.prosemirror {
                 height: 13.5rem; // When the editor is open, fill more space
-                .editor-container {
-                    margin: var(--space-4) 0;
-                }
             }
         }
     }

--- a/src/styles/actor/hazard/_index.scss
+++ b/src/styles/actor/hazard/_index.scss
@@ -113,9 +113,6 @@
 
             &.prosemirror {
                 height: 12.5rem; // When the editor is open, fill more space
-                .editor-container {
-                    margin: var(--space-4) 0;
-                }
             }
         }
 

--- a/src/styles/actor/npc/_index.scss
+++ b/src/styles/actor/npc/_index.scss
@@ -406,9 +406,6 @@
 
                     &.prosemirror {
                         min-height: 18rem;
-                        .editor-container {
-                            margin: var(--space-4) 0;
-                        }
                     }
                 }
             }

--- a/src/styles/actor/party/kingdom/_world.scss
+++ b/src/styles/actor/party/kingdom/_world.scss
@@ -183,9 +183,6 @@ input[type="number"] {
 
         &.prosemirror {
             min-height: 15rem; // When the editor is open, fill more space
-            .editor-container {
-                margin: var(--space-4) 0;
-            }
         }
     }
 }

--- a/src/styles/item/_header.scss
+++ b/src/styles/item/_header.scss
@@ -63,5 +63,6 @@
         flex-basis: 100%;
         margin-top: 0.125rem;
         padding: 0;
+        margin-bottom: 0;
     }
 }

--- a/src/styles/item/_index.scss
+++ b/src/styles/item/_index.scss
@@ -132,8 +132,6 @@
             > section.sidebar,
             > .sheet-body {
                 height: calc(100% - var(--space-10));
-                overflow-y: auto;
-                scrollbar-gutter: stable;
             }
 
             @import "sidebar";
@@ -172,6 +170,7 @@
                     // Allow editor scrolling to take over when editing
                     &.editing {
                         overflow: hidden;
+                        scrollbar-gutter: unset;
 
                         & > section {
                             flex: 1;
@@ -183,8 +182,8 @@
                         border: 1px dotted rgba(75, 74, 68, 0.5);
                         flex: 0 0 auto;
 
-                        .editor-content:not(.ProseMirror) {
-                            padding: 0 0.25em;
+                        .editor-content {
+                            padding: 0 var(--space-4);
                         }
 
                         &:not(.has-content) {

--- a/src/styles/item/_nav.scss
+++ b/src/styles/item/_nav.scss
@@ -5,6 +5,7 @@
     display: flex;
     flex: 0 0 1.75rem;
     line-height: 1.75rem;
+    margin: var(--space-4) 0;
 
     a {
         flex: 1 1 auto;


### PR DESCRIPTION
Also fixes several minor item sheet regressions stemming from double gutters and more foundry css global tweaks.

Prosemirror seems to no longer introduce horizontal padding in its content, which means that our extra padding can be removed, but we do need to put it back in the GM Notes so it doesn't run flush with the border.

![image](https://github.com/user-attachments/assets/fe17b789-90cb-4921-92f2-cf69687112b7)
![image](https://github.com/user-attachments/assets/7ce82223-7818-4fd0-bedb-b19c7f768a7b)
