### PR TITLE
Correct typo in `Guardian's Fury` feat roll option

### DIFF
--- a/packs/feats/archetype/ulfen-guard/guards-fury.json
+++ b/packs/feats/archetype/ulfen-guard/guards-fury.json
@@ -49,7 +49,7 @@
             {
                 "key": "RollOption",
                 "label": "PF2E.SpecificRule.UlfenGuard.GuardsFury.ToggleLabel",
-                "option": "guards-gury-adjacent",
+                "option": "guards-fury-adjacent",
                 "predicate": [
                     "self:effect:rage"
                 ],


### PR DESCRIPTION
Closes #19716