### PR TITLE
Add system changes to facilitate Whirling Swipe

### DIFF
--- a/src/module/actor/creature/document.ts
+++ b/src/module/actor/creature/document.ts
@@ -91,28 +91,17 @@ abstract class CreaturePF2e<
      */
     override getReach({ action = "interact", weapon = null }: GetReachParameters = {}): number {
         const baseReach = this.attributes.reach.base;
-        const weaponReach = weapon?.isOfType("melee") ? weapon.reach : null;
 
         if (action === "interact" || this.type === "familiar") {
-            return baseReach;
-        } else if (typeof weaponReach === "number") {
-            return weaponReach;
+            return this.attributes.reach.base;
+        } else if (weapon?.isOfType("melee", "weapon")) {
+            return weapon.reach ?? baseReach;
         } else {
-            const attacks: { item: ItemPF2e<ActorPF2e>; ready: boolean }[] = weapon
-                ? [{ item: weapon, ready: true }]
-                : (this.system.actions ?? []);
-            const readyAttacks = attacks.filter((a) => a.ready);
-            const traitsFromItems = readyAttacks.map((a) => new Set(a.item.system.traits?.value ?? []));
-            if (traitsFromItems.length === 0) return baseReach;
-
-            const reaches = traitsFromItems.map((traits): number => {
-                if (setHasElement(traits, "reach")) return baseReach + 5;
-
-                const reachNPattern = /^reach-\d{1,3}$/;
-                return Number([...traits].find((t) => reachNPattern.test(t))?.replace("reach-", "")) || baseReach;
-            });
-
-            return Math.max(...reaches);
+            const readiedItems = this.system.actions?.filter((a) => a.ready).map((a) => a.item) ?? [];
+            return Math.max(
+                baseReach,
+                ...readiedItems.map((i) => i.reach).filter((r): r is number => typeof r === "number"),
+            );
         }
     }
 

--- a/src/module/item/melee/document.ts
+++ b/src/module/item/melee/document.ts
@@ -49,6 +49,7 @@ class MeleePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
         return Number(this.system.bonus.value) || 0;
     }
 
+    /** The reach of this attack if melee */
     get reach(): number | null {
         if (this.isRanged) return null;
         const reachTrait = this.system.traits.value.find((t) => /^reach-\d+$/.test(t));

--- a/src/module/item/weapon/document.ts
+++ b/src/module/item/weapon/document.ts
@@ -112,6 +112,17 @@ class WeaponPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
         return this.system.maxRange ?? (this.system.range ? this.system.range * 6 : null);
     }
 
+    /** The reach of this weapon if melee */
+    get reach(): number | null {
+        if (!this.isMelee) return null;
+
+        const actor = this.actor;
+        const baseReach = actor?.isOfType("creature") ? (actor.attributes.reach?.base ?? 5) : 5;
+        const traits = this.system.traits.value;
+        const reachIncrease = traits.includes("reach") ? 5 : 0;
+        return baseReach + reachIncrease;
+    }
+
     /** A single object containing range increment and maximum */
     get range(): RangeData | null {
         const rangeIncrement = this.system.range;

--- a/src/module/rules/rule-element/item-alteration/alteration.ts
+++ b/src/module/rules/rule-element/item-alteration/alteration.ts
@@ -54,7 +54,9 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElement, ItemAlterat
             alteration: {
                 mode: this.mode,
                 itemType: item.type,
-                value: (this.value = this.parent.resolveValue(this.value, fallbackValue)),
+                value: (this.value = this.parent.resolveValue(this.value, fallbackValue, {
+                    resolvables: { targetItem: item },
+                })),
             },
         });
     }

--- a/src/module/rules/rule-element/item-alteration/handlers.ts
+++ b/src/module/rules/rule-element/item-alteration/handlers.ts
@@ -22,22 +22,24 @@ import {
 } from "@system/schema-data-fields.ts";
 import { objectHasKey, setHasElement, tupleHasValue } from "@util";
 import * as R from "remeda";
-import { AELikeRuleElement, type AELikeChangeMode } from "../ae-like.ts";
+import { AELikeDataPrepPhase, AELikeRuleElement, type AELikeChangeMode } from "../ae-like.ts";
 import { ResolvableValueField, RuleElement } from "../index.ts";
 import { adjustCreatureShieldData, getNewInterval, itemHasCounterBadge } from "./helper.ts";
 import fields = foundry.data.fields;
 import validation = foundry.data.validation;
 
