### PR TITLE
Fix hidden check outcome vanishing when player rerolls

### DIFF
--- a/src/module/system/check/check.ts
+++ b/src/module/system/check/check.ts
@@ -570,7 +570,10 @@ class CheckPF2e {
                   const opposer = context.target?.actor === actor.uuid ? context.origin : context.target;
                   const targetFlavor = await this.#createResultFlavor({ degree, self, opposer, targeting });
                   if (targetFlavor) {
-                      htmlQuery(parsedFlavor, ".target-dc-result")?.replaceWith(targetFlavor);
+                      // when players reroll, they cannot extract the gm-visible parts of the HTML
+                      htmlQuery(parsedFlavor, ".target-dc-result")
+                          ? htmlQuery(parsedFlavor, ".target-dc-result")?.replaceWith(targetFlavor)
+                          : htmlQuery(parsedFlavor, ".action")?.insertAdjacentElement("afterend", targetFlavor);
                   }
                   htmlQuery(parsedFlavor, "ul.notes")?.remove();
                   const newNotes = context.notes?.map((n) => new RollNotePF2e(n)) ?? [];

--- a/src/module/system/check/check.ts
+++ b/src/module/system/check/check.ts
@@ -571,9 +571,9 @@ class CheckPF2e {
                   const targetFlavor = await this.#createResultFlavor({ degree, self, opposer, targeting });
                   if (targetFlavor) {
                       // when players reroll, they cannot extract the gm-visible parts of the HTML
-                      htmlQuery(parsedFlavor, ".target-dc-result")
-                          ? htmlQuery(parsedFlavor, ".target-dc-result")?.replaceWith(targetFlavor)
-                          : htmlQuery(parsedFlavor, ".action")?.insertAdjacentElement("afterend", targetFlavor);
+                      if (htmlQuery(parsedFlavor, ".target-dc-result")) {
+                          htmlQuery(parsedFlavor, ".target-dc-result")?.replaceWith(targetFlavor);
+                      } else htmlQuery(parsedFlavor, ".action")?.insertAdjacentElement("afterend", targetFlavor);
                   }
                   htmlQuery(parsedFlavor, "ul.notes")?.remove();
                   const newNotes = context.notes?.map((n) => new RollNotePF2e(n)) ?? [];


### PR DESCRIPTION
Closes #17420

Issue: When a player re-rolls a check with Show Check Outcomes disabled, the check outcome GM box vanishes from the re-roll.

Cause: when the re-roll is generated from the player's end, the gm-visible box isn't present in the HTML for the original roll. Since the elements aren't present, the outcome update code fails to run, removing the box completely.

Resolution: test if the check outcome box is in the old flavor. If it is, use the original workflow to replace the check outcomes. If not, insert a new check outcome element from the reroll after the action section.