### PR TITLE
Update `EnvironmentFeatureBehaviorType` to work with the new token ruler

### DIFF
--- a/src/module/scene/region-behavior/environment-feature.ts
+++ b/src/module/scene/region-behavior/environment-feature.ts
@@ -1,4 +1,5 @@
-import { ZeroToTwo } from "@module/data.ts";
+import type { ZeroToTwo } from "@module/data.ts";
+import type { TokenDocumentPF2e } from "@scene/token-document/document.ts";
 import { RegionBehaviorPF2e } from "./document.ts";
 import fields = foundry.data.fields;
 
@@ -28,6 +29,15 @@ class EnvironmentFeatureBehaviorType extends foundry.data.regionBehaviors.Region
             ),
         };
     }
+
+    protected override _getTerrainEffects(
+        _token: TokenDocumentPF2e,
+        segment: fd.TokenMovementSegmentData,
+    ): DifficultTerrainEffectData[] {
+        // Todo: Handle other actions
+        if (segment.action !== "walk") return [];
+        return [{ name: "difficultTerrainPF2e", difficultTerrain: this.terrain.difficult }];
+    }
 }
 
 interface EnvironmentFeatureBehaviorType
@@ -40,4 +50,10 @@ type EnvironmentFeatureTypeSchema = {
     }>;
 };
 
+interface DifficultTerrainEffectData {
+    name: "difficultTerrainPF2e";
+    difficultTerrain: number;
+}
+
 export { EnvironmentFeatureBehaviorType };
+export type { DifficultTerrainEffectData };

--- a/src/module/scene/terrain-data.ts
+++ b/src/module/scene/terrain-data.ts
@@ -1,0 +1,68 @@
+import type { TokenMeasureMovementPathOptions, TokenMovementCostFunction } from "@client/_types.d.mts";
+import type { ZeroToTwo } from "@module/data.ts";
+import type { DifficultTerrainEffectData } from "./region-behavior/environment-feature.ts";
+import fields = foundry.data.fields;
+
+class TerrainDataPF2e extends foundry.data.TerrainData {
+    static override defineSchema(): TerrainDataSchemaPF2e {
+        const fields = foundry.data.fields;
+        return {
+            ...super.defineSchema(),
+            difficultTerrain: new fields.NumberField({
+                required: true,
+                nullable: false,
+                choices: [0, 1, 2],
+                initial: 0,
+            }),
+        };
+    }
+
+    static override getMovementCostFunction<T extends TokenMovementCostFunction<TerrainDataPF2e>>(
+        token: TokenDocument,
+        options?: TokenMeasureMovementPathOptions,
+    ): T {
+        const baseFunction = super.getMovementCostFunction(token, options);
+        const systemFunction: TokenMovementCostFunction<TerrainDataPF2e> = (from, to, distance, segment) => {
+            const difficulty = segment.terrain?.difficultTerrain;
+            if (difficulty) {
+                return difficulty === 1 ? distance + 5 : difficulty === 2 ? distance + 10 : distance;
+            }
+            return baseFunction(from, to, distance, segment);
+        };
+        return systemFunction as T;
+    }
+
+    static override resolveTerrainEffects(effects: TerrainEffect[]): TerrainDataPF2e | null {
+        let difficulty = 1;
+        let difficultTerrain = 0;
+        for (const effect of effects) {
+            if (effect.name === "difficulty") difficulty *= effect.difficulty;
+            if (effect.name === "difficultTerrainPF2e") {
+                // Only apply the highest version of difficult terrain
+                if (effect.difficultTerrain > difficultTerrain) difficultTerrain = effect.difficultTerrain;
+            }
+        }
+        if (difficulty === 1 && difficultTerrain === 0) return null;
+        return new this({ difficulty, difficultTerrain });
+    }
+
+    override equals(other: TerrainDataPF2e): boolean {
+        if (!(other instanceof TerrainDataPF2e)) return false;
+        return this.difficulty === other.difficulty && this.difficultTerrain === other.difficultTerrain;
+    }
+}
+
+interface CoreTerrainDifficultyEffect {
+    name: "difficulty";
+    difficulty: number;
+}
+
+type TerrainEffect = CoreTerrainDifficultyEffect | DifficultTerrainEffectData;
+
+interface TerrainDataPF2e extends foundry.data.TerrainData, fields.ModelPropsFromSchema<TerrainDataSchemaPF2e> {}
+
+type TerrainDataSchemaPF2e = foundry.data.TerrainDataSchema & {
+    difficultTerrain: fields.NumberField<ZeroToTwo, ZeroToTwo, true, false, true>;
+};
+
+export { TerrainDataPF2e };

