### PR TITLE
Cleanup Book 3 FOTRP NPCs

### DIFF
--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-2-ready-fight/quaking-footfall.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-2-ready-fight/quaking-footfall.json
@@ -56,7 +56,7 @@
         "creatureType": "",
         "details": {
             "description": "<p>Mogaru's steady footsteps pick up speed, causing the earth around him to tremble as though from a powerful earthquake.</p>",
-            "disable": "<p>three @Check[athletics|dc:39|name:Brace a Small Structure or Surface] (trained), @Check[crafting|dc:39|name:Brace a Small Structure or Surface] (trained), or @Check[engineering|dc:39|name:Brace a Small Structure or Surface]{Engineering Lore} (trained) checks to brace a small structure or surface to cancel the effects of the quake in that area; @Check[performance|dc:41|name:Calm Mogaru] (legendary) to calm Mogaru momentarily</p>",
+            "disable": "<p>Three @Check[athletics|dc:39|name:Brace a Small Structure or Surface] (trained), @Check[crafting|dc:39|name:Brace a Small Structure or Surface] (trained), or @Check[engineering|dc:39|name:Brace a Small Structure or Surface]{Engineering Lore} (trained) checks to brace a small structure or surface to cancel the effects of the quake in that area; @Check[performance|dc:41|name:Calm Mogaru] (legendary) to calm Mogaru momentarily</p>",
             "isComplex": false,
             "level": {
                 "value": 14

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-2-ready-fight/swatting-tail.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-2-ready-fight/swatting-tail.json
@@ -27,7 +27,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -40,20 +39,22 @@
             "ac": {
                 "value": 10
             },
+            "emitsSound": "encounter",
             "hardness": 0,
-            "hasHealth": true,
             "hp": {
                 "details": "",
                 "max": 10,
                 "temp": 0,
                 "value": 10
             },
+            "immunities": [],
+            "resistances": [],
             "stealth": {
                 "details": "<p>DC 10</p>",
                 "value": 0
-            }
+            },
+            "weaknesses": []
         },
-        "creatureType": "",
         "details": {
             "description": "<p>Mogaru's tail sweeps forth, causing an arc of devastation in a @Template[cone|distance:60].</p>",
             "disable": "<p>@Check[performance|dc:45|name:Divert Mogaru's Attention] (legendary) or @Check[deception|dc:48|name:Divert Mogaru's Attention] (legendary) to momentarily divert Mogaru's attention</p>",
@@ -71,26 +72,23 @@
         },
         "saves": {
             "fortitude": {
-                "saveDetail": "",
                 "value": 0
             },
             "reflex": {
-                "saveDetail": "",
                 "value": 0
             },
             "will": {
-                "saveDetail": "",
                 "value": 0
             }
         },
-        "statusEffects": [],
         "traits": {
             "rarity": "common",
             "size": {
                 "value": "med"
             },
             "value": [
-                "kaiju"
+                "kaiju",
+                "environmental"
             ]
         }
     },

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/abbot-tsujon.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/abbot-tsujon.json
@@ -370,6 +370,7 @@
                     "invested": null
                 },
                 "expend": null,
+                "grade": null,
                 "group": "club",
                 "hardness": 0,
                 "hp": {
@@ -389,9 +390,9 @@
                     }
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
                 },
                 "quantity": 1,
                 "range": null,
@@ -401,7 +402,9 @@
                 "rules": [],
                 "runes": {
                     "potency": 3,
-                    "property": [],
+                    "property": {
+                        "0": ""
+                    },
                     "striking": 3
                 },
                 "size": "med",
@@ -923,7 +926,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p><strong>Frequency</strong> once per round</p>\n<hr />\n<p><strong>Effect</strong> Abbot Tsujon makes two Strikes, each of which must be an unarmed Strike or crying temple bell Strike. If both hit the same creature, combine their damage for the purpose of resistances and weaknesses. If either Strike hits and deals damage, the target must succeed at a @Check[fortitude|dc:39|traits:incapacitation] save or be @UUID[Compendium.pf2e.conditionitems.Item.Stunned]{Stunned 1} (or @UUID[Compendium.pf2e.conditionitems.Item.Stunned]{Stunned 3} on a critical failure); this save has the incapacitation trait.</p>"
+                    "value": "<p><strong>Frequency</strong> once per round</p><hr /><p><strong>Effect</strong> Abbot Tsujon makes two Strikes, each of which must be an unarmed Strike or crying temple bell Strike. If both hit the same creature, combine their damage for the purpose of resistances and weaknesses. If either Strike hits and deals damage, the target must succeed at a @Check[fortitude|dc:39|traits:incapacitation] save or be @UUID[Compendium.pf2e.conditionitems.Item.Stunned]{Stunned 1} (or @UUID[Compendium.pf2e.conditionitems.Item.Stunned]{Stunned 3} on a critical failure); this save has the incapacitation trait.</p>"
                 },
                 "frequency": {
                     "max": 1,
@@ -987,7 +990,7 @@
             }
         },
         "details": {
-            "blurb": "",
+            "blurb": "Female samsaran abbott",
             "languages": {
                 "details": "",
                 "value": [

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/blue-viper-level-20.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/blue-viper-level-20.json
@@ -38,6 +38,7 @@
                     "invested": null
                 },
                 "expend": null,
+                "grade": null,
                 "group": "sword",
                 "hardness": 0,
                 "hp": {
@@ -57,9 +58,9 @@
                     }
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
                 },
                 "quantity": 1,
                 "range": null,
@@ -97,7 +98,7 @@
                 "compendiumSource": "Compendium.pf2e.equipment-srd.Item.GttLYMT2welSpwCd"
             },
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/acid-flask.webp",
-            "name": "Acid Flask (Major) (Infused)",
+            "name": "Acid Flask (Major)",
             "sort": 200000,
             "system": {
                 "baseItem": "alchemical-bomb",
@@ -115,7 +116,7 @@
                 "damage": {
                     "damageType": "acid",
                     "dice": 1,
-                    "die": "",
+                    "die": null,
                     "persistent": {
                         "faces": 6,
                         "number": 4,
@@ -123,7 +124,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> Strike</p>\n<p>This flask filled with corrosive acid deals 1 acid damage, 4d6 persistent acid damage, and 4 acid splash damage. You gain a +3 item bonus to attack rolls.</p>"
+                    "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> Strike</p>\n<hr />\n<p>This flask filled with corrosive acid deals 1 acid damage, 4d6 persistent acid damage, and 4 acid splash damage. You gain a +3 item bonus to attack rolls.</p>"
                 },
                 "equipped": {
                     "carryType": "worn",
@@ -131,6 +132,7 @@
                     "invested": null
                 },
                 "expend": 1,
+                "grade": null,
                 "group": "bomb",
                 "hardness": 0,
                 "hp": {
@@ -150,9 +152,9 @@
                     }
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Core Rulebook"
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder GM Core"
                 },
                 "quantity": 3,
                 "range": 20,
@@ -194,7 +196,7 @@
                 "compendiumSource": "Compendium.pf2e.equipment-srd.Item.rpbbfkexLhtadBDV"
             },
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/bottled-lightning.webp",
-            "name": "Bottled Lightning (Major) (Infused)",
+            "name": "Bottled Lightning (Major)",
             "sort": 300000,
             "system": {
                 "baseItem": "alchemical-bomb",
@@ -215,7 +217,7 @@
                     "die": "d6"
                 },
                 "description": {
-                    "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> Strike</p>\n<p>Bottled lightning is packed with volatile reagents that create a blast of electricity when they are exposed to air. Bottled lightning deals 4d6 electricity damage and 4 electricity splash damage. On a hit, the target becomes @UUID[Compendium.pf2e.conditionitems.Item.Off-Guard] until the start of your next turn. You gain a +3 item bonus to attack rolls.</p>"
+                    "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> Strike</p><hr /><p>Bottled lightning is packed with volatile reagents that create a blast of electricity when they are exposed to air. Bottled lightning deals 4d6 electricity damage and 4 electricity splash damage. On a hit, the target becomes @UUID[Compendium.pf2e.conditionitems.Item.Off-Guard] until the start of your next turn. You gain a +3 item bonus to attack rolls.</p>"
                 },
                 "equipped": {
                     "carryType": "worn",
@@ -223,6 +225,7 @@
                     "invested": null
                 },
                 "expend": 1,
+                "grade": null,
                 "group": "bomb",
                 "hardness": 0,
                 "hp": {
@@ -242,9 +245,9 @@
                     }
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Core Rulebook"
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
                 },
                 "quantity": 3,
                 "range": 20,
@@ -292,7 +295,7 @@
                 "compendiumSource": "Compendium.pf2e.equipment-srd.Item.4DJQID8GIlxQ7b9C"
             },
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-bombs/frost-vial.webp",
-            "name": "Frost Vial (Major) (Infused)",
+            "name": "Frost Vial (Major)",
             "sort": 400000,
             "system": {
                 "baseItem": "alchemical-bomb",
@@ -313,7 +316,7 @@
                     "die": "d6"
                 },
                 "description": {
-                    "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Strike</p>\n<hr />\n<p>The liquid reagents in this vial rapidly absorb heat when exposed to air. A frost vial deals the listed cold damage and cold splash damage. On a hit, the target takes a status penalty to its Speeds until the end of its next turn. Many types of frost vial also grant an item bonus to attack rolls.</p>\n<p>You gain a +3 item bonus to attack rolls, the bomb deals 4d6 cold damage and 4 cold splash damage, and the target takes a -15-foot penalty.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Frost Vial]</p>"
+                    "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Strike</p><hr /><p>The bright blue liquid reagents in this vial rapidly absorb heat when exposed to air. A frost vial deals 4d6 cold damage and 4 cold splash damage. On a hit, the target takes a -15-foot status penalty to its Speeds until the end of its next turn. You gain a +3 item bonus to attack rolls.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Frost Vial]</p>"
                 },
                 "equipped": {
                     "carryType": "worn",
@@ -321,6 +324,7 @@
                     "invested": null
                 },
                 "expend": 1,
+                "grade": null,
                 "group": "bomb",
                 "hardness": 0,
                 "hp": {
@@ -340,9 +344,9 @@
                     }
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Core Rulebook"
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
                 },
                 "quantity": 3,
                 "range": 20,
@@ -419,6 +423,7 @@
                     "invested": null
                 },
                 "expend": 1,
+                "grade": null,
                 "group": "bomb",
                 "hardness": 0,
                 "hp": {
@@ -499,7 +504,7 @@
                 "compendiumSource": "Compendium.pf2e.equipment-srd.Item.IuGydh0En8LbfnWo"
             },
             "img": "icons/commodities/gems/pearl-rough-turquoise.webp",
-            "name": "Thunderstone (Major) (Infused)",
+            "name": "Blasting Stone (Major)",
             "sort": 600000,
             "system": {
                 "baseItem": "alchemical-bomb",
@@ -520,7 +525,7 @@
                     "die": "d4"
                 },
                 "description": {
-                    "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Strike</p>\n<hr />\n<p>When this stone hits a creature or a hard surface, it explodes with a deafening bang. A thunderstone deals the listed sonic damage and sonic splash damage, and each creature within 10 feet of the space in which the stone exploded must succeed at a @Check[fortitude|dc:36|name:Major Thunderstone|showDC:all] saving throw with the listed DC or be @UUID[Compendium.pf2e.conditionitems.Item.Deafened] until the end of its next turn. Many types of thunderstone grant an item bonus to attack rolls.</p>\n<p>You gain a +3 item bonus to attack rolls. The bomb deals 4d4 sonic damage and 4 sonic splash damage, and the DC is 36.</p>"
+                    "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Strike</p><hr /><p>When this pebble hits a creature or a hard surface, it explodes with a deafening bang. A blasting stone deals 4d4 sonic damage and 4 sonic splash damage, and each creature within 10 feet of the space in which the stone exploded must succeed at a @Check[fortitude|dc:36|name:Major Blasting Stone|showDC:all] saving throw with the listed DC or be @UUID[Compendium.pf2e.conditionitems.Item.Deafened] until the end of its next turn. You gain a +3 item bonus to attack rolls.</p>"
                 },
                 "equipped": {
                     "carryType": "worn",
@@ -528,6 +533,7 @@
                     "invested": null
                 },
                 "expend": 1,
+                "grade": null,
                 "group": "bomb",
                 "hardness": 0,
                 "hp": {
@@ -547,9 +553,9 @@
                     }
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Core Rulebook"
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
                 },
                 "quantity": 2,
                 "range": 20,
@@ -569,7 +575,7 @@
                     "striking": 0
                 },
                 "size": "med",
-                "slug": "thunderstone-major",
+                "slug": "blasting-stone-major",
                 "splashDamage": {
                     "value": 4
                 },
