### PR TITLE
Fix chat token images blocking saves posted to chat once more

### DIFF
--- a/src/module/chat-message/document.ts
+++ b/src/module/chat-message/document.ts
@@ -219,6 +219,7 @@ class ChatMessagePF2e extends ChatMessage {
             const image = document.createElement("img");
             image.alt = actor.name;
             image.src = imageUrl;
+            image.inert = true;
             image.style.transform = `scale(${scale})`;
 
             // If image scale is above 1.2, we might need to add a radial fade to not block out the name

--- a/src/styles/ui/sidebar/chat/_index.scss
+++ b/src/styles/ui/sidebar/chat/_index.scss
@@ -25,6 +25,7 @@
             img {
                 border: none;
                 height: 36px;
+                pointer-events: none;
                 object-fit: contain;
                 width: 36px;
             }

--- a/src/styles/ui/sidebar/chat/_index.scss
+++ b/src/styles/ui/sidebar/chat/_index.scss
@@ -25,7 +25,6 @@
             img {
                 border: none;
                 height: 36px;
-                pointer-events: none;
                 object-fit: contain;
                 width: 36px;
             }


### PR DESCRIPTION
Restores a fix from #17756 that was lost in the v13 migration