--- a/src/scripts/hooks/load.ts
+++ b/src/scripts/hooks/load.ts
@@ -49,6 +49,7 @@ import {
     TileDocumentPF2e,
     TokenDocumentPF2e,
 } from "@scene/index.ts";
+import { TerrainDataPF2e } from "@scene/terrain-data.ts";
 import { PrototypeTokenConfigPF2e } from "@scene/token-document/index.ts";
 import { monkeyPatchFoundry } from "@scripts/🐵🩹.ts";
 import { CheckRoll, StrikeAttackRoll } from "@system/check/roll.ts";
@@ -91,6 +92,7 @@ export const Load = {
         CONFIG.Scene.documentClass = ScenePF2e;
         CONFIG.Tile.documentClass = TileDocumentPF2e;
         CONFIG.Token.documentClass = TokenDocumentPF2e;
+        CONFIG.Token.movement.TerrainData = TerrainDataPF2e;
         CONFIG.Token.prototypeSheetClass = PrototypeTokenConfigPF2e;
         CONFIG.Token.objectClass = TokenPF2e;
         CONFIG.User.documentClass = UserPF2e;

--- a/types/foundry/client/_types.d.mts
+++ b/types/foundry/client/_types.d.mts
@@ -11,6 +11,7 @@ import { PingData } from "./canvas/interaction/_types.mjs";
 import AmbientLight from "./canvas/placeables/light.mjs";
 import Token, { TokenShape } from "./canvas/placeables/token.mjs";
 import PointVisionSource from "./canvas/sources/point-vision-source.mjs";
+import { BaseTerrainData } from "./data/terrain-data.mjs";
 import Roll from "./dice/roll.mjs";
 import { TableResult, TokenDocument, User } from "./documents/_module.mjs";
 import { Color } from "./utils/_module.mjs";
@@ -65,7 +66,7 @@ export interface RulerWaypoint {
     next: RulerWaypoint | null;
 }
 
-export interface TokenMeasuredMovementWaypoint {
+export interface TokenMeasuredMovementWaypoint<TTerrainData extends BaseTerrainData = BaseTerrainData> {
     /** The top-left x-coordinate in pixels (integer). */
     x: number;
 
@@ -94,7 +95,7 @@ export interface TokenMeasuredMovementWaypoint {
     forced: boolean;
 
     /** The terrain data from the previous to this waypoint. */
-    terrain: DataModel | null;
+    terrain: TTerrainData | null;
 
     /** Was this waypoint snapped to the grid? */
     snapped: boolean;
@@ -169,13 +170,14 @@ export interface TokenMeasureMovementPathWaypoint {
     cost?: number | TokenMovementCostFunction;
 }
 
-export interface TokenMovementSegmentData
+export interface TokenMovementSegmentData<TTerrainData extends BaseTerrainData = BaseTerrainData>
     extends Pick<
-        TokenMeasuredMovementWaypoint,
+        TokenMeasuredMovementWaypoint<TTerrainData>,
         "width" | "height" | "shape" | "action" | "teleport" | "forced" | "terrain"
     > {}
 
-export type TokenMovementCostFunction = GridMeasurePathCostFunction3D<TokenMovementSegmentData>;
+export type TokenMovementCostFunction<TTerrainData extends BaseTerrainData = BaseTerrainData> =
+    GridMeasurePathCostFunction3D<TokenMovementSegmentData<TTerrainData>>;
 
 export interface TokenGetCompleteMovementPathWaypoint {
     /**

--- a/types/foundry/client/config.d.mts
+++ b/types/foundry/client/config.d.mts
@@ -46,6 +46,7 @@ import type {
     PointVisionSource,
 } from "./canvas/sources/_module.mjs";
 import ClientDatabaseBackend from "./data/client-backend.mjs";
+import { TerrainData } from "./data/terrain-data.mjs";
 import WorldCollection from "./documents/abstract/world-collection.mjs";
 import * as collections from "./documents/collections/_module.mjs";
 
@@ -442,6 +443,9 @@ export default interface Config<
     /** Configuration for the Token embedded document type and its representation on the game Canvas */
     Token: {
         documentClass: ConstructorOf<TTokenDocument>;
+        movement: {
+            TerrainData: ConstructorOf<TerrainData>;
+        };
         objectClass: ConstructorOf<NonNullable<TTokenDocument["object"]>>;
         prototypeSheetClass: ConstructorOf<PrototypeTokenConfig>;
         ring: TokenRingConfig;

--- a/types/foundry/client/data/region-behaviors/base.d.mts
+++ b/types/foundry/client/data/region-behaviors/base.d.mts
@@ -1,5 +1,7 @@
+import { TokenMovementSegmentData } from "@client/documents/_types.mjs";
 import RegionBehavior from "@client/documents/region-behavior.mjs";
 import { RegionEvent } from "@client/documents/region.mjs";
+import TokenDocument from "@client/documents/token.mjs";
 import { DataSchema } from "@common/abstract/_types.mjs";
 import TypeDataModel from "@common/abstract/type-data.mjs";
 import { REGION_EVENTS } from "@common/constants.mjs";
@@ -47,6 +49,18 @@ export abstract class RegionBehaviorType<
      * @internal
      */
     protected _handleRegionEvent(event: RegionEvent): Promise<void>;
+
+    /**
+     * Get the terrain effects of this behavior for the movement of the given token.
+     * This function is called only for behaviors that are not disabled.
+     * The terrain data is created from the terrain effects
+     * ({@link CONFIG.Token.movement.TerrainData.resolveTerrainEffects}).
+     * Returns an empty array by default.
+     * @param token The token being or about to be moved within the region of this behavior
+     * @param segment The segment data of the token's movement
+     * @returns The terrain effects that apply to this token's movement
+     */
+    protected _getTerrainEffects(token: TokenDocument, segment: TokenMovementSegmentData): object[];
 }
 
 /** Run in the context of a {@link RegionBehaviorType} */

--- a/types/foundry/client/data/terrain-data.d.mts
+++ b/types/foundry/client/data/terrain-data.d.mts
@@ -18,7 +18,7 @@ export abstract class BaseTerrainData<TSchema extends DataSchema = DataSchema> e
      * @param effects An array of terrain effects
      * @returns The terrain data or null
      */
-    static resolveTerrainEffects(effects: object[]): BaseTerrainData;
+    static resolveTerrainEffects(effects: object[]): BaseTerrainData | null;
 
     /**
      * Create the terrain movement cost function for the given token.
@@ -53,9 +53,12 @@ export abstract class BaseTerrainData<TSchema extends DataSchema = DataSchema> e
 export class TerrainData extends BaseTerrainData {
     static override defineSchema(): TerrainDataSchema;
 
-    static override resolveTerrainEffects(effects: Partial<TerrainDataSource>[]): TerrainData;
+    static override resolveTerrainEffects(effects: object[]): TerrainData | null;
 
-    static override getMovementCostFunction(token: TokenDocument): TokenMovementCostFunction;
+    static override getMovementCostFunction(
+        token: TokenDocument,
+        options?: TokenMeasureMovementPathOptions,
+    ): TokenMovementCostFunction;
 
     prepareBaseData(): void;
 


### PR DESCRIPTION
This enables difficult terrain calculations while keeping the core `Modify Movement Cost` functional (if someone wants to use that for whatever reason).
Only for the `walk` action for now. It can't handle elevation yet.

<img width="437" height="290" alt="r" src="https://github.com/user-attachments/assets/e75f3307-8ca1-4a91-af01-65350dc4c437" />
