### PR TITLE
Add name and group alterations to ItemAlteration

### DIFF
--- a/src/module/item/base/sheet/sheet.ts
+++ b/src/module/item/base/sheet/sheet.ts
@@ -339,7 +339,7 @@ class ItemSheetPF2e<TItem extends ItemPF2e> extends fav1.sheets.ItemSheet<TItem,
             htmlQuery(rulesPanel, "a[data-action=regenerate-slug]")?.addEventListener("click", () => {
                 if (this._submitting) return;
 
-                slugInput.value = sluggify(this.item.name);
+                slugInput.value = sluggify(this.item._source.name);
                 const event = new Event("change");
                 slugInput.dispatchEvent(event);
             });

--- a/src/module/rules/rule-element/item-alteration/alteration.ts
+++ b/src/module/rules/rule-element/item-alteration/alteration.ts
@@ -34,9 +34,11 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
         "focus-point-cost",
         "frequency-max",
         "frequency-per",
+        "group",
         "hardness",
         "hp-max",
         "material-type",
+        "name",
         "other-tags",
         "pd-recovery-dc",
         "persistent-damage",
@@ -259,6 +261,13 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
                 data.item.system.cast.focusPoints = (Math.clamp(newValue, 0, 3) || 0) as ZeroToThree;
                 return;
             }
+            case "group": {
+                const validator = ITEM_ALTERATION_VALIDATORS[this.property];
+                if (validator.isValid(data)) {
+                    data.item.system.group = data.alteration.value;
+                }
+                return;
+            }
             case "hardness": {
                 const validator = ITEM_ALTERATION_VALIDATORS[this.property];
                 if (validator.isValid(data)) {
@@ -355,6 +364,13 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
                     if (!otherTags.includes(newValue)) otherTags.push(newValue);
                 } else if (["subtract", "remove"].includes(this.mode)) {
                     otherTags.splice(otherTags.indexOf(newValue), 1);
+                }
+                return;
+            }
+            case "name": {
+                const validator = ITEM_ALTERATION_VALIDATORS[this.property];
+                if (validator.isValid(data)) {
+                    data.item.name = data.alteration.value;
                 }
                 return;
             }

--- a/src/module/rules/rule-element/item-alteration/alteration.ts
+++ b/src/module/rules/rule-element/item-alteration/alteration.ts
@@ -37,7 +37,6 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
         "group",
         "hardness",
         "hp-max",
-        "img",
         "material-type",
         "name",
         "other-tags",
@@ -291,13 +290,6 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
                         hp.brokenThreshold = Math.floor(hp.max / 2);
                     }
                     this.#adjustCreatureShieldData(data.item);
-                }
-                return;
-            }
-            case "img": {
-                const validator = ITEM_ALTERATION_VALIDATORS[this.property];
-                if (validator.isValid(data)) {
-                    data.item.img = data.alteration.value;
                 }
                 return;
             }

--- a/src/module/rules/rule-element/item-alteration/alteration.ts
+++ b/src/module/rules/rule-element/item-alteration/alteration.ts
@@ -37,6 +37,7 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
         "group",
         "hardness",
         "hp-max",
+        "img",
         "material-type",
         "name",
         "other-tags",
@@ -290,6 +291,13 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
                         hp.brokenThreshold = Math.floor(hp.max / 2);
                     }
                     this.#adjustCreatureShieldData(data.item);
+                }
+                return;
+            }
+            case "img": {
+                const validator = ITEM_ALTERATION_VALIDATORS[this.property];
+                if (validator.isValid(data)) {
+                    data.item.img = data.alteration.value;
                 }
                 return;
             }

--- a/src/module/rules/rule-element/item-alteration/schemas.ts
+++ b/src/module/rules/rule-element/item-alteration/schemas.ts
@@ -301,6 +301,38 @@ const ITEM_ALTERATION_VALIDATORS = {
         }),
         value: new StrictNumberField({ required: true, nullable: false, integer: true, initial: undefined } as const),
     }),