@@ -592,79 +598,10 @@
             "type": "weapon"
         },
         {
-            "_id": "ljAsYwPMN3rYSpsH",
-            "_stats": {
-                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.6swrLimere2nZtz9"
-            },
-            "img": "icons/commodities/materials/glass-orb-marble-green.webp",
-            "name": "Dragon Bile (Applied to Body)",
-            "sort": 700000,
-            "system": {
-                "baseItem": null,
-                "bulk": {
-                    "value": 0.1
-                },
-                "category": "potion",
-                "containerId": null,
-                "damage": null,
-                "description": {
-                    "value": "<p>A mix of digestive juices and green dragon poison glands nauseates the victim as its flesh is digested from within.</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> Interact (Contact)</p>\n<p><strong>Saving Throw</strong> DC 37 Fortitude</p>\n<p><strong>Onset</strong> 1 minute</p>\n<p><strong>Maximum Duration</strong> 6 rounds</p>\n<p><strong>Stage 1</strong> @Damage[6d6[poison]] damage and @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 2} (1 round)</p>\n<p><strong>Stage 2</strong> @Damage[7d6[poison]] damage and sickened 3 (1 round)</p>\n<p><strong>Stage 3</strong> @Damage[9d6[poison]] damage and sickened 4 (1 round)</p>"
-                },
-                "equipped": {
-                    "carryType": "worn",
-                    "handsHeld": 0
-                },
-                "hardness": 0,
-                "hp": {
-                    "max": 0,
-                    "value": 0
-                },
-                "level": {
-                    "value": 15
-                },
-                "material": {
-                    "grade": null,
-                    "type": null
-                },
-                "price": {
-                    "value": {
-                        "gp": 925
-                    }
-                },
-                "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
-                },
-                "quantity": 1,
-                "rules": [],
-                "size": "med",
-                "slug": "dragon-bile",
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "alchemical",
-                        "consumable",
-                        "contact",
-                        "poison"
-                    ]
-                },
-                "usage": {
-                    "value": "held-in-one-hand"
-                },
-                "uses": {
-                    "autoDestroy": true,
-                    "max": 1,
-                    "value": 1
-                }
-            },
-            "type": "consumable"
-        },
-        {
             "_id": "9tGAqp6muB77JLmJ",
             "img": "systems/pf2e/icons/default-icons/consumable.svg",
             "name": "Hidden cheek needles",
-            "sort": 800000,
+            "sort": 700000,
             "system": {
                 "baseItem": null,
                 "bulk": {
@@ -725,8 +662,8 @@
                 "compendiumSource": "Compendium.pf2e.equipment-srd.Item.xQS1MSqGQz44FWUh"
             },
             "img": "icons/consumables/potions/potion-flask-corked-tied-necklace-teal.webp",
-            "name": "Black Lotus Extract (Infused)",
-            "sort": 900000,
+            "name": "Black Lotus Extract",
+            "sort": 800000,
             "system": {
                 "baseItem": null,
                 "bulk": {
@@ -736,7 +673,7 @@
                 "containerId": null,
                 "damage": null,
                 "description": {
-                    "value": "<p>Black lotus extract causes severe internal bleeding.</p>\n<hr />\n<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> Interact (Contact)</p>\n<p><strong>Saving Throw</strong> @Check[fortitude|dc:42]</p>\n<p><strong>Onset</strong> 1 minute</p>\n<p><strong>Maximum Duration</strong> 6 rounds</p>\n<p><strong>Stage 1</strong> @Damage[15d6[poison]] damage and @UUID[Compendium.pf2e.conditionitems.Item.Drained]{Drained 1} (1 round)</p>\n<p><strong>Stage 2</strong> @Damage[17d6[poison]] damage and drained 1 (1 round)</p>\n<p><strong>Stage 3</strong> @Damage[20d6[poison]] damage and @UUID[Compendium.pf2e.conditionitems.Item.Drained]{Drained 2} (1 round)</p>"
+                    "value": "<p>Black lotus extract causes severe internal bleeding.</p>\n<hr />\n<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> (manipulate)</p>\n<p><strong>Saving Throw</strong> @Check[fortitude|dc:42]</p>\n<p><strong>Onset</strong> 1 minute</p>\n<p><strong>Maximum Duration</strong> 6 rounds</p>\n<p><strong>Stage 1</strong> @Damage[13d6[poison]] damage and @UUID[Compendium.pf2e.conditionitems.Item.Drained]{Drained 1} (1 round)</p>\n<p><strong>Stage 2</strong> @Damage[15d6[poison]] damage and @UUID[Compendium.pf2e.conditionitems.Item.Drained]{Drained 1} (1 round)</p>\n<p><strong>Stage 3</strong> @Damage[17d6[poison]] damage and @UUID[Compendium.pf2e.conditionitems.Item.Drained]{Drained 2} (1 round)</p>"
                 },
                 "equipped": {
                     "carryType": "worn",
@@ -760,9 +697,9 @@
                     }
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Core Rulebook"
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder GM Core"
                 },
                 "quantity": 5,
                 "rules": [],
@@ -796,8 +733,8 @@
                 "compendiumSource": "Compendium.pf2e.equipment-srd.Item.qK964kZz1ALcysOa"
             },
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-elixirs/elixir-of-life.webp",
-            "name": "Elixir of Life (True) (Infused)",
-            "sort": 1000000,
+            "name": "Elixir of Life (True)",
+            "sort": 900000,
             "system": {
                 "baseItem": null,
                 "bulk": {
@@ -811,7 +748,7 @@
                     "type": "untyped"
                 },
                 "description": {
-                    "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">A</span></p>\n<p>Elixirs of life accelerate a living creature's natural healing processes and immune system. Upon drinking this elixir, you regain @Damage[(10d6+27)[healing]] Hit Points and gain +4 item bonus to saving throws against diseases and poisons for 10 minutes.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Elixir of Life]</p>"
+                    "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> (manipulate)</p><hr /><p>Elixirs of life accelerate a living creature's natural healing processes and immune system. Upon drinking this elixir, you regain @Damage[(10d6+27)[healing]] Hit Points and gain +4 item bonus to saving throws against diseases and poisons for 10 minutes.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Elixir of Life]</p>"
                 },
                 "equipped": {
                     "carryType": "worn",
@@ -835,9 +772,9 @@
                     }
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Core Rulebook"
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder GM Core"
                 },
                 "quantity": 4,
                 "rules": [],
@@ -870,8 +807,8 @@
                 "compendiumSource": "Compendium.pf2e.equipment-srd.Item.GMi5tw0cbMx3ZQPg"
             },
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/mindfog-mist.webp",
-            "name": "Mindfog Mist (Infused)",
-            "sort": 1100000,
+            "name": "Mindfog Mist",
+            "sort": 1000000,
             "system": {
                 "baseItem": null,
                 "bulk": {
@@ -881,7 +818,7 @@
                 "containerId": null,
                 "damage": null,
                 "description": {
-                    "value": "<p>Mindfog mist can be used to undermine spellcasters, as its effect on a victim's mental faculties are swift and powerful.</p>\n<hr />\n<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> Interact (Inhaled)</p>\n<p><strong>Saving Throw</strong> @Check[fortitude|dc:35]</p>\n<p><strong>Onset</strong> 1 round</p>\n<p><strong>Maximum Duration</strong> 6 rounds</p>\n<p><strong>Stage 1</strong> @UUID[Compendium.pf2e.conditionitems.Item.Stupefied]{Stupefied 2} (1 round)</p>\n<p><strong>Stage 2</strong> @UUID[Compendium.pf2e.conditionitems.Item.Confused] and @UUID[Compendium.pf2e.conditionitems.Item.Stupefied]{Stupefied 3} (1 round)</p>\n<p><strong>Stage 3</strong> confused and @UUID[Compendium.pf2e.conditionitems.Item.Stupefied]{Stupefied 4} (1 round)</p>"
+                    "value": "<p>Mindfog mist can be used to undermine spellcasters, as its effect on a victim's mental faculties are swift and powerful.</p>\n<hr />\n<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> (manipulate)</p>\n<p><strong>Saving Throw</strong> @Check[fortitude|dc:35]</p>\n<p><strong>Onset</strong> 1 round</p>\n<p><strong>Maximum Duration</strong> 6 rounds</p>\n<p><strong>Stage 1</strong> @UUID[Compendium.pf2e.conditionitems.Item.Stupefied]{Stupefied 2} (1 round)</p>\n<p><strong>Stage 2</strong> @UUID[Compendium.pf2e.conditionitems.Item.Confused] and @UUID[Compendium.pf2e.conditionitems.Item.Stupefied]{Stupefied 3} (1 round)</p>\n<p><strong>Stage 3</strong> @UUID[Compendium.pf2e.conditionitems.Item.Confused] and @UUID[Compendium.pf2e.conditionitems.Item.Stupefied]{Stupefied 4} (1 round)</p>"
                 },
                 "equipped": {
                     "carryType": "worn",
@@ -905,9 +842,9 @@
                     }
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Core Rulebook"
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder GM Core"
                 },
                 "quantity": 2,
                 "rules": [],
@@ -940,8 +877,8 @@
                 "compendiumSource": "Compendium.pf2e.equipment-srd.Item.5hGJ6CZi0A9OjMd4"
             },
             "img": "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons/oblivion-essence.webp",
-            "name": "Oblivion Essence (Infused)",
-            "sort": 1200000,
+            "name": "Oblivion Essence",
+            "sort": 1100000,
             "system": {
                 "baseItem": null,
                 "bulk": {
@@ -1010,8 +947,8 @@
                 "compendiumSource": "Compendium.pf2e.equipment-srd.Item.gDGPvobJV1QGYBPy"
             },
             "img": "icons/consumables/drinks/wine-amphora-clay-gray.webp",
-            "name": "Tears of Death (Infused)",
-            "sort": 1300000,
+            "name": "Tears of Death",
+            "sort": 1200000,
             "system": {
                 "baseItem": null,
                 "bulk": {
@@ -1021,7 +958,7 @@
                 "containerId": null,
                 "damage": null,
                 "description": {
-                    "value": "<p>Tears of death are among the most powerful of alchemical poisons, distilled from extracts of five other deadly poisons in just the right ratios.</p>\n<hr />\n<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> Interact (Contact)</p>\n<p><strong>Saving Throw</strong> @Check[fortitude|dc:46]</p>\n<p><strong>Onset</strong> 1 minute</p>\n<p><strong>Maximum Duration</strong> 10 minutes</p>\n<p><strong>Stage 1</strong> @Damage[18d6[poison]] damage and @UUID[Compendium.pf2e.conditionitems.Item.Paralyzed] (1 round)</p>\n<p><strong>Stage 2</strong> @Damage[25d6[poison]] damage and paralyzed (1 minute)</p>\n<p><strong>Stage 3</strong> @Damage[30d6[poison]] damage and paralyzed (1 minute)</p>"
+                    "value": "<p>Tears of death are among the most powerful of alchemical poisons, distilled from extracts of five other deadly poisons in just the right ratios.</p>\n<hr />\n<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> (manipulate)</p>\n<p><strong>Saving Throw</strong> @Check[fortitude|dc:44]</p>\n<p><strong>Onset</strong> 1 minute</p>\n<p><strong>Maximum Duration</strong> 10 minutes</p>\n<p><strong>Stage 1</strong> @Damage[20d6[poison]] damage and @UUID[Compendium.pf2e.conditionitems.Item.Paralyzed] (1 round)</p>\n<p><strong>Stage 2</strong> @Damage[22d6[poison]] damage and @UUID[Compendium.pf2e.conditionitems.Item.Paralyzed] (1 minute)</p>\n<p><strong>Stage 3</strong> @Damage[24d6[poison]] damage and @UUID[Compendium.pf2e.conditionitems.Item.Paralyzed] (1 minute)</p>"
                 },
                 "equipped": {
                     "carryType": "worn",
@@ -1045,9 +982,9 @@
                     }
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Core Rulebook"
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder GM Core"
                 },
                 "quantity": 5,
                 "rules": [],
@@ -1062,6 +999,72 @@
                         "infused",
                         "poison",
                         "virulent"
+                    ]
+                },
+                "usage": {
+                    "value": "held-in-two-hands"
+                },
+                "uses": {
+                    "autoDestroy": true,
+                    "max": 1,
+                    "value": 1
+                }
+            },
+            "type": "consumable"
+        },
+        {
+            "_id": "XgObWiapNeFKYvHu",
+            "img": "icons/commodities/materials/glass-orb-marble-green.webp",
+            "name": "Dragon Bile (Applied to body)",
+            "sort": 1300000,
+            "system": {
+                "baseItem": null,
+                "bulk": {
+                    "value": 0.1
+                },
+                "category": "poison",
+                "containerId": null,
+                "damage": null,
+                "description": {
+                    "value": "<p>A mix of digestive juices and green dragon poison glands nauseates the victim as its flesh is digested from within.</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> Interact (Contact)</p>\n<p><strong>Saving Throw</strong> @Check[fortitude|dc:37]</p>\n<p><strong>Onset</strong> 1 minute</p>\n<p><strong>Maximum Duration</strong> 6 rounds</p>\n<p><strong>Stage 1</strong> @Damage[6d6[poison]] damage and @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 2} (1 round)</p>\n<p><strong>Stage 2</strong> @Damage[7d6[poison]] damage and @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 3} (1 round)</p>\n<p><strong>Stage 3</strong> @Damage[9d6[poison]] damage and @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 4} (1 round)</p>"
+                },
+                "equipped": {
+                    "carryType": "worn"
+                },
+                "hardness": 0,
+                "hp": {
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 15
+                },
+                "material": {
+                    "grade": null,
+                    "type": null
+                },
+                "price": {
+                    "per": 1,
+                    "value": {
+                        "gp": 925
+                    }
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Core Rulebook"
+                },
+                "quantity": 1,
+                "rules": [],
+                "size": "med",
+                "slug": "dragon-bile",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "alchemical",
+                        "consumable",
+                        "contact",
+                        "poison"
                     ]
                 },
                 "usage": {
@@ -1086,9 +1089,6 @@
             "name": "Shortsword",
             "sort": 1400000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
                     "value": []
                 },
@@ -1112,16 +1112,12 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "agile",
                         "finesse",
                         "magical",
                         "versatile-s"
                     ]
-                },
-                "weaponType": {
-                    "value": "melee"
                 }
             },
             "type": "melee"
@@ -1137,9 +1133,6 @@
             "name": "Major Acid Flask",
             "sort": 1500000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
                     "value": []
                 },
@@ -1173,7 +1166,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "acid",
                         "alchemical",
@@ -1182,9 +1174,6 @@
                         "range-increment-20",
                         "splash"
                     ]
-                },
-                "weaponType": {
-                    "value": "ranged"
                 }
             },
             "type": "melee"
@@ -1200,9 +1189,6 @@
             "name": "Major Tanglefoot Bag",
             "sort": 1600000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
                     "value": []
                 },
@@ -1243,7 +1229,6 @@
                 ],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "alchemical",
                         "bomb",
@@ -1252,9 +1237,6 @@
                         "range-increment-20",
                         "splash"
                     ]
-                },
-                "weaponType": {
-                    "value": "ranged"
                 }
             },
             "type": "melee"
@@ -1270,9 +1252,6 @@
             "name": "Major Bottled Lightning",
             "sort": 1700000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
                     "value": []
                 },
@@ -1307,7 +1286,6 @@
                 ],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "alchemical",
                         "bomb",
@@ -1316,9 +1294,6 @@
                         "range-increment-20",
                         "splash"
                     ]
-                },
-                "weaponType": {
-                    "value": "ranged"
                 }
             },
             "type": "melee"
@@ -1334,9 +1309,6 @@
             "name": "Major Frost Vial",
             "sort": 1800000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
                     "value": []
                 },
@@ -1371,7 +1343,6 @@
                 ],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "alchemical",
                         "bomb",
@@ -1380,9 +1351,6 @@
                         "range-increment-20",
                         "splash"
                     ]
-                },
-                "weaponType": {
-                    "value": "ranged"
                 }
             },
             "type": "melee"
