### PR TITLE
Reduce gap between certain character details to closer match v12

### DIFF
--- a/src/styles/_forms.scss
+++ b/src/styles/_forms.scss
@@ -10,12 +10,12 @@
     }
 
     .details-input {
+        background-color: rgba($text-dark-color, 0.1);
+        border-bottom: 1px solid var(--color-border-dark-input);
         color: var(--text-dark);
         font-family: var(--body-serif);
         font-weight: bold;
-        width: calc(100% - 6px);
-        border-bottom: 1px solid var(--color-border-dark-input);
-        background-color: rgba($text-dark-color, 0.1);
+        width: 100%;
 
         &::placeholder {
             filter: opacity(0.5);

--- a/src/styles/actor/vehicle/_index.scss
+++ b/src/styles/actor/vehicle/_index.scss
@@ -94,6 +94,7 @@
 
                 .detail-small {
                     display: flex;
+                    gap: var(--space-8);
                 }
             }
 
@@ -101,6 +102,7 @@
                 display: flex;
                 flex-wrap: wrap;
                 padding-top: 8px;
+                column-gap: var(--space-8);
             }
 
             .vehicle-properties > div {


### PR DESCRIPTION
A 8px gap was added in v13, but it was stacking with a pre-existing width calculation on the input element. The same gap was introduced in the vehicle sheet to avoid breaks there as well.

![image](https://github.com/user-attachments/assets/cb7114fe-30b8-42d1-b99c-d724b26461eb)
