### PR TITLE
Support homebrew class traits and use in feat subfeatures (data prep removal)

### DIFF
--- a/src/module/item/feat/data.ts
+++ b/src/module/item/feat/data.ts
@@ -43,14 +43,6 @@ class FeatSystemData extends ItemSystemModel<FeatPF2e, FeatSystemSchema> {
         const senseTypes: Record<SenseType, string> = CONFIG.PF2E.senses;
         const senseAcuities: Record<SenseAcuity, string> = CONFIG.PF2E.senseAcuities;
         const languages: Record<Language, string> = CONFIG.PF2E.languages;
-        const increasableProficiencies: Record<IncreasableProficiency, string> = {
-            ...CONFIG.PF2E.saves,
-            ...CONFIG.PF2E.classTraits,
-            ...CONFIG.PF2E.armorCategories,
-            ...CONFIG.PF2E.weaponCategories,
-            perception: "PF2E.PerceptionLabel",
-            spellcasting: "PF2E.Item.Spell.Plural",
-        };
 
         return {
             ...super.defineSchema(),
@@ -154,7 +146,8 @@ class FeatSystemData extends ItemSystemModel<FeatPF2e, FeatSystemSchema> {
                     { required: false, nullable: false, initial: undefined },
                 ),
                 proficiencies: new RecordField(
-                    new fields.StringField({ required: true, nullable: false, choices: increasableProficiencies }),
+                    // Valid proficiencies are validated during data preparation to facilitate removal
+                    new fields.StringField({ required: true, nullable: false }),
                     new fields.SchemaField({
                         rank: new fields.NumberField<OneToFour, OneToFour, true, false, false>({
                             required: true,
@@ -226,7 +219,6 @@ class FeatSystemData extends ItemSystemModel<FeatPF2e, FeatSystemSchema> {
         const subfeatures = this.subfeatures;
         subfeatures.keyOptions ??= [];
         subfeatures.languages ??= { slots: 0, granted: [] };
-        subfeatures.proficiencies ??= {};
         subfeatures.senses ??= {};
         subfeatures.suppressedFeatures ??= [];
     }
@@ -293,14 +285,11 @@ type FeatSystemSchema = Omit<ItemSystemSchema, "traits"> & {
             false
         >;
         proficiencies: RecordField<
-            fields.StringField<IncreasableProficiency, IncreasableProficiency, true, false, false>,
+            fields.StringField<string, string, true, false, false>,
             fields.SchemaField<{
                 rank: fields.NumberField<OneToFour, OneToFour, true, false, false>;
                 attribute: fields.StringField<AttributeString, AttributeString, true, true, true>;
-            }>,
-            false,
-            false,
-            false
+            }>
         >;
         senses: SensesField;
         suppressedFeatures: fields.ArrayField<fields.DocumentUUIDField<ItemUUID, true, false, false>>;

--- a/src/module/item/feat/document.ts
+++ b/src/module/item/feat/document.ts
@@ -168,6 +168,7 @@ class FeatPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
         build.languages.granted.push(...subfeatures.languages.granted.map((slug) => ({ slug, source: this.name })));
 
         // Proficiency-rank increases
+        const invalidProficiencies: string[] = [];
         for (const [slug, increase] of Object.entries(subfeatures.proficiencies)) {
             const proficiency = ((): { rank: number } | null => {
                 if (slug === "perception") return actor.system.perception;
@@ -181,11 +182,22 @@ class FeatPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
                     const attribute = increase.attribute ?? "str";
                     return (classDCs[slug] ??= { attribute, label: CONFIG.PF2E.classTraits[slug], rank: 0 });
                 }
+
+                invalidProficiencies.push(slug);
                 return null;
             })();
             if (proficiency && increase?.rank) {
                 proficiency.rank = Math.max(proficiency.rank, increase.rank);
             }
+        }
+        if (invalidProficiencies.length) {
+            subfeatures.proficiencies = R.omit(
+                subfeatures.proficiencies,
+                invalidProficiencies as (keyof typeof subfeatures.proficiencies)[],
+            );
+            console.warn(
+                `Invalid proficiency increases on feat ${this.name} (${this.uuid}): ${invalidProficiencies.join(", ")}`,
+            );
         }
 
         // Senses

--- a/src/module/item/feat/sheet.ts
+++ b/src/module/item/feat/sheet.ts
@@ -108,6 +108,9 @@ class FeatSheetPF2e extends ItemSheetPF2e<FeatPF2e> {
         const feat = this.item;
         const localize = localizer("PF2E.Actor.Character");
         const selectedIncreases = feat.system.subfeatures.proficiencies;
+        const invalidKeys = Object.keys(this.item.system._source.subfeatures.proficiencies ?? {}).filter(
+            (k) => !(k in selectedIncreases),
+        );
 
         return {
             other: {
@@ -175,6 +178,16 @@ class FeatSheetPF2e extends ItemSheetPF2e<FeatPF2e> {
                         rank: selectedIncreases[slug]?.rank ?? null,
                     }))
                     .sort((a, b) => a.label.localeCompare(b.label)),
+            },
+            invalid: {
+                group: null,
+                invalid: true,
+                options: invalidKeys.map((slug) => ({
+                    slug,
+                    label: slug,
+                    attribute: null,
+                    rank: null,
+                })),
             },
         };
     }
@@ -285,7 +298,7 @@ class FeatSheetPF2e extends ItemSheetPF2e<FeatPF2e> {
                 }
             } else if (anchor.dataset.action === "delete-proficiency") {
                 const slug = anchor.dataset.slug ?? "";
-                if (slug in feat.system.subfeatures.proficiencies) {
+                if (slug in feat.system._source.subfeatures.proficiencies) {
                     feat.update({ [`system.subfeatures.proficiencies.-=${slug}`]: null });
                 }
             }
@@ -432,7 +445,7 @@ interface FeatSheetData extends ItemSheetDataPF2e<FeatPF2e> {
     hasSenses: boolean;
     languages: LanguageOptions;
     mandatoryTakeOnce: boolean;
-    maxTakableOptions: FormSelectOption[];
+    maxTakableOptions: foundry.applications.fields.FormSelectOption[];
     proficiencies: ProficiencyOptions;
     proficiencyRankOptions: Record<string, string>;
     selfEffect: SelfEffectReference | null;
@@ -455,6 +468,7 @@ interface ProficiencyOptions {
     attacks: ProficiencyOptionGroup;
     defenses: ProficiencyOptionGroup;
     classes: ProficiencyOptionGroup;
+    invalid: ProficiencyOptionGroup<null> & { invalid: true };
 }
 
 interface ProficiencyOptionGroup<TGroup extends string | null = string> {

--- a/src/module/system/settings/homebrew/data.ts
+++ b/src/module/system/settings/homebrew/data.ts
@@ -11,6 +11,7 @@ const HOMEBREW_ELEMENT_KEYS = [
     "languages",
     "armorGroups",
     "baseArmors",
+    "classTraits",
     "weaponCategories",
     "weaponGroups",
     "baseWeapons",
@@ -25,6 +26,7 @@ const HOMEBREW_ELEMENT_KEYS = [
 /** Homebrew elements from some of the above records are propagated to related records */
 const TRAIT_PROPAGATIONS = {
     actionTraits: ["effectTraits"],
+    classTraits: ["featTraits", "spellTraits"],
     creatureTraits: ["ancestryTraits", "hazardTraits"],
     equipmentTraits: ["armorTraits", "consumableTraits"],
     featTraits: ["actionTraits"],

--- a/src/styles/item/_feat-sheet.scss
+++ b/src/styles/item/_feat-sheet.scss
@@ -59,6 +59,10 @@
                 gap: 0.25rem;
                 padding: 0.125rem;
 
+                &.invalid label {
+                    color: var(--color-level-error);
+                }
+
                 label,
                 select.unselected-options {
                     flex-basis: 11rem;

--- a/static/templates/items/feat-details.hbs
+++ b/static/templates/items/feat-details.hbs
@@ -123,7 +123,12 @@
         <ul{{#unless hasProficiencies}} class="empty"{{/unless}}>
             {{#each proficiencies as |group|~}}
                 {{#each group.options as |option|~}}
-                    {{#if option.rank~}}
+                    {{#if group.invalid~}}
+                        <li class="invalid">
+                            <label>{{option.label}}</label>
+                            <a data-action="delete-proficiency" data-slug="{{option.slug}}"><i class="fa-solid fa-trash"></i></a>
+                        </li>
+                    {{else if option.rank~}}
                         <li>
                             <label for="{{@root.fieldIdPrefix}}{{option.slug}}">{{option.label}}</label>
                             <select


### PR DESCRIPTION
Mutually supercedes https://github.com/foundryvtt/pf2e/pull/19529.

Handles it by leveraging the existing checks during feat data preparation rather than trying to solve it in the schema. Technically....invalid proficiencies are valid source data, they're just invalid prep data?

I'm fine with either of the two PRs, but I wanted to make the choices more clear. The featureset is the same (so the images in the other PR match this one), except that the warning with this one is significantly less verbose:

![image](https://github.com/user-attachments/assets/f9b684ff-fd4a-4784-af55-e96bcd2f84ca)
