### PR TITLE
Extract lore slug generation to LorePF2e class

### DIFF
--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -886,10 +886,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
         });
 
         // Assemble lore items, key'd by a normalized slug
-        const loreItems = R.mapToObj(this.itemTypes.lore, (loreItem) => {
-            const rawLoreSlug = sluggify(loreItem.name);
-            return [/\blore\b/.test(rawLoreSlug) ? rawLoreSlug : `${rawLoreSlug}-lore`, loreItem];
-        });
+        const loreItems = R.mapToObj(this.itemTypes.lore, (loreItem) =>  [loreItem.generateSlug(), loreItem]);
 
         // Add Lore skills to skill statistics
         for (const [slug, loreItem] of Object.entries(loreItems)) {

--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -886,7 +886,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
         });
 
         // Assemble lore items, key'd by a normalized slug
-        const loreItems = R.mapToObj(this.itemTypes.lore, (loreItem) =>  [loreItem.generateSlug(), loreItem]);
+        const loreItems = R.mapToObj(this.itemTypes.lore, (loreItem) => [loreItem.generateSlug(), loreItem]);
 
         // Add Lore skills to skill statistics
         for (const [slug, loreItem] of Object.entries(loreItems)) {

--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -886,7 +886,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
         });
 
         // Assemble lore items, key'd by a normalized slug
-        const loreItems = R.mapToObj(this.itemTypes.lore, (loreItem) => [loreItem.generateSlug(), loreItem]);
+        const loreItems = R.mapToObj(this.itemTypes.lore, (loreItem) => [loreItem.slug, loreItem]);
 
         // Add Lore skills to skill statistics
         for (const [slug, loreItem] of Object.entries(loreItems)) {

--- a/src/module/actor/npc/document.ts
+++ b/src/module/actor/npc/document.ts
@@ -360,10 +360,7 @@ class NPCPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | nul
         });
 
         // Assemble lore items, key'd by a normalized slug
-        const loreItems = R.mapToObj(this.itemTypes.lore, (loreItem) => {
-            const rawLoreSlug = sluggify(loreItem.name);
-            return [/\blore\b/.test(rawLoreSlug) ? rawLoreSlug : `${rawLoreSlug}-lore`, loreItem];
-        });
+        const loreItems = R.mapToObj(this.itemTypes.lore, (loreItem) =>  [loreItem.generateSlug(), loreItem]);
 
         // Add Lore skills to skill statistics
         for (const [slug, loreItem] of Object.entries(loreItems)) {

--- a/src/module/actor/npc/document.ts
+++ b/src/module/actor/npc/document.ts
@@ -360,7 +360,7 @@ class NPCPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | nul
         });
 
         // Assemble lore items, key'd by a normalized slug
-        const loreItems = R.mapToObj(this.itemTypes.lore, (loreItem) =>  [loreItem.generateSlug(), loreItem]);
+        const loreItems = R.mapToObj(this.itemTypes.lore, (loreItem) => [loreItem.generateSlug(), loreItem]);
 
         // Add Lore skills to skill statistics
         for (const [slug, loreItem] of Object.entries(loreItems)) {

--- a/src/module/actor/npc/document.ts
+++ b/src/module/actor/npc/document.ts
@@ -360,7 +360,7 @@ class NPCPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | nul
         });
 
         // Assemble lore items, key'd by a normalized slug
-        const loreItems = R.mapToObj(this.itemTypes.lore, (loreItem) => [loreItem.generateSlug(), loreItem]);
+        const loreItems = R.mapToObj(this.itemTypes.lore, (loreItem) => [loreItem.slug, loreItem]);
 
         // Add Lore skills to skill statistics
         for (const [slug, loreItem] of Object.entries(loreItems)) {

--- a/src/module/item/lore.ts
+++ b/src/module/item/lore.ts
@@ -5,7 +5,7 @@ import { ZeroToFour } from "@module/data.ts";
 import { sluggify } from "@util";
 
 class LorePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends ItemPF2e<TParent> {
-    generateSlug(): string {
+    override get slug(): string {
         const rawLoreSlug = sluggify(this.name);
         return /\blore\b/.test(rawLoreSlug) ? rawLoreSlug : `${rawLoreSlug}-lore`;
     }

--- a/src/module/item/lore.ts
+++ b/src/module/item/lore.ts
@@ -2,8 +2,14 @@ import type { ActorPF2e } from "@actor";
 import { ItemPF2e, ItemSheetPF2e } from "@item";
 import { BaseItemSourcePF2e, ItemSystemData, ItemSystemSource, OtherTagsOnly } from "@item/base/data/system.ts";
 import { ZeroToFour } from "@module/data.ts";
+import { sluggify } from "@util";
 
-class LorePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends ItemPF2e<TParent> {}
+class LorePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends ItemPF2e<TParent> {
+    generateSlug(){
+        const rawLoreSlug = sluggify(this.name);
+        return /\blore\b/.test(rawLoreSlug) ? rawLoreSlug : `${rawLoreSlug}-lore`;
+    }
+}
 
 interface LorePF2e<TParent extends ActorPF2e | null> extends ItemPF2e<TParent> {
     readonly _source: LoreSource;

--- a/src/module/item/lore.ts
+++ b/src/module/item/lore.ts
@@ -6,7 +6,7 @@ import { sluggify } from "@util";
 
 class LorePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends ItemPF2e<TParent> {
     override get slug(): string {
-        const rawLoreSlug = sluggify(this.name);
+        const rawLoreSlug = super.slug ?? sluggify(this.name);
         return /\blore\b/.test(rawLoreSlug) ? rawLoreSlug : `${rawLoreSlug}-lore`;
     }
 }

--- a/src/module/item/lore.ts
+++ b/src/module/item/lore.ts
@@ -5,7 +5,7 @@ import { ZeroToFour } from "@module/data.ts";
 import { sluggify } from "@util";
 
 class LorePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends ItemPF2e<TParent> {
-    generateSlug(){
+    generateSlug(): string {
         const rawLoreSlug = sluggify(this.name);
         return /\blore\b/.test(rawLoreSlug) ? rawLoreSlug : `${rawLoreSlug}-lore`;
     }


### PR DESCRIPTION
Localizes Lore slug generation in LorePF2e class.

~Intent: that way Lore slug generation can be monkeypatched by localization modules to make them work with REs that target Lore slugs with English names as selectors/predicates (`CONFIG.PF2E.Item.documentClasses.lore.prototype.generateSlug` would be exposed).~
I'm still going to use it to override lore slugs in translation.

Just want to put it in advance of Battlecry release where Warfare Lore is particularly important.