### PR TITLE
Fix the category of the Bargainer's Instrument

### DIFF
--- a/packs/equipment/bargainers-instrument.json
+++ b/packs/equipment/bargainers-instrument.json
@@ -7,7 +7,7 @@
         "bulk": {
             "value": 0.1
         },
-        "category": "toolkit",
+        "category": "other",
         "containerId": null,
         "damage": null,
         "description": {


### PR DESCRIPTION
Just a small observation that I found. I think the "toolkit" category needs to be looked at as a whole.