### PR TITLE
Auto collapse spell descriptions

### DIFF
--- a/static/templates/chat/spell-card.hbs
+++ b/static/templates/chat/spell-card.hbs
@@ -15,7 +15,7 @@
         </section>
     </header>
 
-    <section class="card-content">
+    <section class="card-content" data-auto-collapse>
         {{{data.description.value}}}
         {{#if data.materials.value}}
             <p><strong>{{localize "PF2E.SpellRequirementsLabel"}}</strong> {{data.materials.value}}</p>


### PR DESCRIPTION
Of the existing items, given that spells are often long and have real buttons, they seemed the obvious choice.

<img width="304" height="673" alt="image" src="https://github.com/user-attachments/assets/04b81053-ca51-4bdd-b572-a602e3b7409a" />
