### PR TITLE
Fix the level and price of Dr. Ushernacht's Astonishing Ink (Major)

### DIFF
--- a/packs/equipment/dr-ushernachts-astonishing-ink-major.json
+++ b/packs/equipment/dr-ushernachts-astonishing-ink-major.json
@@ -19,7 +19,7 @@
             "value": 0
         },
         "level": {
-            "value": 10
+            "value": 17
         },
         "material": {
             "grade": null,
@@ -27,7 +27,7 @@
         },
         "price": {
             "value": {
-                "gp": 160
+                "gp": 2250
             }
         },
         "publication": {


### PR DESCRIPTION
According to Archives of Nethys: https://2e.aonprd.com/Equipment.aspx?ID=3564, this should be level 17 and 2250 gold. The modifier and will save are already correct.