### PR TITLE
Support homebrew class traits and use in feat subfeatures

### DIFF
--- a/src/module/item/feat/data.ts
+++ b/src/module/item/feat/data.ts
@@ -43,13 +43,18 @@ class FeatSystemData extends ItemSystemModel<FeatPF2e, FeatSystemSchema> {
         const senseTypes: Record<SenseType, string> = CONFIG.PF2E.senses;
         const senseAcuities: Record<SenseAcuity, string> = CONFIG.PF2E.senseAcuities;
         const languages: Record<Language, string> = CONFIG.PF2E.languages;
-        const increasableProficiencies: Record<IncreasableProficiency, string> = {
-            ...CONFIG.PF2E.saves,
-            ...CONFIG.PF2E.classTraits,
-            ...CONFIG.PF2E.armorCategories,
-            ...CONFIG.PF2E.weaponCategories,
-            perception: "PF2E.PerceptionLabel",
-            spellcasting: "PF2E.Item.Spell.Plural",
+
+        // Defer creation to allow homebrew content to fill the records
+        let increasableProficiencies: Record<IncreasableProficiency, string> | null = null;
+        const getIncreasableProficiencies = () => {
+            return (increasableProficiencies ??= {
+                ...CONFIG.PF2E.saves,
+                ...CONFIG.PF2E.classTraits,
+                ...CONFIG.PF2E.armorCategories,
+                ...CONFIG.PF2E.weaponCategories,
+                perception: "PF2E.PerceptionLabel",
+                spellcasting: "PF2E.Item.Spell.Plural",
+            });
         };
 
         return {
@@ -154,7 +159,7 @@ class FeatSystemData extends ItemSystemModel<FeatPF2e, FeatSystemSchema> {
                     { required: false, nullable: false, initial: undefined },
                 ),
                 proficiencies: new RecordField(
-                    new fields.StringField({ required: true, nullable: false, choices: increasableProficiencies }),
+                    new fields.StringField({ required: true, nullable: false, choices: getIncreasableProficiencies }),
                     new fields.SchemaField({
                         rank: new fields.NumberField<OneToFour, OneToFour, true, false, false>({
                             required: true,
@@ -226,7 +231,6 @@ class FeatSystemData extends ItemSystemModel<FeatPF2e, FeatSystemSchema> {
         const subfeatures = this.subfeatures;
         subfeatures.keyOptions ??= [];
         subfeatures.languages ??= { slots: 0, granted: [] };
-        subfeatures.proficiencies ??= {};
         subfeatures.senses ??= {};
         subfeatures.suppressedFeatures ??= [];
     }
@@ -297,10 +301,7 @@ type FeatSystemSchema = Omit<ItemSystemSchema, "traits"> & {
             fields.SchemaField<{
                 rank: fields.NumberField<OneToFour, OneToFour, true, false, false>;
                 attribute: fields.StringField<AttributeString, AttributeString, true, true, true>;
-            }>,
-            false,
-            false,
-            false
+            }>
         >;
         senses: SensesField;
         suppressedFeatures: fields.ArrayField<fields.DocumentUUIDField<ItemUUID, true, false, false>>;

--- a/src/module/item/feat/sheet.ts
+++ b/src/module/item/feat/sheet.ts
@@ -108,6 +108,8 @@ class FeatSheetPF2e extends ItemSheetPF2e<FeatPF2e> {
         const feat = this.item;
         const localize = localizer("PF2E.Actor.Character");
         const selectedIncreases = feat.system.subfeatures.proficiencies;
+        const sourceData = this.item.system._source.subfeatures.proficiencies;
+        const invalidKeys = Object.keys(sourceData).filter((k) => !(k in selectedIncreases));
 
         return {
             other: {
@@ -123,6 +125,12 @@ class FeatSheetPF2e extends ItemSheetPF2e<FeatPF2e> {
                         label: game.i18n.localize("PF2E.Actor.Creature.Spellcasting.ShortLabel"),
                         rank: selectedIncreases.spellcasting?.rank ?? null,
                     },
+                    ...invalidKeys.map((slug) => ({
+                        slug,
+                        label: slug,
+                        rank: null,
+                        invalid: true,
+                    })),
                 ].sort((a, b) => a.label.localeCompare(b.label)),
             },
             saves: {
@@ -285,7 +293,7 @@ class FeatSheetPF2e extends ItemSheetPF2e<FeatPF2e> {
                 }
             } else if (anchor.dataset.action === "delete-proficiency") {
                 const slug = anchor.dataset.slug ?? "";
-                if (slug in feat.system.subfeatures.proficiencies) {
+                if (slug in feat.system._source.subfeatures.proficiencies) {
                     feat.update({ [`system.subfeatures.proficiencies.-=${slug}`]: null });
                 }
             }
@@ -432,7 +440,7 @@ interface FeatSheetData extends ItemSheetDataPF2e<FeatPF2e> {
     hasSenses: boolean;
     languages: LanguageOptions;
     mandatoryTakeOnce: boolean;
-    maxTakableOptions: FormSelectOption[];
+    maxTakableOptions: fa.fields.FormSelectOption[];
     proficiencies: ProficiencyOptions;
     proficiencyRankOptions: Record<string, string>;
     selfEffect: SelfEffectReference | null;
@@ -459,7 +467,7 @@ interface ProficiencyOptions {
 
 interface ProficiencyOptionGroup<TGroup extends string | null = string> {
     group: TGroup;
-    options: { slug: string; label: string; rank: OneToFour | null }[];
+    options: { slug: string; label: string; rank: OneToFour | null; invalid?: boolean }[];
 }
 
 interface SenseOption {

--- a/src/module/system/settings/homebrew/data.ts
+++ b/src/module/system/settings/homebrew/data.ts
@@ -11,6 +11,7 @@ const HOMEBREW_ELEMENT_KEYS = [
     "languages",
     "armorGroups",
     "baseArmors",
+    "classTraits",
     "weaponCategories",
     "weaponGroups",
     "baseWeapons",
@@ -25,6 +26,7 @@ const HOMEBREW_ELEMENT_KEYS = [
 /** Homebrew elements from some of the above records are propagated to related records */
 const TRAIT_PROPAGATIONS = {
     actionTraits: ["effectTraits"],
+    classTraits: ["featTraits", "spellTraits"],
     creatureTraits: ["ancestryTraits", "hazardTraits"],
     equipmentTraits: ["armorTraits", "consumableTraits"],
     featTraits: ["actionTraits"],

--- a/src/styles/item/_feat-sheet.scss
+++ b/src/styles/item/_feat-sheet.scss
@@ -57,6 +57,7 @@
                 display: flex;
                 flex-wrap: wrap;
                 gap: 0.25rem;
+                min-height: var(--form-field-height);
                 padding: 0.125rem;
 
                 label,

--- a/static/templates/items/feat-details.hbs
+++ b/static/templates/items/feat-details.hbs
@@ -123,7 +123,12 @@
         <ul{{#unless hasProficiencies}} class="empty"{{/unless}}>
             {{#each proficiencies as |group|~}}
                 {{#each group.options as |option|~}}
-                    {{#if option.rank~}}
+                    {{#if option.invalid~}}
+                        <li class="notification error">
+                            <span>{{option.label}}</span>
+                            <a data-action="delete-proficiency" data-slug="{{option.slug}}"><i class="fa-solid fa-trash"></i></a>
+                        </li>
+                    {{else if option.rank~}}
                         <li>
                             <label for="{{@root.fieldIdPrefix}}{{option.slug}}">{{option.label}}</label>
                             <select

--- a/types/foundry/common/data/fields.d.mts
+++ b/types/foundry/common/data/fields.d.mts
@@ -224,7 +224,7 @@ export abstract class DataField<
      */
     initialize(
         value: unknown,
-        model?: ConstructorOf<abstract.DataModel>,
+        model?: abstract.DataModel,
         options?: object,
     ): MaybeSchemaProp<TModelProp, TRequired, TNullable, THasInitial>;
 
@@ -500,7 +500,7 @@ export class SchemaField<
 
     override initialize(
         value: unknown,
-        model?: ConstructorOf<abstract.DataModel>,
+        model?: abstract.DataModel,
         options?: Record<string, unknown>,
     ): MaybeSchemaProp<TModelProp, TRequired, TNullable, THasInitial>;
 
@@ -641,7 +641,7 @@ export class ObjectField<
 
     override initialize(
         value: unknown,
-        model?: ConstructorOf<abstract.DataModel>,
+        model?: abstract.DataModel,
         options?: ObjectFieldOptions<TSourceProp, TRequired, TNullable, THasInitial>,
     ): MaybeSchemaProp<TModelProp, TRequired, TNullable, THasInitial>;
 
@@ -704,7 +704,7 @@ export class TypedObjectField<
 
     override initialize(
         value: unknown,
-        model?: ConstructorOf<abstract.DataModel>,
+        model?: abstract.DataModel,
         options?: ObjectFieldOptions<Record<string, SourceFromDataField<TField>>, TRequired, TNullable, THasInitial>,
     ): MaybeSchemaProp<Record<string, ModelPropFromDataField<TField>>, TRequired, TNullable, THasInitial>;
 
@@ -797,7 +797,7 @@ export class ArrayField<
 
     override initialize(
         value: JSONValue,
-        model: ConstructorOf<abstract.DataModel>,
+        model: abstract.DataModel,
         options: ArrayFieldOptions<TSourceProp, TRequired, TNullable, THasInitial>,
     ): MaybeSchemaProp<TModelProp, TRequired, TNullable, THasInitial>;
 
@@ -840,7 +840,7 @@ export class SetField<
 
     override initialize(
         value: TSourceProp,
-        model: ConstructorOf<abstract.DataModel>,
+        model: abstract.DataModel,
     ): MaybeSchemaProp<TModelProp, TRequired, TNullable, THasInitial>;
 
     override toObject(value: TModelProp): TSourceProp;
@@ -883,7 +883,7 @@ export class EmbeddedDataField<
 
     override initialize(
         value: MaybeSchemaProp<TModelProp["_source"], TRequired, TNullable, THasInitial>,
-        model: ConstructorOf<abstract.DataModel>,
+        model: abstract.DataModel,
         options?: object,
     ): MaybeSchemaProp<TModelProp, TRequired, TNullable, THasInitial>;
 
@@ -916,7 +916,7 @@ export class EmbeddedDocumentField<
 
     override initialize(
         value: MaybeSchemaProp<TModelProp["_source"], TRequired, TNullable, THasInitial>,
-        model: ConstructorOf<TModelProp>,
+        model: TModelProp,
         options?: Record<string, unknown>,
     ): MaybeSchemaProp<TModelProp, TRequired, TNullable, THasInitial>;
 
@@ -980,7 +980,7 @@ export class EmbeddedCollectionField<
 
     override initialize(
         _value: unknown,
-        model: ConstructorOf<abstract.DataModel>,
+        model?: abstract.DataModel,
     ): MaybeSchemaProp<abstract.EmbeddedCollection<TDocument>, TRequired, TNullable, THasInitial>;
 
     override toObject(
@@ -1089,7 +1089,7 @@ export class ForeignDocumentField<
 
     override initialize(
         value: string,
-        model: ConstructorOf<abstract.DataModel>,
+        model?: abstract.DataModel,
     ): MaybeSchemaProp<TModelProp, TRequired, TNullable, THasInitial>;
 
     toObject(value: TModelProp): MaybeSchemaProp<string, TRequired, TNullable, THasInitial>;
@@ -1366,7 +1366,7 @@ export class TypeDataField<
 
     override initialize(
         value: TSourceProp,
-        model?: ConstructorOf<TDocument>,
+        model?: TDocument,
         options?: Record<string, unknown>,
     ): MaybeSchemaProp<TModelProp, true, false, true>;
 
@@ -1435,7 +1435,7 @@ export class TypedSchemaField<
 
     override initialize(
         value: JSONValue | undefined,
-        model?: ConstructorOf<abstract.DataModel>,
+        model?: abstract.DataModel,
         options?: object,
     ): MaybeSchemaProp<ModelFromTypedSchemaTypes<TTypes>, TRequired, TNullable, THasInitial>;
 


### PR DESCRIPTION
Only via module flags for now. Class traits added will show up in feat subfeatures.
![image](https://github.com/user-attachments/assets/d67b39a7-0e0e-4538-9011-31a8a050e690)

If the module becomes disabled, rather than exploding, it will warn in the console and make the invalid traits deletable

<img width="709" height="472" alt="chrome_2025-07-10_06-36-33" src="https://github.com/user-attachments/assets/2fe14431-1cb7-40c8-a3f7-8573950132e6" />

