### PR TITLE
Add Shattering Earth's Critical Note

### DIFF
--- a/packs/feat-effects/stance-kaiju-stance.json
+++ b/packs/feat-effects/stance-kaiju-stance.json
@@ -46,6 +46,15 @@
                 ]
             },
             {
+                "key": "Note",
+                "outcome": [
+                    "criticalSuccess"
+                ],
+                "selector": "{item|_id}-attack",
+                "text": "PF2E.SpecificRule.Stance.Note.ShatteringEarthStance",
+                "title": "{item|name}"
+            },
+            {
                 "inMemoryOnly": true,
                 "key": "GrantItem",
                 "uuid": "Compendium.pf2e.conditionitems.Item.Clumsy"

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -5940,7 +5940,7 @@
                 "Note": {
                     "CraneStance": "Reduce the DC for High Jump and Long Jump by 5, and when you Leap, you can move an additional 5 feet horizontally or 2 feet vertically.",
                     "GorillaStance": "If you roll a success on an Athletics check to Climb, you get a critical success instead.",
-                    "ShatteringEarthStance": "All creatures other than you that are within 10 feet of the target, including the target itself, take @Damage[(@item.system.damage.dice[splash])[bludgeoning]] point(s) of bludgeoning splash damage.",
+                    "ShatteringEarthStance": "All creatures other than you that are within @Template[type:emanation|distance:10]{10 feet} of the target, including the target itself, take @Damage[(@item.system.damage.dice[splash])[bludgeoning]] damage.",
                     "StokedFlameStance": "If you have access to the flashing sparks' critical specialization effect, you can take an alternate effect instead: if your critical Strike dealt damage, the target takes @Damage[1d6[persistent,fire]] damage.",
                     "WaterfowlStance": "You can deal that creature @Damage[1d6[slashing]] damage. This damage is increased to @Damage[2d6[slashing]] if the weapon has a greater striking rune and @Damage[3d6[slashing]] if it has a major striking rune.",
                     "WildWindStance": "Wind crash strikes ignore concealment and all cover."

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -5940,6 +5940,7 @@
                 "Note": {
                     "CraneStance": "Reduce the DC for High Jump and Long Jump by 5, and when you Leap, you can move an additional 5 feet horizontally or 2 feet vertically.",
                     "GorillaStance": "If you roll a success on an Athletics check to Climb, you get a critical success instead.",
+                    "ShatteringEarthStance": "All creatures other than you that are within 10 feet of the target, including the target itself, take @Damage[(@item.system.damage.dice[splash])[bludgeoning]] point(s) of bludgeoning splash damage.",
                     "StokedFlameStance": "If you have access to the flashing sparks' critical specialization effect, you can take an alternate effect instead: if your critical Strike dealt damage, the target takes @Damage[1d6[persistent,fire]] damage.",
                     "WaterfowlStance": "You can deal that creature @Damage[1d6[slashing]] damage. This damage is increased to @Damage[2d6[slashing]] if the weapon has a greater striking rune and @Damage[3d6[slashing]] if it has a major striking rune.",
                     "WildWindStance": "Wind crash strikes ignore concealment and all cover."


### PR DESCRIPTION
Closes #18670

"On a critical success with a shattering earth attack, all creatures other than you that are within 10 feet of the target, including the target itself, take 1 point of bludgeoning splash damage per weapon damage die."