### PR TITLE
Fix tokens not updating for non-owners

### DIFF
--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -513,7 +513,7 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
         super._onRelatedUpdate(update, operation);
 
         const { actor, scene } = this;
-        if (!actor?.isOwner || !(scene instanceof ScenePF2e)) return;
+        if (!actor || !(scene instanceof ScenePF2e)) return;
 
         // Follow up any actor (or descendant document thereof) modification with a size synchronization
         const activeGM = game.users.activeGM; // Let the active GM take care of updates if available


### PR DESCRIPTION
I don't know the complete reasoning behind change from #19500, but this `isOwner` check prevents updates from TokenImage and TokenLight showing to any player who doesn't own the token until they refresh their browser or the scene is reloaded.