### PR TITLE
Add support for updating certain sub item rule elements

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -993,23 +993,16 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
         // Backward compatibility
         value = typeof itemId === "boolean" ? itemId : (value ?? !this.rollOptions[domain]?.[option]);
 
-        type MaybeRollOption = { key: string; domain?: unknown; option?: unknown };
-        if (typeof itemId === "string") {
-            // An item ID is provided: find the rule on the item
-            const item = this.items.get(itemId, { strict: true });
-            const rule = item.rules.find(
-                (r: MaybeRollOption): r is RollOptionRuleElement =>
-                    r.key === "RollOption" && r.domain === domain && r.option === option,
-            );
-            return rule?.toggle(value, suboption) ?? null;
-        } else {
-            // Less precise: no item ID is provided, so find the rule on the actor
-            const rule = this.rules.find(
-                (r: MaybeRollOption): r is RollOptionRuleElement =>
-                    r.key === "RollOption" && r.domain === domain && r.option === option,
-            );
-            return rule?.toggle(value, suboption) ?? null;
-        }
+        // Find the rule on the actor. The item id provided may be for a sub item, so we search instead of retrieving outright
+        type MaybeRollOption = RuleElementPF2e & { domain?: unknown; option?: unknown };
+        const rule = this.rules.find(
+            (r: MaybeRollOption): r is RollOptionRuleElement =>
+                r.key === "RollOption" &&
+                r.domain === domain &&
+                r.option === option &&
+                (typeof itemId !== "string" || itemId === r.item.id),
+        );
+        return rule?.toggle(value, suboption) ?? null;
     }
 
     /** Ensure newly-created tokens have dimensions matching this actor's size category */

--- a/src/module/rules/rule-element/roll-option/rule-element.ts
+++ b/src/module/rules/rule-element/roll-option/rule-element.ts
@@ -1,4 +1,4 @@
-import { processChoicesFromData } from "@module/rules/helpers.ts";
+import { createBatchRuleElementUpdate, processChoicesFromData } from "@module/rules/helpers.ts";
 import { Predicate } from "@system/predication.ts";
 import {
     DataUnionField,
@@ -382,24 +382,12 @@ class RollOptionRuleElement extends RuleElementPF2e<RollOptionSchema> {
     async toggle(value = !this.resolveValue(), selection: string | null = null): Promise<boolean | null> {
         if (!this.toggleable) throw ErrorPF2e("Attempted to toggle non-toggleable roll option");
 
-        const actor = this.actor;
-        const updates: { _id: string; "system.rules": RuleElementSource[] }[] = [];
-
         if (this.mergeable && selection) {
             // Update the items containing rule elements in the merge family
-            const rulesByItem = R.groupBy(this.#resolveSuboptionRules(), (r) => r.item.id);
-            for (const [itemId, rules] of Object.entries(rulesByItem)) {
-                const item = actor.items.get(itemId, { strict: true });
-                const ruleSources = item.toObject().system.rules;
-                const rollOptionSources = rules
-                    .map((rule) => (typeof rule.sourceIndex === "number" ? ruleSources[rule.sourceIndex] : null))
-                    .filter((source): source is RollOptionSource => source?.key === "RollOption");
-                for (const ruleSource of rollOptionSources) {
-                    ruleSource.value = value;
-                    ruleSource.selection = selection;
-                }
-                updates.push({ _id: itemId, "system.rules": ruleSources });
-            }
+            const rules = this.#resolveSuboptionRules();
+            const updates = createBatchRuleElementUpdate(rules, { value, selection });
+            const result = await this.actor.updateEmbeddedDocuments("Item", updates);
+            return result.length > 0 ? value : null;
         } else {
             // Directly update the rule element on the item
             const ruleSources = this.item.toObject().system.rules;
@@ -408,12 +396,8 @@ class RollOptionRuleElement extends RuleElementPF2e<RollOptionSchema> {
             if (!thisSource) return null;
             thisSource.value = value;
             if (selection) thisSource.selection = selection;
-            updates.push({ _id: this.item.id, "system.rules": ruleSources });
+            return !!(await this.item.update({ "system.rules": ruleSources }));
         }
-
-        const result = await this.actor.updateEmbeddedDocuments("Item", updates);
-
-        return result.length > 0 ? value : null;
     }
 
     /* -------------------------------------------- */


### PR DESCRIPTION
Adds support for toggles and special resource (incidentally) for sub items. Unfortunately, sub items aren't guaranteed to have unique ids, since only the parent receives a new id when duplicated. I attempt to handle that in the batch update, but hopefully it'll be fine without special handling in the toggle method call.

This can wait till after next release if it looks like the scary.