### PR TITLE
Use modifier instead of total DC on inline DC AdjustModifier upgrades

### DIFF
--- a/packs/feats/archetype/crossbow-infiltrator/lethargy-poisoner.json
+++ b/packs/feats/archetype/crossbow-infiltrator/lethargy-poisoner.json
@@ -70,7 +70,7 @@
                     }
                 ],
                 "selector": "inline-dc",
-                "value": "@actor.system.attributes.classDC.dc"
+                "value": "@actor.system.attributes.classDC.totalModifier"
             }
         ],
         "traits": {

--- a/packs/feats/archetype/guerrilla/level-4/snare-expert.json
+++ b/packs/feats/archetype/guerrilla/level-4/snare-expert.json
@@ -44,7 +44,7 @@
                     "item:trait:snare"
                 ],
                 "selector": "inline-dc",
-                "value": "@actor.system.attributes.classDC.dc"
+                "value": "@actor.system.attributes.classDC.totalModifier"
             }
         ],
         "subfeatures": {


### PR DESCRIPTION
Using `dc` as the value was upgrading the DCs to 10 more than they should