### PR TITLE
Fix Hexing Jar RE localization key

### DIFF
--- a/packs/equipment/hexing-jar.json
+++ b/packs/equipment/hexing-jar.json
@@ -54,7 +54,7 @@
                         "value": "nature"
                     },
                     {
-                        "label": "FPF2E.SpecificRule.Witch.Patron.Theme.FaithsFlamekeeper",
+                        "label": "PF2E.SpecificRule.Witch.Patron.Theme.FaithsFlamekeeper",
                         "value": "religion"
                     },
                     {


### PR DESCRIPTION
This one is my fault.

Made a temporary label and I guess didn't select it's entirety when replacing it with a key.