### PR TITLE
Add effect for Extravagant Parry and brush up Dueling Parry

### DIFF
--- a/packs/feat-effects/effect-dueling-parry.json
+++ b/packs/feat-effects/effect-dueling-parry.json
@@ -4,7 +4,7 @@
     "name": "Effect: Dueling Parry",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Extravagant Parry] or @UUID[Compendium.pf2e.feats-srd.Item.Dueling Parry]</p>\n<p>You gain a circumstance bonus to AC.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Dueling Parry]</p>\n<p>You gain a circumstance bonus to AC.</p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -23,6 +23,9 @@
         "rules": [
             {
                 "key": "FlatModifier",
+                "predicate": [
+                    "hands-free:but-really:1"
+                ],
                 "selector": "ac",
                 "type": "circumstance",
                 "value": 2

--- a/packs/feat-effects/effect-dueling-parry.json
+++ b/packs/feat-effects/effect-dueling-parry.json
@@ -24,7 +24,12 @@
             {
                 "key": "FlatModifier",
                 "predicate": [
-                    "hands-free:1"
+                    {
+                        "gte": [
+                            "hands-free",
+                            1
+                        ]
+                    }
                 ],
                 "selector": "ac",
                 "type": "circumstance",

--- a/packs/feat-effects/effect-dueling-parry.json
+++ b/packs/feat-effects/effect-dueling-parry.json
@@ -24,7 +24,7 @@
             {
                 "key": "FlatModifier",
                 "predicate": [
-                    "hands-free:but-really:1"
+                    "hands-free:1"
                 ],
                 "selector": "ac",
                 "type": "circumstance",

--- a/packs/feat-effects/effect-extravagant-parry.json
+++ b/packs/feat-effects/effect-extravagant-parry.json
@@ -35,7 +35,7 @@
                 ],
                 "key": "ChoiceSet",
                 "predicate": [
-                    "hands-free:but-really:0"
+                    "hands-free:0"
                 ],
                 "prompt": "PF2E.SpecificRule.Swashbuckler.ExtravagantParry.Prompt",
                 "rollOption": "extravagant-parry"

--- a/packs/feat-effects/effect-extravagant-parry.json
+++ b/packs/feat-effects/effect-extravagant-parry.json
@@ -1,6 +1,6 @@
 {
     "_id": "YhDjKTWPwoXPVOyv",
-    "img": "icons/skills/melee/hand-grip-sword-white-brown.webp",
+    "img": "icons/skills/melee/blade-tips-double-blue.webp",
     "name": "Effect: Extravagant Parry",
     "system": {
         "description": {
@@ -53,7 +53,12 @@
                 "predicate": [
                     {
                         "or": [
-                            "hands-free:but-really:1",
+                            {
+                                "gte": [
+                                    "hands-free",
+                                    1
+                                ]
+                            },
                             "extravagant-parry:yes"
                         ]
                     }

--- a/packs/feat-effects/effect-extravagant-parry.json
+++ b/packs/feat-effects/effect-extravagant-parry.json
@@ -1,0 +1,78 @@
+{
+    "_id": "YhDjKTWPwoXPVOyv",
+    "img": "icons/skills/melee/hand-grip-sword-white-brown.webp",
+    "name": "Effect: Extravagant Parry",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Extravagant Parry]</p>\n<p>You gain a circumstance bonus to your AC.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "fromSpell": false,
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core 2"
+        },
+        "rules": [
+            {
+                "choices": [
+                    {
+                        "label": "PF2E.UI.RuleElements.ChoiceSet.NoLabel",
+                        "value": "no"
+                    },
+                    {
+                        "label": "PF2E.UI.RuleElements.ChoiceSet.YesLabel",
+                        "value": "yes"
+                    }
+                ],
+                "key": "ChoiceSet",
+                "predicate": [
+                    "hands-free:but-really:0"
+                ],
+                "prompt": "PF2E.SpecificRule.Swashbuckler.ExtravagantParry.Prompt",
+                "rollOption": "extravagant-parry"
+            },
+            {
+                "key": "FlatModifier",
+                "selector": "ac",
+                "slug": "extravagant-parry-bonus",
+                "type": "circumstance",
+                "value": 1
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "upgrade",
+                "predicate": [
+                    {
+                        "or": [
+                            "hands-free:but-really:1",
+                            "extravagant-parry:yes"
+                        ]
+                    }
+                ],
+                "selector": "ac",
+                "slug": "extravagant-parry-bonus",
+                "value": 2
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feats/class/swashbuckler/extravagant-parry.json
+++ b/packs/feats/class/swashbuckler/extravagant-parry.json
@@ -27,8 +27,8 @@
         },
         "rules": [],
         "selfEffect": {
-            "name": "Effect: Dueling Parry",
-            "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Dueling Parry"
+            "name": "Effect: Extravagant Parry",
+            "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Extravagant Parry"
         },
         "traits": {
             "rarity": "common",

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -6198,6 +6198,9 @@
                     "TwirlingThrowNote": "The weapon returns to your hand after the attack",
                     "Unbalancing": "Unbalancing"
                 },
+                "ExtravagantParry": {
+                    "Prompt": "Weapon has the parry trait."
+                },
                 "GoadingFeint": {
                     "Note": "On a successful Feint, the target take a -2 circumstance penalty to attack rolls against you instead of any other effects that you would gain when you Feint. @UUID[Compendium.pf2e.feat-effects.Item.rflbFzV44Fd6aBLE]{Effect: Goading Feint}"
                 },


### PR DESCRIPTION
Looking at the two feats, they do things a bit differently, so they might as well have separate effects.

Dueling Parry now has a predicate on hands-free - let me know if we should remove that. 

