### PR TITLE
Remove non-exclusive class archetypes from early class feature selection

### DIFF
--- a/packs/classfeatures/animistic-practice.json
+++ b/packs/classfeatures/animistic-practice.json
@@ -29,25 +29,7 @@
                 "adjustName": false,
                 "choices": {
                     "filter": [
-                        "item:tag:animistic-practice",
-                        {
-                            "or": [
-                                {
-                                    "and": [
-                                        "class:animist",
-                                        "item:tag:animistic-practice"
-                                    ]
-                                },
-                                {
-                                    "and": [
-                                        "item:tag:animistic-practice",
-                                        {
-                                            "not": "item:tag:class-archetype"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
+                        "item:tag:animistic-practice"
                     ],
                     "itemType": "feat"
                 },

--- a/packs/classfeatures/arcane-school.json
+++ b/packs/classfeatures/arcane-school.json
@@ -29,25 +29,7 @@
                 "adjustName": false,
                 "choices": {
                     "filter": [
-                        "item:tag:wizard-arcane-school",
-                        {
-                            "or": [
-                                {
-                                    "and": [
-                                        "class:wizard",
-                                        "item:tag:wizard-arcane-school"
-                                    ]
-                                },
-                                {
-                                    "and": [
-                                        "item:tag:wizard-arcane-school",
-                                        {
-                                            "not": "item:tag:class-archetype"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
+                        "item:tag:wizard-arcane-school"
                     ]
                 },
                 "flag": "arcaneSchool",

--- a/packs/classfeatures/bloodline.json
+++ b/packs/classfeatures/bloodline.json
@@ -29,25 +29,7 @@
                 "adjustName": false,
                 "choices": {
                     "filter": [
-                        "item:tag:sorcerer-bloodline",
-                        {
-                            "or": [
-                                {
-                                    "and": [
-                                        "class:sorcerer",
-                                        "item:tag:sorcerer-bloodline"
-                                    ]
-                                },
-                                {
-                                    "and": [
-                                        "item:tag:sorcerer-bloodline",
-                                        {
-                                            "not": "item:tag:class-archetype"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
+                        "item:tag:sorcerer-bloodline"
                     ]
                 },
                 "flag": "bloodline",

--- a/packs/classfeatures/cause.json
+++ b/packs/classfeatures/cause.json
@@ -29,7 +29,6 @@
                 "adjustName": false,
                 "choices": {
                     "filter": [
-                        "item:type:feature",
                         "item:tag:champion-cause",
                         {
                             "or": [
@@ -49,24 +48,6 @@
                                     "nor": [
                                         "item:tag:holy",
                                         "item:tag:unholy"
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "or": [
-                                {
-                                    "and": [
-                                        "class:champion",
-                                        "item:tag:champion-cause"
-                                    ]
-                                },
-                                {
-                                    "and": [
-                                        "item:tag:champion-cause",
-                                        {
-                                            "not": "item:tag:class-archetype"
-                                        }
                                     ]
                                 }
                             ]

--- a/packs/classfeatures/conscious-mind.json
+++ b/packs/classfeatures/conscious-mind.json
@@ -29,25 +29,7 @@
                 "adjustName": false,
                 "choices": {
                     "filter": [
-                        "item:tag:psychic-conscious-mind",
-                        {
-                            "or": [
-                                {
-                                    "and": [
-                                        "class:psychic",
-                                        "item:tag:psychic-conscious-mind"
-                                    ]
-                                },
-                                {
-                                    "and": [
-                                        "item:tag:psychic-conscious-mind",
-                                        {
-                                            "not": "item:tag:class-archetype"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
+                        "item:tag:psychic-conscious-mind"
                     ]
                 },
                 "flag": "consciousMind",

--- a/packs/classfeatures/doctrine.json
+++ b/packs/classfeatures/doctrine.json
@@ -29,25 +29,7 @@
                 "adjustName": false,
                 "choices": {
                     "filter": [
-                        "item:tag:cleric-doctrine",
-                        {
-                            "or": [
-                                {
-                                    "and": [
-                                        "class:cleric",
-                                        "item:tag:cleric-doctrine"
-                                    ]
-                                },
-                                {
-                                    "and": [
-                                        "item:tag:cleric-doctrine",
-                                        {
-                                            "not": "item:tag:class-archetype"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
+                        "item:tag:cleric-doctrine"
                     ]
                 },
                 "flag": "doctrine",

--- a/packs/classfeatures/druidic-order.json
+++ b/packs/classfeatures/druidic-order.json
@@ -29,25 +29,7 @@
                 "adjustName": false,
                 "choices": {
                     "filter": [
-                        "item:tag:druid-order",
-                        {
-                            "or": [
-                                {
-                                    "and": [
-                                        "class:druid",
-                                        "item:tag:druid-order"
-                                    ]
-                                },
-                                {
-                                    "and": [
-                                        "item:tag:druid-order",
-                                        {
-                                            "not": "item:tag:class-archetype"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
+                        "item:tag:druid-order"
                     ]
                 },
                 "flag": "druidicOrder",

--- a/packs/classfeatures/elemental-magic.json
+++ b/packs/classfeatures/elemental-magic.json
@@ -45,126 +45,6 @@
                 "rollOption": "elementalist"
             },
             {
-                "adjustName": false,
-                "choices": {
-                    "filter": [
-                        "item:tag:druid-order",
-                        {
-                            "not": "item:tag:class-archetype"
-                        }
-                    ]
-                },
-                "flag": "druidicOrder",
-                "key": "ChoiceSet",
-                "predicate": [
-                    "class:druid"
-                ],
-                "prompt": "PF2E.SpecificRule.Druid.DruidicOrder.Prompt"
-            },
-            {
-                "key": "GrantItem",
-                "predicate": [
-                    "class:druid"
-                ],
-                "uuid": "{item|flags.pf2e.rulesSelections.druidicOrder}"
-            },
-            {
-                "adjustName": false,
-                "choices": {
-                    "filter": [
-                        "item:tag:witch-elementalist-patron",
-                        {
-                            "not": "item:tag:class-archetype"
-                        }
-                    ]
-                },
-                "flag": "patron",
-                "key": "ChoiceSet",
-                "predicate": [
-                    "class:witch"
-                ],
-                "prompt": "PF2E.SpecificRule.Witch.Patron.Prompt"
-            },
-            {
-                "key": "GrantItem",
-                "predicate": [
-                    "class:witch"
-                ],
-                "uuid": "{item|flags.pf2e.rulesSelections.patron}"
-            },
-            {
-                "adjustName": false,
-                "choices": {
-                    "filter": [
-                        "item:tag:sorcerer-bloodline",
-                        {
-                            "not": "item:tag:class-archetype"
-                        }
-                    ]
-                },
-                "flag": "bloodline",
-                "key": "ChoiceSet",
-                "predicate": [
-                    "class:sorcerer"
-                ],
-                "prompt": "PF2E.SpecificRule.Sorcerer.Bloodline.Prompt"
-            },
-            {
-                "key": "GrantItem",
-                "predicate": [
-                    "class:sorcerer"
-                ],
-                "uuid": "{item|flags.pf2e.rulesSelections.bloodline}"
-            },
-            {
-                "adjustName": false,
-                "choices": {
-                    "filter": [
-                        "item:tag:magus-hybrid-study",
-                        {
-                            "not": "item:tag:class-archetype"
-                        }
-                    ]
-                },
-                "flag": "hybridStudy",
-                "key": "ChoiceSet",
-                "predicate": [
-                    "class:magus"
-                ],
-                "prompt": "PF2E.SpecificRule.Magus.HybridStudy.Prompt"
-            },
-            {
-                "key": "GrantItem",
-                "predicate": [
-                    "class:magus"
-                ],
-                "uuid": "{item|flags.pf2e.rulesSelections.hybridStudy}"
-            },
-            {
-                "adjustName": false,
-                "choices": {
-                    "filter": [
-                        "item:tag:wizard-elemental-school",
-                        {
-                            "not": "item:tag:class-archetype"
-                        }
-                    ]
-                },
-                "flag": "arcaneSchool",
-                "key": "ChoiceSet",
-                "predicate": [
-                    "class:wizard"
-                ],
-                "prompt": "PF2E.SpecificRule.Wizard.ArcaneSchool.Prompt"
-            },
-            {
-                "key": "GrantItem",
-                "predicate": [
-                    "class:wizard"
-                ],
-                "uuid": "{item|flags.pf2e.rulesSelections.arcaneSchool}"
-            },
-            {
                 "flag": "elementalistDedication",
                 "key": "GrantItem",
                 "predicate": [
@@ -181,12 +61,7 @@
         ],
         "traits": {
             "otherTags": [
-                "class-archetype",
-                "druid-order",
-                "magus-hybrid-study",
-                "sorcerer-bloodline",
-                "witch-patron",
-                "wizard-arcane-school"
+                "class-archetype"
             ],
             "rarity": "common",
             "value": []

--- a/packs/classfeatures/flexible-spell-preparation.json
+++ b/packs/classfeatures/flexible-spell-preparation.json
@@ -30,102 +30,6 @@
         },
         "rules": [
             {
-                "adjustName": false,
-                "choices": {
-                    "filter": [
-                        "item:tag:cleric-doctrine",
-                        {
-                            "not": "item:tag:class-archetype"
-                        }
-                    ]
-                },
-                "flag": "doctrine",
-                "key": "ChoiceSet",
-                "predicate": [
-                    "class:cleric"
-                ],
-                "prompt": "PF2E.SpecificRule.Cleric.Doctrine.Prompt"
-            },
-            {
-                "key": "GrantItem",
-                "predicate": [
-                    "class:cleric"
-                ],
-                "uuid": "{item|flags.pf2e.rulesSelections.doctrine}"
-            },
-            {
-                "adjustName": false,
-                "choices": {
-                    "filter": [
-                        "item:tag:druid-order",
-                        {
-                            "not": "item:tag:class-archetype"
-                        }
-                    ]
-                },
-                "flag": "druidicOrder",
-                "key": "ChoiceSet",
-                "predicate": [
-                    "class:druid"
-                ],
-                "prompt": "PF2E.SpecificRule.Druid.DruidicOrder.Prompt"
-            },
-            {
-                "key": "GrantItem",
-                "predicate": [
-                    "class:druid"
-                ],
-                "uuid": "{item|flags.pf2e.rulesSelections.druidicOrder}"
-            },
-            {
-                "adjustName": false,
-                "choices": {
-                    "filter": [
-                        "item:tag:witch-patron",
-                        {
-                            "not": "item:tag:class-archetype"
-                        }
-                    ]
-                },
-                "flag": "patron",
-                "key": "ChoiceSet",
-                "predicate": [
-                    "class:witch"
-                ],
-                "prompt": "PF2E.SpecificRule.Witch.Patron.Prompt"
-            },
-            {
-                "key": "GrantItem",
-                "predicate": [
-                    "class:witch"
-                ],
-                "uuid": "{item|flags.pf2e.rulesSelections.patron}"
-            },
-            {
-                "adjustName": false,
-                "choices": {
-                    "filter": [
-                        "item:tag:wizard-arcane-school",
-                        {
-                            "not": "item:tag:class-archetype"
-                        }
-                    ]
-                },
-                "flag": "arcaneSchool",
-                "key": "ChoiceSet",
-                "predicate": [
-                    "class:wizard"
-                ],
-                "prompt": "PF2E.SpecificRule.Wizard.ArcaneSchool.Prompt"
-            },
-            {
-                "key": "GrantItem",
-                "predicate": [
-                    "class:wizard"
-                ],
-                "uuid": "{item|flags.pf2e.rulesSelections.arcaneSchool}"
-            },
-            {
                 "flag": "flexibleSpellcasterDedication",
                 "key": "GrantItem",
                 "predicate": [
@@ -142,11 +46,7 @@
         ],
         "traits": {
             "otherTags": [
-                "class-archetype",
-                "cleric-doctrine",
-                "druid-order",
-                "witch-patron",
-                "wizard-arcane-school"
+                "class-archetype"
             ],
             "rarity": "common",
             "value": []

--- a/packs/classfeatures/gunslingers-way.json
+++ b/packs/classfeatures/gunslingers-way.json
@@ -29,25 +29,7 @@
                 "adjustName": false,
                 "choices": {
                     "filter": [
-                        "item:tag:gunslinger-way",
-                        {
-                            "or": [
-                                {
-                                    "and": [
-                                        "class:gunslinger",
-                                        "item:tag:gunslinger-way"
-                                    ]
-                                },
-                                {
-                                    "and": [
-                                        "item:tag:gunslinger-way",
-                                        {
-                                            "not": "item:tag:class-archetype"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
+                        "item:tag:gunslinger-way"
                     ]
                 },
                 "flag": "way",

--- a/packs/classfeatures/hunters-edge.json
+++ b/packs/classfeatures/hunters-edge.json
@@ -29,25 +29,7 @@
                 "adjustName": false,
                 "choices": {
                     "filter": [
-                        "item:tag:ranger-hunters-edge",
-                        {
-                            "or": [
-                                {
-                                    "and": [
-                                        "class:ranger",
-                                        "item:tag:ranger-hunters-edge"
-                                    ]
-                                },
-                                {
-                                    "and": [
-                                        "item:tag:ranger-hunters-edge",
-                                        {
-                                            "not": "item:tag:class-archetype"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
+                        "item:tag:ranger-hunters-edge"
                     ]
                 },
                 "flag": "huntersEdge",

--- a/packs/classfeatures/hybrid-study.json
+++ b/packs/classfeatures/hybrid-study.json
@@ -29,25 +29,7 @@
                 "adjustName": false,
                 "choices": {
                     "filter": [
-                        "item:tag:magus-hybrid-study",
-                        {
-                            "or": [
-                                {
-                                    "and": [
-                                        "class:magus",
-                                        "item:tag:magus-hybrid-study"
-                                    ]
-                                },
-                                {
-                                    "and": [
-                                        "item:tag:magus-hybrid-study",
-                                        {
-                                            "not": "item:tag:class-archetype"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
+                        "item:tag:magus-hybrid-study"
                     ]
                 },
                 "flag": "hybridStudy",

--- a/packs/classfeatures/innovation.json
+++ b/packs/classfeatures/innovation.json
@@ -29,25 +29,7 @@
                 "adjustName": false,
                 "choices": {
                     "filter": [
-                        "item:tag:inventor-innovation",
-                        {
-                            "or": [
-                                {
-                                    "and": [
-                                        "class:inventor",
-                                        "item:tag:inventor-innovation"
-                                    ]
-                                },
-                                {
-                                    "and": [
-                                        "item:tag:inventor-innovation",
-                                        {
-                                            "not": "item:tag:class-archetype"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
+                        "item:tag:inventor-innovation"
                     ]
                 },
                 "flag": "innovation",

--- a/packs/classfeatures/instinct.json
+++ b/packs/classfeatures/instinct.json
@@ -29,25 +29,7 @@
                 "adjustName": false,
                 "choices": {
                     "filter": [
-                        "item:tag:barbarian-instinct",
-                        {
-                            "or": [
-                                {
-                                    "and": [
-                                        "class:barbarian",
-                                        "item:tag:barbarian-instinct"
-                                    ]
-                                },
-                                {
-                                    "and": [
-                                        "item:tag:barbarian-instinct",
-                                        {
-                                            "not": "item:tag:class-archetype"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
+                        "item:tag:barbarian-instinct"
                     ]
                 },
                 "flag": "instinct",

--- a/packs/classfeatures/light-mortar-innovation.json
+++ b/packs/classfeatures/light-mortar-innovation.json
@@ -55,6 +55,7 @@
         },
         "traits": {
             "otherTags": [
+                "class-archetype",
                 "inventor-innovation"
             ],
             "rarity": "common",

--- a/packs/classfeatures/methodology.json
+++ b/packs/classfeatures/methodology.json
@@ -29,25 +29,7 @@
                 "adjustName": false,
                 "choices": {
                     "filter": [
-                        "item:tag:investigator-methodology",
-                        {
-                            "or": [
-                                {
-                                    "and": [
-                                        "class:investigator",
-                                        "item:tag:investigator-methodology"
-                                    ]
-                                },
-                                {
-                                    "and": [
-                                        "item:tag:investigator-methodology",
-                                        {
-                                            "not": "item:tag:class-archetype"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
+                        "item:tag:investigator-methodology"
                     ]
                 },
                 "flag": "methodology",

--- a/packs/classfeatures/muses.json
+++ b/packs/classfeatures/muses.json
@@ -29,34 +29,16 @@
                 "adjustName": false,
                 "choices": {
                     "filter": [
-                        "item:tag:bard-muse",
-                        {
-                            "or": [
-                                {
-                                    "and": [
-                                        "class:bard",
-                                        "item:tag:bard-muse"
-                                    ]
-                                },
-                                {
-                                    "and": [
-                                        "item:tag:bard-muse",
-                                        {
-                                            "not": "item:tag:class-archetype"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
+                        "item:tag:bard-muse"
                     ]
                 },
-                "flag": "muses",
+                "flag": "muse",
                 "key": "ChoiceSet",
                 "prompt": "PF2E.SpecificRule.Bard.Muse.Prompt"
             },
             {
                 "key": "GrantItem",
-                "uuid": "{item|flags.pf2e.rulesSelections.muses}"
+                "uuid": "{item|flags.pf2e.rulesSelections.muse}"
             }
         ],
         "traits": {

--- a/packs/classfeatures/mystery.json
+++ b/packs/classfeatures/mystery.json
@@ -29,25 +29,7 @@
                 "adjustName": false,
                 "choices": {
                     "filter": [
-                        "item:tag:oracle-mystery",
-                        {
-                            "or": [
-                                {
-                                    "and": [
-                                        "class:oracle",
-                                        "item:tag:oracle-mystery"
-                                    ]
-                                },
-                                {
-                                    "and": [
-                                        "item:tag:oracle-mystery",
-                                        {
-                                            "not": "item:tag:class-archetype"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
+                        "item:tag:oracle-mystery"
                     ]
                 },
                 "flag": "mystery",

--- a/packs/classfeatures/patron.json
+++ b/packs/classfeatures/patron.json
@@ -29,25 +29,7 @@
                 "adjustName": false,
                 "choices": {
                     "filter": [
-                        "item:tag:witch-patron",
-                        {
-                            "or": [
-                                {
-                                    "and": [
-                                        "class:witch",
-                                        "item:tag:witch-patron"
-                                    ]
-                                },
-                                {
-                                    "and": [
-                                        "item:tag:witch-patron",
-                                        {
-                                            "not": "item:tag:class-archetype"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
+                        "item:tag:witch-patron"
                     ]
                 },
                 "flag": "patron",

--- a/packs/classfeatures/research-field.json
+++ b/packs/classfeatures/research-field.json
@@ -29,25 +29,7 @@
                 "adjustName": false,
                 "choices": {
                     "filter": [
-                        "item:tag:alchemist-research-field",
-                        {
-                            "or": [
-                                {
-                                    "and": [
-                                        "class:alchemist",
-                                        "item:tag:alchemist-research-field"
-                                    ]
-                                },
-                                {
-                                    "and": [
-                                        "item:tag:alchemist-research-field",
-                                        {
-                                            "not": "item:tag:class-archetype"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
+                        "item:tag:alchemist-research-field"
                     ]
                 },
                 "flag": "researchField",

--- a/packs/classfeatures/rogues-racket.json
+++ b/packs/classfeatures/rogues-racket.json
@@ -29,25 +29,7 @@
                 "adjustName": false,
                 "choices": {
                     "filter": [
-                        "item:tag:rogue-racket",
-                        {
-                            "or": [
-                                {
-                                    "and": [
-                                        "class:rogue",
-                                        "item:tag:rogue-racket"
-                                    ]
-                                },
-                                {
-                                    "and": [
-                                        "item:tag:rogue-racket",
-                                        {
-                                            "not": "item:tag:class-archetype"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
+                        "item:tag:rogue-racket"
                     ]
                 },
                 "flag": "roguesRacket",

--- a/packs/classfeatures/seneschal.json
+++ b/packs/classfeatures/seneschal.json
@@ -38,12 +38,25 @@
                 ],
                 "reevaluateOnUpdate": true,
                 "uuid": "Compendium.pf2e.feats-srd.Item.Seneschal Witch Dedication"
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:tag:witch-patron"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Witch.Seneschal.AdjustmentsAddendum"
+                    }
+                ]
             }
         ],
         "traits": {
             "otherTags": [
-                "class-archetype",
-                "witch-patron"
+                "class-archetype"
             ],
             "rarity": "common",
             "value": [

--- a/packs/classfeatures/subconscious-mind.json
+++ b/packs/classfeatures/subconscious-mind.json
@@ -29,25 +29,7 @@
                 "adjustName": false,
                 "choices": {
                     "filter": [
-                        "item:tag:psychic-subconscious-mind",
-                        {
-                            "or": [
-                                {
-                                    "and": [
-                                        "class:psychic",
-                                        "item:tag:psychic-subconscious-mind"
-                                    ]
-                                },
-                                {
-                                    "and": [
-                                        "item:tag:psychic-subconscious-mind",
-                                        {
-                                            "not": "item:tag:class-archetype"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
+                        "item:tag:psychic-subconscious-mind"
                     ]
                 },
                 "flag": "subconsciousMind",

--- a/packs/classfeatures/swashbucklers-style.json
+++ b/packs/classfeatures/swashbucklers-style.json
@@ -29,25 +29,7 @@
                 "adjustName": false,
                 "choices": {
                     "filter": [
-                        "item:tag:swashbuckler-style",
-                        {
-                            "or": [
-                                {
-                                    "and": [
-                                        "class:swashbuckler",
-                                        "item:tag:swashbuckler-style"
-                                    ]
-                                },
-                                {
-                                    "and": [
-                                        "item:tag:swashbuckler-style",
-                                        {
-                                            "not": "item:tag:class-archetype"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
+                        "item:tag:swashbuckler-style"
                     ]
                 },
                 "flag": "swashbucklersStyle",

--- a/packs/classfeatures/wellspring-magic.json
+++ b/packs/classfeatures/wellspring-magic.json
@@ -161,10 +161,7 @@
         ],
         "traits": {
             "otherTags": [
-                "bard-muse",
-                "class-archetype",
-                "oracle-mystery",
-                "sorcerer-bloodline"
+                "class-archetype"
             ],
             "rarity": "common",
             "value": []

--- a/packs/feats/archetype/barbarian/barbarian-dedication.json
+++ b/packs/feats/archetype/barbarian/barbarian-dedication.json
@@ -40,8 +40,22 @@
                 "value": 1
             },
             {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        "item:tag:barbarian-instinct",
+                        {
+                            "not": "item:tag:class-archetype"
+                        }
+                    ]
+                },
+                "flag": "instinct",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Barbarian.Instinct.Prompt"
+            },
+            {
                 "key": "GrantItem",
-                "uuid": "Compendium.pf2e.classfeatures.Item.Instinct"
+                "uuid": "{item|flags.pf2e.rulesSelections.instinct}"
             },
             {
                 "key": "GrantItem",

--- a/packs/feats/archetype/bard/bard-dedication.json
+++ b/packs/feats/archetype/bard/bard-dedication.json
@@ -33,7 +33,10 @@
             {
                 "choices": {
                     "filter": [
-                        "item:tag:bard-muse"
+                        "item:tag:bard-muse",
+                        {
+                            "not": "item:tag:class-archetype"
+                        }
                     ],
                     "slugsAsValues": true
                 },

--- a/packs/feats/archetype/champion/champion-dedication.json
+++ b/packs/feats/archetype/champion/champion-dedication.json
@@ -97,8 +97,44 @@
                 "uuid": "Compendium.pf2e.classfeatures.Item.Deity (Champion)"
             },
             {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        "item:tag:champion-cause",
+                        {
+                            "or": [
+                                {
+                                    "and": [
+                                        "item:tag:holy",
+                                        "sanctification:holy"
+                                    ]
+                                },
+                                {
+                                    "and": [
+                                        "item:tag:unholy",
+                                        "sanctification:unholy"
+                                    ]
+                                },
+                                {
+                                    "nor": [
+                                        "item:tag:holy",
+                                        "item:tag:unholy"
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "not": "item:tag:class-archetype"
+                        }
+                    ]
+                },
+                "flag": "cause",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.DeityAndCause.Prompt"
+            },
+            {
                 "key": "GrantItem",
-                "uuid": "Compendium.pf2e.classfeatures.Item.Cause"
+                "uuid": "{item|flags.pf2e.rulesSelections.cause}"
             },
             {
                 "key": "ActiveEffectLike",

--- a/packs/feats/archetype/druid/druid-dedication.json
+++ b/packs/feats/archetype/druid/druid-dedication.json
@@ -37,8 +37,22 @@
                 "value": 1
             },
             {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        "item:tag:druid-order",
+                        {
+                            "not": "item:tag:class-archetype"
+                        }
+                    ]
+                },
+                "flag": "druidicOrder",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Druid.DruidicOrder.Prompt"
+            },
+            {
                 "key": "GrantItem",
-                "uuid": "Compendium.pf2e.classfeatures.Item.Druidic Order"
+                "uuid": "{item|flags.pf2e.rulesSelections.druidicOrder}"
             }
         ],
         "subfeatures": {

--- a/packs/feats/archetype/gunslinger/gunslinger-dedication.json
+++ b/packs/feats/archetype/gunslinger/gunslinger-dedication.json
@@ -31,8 +31,22 @@
         },
         "rules": [
             {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        "item:tag:gunslinger-way",
+                        {
+                            "not": "item:tag:class-archetype"
+                        }
+                    ]
+                },
+                "flag": "way",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Gunslinger.Way.Prompt"
+            },
+            {
                 "key": "GrantItem",
-                "uuid": "Compendium.pf2e.classfeatures.Item.Gunslinger's Way"
+                "uuid": "{item|flags.pf2e.rulesSelections.way}"
             },
             {
                 "definition": [

--- a/packs/feats/archetype/inventor/inventor-dedication.json
+++ b/packs/feats/archetype/inventor/inventor-dedication.json
@@ -41,8 +41,22 @@
                 "uuid": "Compendium.pf2e.feats-srd.Item.Inventor"
             },
             {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        "item:tag:inventor-innovation",
+                        {
+                            "not": "item:tag:class-archetype"
+                        }
+                    ]
+                },
+                "flag": "innovation",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Inventor.Innovation.Prompt"
+            },
+            {
                 "key": "GrantItem",
-                "uuid": "Compendium.pf2e.classfeatures.Item.Innovation"
+                "uuid": "{item|flags.pf2e.rulesSelections.innovation}"
             },
             {
                 "key": "ActiveEffectLike",

--- a/packs/feats/archetype/investigator/investigator-dedication.json
+++ b/packs/feats/archetype/investigator/investigator-dedication.json
@@ -12,7 +12,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>You gain the @UUID[Compendium.pf2e.classfeatures.Item.On the Case] class feature, which grants you both the Pursue a Lead activity and Clue In reaction. You become trained in Society and another skill of your choice. If you were already trained in Society, you instead become trained in an additional skill of your choice. You also become trained in investigator class DC.</p>\n<p>@UUID[Compendium.pf2e.journals.JournalEntry.vx5FGEG34AxI2dow.JournalEntryPage.mmB3EkkdCpLke7Lk]{Investigator}</p>"
+            "value": "<p>You gain the @UUID[Compendium.pf2e.classfeatures.Item.On the Case] class feature, which grants you both the @UUID[Compendium.pf2e.actionspf2e.Item.Pursue a Lead] activity and @UUID[Compendium.pf2e.actionspf2e.Item.Clue In] reaction. You become trained in Society and another skill of your choice. If you were already trained in Society, you instead become trained in an additional skill of your choice. You also become trained in investigator class DC.</p>\n<p>@UUID[Compendium.pf2e.journals.JournalEntry.vx5FGEG34AxI2dow.JournalEntryPage.mmB3EkkdCpLke7Lk]{Investigator}</p>"
         },
         "level": {
             "value": 2

--- a/packs/feats/archetype/oracle/oracle-dedication.json
+++ b/packs/feats/archetype/oracle/oracle-dedication.json
@@ -37,8 +37,22 @@
                 "value": 1
             },
             {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        "item:tag:oracle-mystery",
+                        {
+                            "not": "item:tag:class-archetype"
+                        }
+                    ]
+                },
+                "flag": "mystery",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Oracle.Mystery.Prompt"
+            },
+            {
                 "key": "GrantItem",
-                "uuid": "Compendium.pf2e.classfeatures.Item.Mystery"
+                "uuid": "{item|flags.pf2e.rulesSelections.mystery}"
             },
             {
                 "key": "GrantItem",

--- a/packs/feats/archetype/psychic/psychic-dedication.json
+++ b/packs/feats/archetype/psychic/psychic-dedication.json
@@ -43,6 +43,20 @@
                 "value": 1
             },
             {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        "item:tag:psychic-conscious-mind",
+                        {
+                            "not": "item:tag:class-archetype"
+                        }
+                    ]
+                },
+                "flag": "consciousMind",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.ConsciousMind"
+            },
+            {
                 "key": "GrantItem",
                 "uuid": "Compendium.pf2e.classfeatures.Item.Conscious Mind"
             },

--- a/packs/feats/archetype/sorcerer/sorcerer-dedication.json
+++ b/packs/feats/archetype/sorcerer/sorcerer-dedication.json
@@ -31,8 +31,22 @@
         },
         "rules": [
             {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        "item:tag:sorcerer-bloodline",
+                        {
+                            "not": "item:tag:class-archetype"
+                        }
+                    ]
+                },
+                "flag": "bloodline",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Sorcerer.Bloodline.Prompt"
+            },
+            {
                 "key": "GrantItem",
-                "uuid": "Compendium.pf2e.classfeatures.Item.Bloodline"
+                "uuid": "{item|flags.pf2e.rulesSelections.bloodline}"
             }
         ],
         "subfeatures": {

--- a/packs/feats/archetype/swashbuckler/swashbuckler-dedication.json
+++ b/packs/feats/archetype/swashbuckler/swashbuckler-dedication.json
@@ -34,8 +34,22 @@
         },
         "rules": [
             {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        "item:tag:swashbuckler-style",
+                        {
+                            "not": "item:tag:class-archetype"
+                        }
+                    ]
+                },
+                "flag": "swashbucklersStyle",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Swashbuckler.Style.Prompt"
+            },
+            {
                 "key": "GrantItem",
-                "uuid": "Compendium.pf2e.classfeatures.Item.Swashbuckler's Style"
+                "uuid": "{item|flags.pf2e.rulesSelections.swashbucklersStyle}"
             },
             {
                 "adjustName": false,

--- a/packs/feats/archetype/witch/witch-dedication.json
+++ b/packs/feats/archetype/witch/witch-dedication.json
@@ -31,8 +31,22 @@
         },
         "rules": [
             {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        "item:tag:witch-patron",
+                        {
+                            "not": "item:tag:class-archetype"
+                        }
+                    ]
+                },
+                "flag": "patron",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Witch.Patron.Prompt"
+            },
+            {
                 "key": "GrantItem",
-                "uuid": "Compendium.pf2e.classfeatures.Item.Patron"
+                "uuid": "{item|flags.pf2e.rulesSelections.patron}"
             },
             {
                 "key": "GrantItem",

--- a/packs/feats/class/druid/order-explorer.json
+++ b/packs/feats/class/druid/order-explorer.json
@@ -31,7 +31,10 @@
                 "adjustName": false,
                 "choices": {
                     "filter": [
-                        "item:tag:druid-order"
+                        "item:tag:druid-order",
+                        {
+                            "not": "item:tag:class-archetype"
+                        }
                     ]
                 },
                 "flag": "order",

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -6841,6 +6841,9 @@
                         "WildingSteward": "Wilding Steward"
                     }
                 },
+                "Seneschal": {
+                    "AdjustmentsAddendum": "Instead of your patron's lesson, you gain the @UUID[Compendium.pf2e.spells-srd.Item.IqBfoUaWDennHYoZ]{Manifest Will} hex cantrip and your familiar learns one common 1st-rank spell of your choice from your spell list."
+                },
                 "SympatheticStrike": {
                     "Note": "Until the beginning of your next turn, the target takes a –1 circumstance penalty to its saves against your hexes, or a –2 penalty if the triggering Strike was a critical hit. @UUID[Compendium.pf2e.feat-effects.Item.qBTJYpopY3AwFFUJ]{Effect: Sympathetic Strike}"
                 },


### PR DESCRIPTION
This essentially removes the Wellspring Magic, Elementalist, and Flexible Spellcasting archetypes from class feature selections such as arcane schools and druidic orders. The intent for now is that users should make sure their characters have a valid combination of these features on their own, rather than trying to enforce it ourselves.

This PR also adds or alters Choice Sets in class features and dedication feats so that the latter ones check that a class archetype feature isn't selected, instead of having that filter in the class feature Choice Set.

Finally, this also removes the witch patron tag from Seneschal witch. The class archetype doesn't replace your patron, it merely adjusts its lesson, meaning that for example, Seneschal witches still have their patron's familiar abilities.