### PR TITLE
Add missing : in @Damage for Sword Bash of Arboreal Copse

### DIFF
--- a/packs/battlecry-bestiary/arboreal-copse.json
+++ b/packs/battlecry-bestiary/arboreal-copse.json
@@ -179,7 +179,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The arboreal copse uses their blunt stone longswords to pummel its foes. Each enemy in a @Template[type:emanation|distance:10] must attempt a @Check[reflex|dc:25|basic|optionsarea-effect] save. The damage depends on the number of actions.</p>\n<p><span class=\"action-glyph\">1</span> @Damage[(1d8+1)[bludgeoning]|options:area-damage] damage</p>\n<p><span class=\"action-glyph\">2</span> @Damage[(2d8+9)[bludgeoning]|options:area-damage] damage</p>\n<p><span class=\"action-glyph\">3</span> @Damage[(3d8+10)[bludgeoning]|options:area-damage] damage</p>"
+                    "value": "<p>The arboreal copse uses their blunt stone longswords to pummel its foes. Each enemy in a @Template[type:emanation|distance:10] must attempt a @Check[reflex|dc:25|basic|options:area-effect] save. The damage depends on the number of actions.</p>\n<p><span class=\"action-glyph\">1</span> @Damage[(1d8+1)[bludgeoning]|options:area-damage] damage</p>\n<p><span class=\"action-glyph\">2</span> @Damage[(2d8+9)[bludgeoning]|options:area-damage] damage</p>\n<p><span class=\"action-glyph\">3</span> @Damage[(3d8+10)[bludgeoning]|options:area-damage] damage</p>"
                 },
                 "publication": {
                     "license": "OGL",


### PR DESCRIPTION
Had a look for similar mistakes elsewhere in the data. Couldn't find any.