@@ -1398,9 +1366,6 @@
             "name": "Major Thunderstone",
             "sort": 1900000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
                     "value": []
                 },
@@ -1435,7 +1400,6 @@
                 ],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "alchemical",
                         "bomb",
@@ -1444,9 +1408,46 @@
                         "sonic",
                         "splash"
                     ]
+                }
+            },
+            "type": "melee"
+        },
+        {
+            "_id": "iFlQx2R7JEwwwrt7",
+            "img": "systems/pf2e/icons/default-icons/melee.svg",
+            "name": "Hidden Cheek Needles",
+            "sort": 2000000,
+            "system": {
+                "attackEffects": {
+                    "value": [
+                        "black-lotus-extract",
+                        "tears-of-death"
+                    ]
                 },
-                "weaponType": {
-                    "value": "ranged"
+                "bonus": {
+                    "value": 35
+                },
+                "damageRolls": {
+                    "yLm2wZMWJqid0bFR": {
+                        "damage": "9",
+                        "damageType": "piercing"
+                    }
+                },
+                "description": {
+                    "value": "<p>Only one poison is applied</p>"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "value": [
+                        "concealable",
+                        "range-increment-10"
+                    ]
                 }
             },
             "type": "melee"
@@ -1455,7 +1456,7 @@
             "_id": "LF5gi4818bCXaIHR",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Infused Items",
-            "sort": 2000000,
+            "sort": 2100000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -1475,7 +1476,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -1485,7 +1485,7 @@
             "_id": "JCUCSFZaASOsRhNG",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "+3 status to all saves vs. transmutation",
-            "sort": 2100000,
+            "sort": 2200000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -1515,7 +1515,6 @@
                 ],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -1525,7 +1524,7 @@
             "_id": "aT1K6zkwI73D4tJ8",
             "img": "systems/pf2e/icons/actions/Reaction.webp",
             "name": "Poisoned Coat",
-            "sort": 2200000,
+            "sort": 2300000,
             "system": {
                 "actionType": {
                     "value": "reaction"
@@ -1545,7 +1544,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -1555,7 +1553,7 @@
             "_id": "G1wu8KW1gALb7KbD",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Pinpoint Poisoner",
-            "sort": 2300000,
+            "sort": 2400000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -1575,7 +1573,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -1585,7 +1582,7 @@
             "_id": "sUXeC5liFm6oJVn7",
             "img": "systems/pf2e/icons/actions/ThreeActions.webp",
             "name": "Plum Rain Deluge",
-            "sort": 2400000,
+            "sort": 2500000,
             "system": {
                 "actionType": {
                     "value": "action"
@@ -1610,7 +1607,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "certain-kill"
                     ]
@@ -1622,7 +1618,7 @@
             "_id": "Tt37ijMg1fiX7fGx",
             "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Poison Spray",
-            "sort": 2500000,
+            "sort": 2600000,
             "system": {
                 "actionType": {
                     "value": "action"
@@ -1642,7 +1638,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -1652,7 +1647,7 @@
             "_id": "rbtSqixbTXvvcmJc",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Potent Poisoner",
-            "sort": 2600000,
+            "sort": 2700000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -1669,10 +1664,26 @@
                     "remaster": false,
                     "title": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "key": "AdjustModifier",
+                        "mode": "override",
+                        "predicate": [
+                            "item:trait:infused",
+                            "item:trait:poison",
+                            {
+                                "gt": [
+                                    "47",
+                                    "inline-dc:value"
+                                ]
+                            }
+                        ],
+                        "selector": "inline-dc",
+                        "value": "37"
+                    }
+                ],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -1682,7 +1693,7 @@
             "_id": "UUgL7mamcQM9PkU0",
             "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Quick Application",
-            "sort": 2700000,
+            "sort": 2800000,
             "system": {
                 "actionType": {
                     "value": "action"
@@ -1702,7 +1713,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -1712,7 +1722,7 @@
             "_id": "TJSUkfiilrbozvGh",
             "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Quick Bomber",
-            "sort": 2800000,
+            "sort": 2900000,
             "system": {
                 "actionType": {
                     "value": "action"
@@ -1732,7 +1742,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -1742,7 +1751,7 @@
             "_id": "KNsjthb0m0ASdoMo",
             "img": "systems/pf2e/icons/actions/TwoActions.webp",
             "name": "Toxic Escape",
-            "sort": 2900000,
+            "sort": 3000000,
             "system": {
                 "actionType": {
                     "value": "action"
@@ -1762,7 +1771,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -1819,7 +1827,7 @@
             }
         },
         "details": {
-            "blurb": "",
+            "blurb": "Male ysoki poisoner",
             "languages": {
                 "details": "",
                 "value": [

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/blue-viper-level-20.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/blue-viper-level-20.json
@@ -504,7 +504,7 @@
                 "compendiumSource": "Compendium.pf2e.equipment-srd.Item.IuGydh0En8LbfnWo"
             },
             "img": "icons/commodities/gems/pearl-rough-turquoise.webp",
-            "name": "Blasting Stone (Major)",
+            "name": "Thunderstone (Major) (Infused)",
             "sort": 600000,
             "system": {
                 "baseItem": "alchemical-bomb",
@@ -525,7 +525,7 @@
                     "die": "d4"
                 },
                 "description": {
-                    "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Strike</p><hr /><p>When this pebble hits a creature or a hard surface, it explodes with a deafening bang. A blasting stone deals 4d4 sonic damage and 4 sonic splash damage, and each creature within 10 feet of the space in which the stone exploded must succeed at a @Check[fortitude|dc:36|name:Major Blasting Stone|showDC:all] saving throw with the listed DC or be @UUID[Compendium.pf2e.conditionitems.Item.Deafened] until the end of its next turn. You gain a +3 item bonus to attack rolls.</p>"
+                    "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> Strike</p>\n<hr />\n<p>When this stone hits a creature or a hard surface, it explodes with a deafening bang. A thunderstone deals the listed sonic damage and sonic splash damage, and each creature within 10 feet of the space in which the stone exploded must succeed at a @Check[fortitude|dc:36|name:Major Thunderstone|showDC:all] saving throw with the listed DC or be @UUID[Compendium.pf2e.conditionitems.Item.Deafened] until the end of its next turn. Many types of thunderstone grant an item bonus to attack rolls.</p>\n<p>You gain a +3 item bonus to attack rolls. The bomb deals 4d4 sonic damage and 4 sonic splash damage, and the DC is 36.</p>"
                 },
                 "equipped": {
                     "carryType": "worn",
@@ -533,7 +533,6 @@
                     "invested": null
                 },
                 "expend": 1,
-                "grade": null,
                 "group": "bomb",
                 "hardness": 0,
                 "hp": {
@@ -553,9 +552,9 @@
                     }
                 },
                 "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Pathfinder Player Core 2"
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": "Pathfinder Core Rulebook"
                 },
                 "quantity": 2,
                 "range": 20,
@@ -575,7 +574,7 @@
                     "striking": 0
                 },
                 "size": "med",
-                "slug": "blasting-stone-major",
+                "slug": "thunderstone-major",
                 "splashDamage": {
                     "value": 4
                 },

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/canopy-elder.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/canopy-elder.json
@@ -27,6 +27,9 @@
                     "title": ""
                 },
                 "rules": [],
+                "showSlotlessLevels": {
+                    "value": false
+                },
                 "slots": {},
                 "slug": null,
                 "spelldc": {
@@ -233,11 +236,7 @@
             "name": "Branch",
             "sort": 500000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
-                    "custom": "",
                     "value": [
                         "improved-push"
                     ]
@@ -262,13 +261,9 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "reach-15"
                     ]
-                },
-                "weaponType": {
-                    "value": "melee"
                 }
             },
             "type": "melee"
@@ -279,11 +274,7 @@
             "name": "Root",
             "sort": 600000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
-                    "custom": "",
                     "value": [
                         "trip"
                     ]
@@ -308,13 +299,9 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "reach-30"
                     ]
-                },
-                "weaponType": {
-                    "value": "melee"
                 }
             },
             "type": "melee"
@@ -325,11 +312,7 @@
             "name": "Vine",
             "sort": 700000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
-                    "custom": "",
                     "value": [
                         "improved-grab"
                     ]
@@ -354,14 +337,10 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "agile",
                         "reach-40"
                     ]
-                },
-                "weaponType": {
-                    "value": "melee"
                 }
             },
             "type": "melee"
@@ -393,7 +372,6 @@
                 "rules": [],
                 "slug": "tremorsense",
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -423,7 +401,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -456,7 +433,6 @@
                 "rules": [],
                 "slug": "constant-spells",
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -489,7 +465,6 @@
                 "rules": [],
                 "slug": "attack-of-opportunity",
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -509,7 +484,7 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p>The canopy elder grows a mesh of vines around its broken branches, repairing the damage and restoring 40 HP to itself. The canopy elder can't use Vine Splint again for [[/gmr 1d4 #Recharge Vine Splint]]{1d4 rounds}.</p>"
+                    "value": "<p>The canopy elder grows a mesh of vines around its broken branches, repairing the damage and restoring @Damage[40[healing]] HP to itself. The canopy elder can't use Vine Splint again for [[/gmr 1d4 #Recharge Vine Splint]]{1d4 rounds}.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -519,7 +494,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "healing"
                     ]
@@ -551,7 +525,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -581,7 +554,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -614,7 +586,6 @@
                 "rules": [],
                 "slug": "improved-grab",
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -626,7 +597,7 @@
                 "compendiumSource": "Compendium.pf2e.bestiary-ability-glossary-srd.Item.6l7e7CHQLESlI57U"
             },
             "img": "systems/pf2e/icons/actions/FreeAction.webp",
-            "name": "Improved Push",
+            "name": "Improved Push (20 Feet)",
             "sort": 1600000,
             "system": {
                 "actionType": {
@@ -647,7 +618,6 @@
                 "rules": [],
                 "slug": "improved-push",
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/cloudsplitter.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/cloudsplitter.json
@@ -1196,7 +1196,7 @@
             }
         },
         "details": {
-            "blurb": "",
+            "blurb": "Variant kirin",
             "languages": {
                 "details": "telepathy 100 feet",
                 "value": [

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/dancing-night-parade.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/dancing-night-parade.json
@@ -57,11 +57,27 @@
                     "remaster": false,
                     "title": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "effects": [],
+                        "key": "Aura",
+                        "radius": 60,
+                        "traits": [
+                            "auditory",
+                            "emotion",
+                            "mental"
+                        ]
+                    }
+                ],
                 "slug": null,
                 "traits": {
                     "rarity": "common",
-                    "value": []
+                    "value": [
+                        "auditory",
+                        "aura",
+                        "emotion",
+                        "mental"
+                    ]
                 }
             },
             "type": "action"
@@ -313,7 +329,7 @@
             ]
         },
         "details": {
-            "blurb": "",
+            "blurb": "Troop of corporeal spirits",
             "languages": {
                 "details": "",
                 "value": []

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/desecrated-guardian.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/desecrated-guardian.json
@@ -9,11 +9,7 @@
             "name": "Jaws",
             "sort": 100000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
-                    "custom": "",
                     "value": [
                         "improved-grab"
                     ]
@@ -38,16 +34,12 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "deadly-3d12",
                         "magical",
                         "reach-20",
                         "unarmed"
                     ]
-                },
-                "weaponType": {
-                    "value": "melee"
                 }
             },
             "type": "melee"
@@ -58,11 +50,7 @@
             "name": "Tail",
             "sort": 200000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
-                    "custom": "",
                     "value": [
                         "improved-grab"
                     ]
@@ -87,14 +75,10 @@
                 "rules": [],
                 "slug": "tail",
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "magical",
                         "reach-30"
                     ]
-                },
-                "weaponType": {
-                    "value": "melee"
                 }
             },
             "type": "melee"
@@ -126,7 +110,6 @@
                 "rules": [],
                 "slug": "lifesense",
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -159,7 +142,6 @@
                 "rules": [],
                 "slug": "attack-of-opportunity",
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -198,11 +180,9 @@
                 ],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "aura",
-                        "divine",
-                        "evil"
+                        "divine"
                     ]
                 }
             },
@@ -222,7 +202,7 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p>The desecrated guardian draws in rubble from the surrounding area to rebuild its damaged body. It recovers 8d6 Hit Points. It can only use this ability if it is near suitable rock or rubble.</p>"
+                    "value": "<p>The desecrated guardian draws in rubble from the surrounding area to rebuild its damaged body. It recovers @Damage[8d6[healing]] Hit Points. It can only use this ability if it is near suitable rock or rubble.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -232,7 +212,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "divine",
                         "earth",
@@ -266,7 +245,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -296,7 +274,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -329,7 +306,6 @@
                 "rules": [],
                 "slug": "constrict",
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -362,7 +338,6 @@
                 "rules": [],
                 "slug": "swallow-whole",
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "attack"
                     ]
@@ -397,7 +372,6 @@
                 "rules": [],
                 "slug": "trample",
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -430,7 +404,6 @@
                 "rules": [],
                 "slug": "improved-grab",
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -482,6 +455,16 @@
                 },
                 {
                     "type": "mental"
+                }
+            ],
+            "resistances": [
+                {
+                    "doubleVs": [],
+                    "exceptions": [
+                        "adamantine"
+                    ],
+                    "type": "physical",
+                    "value": 15
                 }
             ],
             "speed": {
@@ -561,7 +544,8 @@
             },
             "value": [
                 "construct",
-                "evil"
+                "evil",
+                "unholy"
             ]
         }
     },

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/dimensional-darkside-mirror.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/dimensional-darkside-mirror.json
@@ -59,8 +59,8 @@
         },
         "creatureType": "",
         "details": {
-            "description": "<p>A magic mirror replaces characters with evil mirror duplicates from another dimension.</p>",
-            "disable": "<p>@Check[thievery|dc:40|name:Retrieve a Creature] (legendary) to retrieve a creature from the other dimension within 10 minutes of the switch (possible only if their mirror duplicate is dead), @Check[thievery|dc:45|name:Disable the Mirror] (master) to permanently disable the mirror once all mirror duplicates are dead, or @UUID[Compendium.pf2e.spells-srd.Item.Dispel Magic] (8th rank; counteract DC 37) to counteract the mirror for 1 minute and prevent additional replacements during that time</p>\n<p>the mirror can't be damaged while any mirror duplicate is alive</p>",
+            "description": "<p>A magic mirror replaces characters with evil mirror duplicates from another dimension.</p><p>The mirror can't be damaged while any mirror duplicate is alive</p>",
+            "disable": "<p>@Check[thievery|dc:40|name:Retrieve a Creature] (legendary) to retrieve a creature from the other dimension within 10 minutes of the switch (possible only if their mirror duplicate is dead), @Check[thievery|dc:45|name:Disable the Mirror] (master) to permanently disable the mirror once all mirror duplicates are dead, or @UUID[Compendium.pf2e.spells-srd.Item.Dispel Magic] (8th rank; counteract DC 37) to counteract the mirror for 1 minute and prevent additional replacements during that time</p>",
             "isComplex": true,
             "level": {
                 "value": 19

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/flying-mountain-kaminari.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/flying-mountain-kaminari.json
@@ -344,7 +344,7 @@
             }
         },
         "details": {
-            "blurb": "",
+            "blurb": "Kami of lightning and thunder",
             "languages": {
                 "details": "",
                 "value": [

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/gumiho.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/gumiho.json
@@ -27,6 +27,9 @@
                     "title": ""
                 },
                 "rules": [],
+                "showSlotlessLevels": {
+                    "value": false
+                },
                 "slots": {
                     "slot3": {
                         "max": 3,
@@ -65,7 +68,8 @@
                 },
                 "tradition": {
                     "value": "occult"
-                }
+                },
+                "traits": {}
             },
             "type": "spellcastingEntry"
         },
