### PR TITLE
Fix jabali's rarity

### DIFF
--- a/packs/pathfinder-monster-core/jabali.json
+++ b/packs/pathfinder-monster-core/jabali.json
@@ -845,7 +845,7 @@
             }
         },
         "traits": {
-            "rarity": "uncommon",
+            "rarity": "common",
             "size": {
                 "value": "lg"
             },


### PR DESCRIPTION
jabali has to be a common creature. See https://2e.aonprd.com/Monsters.aspx?ID=3004