### PR TITLE
Fix type error in rule element creation

### DIFF
--- a/src/module/item/effect/document.ts
+++ b/src/module/item/effect/document.ts
@@ -47,7 +47,7 @@ class EffectPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ab
     }
 
     /** Unless this effect is temporarily constructed, ignore rule elements if it is expired */
-    override prepareRuleElements(options?: RuleElementOptions): RuleElementPF2e[] {
+    override prepareRuleElements(options?: Omit<RuleElementOptions, "parent">): RuleElementPF2e[] {
         if (this.isExpired && this.actor?.items.has(this.id)) {
             for (const rule of this.system.rules) {
                 rule.ignored = true;

--- a/src/module/rules/rule-element/base.ts
+++ b/src/module/rules/rule-element/base.ts
@@ -557,6 +557,7 @@ interface ResolveValueParams {
 }
 
 interface RuleElementOptions extends DataModelConstructionContext<ItemPF2e<ActorPF2e>> {
+    parent: ItemPF2e<ActorPF2e>;
     /** If created from an item, the index in the source data */
     sourceIndex?: number;
     /** If data validation fails for any reason, do not emit console warnings */


### PR DESCRIPTION
parent became optional during the v13 beta cycle in the base interface. The change in effect was to make it match the super class's method signature.