### PR TITLE
Add statistics to Xulgath Dinosaur Cavalry's Trample ability

### DIFF
--- a/packs/battlecry-bestiary/xulgath-dinosaur-cavalry.json
+++ b/packs/battlecry-bestiary/xulgath-dinosaur-cavalry.json
@@ -207,7 +207,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>[Size], [Listed Strike], @Check[reflex|dc:|basic]</p>\n<hr />\n<p>@Localize[PF2E.NPC.Abilities.Glossary.Trample]</p>"
+                    "value": "<p>Large or smaller, @Damage[(2d6+2)[bludgeoning]], @Check[reflex|dc:30|basic]</p>\n<hr />\n<p>@Localize[PF2E.NPC.Abilities.Glossary.Trample]</p>"
                 },
                 "publication": {
                     "license": "ORC",


### PR DESCRIPTION
Technically it's different from other tramples, since it doesn't reference a Strike, but just uses the 1-action damage from the troop damaging ability.