### PR TITLE
Add Toggle Compendium Browser keybinding

### DIFF
--- a/src/scripts/register-keybindings.ts
+++ b/src/scripts/register-keybindings.ts
@@ -41,6 +41,25 @@ export function registerKeybindings(): void {
         },
     });
 
+    game.keybindings.register("pf2e", "open-compendium-browser", {
+        name: "PF2E.Keybinding.OpenCompendiumBrowser.Label",
+        hint: "PF2E.Keybinding.OpenCompendiumBrowser.Hint",
+        editable: [],
+        onDown: (): boolean => {
+            const cb = game.pf2e.compendiumBrowser;
+            if (cb.rendered) {
+                if (cb.minimized) {
+                    cb.maximize();
+                } else {
+                    cb.close();
+                }
+            } else {
+                cb.render({ force: true });
+            }
+            return true;
+        },
+    });
+
     // Defer to the GM Vision module if enabled
     if (!game.modules.get("gm-vision")?.active) {
         game.keybindings.register("pf2e", "gmVision", {

--- a/src/scripts/register-keybindings.ts
+++ b/src/scripts/register-keybindings.ts
@@ -41,6 +41,8 @@ export function registerKeybindings(): void {
         },
     });
 
+    // Record the last tab that was open
+    let previousCompendiumBrowserTab = "";
     game.keybindings.register("pf2e", "open-compendium-browser", {
         name: "PF2E.Keybinding.OpenCompendiumBrowser.Label",
         hint: "PF2E.Keybinding.OpenCompendiumBrowser.Hint",
@@ -51,8 +53,11 @@ export function registerKeybindings(): void {
                 if (cb.minimized) {
                     cb.maximize();
                 } else {
+                    previousCompendiumBrowserTab = cb.element.querySelector("nav .active")?.dataset.tabName ?? "";
                     cb.close();
                 }
+            } else if (previousCompendiumBrowserTab) {
+                cb.tabs[previousCompendiumBrowserTab].open();
             } else {
                 cb.render({ force: true });
             }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2818,6 +2818,10 @@
                 "Hint": "Place a waypoint while using drag measurement.",
                 "Label": "Place Waypoint (Drag Measurement)"
             },
+            "OpenCompendiumBrowser": {
+                "Hint": "Open or close the compendium browser.",
+                "Label": "Toggle Compendium Browser"
+            },
             "TogglePartySheet": {
                 "Hint": "Open or close the sheet of the active or (if a player) assigned party.",
                 "Label": "Toggle Party Sheet"


### PR DESCRIPTION
Adds an unbound keybinding that opens/closes the Compendium Browser.

It follows the same logic as the Toggle Party Sheet keybinding, where the CB will be maximized instead of closed if it were minimized, otherwise following the open/close logic.

It records the last opened tab (if any) to re-open the CB at that tab instead of re-opening at the initial "blank" state for a better UX since the user will not want to re-activate the tab on each toggle.