### PR TITLE
Delay Alchemical Discoveries' versatile vials addition after most skill upgrades

### DIFF
--- a/packs/feats/class/investigator/alchemical-discoveries.json
+++ b/packs/feats/class/investigator/alchemical-discoveries.json
@@ -34,6 +34,7 @@
                 "key": "ActiveEffectLike",
                 "mode": "add",
                 "path": "system.resources.versatileVials.max",
+                "priority": 60,
                 "value": "@actor.system.skills.crafting.rank - 1"
             }
         ],


### PR DESCRIPTION
The default for upgrade is 40, and the highest priority for skill upgrades in the system that isn't beforeDerived (at which point we can't alter versatile vials) seems to be 51—right after the default for Roll Option. 60 would give us enough wiggle room.

Worth noting that this rule element doesn't work with dropdown skill menus which need to be done at the `beforeDerived` phase. I don't think there is a data side solution for that.

Closes #19463