### PR TITLE
Add REs to Walking Cauldron

### DIFF
--- a/packs/equipment/walking-cauldron.json
+++ b/packs/equipment/walking-cauldron.json
@@ -39,7 +39,8 @@
                 "key": "RollOption",
                 "option": "walking-cauldron-walking",
                 "toggleable": true,
-                "value": true
+                "value": true,
+                "label": "PF2E.SpecificRule.Equipment.WalkingCauldron.ToggleLabel"
             },
             {
                 "itemType": "equipment",

--- a/packs/equipment/walking-cauldron.json
+++ b/packs/equipment/walking-cauldron.json
@@ -34,7 +34,25 @@
             "title": "Pathfinder GM Core"
         },
         "quantity": 1,
-        "rules": [],
+        "rules": [
+            {
+                "key": "RollOption",
+                "option": "walking-cauldron-walking",
+                "toggleable": true,
+                "value": true
+            },
+            {
+                "itemType": "equipment",
+                "key": "ItemAlteration",
+                "mode": "override",
+                "predicate": [
+                    "walking-cauldron-walking",
+                    "item:slug:walking-cauldron"
+                ],
+                "property": "bulk",
+                "value": 0
+            }
+        ],
         "size": "med",
         "traits": {
             "rarity": "common",

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -3656,6 +3656,9 @@
                 "UnholyWater": {
                     "Note": "Can damage only creatures with the holy trait."
                 },
+                "WalkingCauldron": {
+                    "ToggleLabel": "Walking Cauldron Animated?"
+                },
                 "WemmuthTrinket": {
                     "Description": "Creatures who fail or critically fail their Reflex saves also take @Damage[(@item.rank)[piercing]]."
                 },

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -3657,7 +3657,7 @@
                     "Note": "Can damage only creatures with the holy trait."
                 },
                 "WalkingCauldron": {
-                    "ToggleLabel": "Walking Cauldron Animated?"
+                    "ToggleLabel": "Walking Cauldron - Animated"
                 },
                 "WemmuthTrinket": {
                     "Description": "Creatures who fail or critically fail their Reflex saves also take @Damage[(@item.rank)[piercing]]."

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -3657,7 +3657,7 @@
                     "Note": "Can damage only creatures with the holy trait."
                 },
                 "WalkingCauldron": {
-                    "ToggleLabel": "Walking Cauldron - Animated"
+                    "ToggleLabel": "Walking Cauldron – Animated"
                 },
                 "WemmuthTrinket": {
                     "Description": "Creatures who fail or critically fail their Reflex saves also take @Damage[(@item.rank)[piercing]]."


### PR DESCRIPTION
Closes #5064

Allows players to toggle the Bulk of the Cauldron to represent it walking. The container stuff isn't doable at this time.