### PR TITLE
Fix Familiars prepping REs that affect the canvas on game load

### DIFF
--- a/src/module/actor/familiar/document.ts
+++ b/src/module/actor/familiar/document.ts
@@ -141,7 +141,7 @@ class FamiliarPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e 
 
     /** Skip rule-element preparation if there is no master unless it is the pre-ready prep */
     protected override prepareRuleElements(): RuleElementPF2e[] {
-        return (this.master || !game.ready) ? super.prepareRuleElements() : [];
+        return this.master || !game.ready ? super.prepareRuleElements() : [];
     }
 
     override prepareDerivedData(): void {

--- a/src/module/actor/familiar/document.ts
+++ b/src/module/actor/familiar/document.ts
@@ -139,9 +139,9 @@ class FamiliarPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e 
         }
     }
 
-    /** Skip rule-element preparation if there is no master */
+    /** Skip rule-element preparation if there is no master unless it is the pre-ready prep */
     protected override prepareRuleElements(): RuleElementPF2e[] {
-        return this.master ? super.prepareRuleElements() : [];
+        return (this.master || !game.ready) ? super.prepareRuleElements() : [];
     }
 
     override prepareDerivedData(): void {


### PR DESCRIPTION
Closes #17182

Core issue: Familiars skip RE prepping if they don't have a master but due to timing, no familiar has a master on the first run of data prep when the world is loading. The master does trigger a reset and reload of their Familiar before the canvas is shown, but it happens after everything is loaded and can't render REs that impact the canvas.

Certain REs, to appear when the canvas is ready, need to be prepped beforehand. This impacts TokenLight and Aura at least.

REs that rely on the master will fail validation on load with a warning but immediately be re-prepped by the master-triggered reset and reload.