### PR TITLE
Fix `EphemeralEffectRuleElement#alterations` initializing as `undefined`

### DIFF
--- a/src/module/rules/rule-element/ephemeral-effect.ts
+++ b/src/module/rules/rule-element/ephemeral-effect.ts
@@ -20,7 +20,7 @@ class EphemeralEffectRuleElement extends RuleElementPF2e<EphemeralEffectSchema> 
             ),
             uuid: new fields.StringField({ required: true, blank: false, nullable: false, initial: undefined }),
             adjustName: new fields.BooleanField({ required: true, nullable: false, initial: true }),
-            alterations: new fields.ArrayField(alterationField, { required: false, nullable: false }),
+            alterations: new fields.ArrayField(alterationField, { required: false, nullable: false, initial: [] }),
         };
     }
 


### PR DESCRIPTION
In v12 an `ArrayField` that wasn't `required` and had no initial value was cast to an empty array. In v13 it's cast to `undefined` instead.
I've looked for other instances where this would be a bug now but haven't found anything.

- Closes #19343 