@@ -1023,11 +1027,8 @@
             "type": "spell"
         },
         {
-            "_id": "12NbBWM5piSrRxih",
-            "_stats": {
-                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.WTVLL9xk0Tk87w93"
-            },
-            "img": "systems/pf2e/icons/default-icons/equipment.svg",
+            "_id": "H1rrAhTLIqcgCBVW",
+            "img": "systems/pf2e/icons/equipment/consumables/talismans/jade-bauble.webp",
             "name": "Fox Marble",
             "sort": 1600000,
             "system": {
@@ -1037,7 +1038,7 @@
                 },
                 "containerId": null,
                 "description": {
-                    "value": "<p>A gumiho wears a strange green amulet around its neck. This fox marble stores all of the gumiho's knowledge. By focusing on the marble, a gumiho can perfectly recall anything it has experienced in its lifetime. A creature who manages to steal a gumiho's fox marble is lucky indeed, for they can also use it to access the gumiho's memories. However, if the gumiho still lives, the vengeful fox will stop at nothing to recover its marble.</p>\n<p>Whoever wears a fox marble gains a +2 item bonus to all checks to Recall Knowledge.</p>"
+                    "value": "<p>A gumiho wears a strange green amulet around its neck. This fox marble stores all of the gumiho's knowledge. By focusing on the marble, a gumiho can perfectly recall anything it has experienced in its lifetime. A creature who manages to steal a gumiho's fox marble is lucky indeed, for they can also use it to access the gumiho's memories. However, if the gumiho still lives, the vengeful fox will stop at nothing to recover its marble.</p>\n<p>Whoever wears a fox marble gains a +2 item bonus to all checks to @UUID[Compendium.pf2e.actionspf2e.Item.Recall Knowledge].</p>"
                 },
                 "equipped": {
                     "carryType": "worn",
@@ -1061,7 +1062,7 @@
                 "publication": {
                     "license": "OGL",
                     "remaster": false,
-                    "title": ""
+                    "title": "Pathfinder #168: King of the Mountain"
                 },
                 "quantity": 1,
                 "rules": [
@@ -1070,61 +1071,7 @@
                         "predicate": [
                             "action:recall-knowledge"
                         ],
-                        "selector": "arcana",
-                        "type": "item",
-                        "value": 2
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": [
-                            "action:recall-knowledge"
-                        ],
-                        "selector": "crafting",
-                        "type": "item",
-                        "value": 2
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": [
-                            "action:recall-knowledge"
-                        ],
-                        "selector": "medicine",
-                        "type": "item",
-                        "value": 2
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": [
-                            "action:recall-knowledge"
-                        ],
-                        "selector": "nature",
-                        "type": "item",
-                        "value": 2
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": [
-                            "action:recall-knowledge"
-                        ],
-                        "selector": "occultism",
-                        "type": "item",
-                        "value": 2
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": [
-                            "action:recall-knowledge"
-                        ],
-                        "selector": "religion",
-                        "type": "item",
-                        "value": 2
-                    },
-                    {
-                        "key": "FlatModifier",
-                        "predicate": [
-                            "action:recall-knowledge"
-                        ],
-                        "selector": "society",
+                        "selector": "skill-check",
                         "type": "item",
                         "value": 2
                     }
@@ -1147,9 +1094,6 @@
             "name": "Claw",
             "sort": 1700000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
                     "value": []
                 },
@@ -1173,15 +1117,11 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "agile",
                         "finesse",
                         "unarmed"
                     ]
-                },
-                "weaponType": {
-                    "value": "melee"
                 }
             },
             "type": "melee"
@@ -1192,9 +1132,6 @@
             "name": "Jaws",
             "sort": 1800000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
                     "value": []
                 },
@@ -1218,14 +1155,10 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "finesse",
                         "unarmed"
                     ]
-                },
-                "weaponType": {
-                    "value": "melee"
                 }
             },
             "type": "melee"
@@ -1254,7 +1187,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "emotion",
                         "incapacitation",
@@ -1289,7 +1221,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -1322,7 +1253,6 @@
                 "rules": [],
                 "slug": "change-shape",
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "concentrate",
                         "occult",
@@ -1353,10 +1283,22 @@
                     "remaster": false,
                     "title": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "key": "Note",
+                        "outcome": [
+                            "criticalSuccess"
+                        ],
+                        "selector": [
+                            "claw-damage",
+                            "jaws-damage"
+                        ],
+                        "text": "{item|system.description.value}",
+                        "title": "{item|name}"
+                    }
+                ],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/inmyeonjo.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/inmyeonjo.json
@@ -27,6 +27,9 @@
                     "title": ""
                 },
                 "rules": [],
+                "showSlotlessLevels": {
+                    "value": false
+                },
                 "slots": {
                     "slot2": {
                         "max": 3,
@@ -65,7 +68,8 @@
                 },
                 "tradition": {
                     "value": "occult"
-                }
+                },
+                "traits": {}
             },
             "type": "spellcastingEntry"
         },
@@ -1132,9 +1136,6 @@
             "name": "Talon",
             "sort": 1700000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
                     "value": []
                 },
@@ -1158,16 +1159,12 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "agile",
                         "finesse",
                         "reach-15",
                         "unarmed"
                     ]
-                },
-                "weaponType": {
-                    "value": "melee"
                 }
             },
             "type": "melee"
@@ -1178,9 +1175,6 @@
             "name": "Tail",
             "sort": 1800000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
                     "value": []
                 },
@@ -1204,15 +1198,11 @@
                 "rules": [],
                 "slug": "tail",
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "agile",
                         "finesse",
                         "reach-25"
                     ]
-                },
-                "weaponType": {
-                    "value": "melee"
                 }
             },
             "type": "melee"
@@ -1244,7 +1234,6 @@
                 "rules": [],
                 "slug": "telepathy",
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "aura",
                         "magical"
@@ -1277,7 +1266,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -1307,7 +1295,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -1327,7 +1314,7 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p>Creatures farther than 60 feet from an inmyeonjo see it only as the generic form of a huge bird. An inmyeonjo has concealment against attacks originating farther than 60 feet away.</p>"
+                    "value": "<p>Creatures farther than 60 feet from an inmyeonjo see it only as the generic form of a huge bird. An inmyeonjo has @UUID[Compendium.pf2e.conditionitems.Item.Concealed]{Concealment} against attacks originating farther than 60 feet away.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -1337,7 +1324,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/ji-yook-gumiho-form.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/ji-yook-gumiho-form.json
@@ -38,6 +38,7 @@
                     "invested": null
                 },
                 "expend": null,
+                "grade": null,
                 "group": "dart",
                 "hardness": 0,
                 "hp": {
@@ -57,9 +58,9 @@
                     }
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
                 },
                 "quantity": 5,
                 "range": 20,
@@ -87,6 +88,7 @@
                     ]
                 },
                 "usage": {
+                    "canBeAmmo": true,
                     "value": "held-in-one-hand"
                 }
             },
@@ -98,7 +100,7 @@
                 "compendiumSource": "Compendium.pf2e.equipment-srd.Item.FNDq4NFSN0g2HKWO"
             },
             "img": "icons/equipment/hand/gauntlet-simple-leather-brown-gold.webp",
-            "name": "+3 Greater Striking Handwraps of Mighty Blows",
+            "name": "Handwraps of Mighty Blows",
             "sort": 200000,
             "system": {
                 "baseItem": null,
@@ -128,6 +130,7 @@
                     "invested": false
                 },
                 "expend": null,
+                "grade": null,
                 "group": "brawling",
                 "hardness": 0,
                 "hp": {
@@ -135,7 +138,7 @@
                     "value": 0
                 },
                 "level": {
-                    "value": 16
+                    "value": 2
                 },
                 "material": {
                     "grade": null,
@@ -143,13 +146,13 @@
                 },
                 "price": {
                     "value": {
-                        "gp": 10000
+                        "gp": 35
                     }
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder GM Core"
                 },
                 "quantity": 1,
                 "range": null,
@@ -165,17 +168,16 @@
                 "size": "med",
                 "slug": "handwraps-of-mighty-blows",
                 "splashDamage": {
-                    "value": null
+                    "value": 0
                 },
                 "traits": {
+                    "otherTags": [
+                        "handwraps-of-mighty-blows"
+                    ],
                     "rarity": "common",
                     "value": [
-                        "agile",
-                        "finesse",
                         "invested",
-                        "magical",
-                        "nonlethal",
-                        "unarmed"
+                        "magical"
                     ]
                 },
                 "usage": {
@@ -211,6 +213,7 @@
                     "inSlot": true,
                     "invested": false
                 },
+                "grade": null,
                 "group": "cloth",
                 "hardness": 0,
                 "hp": {
@@ -327,14 +330,11 @@
             "name": "Claw",
             "sort": 500000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
                     "value": []
                 },
                 "bonus": {
-                    "value": 31
+                    "value": 34
                 },
                 "damageRolls": {
                     "eo1mf6mtds8kw3zpw1xv": {
@@ -353,7 +353,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "agile",
                         "finesse",
@@ -361,9 +360,6 @@
                         "nonlethal",
                         "unarmed"
                     ]
-                },
-                "weaponType": {
-                    "value": "melee"
                 }
             },
             "type": "melee"
@@ -379,9 +375,6 @@
             "name": "Dart",
             "sort": 600000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
                     "value": []
                 },
@@ -405,16 +398,12 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "agile",
                         "magical",
                         "reload-0",
                         "thrown-20"
                     ]
-                },
-                "weaponType": {
-                    "value": "ranged"
                 }
             },
             "type": "melee"
@@ -425,9 +414,6 @@
             "name": "Foxfire",
             "sort": 700000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
                     "value": []
                 },
@@ -451,13 +437,9 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "range-increment-20"
                     ]
-                },
-                "weaponType": {
-                    "value": "ranged"
                 }
             },
             "type": "melee"
@@ -486,7 +468,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -516,7 +497,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "illusion"
                     ]
@@ -551,7 +531,6 @@
                 "rules": [],
                 "slug": "change-shape",
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "concentrate",
                         "divine",
@@ -585,7 +564,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "concentrate",
                         "divine",
@@ -650,7 +628,6 @@
                 ],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "electricity",
                         "flourish",
@@ -684,7 +661,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -734,7 +710,6 @@
                 ],
                 "slug": "sneak-attack",
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -764,7 +739,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "emotion",
                         "fear"
@@ -821,7 +795,7 @@
             }
         },
         "details": {
-            "blurb": "",
+            "blurb": "Dimensional superposition form of Ji-yook",
             "languages": {
                 "details": "(can't speak any language)",
                 "value": [

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/jin-hae.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/jin-hae.json
@@ -27,6 +27,9 @@
                     "title": ""
                 },
                 "rules": [],
+                "showSlotlessLevels": {
+                    "value": false
+                },
                 "slots": {},
                 "slug": null,
                 "spelldc": {
@@ -36,7 +39,8 @@
                 },
                 "tradition": {
                     "value": "divine"
-                }
+                },
+                "traits": {}
             },
             "type": "spellcastingEntry"
         },
