### PR TITLE
Pass initial `value` to `Svelecte` in the `SvelectePf2e` component

### DIFF
--- a/src/module/sheet/components/svelecte-pf2e.svelte
+++ b/src/module/sheet/components/svelecte-pf2e.svelte
@@ -44,7 +44,7 @@
     const className = $derived((props.class ?? "" + " pf2e").trim());
 </script>
 
-<Svelecte {...props} class={className} {positionResolver} />
+<Svelecte {...props} {value} class={className} {positionResolver} />
 
 <style>
     :global {


### PR DESCRIPTION
`value` is destructured out of the rest of the `props` to make it bindable but it's never passed to the `Svelecte` component after that.

Closes #19760