### PR TITLE
Correct Animate Dream's spell list and resistances (Gatewalkers version)

### DIFF
--- a/packs/gatewalkers-bestiary/book-3-dreamers-of-the-nameless-spires/animate-dream.json
+++ b/packs/gatewalkers-bestiary/book-3-dreamers-of-the-nameless-spires/animate-dream.json
@@ -392,6 +392,7 @@
                     "value": 1
                 },
                 "location": {
+                    "heightenedLevel": 3,
                     "value": "oNmHvve4Vcwj6IiO"
                 },
                 "publication": {
@@ -465,6 +466,7 @@
                     "value": 1
                 },
                 "location": {
+                    "heightenedLevel": 4,
                     "value": "oNmHvve4Vcwj6IiO"
                 },
                 "publication": {

--- a/packs/gatewalkers-bestiary/book-3-dreamers-of-the-nameless-spires/animate-dream.json
+++ b/packs/gatewalkers-bestiary/book-3-dreamers-of-the-nameless-spires/animate-dream.json
@@ -716,7 +716,7 @@
                     "exceptions": [
                         "force",
                         "ghost-touch",
-                        "void"
+                        "spirit"
                     ],
                     "type": "all-damage",
                     "value": 5


### PR DESCRIPTION
Fear should be heightened to 3rd rank and sleep to 4th rank per the PDF.