### PR TITLE
Audit automation and formatting on Jotunborn feats

### DIFF
--- a/packs/feat-effects/effect-plane-stepping-dash.json
+++ b/packs/feat-effects/effect-plane-stepping-dash.json
@@ -1,0 +1,44 @@
+{
+    "_id": "3KhE0e2CWU7F27bJ",
+    "img": "icons/skills/movement/feet-winged-boots-glowing-yellow.webp",
+    "name": "Effect: Plane-Stepping Dash",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Plane-Stepping Dash]</p>\n<p>You gain a +5-foot status bonus to your Speed.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "fromSpell": false,
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Battlecry!"
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "selector": "land-speed",
+                "type": "status",
+                "value": 5
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feat-effects/stance-jotuns-battle-stance.json
+++ b/packs/feat-effects/stance-jotuns-battle-stance.json
@@ -29,7 +29,10 @@
                 "predicate": [
                     "item:equipped",
                     "item:melee",
-                    "item:usage:hands:2"
+                    "item:usage:hands:2",
+                    {
+                        "not": "feat:jotuns-heart"
+                    }
                 ],
                 "property": "traits",
                 "value": "reach"

--- a/packs/feats/ancestry/jotunborn/level-1/caretakers-restoration.json
+++ b/packs/feats/ancestry/jotunborn/level-1/caretakers-restoration.json
@@ -12,7 +12,7 @@
         },
         "category": "ancestry",
         "description": {
-            "value": "<p><strong>Frequency</strong> once per day</p>\n<p><strong>Trigger</strong> An item you're holding, wearing, or wielding becomes broken but not destroyed.</p><hr /><p>The stewarding abilities of your forebears allows you to repair objects important to you. The triggering item is restored to a number of Hit Points that is 1 higher than its Broken Threshold. For example, a steel shield with a Broken Threshold of 10 is restored to 11 Hit Points.</p>"
+            "value": "<p><strong>Frequency</strong> once per day</p>\n<p><strong>Trigger</strong> An item you're holding, wearing, or wielding becomes @UUID[Compendium.pf2e.conditionitems.Item.Broken] but not destroyed.</p><hr /><p>The stewarding abilities of your forebears allows you to repair objects important to you. The triggering item is restored to a number of Hit Points that is 1 higher than its Broken Threshold. For example, a steel shield with a Broken Threshold of 10 is restored to 11 Hit Points.</p>"
         },
         "frequency": {
             "max": 1,

--- a/packs/feats/ancestry/jotunborn/level-1/jotunborn-lore.json
+++ b/packs/feats/ancestry/jotunborn/level-1/jotunborn-lore.json
@@ -12,7 +12,7 @@
         },
         "category": "ancestry",
         "description": {
-            "value": "<p>You were taught the history of your people's planar travels as well as the skills necessary to thrive in sub-planar environments. You become trained in Occultism and Survival. If you would automatically become trained in one of those skills (from your background or class, for example), you instead become trained in a skill of your choice. You also gain the @UUID[Compendium.pf2e.feats-srd.Item.Additional Lore] general feat for Jotunborn Lore.</p><hr /><p><strong>Special</strong> If you have the sage jotunborn heritage, you gain the Additional Lore feat a second time for a lore of your choice.</p>"
+            "value": "<p>You were taught the history of your people's planar travels as well as the skills necessary to thrive in sub-planar environments. You become trained in Occultism and Survival. If you would automatically become trained in one of those skills (from your background or class, for example), you instead become trained in a skill of your choice. You also gain the @UUID[Compendium.pf2e.feats-srd.Item.Additional Lore] general feat for Jotunborn Lore.</p><hr /><p><strong>Special</strong> If you have the @UUID[Compendium.pf2e.heritages.Item.Sage Jotunborn] heritage, you gain the Additional Lore feat a second time for a lore of your choice.</p>"
         },
         "level": {
             "value": 1

--- a/packs/feats/ancestry/jotunborn/level-1/jotunborn-weapon-familiarity.json
+++ b/packs/feats/ancestry/jotunborn/level-1/jotunborn-weapon-familiarity.json
@@ -59,28 +59,6 @@
                 "label": "PF2E.SpecificRule.MartialProficiency.AdvancedJotunbornWeapons",
                 "sameAs": "martial",
                 "slug": "advanced-jotunborn-weapons"
-            },
-            {
-                "key": "CriticalSpecialization",
-                "predicate": [
-                    {
-                        "gte": [
-                            "self:level",
-                            5
-                        ]
-                    },
-                    {
-                        "or": [
-                            "item:trait:jotunborn",
-                            "item:base:bola",
-                            "item:base:greataxe",
-                            "item:base:halberd",
-                            "item:base:maul",
-                            "item:base:longspear",
-                            "item:base:war-flail"
-                        ]
-                    }
-                ]
             }
         ],
         "subfeatures": {

--- a/packs/feats/ancestry/jotunborn/level-1/plane-stepping-dash.json
+++ b/packs/feats/ancestry/jotunborn/level-1/plane-stepping-dash.json
@@ -12,7 +12,7 @@
         },
         "category": "ancestry",
         "description": {
-            "value": "<p><strong>Frequency</strong> once per day</p><hr /><p>You move with magical swiftness, treading between planar boundaries to shorten your journey. Stride once; this Stride does not trigger reactions normally triggered by movement. Once this Stride is complete, you gain a +5-foot status bonus to your Speed until the start of your next turn.</p>"
+            "value": "<p><strong>Frequency</strong> once per day</p><hr /><p>You move with magical swiftness, treading between planar boundaries to shorten your journey. Stride once; this Stride does not trigger reactions normally triggered by movement.</p>\n<p>Once this Stride is complete, you gain a +5-foot status bonus to your Speed until the start of your next turn.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Plane-Stepping Dash]</p>"
         },
         "frequency": {
             "max": 1,

--- a/packs/feats/ancestry/jotunborn/level-13/iivlars-boundary-break.json
+++ b/packs/feats/ancestry/jotunborn/level-13/iivlars-boundary-break.json
@@ -25,7 +25,45 @@
             "remaster": true,
             "title": "Pathfinder Battlecry!"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:flicker",
+                    "spellcasting:innate"
+                ],
+                "property": "other-tags",
+                "value": "ancestral-spell"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:flicker",
+                    "spellcasting:innate"
+                ],
+                "property": "other-tags",
+                "value": "ancestral-spell:jotunborn"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:flicker",
+                    "spellcasting:innate"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Jotunborn.IivlarsBoundaryBreak.DescriptionAddendum"
+                    }
+                ]
+            }
+        ],
         "subfeatures": {
             "proficiencies": {},
             "senses": {},

--- a/packs/feats/ancestry/jotunborn/level-13/jotuns-restoration.json
+++ b/packs/feats/ancestry/jotunborn/level-13/jotuns-restoration.json
@@ -12,7 +12,7 @@
         },
         "category": "ancestry",
         "description": {
-            "value": "<p>You've mastered how to tap into your restorative powers at a higher frequency. You can use Caretaker's Restoration once per hour instead of once per day.</p>"
+            "value": "<p>You've mastered how to tap into your restorative powers at a higher frequency. You can use @UUID[Compendium.pf2e.feats-srd.Item.Caretaker's Restoration] once per hour instead of once per day.</p>"
         },
         "level": {
             "value": 13

--- a/packs/feats/ancestry/jotunborn/level-17/jotuns-heart.json
+++ b/packs/feats/ancestry/jotunborn/level-17/jotuns-heart.json
@@ -12,7 +12,7 @@
         },
         "category": "ancestry",
         "description": {
-            "value": "<p>You have unlocked the power of a true giant within you. Your size becomes Huge. You have a 10-foot reach. Your maximum Hit Points increase by your level.</p><hr /><p><strong>Special</strong> When you enter Jotun's Battle Stance, instead of its previous effects, it now increases the reach of any weapon you are wielding, or your fist unarmed attack, by 5 feet.</p>"
+            "value": "<p>You have unlocked the power of a true giant within you. Your size becomes Huge. You have a 10-foot reach. Your maximum Hit Points increase by your level.</p><hr /><p><strong>Special</strong> When you enter @UUID[Compendium.pf2e.feats-srd.Item.Jotun's Battle Stance], instead of its previous effects, it now increases the reach of any weapon you are wielding, or your fist unarmed attack, by 5 feet.</p>"
         },
         "level": {
             "value": 17
@@ -42,6 +42,28 @@
                 "key": "FlatModifier",
                 "selector": "hp",
                 "value": "@actor.level"
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Jotunborn.JotunsHeart.ToggleLabel",
+                "option": "jotuns-heart-reach",
+                "phase": "afterDerived",
+                "predicate": [
+                    "self:effect:jotuns-battle-stance"
+                ],
+                "priority": 19,
+                "toggleable": true,
+                "value": true
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "system.attributes.reach.base",
+                "phase": "afterDerived",
+                "predicate": [
+                    "jotuns-heart-reach"
+                ],
+                "value": 5
             }
         ],
         "subfeatures": {

--- a/packs/feats/ancestry/jotunborn/level-17/jotuns-transposition.json
+++ b/packs/feats/ancestry/jotunborn/level-17/jotuns-transposition.json
@@ -25,7 +25,30 @@
             "remaster": true,
             "title": "Pathfinder Battlecry!"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:interplanar-teleport",
+                    "spellcasting:innate"
+                ],
+                "property": "other-tags",
+                "value": "ancestral-spell"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:interplanar-teleport",
+                    "spellcasting:innate"
+                ],
+                "property": "other-tags",
+                "value": "ancestral-spell:jotunborn"
+            }
+        ],
         "subfeatures": {
             "proficiencies": {},
             "senses": {},

--- a/packs/feats/ancestry/jotunborn/level-5/planar-resilience.json
+++ b/packs/feats/ancestry/jotunborn/level-5/planar-resilience.json
@@ -44,7 +44,7 @@
             {
                 "key": "Resistance",
                 "type": "{item|flags.pf2e.rulesSelections.resistance}",
-                "value": "floor(@actor.level/2)"
+                "value": "max(1,floor(@actor.level / 2))"
             }
         ],
         "subfeatures": {

--- a/packs/feats/ancestry/jotunborn/level-5/pounding-leap.json
+++ b/packs/feats/ancestry/jotunborn/level-5/pounding-leap.json
@@ -29,7 +29,23 @@
             "remaster": true,
             "title": "Pathfinder Battlecry!"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    {
+                        "or": [
+                            "action:high-jump",
+                            "action:long-jump"
+                        ]
+                    },
+                    "pounding-leap"
+                ],
+                "selector": "athletics",
+                "type": "circumstance",
+                "value": 2
+            }
+        ],
         "subfeatures": {
             "proficiencies": {},
             "senses": {},

--- a/packs/feats/ancestry/jotunborn/level-9/iivlars-deflection.json
+++ b/packs/feats/ancestry/jotunborn/level-9/iivlars-deflection.json
@@ -12,7 +12,7 @@
         },
         "category": "ancestry",
         "description": {
-            "value": "<p><strong>Trigger</strong> You are struck by a critical hit that deals physical damage.</p><hr /><p>You're able to use the silk woven into your skin to deflect attacks, reducing the deadliness of grievous blows. Attempt a @Check[flat|dc:17]. If you are successful, the attack becomes a normal hit.</p>"
+            "value": "<p><strong>Trigger</strong> You are struck by a critical hit that deals physical damage.</p><hr /><p>You're able to use the silk woven into your skin to deflect attacks, reducing the deadliness of grievous blows. Attempt a @Check[flat|dc:17|showDC:all]. If you are successful, the attack becomes a normal hit.</p>"
         },
         "level": {
             "value": 9

--- a/packs/feats/ancestry/jotunborn/level-9/plane-step.json
+++ b/packs/feats/ancestry/jotunborn/level-9/plane-step.json
@@ -12,7 +12,7 @@
         },
         "category": "ancestry",
         "description": {
-            "value": "<p>You temporarily move just beyond the threshold of the current plane, granting you concealment until the end of your next turn. You remain clearly visible while stepping outside of a plane in this way and you can't use this concealment to Hide or @UUID[Compendium.pf2e.actionspf2e.Item.Sneak].</p>"
+            "value": "<p>You temporarily move just beyond the threshold of the current plane, granting you @UUID[Compendium.pf2e.conditionitems.Item.Concealed]{Concealment} until the end of your next turn. You remain clearly visible while stepping outside of a plane in this way and you can't use this concealment to @UUID[Compendium.pf2e.actionspf2e.Item.Hide] or @UUID[Compendium.pf2e.actionspf2e.Item.Sneak].</p>"
         },
         "level": {
             "value": 9

--- a/packs/heritages/jotunborn/weaver-jotunborn.json
+++ b/packs/heritages/jotunborn/weaver-jotunborn.json
@@ -10,7 +10,7 @@
             "uuid": "Compendium.pf2e.ancestries.Item.gayvFCiQcGNCA7aM"
         },
         "description": {
-            "value": "<p>You've mastered the art of iivlar silk weaving, a technique that requires a fine attention to detail. You are trained in Crafting. You gain a +1 circumstance bonus to Perception checks to @UUID[Compendium.pf2e.actionspf2e.Item.Seek] when searching for @UUID[Compendium.pf2e.conditionitems.Item.Hidden] details like secret doors or traps.</p>"
+            "value": "<p>You've mastered the art of iivlar silk weaving, a technique that requires a fine attention to detail. You are trained in Crafting. You gain a +1 circumstance bonus to Perception checks to @UUID[Compendium.pf2e.actionspf2e.Item.Seek] when searching for hidden details like secret doors or traps.</p>"
         },
         "publication": {
             "license": "ORC",
@@ -22,6 +22,16 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.skills.crafting.rank",
+                "value": 1
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "action:seek",
+                    "secret-doors-or-traps"
+                ],
+                "selector": "perception",
+                "type": "circumstance",
                 "value": 1
             }
         ],

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -4680,6 +4680,14 @@
                 }
             },
             "ItemStrike": "{item} Strike",