-/** A `SchemaField` reappropriated for validation of specific item alterations */
+/**
+ * A `SchemaField` reappropriated for validation of specific item alterations.
+ * Each modifiable ItemAlteration property is a different instance of this class, which is delegated to by ItemAlteration.
+ */
 class ItemAlterationHandler<TSchema extends AlterationSchema> extends fields.SchemaField<TSchema> {
     #validateForItem?: (
         item: ItemPF2e | ItemSourcePF2e,
         alteration: MaybeAlterationData,
     ) => validation.DataModelValidationFailure | void;
 
-    operableOnInstances: boolean;
-
-    operableOnSource: boolean;
+    /** Valid AELike prep phases for this alteration. By default its "applyAEs" only */
+    supportedPhases: ItemAlterationPrepPhase[];
 
     /** A registered handler function for the item alteration. The validation should be performed inside */
     handle: (data: AlterationApplicationData) => void;
@@ -46,8 +48,7 @@ class ItemAlterationHandler<TSchema extends AlterationSchema> extends fields.Sch
         super(options.fields, R.omit(options, ["fields"]));
         if (options.validateForItem) this.#validateForItem = options.validateForItem;
         this.handle = options.handle.bind(this);
-        this.operableOnInstances = options.operableOnInstances ?? true;
-        this.operableOnSource = options.operableOnSource ?? true;
+        this.supportedPhases = options.supportedPhases ?? ["applyAEs"];
     }
 
     /**
@@ -73,14 +74,6 @@ class ItemAlterationHandler<TSchema extends AlterationSchema> extends fields.Sch
         if (item.type !== alteration.itemType) return false;
         const forItemFailure = this.#validateForItem?.(item, alteration);
         if (forItemFailure) throw new validation.DataModelValidationError(forItemFailure);
-
-        if (!this.operableOnInstances && item instanceof foundry.abstract.Document) {
-            throw new validation.DataModelValidationError("may only be applied to source data");
-        }
-
-        if (!this.operableOnSource && !(item instanceof foundry.abstract.Document)) {
-            throw new validation.DataModelValidationError("may only be applied to existing items");
-        }
 
         return true;
     }
@@ -668,6 +661,7 @@ const ITEM_ALTERATION_HANDLERS = {
                 initial: undefined,
             } as const),
         },
+        supportedPhases: ["afterDerived"],
         validateForItem(item): validation.DataModelValidationFailure | void {
             if (item.system.slug !== "persistent-damage") {
                 return new validation.DataModelValidationFailure({
@@ -1042,6 +1036,7 @@ const ITEM_ALTERATION_HANDLERS = {
                 { required: true, nullable: false },
             ),
         },
+        supportedPhases: ["applyAEs", "beforeDerived"],
         validateForItem: (_item, alteration): validation.DataModelValidationFailure | void => {
             if (alteration.mode !== "add" && typeof alteration.value === "object") {
                 return new validation.DataModelValidationFailure({
@@ -1051,29 +1046,26 @@ const ITEM_ALTERATION_HANDLERS = {
         },
         handle: function (data: AlterationApplicationData) {
             if (!this.isValid(data)) return;
-            const resolvedTrait = R.isPlainObject(data.alteration.value)
-                ? `${data.alteration.value.trait}-${data.rule.resolveValue(data.alteration.value.annotation)}`
-                : data.alteration.value;
+            const { item, rule, alteration } = data;
+            const resolvedTrait = R.isPlainObject(alteration.value)
+                ? `${alteration.value.trait}-${rule.resolveValue(alteration.value.annotation, null, { resolvables: { targetItem: item } })}`
+                : alteration.value;
             const documentClasses: Record<string, typeof ItemPF2e> = CONFIG.PF2E.Item.documentClasses;
-            const validTraits = documentClasses[data.item.type].validTraits;
+            const validTraits = documentClasses[item.type].validTraits;
             if (!objectHasKey(validTraits, resolvedTrait)) {
                 throw new validation.DataModelValidationError(`${resolvedTrait} is not a valid choice`);
             }
 
-            const newValue = AELikeRuleElement.getNewValue(
-                data.alteration.mode,
-                data.item.system.traits.value,
-                resolvedTrait,
-            );
+            const newValue = AELikeRuleElement.getNewValue(alteration.mode, item.system.traits.value, resolvedTrait);
             if (!newValue) return;
             if (newValue instanceof validation.DataModelValidationFailure) {
                 throw newValue.asError();
             }
-            if (data.item.system.traits.value) {
-                if (data.alteration.mode === "add") {
-                    addOrUpgradeTrait(data.item.system.traits, newValue);
-                } else if (["subtract", "remove"].includes(data.alteration.mode)) {
-                    removeTrait(data.item.system.traits, newValue);
+            if (item.system.traits.value) {
+                if (alteration.mode === "add") {
+                    addOrUpgradeTrait(item.system.traits, newValue);
+                } else if (["subtract", "remove"].includes(alteration.mode)) {
+                    removeTrait(item.system.traits, newValue);
                 }
             }
         },
@@ -1088,10 +1080,9 @@ interface AlterationFieldOptions<
         item: ItemPF2e | ItemSourcePF2e,
         alteration: MaybeAlterationData,
     ) => validation.DataModelValidationFailure | void;
-    /** Whether this alteration can be used with an `ItemPF2e` instance */
-    operableOnInstances?: boolean;
-    /** Whether this alteration can be used with item source data */
-    operableOnSource?: boolean;
+    /** Valid AELike prep phases for this alteration. By default its "applyAEs" only */
+    supportedPhases?: ItemAlterationPrepPhase[];
+    /** Handler function that applies the alteration to a given item or source */
     handle: (this: ItemAlterationHandler<TSchema>, data: AlterationApplicationData) => void;
 }
 
