### PR TITLE
Fix prototype token size link being applied even if disabled

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -944,19 +944,10 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
 
     /** Set defaults for this actor's prototype token */
     private preparePrototypeToken(): void {
-        const linkToActorSize = SIZE_LINKABLE_ACTOR_TYPES.has(this.type);
-        const size = this.system.traits?.size;
-
-        if (linkToActorSize && size) {
-            const width = size.width / 5;
-            const height = size.length / 5;
-            if (this.prototypeToken.width !== width || this.prototypeToken.height !== height) {
-                this.prototypeToken.updateSource({ width, height });
-            }
-        }
-
-        this.prototypeToken.flags = fu.mergeObject({ pf2e: { linkToActorSize } }, this.prototypeToken.flags);
-        TokenDocumentPF2e.assignDefaultImage(this.prototypeToken);
+        this.prototypeToken.flags = fu.mergeObject(
+            { pf2e: { linkToActorSize: SIZE_LINKABLE_ACTOR_TYPES.has(this.type) } },
+            this.prototypeToken.flags,
+        );
         TokenDocumentPF2e.prepareScale(this.prototypeToken);
     }
 


### PR DESCRIPTION
This did nothing except locking the prototype token size to the actor size even if that was disabled.