### PR TITLE
Fix base spell variant not getting restored internally

### DIFF
--- a/src/module/chat-message/data.ts
+++ b/src/module/chat-message/data.ts
@@ -21,7 +21,7 @@ export interface ItemOriginFlag {
     uuid: string;
     castRank?: number;
     messageId?: string;
-    variant?: { overlays: string[] };
+    variant?: { overlays: string[] } | null;
     rollOptions?: string[];
 }
 

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -1099,10 +1099,7 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
     override getOriginData(): ItemOriginFlag {
         const flag = super.getOriginData();
         flag.castRank = this.rank;
-        if (this.isVariant && this.appliedOverlays) {
-            flag.variant = { overlays: [...this.appliedOverlays.values()] };
-        }
-
+        flag.variant = this.isVariant && this.appliedOverlays ? { overlays: [...this.appliedOverlays.values()] } : null;
         return flag;
     }
 


### PR DESCRIPTION
Internal only bugfix to fix `game.messages.contents.at(-1).item`, which impacted some modules. The content was updated with the base variant, so we never really noticed the issues.