### PR TITLE
Exclude flat checks from adjusting `inline-dc`

### DIFF
--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -875,7 +875,9 @@ function getCheckDC({
         const idDomain = item ? `${item.id}-inline-dc` : null;
         const slugDomain = `${sluggify(name)}-inline-dc`;
         const domains =
-            params.type === "flat" ? ["flat-check"] : ["inline-dc", idDomain, slugDomain].filter(R.isTruthy);
+            params.type === "flat"
+                ? ["inline-flat-check-dc"]
+                : ["all", "inline-dc", idDomain, slugDomain].filter(R.isTruthy);
         const modifier = new ModifierPF2e({
             slug: "base",
             label: "PF2E.ModifierTitle",

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -889,7 +889,7 @@ function getCheckDC({
                 domains,
                 modifiers: [modifier],
             },
-            { extraRollOptions: [`inline-dc:value:${base}`], item },
+            { extraRollOptions: [`inline-dc:type:${params.type}`, `inline-dc:value:${base}`], item },
         );
         return String(stat.dc.value);
     }

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -874,7 +874,8 @@ function getCheckDC({
     if (base && actor && !immutable) {
         const idDomain = item ? `${item.id}-inline-dc` : null;
         const slugDomain = `${sluggify(name)}-inline-dc`;
-        const domains = [params.type !== "flat" ? "all" : null, "inline-dc", idDomain, slugDomain].filter(R.isTruthy);
+        const domains =
+            params.type === "flat" ? ["flat-check"] : ["inline-dc", idDomain, slugDomain].filter(R.isTruthy);
         const modifier = new ModifierPF2e({
             slug: "base",
             label: "PF2E.ModifierTitle",
@@ -889,7 +890,7 @@ function getCheckDC({
                 domains,
                 modifiers: [modifier],
             },
-            { extraRollOptions: [`inline-dc:type:${params.type}`, `inline-dc:value:${base}`], item },
+            { extraRollOptions: [`inline-dc:value:${base}`], item },
         );
         return String(stat.dc.value);
     }


### PR DESCRIPTION
Required to exclude some check types (e.g. flat check) from being adjusted by rule elements.