### PR TITLE
Add build check for localization keys correctness in rule elements

### DIFF
--- a/build/lib/compendium-pack.ts
+++ b/build/lib/compendium-pack.ts
@@ -306,9 +306,7 @@ class CompendiumPack {
                         if(v.match(/^PF2E\.[^{}]+$/) && !localizationKeys.includes(v)){
                             throw PackError(`${docSource.name} has a rule element with an invalid localization key ${v}`);
                         }
-
                     }
-
                 }
             }
 

--- a/build/lib/compendium-pack.ts
+++ b/build/lib/compendium-pack.ts
@@ -14,6 +14,10 @@ import path from "path";
 import * as R from "remeda";
 import systemJSON from "../../static/system.json";
 import coreIconsJSON from "../core-icons.json";
+import systemLocalizationKeysJSON from "../../static/lang/en.json"
+import ruleElementsLocalizationKeysJSON from "../../static/lang/re-en.json"
+import actionsLocalizationKeysJSON from "../../static/lang/action-en.json"
+import kingmakerLocalizationKeysJSON from "../../static/lang/kingmaker-en.json"
 import "./foundry-utils.ts";
 import { PackError, getFilesRecursively } from "./helpers.ts";
 import { DBFolder, LevelDatabase } from "./level-database.ts";
