### PR TITLE
Automate damage and focus point expenditure of Consecrate Spell

### DIFF
--- a/packs/feats/class/shared-class-feats/consecrate-spell.json
+++ b/packs/feats/class/shared-class-feats/consecrate-spell.json
@@ -12,7 +12,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>You infuse a spell with the power of your faith, consecrating it. If the next action you use is to Cast a Spell that targets a single undead, you can expend a Focus Point, channeling the power of your focus spells into the primary spell. If you do, the spell you cast deals additional good or vitality damage (your choice) equal to the rank of your focus spells. As normal for additional damage, this additional damage is doubled if the spell cast requires an attack roll and the result of the attack roll is a critical hit, or if the spell cast requires a saving throw and the result of the saving throw is a critical failure.</p>"
+            "value": "<p>You infuse a spell with the power of your faith, consecrating it. If the next action you use is to Cast a Spell that targets a single undead, you can expend a Focus Point, channeling the power of your focus spells into the primary spell. If you do, the spell you cast deals additional @Damage[(ceil(@actor.level / 2))[spirit]]{spirit} or @Damage[(ceil(@actor.level / 2))[vitality]]{vitality} damage (your choice) equal to the rank of your focus spells. As normal for additional damage, this additional damage is doubled if the spell cast requires an attack roll and the result of the attack roll is a critical hit, or if the spell cast requires a saving throw and the result of the saving throw is a critical failure.</p>"
         },
         "level": {
             "value": 10
@@ -32,7 +32,36 @@
             "remaster": false,
             "title": "Pathfinder Lost Omens Knights of Lastwall"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "RollOption",
+                "label": "PF2E.TraitSpellshape",
+                "mergeable": true,
+                "option": "spellshape",
+                "placement": "spellcasting",
+                "suboptions": [
+                    {
+                        "label": "{item|name}",
+                        "value": "consecrate-spell"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "spellshape:consecrate-spell"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "{item|description}"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "uncommon",
             "value": [

--- a/packs/feats/class/shared-class-feats/consecrate-spell.json
+++ b/packs/feats/class/shared-class-feats/consecrate-spell.json
@@ -12,7 +12,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>You infuse a spell with the power of your faith, consecrating it. If the next action you use is to Cast a Spell that targets a single undead, you can expend a Focus Point, channeling the power of your focus spells into the primary spell. If you do, the spell you cast deals additional @Damage[(ceil(@actor.level / 2))[spirit]]{spirit} or @Damage[(ceil(@actor.level / 2))[vitality]]{vitality} damage (your choice) equal to the rank of your focus spells. As normal for additional damage, this additional damage is doubled if the spell cast requires an attack roll and the result of the attack roll is a critical hit, or if the spell cast requires a saving throw and the result of the saving throw is a critical failure.</p>"
+            "value": "<p>You infuse a spell with the power of your faith, consecrating it. If the next action you use is to Cast a Spell that targets a single undead, you can expend a Focus Point, channeling the power of your focus spells into the primary spell. If you do, the spell you cast deals additional spirit or vitality damage (your choice) equal to the rank of your focus spells. As normal for additional damage, this additional damage is doubled if the spell cast requires an attack roll and the result of the attack roll is a critical hit, or if the spell cast requires a saving throw and the result of the saving throw is a critical failure.</p>"
         },
         "level": {
             "value": 10
@@ -48,6 +48,26 @@
                 "toggleable": true
             },
             {
+                "alwaysActive": true,
+                "key": "RollOption",
+                "option": "consecrate-spell-damage",
+                "placement": "spellcasting",
+                "predicate": [
+                    "spellshape:consecrate-spell"
+                ],
+                "suboptions": [
+                    {
+                        "label": "PF2E.TraitSpirit",
+                        "value": "spirit"
+                    },
+                    {
+                        "label": "PF2E.TraitVitality",
+                        "value": "vitality"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
                 "itemType": "spell",
                 "key": "ItemAlteration",
                 "mode": "add",
@@ -60,6 +80,25 @@
                         "text": "{item|description}"
                     }
                 ]
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "spellshape:consecrate-spell"
+                ],
+                "property": "focus-point-cost",
+                "value": 1
+            },
+            {
+                "damageType": "{item|flags.pf2e.rulesSelections.consecrateSpellDamage}",
+                "key": "FlatModifier",
+                "predicate": [
+                    "spellshape:consecrate-spell"
+                ],
+                "selector": "spell-damage",
+                "value": "ceil(@actor.level / 2)"
             }
         ],
         "traits": {


### PR DESCRIPTION
Good damage converted to spirit damage. Do we have a rule on when to add the (un)holy trait to this pre-remaster stuff? As far as official stuff, all I found was [this](https://downloads.paizo.com/RemasterCorePreview.pdf):

![image](https://github.com/user-attachments/assets/cea264fd-4c14-4f35-8e4a-39c7c8464c03)

Which makes adding the trait more of a vibes-based thing. Let me know if you want the holy trait in there.