### PR TITLE
Fix TokenImage form opacity and scale inputs

### DIFF
--- a/src/module/item/base/sheet/rule-element-form/token-image.ts
+++ b/src/module/item/base/sheet/rule-element-form/token-image.ts
@@ -1,6 +1,5 @@
 import { RuleElementSource } from "@module/rules/index.ts";
 import type { TokenImageRuleElement } from "@module/rules/rule-element/token-image.ts";
-import { htmlQuery } from "@util";
 import * as R from "remeda";
 import { RuleElementForm, RuleElementFormSheetData, RuleElementFormTabData } from "./base.ts";
 
@@ -23,13 +22,11 @@ class TokenImageForm extends RuleElementForm<RuleElementSource, TokenImageRuleEl
     override activateListeners(html: HTMLElement): void {
         super.activateListeners(html);
 
-        const tintInput = htmlQuery<HTMLInputElement>(html, `input[name="system.rules.${this.index}.tint"]`);
+        const tintInput = html.querySelector<HTMLInputElement>(`input[name="system.rules.${this.index}.tint"]`);
         if (tintInput) tintInput.id = `${this.fieldIdPrefix}-tint`;
-
         for (const fieldName of ["alpha", "scale"] as const) {
-            const checkbox = htmlQuery<HTMLInputElement>(html, `input[data-action=toggle-${fieldName}]`);
-            const input = htmlQuery<HTMLInputElement>(
-                html,
+            const checkbox = html.querySelector<HTMLInputElement>(`input[data-action=toggle-${fieldName}]`);
+            const input = html.querySelector<fa.elements.HTMLRangePickerElement>(
                 `range-picker[name="system.rules.${this.index}.${fieldName}"]`,
             );
             if (!(checkbox && input)) continue;

--- a/src/module/item/base/sheet/rule-element-form/token-image.ts
+++ b/src/module/item/base/sheet/rule-element-form/token-image.ts
@@ -28,7 +28,10 @@ class TokenImageForm extends RuleElementForm<RuleElementSource, TokenImageRuleEl
 
         for (const fieldName of ["alpha", "scale"] as const) {
             const checkbox = htmlQuery<HTMLInputElement>(html, `input[data-action=toggle-${fieldName}]`);
-            const input = htmlQuery<HTMLInputElement>(html, `range-picker[name="system.rules.${this.index}.${fieldName}"]`);
+            const input = htmlQuery<HTMLInputElement>(
+                html,
+                `range-picker[name="system.rules.${this.index}.${fieldName}"]`,
+            );
             if (!(checkbox && input)) continue;
             input.id = `${this.fieldIdPrefix}-${fieldName}`;
             input.disabled = this.object[fieldName] === null;

--- a/src/module/item/base/sheet/rule-element-form/token-image.ts
+++ b/src/module/item/base/sheet/rule-element-form/token-image.ts
@@ -28,7 +28,7 @@ class TokenImageForm extends RuleElementForm<RuleElementSource, TokenImageRuleEl
 
         for (const fieldName of ["alpha", "scale"] as const) {
             const checkbox = htmlQuery<HTMLInputElement>(html, `input[data-action=toggle-${fieldName}]`);
-            const input = htmlQuery<HTMLInputElement>(html, `input[name="system.rules.${this.index}.${fieldName}"]`);
+            const input = htmlQuery<HTMLInputElement>(html, `range-picker[name="system.rules.${this.index}.${fieldName}"]`);
             if (!(checkbox && input)) continue;
             input.id = `${this.fieldIdPrefix}-${fieldName}`;
             input.disabled = this.object[fieldName] === null;


### PR DESCRIPTION
Updates code to recognize the change made to the slider for opacity and scale to be a `range-picker` instead of an `input` from #19019. This allows the checkbox to correctly disable the `range-picker`.