### PR TITLE
Fix type of EffectContextData

### DIFF
--- a/src/module/item/abstract-effect/data.ts
+++ b/src/module/item/abstract-effect/data.ts
@@ -43,13 +43,13 @@ interface EffectContextData {
         token: TokenDocumentUUID | null;
         item: ItemUUID | null;
         spellcasting: EffectContextSpellcastingData | null;
-        rollOptions?: string[];
+        rollOptions: string[];
     };
     target: {
         actor: ActorUUID;
         token: TokenDocumentUUID | null;
     } | null;
-    roll: Pick<CheckRoll, "total" | "degreeOfSuccess"> | null;
+    roll: Pick<foundry.dice.Rolled<CheckRoll>, "total" | "degreeOfSuccess"> | null;
 }
 
 interface EffectContextSpellcastingData {


### PR DESCRIPTION
Alternatively we can make it use `ModelPropsFromSchema<EffectContextDataSchema>`