### PR TITLE
Fix deleting effect badges

### DIFF
--- a/src/module/item/effect/sheet.ts
+++ b/src/module/item/effect/sheet.ts
@@ -53,7 +53,7 @@ export class EffectSheetPF2e extends ItemSheetPF2e<EffectPF2e> {
         });
 
         htmlQuery(html, "[data-action=badge-delete]")?.addEventListener("click", () => {
-            this.item.update({ "system.-=badge": null });
+            this.item.update({ "system.badge": null });
         });
 
         htmlQuery(html, "[data-action=badge-add-label")?.addEventListener("click", () => {


### PR DESCRIPTION
It turns out that changing required to false but keeping initial as null also fixes this bug. It seems that the only real difference between required true/false if initial is set, is that required false allows -= to work, and required true forbids it.

But it was easy enough to change deleting the badge to setting it to null.