### PR TITLE
Fix drag drop after changing active party

### DIFF
--- a/src/module/apps/sidebar/actor-directory.ts
+++ b/src/module/apps/sidebar/actor-directory.ts
@@ -99,6 +99,16 @@ class ActorDirectoryPF2e extends fa.sidebar.tabs.ActorDirectory<ActorPF2e<null>>
         game.settings.set("pf2e", "activePartyFolderState", this.#extraFolders[game.actors.party?.id ?? ""] ?? true);
     }
 
+    override render(options: Partial<HandlebarsRenderOptions> = {}): Promise<this> {
+        // Ensure the entire directory gets re-rendered when the parties are
+        // This prevents drag/drop events from breaking on party only re-renders such as changing the active one
+        if (options.parts && options.parts.includes("parties") && !options.parts.includes("directory")) {
+            options.parts.push("directory");
+        }
+
+        return super.render(options);
+    }
+
     override async _onRender(context: object, options: HandlebarsRenderOptions): Promise<void> {
         // Move the party list into the directory part
         // This must occur before super._onRender() so that drag/drop is registered correctly


### PR DESCRIPTION
drag drop events are registered in DocumentDirectory's _onRender if the change was to a directory partial. To avoid double registration, instead of trying to trick super._onRender(), we re-render the directory list when the parties are updated.