@@ -57,6 +61,13 @@ function isItemSource(docSource: PackEntry): docSource is ItemSourcePF2e {
  *  as upstream adds more icons.
  */
 const coreIcons = new Set(coreIconsJSON);
+
+const localizationKeys = Object.keys({
+    ...fu.flattenObject(systemLocalizationKeysJSON),
+    ...fu.flattenObject(ruleElementsLocalizationKeysJSON),
+    ...fu.flattenObject(actionsLocalizationKeysJSON),
+    ...fu.flattenObject(kingmakerLocalizationKeysJSON)
+});
 
 class CompendiumPack {
     packId: string;
@@ -286,6 +297,18 @@ class CompendiumPack {
                 const featCategory = docSource.system.category;
                 if (!setHasElement(FEAT_OR_FEATURE_CATEGORIES, featCategory)) {
                     throw PackError(`${docSource.name} has an unrecognized feat category: ${featCategory}`);
+                }
+            }
+
+            for(const rule of docSource.system.rules){
+                for(const v of Object.values(fu.flattenObject(rule))){
+                    if (typeof v === "string"){
+                        if(v.match(/^PF2E\.[^{}]+$/) && !localizationKeys.includes(v)){
+                            throw PackError(`${docSource.name} has a rule element with an invalid localization key ${v}`);
+                        }
+
+                    }
+
                 }
             }
 

--- a/build/lib/compendium-pack.ts
+++ b/build/lib/compendium-pack.ts
@@ -14,10 +14,10 @@ import path from "path";
 import * as R from "remeda";
 import systemJSON from "../../static/system.json";
 import coreIconsJSON from "../core-icons.json";
-import systemLocalizationKeysJSON from "../../static/lang/en.json"
-import ruleElementsLocalizationKeysJSON from "../../static/lang/re-en.json"
-import actionsLocalizationKeysJSON from "../../static/lang/action-en.json"
-import kingmakerLocalizationKeysJSON from "../../static/lang/kingmaker-en.json"
+import systemLocalizationKeysJSON from "../../static/lang/en.json";
+import ruleElementsLocalizationKeysJSON from "../../static/lang/re-en.json";
+import actionsLocalizationKeysJSON from "../../static/lang/action-en.json";
+import kingmakerLocalizationKeysJSON from "../../static/lang/kingmaker-en.json";
 import "./foundry-utils.ts";
 import { PackError, getFilesRecursively } from "./helpers.ts";
 import { DBFolder, LevelDatabase } from "./level-database.ts";
@@ -66,7 +66,7 @@ const localizationKeys = Object.keys({
     ...fu.flattenObject(systemLocalizationKeysJSON),
     ...fu.flattenObject(ruleElementsLocalizationKeysJSON),
     ...fu.flattenObject(actionsLocalizationKeysJSON),
-    ...fu.flattenObject(kingmakerLocalizationKeysJSON)
+    ...fu.flattenObject(kingmakerLocalizationKeysJSON),
 });
 
 class CompendiumPack {
@@ -300,11 +300,13 @@ class CompendiumPack {
                 }
             }
 
-            for(const rule of docSource.system.rules){
-                for(const v of Object.values(fu.flattenObject(rule))){
-                    if (typeof v === "string"){
-                        if(v.match(/^PF2E\.[^{}]+$/) && !localizationKeys.includes(v)){
-                            throw PackError(`${docSource.name} has a rule element with an invalid localization key ${v}`);
+            for (const rule of docSource.system.rules) {
+                for (const v of Object.values(fu.flattenObject(rule))) {
+                    if (typeof v === "string") {
+                        if (v.match(/^PF2E\.[^{}]+$/) && !localizationKeys.includes(v)) {
+                            throw PackError(
+                                `${docSource.name} has a rule element with an invalid localization key ${v}`,
+                            );
                         }
                     }
                 }

--- a/build/lib/foundry-utils.ts
+++ b/build/lib/foundry-utils.ts
@@ -119,7 +119,7 @@ export function getType(variable: unknown): string {
    * @return    A flattened object
    */
 function flattenObject(obj:object, _d = 0) {
-    const flat:{[id:string]: any} = {};
+    const flat:{[id:string]: string|number|null} = {};
     if (_d > 100) {
         throw new Error("Maximum depth exceeded");
     }
@@ -127,9 +127,15 @@ function flattenObject(obj:object, _d = 0) {
         let t = getType(v);
         if (t === "Array"){
             for(const k1 in v){
-                const inner = flattenObject(v[k1], _d+2);
-                for (const [ik, iv] of Object.entries(inner))
-                    flat[`${k}.${k1}.${ik}`] = iv;
+                const t1 = getType(v[k1]);
+                if(["number", "string"].includes(t1)){
+                    flat[`${k}.${k1}`] = v[k1];
+                }
+                else {
+                    const inner = flattenObject(v[k1], _d+2);
+                    for (const [ik, iv] of Object.entries(inner))
+                        flat[`${k}.${k1}.${ik}`] = iv;
+                }
             }
         }
         else if (t === "Object") {

--- a/build/lib/foundry-utils.ts
+++ b/build/lib/foundry-utils.ts
@@ -113,6 +113,38 @@ export function getType(variable: unknown): string {
 }
 
 /**
+   * Flatten a possibly multi-dimensional object to a one-dimensional one by converting all nested keys to dot notation
+   * @param obj The object to flatten
+   * @param _d  Track the recursion depth to prevent overflow
+   * @return    A flattened object
+   */
+function flattenObject(obj:object, _d = 0) {
+    const flat:{[id:string]: any} = {};
+    if (_d > 100) {
+        throw new Error("Maximum depth exceeded");
+    }
+    for (let [k, v] of Object.entries(obj)) {
+        let t = getType(v);
+        if (t === "Array"){
+            for(const k1 in v){
+                const inner = flattenObject(v[k1], _d+2);
+                for (const [ik, iv] of Object.entries(inner))
+                    flat[`${k}.${k1}.${ik}`] = iv;
+            }
+        }
+        else if (t === "Object") {
+            if (isEmpty(v)) flat[k] = v;
+            let inner = flattenObject(v, _d + 1);
+            for (let [ik, iv] of Object.entries(inner)) {
+                flat[`${k}.${ik}`] = iv;
+            }
+        }
+        else flat[k] = v;
+    }
+    return flat;
+}
+
+/**
  * Expand a flattened object to be a standard multi-dimensional nested Object by converting all dot-notation keys to
  * inner objects.
  *
@@ -405,6 +437,7 @@ const f = (global.foundry = {
         diffObject,
         duplicate,
         expandObject,
+        flattenObject,
         isEmpty,
         getType,
         mergeObject,

--- a/build/lib/foundry-utils.ts
+++ b/build/lib/foundry-utils.ts
@@ -113,39 +113,35 @@ export function getType(variable: unknown): string {
 }
 
 /**
-   * Flatten a possibly multi-dimensional object to a one-dimensional one by converting all nested keys to dot notation
-   * @param obj The object to flatten
-   * @param _d  Track the recursion depth to prevent overflow
-   * @return    A flattened object
-   */
-function flattenObject(obj:object, _d = 0) {
-    const flat:{[id:string]: string|number|null} = {};
+ * Flatten a possibly multi-dimensional object to a one-dimensional one by converting all nested keys to dot notation
+ * @param obj The object to flatten
+ * @param _d  Track the recursion depth to prevent overflow
+ * @return    A flattened object
+ */
+function flattenObject(obj: object, _d = 0) {
+    const flat: { [id: string]: string | number | null } = {};
     if (_d > 100) {
         throw new Error("Maximum depth exceeded");
     }
     for (let [k, v] of Object.entries(obj)) {
         let t = getType(v);
-        if (t === "Array"){
-            for(const k1 in v){
+        if (t === "Array") {
+            for (const k1 in v) {
                 const t1 = getType(v[k1]);
-                if(["number", "string"].includes(t1)){
+                if (["number", "string"].includes(t1)) {
                     flat[`${k}.${k1}`] = v[k1];
-                }
-                else {
-                    const inner = flattenObject(v[k1], _d+2);
-                    for (const [ik, iv] of Object.entries(inner))
-                        flat[`${k}.${k1}.${ik}`] = iv;
+                } else {
+                    const inner = flattenObject(v[k1], _d + 2);
+                    for (const [ik, iv] of Object.entries(inner)) flat[`${k}.${k1}.${ik}`] = iv;
                 }
             }
-        }
-        else if (t === "Object") {
+        } else if (t === "Object") {
             if (isEmpty(v)) flat[k] = v;
             let inner = flattenObject(v, _d + 1);
             for (let [ik, iv] of Object.entries(inner)) {
                 flat[`${k}.${ik}`] = iv;
             }
-        }
-        else flat[k] = v;
+        } else flat[k] = v;
     }
     return flat;
 }

--- a/packs/feats/ancestry/versatile-heritages/dragonblood/scaly-hide.json
+++ b/packs/feats/ancestry/versatile-heritages/dragonblood/scaly-hide.json
@@ -61,7 +61,7 @@
                         "not": "self:armored"
                     }
                 ],
-                "relabel": "PF2E.SpecificRule.ScalyHide.BracersOfArmor",
+                "relabel": "PF2E.SpecificRule.Dragonblood.ScalyHide.BracersOfArmor",
                 "selector": "ac",
                 "slug": "bands-of-force",
                 "value": "@actor.flags.pf2e.scalyHideBonus"
@@ -74,7 +74,7 @@
                         "not": "self:armored"
                     }
                 ],
-                "relabel": "PF2E.SpecificRule.ScalyHide.ExplorersClothing",
+                "relabel": "PF2E.SpecificRule.Dragonblood.ScalyHide.ExplorersClothing",
                 "selector": "ac",
                 "slug": "explorers-clothing",
                 "value": "@actor.flags.pf2e.scalyHideBonus"
@@ -87,7 +87,7 @@
                         "not": "self:armored"
                     }
                 ],
-                "relabel": "PF2E.SpecificRule.ScalyHide.MageArmor",
+                "relabel": "PF2E.SpecificRule.Dragonblood.ScalyHide.MageArmor",
                 "selector": "ac",
                 "slug": "mage-armor",
                 "value": "@actor.flags.pf2e.scalyHideBonus"

--- a/packs/feats/archetype/halcyon-speaker/speak-for-the-gravelands.json
+++ b/packs/feats/archetype/halcyon-speaker/speak-for-the-gravelands.json
@@ -70,7 +70,7 @@
                 "priority": 49,
                 "suboptions": [
                     {
-                        "label": "PF2E.Terrain.Gravelands",
+                        "label": "PF2E.SpecificRule.Geomancer.SpeakForTheGravelands.GravelandsLabel",
                         "value": "gravelands"
                     }
                 ],

--- a/packs/spell-effects/spell-effect-divine-vessel-9th-level.json
+++ b/packs/spell-effects/spell-effect-divine-vessel-9th-level.json
@@ -25,28 +25,28 @@
                 "adjustName": true,
                 "choices": [
                     {
-                        "label": "PF2E.TraitChaotic",
+                        "label": "Chaotic",
                         "value": {
                             "chosen": "chaotic",
                             "opposite": "lawful"
                         }
                     },
                     {
-                        "label": "PF2E.TraitEvil",
+                        "label": "Evil",
                         "value": {
                             "chosen": "evil",
                             "opposite": "good"
                         }
                     },
                     {
-                        "label": "PF2E.TraitGood",
+                        "label": "Good",
                         "value": {
                             "chosen": "good",
                             "opposite": "evil"
                         }
                     },
                     {
-                        "label": "PF2E.TraitLawful",
+                        "label": "Lawful",
                         "value": {
                             "chosen": "lawful",
                             "opposite": "chaotic"

--- a/packs/spell-effects/spell-effect-divine-vessel.json
+++ b/packs/spell-effects/spell-effect-divine-vessel.json
@@ -25,28 +25,28 @@
                 "adjustName": true,
                 "choices": [
                     {
-                        "label": "PF2E.TraitChaotic",
+                        "label": "Chaotic",
                         "value": {
                             "chosen": "chaotic",
                             "opposite": "lawful"
                         }
                     },
                     {
-                        "label": "PF2E.TraitEvil",
+                        "label": "Evil",
                         "value": {
                             "chosen": "evil",
                             "opposite": "good"
                         }
                     },
                     {
-                        "label": "PF2E.TraitGood",
+                        "label": "Good",
                         "value": {
                             "chosen": "good",
                             "opposite": "evil"
                         }
                     },
                     {
-                        "label": "PF2E.TraitLawful",
+                        "label": "Lawful",
                         "value": {
                             "chosen": "lawful",
                             "opposite": "chaotic"


### PR DESCRIPTION
This will iterate over all the fields in RE data, find those matching /^PF2E\.[^{}]+$/, and check if those are present in the static files.
The curvy braces makes it ignore those dynamic keys like class keys on some feats.
In addition, fixed some incorrect keys I found with this approach. Divine Vessel keys are not fixable as the traits no longer exist. Not sure what to do with those. Maybe have a list of exceptions.

Important: the flattenObject I used was based on core Foundry's, but it's modified to be able to handle arrays (Foundry implementation considers arrays unflattable). I exported it together with other foundry-utils functions, but I'm not sure that's a correct thing to do.