### PR TITLE
Replace collapsed actions with general minHeight based solution

### DIFF
--- a/src/module/chat-message/document.ts
+++ b/src/module/chat-message/document.ts
@@ -243,6 +243,19 @@ class ChatMessagePF2e extends ChatMessage {
             }
         }
 
+        // If the description has auto-collapse, collapse if text exceeds a certain length
+        // Its not possible to check the actual size if its not in the DOM yet
+        const collapsableElement = html.querySelector<HTMLElement>(
+            ".description[data-auto-collapse], .card-content[data-auto-collapse]",
+        );
+        if (collapsableElement && collapsableElement.innerText.length > 250) {
+            collapsableElement.classList.add("collapsed");
+            collapsableElement.dataset.action = "expand-description";
+            collapsableElement.dataset.tooltipClass = "pf2e";
+            collapsableElement.dataset.tooltip = "PF2E.Action.ExpandDescription";
+            collapsableElement.after(createHTMLElement("div", { classes: ["shadow"] }));
+        }
+
         if (!this.flags.pf2e.suppressDamageButtons && this.isDamageRoll) {
             // Mark each button group with the index in the message's `rolls` array
             htmlQueryAll(html, ".damage-application").forEach((buttons, index) => {

--- a/src/module/chat-message/helpers.ts
+++ b/src/module/chat-message/helpers.ts
@@ -52,23 +52,9 @@ async function createUseActionMessage(
         traits: item.system.traits.value.map((t) => traitSlugToObject(t, CONFIG.PF2E.actionTraits)),
     });
 
-    // Get a preview slice of the message
-    const previewLength = 100;
-    const descriptionPreview = ((): string | null => {
-        if (item.actor.pack) return null;
-        const tempDiv = document.createElement("div");
-        const documentTypes = [...CONST.DOCUMENT_LINK_TYPES, "Compendium", "UUID"];
-        const linkPattern = new RegExp(`@(${documentTypes.join("|")})\\[([^#\\]]+)(?:#([^\\]]+))?](?:{([^}]+)})?`, "g");
-        tempDiv.innerHTML = item.description.replace(linkPattern, (_match, ...args) => args[3]);
-
-        return tempDiv.innerText.slice(0, previewLength);
-    })();
     const content = await fa.handlebars.renderTemplate("systems/pf2e/templates/chat/action/collapsed.hbs", {
         actor: item.actor,
-        description: {
-            full: descriptionPreview && descriptionPreview.length < previewLength ? item.description : null,
-            preview: descriptionPreview,
-        },
+        description: item.description,
         selfEffect: !!item.system.selfEffect,
         craftedItem: craftedItem?.toAnchor({ attrs: { draggable: "true" } }).outerHTML,
         withoutResources: craftedItem && !consumeResources,

--- a/src/styles/legacy/_chat.scss
+++ b/src/styles/legacy/_chat.scss
@@ -61,27 +61,6 @@
     .card-content {
         margin: 0;
 
-        p {
-            margin: var(--space-4) 0;
-            min-height: unset;
-
-            &.item-block-line {
-                --wrap-indent: var(--space-14);
-                line-height: 1.25rem;
-                margin: 0;
-                padding: 0 0 0 var(--wrap-indent);
-                text-indent: calc(-1 * var(--wrap-indent));
-
-                .adjusted {
-                    text-decoration: underline dotted 1px black;
-                }
-
-                &:first-child {
-                    margin-top: var(--space-1);
-                }
-            }
-        }
-
         hr.item-block-divider {
             margin-top: var(--space-3);
         }

--- a/src/styles/ui/sidebar/chat/_action.scss
+++ b/src/styles/ui/sidebar/chat/_action.scss
@@ -50,6 +50,7 @@
         margin-bottom: 0rem;
         position: relative;
 
+        // Remove in a few releases
         a.preview {
             height: 4.5ch;
             display: block;
@@ -70,6 +71,7 @@
             }
         }
 
+        // Remove in a few releases
         .shadow {
             border-bottom: 1px solid rgba(black, 0.05);
             height: 6px;

--- a/src/styles/ui/sidebar/chat/_index.scss
+++ b/src/styles/ui/sidebar/chat/_index.scss
@@ -100,6 +100,56 @@
     > .message-content {
         @import "conditions";
 
+        > .description,
+        > .chat-card .card-content {
+            &.collapsed {
+                cursor: pointer;
+                max-height: 4.5rem;
+                mask-image: linear-gradient(to bottom, black, transparent);
+                overflow: hidden;
+
+                * {
+                    pointer-events: none;
+                }
+
+                + .shadow {
+                    border-bottom: 1px solid rgba(black, 0.05);
+                    height: 6px;
+                    position: relative;
+                    top: -8px;
+                    margin-bottom: -6px;
+                    z-index: 1;
+                }
+
+                &:hover + .shadow {
+                    box-shadow: 0 1px 6px var(--color-shadow-primary);
+                    clip-path: polygon(0 10%, 100% 10%, 100% 200%, 0 200%);
+                    width: 100%;
+                }
+            }
+
+            p {
+                margin: var(--space-4) 0;
+                min-height: unset;
+
+                &.item-block-line {
+                    --wrap-indent: var(--space-14);
+                    line-height: 1.25rem;
+                    margin: 0;
+                    padding: 0 0 0 var(--wrap-indent);
+                    text-indent: calc(-1 * var(--wrap-indent));
+
+                    .adjusted {
+                        text-decoration: underline dotted 1px black;
+                    }
+
+                    &:first-child {
+                        margin-top: var(--space-1);
+                    }
+                }
+            }
+        }
+
         .addendum {
             @include frame-elegant;
             background: rgba($alt-dark, 0.1);

--- a/static/templates/chat/action/collapsed.hbs
+++ b/static/templates/chat/action/collapsed.hbs
@@ -2,14 +2,9 @@
     <div class="notification warning">{{localize "PF2E.Item.Ability.CraftedItem.CraftedWithoutResources"}}</div>
 {{/if}}
 
-{{#if description.full~}}
-    <div class="description">{{{description.full}}}</div>
-{{~else if description.preview~}}
-    <div class="description" data-tooltip-class="pf2e">
-        <a class="preview" data-action="expand-description" data-tooltip="{{localize "PF2E.Action.ExpandDescription"}}">{{description.preview}}</a>
-        <div class="shadow"></div>
-    </div>
-{{~/if}}
+<div class="description" data-auto-collapse>
+    {{{description}}}
+</div>
 
 {{#if (or selfEffect craftedItem)}}
     <div class="message-buttons">


### PR DESCRIPTION
This allows any description or card-content to become auto-previewable if it has the `data-auto-collapse` property. The preview is now based on min-height rather than text only as well.

I went for an approach that had minimal dom manipulation with no wrapper elements, so I needed to do something a bit weird with the shadow element since otherwise the mask-image would have made it invisible. Hopefully that's ok.

After this it should be easy to leverage on things like spells.

https://github.com/user-attachments/assets/70491c26-735b-4879-80e1-df74e69ecabe

