### PR TITLE
Create encumbrance css color variables

### DIFF
--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -48,7 +48,6 @@ body,
     --color-pf-tertiary: #{$tertiary-color};
     --color-pf-tertiary-dark: #{color.adjust($tertiary-color, $lightness: -10%)};
     --color-pf-tertiary-darker: #{color.adjust($tertiary-color, $lightness: -20%)};
-    --color-pf-tertiary-darkest: #{color.adjust($tertiary-color, $lightness: -51%)};
     --color-pf-tertiary-light: #{color.adjust($tertiary-color, $lightness: 10%)};
     --primary: var(--color-pf-primary);
     --secondary: var(--color-pf-secondary);
@@ -117,6 +116,11 @@ body,
     --color-proficiency-expert: #3c005e;
     --color-proficiency-master: #664400;
     --color-proficiency-legendary: #{$primary-color};
+
+    /** Encumbrance */
+    --color-pf-bulk-normal: var(--color-pf-secondary);
+    --color-pf-bulk-encumbered: var(--color-level-warning-bg);
+    --color-pf-bulk-exceeded: var(--color-level-error-bg);
 
     /* Value adjustments (e.g. weak/elite) */
     --color-pf-text-adjusted-higher: #009988;

--- a/src/styles/actor/_inventory.scss
+++ b/src/styles/actor/_inventory.scss
@@ -328,7 +328,7 @@
                     width: 100%;
 
                     .bar {
-                        background-color: var(--color-pf-secondary);
+                        background-color: var(--color-pf-bulk-normal);
                         border-radius: 0 2px 2px 0;
                         box-shadow:
                             inset 0 0 0 1px rgba(black, 0.5),
@@ -345,7 +345,7 @@
                     }
 
                     &.over-limit .container-capacity-bar {
-                        background-color: var(--color-pf-primary);
+                        background-color: var(--color-pf-bulk-exceeded);
                     }
                 }
             }
@@ -443,7 +443,7 @@
             }
 
             .encumbrance-bar {
-                background-color: var(--color-pf-secondary);
+                background-color: var(--color-pf-bulk-normal);
                 box-shadow:
                     inset 0 0 0 1px rgba(black, 0.5),
                     inset 0 0 0 2px rgba(white, 0.2);
@@ -455,11 +455,11 @@
             }
 
             &.encumbered .encumbrance-bar {
-                background-color: var(--color-pf-tertiary-darkest);
+                background-color: var(--color-pf-bulk-encumbered);
             }
 
             &.over-limit .encumbrance-bar {
-                background-color: var(--color-pf-primary);
+                background-color: var(--color-pf-bulk-exceeded);
             }
 
             .encumbrance-label {


### PR DESCRIPTION
Encumbrance colors, outside of the base, serve as a warning/error state than a thematic choice, and shouldn't be influenced by sheet themes except purposefully.

The colors are *slightly* different, but here they are:

![image](https://github.com/user-attachments/assets/7499a0bb-0eb0-4bc5-8e0c-3ad07897b5cf)

![image](https://github.com/user-attachments/assets/dd30758f-c7db-4df6-abef-cad2a3825781)
