### PR TITLE
Upgrade base size of Devrin's Cunning Stance to PC2 Marshal aura

### DIFF
--- a/packs/feat-effects/stance-devrins-cunning-stance.json
+++ b/packs/feat-effects/stance-devrins-cunning-stance.json
@@ -29,7 +29,7 @@
                     },
                     {
                         "label": "PF2E.Check.Result.Degree.Check.success",
-                        "value": 10
+                        "value": 15
                     }
                 ],
                 "flag": "auraRadius",


### PR DESCRIPTION
Closes #19213
It still increases the aura's size to 20 feet on a critical success, but its success size should be the same as the remastered Marshal's Aura, since there is no mention of 10 ft. specifically.