### PR TITLE
Restore wheel rotation for unlocked measured template previews and add a tooltip explaining the new placement workflow

### DIFF
--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -325,6 +325,10 @@ class TextEditorPF2e extends foundry.applications.ux.TextEditor {
             html.setAttribute("data-pf2-distance", params.distance);
             if (params.traits !== "") html.setAttribute("data-pf2-traits", params.traits);
             if (params.type === "line") html.setAttribute("data-pf2-width", params.width ?? "5");
+            if (["cone", "line"].includes(params.type)) {
+                html.setAttribute("data-tooltip", "PF2E.Item.Spell.MeasuredTemplate.PlacementTooltip");
+                html.setAttribute("data-tooltip-class", "pf2e");
+            }
             if (params.itemUuid !== "") html.setAttribute("data-item-uuid", params.itemUuid);
             return html;
         }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2678,7 +2678,8 @@
                 "LineSplit": ";",
                 "MeasuredTemplate": {
                     "Clear": "Clear Placed Templates",
-                    "Place": "Place {area}"
+                    "Place": "Place {area}",
+                    "PlacementTooltip": "<strong>Left-click</strong> to lock the position on the canvas and enable rotation. Click again to place.<br><strong>Right-click</strong> to unlock or cancel.<br>Hold <strong>Shift</strong> to place directly without rotation.<br>Hold <strong>Ctrl</strong> to disable grid snapping while rotating."
                 },
                 "Plural": "Spells",
                 "Rank": {

--- a/static/templates/actors/partials/item-summary.hbs
+++ b/static/templates/actors/partials/item-summary.hbs
@@ -48,7 +48,15 @@
                 <button type="button" class="blue spell_damage" data-action="spellDamage">{{localize chatData.damageLabel}}: {{chatData.formula}}</button>
             {{/if}}
             {{#if (and chatData.area (not chatData.isAura))}}
-                <button type="button" class="blue" data-action="spellTemplate" data-visibility="owner">
+                <button
+                    type="button"
+                    class="blue"
+                    data-action="spellTemplate"
+                    data-visibility="owner"
+                    {{#if (or (eq chatData.area.type "cone") (eq chatData.area.type "line"))}}
+                        data-tooltip="PF2E.Item.Spell.MeasuredTemplate.PlacementTooltip"
+                    {{/if}}
+                >
                     {{localize "PF2E.Item.Spell.MeasuredTemplate.Place" area=chatData.area.label}}
                 </button>
             {{/if}}

--- a/static/templates/chat/spell-card.hbs
+++ b/static/templates/chat/spell-card.hbs
@@ -54,8 +54,15 @@
                         </div>
                     {{/if}}
                     {{#if (and data.area (not data.isAura))}}
-                        <div class="spell-button">
-                            <button type="button" data-action="spell-template" data-visibility="owner">
+                        <div class="spell-button" data-tooltip-class="pf2e">
+                            <button
+                                type="button"
+                                data-action="spell-template"
+                                data-visibility="owner"
+                                {{#if (or (eq data.area.type "cone") (eq data.area.type "line"))}}
+                                    data-tooltip="PF2E.Item.Spell.MeasuredTemplate.PlacementTooltip"
+                                {{/if}}
+                            >
                                 {{localize "PF2E.Item.Spell.MeasuredTemplate.Place" area=data.area.label}}
                             </button>
                             <button class="small hidden" type="button" data-action="spell-template-clear" data-visibility="owner" data-tooltip="{{localize "PF2E.Item.Spell.MeasuredTemplate.Clear"}}">


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/acd994f3-707d-4fd0-92c6-be6ecd20c156)

![image](https://github.com/user-attachments/assets/3fcae736-e0c2-4164-98c9-40acf8a90e15)
