### PR TITLE
Automate several permanent quickened-granting features

### DIFF
--- a/packs/age-of-ashes-bestiary/book-6-broken-promises/inizra-arumelo.json
+++ b/packs/age-of-ashes-bestiary/book-6-broken-promises/inizra-arumelo.json
@@ -566,14 +566,34 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>Inizra is permanently @UUID[Compendium.pf2e.conditionitems.Item.Quickened]{Quickened 1}. She can use her extra action only to Strike.</p>"
+                    "value": "<p>Inizra is permanently @UUID[Compendium.pf2e.conditionitems.Item.Quickened]. She can use her extra action only to Strike.</p>"
                 },
                 "publication": {
                     "license": "OGL",
                     "remaster": false,
                     "title": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "inMemoryOnly": true,
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.conditionitems.Item.Quickened"
+                    },
+                    {
+                        "itemType": "condition",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "predicate": [
+                            "item:granter:id:{item|id}"
+                        ],
+                        "property": "description",
+                        "value": [
+                            {
+                                "text": "{item|description}"
+                            }
+                        ]
+                    }
+                ],
                 "slug": null,
                 "traits": {
                     "rarity": "common",

--- a/packs/blood-lords-bestiary/book-6-ghost-kings-rage/mithral-golem.json
+++ b/packs/blood-lords-bestiary/book-6-ghost-kings-rage/mithral-golem.json
@@ -4,47 +4,10 @@
     "img": "systems/pf2e/icons/default-icons/npc.svg",
     "items": [
         {
-            "_id": "gm13winmstas1ock",
-            "_stats": {
-                "compendiumSource": "Compendium.pf2e.conditionitems.Item.nlCjDvLMf2EkV2dl"
-            },
-            "img": "systems/pf2e/icons/conditions/quickened.webp",
-            "name": "Quickened",
-            "sort": 100000,
-            "system": {
-                "description": {
-                    "value": "<p>You gain 1 additional action at the start of your turn each round. Many effects that make you quickened specify the types of actions you can use with this additional action. If you become quickened from multiple sources, you can use the extra action you've been granted for any single action allowed by any of the effects that made you quickened. Because quickened has its effect at the start of your turn, you don't immediately gain actions if you become quickened during your turn.</p>"
-                },
-                "duration": {
-                    "value": 0
-                },
-                "group": null,
-                "overrides": [],
-                "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
-                },
-                "references": {
-                    "children": [],
-                    "immunityFrom": [],
-                    "overriddenBy": [],
-                    "overrides": []
-                },
-                "rules": [],
-                "slug": "quickened",
-                "value": {
-                    "isValued": false,
-                    "value": null
-                }
-            },
-            "type": "condition"
-        },
-        {
             "_id": "USVxY3qpSEozrQU8",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Fist",
-            "sort": 200000,
+            "sort": 100000,
             "system": {
                 "attack": {
                     "value": ""
@@ -90,7 +53,7 @@
             "_id": "bkajUVm6XDKbIO89",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Spike",
-            "sort": 300000,
+            "sort": 200000,
             "system": {
                 "attack": {
                     "value": ""
@@ -136,7 +99,7 @@
             "_id": "ooPhbtvdtMFxysJe",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Evasion",
-            "sort": 400000,
+            "sort": 300000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -177,7 +140,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Golem Antimagic",
-            "sort": 500000,
+            "sort": 400000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -207,7 +170,7 @@
             "_id": "5PRYxLiEoiOScKcc",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Swift Steps",
-            "sort": 600000,
+            "sort": 500000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -224,7 +187,27 @@
                     "remaster": false,
                     "title": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "inMemoryOnly": true,
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.conditionitems.Item.Quickened"
+                    },
+                    {
+                        "itemType": "condition",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "predicate": [
+                            "item:granter:id:{item|id}"
+                        ],
+                        "property": "description",
+                        "value": [
+                            {
+                                "text": "{item|description}"
+                            }
+                        ]
+                    }
+                ],
                 "slug": null,
                 "traits": {
                     "rarity": "common",
@@ -237,7 +220,7 @@
             "_id": "Y2DLiZGrL1Rc9uJZ",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Vulnerable to Slow",
-            "sort": 700000,
+            "sort": 600000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -267,7 +250,7 @@
             "_id": "ILOl1dY50IaR6WPN",
             "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Liquefy",
-            "sort": 800000,
+            "sort": 700000,
             "system": {
                 "actionType": {
                     "value": "action"
@@ -311,7 +294,7 @@
             "_id": "rjVHVaa9BN3ZAiKL",
             "img": "systems/pf2e/icons/actions/ThreeActions.webp",
             "name": "Spike Storm",
-            "sort": 900000,
+            "sort": 800000,
             "system": {
                 "actionType": {
                     "value": "action"

--- a/packs/classfeatures/abundant-vials.json
+++ b/packs/classfeatures/abundant-vials.json
@@ -11,7 +11,7 @@
         },
         "category": "classfeature",
         "description": {
-            "value": "<p>You're permanently @UUID[Compendium.pf2e.conditionitems.Item.Quickened], and can use the extra action only to use @UUID[Compendium.pf2e.actionspf2e.Item.Quick Alchemy] to create a quick vial. You can create only one vial with this action, even if you have double brew or a similar ability.</p>"
+            "value": "<p>You're permanently @UUID[Compendium.pf2e.conditionitems.Item.Quickened], and can use the extra action only to use @UUID[Compendium.pf2e.actionspf2e.Item.Quick Alchemy] to create a quick vial. You can create only one vial with this action, even if you have @UUID[Compendium.pf2e.classfeatures.Item.Double Brew] or a similar ability.</p>"
         },
         "level": {
             "value": 17
@@ -24,7 +24,27 @@
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [],
+        "rules": [
+            {
+                "inMemoryOnly": true,
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.conditionitems.Item.Quickened"
+            },
+            {
+                "itemType": "condition",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:granter:id:{item|id}"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "{item|description}"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/archetype/artillerist/master-siege-engineer.json
+++ b/packs/feats/archetype/artillerist/master-siege-engineer.json
@@ -29,7 +29,27 @@
             "remaster": true,
             "title": "Pathfinder Guns & Gears"
         },
-        "rules": [],
+        "rules": [
+            {
+                "inMemoryOnly": true,
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.conditionitems.Item.Quickened"
+            },
+            {
+                "itemType": "condition",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:granter:id:{item|id}"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "{item|description}"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/class/bard/eternal-composition.json
+++ b/packs/feats/class/bard/eternal-composition.json
@@ -29,7 +29,27 @@
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [],
+        "rules": [
+            {
+                "inMemoryOnly": true,
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.conditionitems.Item.Quickened"
+            },
+            {
+                "itemType": "condition",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:granter:id:{item|id}"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "{item|description}"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/class/fighter/weapon-supremacy.json
+++ b/packs/feats/class/fighter/weapon-supremacy.json
@@ -25,7 +25,27 @@
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [],
+        "rules": [
+            {
+                "inMemoryOnly": true,
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.conditionitems.Item.Quickened"
+            },
+            {
+                "itemType": "condition",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:granter:id:{item|id}"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "{item|description}"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/class/gunslinger/perfect-readiness.json
+++ b/packs/feats/class/gunslinger/perfect-readiness.json
@@ -25,7 +25,27 @@
             "remaster": true,
             "title": "Pathfinder Guns & Gears"
         },
-        "rules": [],
+        "rules": [
+            {
+                "inMemoryOnly": true,
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.conditionitems.Item.Quickened"
+            },
+            {
+                "itemType": "condition",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:granter:id:{item|id}"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "{item|description}"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/class/inventor/full-automation.json
+++ b/packs/feats/class/inventor/full-automation.json
@@ -29,7 +29,42 @@
             "remaster": true,
             "title": "Pathfinder Guns & Gears"
         },
-        "rules": [],
+        "rules": [
+            {
+                "inMemoryOnly": true,
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.conditionitems.Item.Quickened"
+            },
+            {
+                "itemType": "condition",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:granter:id:{item|id}"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "predicate": [
+                            "feature:armor-innovation"
+                        ],
+                        "text": "PF2E.SpecificRule.Inventor.FullAutomation.QuickenedAddendum.Armor"
+                    },
+                    {
+                        "predicate": [
+                            "feature:construct-innovation"
+                        ],
+                        "text": "PF2E.SpecificRule.Inventor.FullAutomation.QuickenedAddendum.Construct"
+                    },
+                    {
+                        "predicate": [
+                            "feature:weapon-innovation"
+                        ],
+                        "text": "PF2E.SpecificRule.Inventor.FullAutomation.QuickenedAddendum.Weapon"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/class/investigator/just-the-facts.json
+++ b/packs/feats/class/investigator/just-the-facts.json
@@ -12,7 +12,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>You fundamentally understand everything to the point where your research can't possibly be wrong. You are permanently @UUID[Compendium.pf2e.conditionitems.Item.Quickened] and can use the extra action to Recall Knowledge. In addition, you gain the following benefits with Recall Knowledge.</p><ul><li>Your checks to Recall Knowledge are no longer secret.</li><li>When you Recall Knowledge, you use the outcome for one degree of success better than the result of your check.</li><li>If an effect (such as Dubious Knowledge) would give you inaccurate information from your Recall Knowledge check, you know which information is inaccurate.</li><li><p>When one of your allies Recalls Knowledge and gains false information, you also know that information is inaccurate if they share it with you</p>\n</li></ul>"
+            "value": "<p>You fundamentally understand everything to the point where your research can't possibly be wrong. You are permanently @UUID[Compendium.pf2e.conditionitems.Item.Quickened] and can use the extra action to @UUID[Compendium.pf2e.actionspf2e.Item.Recall Knowledge]. In addition, you gain the following benefits with Recall Knowledge.</p><ul><li>Your checks to Recall Knowledge are no longer secret.</li><li>When you Recall Knowledge, you use the outcome for one degree of success better than the result of your check.</li><li>If an effect (such as @UUID[Compendium.pf2e.feats-srd.Item.Dubious Knowledge]) would give you inaccurate information from your Recall Knowledge check, you know which information is inaccurate.</li><li><p>When one of your allies Recalls Knowledge and gains false information, you also know that information is inaccurate if they share it with you</p></li></ul>"
         },
         "level": {
             "value": 20
@@ -29,7 +29,37 @@
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [],
+        "rules": [
+            {
+                "inMemoryOnly": true,
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.conditionitems.Item.Quickened"
+            },
+            {
+                "itemType": "condition",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:granter:id:{item|id}"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Investigator.JustTheFacts.QuickenedAddendum"
+                    }
+                ]
+            },
+            {
+                "adjustment": {
+                    "all": "one-degree-better"
+                },
+                "key": "AdjustDegreeOfSuccess",
+                "predicate": [
+                    "action:recall-knowledge"
+                ],
+                "selector": "skill-check"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/class/investigator/thorough-research.json
+++ b/packs/feats/class/investigator/thorough-research.json
@@ -28,11 +28,15 @@
         "rules": [
             {
                 "key": "Note",
+                "outcome": [
+                    "success",
+                    "criticalSuccess"
+                ],
                 "predicate": [
                     "action:recall-knowledge"
                 ],
                 "selector": "skill-check",
-                "text": "When you roll a success at a Recall Knowledge, you learn an additional fact. When you critically succed, you can gain even more additional information or context than normal.",
+                "text": "{item|description}",
                 "title": "{item|name}"
             }
         ],

--- a/packs/feats/class/kineticist/kinetic-pinnacle.json
+++ b/packs/feats/class/kineticist/kinetic-pinnacle.json
@@ -25,7 +25,27 @@
             "remaster": true,
             "title": "Pathfinder Rage of Elements"
         },
-        "rules": [],
+        "rules": [
+            {
+                "inMemoryOnly": true,
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.conditionitems.Item.Quickened"
+            },
+            {
+                "itemType": "condition",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:granter:id:{item|id}"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "{item|description}"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/class/magus/supreme-spellstrike.json
+++ b/packs/feats/class/magus/supreme-spellstrike.json
@@ -12,7 +12,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>You've made it almost effortless to combine spells and attacks. You're permanently @UUID[Compendium.pf2e.conditionitems.Item.Quickened]. You can use your extra action only to Strike or to recharge Spellstrike.</p>"
+            "value": "<p>You've made it almost effortless to combine spells and attacks. You're permanently @UUID[Compendium.pf2e.conditionitems.Item.Quickened]. You can use your extra action only to Strike or to recharge @UUID[Compendium.pf2e.actionspf2e.Item.Spellstrike].</p>"
         },
         "level": {
             "value": 20
@@ -29,7 +29,27 @@
             "remaster": false,
             "title": "Pathfinder Secrets of Magic"
         },
-        "rules": [],
+        "rules": [
+            {
+                "inMemoryOnly": true,
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.conditionitems.Item.Quickened"
+            },
+            {
+                "itemType": "condition",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:granter:id:{item|id}"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "{item|description}"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/class/monk/enduring-quickness.json
+++ b/packs/feats/class/monk/enduring-quickness.json
@@ -25,7 +25,27 @@
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [],
+        "rules": [
+            {
+                "inMemoryOnly": true,
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.conditionitems.Item.Quickened"
+            },
+            {
+                "itemType": "condition",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:granter:id:{item|id}"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "{item|description}"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/class/summoner/eternal-boost.json
+++ b/packs/feats/class/summoner/eternal-boost.json
@@ -25,7 +25,27 @@
             "remaster": false,
             "title": "Pathfinder Secrets of Magic"
         },
-        "rules": [],
+        "rules": [
+            {
+                "inMemoryOnly": true,
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.conditionitems.Item.Quickened"
+            },
+            {
+                "itemType": "condition",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:granter:id:{item|id}"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "{item|description}"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/lost-omens-bestiary/monsters-of-myth/kothogaz-dance-of-disharmony.json
+++ b/packs/lost-omens-bestiary/monsters-of-myth/kothogaz-dance-of-disharmony.json
@@ -295,14 +295,34 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p>Kothogaz is permanently @UUID[Compendium.pf2e.conditionitems.Item.Quickened]{Quickened 1}. It can use this extra action to Stride or Strike.</p>"
+                    "value": "<p>Kothogaz is permanently @UUID[Compendium.pf2e.conditionitems.Item.Quickened]. It can use this extra action to Stride or Strike.</p>"
                 },
                 "publication": {
                     "license": "OGL",
                     "remaster": false,
                     "title": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "inMemoryOnly": true,
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.conditionitems.Item.Quickened"
+                    },
+                    {
+                        "itemType": "condition",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "predicate": [
+                            "item:granter:id:{item|id}"
+                        ],
+                        "property": "description",
+                        "value": [
+                            {
+                                "text": "{item|description}"
+                            }
+                        ]
+                    }
+                ],
                 "slug": null,
                 "traits": {
                     "rarity": "common",

--- a/packs/pathfinder-bestiary-3/danava-titan.json
+++ b/packs/pathfinder-bestiary-3/danava-titan.json
@@ -1621,14 +1621,34 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p>The titan is as ever-moving as ocean waves. They're permanently @UUID[Compendium.pf2e.conditionitems.Item.Quickened]{Quickened 1}, and the extra action can only be used to Stride, Strike, or Sustain a Spell, or as one of the actions necessary to Cast @UUID[Compendium.pf2e.spells-srd.Item.Dispel Magic].</p>"
+                    "value": "<p>The titan is as ever-moving as ocean waves. They're permanently @UUID[Compendium.pf2e.conditionitems.Item.Quickened], and the extra action can only be used to Stride, Strike, or Sustain a Spell, or as one of the actions necessary to Cast @UUID[Compendium.pf2e.spells-srd.Item.Dispel Magic].</p>"
                 },
                 "publication": {
                     "license": "OGL",
                     "remaster": false,
                     "title": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "inMemoryOnly": true,
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.conditionitems.Item.Quickened"
+                    },
+                    {
+                        "itemType": "condition",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "predicate": [
+                            "item:granter:id:{item|id}"
+                        ],
+                        "property": "description",
+                        "value": [
+                            {
+                                "text": "{item|description}"
+                            }
+                        ]
+                    }
+                ],
                 "slug": null,
                 "traits": {
                     "rarity": "common",

--- a/packs/pathfinder-bestiary-3/mithral-golem.json
+++ b/packs/pathfinder-bestiary-3/mithral-golem.json
@@ -3,47 +3,10 @@
     "img": "systems/pf2e/icons/default-icons/npc.svg",
     "items": [
         {
-            "_id": "gm13winmstas1ock",
-            "_stats": {
-                "compendiumSource": "Compendium.pf2e.conditionitems.Item.nlCjDvLMf2EkV2dl"
-            },
-            "img": "systems/pf2e/icons/conditions/quickened.webp",
-            "name": "Quickened",
-            "sort": 100000,
-            "system": {
-                "description": {
-                    "value": "<p>You gain 1 additional action at the start of your turn each round. Many effects that make you quickened specify the types of actions you can use with this additional action. If you become quickened from multiple sources, you can use the extra action you've been granted for any single action allowed by any of the effects that made you quickened. Because quickened has its effect at the start of your turn, you don't immediately gain actions if you become quickened during your turn.</p>"
-                },
-                "duration": {
-                    "value": 0
-                },
-                "group": null,
-                "overrides": [],
-                "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
-                },
-                "references": {
-                    "children": [],
-                    "immunityFrom": [],
-                    "overriddenBy": [],
-                    "overrides": []
-                },
-                "rules": [],
-                "slug": "quickened",
-                "value": {
-                    "isValued": false,
-                    "value": null
-                }
-            },
-            "type": "condition"
-        },
-        {
             "_id": "USVxY3qpSEozrQU8",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Fist",
-            "sort": 200000,
+            "sort": 100000,
             "system": {
                 "attack": {
                     "value": ""
@@ -90,7 +53,7 @@
             "_id": "bkajUVm6XDKbIO89",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Spike",
-            "sort": 300000,
+            "sort": 200000,
             "system": {
                 "attack": {
                     "value": ""
@@ -136,7 +99,7 @@
             "_id": "ooPhbtvdtMFxysJe",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Evasion",
-            "sort": 400000,
+            "sort": 300000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -184,7 +147,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Golem Antimagic",
-            "sort": 500000,
+            "sort": 400000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -214,7 +177,7 @@
             "_id": "5PRYxLiEoiOScKcc",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Swift Steps",
-            "sort": 600000,
+            "sort": 500000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -231,7 +194,27 @@
                     "remaster": false,
                     "title": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "inMemoryOnly": true,
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.conditionitems.Item.Quickened"
+                    },
+                    {
+                        "itemType": "condition",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "predicate": [
+                            "item:granter:id:{item|id}"
+                        ],
+                        "property": "description",
+                        "value": [
+                            {
+                                "text": "{item|description}"
+                            }
+                        ]
+                    }
+                ],
                 "slug": null,
                 "traits": {
                     "rarity": "common",
@@ -244,7 +227,7 @@
             "_id": "Y2DLiZGrL1Rc9uJZ",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Vulnerable to Slow",
-            "sort": 700000,
+            "sort": 600000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -274,7 +257,7 @@
             "_id": "ILOl1dY50IaR6WPN",
             "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Liquefy",
-            "sort": 800000,
+            "sort": 700000,
             "system": {
                 "actionType": {
                     "value": "action"
@@ -318,7 +301,7 @@
             "_id": "rjVHVaa9BN3ZAiKL",
             "img": "systems/pf2e/icons/actions/ThreeActions.webp",
             "name": "Spike Storm",
-            "sort": 900000,
+            "sort": 800000,
             "system": {
                 "actionType": {
                     "value": "action"

--- a/packs/prey-for-death-bestiary/silver-saber.json
+++ b/packs/prey-for-death-bestiary/silver-saber.json
@@ -348,8 +348,23 @@
                 },
                 "rules": [
                     {
+                        "inMemoryOnly": true,
                         "key": "GrantItem",
                         "uuid": "Compendium.pf2e.conditionitems.Item.Quickened"
+                    },
+                    {
+                        "itemType": "condition",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "predicate": [
+                            "item:granter:id:{item|id}"
+                        ],
+                        "property": "description",
+                        "value": [
+                            {
+                                "text": "{item|description}"
+                            }
+                        ]
                     }
                 ],
                 "slug": null,

--- a/packs/stolen-fate-bestiary/book-3-worst-of-all-possible-worlds/nornhound.json
+++ b/packs/stolen-fate-bestiary/book-3-worst-of-all-possible-worlds/nornhound.json
@@ -958,7 +958,27 @@
                     "remaster": false,
                     "title": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "inMemoryOnly": true,
+                        "key": "GrantItem",
+                        "uuid": "Compendium.pf2e.conditionitems.Item.Quickened"
+                    },
+                    {
+                        "itemType": "condition",
+                        "key": "ItemAlteration",
+                        "mode": "add",
+                        "predicate": [
+                            "item:granter:id:{item|id}"
+                        ],
+                        "property": "description",
+                        "value": [
+                            {
+                                "text": "{item|description}"
+                            }
+                        ]
+                    }
+                ],
                 "slug": null,
                 "traits": {
                     "value": []

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -4325,6 +4325,13 @@
                 "BoostModulation": {
                     "Prompt": "Select an additional offensive boost"
                 },
+                "FullAutomation": {
+                    "QuickenedAddendum": {
+                        "Armor": "You're permanently quickened. You can use the extra action to Stride, Step, or use a form of movement provided by your innovation (such as Fly or Swim).",
+                        "Construct": "You're permanently quickened. You can use the extra action to Command your construct innovation (or to provide 1 of the actions if you choose to spend 2 actions to Command your construct).",
+                        "Weapon": "You're permanently quickened. You can use the extra action to Strike with your innovation."
+                    }
+                },
                 "Innovation": {
                     "Armor": {
                         "AllowedDrops": "level-zero unique armor",
@@ -4408,6 +4415,9 @@
                     "Attack": "Attack Stratagem",
                     "Defensive": "Defensive Stratagem",
                     "Skill": "Skill Stratagem"
+                },
+                "JustTheFacts": {
+                    "QuickenedAddendum": "You are permanently quickened and can use the extra action to @UUID[Compendium.pf2e.actionspf2e.Item.1OagaWtBpVXExToo]{Recall Knowledge}."
                 },
                 "Methodology": {
                     "Prompt": "Select a methodology."

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -4417,7 +4417,7 @@
                     "Skill": "Skill Stratagem"
                 },
                 "JustTheFacts": {
-                    "QuickenedAddendum": "You are permanently quickened and can use the extra action to @UUID[Compendium.pf2e.actionspf2e.Item.1OagaWtBpVXExToo]{Recall Knowledge}."
+                    "QuickenedAddendum": "You are permanently quickened and can use the extra action to Recall Knowledge."
                 },
                 "Methodology": {
                     "Prompt": "Select a methodology."


### PR DESCRIPTION
Also
- Add degree of success adjustment to Just the Facts.
- Predicate Note on Thorough Research and remove unlocalized text.
- Replace Quickened 1 in some monster abilities with just Quickened as an obvious Paizo error.
- Add some missing compendium links.