### PR TITLE
Fix spacing between strike tag rows

### DIFF
--- a/src/styles/_tags.scss
+++ b/src/styles/_tags.scss
@@ -83,6 +83,11 @@
             opacity: 0.7;
         }
     }
+
+    hr.vr {
+        height: 1.25em;
+        margin: var(--space-1) var(--space-2);
+    }
 }
 
 // Allow tags to recieve events and disable just the rarity dropdown
@@ -162,11 +167,6 @@ tags.tagify {
         .tagify__tag-text {
             text-transform: uppercase;
         }
-    }
-
-    hr.vr {
-        height: 1.25em;
-        margin: var(--space-1) var(--space-2);
     }
 
     // Tone down disabled effects so we still see trait colors


### PR DESCRIPTION
There is a global hr.vr as well, but the margin of that one was being overriden by `.chat-message hr`. This caused the gap between rows 1 and 2 to be higher than normal, and was more obvious if a strike card ever got to 3 rows

Before:
<img width="298" height="344" alt="image" src="https://github.com/user-attachments/assets/18746c4b-1230-4ea2-8896-3cca80ebf6fb" />

After: 
<img width="297" height="325" alt="image" src="https://github.com/user-attachments/assets/92e7a7cf-2e2e-43fb-87e5-7bacfa4c170c" />


