### PR TITLE
Add traits.value list to commander and guardian classes.

### DIFF
--- a/packs/classes/commander.json
+++ b/packs/classes/commander.json
@@ -219,7 +219,8 @@
             ]
         },
         "traits": {
-            "rarity": "common"
+            "rarity": "common",
+            "value": []
         }
     },
     "type": "class"

--- a/packs/classes/guardian.json
+++ b/packs/classes/guardian.json
@@ -219,7 +219,8 @@
             ]
         },
         "traits": {
-            "rarity": "common"
+            "rarity": "common",
+            "value": []
         }
     },
     "type": "class"


### PR DESCRIPTION
Hey all, I maintain a local sql database with pf2e content for myself and my local group. Saw that commander and guardian classes got added so ran some scripts to rebuild the dataset and noticed it was breaking on the new classes. Appears that other classes have a `value` list that is empty under their `traits` tag but this is missing from the commander and guardian classes. To avoid data drift and arbitrary uniqueness among that classes, this is simply adding that empty list to those 2 new classes. 

Realistically, this list is always empty for all classes. I'm not familiar with the entire codebase itself to know about removing this `traits.value` list from all the classes. However, the commander and guardian classes function fine without it. If that's the case and it is always an empty list for all the classes, removing the key/value might be a good call. 