### PR TITLE
Lift basic tag color variable to base colors

### DIFF
--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -53,6 +53,7 @@ body,
     --primary: var(--color-pf-primary);
     --secondary: var(--color-pf-secondary);
     --tertiary: var(--color-pf-tertiary);
+    --tag-color: var(--color-pf-alternate-dark);
 
     --alt: var(--color-pf-alternate);
     --alt-dark: var(--color-pf-alternate-dark);
@@ -378,6 +379,7 @@ body.theme-dark .application:not(.themed),
 .themed.theme-dark {
     --color-text-tertiary: var(--color-light-4);
     --visibility-gm-bg: var(--color-cool-4);
+    --tag-color: var(--color-text-tertiary);
 
     .tagify {
         --tags-border-color: var(--color-dark-6);

--- a/src/styles/_tags.scss
+++ b/src/styles/_tags.scss
@@ -186,7 +186,6 @@ tags.tagify {
 
 .tags.light > .tag,
 .tags > .tag.light {
-    --tag-color: var(--color-pf-alternate-dark);
     align-items: center;
     background: none;
     border-radius: 2px;
@@ -201,10 +200,6 @@ tags.tagify {
     padding: 0 var(--space-4);
     white-space: nowrap;
     width: auto;
-
-    .theme-dark & {
-        --tag-color: var(--color-text-tertiary);
-    }
 }
 
 .chat-message .tags {


### PR DESCRIPTION
Needed to fix an issue with an sf2e theme, but lifting these sorts of variables to the top should make life easier overall.

The existing overrides seem to still work, as well as dark mode formula picker.