### PR TITLE
Add activate button for consumables created via quick alchemy

### DIFF
--- a/src/module/chat-message/helpers.ts
+++ b/src/module/chat-message/helpers.ts
@@ -58,6 +58,7 @@ async function createUseActionMessage(
         selfEffect: !!item.system.selfEffect,
         craftedItem: craftedItem?.toAnchor({ attrs: { draggable: "true" } }).outerHTML,
         withoutResources: craftedItem && !consumeResources,
+        activate: craftedItem?.type === "consumable" && craftedItem.system.usage.type === "held" ? craftedItem : null,
     });
     const flags: { pf2e: ChatMessageFlagsPF2e["pf2e"] } = { pf2e: {} };
     if (item.system.selfEffect) {

--- a/src/styles/legacy/_chat.scss
+++ b/src/styles/legacy/_chat.scss
@@ -66,7 +66,32 @@
         }
     }
 
-    .card-buttons {
+    footer {
+        padding: var(--space-3) 0 0;
+        border-top: 2px groove white;
+
+        span {
+            border-right: 2px groove white;
+            padding: 0 var(--space-4) 0 0;
+            font-size: var(--font-size-12);
+
+            &:last-child {
+                border-right: none;
+                padding-right: 0;
+            }
+        }
+    }
+
+    .card-buttons-two-column {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        grid-column-gap: var(--space-4);
+    }
+}
+
+.message-content {
+    .card-buttons,
+    .message-buttons {
         display: flex;
         flex-basis: 100%;
         flex-direction: column;
@@ -111,27 +136,5 @@
         .hidden-to-others {
             background: var(--visibility-gm-bg);
         }
-    }
-
-    footer {
-        padding: var(--space-3) 0 0;
-        border-top: 2px groove white;
-
-        span {
-            border-right: 2px groove white;
-            padding: 0 var(--space-4) 0 0;
-            font-size: var(--font-size-12);
-
-            &:last-child {
-                border-right: none;
-                padding-right: 0;
-            }
-        }
-    }
-
-    .card-buttons-two-column {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        grid-column-gap: var(--space-4);
     }
 }

--- a/src/styles/ui/sidebar/chat/_action.scss
+++ b/src/styles/ui/sidebar/chat/_action.scss
@@ -82,17 +82,7 @@
     }
 
     .message-buttons {
-        display: flex;
-        gap: 0.5rem;
-        margin: 0.5rem 0 var(--space-2);
-
         button {
-            align-items: center;
-            display: flex;
-            flex: 1;
-            justify-content: center;
-            position: relative;
-
             .cue {
                 position: absolute;
                 right: 0.5rem;
@@ -105,16 +95,16 @@
             }
         }
 
-        &:has(.effect-applied, .crafted-item) {
+        .crafted-item,
+        .effect-applied {
             align-items: center;
             color: var(--color-text-dark-secondary);
+            display: flex;
             font-style: italic;
-            flex-direction: column;
-            gap: var(--space-8);
+            gap: var(--space-4);
             justify-content: center;
             min-height: 2.1rem;
             padding-bottom: 0.1rem;
-            text-align: center;
         }
     }
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1761,7 +1761,10 @@
                 "Envision": "envision",
                 "EnvisionSheetLabel": "Envision",
                 "Interact": "Interact",
-                "Label": "Activation"
+                "Label": "Activation",
+                "Warning": {
+                    "ItemDoesNotExist": "Item to activate does not exist"
+                }
             },
             "Affliction": {
                 "AddStage": "Add Stage",

--- a/static/templates/chat/action/collapsed.hbs
+++ b/static/templates/chat/action/collapsed.hbs
@@ -6,7 +6,7 @@
     {{{description}}}
 </div>
 
-{{#if (or selfEffect craftedItem)}}
+{{#if (or selfEffect craftedItem activate)}}
     <div class="message-buttons">
         {{#if craftedItem}}
             <div class="crafted-item">
@@ -16,6 +16,11 @@
         {{#if selfEffect}}
             <button type="button" data-action="applyEffect" data-targets="{{actor.uuid}}" data-visibility="owner">
                 {{localize "PF2E.Action.ApplyEffect"}}
+            </button>
+        {{/if}}
+        {{#if activate}}
+            <button type="button" data-action="activate" data-uuid="{{activate.uuid}}" data-visibility="owner">
+                {{localize "PF2E.Item.Activation.Activate"}}
             </button>
         {{/if}}
     </div>


### PR DESCRIPTION
It can be better once there is an actual activation workflow for consumables, but this should reduce people's reliance on that alchemist module a tad.

https://github.com/user-attachments/assets/4cc3044d-9649-4894-af26-e434d8e4c617

