### PR TITLE
Add effect for Sympathetic Strike and correct its action cost and frequency

### DIFF
--- a/packs/feat-effects/effect-portents-of-the-haruspex.json
+++ b/packs/feat-effects/effect-portents-of-the-haruspex.json
@@ -34,7 +34,7 @@
             "value": 1
         },
         "level": {
-            "value": 1
+            "value": 4
         },
         "publication": {
             "license": "ORC",

--- a/packs/feat-effects/effect-sympathetic-strike.json
+++ b/packs/feat-effects/effect-sympathetic-strike.json
@@ -1,0 +1,94 @@
+{
+    "_id": "qBTJYpopY3AwFFUJ",
+    "img": "icons/creatures/claws/claw-talons-glowing-orange.webp",
+    "name": "Effect: Sympathetic Strike",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Sympathetic Strike]</p>\n<p>You take –1 circumstance penalty to your saves against the origin's hexes, or a –2 penalty if the triggering Strike was a critical hit.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "fromSpell": false,
+        "level": {
+            "value": 4
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [
+            {
+                "adjustName": false,
+                "choices": [
+                    {
+                        "label": "PF2E.Check.Result.Degree.Check.criticalSuccess",
+                        "predicate": [
+                            {
+                                "or": [
+                                    "parent:context:check:outcome:3",
+                                    {
+                                        "not": {
+                                            "gte": [
+                                                "parent:context:check:outcome",
+                                                0
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        ],
+                        "value": -2
+                    },
+                    {
+                        "label": "PF2E.Check.Result.Degree.Check.success",
+                        "predicate": [
+                            {
+                                "or": [
+                                    "parent:context:check:outcome:2",
+                                    {
+                                        "not": {
+                                            "gte": [
+                                                "parent:context:check:outcome",
+                                                0
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        ],
+                        "value": -1
+                    }
+                ],
+                "flag": "penalty",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.DegreeOfSuccess"
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "item:trait:hex",
+                    "origin:signature:{item|origin.signature}"
+                ],
+                "selector": "saving-throw",
+                "type": "circumstance",
+                "value": "@item.flags.pf2e.rulesSelections.penalty"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feats/class/witch/sympathetic-strike.json
+++ b/packs/feats/class/witch/sympathetic-strike.json
@@ -5,14 +5,18 @@
     "name": "Sympathetic Strike",
     "system": {
         "actionType": {
-            "value": "passive"
+            "value": "action"
         },
         "actions": {
-            "value": null
+            "value": 1
         },
         "category": "class",
         "description": {
-            "value": "<p><strong>Frequency</strong> once per round</p>\n<hr />\n<p>You collect your patron's magic into one of your witch armaments, causing them to shine with runes, light, or another signifier of your patron. Make an unarmed Strike with one with your witch's armaments. If you hit, you establish a sympathetic link with the target, making it easier for your patron to affect them. Until the beginning of your next turn, the target takes a –1 circumstance penalty to its saves against your hexes, or a –2 penalty if the triggering Strike was a critical hit.</p>"
+            "value": "<p><strong>Frequency</strong> once per round</p><hr /><p>You collect your patron's magic into one of your witch armaments, causing them to shine with runes, light, or another signifier of your patron.</p>\n<p>Make an unarmed Strike with one with your witch's armaments. If you hit, you establish a sympathetic link with the target, making it easier for your patron to affect them. Until the beginning of your next turn, the target takes a –1 circumstance penalty to its saves against your hexes, or a –2 penalty if the triggering Strike was a critical hit.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Sympathetic Strike]</p>"
+        },
+        "frequency": {
+            "max": 1,
+            "per": "round"
         },
         "level": {
             "value": 4
@@ -29,7 +33,28 @@
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [],
+        "rules": [
+            {
+                "domain": "unarmed-attack-roll",
+                "key": "RollOption",
+                "option": "sympathetic-strike",
+                "toggleable": true
+            },
+            {
+                "key": "Note",
+                "outcome": [
+                    "success",
+                    "criticalSuccess"
+                ],
+                "predicate": [
+                    "item:tag:witchs-armaments",
+                    "sympathetic-strike"
+                ],
+                "selector": "unarmed-attack-roll",
+                "text": "PF2E.SpecificRule.Witch.SympatheticStrike.Note",
+                "title": "{item|name}"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/class/witch/wild-witchs-armaments.json
+++ b/packs/feats/class/witch/wild-witchs-armaments.json
@@ -12,7 +12,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>Your patron's power continues to enhance your natural offensive capabilities. You gain additional effects for any of the unarmed Strikes you chose from Witch's Armaments. If you took that feat multiple times to gain multiple attacks, you gain the appropriate additional effects.</p><ul><li><strong>Eldritch Nails</strong> Your nails can tear and rend with the force of a beast. If you hit the same enemy with two consecutive nails Strikes, that enemy takes additional slashing damage equal to half your level on the second Strike.</li><li><strong>Iron Teeth</strong> Like a true predator, your teeth can crunch bone. A creature that you critically hit with a jaws Strike must succeed at a @Check[fortitude|against:class-spell] save against the higher of your class DC or spell DC or become @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 1}.</li><li><strong>Living Hair</strong> Part of your hair hardens into sharp quills that you can eject with force. You gain a quills ranged unarmed strike that deals @Damage[1d4[piercing]] damage with a range of 15 feet. Your quills are in the dart group.</li></ul>"
+            "value": "<p>Your patron's power continues to enhance your natural offensive capabilities. You gain additional effects for any of the unarmed Strikes you chose from Witch's Armaments. If you took that feat multiple times to gain multiple attacks, you gain the appropriate additional effects.</p><ul><li><strong>Eldritch Nails</strong> Your nails can tear and rend with the force of a beast. If you hit the same enemy with two consecutive nails Strikes, that enemy takes additional slashing damage equal to half your level on the second Strike.</li><li><strong>Iron Teeth</strong> Like a true predator, your teeth can crunch bone. A creature that you critically hit with a jaws Strike must succeed at a @Check[fortitude|against:class-spell] save against the higher of your class DC or spell DC or become @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 1}.</li><li><strong>Living Hair</strong> Part of your hair hardens into sharp quills that you can eject with force. You gain a quills ranged unarmed strike that deals 1d4 piercing damage with a range of 15 feet. Your quills are in the dart group.</li></ul>"
         },
         "level": {
             "value": 6
@@ -42,9 +42,11 @@
             {
                 "key": "FlatModifier",
                 "predicate": [
-                    "wild-witchs-armaments:nails"
+                    "wild-witchs-armaments:nails",
+                    "item:slug:eldritch-nails",
+                    "item:tag:witchs-armaments"
                 ],
-                "selector": "eldritch-nails-damage",
+                "selector": "unarmed-damage",
                 "value": "floor(@actor.level/2)"
             },
             {
@@ -53,9 +55,11 @@
                     "criticalSuccess"
                 ],
                 "predicate": [
-                    "witchs-armaments:teeth"
+                    "witchs-armaments:teeth",
+                    "item:slug:iron-teeth",
+                    "item:tag:witchs-armaments"
                 ],
-                "selector": "iron-teeth-damage",
+                "selector": "unarmed-attack-roll",
                 "text": "PF2E.SpecificRule.Witch.WildWitchsArmaments.IronTeeth.Note",
                 "title": "{item|name}"
             },
@@ -75,11 +79,21 @@
                     "witchs-armaments:hair"
                 ],
                 "range": {
-                    "increment": 30
+                    "max": 15
                 },
                 "traits": [
                     "unarmed"
                 ]
+            },
+            {
+                "itemType": "weapon",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:id:{item|id}"
+                ],
+                "property": "other-tags",
+                "value": "witchs-armaments"
             }
         ],
         "traits": {

--- a/packs/feats/class/witch/witchs-armaments.json
+++ b/packs/feats/class/witch/witchs-armaments.json
@@ -133,6 +133,16 @@
                     "trip",
                     "unarmed"
                 ]
+            },
+            {
+                "itemType": "weapon",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:id:{item|id}"
+                ],
+                "property": "other-tags",
+                "value": "witchs-armaments"
             }
         ],
         "traits": {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -6522,6 +6522,9 @@
                         "WildingSteward": "Wilding Steward"
                     }
                 },
+                "SympatheticStrike": {
+                    "Note": "Until the beginning of your next turn, the target takes a –1 circumstance penalty to its saves against your hexes, or a –2 penalty if the triggering Strike was a critical hit. @UUID[Compendium.pf2e.feat-effects.Item.qBTJYpopY3AwFFUJ]{Effect: Sympathetic Strike}"
+                },
                 "WildWitchsArmaments": {
                     "EldritchNails": {
                         "RollOptionLabel": "You hit the same enemy with two consecutive nail strikes"


### PR DESCRIPTION
Also
- Use Item Alteration to tag Witch Armaments as such.
- Update Wild Witch Armaments to use said tags, as well as tagging Quills Strike as a witch armament and fix its range to be max 15 rather than a 30 increment.
- Fix level of Portents of the Haruspex effect.