### PR TITLE
Add class description to Battlecry! iconics and fix path to token texture

### DIFF
--- a/packs/iconics/grimmyr-level-1.json
+++ b/packs/iconics/grimmyr-level-1.json
@@ -2193,7 +2193,7 @@
     "prototypeToken": {
         "name": "Grimmyr",
         "texture": {
-            "src": "systems/pf2e/icons/iconics/GrimmyrFull.web"
+            "src": "systems/pf2e/icons/iconics/GrimmyrFull.webp"
         }
     },
     "system": {

--- a/packs/iconics/grimmyr-level-1.json
+++ b/packs/iconics/grimmyr-level-1.json
@@ -49,7 +49,7 @@
                     "unarmored": 1
                 },
                 "description": {
-                    "value": ""
+                    "value": "<p><em>Death and danger from all manner of enemies threaten all that you and your companions hold dear. But you are the shield, the steel wall that holds back the tide of opposition. You're clad in armor you wear like a second skin and can angle it to protect yourself and your allies from damage and keep foes at bay. Allies look to you to safeguard them, whether they stand beside you on the battlefield or remain on the back lines, and enemies see you for the imposing threat you are. Be it to friend or foe, your presence is difficult to ignore.</em></p>\n<p>@UUID[Compendium.pf2e.journals.JournalEntry.kzxu2dI7tFxv6Ix6.JournalEntryPage.SUwUvef7khs2ZlrK]{Guardian}</p>"
                 },
                 "generalFeatLevels": {
                     "value": [
@@ -2193,7 +2193,7 @@
     "prototypeToken": {
         "name": "Grimmyr",
         "texture": {
-            "src": "systems/pf2e/icons/iconics/Grimmyr.webp"
+            "src": "systems/pf2e/icons/iconics/GrimmyrFull.web"
         }
     },
     "system": {

--- a/packs/iconics/grimmyr-level-3.json
+++ b/packs/iconics/grimmyr-level-3.json
@@ -49,7 +49,7 @@
                     "unarmored": 1
                 },
                 "description": {
-                    "value": ""
+                    "value": "<p><em>Death and danger from all manner of enemies threaten all that you and your companions hold dear. But you are the shield, the steel wall that holds back the tide of opposition. You're clad in armor you wear like a second skin and can angle it to protect yourself and your allies from damage and keep foes at bay. Allies look to you to safeguard them, whether they stand beside you on the battlefield or remain on the back lines, and enemies see you for the imposing threat you are. Be it to friend or foe, your presence is difficult to ignore.</em></p>\n<p>@UUID[Compendium.pf2e.journals.JournalEntry.kzxu2dI7tFxv6Ix6.JournalEntryPage.SUwUvef7khs2ZlrK]{Guardian}</p>"
                 },
                 "generalFeatLevels": {
                     "value": [
@@ -2498,7 +2498,7 @@
     "prototypeToken": {
         "name": "Grimmyr",
         "texture": {
-            "src": "systems/pf2e/icons/iconics/Grimmyr.webp"
+            "src": "systems/pf2e/icons/iconics/GrimmyrFull.webp"
         }
     },
     "system": {

--- a/packs/iconics/grimmyr-level-5.json
+++ b/packs/iconics/grimmyr-level-5.json
@@ -49,7 +49,7 @@
                     "unarmored": 1
                 },
                 "description": {
-                    "value": ""
+                    "value": "<p><em>Death and danger from all manner of enemies threaten all that you and your companions hold dear. But you are the shield, the steel wall that holds back the tide of opposition. You're clad in armor you wear like a second skin and can angle it to protect yourself and your allies from damage and keep foes at bay. Allies look to you to safeguard them, whether they stand beside you on the battlefield or remain on the back lines, and enemies see you for the imposing threat you are. Be it to friend or foe, your presence is difficult to ignore.</em></p>\n<p>@UUID[Compendium.pf2e.journals.JournalEntry.kzxu2dI7tFxv6Ix6.JournalEntryPage.SUwUvef7khs2ZlrK]{Guardian}</p>"
                 },
                 "generalFeatLevels": {
                     "value": [
@@ -2829,7 +2829,7 @@
     "prototypeToken": {
         "name": "Grimmyr",
         "texture": {
-            "src": "systems/pf2e/icons/iconics/Grimmyr.webp"
+            "src": "systems/pf2e/icons/iconics/GrimmyrFull.webp"
         }
     },
     "system": {

--- a/packs/iconics/ulka-level-1.json
+++ b/packs/iconics/ulka-level-1.json
@@ -346,7 +346,7 @@
                     "unarmored": 1
                 },
                 "description": {
-                    "value": ""
+                    "value": "<p><em>You approach battle with the knowledge that tactics and strategy are every bit as crucial as brute strength or numbers. You might have trained in classical theories of warfare and strategy at a military academy, or you might have refined your techniques through hard-won experience as part of an army or mercenary company. Regardless of how you came by your knowledge, you have a gift for signaling your allies from across the battlefield and deploying commands to rout even the most desperate conflicts, empowering your squad to exceed their limits and claim victory.</em></p>\n<p>@UUID[Compendium.pf2e.journals.JournalEntry.kzxu2dI7tFxv6Ix6.JournalEntryPage.BhnMSPWXfCshRvR0]{Commander}</p>"
                 },
                 "generalFeatLevels": {
                     "value": [
@@ -2320,7 +2320,7 @@
     "prototypeToken": {
         "name": "Ulka",
         "texture": {
-            "src": "systems/pf2e/icons/iconics/Ulka.webp"
+            "src": "systems/pf2e/icons/iconics/UlkaFull.webp"
         }
     },
     "system": {

--- a/packs/iconics/ulka-level-3.json
+++ b/packs/iconics/ulka-level-3.json
@@ -346,7 +346,7 @@
                     "unarmored": 1
                 },
                 "description": {
-                    "value": ""
+                    "value": "<p><em>You approach battle with the knowledge that tactics and strategy are every bit as crucial as brute strength or numbers. You might have trained in classical theories of warfare and strategy at a military academy, or you might have refined your techniques through hard-won experience as part of an army or mercenary company. Regardless of how you came by your knowledge, you have a gift for signaling your allies from across the battlefield and deploying commands to rout even the most desperate conflicts, empowering your squad to exceed their limits and claim victory.</em></p>\n<p>@UUID[Compendium.pf2e.journals.JournalEntry.kzxu2dI7tFxv6Ix6.JournalEntryPage.BhnMSPWXfCshRvR0]{Commander}</p>"
                 },
                 "generalFeatLevels": {
                     "value": [
@@ -2645,7 +2645,7 @@
     "prototypeToken": {
         "name": "Ulka",
         "texture": {
-            "src": "systems/pf2e/icons/iconics/Ulka.webp"
+            "src": "systems/pf2e/icons/iconics/UlkaFull.webp"
         }
     },
     "system": {

--- a/packs/iconics/ulka-level-5.json
+++ b/packs/iconics/ulka-level-5.json
@@ -346,7 +346,7 @@
                     "unarmored": 1
                 },
                 "description": {
-                    "value": ""
+                    "value": "<p><em>You approach battle with the knowledge that tactics and strategy are every bit as crucial as brute strength or numbers. You might have trained in classical theories of warfare and strategy at a military academy, or you might have refined your techniques through hard-won experience as part of an army or mercenary company. Regardless of how you came by your knowledge, you have a gift for signaling your allies from across the battlefield and deploying commands to rout even the most desperate conflicts, empowering your squad to exceed their limits and claim victory.</em></p>\n<p>@UUID[Compendium.pf2e.journals.JournalEntry.kzxu2dI7tFxv6Ix6.JournalEntryPage.BhnMSPWXfCshRvR0]{Commander}</p>"
                 },
                 "generalFeatLevels": {
                     "value": [
@@ -3117,7 +3117,7 @@
     "prototypeToken": {
         "name": "Ulka",
         "texture": {
-            "src": "systems/pf2e/icons/iconics/Ulka.webp"
+            "src": "systems/pf2e/icons/iconics/UlkaFull.webp"
         }
     },
     "system": {


### PR DESCRIPTION
Partially addresses #19774, no tokens yet but the path to the fallback image was wrong