### PR TITLE
Extend modular logic to allow for more configuration setups

### DIFF
--- a/packs/equipment/switchscythe.json
+++ b/packs/equipment/switchscythe.json
@@ -66,7 +66,8 @@
             "rarity": "uncommon",
             "value": [
                 "fatal-d10",
-                "gnome"
+                "gnome",
+                "modular-p-grapple-s-sweep"
             ]
         },
         "usage": {

--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -1125,7 +1125,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
         // Process again (first done during weapon data preparation) in case of late-arriving strike adjustment
         processTwoHandTrait(weapon);
         const weaponTraits = weapon.traits;
-        const weaponRollOptions = new Set(weapon.getRollOptions("item"));
+                const weaponRollOptions = new Set(weapon.getRollOptions("item"));
         const proficiencyRank = getItemProficiencyRank(this, weapon, weaponRollOptions);
         const meleeOrRanged = weapon.isMelee ? "melee" : "ranged";
         const baseOptions = [

--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -1125,7 +1125,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
         // Process again (first done during weapon data preparation) in case of late-arriving strike adjustment
         processTwoHandTrait(weapon);
         const weaponTraits = weapon.traits;
-                const weaponRollOptions = new Set(weapon.getRollOptions("item"));
+        const weaponRollOptions = new Set(weapon.getRollOptions("item"));
         const proficiencyRank = getItemProficiencyRank(this, weapon, weaponRollOptions);
         const meleeOrRanged = weapon.isMelee ? "melee" : "ranged";
         const baseOptions = [

--- a/src/module/actor/character/helpers.ts
+++ b/src/module/actor/character/helpers.ts
@@ -196,10 +196,7 @@ class WeaponAuxiliaryAction {
     get options(): SheetOptions | null {
         if (this.annotation === "modular") {
             const toggles = this.weapon.system.traits.toggles;
-            return createSheetOptions(
-                R.pick(CONFIG.PF2E.damageTypes, toggles.modular.options),
-                [toggles.modular.selected ?? []].flat(),
-            );
+            return createSheetOptions(toggles.modularTraitConfigs, [toggles.modular.selected ?? []].flat());
         }
         return null;
     }
@@ -214,7 +211,7 @@ class WeaponAuxiliaryAction {
 
         if (this.carryType) {
             await actor.changeCarryType(this.weapon, { carryType: this.carryType, handsHeld: this.hands ?? 0 });
-        } else if (selection && tupleHasValue(weapon.system.traits.toggles.modular.options, selection)) {
+        } else if (selection && weapon.system.traits.toggles.modular.options.includes(selection)) {
             const updated = await weapon.system.traits.toggles.update({ trait: "modular", selected: selection });
             if (!updated) return;
         } else if (this.action === "raise-a-shield") {

--- a/src/module/item/weapon/data.ts
+++ b/src/module/item/weapon/data.ts
@@ -96,7 +96,7 @@ interface WeaponTraitsSource extends PhysicalItemTraits<WeaponTrait> {
     otherTags: OtherWeaponTag[];
     toggles?: {
         doubleBarrel?: { selected: boolean };
-        modular?: { selected: DamageType | null };
+        modular?: { selected: string | null };
         versatile?: { selected: DamageType | null };
     };
 }
@@ -181,7 +181,7 @@ interface ComboWeaponMeleeUsage {
     damage: { type: DamageType; die: DamageDieSize };
     group: MeleeWeaponGroup;
     traits?: WeaponTrait[];
-    traitToggles?: { modular: DamageType | null; versatile: DamageType | null };
+    traitToggles?: { modular: string | null; versatile: DamageType | null };
 }
 
 export type {

--- a/src/module/item/weapon/document.ts
+++ b/src/module/item/weapon/document.ts
@@ -169,7 +169,7 @@ class WeaponPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
             // add options
             damageType:
                 this.system.traits.toggles.versatile.selected ??
-                this.system.traits.toggles.modular.selected ??
+                this.system.traits.toggles.modularConfigData?.damageType ??
                 this.system.damage.damageType,
         };
     }

--- a/src/module/item/weapon/document.ts
+++ b/src/module/item/weapon/document.ts
@@ -544,7 +544,9 @@ class WeaponPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
 
     /** Generate a clone of this thrown melee weapon with its thrown usage overlain, or `null` if not applicable */
     private toThrownUsage(): this | null {
-        const traits = this._source.system.traits.value;
+        const traits = this._source.system.traits.value.concat(
+            this.system.traits.toggles.modularConfigData?.traits ?? [],
+        );
         const thrownTrait = traits.find((t) => /^thrown-\d{1,3}$/.test(t));
         if (this.isRanged || !thrownTrait) return null;
 

--- a/src/module/item/weapon/trait-toggles.ts
+++ b/src/module/item/weapon/trait-toggles.ts
@@ -33,7 +33,7 @@ class WeaponTraitToggles {
         const weapon = this.parent;
         const modulars = weapon.system.traits.value.filter((trait) => trait.startsWith("modular"));
         if (modulars.length === 0) return {};
-        const configs = modulars.map((trait) => CONFIG.PF2E.modularConfigs[trait]);
+        const configs = modulars.map((trait) => CONFIG.PF2E.modularConfigurations[trait]);
         if (configs.length === 0) return {};
         if (configs.length > 1) {
             throw ErrorPF2e("weapon with multiple valid modular traits found");

--- a/src/module/item/weapon/trait-toggles.ts
+++ b/src/module/item/weapon/trait-toggles.ts
@@ -2,8 +2,9 @@ import type { ActorPF2e } from "@actor";
 import type { WeaponPF2e } from "@item";
 import { nextDamageDieSize } from "@system/damage/helpers.ts";
 import type { DamageType } from "@system/damage/types.ts";
-import { objectHasKey, tupleHasValue } from "@util";
+import { ErrorPF2e, objectHasKey, tupleHasValue } from "@util";
 import { upgradeWeaponTrait } from "./helpers.ts";
+import { ModularConfig } from "@scripts/config/modular.ts";
 
 /** A helper class to handle toggleable weapon traits */
 class WeaponTraitToggles {
@@ -27,18 +28,51 @@ class WeaponTraitToggles {
         return { selected };
     }
 
-    get modular(): { options: DamageType[]; selected: DamageType | null } {
+    /** Gets all the valid configurations for the weapon's modular trait */
+    get modularTraitConfigs(): Record<string, ModularConfig> {
         const weapon = this.parent;
-        const options = this.#resolveOptions("modular");
+        const modulars = weapon.system.traits.value.filter((trait) => trait.startsWith("modular"));
+        if (modulars.length === 0) return {};
+        const configs = modulars.map((trait) => CONFIG.PF2E.modularConfigs[trait]);
+        if (configs.length === 0) return {};
+        if (configs.length > 1) {
+            throw ErrorPF2e("weapon with multiple valid modular traits found");
+        }
+
+        return configs[0];
+    }
+
+    get modular(): { options: string[]; selected: string | null } {
+        const weapon = this.parent;
+
+        const configs = this.modularTraitConfigs;
+
         const sourceSelection = weapon._source.system.traits.toggles?.modular?.selected;
-        const selected = tupleHasValue(options, sourceSelection)
-            ? sourceSelection
-            : // If the weapon's damage type is represented among the modular options, set the selection to it
-              options.includes(weapon.system.damage.damageType)
-              ? weapon.system.damage.damageType
-              : null;
+        const selected = this.#resolveChosenModularConfig(sourceSelection);
+        const options = Object.keys(configs);
 
         return { options, selected };
+    }
+
+    /** Gets the selected modular configuration's data */
+    get modularConfigData(): ModularConfig | null {
+        return this.modular.selected ? this.modularTraitConfigs[this.modular.selected] : null;
+    }
+
+    /** Chooses a modular config based on selection, or default damage type if applicable */
+    #resolveChosenModularConfig(selection: string | null | undefined): string | null {
+        const configs = this.modularTraitConfigs;
+        if (selection && configs[selection]) return selection;
+
+        const defaultDamageType = this.parent.system.damage.damageType;
+        for (const configKey in configs) {
+            if (Object.prototype.hasOwnProperty.call(configs, configKey)) {
+                const element = configs[configKey];
+                if (element.damageType && element.damageType === defaultDamageType) return configKey;
+            }
+        }
+
+        return null;
     }
 
     get versatile(): { options: DamageType[]; selected: DamageType | null } {
@@ -50,13 +84,11 @@ class WeaponTraitToggles {
     }
 
     /** Collect selectable damage types among a list of toggleable weapon traits */
-    #resolveOptions(toggle: "modular" | "versatile"): DamageType[] {
+    #resolveOptions(toggle: "versatile"): DamageType[] {
         const weapon = this.parent;
         const types = weapon.system.traits.value
             .filter((t) => t.startsWith(toggle))
             .flatMap((trait): DamageType | DamageType[] => {
-                if (trait === "modular") return ["bludgeoning", "piercing", "slashing"];
-
                 const damageType = /^versatile-(\w+)$/.exec(trait)?.at(1);
                 switch (damageType) {
                     case "b":
@@ -72,14 +104,18 @@ class WeaponTraitToggles {
             });
 
         const allOptions = Array.from(new Set(types));
-        return toggle === "modular"
-            ? allOptions
-            : // Filter out any versatile options that are the same as the weapon's base damage type
-              allOptions.filter((t) => weapon.system.damage.damageType !== t);
+        // Filter out any versatile options that are the same as the weapon's base damage type
+        return allOptions.filter((t) => weapon.system.damage.damageType !== t);
     }
 
     applyChanges(): void {
         const weapon = this.parent;
+
+        if (this.modular.selected) {
+            const traits = weapon.system.traits;
+            traits.value = traits.value.concat(this.modularConfigData?.traits as typeof traits.value);
+        }
+
         if (this.doubleBarrel.selected && !weapon.flags.pf2e.damageFacesUpgraded) {
             weapon.system.damage.die &&= nextDamageDieSize({ upgrade: weapon.system.damage.die });
             const traits = weapon.system.traits;
@@ -125,11 +161,16 @@ interface ToggleDoubleBarrelParams {
     selected: boolean;
 }
 
-interface ToggleModularVersatileParams {
-    trait: "modular" | "versatile";
+interface ToggleVersatileParams {
+    trait: "versatile";
     selected: DamageType | null;
 }
 
-type ToggleWeaponTraitParams = ToggleDoubleBarrelParams | ToggleModularVersatileParams;
+interface ToggleModularParams {
+    trait: "modular";
+    selected: string;
+}
+
+type ToggleWeaponTraitParams = ToggleDoubleBarrelParams | ToggleVersatileParams | ToggleModularParams;
 
 export { WeaponTraitToggles };

--- a/src/module/rules/rule-element/strike.ts
+++ b/src/module/rules/rule-element/strike.ts
@@ -409,7 +409,7 @@ interface StrikeSource extends RuleElementSource {
 
 interface UpdateToggleParams {
     trait: "modular" | "versatile";
-    selected: DamageType | null;
+    selected: string | null;
 }
 
 export { StrikeRuleElement };

--- a/src/scripts/config/index.ts
+++ b/src/scripts/config/index.ts
@@ -75,6 +75,7 @@ import {
     vehicleTraits,
     weaponTraits,
 } from "./traits.ts";
+import { modularConfigs } from "./modular.ts";
 
 export type StatusEffectIconTheme = "default" | "blackWhite";
 
@@ -690,6 +691,8 @@ export const PF2ECONFIG = {
         ultimate: { level: 18, hardness: 6, maxHP: 100, credits: 800000 },
         paragon: { level: 20, hardness: 7, maxHP: 120, credits: 320000 },
     },
+
+    modularConfigs,
 
     weaponReload,
     armorCategories,

--- a/src/scripts/config/index.ts
+++ b/src/scripts/config/index.ts
@@ -692,7 +692,7 @@ export const PF2ECONFIG = {
         paragon: { level: 20, hardness: 7, maxHP: 120, credits: 320000 },
     },
 
-    modularConfigs,
+    modularConfigurations: modularConfigs,
 
     weaponReload,
     armorCategories,

--- a/src/scripts/config/modular.ts
+++ b/src/scripts/config/modular.ts
@@ -1,0 +1,44 @@
+import { DamageType } from "@system/damage/index.ts";
+import { damageTypes } from "./damage.ts";
+import { WeaponTrait } from "@item/weapon/types.ts";
+
+interface ModularConfig {
+    label: string;
+    damageType?: DamageType;
+    traits: WeaponTrait[];
+}
+
+const modularConfigs: Record<string, Record<string, ModularConfig>> = {
+    modular: {
+        bludgeoning: {
+            label: damageTypes.bludgeoning,
+            damageType: "bludgeoning",
+            traits: [],
+        },
+        piercing: {
+            label: damageTypes.piercing,
+            damageType: "piercing",
+            traits: [],
+        },
+        slashing: {
+            label: damageTypes.slashing,
+            damageType: "slashing",
+            traits: [],
+        },
+    },
+    "modular-p-grapple-s-sweep": {
+        "p-and-grapple": {
+            label: "PF2E.Item.Weapon.ModularConfigs.PAndGrapple",
+            damageType: "piercing",
+            traits: ["grapple"],
+        },
+        "s-and-sweep": {
+            label: "PF2E.Item.Weapon.ModularConfigs.SAndSweep",
+            damageType: "slashing",
+            traits: ["sweep"],
+        },
+    },
+};
+
+export { modularConfigs };
+export type { ModularConfig };

--- a/src/scripts/config/traits.ts
+++ b/src/scripts/config/traits.ts
@@ -471,6 +471,7 @@ const weaponTraits = {
     magical: "PF2E.TraitMagical",
     mental: "PF2E.TraitMental",
     modular: "PF2E.TraitModular",
+    "modular-p-grapple-s-sweep": "PF2E.TraitModularPGrappleSSweep",
     monk: "PF2E.TraitMonk",
     mythic: "PF2E.TraitMythic",
     nonlethal: "PF2E.TraitNonlethal",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2781,6 +2781,10 @@
                     "Hint": "A combination weapon has a firearm form or usage and a melee weapon form or usage. Switching between the melee weapon usage and the firearm usage requires an Interact action. However, if your last action was a successful melee Strike against a foe using a combination weapon, you can make a firearm Strike with the combination weapon against that foe without fully switching to the firearm usage, firing the firearm just as you hit with the melee attack. In this case, the combination weapon returns to its melee usage after the firearm Strike.",
                     "Label": "Melee Usage"
                 },
+                "ModularConfigs": {
+                    "PAndGrapple": "P and grapple",
+                    "SAndSweep": "S and sweep"
+                },
                 "NoRangeMelee": "None (Melee)",
                 "RangeIncrementN": {
                     "Hint": "Ranged and thrown weapons have a range increment. Attacks with these weapons work normally up to that distance. Attack rolls beyond a weapon's range increment take a -2 penalty for each additional multiple of that increment between you and the target. Attacks beyond the sixth range increment are impossible.",
@@ -4868,6 +4872,7 @@
         "TraitMissive": "Missive",
         "TraitModification": "Modification",
         "TraitModular": "Modular B, P, or S",
+        "TraitModularPGrappleSSweep": "Modular (P and grapple, or S and sweep)",
         "TraitMonitor": "Monitor",
         "TraitMonk": "Monk",
         "TraitMorlock": "Morlock",


### PR DESCRIPTION
This PR extends the usage of modular beyond just changing the damage type to B, P, or S.
- The existing B-P-S switcher modular trait is kept as-is so that no migration is necessary.
- Several parts of the code where it is assumed that the modular selection can only be a damage type is changed to be just a string (which should be the key of the modular config, see below).
- A new PF2E config is introduced, called `modularConfigs`, that matches traits to sets of modular configs, which they themselves match a string key to an optional damage type (optional because SF2's shock truncheon), an array of traits (that can be empty), and a label that is effectively the localisation of the key of the config.
- Added the modular trait to Switchscythe, with the Switchscythe-specifics.

Though not present here, I've tested this with a few setups, like having a thrown trait in the modular trait, or with combination weapons.
Here's a visual demonstration:

https://github.com/user-attachments/assets/be670cd4-111e-48bc-8f78-b273c5749224

There are a few spots where I'm not sure if I approached this correctly -- `WeaponTraitToggles`'s `applyChanges()` and `WeaponPF2e`'s `toThrownUsage()`, I'm not *too* sure about, the latter I think might benefit more from a reorganisation from when data is handled? But I don't know enough about the system to feel out how it would best be reorganised, so consider this a "half-draft" PR.