@@ -1122,5 +1113,8 @@ type TraitsValueConfigField = fields.SchemaField<{
     trait: fields.StringField<string, string, true, false>;
     annotation: ResolvableValueField<true, false>;
 }>;
+
+type ItemAlterationPrepPhase = Exclude<AELikeDataPrepPhase, "beforeRoll">;
+
 export { ITEM_ALTERATION_HANDLERS, ItemAlterationHandler };
-export type { AlterationApplicationData, AlterationFieldOptions, AlterationSchema };
+export type { AlterationApplicationData, AlterationFieldOptions, AlterationSchema, ItemAlterationPrepPhase };

--- a/src/module/rules/rule-element/item-alteration/rule-element.ts
+++ b/src/module/rules/rule-element/item-alteration/rule-element.ts
@@ -2,11 +2,13 @@ import type { ActorPF2e } from "@actor";
 import type { ItemPF2e, PhysicalItemPF2e } from "@item";
 import type { ItemType } from "@item/base/data/index.ts";
 import { PHYSICAL_ITEM_TYPES } from "@item/physical/values.ts";
+import { objectHasKey } from "@util";
 import * as R from "remeda";
 import { AELikeRuleElement } from "../ae-like.ts";
 import { RuleElement, RuleElementOptions } from "../base.ts";
 import type { ModelPropsFromRESchema, RuleElementSchema, RuleElementSource } from "../data.ts";
 import { ItemAlteration, ItemAlterationProperty, ItemAlterationSchema } from "./alteration.ts";
+import { ITEM_ALTERATION_HANDLERS, ItemAlterationPrepPhase } from "./handlers.ts";
 import fields = foundry.data.fields;
 
 class ItemAlterationRuleElement extends RuleElement<ItemAlterationRuleSchema> {
@@ -45,6 +47,17 @@ class ItemAlterationRuleElement extends RuleElement<ItemAlterationRuleSchema> {
                 initial: undefined,
             }),
             battleForm: new fields.BooleanField(),
+            phase: new fields.StringField({
+                required: true,
+                choices: ["applyAEs", "beforeDerived", "afterDerived"],
+                initial: (data: unknown) => {
+                    const property = R.isPlainObject(data) ? data["property"] : null;
+                    const handler = objectHasKey(ITEM_ALTERATION_HANDLERS, property)
+                        ? ITEM_ALTERATION_HANDLERS[property]
+                        : null;
+                    return (handler?.supportedPhases ?? ["applyAEs"])[0];
+                },
+            }),
             ...ItemAlteration.defineSchema(),
         };
     }
