### PR TITLE
Cleanup NPC `system.skills` data entry/migration mistakes

### DIFF
--- a/packs/claws-of-the-tyrant-bestiary/2-ashes-for-ozem/chernasardo-ranger.json
+++ b/packs/claws-of-the-tyrant-bestiary/2-ashes-for-ozem/chernasardo-ranger.json
@@ -720,9 +720,6 @@
                 "base": 13,
                 "special": []
             },
-            "acrobatics+13": {
-                "base": null
-            },
             "athletics": {
                 "base": 12,
                 "special": []

--- a/packs/curtain-call-bestiary/book-1-stage-fright/fallenta.json
+++ b/packs/curtain-call-bestiary/book-1-stage-fright/fallenta.json
@@ -2777,9 +2777,6 @@
                 "base": 20,
                 "special": []
             },
-            "intimidation\n+20": {
-                "base": null
-            },
             "occultism": {
                 "base": 19,
                 "special": []

--- a/packs/curtain-call-bestiary/book-1-stage-fright/graverobber.json
+++ b/packs/curtain-call-bestiary/book-1-stage-fright/graverobber.json
@@ -606,9 +606,6 @@
             "thievery": {
                 "base": 22,
                 "special": []
-            },
-            "thievery\n+22": {
-                "base": null
             }
         },
         "traits": {

--- a/packs/curtain-call-bestiary/book-2-singer-stalker-skinsaw-man/izhkarial.json
+++ b/packs/curtain-call-bestiary/book-2-singer-stalker-skinsaw-man/izhkarial.json
@@ -1382,9 +1382,6 @@
                 "base": 28,
                 "special": []
             },
-            "society\n+28": {
-                "base": null
-            },
             "survival": {
                 "base": 26,
                 "special": []

--- a/packs/curtain-call-bestiary/book-2-singer-stalker-skinsaw-man/oriole.json
+++ b/packs/curtain-call-bestiary/book-2-singer-stalker-skinsaw-man/oriole.json
@@ -4089,12 +4089,6 @@
                 "base": 19,
                 "special": []
             },
-            "or singing)": {
-                "base": null
-            },
-            "orating": {
-                "base": null
-            },
             "performance": {
                 "base": 29,
                 "special": [
@@ -4106,9 +4100,6 @@
                         ]
                     }
                 ]
-            },
-            "performing comedy": {
-                "base": null
             },
             "society": {
                 "base": 23,

--- a/packs/curtain-call-bestiary/book-3-bring-the-house-down/blackfingers.json
+++ b/packs/curtain-call-bestiary/book-3-bring-the-house-down/blackfingers.json
@@ -1553,9 +1553,6 @@
                 "base": 35,
                 "special": []
             },
-            "intimidate": {
-                "base": 35
-            },
             "intimidation": {
                 "base": 35,
                 "special": []

--- a/packs/curtain-call-bestiary/book-3-bring-the-house-down/gray-master.json
+++ b/packs/curtain-call-bestiary/book-3-bring-the-house-down/gray-master.json
@@ -1005,9 +1005,6 @@
                 "base": 36,
                 "special": []
             },
-            "intimidate": {
-                "base": 38
-            },
             "intimidation": {
                 "base": 38,
                 "special": []

--- a/packs/curtain-call-bestiary/book-3-bring-the-house-down/prince-of-propaganda.json
+++ b/packs/curtain-call-bestiary/book-3-bring-the-house-down/prince-of-propaganda.json
@@ -1339,7 +1339,7 @@
             "diplomacy": {
                 "base": 38
             },
-            "intimidate": {
+            "intimidation": {
                 "base": 40
             },
             "religion": {

--- a/packs/myth-speaker-bestiary/book-2-death-sails-a-wine-dark-sea/amnerion.json
+++ b/packs/myth-speaker-bestiary/book-2-death-sails-a-wine-dark-sea/amnerion.json
@@ -1489,9 +1489,6 @@
             }
         },
         "skills": {
-            "+42": {
-                "base": null
-            },
             "arcana": {
                 "base": 37,
                 "special": []

--- a/packs/pathfinder-npc-core/devotee/penitent-of-calistria.json
+++ b/packs/pathfinder-npc-core/devotee/penitent-of-calistria.json
@@ -670,9 +670,6 @@
             }
         },
         "skills": {
-            "+6": {
-                "base": null
-            },
             "athletics": {
                 "base": 6,
                 "special": []

--- a/packs/pathfinder-npc-core/official/captain-of-the-guard.json
+++ b/packs/pathfinder-npc-core/official/captain-of-the-guard.json
@@ -947,9 +947,6 @@
             "athletics": {
                 "base": 15
             },
-            "athletics+15": {
-                "base": null
-            },
             "diplomacy": {
                 "base": 11
             },

--- a/packs/pathfinder-npc-core/scholar/eldritch-emeritus.json
+++ b/packs/pathfinder-npc-core/scholar/eldritch-emeritus.json
@@ -3049,9 +3049,6 @@
                 "base": 36,
                 "special": []
             },
-            "intimidate": {
-                "base": 30
-            },
             "intimidation": {
                 "base": 30,
                 "special": []

--- a/packs/pathfinder-npc-core/villain/conspiracist.json
+++ b/packs/pathfinder-npc-core/villain/conspiracist.json
@@ -403,9 +403,6 @@
                 "base": -1,
                 "special": []
             },
-            "occultism –1": {
-                "base": null
-            },
             "performance": {
                 "base": 10,
                 "special": []

--- a/packs/pfs-season-5-bestiary/5-20/asper-hajeri-9-10.json
+++ b/packs/pfs-season-5-bestiary/5-20/asper-hajeri-9-10.json
@@ -2003,10 +2003,7 @@
                 "base": 24
             },
             "occultism": {
-                "base": 20
-            },
-            "occultism+23": {
-                "base": null
+                "base": 23
             },
             "religion": {
                 "base": 21

--- a/packs/pfs-season-6-bestiary/6-05/big-katsu.json
+++ b/packs/pfs-season-6-bestiary/6-05/big-katsu.json
@@ -569,9 +569,6 @@
             "athletics": {
                 "base": 12
             },
-            "intimidate": {
-                "base": 10
-            },
             "intimidation": {
                 "base": 10
             },

--- a/packs/prey-for-death-bestiary/saviya.json
+++ b/packs/prey-for-death-bestiary/saviya.json
@@ -4600,9 +4600,6 @@
                 "base": 33,
                 "special": []
             },
-            "nature\n+33": {
-                "base": null
-            },
             "religion": {
                 "base": 35,
                 "special": []

--- a/packs/shades-of-blood-bestiary/book-3-to-blot-out-the-sun/clockwork-sentry.json
+++ b/packs/shades-of-blood-bestiary/book-3-to-blot-out-the-sun/clockwork-sentry.json
@@ -1019,12 +1019,6 @@
                         ]
                     }
                 ]
-            },
-            "or trip)": {
-                "base": null
-            },
-            "shove": {
-                "base": null
             }
         },
         "traits": {


### PR DESCRIPTION
Mainly to prevent potential future issues during migrations, but some of these are causing issues now (e.g Asper Hajeri 9-10 likely has an incorrect Occultism modifier).
I've left notes on a few of these changes, as someone needs to double check the sourcebook for them.