+            "Jotunborn": {
+                "IivlarsBoundaryBreak": {
+                    "DescriptionAddendum": "When you Sustain this spell, increase the distance you teleport to 15 feet."
+                },
+                "JotunsHeart": {
+                    "ToggleLabel": "Jotun's Heart — Increase reach of weapon or fist"
+                }
+            },
             "KeepPace": {
                 "BountyHunter": "When your hunted prey tries to bolt, you follow. You Stride up to your Speed, following your hunted prey and keeping it in reach throughout its movement until it stops moving or you've moved your full Speed. You can use Keep Pace to @UUID[Compendium.pf2e.actionspf2e.Item.H6v1VgowHaKHnVlG]{Burrow}, @UUID[Compendium.pf2e.actionspf2e.Item.pprgrYQ1QnIDGZiy]{Climb}, @UUID[Compendium.pf2e.actionspf2e.Item.cS9nfDRGD83bNU1p]{Fly}, or @UUID[Compendium.pf2e.actionspf2e.Item.c8TGiZ48ygoSPofx]{Swim} instead of Stride if you have the appropriate movement type.",
                 "GameHunter": "Once you are upon your prey, they can't escape. @UUID[Compendium.pf2e.actionspf2e.Item.Bcxarzksqt9ezrs6]{Stride} up to your Speed, following the foe and keeping it in reach throughout its movement until it stops moving or you've moved your full Speed. You can use Keep Pace to @UUID[Compendium.pf2e.actionspf2e.Item.H6v1VgowHaKHnVlG]{Burrow}, @UUID[Compendium.pf2e.actionspf2e.Item.pprgrYQ1QnIDGZiy]{Climb}, @UUID[Compendium.pf2e.actionspf2e.Item.cS9nfDRGD83bNU1p]{Fly}, or @UUID[Compendium.pf2e.actionspf2e.Item.c8TGiZ48ygoSPofx]{Swim} instead of Stride if you have the corresponding movement type.",


### PR DESCRIPTION
For Plane-Stepping Dash I didn't make it a self effect since the speed bonus occurs only after the Stride, which I think a self effect would create a weird workflow for.

In Jotun's Heart, the Roll Option toggle is left as `true` on purpose since more often than not the user will be attacking using a weapon or their fists rather than an unaffected unarmed attack.