### PR TITLE
Preserve certain changes when chaining spell.loadVariant()

### DIFF
--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -471,7 +471,7 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
     loadVariant(options: SpellVariantOptions = {}): SpellPF2e | null {
         if (this.original) {
             const entryId = this.system.location.value;
-            const overlayIds = Array.from(this.appliedOverlays?.values() ?? []);
+            const overlayIds = this.appliedOverlays?.values().toArray() ?? [];
             return this.original.loadVariant({ entryId, overlayIds, ...options });
         }
         const { castRank, overlayIds } = options;


### PR DESCRIPTION
Doesn't fix any known bugs, but improves its consistency. Prerequisite for something else.