### PR TITLE
Grant Tactics feature with Commander Dedication

### DIFF
--- a/packs/classfeatures/tactics.json
+++ b/packs/classfeatures/tactics.json
@@ -85,10 +85,16 @@
                 },
                 "flag": "thirdTactic",
                 "key": "ChoiceSet",
+                "predicate": [
+                    "class:commander"
+                ],
                 "prompt": "PF2E.SpecificRule.Commander.Tactics.Prompt"
             },
             {
                 "key": "GrantItem",
+                "predicate": [
+                    "class:commander"
+                ],
                 "uuid": "{item|flags.pf2e.rulesSelections.thirdTactic}"
             },
             {
@@ -107,10 +113,16 @@
                 },
                 "flag": "fourthTactic",
                 "key": "ChoiceSet",
+                "predicate": [
+                    "class:commander"
+                ],
                 "prompt": "PF2E.SpecificRule.Commander.Tactics.Prompt"
             },
             {
                 "key": "GrantItem",
+                "predicate": [
+                    "class:commander"
+                ],
                 "uuid": "{item|flags.pf2e.rulesSelections.fourthTactic}"
             },
             {
@@ -129,10 +141,16 @@
                 },
                 "flag": "fifthTactic",
                 "key": "ChoiceSet",
+                "predicate": [
+                    "class:commander"
+                ],
                 "prompt": "PF2E.SpecificRule.Commander.Tactics.Prompt"
             },
             {
                 "key": "GrantItem",
+                "predicate": [
+                    "class:commander"
+                ],
                 "uuid": "{item|flags.pf2e.rulesSelections.fifthTactic}"
             }
         ],

--- a/packs/feats/archetype/commander/commander-dedication.json
+++ b/packs/feats/archetype/commander/commander-dedication.json
@@ -47,48 +47,8 @@
                 "traits": []
             },
             {
-                "adjustName": false,
-                "choices": {
-                    "filter": [
-                        "item:trait:tactic",
-                        {
-                            "or": [
-                                "item:tag:commander-mobility-tactic",
-                                "item:tag:commander-offensive-tactic"
-                            ]
-                        }
-                    ],
-                    "itemType": "action"
-                },
-                "flag": "firstTactic",
-                "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.Commander.Tactics.Prompt"
-            },
-            {
                 "key": "GrantItem",
-                "uuid": "{item|flags.pf2e.rulesSelections.firstTactic}"
-            },
-            {
-                "adjustName": false,
-                "choices": {
-                    "filter": [
-                        "item:trait:tactic",
-                        {
-                            "or": [
-                                "item:tag:commander-mobility-tactic",
-                                "item:tag:commander-offensive-tactic"
-                            ]
-                        }
-                    ],
-                    "itemType": "action"
-                },
-                "flag": "secondTactic",
-                "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.Commander.Tactics.Prompt"
-            },
-            {
-                "key": "GrantItem",
-                "uuid": "{item|flags.pf2e.rulesSelections.secondTactic}"
+                "uuid": "Compendium.pf2e.classfeatures.Item.Tactics"
             }
         ],
         "subfeatures": {


### PR DESCRIPTION
Instead of duplicating Choice Sets, the dedication says you gain the tactics class feature, and so we restrict the existing REs in that feature accordingly instead