### PR TITLE
Add slug to Barghest's Unhealing Wound

### DIFF
--- a/packs/pathfinder-monster-core/barghest.json
+++ b/packs/pathfinder-monster-core/barghest.json
@@ -522,7 +522,7 @@
                     "title": "Pathfinder Monster Core"
                 },
                 "rules": [],
-                "slug": null,
+                "slug": "unhealing-wound",
                 "traits": {
                     "value": [
                         "curse",


### PR DESCRIPTION
Makes the claw attack recognize it with translated name.