### PR TITLE
Condense various Parry feat effects

### DIFF
--- a/packs/equipment-effects/effect-parry.json
+++ b/packs/equipment-effects/effect-parry.json
@@ -36,6 +36,7 @@
                 "predicate": [
                     {
                         "or": [
+                            "feat:defensive-armaments",
                             "feat:extravagant-parry",
                             "feat:twin-parry"
                         ]

--- a/packs/equipment-effects/effect-parry.json
+++ b/packs/equipment-effects/effect-parry.json
@@ -4,7 +4,7 @@
     "name": "Effect: Parry",
     "system": {
         "description": {
-            "value": "<p>You gain a +1 circumstance bonus to AC.</p>"
+            "value": "<p>You gain a circumstance bonus to AC.</p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -21,6 +21,30 @@
             "title": "Pathfinder Player Core"
         },
         "rules": [
+            {
+                "choices": [
+                    {
+                        "label": "PF2E.UI.RuleElements.ChoiceSet.NoLabel",
+                        "value": "no"
+                    },
+                    {
+                        "label": "PF2E.UI.RuleElements.ChoiceSet.YesLabel",
+                        "value": "yes"
+                    }
+                ],
+                "key": "ChoiceSet",
+                "predicate": [
+                    {
+                        "or": [
+                            "feat:extravagant-parry",
+                            "feat:twin-parry"
+                        ]
+                    },
+                    "hands-free:0"
+                ],
+                "prompt": "PF2E.SpecificRule.Parry.Prompt",
+                "rollOption": "parry-bonus-upgrade"
+            },
             {
                 "key": "FlatModifier",
                 "selector": "ac",

--- a/packs/equipment-effects/effect-parry.json
+++ b/packs/equipment-effects/effect-parry.json
@@ -34,14 +34,7 @@
                 ],
                 "key": "ChoiceSet",
                 "predicate": [
-                    {
-                        "or": [
-                            "feat:defensive-armaments",
-                            "feat:extravagant-parry",
-                            "feat:twin-parry"
-                        ]
-                    },
-                    "hands-free:0"
+                    "weapon-parry"
                 ],
                 "prompt": "PF2E.SpecificRule.Parry.Prompt",
                 "rollOption": "parry-bonus-upgrade"

--- a/packs/feats/class/fighter/dueling-parry.json
+++ b/packs/feats/class/fighter/dueling-parry.json
@@ -25,10 +25,36 @@
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "AdjustModifier",
+                "mode": "upgrade",
+                "predicate": [
+                    {
+                        "gte": [
+                            "hands-free",
+                            1
+                        ]
+                    }
+                ],
+                "selector": "ac",
+                "slug": "parry-bonus",
+                "value": 2
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "override",
+                "predicate": [
+                    "hands-free:0"
+                ],
+                "selector": "ac",
+                "slug": "parry-bonus",
+                "value": 0
+            }
+        ],
         "selfEffect": {
-            "name": "Effect: Dueling Parry",
-            "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Dueling Parry"
+            "name": "Effect: Parry",
+            "uuid": "Compendium.pf2e.equipment-effects.Item.Effect: Parry"
         },
         "traits": {
             "rarity": "common",

--- a/packs/feats/class/gunslinger/defensive-armaments.json
+++ b/packs/feats/class/gunslinger/defensive-armaments.json
@@ -55,6 +55,10 @@
                 "type": "splash"
             },
             {
+                "key": "RollOption",
+                "option": "weapon-parry"
+            },
+            {
                 "key": "AdjustModifier",
                 "mode": "upgrade",
                 "predicate": [

--- a/packs/feats/class/gunslinger/defensive-armaments.json
+++ b/packs/feats/class/gunslinger/defensive-armaments.json
@@ -53,6 +53,16 @@
                     "self:effect:parry"
                 ],
                 "type": "splash"
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "upgrade",
+                "predicate": [
+                    "parry-bonus-upgrade:yes"
+                ],
+                "selector": "ac",
+                "slug": "parry-bonus",
+                "value": 2
             }
         ],
         "traits": {

--- a/packs/feats/class/shared-class-feats/twin-parry.json
+++ b/packs/feats/class/shared-class-feats/twin-parry.json
@@ -45,6 +45,10 @@
                 "selector": "ac",
                 "slug": "parry-bonus",
                 "value": 2
+            },
+            {
+                "key": "RollOption",
+                "option": "weapon-parry"
             }
         ],
         "selfEffect": {

--- a/packs/feats/class/shared-class-feats/twin-parry.json
+++ b/packs/feats/class/shared-class-feats/twin-parry.json
@@ -12,7 +12,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p><strong>Requirements</strong> You are wielding two melee weapons, one in each hand.</p>\n<hr />\n<p>You use your two weapons to parry attacks. You gain a +1 circumstance bonus to AC until the start of your next turn, or a +2 circumstance bonus if either weapon has the parry trait. You lose this circumstance bonus if you no longer meet this feat's requirement.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Twin Parry]</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Twin Parry (Parry Trait)]</p>"
+            "value": "<p><strong>Requirements</strong> You are wielding two melee weapons, one in each hand.</p><hr /><p>You use your two weapons to parry attacks. You gain a +1 circumstance bonus to AC until the start of your next turn, or a +2 circumstance bonus if either weapon has the parry trait. You lose this circumstance bonus if you no longer meet this feat's requirement.</p>"
         },
         "level": {
             "value": 4
@@ -25,13 +25,37 @@
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "AdjustModifier",
+                "mode": "upgrade",
+                "predicate": [
+                    {
+                        "or": [
+                            {
+                                "gte": [
+                                    "hands-free",
+                                    1
+                                ]
+                            },
+                            "parry-bonus-upgrade:yes"
+                        ]
+                    }
+                ],
+                "selector": "ac",
+                "slug": "parry-bonus",
+                "value": 2
+            }
+        ],
+        "selfEffect": {
+            "name": "Effect: Parry",
+            "uuid": "Compendium.pf2e.equipment-effects.Item.Effect: Parry"
+        },
         "traits": {
             "rarity": "common",
             "value": [
                 "fighter",
-                "ranger",
-                "swashbuckler"
+                "ranger"
             ]
         }
     },

