### PR TITLE
Adjust Compendium Browser settings CSS for v13

### DIFF
--- a/src/styles/system/_compendium-browser-settings.scss
+++ b/src/styles/system/_compendium-browser-settings.scss
@@ -39,7 +39,7 @@
 
     .outer-container {
         display: flex;
-        height: 95%;
+        height: 93%;
         flex-direction: column;
         margin-bottom: 10px;
 
@@ -63,6 +63,7 @@
                 display: flex;
                 flex-direction: row;
                 flex-wrap: wrap;
+                justify-content: space-around;
                 gap: 1em;
                 width: 100%;
 
@@ -103,6 +104,7 @@
         justify-content: space-evenly;
         align-items: center;
         background: var(--secondary);
+        line-height: unset;
         background:
             url("/assets/sheet/border-pattern.webp") repeat-x top,
             url("/assets/sheet/border-pattern.webp") repeat-x bottom,
@@ -127,10 +129,5 @@
                 border-top: 4px solid var(--sidebar-label);
             }
         }
-    }
-
-    button.save-settings {
-        background: rgba(0, 0, 0, 0.1);
-        border: 2px groove var(--color-border-light-highlight);
     }
 }


### PR DESCRIPTION
Before:

<img width="609" height="535" alt="before" src="https://github.com/user-attachments/assets/a844f558-992b-445a-9523-24ed55a11327" />


After:

<img width="641" height="548" alt="after" src="https://github.com/user-attachments/assets/2be392a3-fd58-4d3c-9f6c-bc0bca6fa301" />


Closes #19859 