@@ -102,105 +106,15 @@
             "type": "spell"
         },
         {
-            "_id": "NtJHFwQeHn8lF6Z2",
-            "_stats": {
-                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.O3XAH3VkOx9a0FyD"
-            },
-            "img": "systems/pf2e/icons/default-icons/weapon.svg",
-            "name": "Hook Sword",
-            "sort": 300000,
-            "system": {
-                "baseItem": null,
-                "bonus": {
-                    "value": 0
-                },
-                "bonusDamage": {
-                    "value": 0
-                },
-                "bulk": {
-                    "value": 1
-                },
-                "category": "simple",
-                "containerId": null,
-                "damage": {
-                    "damageType": "slashing",
-                    "dice": 1,
-                    "die": "d6"
-                },
-                "description": {
-                    "value": "<p>This long sword has a hook near the tip which makes it easy to snag an opponent or their weapons.</p>"
-                },
-                "equipped": {
-                    "carryType": "worn",
-                    "handsHeld": 0,
-                    "invested": null
-                },
-                "expend": null,
-                "group": "sword",
-                "hardness": 0,
-                "hp": {
-                    "max": 0,
-                    "value": 0
-                },
-                "level": {
-                    "value": 0
-                },
-                "material": {
-                    "grade": null,
-                    "type": null
-                },
-                "price": {
-                    "value": {
-                        "gp": 3
-                    }
-                },
-                "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
-                },
-                "quantity": 1,
-                "range": null,
-                "reload": {
-                    "value": null
-                },
-                "rules": [],
-                "runes": {
-                    "potency": 0,
-                    "property": [],
-                    "striking": 0
-                },
-                "size": "med",
-                "slug": "hook-sword",
-                "splashDamage": {
-                    "value": 0
-                },
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "disarm",
-                        "monk",
-                        "parry",
-                        "trip",
-                        "twin"
-                    ]
-                },
-                "usage": {
-                    "value": "held-in-one-hand"
-                }
-            },
-            "type": "weapon"
-        },
-        {
             "_id": "aDN0RcvG4E7jcGLL",
             "_stats": {
                 "compendiumSource": "Compendium.pf2e.equipment-srd.Item.yUgOLSyb4pGGxfCR"
             },
             "img": "systems/pf2e/icons/default-icons/weapon.svg",
             "name": "Feng Huo Lun",
-            "sort": 400000,
+            "sort": 300000,
             "system": {
-                "baseItem": null,
+                "baseItem": "feng-huo-lun",
                 "bonus": {
                     "value": 0
                 },
@@ -215,10 +129,10 @@
                 "damage": {
                     "damageType": "slashing",
                     "dice": 1,
-                    "die": "d6"
+                    "die": "d4"
                 },
                 "description": {
-                    "value": "<p>This large, flat steel ring features several protruding blades typically stylized to resemble flames.</p>"
+                    "value": "<p>Also known as wind and fire wheels, these large, flat steel rings feature several protruding blades typically stylized to resemble flames.</p>"
                 },
                 "equipped": {
                     "carryType": "worn",
@@ -226,6 +140,7 @@
                     "invested": null
                 },
                 "expend": null,
+                "grade": null,
                 "group": "knife",
                 "hardness": 0,
                 "hp": {
@@ -245,11 +160,11 @@
                     }
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Treasure Vault (Remastered)"
                 },
-                "quantity": 1,
+                "quantity": 2,
                 "range": null,
                 "reload": {
                     "value": null
@@ -266,13 +181,105 @@
                     "value": 0
                 },
                 "traits": {
-                    "rarity": "common",
+                    "rarity": "uncommon",
                     "value": [
                         "agile",
                         "disarm",
                         "finesse",
                         "monk",
                         "parry",
+                        "twin",
+                        "versatile-p"
+                    ]
+                },
+                "usage": {
+                    "value": "held-in-one-hand"
+                }
+            },
+            "type": "weapon"
+        },
+        {
+            "_id": "q9SNkKSO6ejVLV8C",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.O3XAH3VkOx9a0FyD"
+            },
+            "img": "systems/pf2e/icons/equipment/weapons/hook-sword.webp",
+            "name": "Hook Sword",
+            "sort": 400000,
+            "system": {
+                "baseItem": "hook-sword",
+                "bonus": {
+                    "value": 0
+                },
+                "bonusDamage": {
+                    "value": 0
+                },
+                "bulk": {
+                    "value": 1
+                },
+                "category": "advanced",
+                "containerId": null,
+                "damage": {
+                    "damageType": "slashing",
+                    "dice": 1,
+                    "die": "d6"
+                },
+                "description": {
+                    "value": "<p>This long sword has a hook near the tip, making it easy to snag an opponent or their weapons.</p>"
+                },
+                "equipped": {
+                    "carryType": "worn",
+                    "handsHeld": 0,
+                    "invested": null
+                },
+                "expend": null,
+                "grade": null,
+                "group": "sword",
+                "hardness": 0,
+                "hp": {
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 0
+                },
+                "material": {
+                    "grade": null,
+                    "type": null
+                },
+                "price": {
+                    "value": {
+                        "gp": 3
+                    }
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Treasure Vault (Remastered)"
+                },
+                "quantity": 2,
+                "range": null,
+                "reload": {
+                    "value": null
+                },
+                "rules": [],
+                "runes": {
+                    "potency": 0,
+                    "property": [],
+                    "striking": 0
+                },
+                "size": "med",
+                "slug": "hook-sword",
+                "splashDamage": {
+                    "value": 0
+                },
+                "traits": {
+                    "rarity": "uncommon",
+                    "value": [
+                        "disarm",
+                        "monk",
+                        "parry",
+                        "trip",
                         "twin"
                     ]
                 },
@@ -284,11 +291,6 @@
         },
         {
             "_id": "nl7k5HK7TqZfntnR",
-            "flags": {
-                "pf2e": {
-                    "linkedWeapon": "NtJHFwQeHn8lF6Z2"
-                }
-            },
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Hook Sword",
             "sort": 500000,
@@ -336,11 +338,6 @@
         },
         {
             "_id": "yIoJFTEAk52gbWvj",
-            "flags": {
-                "pf2e": {
-                    "linkedWeapon": "NtJHFwQeHn8lF6Z2"
-                }
-            },
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Linked Hook Swords",
             "sort": 600000,
@@ -870,7 +867,7 @@
             }
         },
         "details": {
-            "blurb": "",
+            "blurb": "Female phantom knight",
             "languages": {
                 "details": "",
                 "value": [

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/laruhao.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/laruhao.json
@@ -322,6 +322,7 @@
                     "invested": null
                 },
                 "expend": null,
+                "grade": null,
                 "group": "knife",
                 "hardness": 0,
                 "hp": {
@@ -336,12 +337,14 @@
                     "type": null
                 },
                 "price": {
-                    "value": {}
+                    "value": {
+                        "sp": 11
+                    }
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Treasure Vault (Remastered)"
                 },
                 "quantity": 1,
                 "range": null,
@@ -357,7 +360,7 @@
                 "size": "med",
                 "slug": "fighting-fan",
                 "splashDamage": {
-                    "value": null
+                    "value": 0
                 },
                 "traits": {
                     "rarity": "uncommon",
@@ -562,7 +565,7 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p>Laruhao sends out a pulse of inviting melody that calls more yokai from the ether, restoring 30 Hit Points to the dancing night parade.</p>"
+                    "value": "<p>Laruhao sends out a pulse of inviting melody that calls more yokai from the ether, restoring @Damage[30[healing]] Hit Points to the dancing night parade.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -712,9 +715,9 @@
             }
         },
         "details": {
-            "blurb": "",
+            "blurb": "Male humanoid minstrel",
             "languages": {
-                "details": "",
+                "details": "tongues",
                 "value": [
                     "senzar",
                     "tien"

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/rai-sho-disciple.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/rai-sho-disciple.json
@@ -613,7 +613,7 @@
             }
         },
         "details": {
-            "blurb": "",
+            "blurb": "Tian-la monk",
             "languages": {
                 "details": "",
                 "value": [

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/rai-sho-postulant.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/rai-sho-postulant.json
@@ -227,8 +227,12 @@
                     {
                         "key": "FlatModifier",
                         "predicate": [
-                            "fear",
-                            "dreams"
+                            {
+                                "or": [
+                                    "fear",
+                                    "dreams"
+                                ]
+                            }
                         ],
                         "selector": "saving-throw",
                         "type": "status",
@@ -257,7 +261,7 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p>rai sho postulants gain a +4 status bonus to saves against fear and against spells and abilities that affect dreams. A rai sho postulant that falls prey to a supernatural nightmare loses this ability and becomes permanently enraged, gaining a +1 status bonus to attack and damage status bonus to attack and damage rolls and a -1 status penalty to AC.</p>"
+                    "value": "<p>Rai Sho Postulants gain a +4 status bonus to saves against fear and against spells and abilities that affect dreams. A Rai Sho Postulant that falls prey to a supernatural nightmare loses this ability and becomes permanently enraged, gaining a +1 status bonus to attack and damage status bonus to attack and damage rolls and a -1 status penalty to AC.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -347,7 +351,7 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> The rai sho postulant is hidden or undetected while not in combat, and a creature would observe it.</p>\n<hr />\n<p><strong>Effect</strong> The rai sho postulant Strides or Climbs up to half its Speed to a location where it can Hide, then Hides. If its new Stealth check result meets or exceeds the triggering creature's Perception DC, the yeti remains hidden.</p>"
+                    "value": "<p><strong>Trigger</strong> The Rai Sho Postulant is hidden or undetected while not in combat, and a creature would observe it.</p><hr /><p><strong>Effect</strong> The Rai Sho Postulant Strides or Climbs up to half its Speed to a location where it can Hide, then Hides. If its new Stealth check result meets or exceeds the triggering creature's Perception DC, the yeti remains hidden.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -377,7 +381,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p><strong>Frequency</strong> once per round</p>\n<hr />\n<p><strong>Effect</strong> The Rai Sho postulant makes two Strikes, which can be any combination of claw or icicle Strikes. If both hit the same creature, combine their damage for the purpose of resistances and weaknesses. If either Strike hits and deals damage, the target must succeed at a @Check[fortitude|dc:37|traits:incapacitation] save or be @UUID[Compendium.pf2e.conditionitems.Item.Stunned]{Stunned 1} (or @UUID[Compendium.pf2e.conditionitems.Item.Stunned]{Stunned 3} on a critical failure); this save has the incapacitation trait.</p>"
+                    "value": "<p><strong>Frequency</strong> once per round</p><hr /><p><strong>Effect</strong> The Rai Sho Postulant makes two Strikes, which can be any combination of claw or icicle Strikes. If both hit the same creature, combine their damage for the purpose of resistances and weaknesses. If either Strike hits and deals damage, the target must succeed at a @Check[fortitude|dc:37|traits:incapacitation] save or be @UUID[Compendium.pf2e.conditionitems.Item.Stunned]{Stunned 1} (or @UUID[Compendium.pf2e.conditionitems.Item.Stunned]{Stunned 3} on a critical failure); this save has the incapacitation trait.</p>"
                 },
                 "frequency": {
                     "max": 1,
@@ -414,7 +418,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> The rai sho postulant hits a creature in the first round of combat and the rai sho postulant was @UUID[Compendium.pf2e.conditionitems.Item.Hidden] from that creature at the start of combat.</p>\n<hr />\n<p><strong>Effect</strong> Each enemy within 30 feet that witnesses the attack (including the target of the attack) must attempt a @Check[will|dc:37] save. On a failure, the creature is @UUID[Compendium.pf2e.conditionitems.Item.Frightened]{Frightened 2}; on a critical failure, it's @UUID[Compendium.pf2e.conditionitems.Item.Frightened]{Frightened 4}.</p>"
+                    "value": "<p><strong>Trigger</strong> The Rai Sho Postulant hits a creature in the first round of combat and the Rai Sho Postulant was @UUID[Compendium.pf2e.conditionitems.Item.Hidden] from that creature at the start of combat.</p><hr /><p><strong>Effect</strong> Each enemy within 30 feet that witnesses the attack (including the target of the attack) must attempt a @Check[will|dc:37] save. On a failure, the creature is @UUID[Compendium.pf2e.conditionitems.Item.Frightened]{Frightened 2}; on a critical failure, it's @UUID[Compendium.pf2e.conditionitems.Item.Frightened]{Frightened 4}.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -493,7 +497,7 @@
             ]
         },
         "details": {
-            "blurb": "",
+            "blurb": "Yeti martial artist",
             "languages": {
                 "details": "",
                 "value": [

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/ran-to-level-20.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/ran-to-level-20.json
@@ -38,6 +38,7 @@
                     "invested": null
                 },
                 "expend": null,
+                "grade": null,
                 "group": "brawling",
                 "hardness": 0,
                 "hp": {
@@ -57,9 +58,9 @@
                     }
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
                 },
                 "quantity": 1,
                 "range": null,
@@ -125,6 +126,7 @@
                     "invested": null
                 },
                 "expend": 1,
+                "grade": null,
                 "group": "sling",
                 "hardness": 0,
                 "hp": {
@@ -144,9 +146,9 @@
                     }
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
                 },
                 "quantity": 1,
                 "range": 80,
@@ -162,7 +164,7 @@
                 "size": "med",
                 "slug": "halfling-sling-staff",
                 "splashDamage": {
-                    "value": null
+                    "value": 0
                 },
                 "traits": {
                     "rarity": "uncommon",
@@ -204,6 +206,7 @@
                     "inSlot": true,
                     "invested": false
                 },
+                "grade": null,
                 "group": "leather",
                 "hardness": 0,
                 "hp": {
@@ -266,7 +269,7 @@
                     "type": "fire"
                 },
                 "description": {
-                    "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> Interact</p>\n<p>This piece of ammunition is coated in gritty black soot. When activated <em>explosive ammunition</em> hits a target, the missile explodes in a @Template[burst|distance:10], dealing [[/r10d6]] fire damage to each creature in the area (including the target). Each creature must attempt a @Check[reflex|dc:30|basic|name:Greater Explosive Ammunition] save.</p>"
+                    "value": "<p><strong>Ammunition</strong> any</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> (manipulate)</p>\n<hr />\n<p>This piece of ammunition is coated in gritty black soot. When activated <em>greater explosive ammunition</em> hits a target, the missile explodes in a @Template[burst|distance:10], dealing @Damage[10d6[fire]|options:area-damage] damage to each creature in the area (including the target). Each creature must attempt a @Check[reflex|dc:30|basic|options:area-effect] save.</p>"
                 },
                 "equipped": {
                     "carryType": "worn",
@@ -285,17 +288,25 @@
                     "type": null
                 },
                 "price": {
+                    "per": 1,
                     "value": {
                         "gp": 520
                     }
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder GM Core"
                 },
                 "quantity": 5,
-                "rules": [],
+                "rules": [
+                    {
+                        "key": "Note",
+                        "selector": "{item|_id}-damage",
+                        "text": "PF2E.AmmunitionNotes.ExplosiveAmmunition.Greater.Text",
+                        "title": "PF2E.AmmunitionNotes.ExplosiveAmmunition.Greater.Title"
+                    }
+                ],
                 "size": "med",
                 "slug": "explosive-ammunition-greater",
                 "traits": {
@@ -359,9 +370,9 @@
                     }
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
                 },
                 "quantity": 20,
                 "rules": [],
@@ -394,11 +405,7 @@
             "name": "Gauntlet",
             "sort": 600000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
-                    "custom": "",
                     "value": [
                         "improved-grab"
                     ]
@@ -423,15 +430,11 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "agile",
                         "free-hand",
                         "magical"
                     ]
-                },
-                "weaponType": {
-                    "value": "melee"
                 }
             },
             "type": "melee"
@@ -470,7 +473,6 @@
                 ],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -503,7 +505,6 @@
                 "rules": [],
                 "slug": "attack-of-opportunity",
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -533,7 +534,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -566,7 +566,6 @@
                 "rules": [],
                 "slug": "constrict",
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -596,7 +595,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -631,7 +629,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "certain-kill"
                     ]
@@ -663,7 +660,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -698,7 +694,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -731,7 +726,6 @@
                 "rules": [],
                 "slug": "improved-grab",
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -758,7 +752,8 @@
                     "title": ""
                 },
                 "rules": [],
-                "slug": null
+                "slug": null,
+                "traits": {}
             },
             "type": "lore"
         }
