### PR TITLE
Don't auto adjust price using grade for specific magic weapons

### DIFF
--- a/src/module/item/physical/helpers.ts
+++ b/src/module/item/physical/helpers.ts
@@ -35,7 +35,7 @@ function computePrice(item: PhysicalItemPF2e): CoinsPF2e {
     const runeValue = item.isSpecific ? 0 : runesData.reduce((sum, rune) => sum + rune.price, 0) - reinforcingRuneValue;
 
     const basePrice = materialValue > 0 || runeValue > 0 ? new CoinsPF2e() : item.price.value;
-    const gradeValue = getGradeData(item).price;
+    const gradeValue = item.isSpecific ? 0 : getGradeData(item).price;
     const afterMaterialAndRunes = runeValue
         ? new CoinsPF2e({ gp: runeValue + materialValue })
         : basePrice.plus({ gp: gradeValue + materialValue });


### PR DESCRIPTION
Eventually we'll figure out what to do with specific magic X items exactly once there's more content, but it should behave more consistently for now.