### PR TITLE
Fix routine action cost for Bee-Induced Panic

### DIFF
--- a/packs/wardens-of-wildwood-bestiary/book-1-packbreaker/bee-induced-panic.json
+++ b/packs/wardens-of-wildwood-bestiary/book-1-packbreaker/bee-induced-panic.json
@@ -35,7 +35,7 @@
                 "title": "Pathfinder #201: Pactbreaker"
             },
             "reset": "",
-            "routine": "<p>(one action) Panicked attendees suffer stings and accidentally injure one another in their fear and confusion. Increase the Casualties score by 1. This increases to [[/gmr 1d3 #Casualties]] if one swarm is stinging the crowd, and it increases to [[/gmr 1d3+1 #Casualties]] if both swarms are stinging the crowd.</p>"
+            "routine": "<p><span class=\"action-glyph\">3</span> Panicked attendees suffer stings and accidentally injure one another in their fear and confusion. Increase the Casualties score by 1. This increases to [[/gmr 1d3 #Casualties]] if one swarm is stinging the crowd, and it increases to [[/gmr 1d3+1 #Casualties]] if both swarms are stinging the crowd.</p>"
         },
         "saves": {
             "fortitude": {


### PR DESCRIPTION
The formatting is usual for a hazard, but it matches the source.
<img width="336" height="118" alt="Screen Shot 2025-07-24 at 11 45 07 AM" src="https://github.com/user-attachments/assets/2c644aa9-dffb-4bfb-9654-4a075019f857" />

Closes https://github.com/foundryvtt/pf2e/issues/19698