+    "group": new ItemAlterationValidator(
+        {
+            itemType: new fields.StringField({ required: true, choices: ["armor", "weapon"] }),
+            mode: new fields.StringField({ required: true, choices: ["override"] }),
+            value: new fields.StringField({
+                required: true,
+                nullable: false,
+                initial: undefined,
+            } as const),
+        },
+        {
+            validateForItem: (item, alteration): validation.DataModelValidationFailure | void => {
+                const value = alteration.value;
+                if (item.type === "armor") {
+                    const validTraits = CONFIG.PF2E.armorGroups;
+                    if (typeof value !== "string" || !(value in validTraits)) {
+                        return new validation.DataModelValidationFailure({
+                            message: `${alteration.value} is not a valid armor group`
+                        });
+                    }
+                }
+                else if (item.type ==="weapon") {
+                    const validTraits = CONFIG.PF2E.weaponGroups;
+                    if (typeof value !== "string" || !(value in validTraits)) {
+                        return new validation.DataModelValidationFailure({
+                            message: `${alteration.value} is not a valid weapon group`
+                        });
+                    }
+                }
+            },
+        }
+    ),
     hardness: new ItemAlterationValidator({
         itemType: new fields.StringField({ required: true, choices: Array.from(PHYSICAL_ITEM_TYPES) }),
         mode: new fields.StringField({
@@ -465,6 +497,11 @@ const ITEM_ALTERATION_VALIDATORS = {
             blank: false,
             initial: undefined,
         } as const),
+    }),
+    "name": new ItemAlterationValidator({
+        itemType: new fields.StringField({required: true}),
+        mode: new fields.StringField({required: true, choices: ["override"],}),
+        value: new fields.StringField({required: true,nullable: false,blank: false,} as const),
     }),
     "speed-penalty": new ItemAlterationValidator({
         itemType: new fields.StringField({

--- a/src/module/rules/rule-element/item-alteration/schemas.ts
+++ b/src/module/rules/rule-element/item-alteration/schemas.ts
@@ -377,6 +377,16 @@ const ITEM_ALTERATION_VALIDATORS = {
             initial: undefined,
         } as const),
     }),
+    img: new ItemAlterationValidator({
+        itemType: new fields.StringField({ required: true }),
+        mode: new fields.StringField({ required: true, choices: ["override"] }),
+        value: new fields.FilePathField({
+            required: true,
+            nullable: false,
+            blank: false,
+            categories: ["IMAGE"],
+        } as const),
+    }),
     "material-type": new ItemAlterationValidator({
         itemType: new fields.StringField({ required: true, choices: Array.from(PHYSICAL_ITEM_TYPES) }),
         mode: new fields.StringField({ required: true, choices: ["override"] }),

--- a/src/module/rules/rule-element/item-alteration/schemas.ts
+++ b/src/module/rules/rule-element/item-alteration/schemas.ts
@@ -301,7 +301,7 @@ const ITEM_ALTERATION_VALIDATORS = {
         }),
         value: new StrictNumberField({ required: true, nullable: false, integer: true, initial: undefined } as const),
     }),
-    "group": new ItemAlterationValidator(
+    group: new ItemAlterationValidator(
         {
             itemType: new fields.StringField({ required: true, choices: ["armor", "weapon"] }),
             mode: new fields.StringField({ required: true, choices: ["override"] }),
@@ -318,20 +318,19 @@ const ITEM_ALTERATION_VALIDATORS = {
                     const validTraits = CONFIG.PF2E.armorGroups;
                     if (typeof value !== "string" || !(value in validTraits)) {
                         return new validation.DataModelValidationFailure({
-                            message: `${alteration.value} is not a valid armor group`
+                            message: `${alteration.value} is not a valid armor group`,
                         });
                     }
-                }
-                else if (item.type ==="weapon") {
+                } else if (item.type === "weapon") {
                     const validTraits = CONFIG.PF2E.weaponGroups;
                     if (typeof value !== "string" || !(value in validTraits)) {
                         return new validation.DataModelValidationFailure({
-                            message: `${alteration.value} is not a valid weapon group`
+                            message: `${alteration.value} is not a valid weapon group`,
                         });
                     }
                 }
             },
-        }
+        },
     ),
     hardness: new ItemAlterationValidator({
         itemType: new fields.StringField({ required: true, choices: Array.from(PHYSICAL_ITEM_TYPES) }),
@@ -498,10 +497,10 @@ const ITEM_ALTERATION_VALIDATORS = {
             initial: undefined,
         } as const),
     }),
