### PR TITLE
Add ability to configure thrown base weapons

### DIFF
--- a/src/module/item/weapon/document.ts
+++ b/src/module/item/weapon/document.ts
@@ -135,7 +135,8 @@ class WeaponPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
 
     /** Whether the weapon in its current usage is thrown: a thrown-only weapon or a thrown usage of a melee weapon */
     get isThrown(): boolean {
-        return this.isRanged && (this.baseType === "alchemical-bomb" || this.system.traits.value.includes("thrown"));
+        const isThrownBaseType = tupleHasValue(CONFIG.PF2E.thrownBaseWeapons, this.baseType);
+        return this.isRanged && (isThrownBaseType || this.system.traits.value.includes("thrown"));
     }
 
     /** Whether the weapon is _can be_ thrown: a thrown-only weapon or one that has a throwable usage */

--- a/src/scripts/config/index.ts
+++ b/src/scripts/config/index.ts
@@ -656,6 +656,9 @@ export const PF2ECONFIG = {
     consumableCategories,
     identification: configFromLocalization(EN_JSON.PF2E.identification, "PF2E.identification"),
 
+    /** Base weapons that should always be treated as thrown */
+    thrownBaseWeapons: ["alchemical-bomb"] as const,
+
     preparationType: {
         prepared: "PF2E.PreparationTypePrepared",
         spontaneous: "PF2E.PreparationTypeSpontaneous",


### PR DESCRIPTION
Starfinder needs grenades to be treated as thrown for the purposes of not consuming ammo.