### PR TITLE
Turn `TokenConfigMixinPF2e.PARTS` into a getter

### DIFF
--- a/src/module/scene/token-document/sheets/mixin.ts
+++ b/src/module/scene/token-document/sheets/mixin.ts
@@ -26,11 +26,11 @@ function TokenConfigMixinPF2e<TBase extends ReturnType<typeof TokenApplicationMi
             },
         };
 
-        static override PARTS = (() => {
+        static override get PARTS() {
             const parts = { ...super.PARTS };
             parts["appearance"].template = "systems/pf2e/templates/scene/token/appearance.hbs";
             return parts;
-        })();
+        }
 
         get linkToActorSize(): boolean {
             return !!this.token.flags.pf2e.linkToActorSize;


### PR DESCRIPTION
Closes #19707.