### PR TITLE
Add inline healing roll to Rallying Banner

### DIFF
--- a/packs/feats/class/commander/rallying-banner.json
+++ b/packs/feats/class/commander/rallying-banner.json
@@ -12,7 +12,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p><strong>Frequency</strong> once per 10 minutes</p><hr /><p>Your banner waves high, reminding your allies that the fight can still be won. You restore 4d6 Hit Points to each ally within the aura of your commander's banner. This healing increases by an additional 1d6 at 10th level and every 2 levels thereafter.</p>\n<p>Since this healing relies on drawing from your allies' morale and adrenaline, the healing it grants is halved when used outside of combat.</p>"
+            "value": "<p><strong>Frequency</strong> once per 10 minutes</p><hr /><p>Your banner waves high, reminding your allies that the fight can still be won. You restore @Damage[(max(4,(4 + floor((@actor.level - 8)/2))))d6[healing]] Hit Points to each ally within the aura of your commander's banner. This healing increases by an additional 1d6 at 10th level and every 2 levels thereafter.</p>\n<p>Since this healing relies on drawing from your allies' morale and adrenaline, the healing it grants is halved when used outside of combat.</p>"
         },
         "frequency": {
             "max": 1,


### PR DESCRIPTION
Worth noting that healing damage rolls don't support applying half the healing (with the exception of spells like _heal_)