### PR TITLE
Remove actor clone from inventory preparation

### DIFF
--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -191,7 +191,8 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends fav1.sheets.Acto
     }
 
     protected prepareInventory(): SheetInventory {
-        const items = [...iterateAllItems(this.actor)].filter((i) => i.isOfType("physical"));
+        const actor = this.actor;
+        const items = [...iterateAllItems(actor)].filter((i) => i.isOfType("physical"));
         this.#inventorySearchEngine.removeAll();
         this.#inventorySearchEngine.addAll(items.map((i) => R.pick(i, ["uuid", "name"])));
 
@@ -212,7 +213,6 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends fav1.sheets.Acto
             { label: game.i18n.localize("PF2E.Item.Container.Plural"), types: ["backpack"], items: [] },
         ];
 
-        const actor = this.actor.clone({}, { keepId: true });
         for (const item of actor.inventory.contents.sort((a, b) => (a.sort || 0) - (b.sort || 0))) {
             if (item.isInContainer) continue;
             const section = sections.find((s) => s.types.includes(item.type));


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/19349 though the root problem remains

Removes what seems to be a not necessary or no longer necessary actor clone during data prep. The incorrect data is due to a core bug, but I think we're better without the clone anyways unless there's something I'm missing.

EDIT: Yeah without, a somewhat modified Jirelle's re-render goes from 90ms to 50ms on my machine. Appreciable speedup, though its a bit concerning how a single clone is that expensive. It likely doesn't matter in most scenarios at least.