@@ -813,7 +808,7 @@
             }
         },
         "details": {
-            "blurb": "",
+            "blurb": "Male frost goblin wrestler",
             "languages": {
                 "details": "",
                 "value": [

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/shino-hakusa-level-20.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/shino-hakusa-level-20.json
@@ -9,7 +9,7 @@
                 "compendiumSource": "Compendium.pf2e.equipment-srd.Item.FNDq4NFSN0g2HKWO"
             },
             "img": "icons/equipment/hand/gauntlet-simple-leather-brown-gold.webp",
-            "name": "+3 Major Striking Greater Shock Handwraps of Mighty Blows",
+            "name": "Handwraps of Mighty Blows",
             "sort": 100000,
             "system": {
                 "baseItem": null,
@@ -34,10 +34,12 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "inSlot": false,
                     "invested": false
                 },
                 "expend": null,
+                "grade": null,
                 "group": "brawling",
                 "hardness": 0,
                 "hp": {
@@ -45,7 +47,7 @@
                     "value": 0
                 },
                 "level": {
-                    "value": 16
+                    "value": 2
                 },
                 "material": {
                     "grade": null,
@@ -53,13 +55,13 @@
                 },
                 "price": {
                     "value": {
-                        "gp": 10500
+                        "gp": 35
                     }
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder GM Core"
                 },
                 "quantity": 1,
                 "range": null,
@@ -77,17 +79,16 @@
                 "size": "med",
                 "slug": "handwraps-of-mighty-blows",
                 "splashDamage": {
-                    "value": null
+                    "value": 0
                 },
                 "traits": {
+                    "otherTags": [
+                        "handwraps-of-mighty-blows"
+                    ],
                     "rarity": "common",
                     "value": [
-                        "agile",
-                        "finesse",
                         "invested",
-                        "magical",
-                        "nonlethal",
-                        "unarmed"
+                        "magical"
                     ]
                 },
                 "usage": {
@@ -113,7 +114,7 @@
                 "containerId": null,
                 "damage": null,
                 "description": {
-                    "value": "<p>Upon drinking this effervescent concoction, you gain a fly Speed of 40 feet for 1 hour.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Potion of Flying (Greater)]</p>"
+                    "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> (manipulate)</p><hr /><p>Upon drinking this effervescent concoction, you gain a fly Speed of 40 feet for 1 hour.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Potion of Flying (Greater)]</p>"
                 },
                 "equipped": {
                     "carryType": "worn",
@@ -132,14 +133,15 @@
                     "type": null
                 },
                 "price": {
+                    "per": 1,
                     "value": {
                         "gp": 1000
                     }
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder GM Core"
                 },
                 "quantity": 1,
                 "rules": [],
@@ -165,16 +167,76 @@
             "type": "consumable"
         },
         {
+            "_id": "3feDDsgcNTU2Ky9a",
+            "img": "systems/pf2e/icons/equipment/consumables/potions/potion-of-quickness.webp",
+            "name": "Potion of Quickness",
+            "sort": 300000,
+            "system": {
+                "baseItem": null,
+                "bulk": {
+                    "value": 0.1
+                },
+                "category": "potion",
+                "containerId": null,
+                "damage": null,
+                "description": {
+                    "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">A</span> (manipulate)</p>\n<hr />\n<p>Drinking this silver potion grants you the effects of @UUID[Compendium.pf2e.spells-srd.Item.Haste] for 1 minute.</p>"
+                },
+                "equipped": {
+                    "carryType": "worn"
+                },
+                "hardness": 0,
+                "hp": {
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 8
+                },
+                "material": {
+                    "grade": null,
+                    "type": null
+                },
+                "price": {
+                    "value": {
+                        "gp": 90
+                    }
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder GM Core"
+                },
+                "quantity": 1,
+                "rules": [],
+                "size": "med",
+                "slug": "potion-of-quickness",
+                "traits": {
+                    "rarity": "common",
+                    "value": [
+                        "consumable",
+                        "magical",
+                        "potion"
+                    ]
+                },
+                "usage": {
+                    "value": "held-in-one-hand"
+                },
+                "uses": {
+                    "autoDestroy": true,
+                    "max": 1,
+                    "value": 1
+                }
+            },
+            "type": "consumable"
+        },
+        {
             "_id": "bCOakEf7smKHKKwk",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Fingers",
-            "sort": 300000,
+            "sort": 400000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
-                    "custom": "",
                     "value": [
                         "ki-absorption"
                     ]
@@ -199,16 +261,12 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "agile",
                         "finesse",
                         "magical",
                         "unarmed"
                     ]
-                },
-                "weaponType": {
-                    "value": "melee"
                 }
             },
             "type": "melee"
@@ -217,13 +275,9 @@
             "_id": "pxokcB1Sp4D1G3rx",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Palm",
-            "sort": 400000,
+            "sort": 500000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
-                    "custom": "",
                     "value": [
                         "ki-absorption"
                     ]
@@ -248,16 +302,12 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "forceful",
                         "magical",
                         "shove",
                         "unarmed"
                     ]
-                },
-                "weaponType": {
-                    "value": "melee"
                 }
             },
             "type": "melee"
@@ -266,11 +316,8 @@
             "_id": "yD2IaxM69CHUu1UK",
             "img": "systems/pf2e/icons/default-icons/melee.svg",
             "name": "Vitality Blast",
-            "sort": 500000,
+            "sort": 600000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
                     "value": []
                 },
@@ -294,7 +341,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "magical",
                         "range-increment-60",
@@ -302,9 +348,6 @@
                         "versatile-vitality",
                         "void"
                     ]
-                },
-                "weaponType": {
-                    "value": "ranged"
                 }
             },
             "type": "melee"
@@ -316,7 +359,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Lifesense",
-            "sort": 600000,
+            "sort": 700000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -336,7 +379,6 @@
                 "rules": [],
                 "slug": "lifesense",
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -346,7 +388,7 @@
             "_id": "MvxbezFGff7wEUpC",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "+3 status to all saves vs. necromancy",
-            "sort": 700000,
+            "sort": 800000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -376,7 +418,6 @@
                 ],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -386,7 +427,7 @@
             "_id": "YffdaPTIHotKDCFb",
             "img": "systems/pf2e/icons/actions/Reaction.webp",
             "name": "Nimble Dodge",
-            "sort": 800000,
+            "sort": 900000,
             "system": {
                 "actionType": {
                     "value": "reaction"
@@ -422,7 +463,6 @@
                 ],
                 "slug": "nimble-dodge",
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -432,7 +472,7 @@
             "_id": "3GSuzF761kYVoOes",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Ki Absorption",
-            "sort": 900000,
+            "sort": 1000000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -452,7 +492,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -462,7 +501,7 @@
             "_id": "A69rHlLGVpQNMDQ4",
             "img": "systems/pf2e/icons/actions/TwoActions.webp",
             "name": "Pressure Point Attack",
-            "sort": 1000000,
+            "sort": 1100000,
             "system": {
                 "actionType": {
                     "value": "action"
@@ -482,7 +521,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -495,7 +533,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Sneak Attack",
-            "sort": 1100000,
+            "sort": 1200000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -532,7 +570,6 @@
                 ],
                 "slug": "sneak-attack",
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -542,7 +579,7 @@
             "_id": "9AvQJLThXbUUdWNT",
             "img": "systems/pf2e/icons/actions/TwoActions.webp",
             "name": "Swallows in Flight",
-            "sort": 1200000,
+            "sort": 1300000,
             "system": {
                 "actionType": {
                     "value": "action"
@@ -567,7 +604,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "certain-kill",
                         "void"
@@ -622,7 +658,7 @@
             }
         },
         "details": {
-            "blurb": "",
+            "blurb": "Female Tian-Shu ninja",
             "languages": {
                 "details": "",
                 "value": [

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/spinel-leviathan-syndara.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/spinel-leviathan-syndara.json
@@ -9,9 +9,6 @@
             "name": "Spatial Pincers",
             "sort": 100000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
                     "value": []
                 },
@@ -35,15 +32,11 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "magical",
                         "reach-15",
                         "versatile-s"
                     ]
-                },
-                "weaponType": {
-                    "value": "melee"
                 }
             },
             "type": "melee"
@@ -54,11 +47,7 @@
             "name": "Tentacle",
             "sort": 200000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
-                    "custom": "",
                     "value": [
                         "improved-grab"
                     ]
@@ -83,16 +72,12 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "agile",
                         "magical",
                         "reach-20",
                         "unarmed"
                     ]
-                },
-                "weaponType": {
-                    "value": "melee"
                 }
             },
             "type": "melee"
@@ -103,9 +88,6 @@
             "name": "Warpspines",
             "sort": 300000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
                     "value": []
                 },
@@ -134,7 +116,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "agile",
                         "brutal",
@@ -143,9 +124,6 @@
                         "range-increment-120",
                         "splash"
                     ]
-                },
-                "weaponType": {
-                    "value": "ranged"
                 }
             },
             "type": "melee"
@@ -174,7 +152,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "divine",
                         "teleportation"
@@ -207,7 +184,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -237,7 +213,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "divine",
                         "teleportation"
@@ -270,7 +245,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -352,7 +326,6 @@
                 ],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -385,7 +358,6 @@
                 "rules": [],
                 "slug": "attack-of-opportunity",
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -415,7 +387,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -445,7 +416,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -475,7 +445,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "divine"
                     ]
@@ -497,7 +466,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>With great regret, Syndara calls his masterpieces from the firmament to crash down upon his enemies. He flings four worldspheres to any four points within 500 feet. Each worldsphere deals 20d6 damage in a @Template[burst|distance:40] (@Check[reflex|dc:48|basic] save). Syndara chooses the type of damage for each worldsphere, which can be any type he chooses, though each worldsphere must deal a different type of damage. On a failed save, the target is pushed to the edge of the burst. No matter how many overlapping explosions it's caught in, a creature can take damage from only one worldsphere per round. Syndara is immune to the damage dealt by his worldspheres. Syndara can't use Mover of Worlds again for [[/gmr 1d4 #Recharge Mover of Worlds]]{1d4 rounds}.</p>"
+                    "value": "<p>With great regret, Syndara calls his masterpieces from the firmament to crash down upon his enemies. He flings four worldspheres to any four points within 500 feet. Each worldsphere deals @Damage[20d6[untyped]] damage in a @Template[burst|distance:40] (@Check[reflex|dc:48|basic] save). Syndara chooses the type of damage for each worldsphere, which can be any type he chooses, though each worldsphere must deal a different type of damage. On a failed save, the target is pushed to the edge of the burst. No matter how many overlapping explosions it's caught in, a creature can take damage from only one worldsphere per round. Syndara is immune to the damage dealt by his worldspheres. Syndara can't use Mover of Worlds again for [[/gmr 1d4 #Recharge Mover of Worlds]]{1d4 rounds}.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -507,7 +476,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "divine"
                     ]
@@ -542,7 +510,6 @@
                 "rules": [],
                 "slug": "rend",
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -575,7 +542,6 @@
                 "rules": [],
                 "slug": "improved-grab",
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -602,7 +568,8 @@
                     "title": ""
                 },
                 "rules": [],
-                "slug": null
+                "slug": null,
+                "traits": {}
             },
             "type": "lore"
         }
@@ -657,6 +624,20 @@
                     "type": "fear-effects"
                 }
             ],
+            "resistances": [
+                {
+                    "doubleVs": [],
+                    "exceptions": [],
+                    "type": "electricity",
+                    "value": 25
+                },
+                {
+                    "doubleVs": [],
+                    "exceptions": [],
+                    "type": "mental",
+                    "value": 25
+                }
+            ],
             "speed": {
                 "otherSpeeds": [
                     {
@@ -669,7 +650,7 @@
             "weaknesses": []
         },
         "details": {
-            "blurb": "",
+            "blurb": "Syndara the Sculptor's final form",
             "languages": {
                 "details": "",
                 "value": [

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/sthira.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/sthira.json
@@ -27,6 +27,9 @@
                     "title": ""
                 },
                 "rules": [],
+                "showSlotlessLevels": {
+                    "value": false
+                },
                 "slots": {},
                 "slug": null,
                 "spelldc": {
@@ -36,7 +39,8 @@
                 },
                 "tradition": {
                     "value": "primal"
-                }
+                },
+                "traits": {}
             },
             "type": "spellcastingEntry"
         },
@@ -457,6 +461,7 @@
                     "invested": null
                 },
                 "expend": null,
+                "grade": null,
                 "group": "sword",
                 "hardness": 0,
                 "hp": {
@@ -519,11 +524,7 @@
             "name": "Greatsword",
             "sort": 800000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
-                    "custom": "",
                     "value": [
                         "frostbite"
                     ]
@@ -552,15 +553,11 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "magical",
                         "reach-10",
                         "versatile-p"
                     ]
-                },
-                "weaponType": {
-                    "value": "melee"
                 }
             },
             "type": "melee"
@@ -571,11 +568,7 @@
             "name": "Fist",
             "sort": 900000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
-                    "custom": "",
                     "value": [
                         "frostbite",
                         "improved-grab"
@@ -605,15 +598,11 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "magical",
                         "reach-10",
                         "unarmed"
                     ]
-                },
-                "weaponType": {
-                    "value": "melee"
                 }
             },
             "type": "melee"
@@ -642,7 +631,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "primal"
                     ]
@@ -677,7 +665,6 @@
                 "rules": [],
                 "slug": "attack-of-opportunity",
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -707,7 +694,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "cold"
                     ]
@@ -749,7 +735,6 @@
                 ],
                 "slug": "negative-healing",
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -789,7 +774,6 @@
                 ],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "aura",
                         "cold",
@@ -823,7 +807,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -856,7 +839,6 @@
                 "rules": [],
                 "slug": "improved-grab",
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -925,7 +907,14 @@
             "speed": {
                 "otherSpeeds": [],
                 "value": 25
-            }
+            },
+            "weaknesses": [
+                {
+                    "exceptions": [],
+                    "type": "fire",
+                    "value": 20
+                }
+            ]
         },
         "details": {
             "blurb": "",
@@ -967,7 +956,7 @@
         "saves": {
             "fortitude": {
                 "saveDetail": "",
-                "value": 29
+                "value": 39
             },
             "reflex": {
                 "saveDetail": "",

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/syndara-the-sculptor.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/syndara-the-sculptor.json
@@ -27,6 +27,9 @@
                     "title": ""
                 },
                 "rules": [],
+                "showSlotlessLevels": {
+                    "value": false
+                },
                 "slots": {},
                 "slug": null,
                 "spelldc": {
@@ -36,7 +39,8 @@
                 },
                 "tradition": {
                     "value": "primal"
-                }
+                },
+                "traits": {}
             },
             "type": "spellcastingEntry"
         },