--- a/packs/feats/class/swashbuckler/extravagant-parry.json
+++ b/packs/feats/class/swashbuckler/extravagant-parry.json
@@ -45,6 +45,10 @@
                 "selector": "ac",
                 "slug": "parry-bonus",
                 "value": 2
+            },
+            {
+                "key": "RollOption",
+                "option": "weapon-parry"
             }
         ],
         "selfEffect": {

--- a/packs/feats/class/swashbuckler/extravagant-parry.json
+++ b/packs/feats/class/swashbuckler/extravagant-parry.json
@@ -25,10 +25,31 @@
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "AdjustModifier",
+                "mode": "upgrade",
+                "predicate": [
+                    {
+                        "or": [
+                            {
+                                "gte": [
+                                    "hands-free",
+                                    1
+                                ]
+                            },
+                            "parry-bonus-upgrade:yes"
+                        ]
+                    }
+                ],
+                "selector": "ac",
+                "slug": "parry-bonus",
+                "value": 2
+            }
+        ],
         "selfEffect": {
-            "name": "Effect: Dueling Parry",
-            "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Dueling Parry"
+            "name": "Effect: Parry",
+            "uuid": "Compendium.pf2e.equipment-effects.Item.Effect: Parry"
         },
         "traits": {
             "rarity": "common",

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -5254,6 +5254,9 @@
             "PackAttack": {
                 "Label": "Target is Within Range of At Least Two Allies"
             },
+            "Parry": {
+                "Prompt": "Weapon has the parry trait?"
+            },
             "PathfinderAgentDedication": {
                 "ThoroughReports": "Thorough Reports"
             },

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -5255,7 +5255,7 @@
                 "Label": "Target is Within Range of At Least Two Allies"
             },
             "Parry": {
-                "Prompt": "Weapon has the parry trait?"
+                "Prompt": "Are you wielding a weapon with the parry trait?"
             },
             "PathfinderAgentDedication": {
                 "ThoroughReports": "Thorough Reports"


### PR DESCRIPTION
Feats tackled in this PR:
- Defensive Armaments (thanks @Mikkidez)
- Dueling Parry
- Extravagant Parry
- Twin Parry


I did not delete and redirect the effects, as those might need a migration. If that is not the case, let me know.