### PR TITLE
Fix the level of primal howl feat

### DIFF
--- a/packs/feats/class/druid/primal-howl.json
+++ b/packs/feats/class/druid/primal-howl.json
@@ -15,7 +15,7 @@
             "value": "<p>Your companion can let out a howl laced with your primal magic. It gains the @UUID[Compendium.pf2e.actionspf2e.Item.Primal Howl] advanced maneuver, in addition to any advanced maneuvers it already knows.</p>"
         },
         "level": {
-            "value": 8
+            "value": 10
         },
         "prerequisites": {
             "value": [


### PR DESCRIPTION
Level 10 in player core. (Errata checked). Thanks to Darny