@@ -107,11 +111,7 @@
             "name": "Palm",
             "sort": 300000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
-                    "custom": "",
                     "value": [
                         "vicious-impact"
                     ]
@@ -136,16 +136,12 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "agile",
                         "finesse",
                         "reach-10",
                         "unarmed"
                     ]
-                },
-                "weaponType": {
-                    "value": "melee"
                 }
             },
             "type": "melee"
@@ -156,11 +152,7 @@
             "name": "Knifehand",
             "sort": 400000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
-                    "custom": "",
                     "value": [
                         "vicious-impact"
                     ]
@@ -185,7 +177,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "deadly-d10",
                         "finesse",
@@ -193,229 +184,6 @@
                         "unarmed",
                         "versatile-p"
                     ]
-                },
-                "weaponType": {
-                    "value": "melee"
-                }
-            },
-            "type": "melee"
-        },
-        {
-            "_id": "TLoJoqAT9mWEbPg0",
-            "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Elemental Gateway (Acid)",
-            "sort": 500000,
-            "system": {
-                "attack": {
-                    "value": ""
-                },
-                "attackEffects": {
-                    "value": []
-                },
-                "bonus": {
-                    "value": 39
-                },
-                "damageRolls": {
-                    "3adwbf4kxowmgrdo9cos": {
-                        "damage": "4d10+19",
-                        "damageType": "acid"
-                    }
-                },
-                "description": {
-                    "value": ""
-                },
-                "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
-                },
-                "rules": [],
-                "slug": null,
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "acid",
-                        "range-increment-120"
-                    ]
-                },
-                "weaponType": {
-                    "value": "ranged"
-                }
-            },
-            "type": "melee"
-        },
-        {
-            "_id": "7REDd3wY9c8AO5OJ",
-            "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Elemental Gateway (Cold)",
-            "sort": 600000,
-            "system": {
-                "attack": {
-                    "value": ""
-                },
-                "attackEffects": {
-                    "value": []
-                },
-                "bonus": {
-                    "value": 39
-                },
-                "damageRolls": {
-                    "c35w9idmfsh6722fgb2c": {
-                        "damage": "4d10+19",
-                        "damageType": "cold"
-                    }
-                },
-                "description": {
-                    "value": ""
-                },
-                "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
-                },
-                "rules": [],
-                "slug": null,
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "cold",
-                        "range-increment-120"
-                    ]
-                },
-                "weaponType": {
-                    "value": "ranged"
-                }
-            },
-            "type": "melee"
-        },
-        {
-            "_id": "JpXjBUOBF3xnisHf",
-            "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Elemental Gateway (Electricity)",
-            "sort": 700000,
-            "system": {
-                "attack": {
-                    "value": ""
-                },
-                "attackEffects": {
-                    "value": []
-                },
-                "bonus": {
-                    "value": 39
-                },
-                "damageRolls": {
-                    "ko4hw47cu7tmprqeiuen": {
-                        "damage": "4d10+19",
-                        "damageType": "electricity"
-                    }
-                },
-                "description": {
-                    "value": ""
-                },
-                "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
-                },
-                "rules": [],
-                "slug": null,
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "electricity",
-                        "range-increment-120"
-                    ]
-                },
-                "weaponType": {
-                    "value": "ranged"
-                }
-            },
-            "type": "melee"
-        },
-        {
-            "_id": "k8wpqGYhmssGLu9Z",
-            "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Elemental Gateway (Fire)",
-            "sort": 800000,
-            "system": {
-                "attack": {
-                    "value": ""
-                },
-                "attackEffects": {
-                    "value": []
-                },
-                "bonus": {
-                    "value": 39
-                },
-                "damageRolls": {
-                    "7jqdhovaan3fxer34jqn": {
-                        "damage": "4d10+19",
-                        "damageType": "fire"
-                    }
-                },
-                "description": {
-                    "value": ""
-                },
-                "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
-                },
-                "rules": [],
-                "slug": null,
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "fire",
-                        "range-increment-120"
-                    ]
-                },
-                "weaponType": {
-                    "value": "ranged"
-                }
-            },
-            "type": "melee"
-        },
-        {
-            "_id": "DMNKfGAALmbt1yaq",
-            "img": "systems/pf2e/icons/default-icons/melee.svg",
-            "name": "Elemental Gateway (Sonic)",
-            "sort": 900000,
-            "system": {
-                "attack": {
-                    "value": ""
-                },
-                "attackEffects": {
-                    "value": []
-                },
-                "bonus": {
-                    "value": 39
-                },
-                "damageRolls": {
-                    "ve1ry38i9jnwsvwl9goc": {
-                        "damage": "4d10+19",
-                        "damageType": "sonic"
-                    }
-                },
-                "description": {
-                    "value": ""
-                },
-                "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
-                },
-                "rules": [],
-                "slug": null,
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "range-increment-120",
-                        "sonic"
-                    ]
-                },
-                "weaponType": {
-                    "value": "ranged"
                 }
             },
             "type": "melee"
@@ -424,7 +192,7 @@
             "_id": "Gx6U0uhAZqRqns0c",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Keeper of the Lighthouse",
-            "sort": 1000000,
+            "sort": 500000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -444,7 +212,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -454,7 +221,7 @@
             "_id": "0R91Xrww4KkX2os5",
             "img": "systems/pf2e/icons/actions/Reaction.webp",
             "name": "Portal Redirection",
-            "sort": 1100000,
+            "sort": 600000,
             "system": {
                 "actionType": {
                     "value": "reaction"
@@ -474,7 +241,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "divine",
                         "teleportation"
@@ -487,7 +253,7 @@
             "_id": "U7y9xQFt237yGtMb",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Spatial Sense",
-            "sort": 1200000,
+            "sort": 700000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -507,7 +273,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -520,7 +285,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Constant Spells",
-            "sort": 1300000,
+            "sort": 800000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -540,7 +305,6 @@
                 "rules": [],
                 "slug": "constant-spells",
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -550,7 +314,7 @@
             "_id": "dBUpMNA6jdIjGiWq",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "+2 status to all saves vs. chaotic",
-            "sort": 1400000,
+            "sort": 900000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -580,7 +344,6 @@
                 ],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -593,7 +356,7 @@
             },
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Fast Healing 20",
-            "sort": 1500000,
+            "sort": 1000000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -619,7 +382,6 @@
                 ],
                 "slug": "fast-healing",
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -632,7 +394,7 @@
             },
             "img": "systems/pf2e/icons/actions/Reaction.webp",
             "name": "Attack of Opportunity",
-            "sort": 1600000,
+            "sort": 1100000,
             "system": {
                 "actionType": {
                     "value": "reaction"
@@ -652,7 +414,6 @@
                 "rules": [],
                 "slug": "attack-of-opportunity",
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -662,7 +423,7 @@
             "_id": "BwqLC9l3XRUzeiYU",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Essence Reflection",
-            "sort": 1700000,
+            "sort": 1200000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -682,7 +443,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -692,7 +452,7 @@
             "_id": "DKODgSSppVR1pK2W",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Extradimensional Immunity",
-            "sort": 1800000,
+            "sort": 1300000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -712,7 +472,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -722,7 +481,7 @@
             "_id": "LPEmiljFa52Qpans",
             "img": "systems/pf2e/icons/actions/TwoActions.webp",
             "name": "Gateway Onslaught",
-            "sort": 1900000,
+            "sort": 1400000,
             "system": {
                 "actionType": {
                     "value": "action"
@@ -739,10 +498,59 @@
                     "remaster": false,
                     "title": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "alwaysActive": true,
+                        "key": "RollOption",
+                        "label": "Elemental Gateway",
+                        "option": "elemental-gateway-choice",
+                        "selection": "cold",
+                        "suboptions": [
+                            {
+                                "label": "PF2E.TraitAcid",
+                                "value": "acid"
+                            },
+                            {
+                                "label": "PF2E.TraitCold",
+                                "value": "cold"
+                            },
+                            {
+                                "label": "PF2E.TraitElectricity",
+                                "value": "electricity"
+                            },
+                            {
+                                "label": "PF2E.TraitFire",
+                                "value": "fire"
+                            },
+                            {
+                                "label": "PF2E.TraitSonic",
+                                "value": "sonic"
+                            }
+                        ],
+                        "toggleable": true,
+                        "value": true
+                    },
+                    {
+                        "attackModifier": 39,
+                        "category": "simple",
+                        "damage": {
+                            "base": {
+                                "damageType": "{item|flags.pf2e.rulesSelections.elementalGatewayChoice}",
+                                "dice": 4,
+                                "die": "d10",
+                                "modifier": 19
+                            }
+                        },
+                        "key": "Strike",
+                        "label": "Elemental Gateway",
+                        "slug": "elemental-gateway",
+                        "traits": [
+                            "range-120"
+                        ]
+                    }
+                ],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "teleportation"
                     ]
@@ -754,7 +562,7 @@
             "_id": "fNZJ6zX3sKTikjmd",
             "img": "systems/pf2e/icons/actions/OneAction.webp",
             "name": "Planar Restructuring",
-            "sort": 2000000,
+            "sort": 1500000,
             "system": {
                 "actionType": {
                     "value": "action"
@@ -764,7 +572,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p><strong>Requirements</strong> Syndara is in the Glass Lighthouse</p>\n<hr />\n<p><strong>Effect</strong> Syndara exerts his will over the Glass Lighthouse to cause one of several effects. The effect is magical, but Syndara isn't using magic when he takes this action-just triggering a magical effect he already set up. The level for each of these effects is 10, and any save is DC 45. Syndara or Syndara's Reflection can't use Planar Restructuring for [[/gmr 1d4 #Recharge Planar Restructuring]]{1d4 rounds}.</p>\n<p>- Accelerate/Decelerate Syndara affects the flow of time around a target within 60 feet, affecting them with either haste or slow.</p>\n<p>- Deny Syndara rejects the existence of a power other than his own, affecting an object with disjunction.</p>\n<p>- Rewind Syndara rewinds time to undo harm. He or his reflection are affected by the two-action version of heal or by restoration.</p>\n<p>- Rise Syndara creates a gravitational nexus of reverse gravity.</p>\n<p>- Sequester Syndara folds space to affect a creature with resilient sphere.</p>"
+                    "value": "<p><strong>Requirements</strong> Syndara is in the Glass Lighthouse</p><hr /><p><strong>Effect</strong> Syndara exerts his will over the Glass Lighthouse to cause one of several effects. The effect is magical, but Syndara isn't using magic when he takes this action-just triggering a magical effect he already set up. The level for each of these effects is 10, and any save is DC 45. Syndara or Syndara's Reflection can't use Planar Restructuring for [[/gmr 1d4 #Recharge Planar Restructuring]]{1d4 rounds}.</p>\n<p>- <strong>Accelerate/Decelerate</strong> Syndara affects the flow of time around a target within 60 feet, affecting them with either @UUID[Compendium.pf2e.spells-srd.Item.Haste] or @UUID[Compendium.pf2e.spells-srd.Item.Slow].</p>\n<p>- <strong>Deny</strong> Syndara rejects the existence of a power other than his own, affecting an object with @UUID[Compendium.pf2e.spells-srd.Item.Disjunction].</p>\n<p>- <strong>Rewind</strong> Syndara rewinds time to undo harm. He or his reflection are affected by the two-action version of @UUID[Compendium.pf2e.spells-srd.Item.Heal] or by @UUID[Compendium.pf2e.spells-srd.Item.Restoration].</p>\n<p>- <strong>Rise</strong> Syndara creates a gravitational nexus of reverse gravity.</p>\n<p>- <strong>Sequester</strong> Syndara folds space to affect a creature with resilient sphere.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -774,7 +582,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "concentrate"
                     ]
@@ -786,7 +593,7 @@
             "_id": "Tw5zLedbZPCJUXOf",
             "img": "systems/pf2e/icons/actions/TwoActions.webp",
             "name": "Temporal Flurry",
-            "sort": 2100000,
+            "sort": 1600000,
             "system": {
                 "actionType": {
                     "value": "action"
@@ -811,7 +618,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -821,7 +627,7 @@
             "_id": "G91glv6yQKQIi54b",
             "img": "systems/pf2e/icons/actions/Passive.webp",
             "name": "Vicious Impact",
-            "sort": 2200000,
+            "sort": 1700000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -841,7 +647,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -851,7 +656,7 @@
             "_id": "cBzZIOSMTaFYSiaM",
             "img": "systems/pf2e/icons/actions/FreeAction.webp",
             "name": "Walk the Spiral",
-            "sort": 2300000,
+            "sort": 1800000,
             "system": {
                 "actionType": {
                     "value": "free"
@@ -868,10 +673,41 @@
                     "remaster": false,
                     "title": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "key": "RollOption",
+                        "option": "walk-the-spiral",
+                        "selection": "1",
+                        "suboptions": [
+                            {
+                                "label": "PF2E.SpecificRule.Numbers.One",
+                                "value": "1"
+                            },
+                            {
+                                "label": "PF2E.SpecificRule.Numbers.Two",
+                                "value": "2"
+                            },
+                            {
+                                "label": "PF2E.SpecificRule.Numbers.Three",
+                                "value": "3"
+                            }
+                        ],
+                        "toggleable": true,
+                        "value": true
+                    },
+                    {
+                        "hideIfDisabled": true,
+                        "key": "FlatModifier",
+                        "predicate": [
+                            "walk-the-spiral"
+                        ],
+                        "selector": "attack",
+                        "type": "circumstance",
+                        "value": "{item|flags.pf2e.rulesSelections.walkTheSpiral}"
+                    }
+                ],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -881,7 +717,7 @@
             "_id": "XRQqPpbcKxQZtcAr",
             "img": "systems/pf2e/icons/default-icons/lore.svg",
             "name": "Demiplane Lore",
-            "sort": 2400000,
+            "sort": 1900000,
             "system": {
                 "description": {
                     "value": ""
@@ -898,7 +734,8 @@
                     "title": ""
                 },
                 "rules": [],
-                "slug": null
+                "slug": null,
+                "traits": {}
             },
             "type": "lore"
         }
@@ -946,7 +783,7 @@
             }
         },
         "details": {
-            "blurb": "",
+            "blurb": "male axomite grandmaster",
             "languages": {
                 "details": "",
                 "value": [

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/syu-tak-nwa-level-20.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/syu-tak-nwa-level-20.json
@@ -2489,9 +2489,6 @@
             "name": "Hair",
             "sort": 3300000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
                     "value": []
                 },
@@ -2515,7 +2512,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "agile",
                         "finesse",
@@ -2525,9 +2521,6 @@
                         "unarmed",
                         "versatile-s"
                     ]
-                },
-                "weaponType": {
-                    "value": "melee"
                 }
             },
             "type": "melee"
