### PR TITLE
Widen Clue In's Flat Modifier selector to apply to any check

### DIFF
--- a/packs/feat-effects/effect-clue-in.json
+++ b/packs/feat-effects/effect-clue-in.json
@@ -4,7 +4,7 @@
     "name": "Effect: Clue In",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.actionspf2e.Item.Clue In]</p>\n<p>Whenever you attempt a Perception or skill check to investigate a designated subject, you gain a +1 circumstance bonus to the check.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.actionspf2e.Item.Clue In]</p>\n<p>You gain a +1 circumstance bonus to your check. If the origin has investigator expertise, this bonus increases to +2.</p>"
         },
         "duration": {
             "expiry": null,
@@ -23,27 +23,8 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "predicate": [
-                    {
-                        "or": [
-                            {
-                                "not": "check:type:saving-throw"
-                            },
-                            {
-                                "and": [
-                                    "check:type:saving-throw",
-                                    "parent:origin:item:tag:detectives-readiness"
-                                ]
-                            }
-                        ]
-                    }
-                ],
                 "removeAfterRoll": "if-enabled",
-                "selector": [
-                    "perception",
-                    "skill-check",
-                    "saving-throw"
-                ],
+                "selector": "check",
                 "slug": "clue-in",
                 "type": "circumstance",
                 "value": 1
@@ -54,11 +35,7 @@
                 "predicate": [
                     "parent:origin:item:tag:investigator-expertise"
                 ],
-                "selectors": [
-                    "skill-check",
-                    "perception",
-                    "saving-throw"
-                ],
+                "selector": "check",
                 "slug": "clue-in",
                 "value": 2
             }

--- a/packs/feats/class/investigator/detectives-readiness.json
+++ b/packs/feats/class/investigator/detectives-readiness.json
@@ -33,20 +33,9 @@
                 "predicate": [
                     "item:slug:clue-in"
                 ],
-                "property": "other-tags",
-                "value": "detectives-readiness"
-            },
-            {
-                "itemType": "action",
-                "key": "ItemAlteration",
-                "mode": "add",
-                "predicate": [
-                    "item:slug:clue-in"
-                ],
                 "property": "description",
                 "value": [
                     {
-                        "divider": true,
                         "text": "PF2E.SpecificRule.Investigator.DetectivesReadiness.ClueInAddendum"
                     }
                 ]


### PR DESCRIPTION
Closes #19840 

Since the effect should only be added if the bonus *can* be used, we're fine to open it up and let GMs decide when players are allowed to use it. This also removes Detective's Readiness Clue In automation, which is superfluous with this implementation.