### PR TITLE
Update svelte and svelecte dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,8 @@
                 "nouislider": "^15.8.1",
                 "remeda": "^2.21.3",
                 "sortablejs": "^1.15.6",
-                "svelecte": "^5.2.0",
-                "svelte": "^5.36.13",
+                "svelecte": "^5.2.1",
+                "svelte": "^5.36.17",
                 "uuid": "^11.1.0"
             },
             "devDependencies": {
@@ -8992,18 +8992,18 @@
             }
         },
         "node_modules/svelecte": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/svelecte/-/svelecte-5.2.0.tgz",
-            "integrity": "sha512-xLg32wrb8FMg5scyMjSHl9eETQaI2pH3XfgtmHfZZ7pdo+5IsE7/pPZrF9T0AzTNhZHfbp23AJTqUeIkMTqDgA==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/svelecte/-/svelecte-5.2.1.tgz",
+            "integrity": "sha512-DqKSqWUqKQj8ydNMfPNMph9QkzokgEnp+niUbZiKNOlqeV4kHQcKPzQ/QPjcEu0SAnEAyHVtMy6W1fE35LyPbw==",
             "license": "MIT",
             "peerDependencies": {
                 "svelte": "^5.2.7"
             }
         },
         "node_modules/svelte": {
-            "version": "5.36.13",
-            "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.36.13.tgz",
-            "integrity": "sha512-LnSywHHQM/nJekC65d84T1Yo85IeCYN4AryWYPhTokSvcEAFdYFCfbMhX1mc0zHizT736QQj0nalUk+SXaWrEQ==",
+            "version": "5.36.17",
+            "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.36.17.tgz",
+            "integrity": "sha512-yxJVoHo3Km6+BlQLO3MXrhpZ8eeBuy/UOvEKLkmyQ8QmMFIkL0Hxs+DdmHBgAJazkc9o91TkTPgP6CvGenU1Ig==",
             "license": "MIT",
             "dependencies": {
                 "@ampproject/remapping": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -104,8 +104,8 @@
         "nouislider": "^15.8.1",
         "remeda": "^2.21.3",
         "sortablejs": "^1.15.6",
-        "svelecte": "^5.2.0",
-        "svelte": "^5.36.13",
+        "svelecte": "^5.2.1",
+        "svelte": "^5.36.17",
         "uuid": "^11.1.0"
     }
 }


### PR DESCRIPTION
Most recent svelte patch release, though not most recent. There's nothing we need from the minor release yet.