@@ -2538,9 +2531,6 @@
             "name": "Braid",
             "sort": 3400000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
                     "value": []
                 },
@@ -2564,16 +2554,12 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "forceful",
                         "reach-10",
                         "shove",
                         "unarmed"
                     ]
-                },
-                "weaponType": {
-                    "value": "melee"
                 }
             },
             "type": "melee"
@@ -2602,7 +2588,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -2632,7 +2617,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -2672,7 +2656,6 @@
                 ],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -2702,7 +2685,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -2732,7 +2714,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -2752,7 +2733,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>Syu Tak-nwa tears thousands of minute portals into space, sending a single hair through each. The hairs emerge at a space within 30 feet, braiding and twining together to create a cube 20 feet to each side. This has the effects of a 10th-rank force cage, except that Syu Tak-nwa does not need to sustain the basket; it has a duration of 1 minute. While the Silkworm's Basket persists, Syu Tak-nwa is quickened and can use the extra action only to make a hair or braid Strike against any target within the basket, regardless of her distance to them. She can't create more than one basket at a time.</p>"
+                    "value": "<p>Syu Tak-nwa tears thousands of minute portals into space, sending a single hair through each. The hairs emerge at a space within 30 feet, braiding and twining together to create a cube 20 feet to each side. This has the effects of a 10th-rank force cage, except that Syu Tak-nwa does not need to sustain the basket; it has a duration of 1 minute. While the Silkworm's Basket persists, Syu Tak-nwa is @UUID[Compendium.pf2e.conditionitems.Item.Quickened] and can use the extra action only to make a hair or braid Strike against any target within the basket, regardless of her distance to them. She can't create more than one basket at a time.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -2762,7 +2743,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "certain-kill"
                     ]
@@ -2809,7 +2789,6 @@
                 ],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -2866,7 +2845,7 @@
             }
         },
         "details": {
-            "blurb": "",
+            "blurb": "Female Tian-Hwan white-haired witch",
             "languages": {
                 "details": "",
                 "value": [
@@ -2910,7 +2889,7 @@
         "saves": {
             "fortitude": {
                 "saveDetail": "",
-                "value": 32
+                "value": 31
             },
             "reflex": {
                 "saveDetail": "",

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/takatorra-daitengu-form.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/takatorra-daitengu-form.json
@@ -30,7 +30,7 @@
                     "die": "d6"
                 },
                 "description": {
-                    "value": "<p>This fan-shaped sword, designed by members of the tengu ancestry, has five broad blades that join at its hilt. Tengu sailors also use gale blades as makeshift weather vanes, as the sword spins to show the wind's direction when loosely held aloft.</p>"
+                    "value": "<p>This fan-shaped sword designed by tengu smiths has five broad blades that join at its hilt. Tengu sailors use them as makeshift weather vanes, for the sword spins in the wind's direction when loosely held aloft.</p>"
                 },
                 "equipped": {
                     "carryType": "worn",
@@ -38,6 +38,7 @@
                     "invested": null
                 },
                 "expend": null,
+                "grade": null,
                 "group": "sword",
                 "hardness": 0,
                 "hp": {
@@ -57,9 +58,9 @@
                     }
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core 2"
                 },
                 "quantity": 1,
                 "range": null,
@@ -103,9 +104,6 @@
             "name": "Tengu Gale Blade",
             "sort": 200000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
                     "value": []
                 },
@@ -129,16 +127,12 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "agile",
                         "disarm",
                         "finesse",
                         "magical"
                     ]
-                },
-                "weaponType": {
-                    "value": "melee"
                 }
             },
             "type": "melee"
@@ -149,9 +143,6 @@
             "name": "Vacuum Slash",
             "sort": 300000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
                     "value": []
                 },
@@ -175,14 +166,10 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "air",
                         "range-increment-120"
                     ]
-                },
-                "weaponType": {
-                    "value": "ranged"
                 }
             },
             "type": "melee"
@@ -212,8 +199,12 @@
                     {
                         "key": "FlatModifier",
                         "predicate": [
-                            "air",
-                            "electricity"
+                            {
+                                "or": [
+                                    "air",
+                                    "electricity"
+                                ]
+                            }
                         ],
                         "selector": "saving-throw",
                         "type": "status",
@@ -222,7 +213,6 @@
                 ],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -255,7 +245,6 @@
                 "rules": [],
                 "slug": "attack-of-opportunity",
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -285,7 +274,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "air"
                     ]
@@ -317,7 +305,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "air"
                     ]
@@ -349,7 +336,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -379,7 +365,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "flourish"
                     ]
@@ -435,7 +420,7 @@
             }
         },
         "details": {
-            "blurb": "",
+            "blurb": "Dimensional superposition form of Takatorra",
             "languages": {
                 "details": "(can't speak any language)",
                 "value": [

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/tino-oni-form.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/tino-oni-form.json
@@ -38,6 +38,7 @@
                     "invested": null
                 },
                 "expend": null,
+                "grade": null,
                 "group": "club",
                 "hardness": 0,
                 "hp": {
@@ -57,9 +58,9 @@
                     }
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder Player Core"
                 },
                 "quantity": 1,
                 "range": null,
@@ -97,9 +98,6 @@
             "name": "Head",
             "sort": 200000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
                     "value": []
                 },
@@ -123,16 +121,12 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "deadly-d10",
                         "reach-10",
                         "sweep",
                         "unholy"
                     ]
-                },
-                "weaponType": {
-                    "value": "melee"
                 }
             },
             "type": "melee"
@@ -143,9 +137,6 @@
             "name": "Fist",
             "sort": 300000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
                     "value": []
                 },
@@ -169,7 +160,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "agile",
                         "finesse",
@@ -178,9 +168,6 @@
                         "unarmed",
                         "unholy"
                     ]
-                },
-                "weaponType": {
-                    "value": "melee"
                 }
             },
             "type": "melee"
@@ -196,9 +183,6 @@
             "name": "Kanabo",
             "sort": 400000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
                     "value": []
                 },
@@ -222,49 +206,15 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "backswing",
                         "reach-15",
                         "shove",
                         "unholy"
                     ]
-                },
-                "weaponType": {
-                    "value": "melee"
                 }
             },
             "type": "melee"
-        },
-        {
-            "_id": "3hpsCGuCLcySWA7D",
-            "img": "systems/pf2e/icons/actions/Passive.webp",
-            "name": "Toughest Teamwork: Catapult Ally",
-            "sort": 500000,
-            "system": {
-                "actionType": {
-                    "value": "passive"
-                },
-                "actions": {
-                    "value": null
-                },
-                "category": "interaction",
-                "description": {
-                    "value": "<p><strong>Trigger</strong> An ally using a move action moves within reach of Tino's kanabo</p>\n<hr />\n<p><strong>Effect</strong> Tino scoops his ally with his kanabo and flings them 30 feet in any direction. They can continue any remainder of their movement from their landing location</p>"
-                },
-                "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
-                },
-                "rules": [],
-                "slug": null,
-                "traits": {
-                    "rarity": "common",
-                    "value": []
-                }
-            },
-            "type": "action"
         },
         {
             "_id": "xyaQCek6PhhvGzLk",
@@ -273,7 +223,7 @@
             },
             "img": "systems/pf2e/icons/actions/Reaction.webp",
             "name": "Ferocity",
-            "sort": 600000,
+            "sort": 500000,
             "system": {
                 "actionType": {
                     "value": "reaction"
@@ -294,7 +244,6 @@
                 "rules": [],
                 "slug": "ferocity",
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -307,7 +256,7 @@
             },
             "img": "systems/pf2e/icons/actions/Reaction.webp",
             "name": "Retributive Strike",
-            "sort": 700000,
+            "sort": 600000,
             "system": {
                 "actionType": {
                     "value": "reaction"
@@ -327,7 +276,35 @@
                 "rules": [],
                 "slug": "retributive-strike",
                 "traits": {
-                    "rarity": "common",
+                    "value": []
+                }
+            },
+            "type": "action"
+        },
+        {
+            "_id": "3hpsCGuCLcySWA7D",
+            "img": "systems/pf2e/icons/actions/Passive.webp",
+            "name": "Toughest Teamwork: Catapult Ally",
+            "sort": 700000,
+            "system": {
+                "actionType": {
+                    "value": "reaction"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "defensive",
+                "description": {
+                    "value": "<p><strong>Trigger</strong> An ally using a move action moves within reach of Tino's kanabo</p>\n<hr />\n<p><strong>Effect</strong> Tino scoops his ally with his kanabo and flings them 30 feet in any direction. They can continue any remainder of their movement from their landing location</p>"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [],
+                "slug": null,
+                "traits": {
                     "value": []
                 }
             },
@@ -372,7 +349,6 @@
                 ],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -399,10 +375,24 @@
                     "remaster": false,
                     "title": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "key": "RollOption",
+                        "option": "kanabo-to-oni",
+                        "toggleable": true
+                    },
+                    {
+                        "diceNumber": 2,
+                        "dieSize": "d10",
+                        "key": "DamageDice",
+                        "predicate": [
+                            "kanabo-to-oni"
+                        ],
+                        "selector": "kanabo-damage"
+                    }
+                ],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -432,7 +422,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -462,7 +451,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "flourish"
                     ]
@@ -494,7 +482,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -521,7 +508,8 @@
                     "title": ""
                 },
                 "rules": [],
-                "slug": null
+                "slug": null,
+                "traits": {}
             },
             "type": "lore"
         }
@@ -568,7 +556,7 @@
             }
         },
         "details": {
-            "blurb": "",
+            "blurb": "Dimensional superposition form of Tino Tung",
             "languages": {
                 "details": "(can't speak any language)",
                 "value": [

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/yabin-white-serpent-form.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/yabin-white-serpent-form.json
@@ -27,6 +27,9 @@
                     "title": ""
                 },
                 "rules": [],
+                "showSlotlessLevels": {
+                    "value": false
+                },
                 "slots": {
                     "slot5": {
                         "max": 4,
@@ -57,7 +60,8 @@
                 },
                 "tradition": {
                     "value": "arcane"
-                }
+                },
+                "traits": {}
             },
             "type": "spellcastingEntry"
         },
@@ -1877,11 +1881,10 @@
             "name": "Fangs",
             "sort": 2600000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
-                    "value": []
+                    "value": [
+                        "white-serpent-venom"
+                    ]
                 },
                 "bonus": {
                     "value": 33
@@ -1903,14 +1906,10 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "finesse",
                         "reach-10"
                     ]
-                },
-                "weaponType": {
-                    "value": "melee"
                 }
             },
             "type": "melee"
@@ -1921,11 +1920,7 @@
             "name": "Venom",
             "sort": 2700000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
-                    "custom": "",
                     "value": [
                         "white-serpent-venom"
                     ]
@@ -1950,13 +1945,9 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "range-20"
                     ]
-                },
-                "weaponType": {
-                    "value": "ranged"
                 }
             },
             "type": "melee"
@@ -1982,10 +1973,19 @@
                     "remaster": false,
                     "title": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "effects": [],
+                        "key": "Aura",
+                        "radius": 10,
+                        "traits": [
+                            "poison",
+                            "water"
+                        ]
+                    }
+                ],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "aura",
                         "poison",
@@ -2019,7 +2019,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -2049,7 +2048,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -2079,7 +2077,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "poison",
                         "virulent"
@@ -2145,7 +2142,7 @@
             }
         },
         "details": {
-            "blurb": "",
+            "blurb": "Dimensional superposition form of Yabin the Just",
             "languages": {
                 "details": "(can't speak any language)",
                 "value": [

--- a/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/yoh-souran.json
+++ b/packs/fists-of-the-ruby-phoenix-bestiary/book-3-king-of-the-mountain/yoh-souran.json
@@ -38,6 +38,7 @@
                     "invested": null
                 },
                 "expend": 1,
+                "grade": null,
                 "group": "crossbow",
                 "hardness": 0,
                 "hp": {
@@ -98,9 +99,6 @@
             "name": "Heavy Crossbow",
             "sort": 200000,
             "system": {
-                "attack": {
-                    "value": ""
-                },
                 "attackEffects": {
                     "value": []
                 },
@@ -124,14 +122,10 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "range-increment-120",
                         "reload-2"
                     ]
-                },
-                "weaponType": {
-                    "value": "ranged"
                 }
             },
             "type": "melee"
@@ -164,7 +158,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "manipulate"
                     ]
@@ -219,7 +212,6 @@
                 ],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": []
                 }
             },
@@ -249,7 +241,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "manipulate"
                     ]
@@ -285,7 +276,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "manipulate"
                     ]
@@ -317,7 +307,6 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "rarity": "common",
                     "value": [
                         "manipulate"
                     ]
@@ -346,7 +335,8 @@
                     "title": ""
                 },
                 "rules": [],
-                "slug": null
+                "slug": null,
+                "traits": {}
             },
             "type": "lore"
         },
@@ -371,7 +361,8 @@
                     "title": ""
                 },
                 "rules": [],
-                "slug": null
+                "slug": null,
+                "traits": {}
             },
             "type": "lore"
         }
@@ -418,7 +409,7 @@
             }
         },
         "details": {
-            "blurb": "",
+            "blurb": "male human pilot",
             "languages": {
                 "details": "",
                 "value": [


### PR DESCRIPTION
This is a creature-by-creature audit of the Book 3 AP NPCs for Fists of the Ruby Phoenix.

Upgrades some automations but mostly focused on fixing errors and adding missing data.

I also refreshed inventory items where applicable where some of the older versions were broken or lacked data. Didn't touch any spells because I know those need to stay as they are.

Includes a couple updates to Book 2 Hazards as well.

A note: Shino has a "potion of haste" in the book, which was never an item to begin with. I added a potion of quickness to her inventory based on the intent there.