-    "name": new ItemAlterationValidator({
-        itemType: new fields.StringField({required: true}),
-        mode: new fields.StringField({required: true, choices: ["override"],}),
-        value: new fields.StringField({required: true,nullable: false,blank: false,} as const),
+    name: new ItemAlterationValidator({
+        itemType: new fields.StringField({ required: true }),
+        mode: new fields.StringField({ required: true, choices: ["override"] }),
+        value: new fields.StringField({ required: true, nullable: false, blank: false } as const),
     }),
     "speed-penalty": new ItemAlterationValidator({
         itemType: new fields.StringField({

--- a/src/module/rules/rule-element/item-alteration/schemas.ts
+++ b/src/module/rules/rule-element/item-alteration/schemas.ts
@@ -9,11 +9,12 @@ import { DamageRoll } from "@system/damage/roll.ts";
 import type { DamageDiceFaces, DamageType } from "@system/damage/types.ts";
 import { DAMAGE_DICE_FACES } from "@system/damage/values.ts";
 import { PredicateField, SlugField, StrictNumberField } from "@system/schema-data-fields.ts";
-import { objectHasKey, tupleHasValue } from "@util";
+import { objectHasKey, setHasElement, tupleHasValue } from "@util";
 import * as R from "remeda";
 import type { AELikeChangeMode } from "../ae-like.ts";
 import fields = foundry.data.fields;
 import validation = foundry.data.validation;
+import { MANDATORY_RANGED_GROUPS } from "@item/weapon/values.ts";
 
 /** A `SchemaField` reappropriated for validation of specific item alterations */
 class ItemAlterationValidator<TSchema extends AlterationSchema> extends fields.SchemaField<TSchema> {
@@ -317,25 +318,25 @@ const ITEM_ALTERATION_VALIDATORS = {
                 if (item.type === "armor") {
                     if (group !== null && !objectHasKey(CONFIG.PF2E.armorGroups, group)) {
                         return new validation.DataModelValidationFailure({
-                            message: `${alteration.value} is not a valid armor group`,
+                            message: `${group} is not a valid armor group`,
                         });
                     }
                 } else if (item.type === "weapon") {
                     if (group !== null && !objectHasKey(CONFIG.PF2E.weaponGroups, group)) {
                         return new validation.DataModelValidationFailure({
-                            message: `${alteration.value} is not a valid weapon group`,
+                            message: `${group} is not a valid weapon group`,
                         });
                     } else {
-                        const alterIsMelee = objectHasKey(CONFIG.PF2E.meleeWeaponGroups, group);
-                        const originalIsMelee = objectHasKey(CONFIG.PF2E.meleeWeaponGroups, item.system.group);
-                        if (alterIsMelee !== originalIsMelee) {
-                            if (alterIsMelee) {
+                        const alterIsMandatoryRanged = setHasElement(MANDATORY_RANGED_GROUPS, group);
+                        const originalIsMandatoryRanged = setHasElement(MANDATORY_RANGED_GROUPS, item.system.group);
+                        if (alterIsMandatoryRanged !== originalIsMandatoryRanged) {
+                            if (alterIsMandatoryRanged) {
                                 return new validation.DataModelValidationFailure({
-                                    message: `Cannot alter a ranged weapon group to a melee weapon group`,
+                                    message: `Cannot alter ${item.system.group} into ${group}, a mandatory ranged group`,
                                 });
-                            } else if (originalIsMelee) {
+                            } else if (originalIsMandatoryRanged) {
                                 return new validation.DataModelValidationFailure({
-                                    message: `Cannot alter a melee weapon group to a ranged weapon group`,
+                                    message: `Cannot alter ${item.system.group} into ${group}, a non-mandatory ranged group`,
                                 });
                             }
                         }

--- a/src/module/rules/rule-element/item-alteration/schemas.ts
+++ b/src/module/rules/rule-element/item-alteration/schemas.ts
@@ -377,16 +377,6 @@ const ITEM_ALTERATION_VALIDATORS = {
             initial: undefined,
         } as const),
     }),
-    img: new ItemAlterationValidator({
-        itemType: new fields.StringField({ required: true }),
-        mode: new fields.StringField({ required: true, choices: ["override"] }),
-        value: new fields.FilePathField({
-            required: true,
-            nullable: false,
-            blank: false,
-            categories: ["IMAGE"],
-        } as const),
-    }),
     "material-type": new ItemAlterationValidator({
         itemType: new fields.StringField({ required: true, choices: Array.from(PHYSICAL_ITEM_TYPES) }),
         mode: new fields.StringField({ required: true, choices: ["override"] }),

--- a/src/module/rules/rule-element/item-alteration/schemas.ts
+++ b/src/module/rules/rule-element/item-alteration/schemas.ts
@@ -9,7 +9,7 @@ import { DamageRoll } from "@system/damage/roll.ts";
 import type { DamageDiceFaces, DamageType } from "@system/damage/types.ts";
 import { DAMAGE_DICE_FACES } from "@system/damage/values.ts";
 import { PredicateField, SlugField, StrictNumberField } from "@system/schema-data-fields.ts";
-import { tupleHasValue } from "@util";
+import { objectHasKey, tupleHasValue } from "@util";
 import * as R from "remeda";
 import type { AELikeChangeMode } from "../ae-like.ts";
 import fields = foundry.data.fields;
@@ -313,20 +313,32 @@ const ITEM_ALTERATION_VALIDATORS = {
         },
         {
             validateForItem: (item, alteration): validation.DataModelValidationFailure | void => {
-                const value = alteration.value;
+                const group = alteration.value;
                 if (item.type === "armor") {
-                    const validTraits = CONFIG.PF2E.armorGroups;
-                    if (typeof value !== "string" || !(value in validTraits)) {
+                    if (group !== null && !objectHasKey(CONFIG.PF2E.armorGroups, group)) {
                         return new validation.DataModelValidationFailure({
                             message: `${alteration.value} is not a valid armor group`,
                         });
                     }
                 } else if (item.type === "weapon") {
-                    const validTraits = CONFIG.PF2E.weaponGroups;
-                    if (typeof value !== "string" || !(value in validTraits)) {
+                    if (group !== null && !objectHasKey(CONFIG.PF2E.weaponGroups, group)) {
                         return new validation.DataModelValidationFailure({
                             message: `${alteration.value} is not a valid weapon group`,
                         });
+                    } else {
+                        const alterIsMelee = objectHasKey(CONFIG.PF2E.meleeWeaponGroups, group);
+                        const originalIsMelee = objectHasKey(CONFIG.PF2E.meleeWeaponGroups, item.system.group);
+                        if (alterIsMelee !== originalIsMelee) {
+                            if (alterIsMelee) {
+                                return new validation.DataModelValidationFailure({
+                                    message: `Cannot alter a ranged weapon group to a melee weapon group`,
+                                });
+                            } else if (originalIsMelee) {
+                                return new validation.DataModelValidationFailure({
+                                    message: `Cannot alter a melee weapon group to a ranged weapon group`,
+                                });
+                            }
+                        }
                     }
                 }
             },

--- a/src/module/rules/rule-element/item-alteration/schemas.ts
+++ b/src/module/rules/rule-element/item-alteration/schemas.ts
@@ -1,5 +1,5 @@
 import type { DataFieldOptions } from "@common/data/_types.d.mts";
-import type { ItemPF2e } from "@item";
+import type { ItemPF2e, WeaponPF2e } from "@item";
 import type { ItemSourcePF2e, ItemType } from "@item/base/data/index.ts";
 import type { ItemTrait } from "@item/base/types.ts";
 import { itemIsOfType } from "@item/helpers.ts";
@@ -326,20 +326,31 @@ const ITEM_ALTERATION_VALIDATORS = {
                         return new validation.DataModelValidationFailure({
                             message: `${group} is not a valid weapon group`,
                         });
-                    } else {
-                        const alterIsMandatoryRanged = setHasElement(MANDATORY_RANGED_GROUPS, group);
-                        const originalIsMandatoryRanged = setHasElement(MANDATORY_RANGED_GROUPS, item.system.group);
-                        if (alterIsMandatoryRanged !== originalIsMandatoryRanged) {
-                            if (alterIsMandatoryRanged) {
-                                return new validation.DataModelValidationFailure({
-                                    message: `Cannot alter ${item.system.group} into ${group}, a mandatory ranged group`,
-                                });
-                            } else if (originalIsMandatoryRanged) {
-                                return new validation.DataModelValidationFailure({
-                                    message: `Cannot alter ${item.system.group} into ${group}, a non-mandatory ranged group`,
-                                });
-                            }
-                        }
+                    }
+
+                    const weapon = item as WeaponPF2e;
+
+                    const rangedOnlyTraits = ["combination", "thrown"] as const;
+                    const hasRangedOnlyTraits =
+                        rangedOnlyTraits.some((trait) => weapon.traits.has(trait)) ||
+                        weapon.traits.some((trait) => /^volley-\d+$/.test(trait));
+                    const hasMeleeOnlyTraits = weapon.traits.some((trait) => /^thrown-\d+$/.test(trait));
+
+                    const alterIsMandatoryRanged = setHasElement(MANDATORY_RANGED_GROUPS, group) || hasRangedOnlyTraits;
+                    const originalIsMandatoryRanged =
+                        setHasElement(MANDATORY_RANGED_GROUPS, weapon.system.group) || hasRangedOnlyTraits;
+
+                    const alterIsMandatoryMelee = !alterIsMandatoryRanged && hasMeleeOnlyTraits;
+                    const originalIsMandatoryMelee = !originalIsMandatoryRanged && hasMeleeOnlyTraits;
+
+                    if (alterIsMandatoryMelee !== originalIsMandatoryMelee) {
+                        return new validation.DataModelValidationFailure({
+                            message: `Cannot alter ${weapon.system.group} into ${group} because of melee only traits.`,
+                        });
+                    } else if (alterIsMandatoryRanged !== originalIsMandatoryRanged) {
+                        return new validation.DataModelValidationFailure({
+                            message: `Cannot alter ${weapon.system.group} into ${group} because one is ranged only.`,
+                        });
                     }
                 }
             },

--- a/static/templates/items/weapon-details.hbs
+++ b/static/templates/items/weapon-details.hbs
@@ -9,7 +9,7 @@
     </div>
     <div class="form-group">
         <label for="{{fieldIdPrefix}}group">{{localize "PF2E.WeaponGroupLabel"}}</label>
-        <select name="system.group" id="{{fieldIdPrefix}}group">
+        <select id="{{fieldIdPrefix}}group" data-property="system.group">
             {{selectOptions groups selected=data.group blank=""}}
         </select>
     </div>


### PR DESCRIPTION
This adds `group` and `name` alterations to ItemAlteration. Group validation checks to make sure if the itemType is `weapon` then it checks for valid weapon groups, and same for `armor` and armor groups. Also includes validation to prevent changing "ranged only" and "melee only" weapons into incompatible groups, to prevent alterations that create invalid weapon states.

Name alteration works but if we want to restrict it to just weapon and armor names for now I can add that, since that's all that's needed at the moment.

----

These were added because I'm working on some Starfinder Mechanic playtest data entry and being able to alter weapon groups and rename weapons was useful to selecting different turret weapon arrays, which changes an existing turret weapon item to have different properties. And it's useful to use a weapon item rather than a generated strike, because this weapon can have upgrades and improvements applied to it like any other weapon.