### PR TITLE
Refine token distance text

### DIFF
--- a/src/module/canvas/helpers.ts
+++ b/src/module/canvas/helpers.ts
@@ -21,7 +21,7 @@ function measureDistanceCuboid(
     } = {},
 ): number {
     if (canvas.grid.type !== CONST.GRID_TYPES.SQUARE) {
-        return canvas.grid.measurePath([r0, r1]).distance;
+        return Math.round(canvas.grid.measurePath([r0, r1]).distance);
     }
 
     const gridWidth = canvas.grid.sizeX;

--- a/src/module/canvas/token/object.ts
+++ b/src/module/canvas/token/object.ts
@@ -152,7 +152,7 @@ class TokenPF2e<TDocument extends TokenDocumentPF2e = TokenDocumentPF2e> extends
     get #canSeeDistance(): boolean {
         if (!this.visible || this.isPreview || this.document.isSecret || this.controlled) return false;
         const isHover = this.hover || this.layer.highlightObjects;
-        return isHover && canvas.tokens.controlled.length === 1;
+        return isHover && (canvas.tokens.controlled.length === 1 || !!game.user.character?.getActiveTokens().length);
     }
 
     isAdjacentTo(token: TokenPF2e): boolean {
@@ -307,9 +307,12 @@ class TokenPF2e<TDocument extends TokenDocumentPF2e = TokenDocumentPF2e> extends
 
     #refreshDistanceText(): void {
         if (!this.#canSeeDistance) return;
-        const controlledToken = canvas.tokens.controlled[0];
+        const controlledToken = canvas.tokens.controlled[0] ?? game.user.character?.getActiveTokens()[0];
+        if (!controlledToken) return;
         const distanceText = this.#distanceText;
-        distanceText.text = game.i18n.format("PF2E.Token.Distance", { distance: controlledToken.distanceTo(this) });
+        const unit = canvas.scene?.grid.units ?? "";
+        const formatArgs = { distance: controlledToken.distanceTo(this), unit };
+        distanceText.text = game.i18n.format("PF2E.Token.Distance", formatArgs).trim();
         const nameplate = this.nameplate;
         const nameOffset = nameplate.visible ? nameplate.position.y + nameplate.height - 2 : nameplate.position.y;
         this.#distanceText.position.set(nameplate.position.x, nameOffset);

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3983,7 +3983,7 @@
         "Token": {
             "ActorLinkForced": "{type} actors cannot be unlinked.",
             "Appearance": "Appearance",
-            "Distance": "Distance: {distance}ft",
+            "Distance": "Distance: {distance} {unit}",
             "Flanking": "Flanking",
             "SecretDisposition": {
                 "Label": "Secret Disposition",


### PR DESCRIPTION
- Round non-square-grid value in `measureDistanceCuboid`
- Use grid units from viewed scene
- Fall back to token of assigned character if no token is controlled