@@ -55,10 +68,14 @@ class ItemAlterationRuleElement extends RuleElement<ItemAlterationRuleSchema> {
         if (!data.itemId && !data.itemType) {
             throw Error("one of itemId and itemType must be defined");
         }
-    }
 
-    /** Alteration properties that should be processed at the end of data preparation */
-    static #DELAYED_PROPERTIES = ["pd-recovery-dc"];
+        // Validate that the phase is supported by the property
+        const { property, phase } = data;
+        const handler = objectHasKey(ITEM_ALTERATION_HANDLERS, property) ? ITEM_ALTERATION_HANDLERS[property] : null;
+        if (phase && handler && !handler.supportedPhases.includes(phase)) {
+            throw Error(`phase: ${phase} is not a valid choice, must be one of ${handler.supportedPhases.join(", ")}`);
+        }
+    }
 
     /** Alteration properties that should only be processed when requested directly */
     static #LAZY_PROPERTIES = ["description"];
@@ -103,21 +120,27 @@ class ItemAlterationRuleElement extends RuleElement<ItemAlterationRuleSchema> {
     }
 
     override onApplyActiveEffects(): void {
-        const actor = this.actor;
         if (this.ignored) return;
         if (this.battleForm && !this.predicate.includes("battle-form")) this.predicate.push("battle-form");
 
-        actor.synthetics.itemAlterations.push(this);
-        const isDelayed = this.constructor.#DELAYED_PROPERTIES.includes(this.property);
-        if (!this.isLazy && !isDelayed) {
+        if (!this.isLazy && this.phase === "applyAEs") {
+            this.actor.synthetics.itemAlterations.push(this);
+            this.applyAlteration();
+        }
+    }
+
+    override beforePrepareData(): void {
+        if (this.ignored) return;
+        if (!this.isLazy && this.phase === "beforeDerived") {
+            this.actor.synthetics.itemAlterations.push(this);
             this.applyAlteration();
         }
     }
 
     override afterPrepareData(): void {
         if (this.ignored) return;
-        const isDelayed = this.constructor.#DELAYED_PROPERTIES.includes(this.property);
-        if (!this.isLazy && isDelayed) {
+        if (!this.isLazy && this.phase === "afterDerived") {
+            this.actor.synthetics.itemAlterations.push(this);
             this.applyAlteration();
         }
     }
@@ -198,6 +221,8 @@ type ItemAlterationRuleSchema = RuleElementSchema &
         itemId: fields.StringField<string, string, false, false, false>;
         /** Whether this rule element is compatible with battle forms */
         battleForm: fields.BooleanField;
+        /** The phase to run the alteration in. Most only support applyAEs */
+        phase: fields.StringField<ItemAlterationPrepPhase, ItemAlterationPrepPhase, true, false, true>;
     };
 
 interface ApplyAlterationOptions {


### PR DESCRIPTION
Because whirling swipe isn't in pf2e, and each change in isolation doesn't look relevant until you put them all together, I did it all in one. Let me know if any look fine to split into a new PR.

1) Include `targetItem` as a resolvable for item alterations, so that item alterations can refer to sibling properties
2) `phase` is now supported for item alterations. This allows traits to be set after CreatureSize REs occur. What phases are allowed depend on the property. Delayed properties (persistent damage dc) were refactored to use the phase property.
3) `WeaponPF2e#reach` to mirror `MeleePF2e#reach`, so that we can actually access it within the item alteration. getReach() now delegates work to the getters. I wouldn't mind a reach.base and reach.attack fields to mirror what we do in the actor's reach data though, either as a getter or as system data, but then we will have to change `melee.reach` to correspond.

Afterwards, this implements whirling swipe:

```json
{
  "domain": "all",
  "key": "RollOption",
  "option": "whirling-swipe",
  "toggleable": true
}
```

```json
{
  "key": "ItemAlteration",
  "itemType": "weapon",
  "property": "traits",
  "mode": "add",
  "phase": "beforeDerived",
  "value": {
    "trait": "area-burst",
    "annotation": "max(5, @targetItem.reach)"
  },
  "predicate": [
    "item:melee",
    "item:hands-held:2",
    "whirling-swipe"
  ]
}
```