### PR TITLE
Add images for inline `cube`, `cylinder`, and `square` template buttons

### DIFF
--- a/src/styles/_globals.scss
+++ b/src/styles/_globals.scss
@@ -318,23 +318,33 @@ span[data-pf2-effect-area] {
         margin-right: 0.25em;
     }
 
+    // EFFECT_AREA_SHAPES
+
+    &[data-pf2-effect-area="burst"]::before {
+        content: "\f111";
+    }
+
     &[data-pf2-effect-area="cone"]::before {
         content: "\f104";
     }
 
-    &[data-pf2-effect-area="line"]::before {
-        content: "\f7a5";
+    &[data-pf2-effect-area="cube"]::before {
+        content: "\f1b2";
     }
 
-    &[data-pf2-effect-area="burst"]::before {
-        content: "\f111";
+    &[data-pf2-effect-area="cylinder"]::before {
+        content: "\f1c0";
     }
 
     &[data-pf2-effect-area="emanation"]::before {
         content: "\f192";
     }
 
-    &[data-pf2-effect-area="rect"]::before {
+    &[data-pf2-effect-area="line"]::before {
+        content: "\f7a5";
+    }
+
+    &[data-pf2-effect-area="square"]::before {
         content: "\f0c8";
     }
 }


### PR DESCRIPTION
Repurposed `rect` to `square`, as `rect` isn't included in `EFFECT_AREA_SHAPES`.