### PR TITLE
Fix Dullahan Keen Note outcome and localization key

### DIFF
--- a/packs/pathfinder-monster-core/dullahan.json
+++ b/packs/pathfinder-monster-core/dullahan.json
@@ -304,14 +304,14 @@
                     {
                         "key": "Note",
                         "outcome": [
-                            "success"
+                            "criticalSuccess"
                         ],
                         "predicate": [
                             "check:total:natural:19"
                         ],
                         "selector": "{item|_id}-attack",
                         "text": "PF2E.AttackEffects.IncreasedCriticalChance",
-                        "title": "PF2E.WeaponPropertyRune.keen",
+                        "title": "PF2E.WeaponPropertyRune.keen.Name",
                         "visibility": "gm"
                     }
                 ],
@@ -386,14 +386,14 @@
                     {
                         "key": "Note",
                         "outcome": [
-                            "success"
+                            "criticalSuccess"
                         ],
                         "predicate": [
                             "check:total:natural:19"
                         ],
                         "selector": "{item|_id}-attack",
                         "text": "PF2E.AttackEffects.IncreasedCriticalChance",
-                        "title": "PF2E.WeaponPropertyRune.keen",
+                        "title": "PF2E.WeaponPropertyRune.keen.Name",
                         "visibility": "gm"
                     }
                 ],
@@ -514,14 +514,14 @@
                     {
                         "key": "Note",
                         "outcome": [
-                            "success"
+                            "criticalSuccess"
                         ],
                         "predicate": [
                             "check:total:natural:19"
                         ],
                         "selector": "{item|_id}-attack",
                         "text": "PF2E.AttackEffects.IncreasedCriticalChance",
-                        "title": "PF2E.WeaponPropertyRune.keen",
+                        "title": "PF2E.WeaponPropertyRune.keen.Name",
                         "visibility": "gm"
                     }
                 ],


### PR DESCRIPTION
As it was, the Note was never displayed, as the result is already promoted by the time this Note checks it.

But should this Note even be here? Dullahan's Strikes all add Head Hunter as an additional effect, and that one has a link to the Keen rune in it's description.