### PR TITLE
Fix filtering `SpellcastingEntry`s in `Actor#prepareData`

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -31,7 +31,6 @@ import { createDisintegrateEffect } from "@item/effect/helpers.ts";
 import { itemIsOfType } from "@item/helpers.ts";
 import { CoinsPF2e } from "@item/physical/coins.ts";
 import { getDefaultEquipStatus } from "@item/physical/helpers.ts";
-import { MAGIC_TRADITIONS } from "@item/spell/values.ts";
 import { ActiveEffectPF2e } from "@module/active-effect.ts";
 import type { TokenPF2e } from "@module/canvas/index.ts";
 import { ChatMessagePF2e } from "@module/chat-message/document.ts";
@@ -804,7 +803,7 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
         // Those that don't may be extending special statistics and need to run afterwards
         // NOTE: Later on special statistics should have support for phases (with class/spell dc defaulting to last)
         const spellcasting = this.itemTypes.spellcastingEntry;
-        const traditionBased = spellcasting.filter((s) => setHasElement(MAGIC_TRADITIONS, s.system.proficiency.slug));
+        const traditionBased = spellcasting.filter((s) => s.system.proficiency.slug === "base-spellcasting");
         const nonTraditionBased = spellcasting.filter((s) => !traditionBased.includes(s));
         for (const entry of traditionBased) {
             entry.prepareStatistic();

--- a/src/module/item/spellcasting-entry/document.ts
+++ b/src/module/item/spellcasting-entry/document.ts
@@ -94,6 +94,7 @@ class SpellcastingEntryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null>
         this.spells = null;
         this.system.prepared.flexible ??= false;
         this.system.prepared.validItems ||= null;
+        this.system.proficiency.slug ||= "base-spellcasting";
 
         if (this.isPrepared) {
             const isFlexible = this.isFlexible;
@@ -164,7 +165,7 @@ class SpellcastingEntryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null>
         // NPCs prepare spellcasting with explicit values.
         if (actor.isOfType("character")) {
             // Spellcasting entries extend other statistics, usually a tradition, but sometimes class dc
-            const baseStat = actor.getStatistic(this.system.proficiency.slug || "base-spellcasting");
+            const baseStat = actor.getStatistic(this.system.proficiency.slug);
             if (!baseStat) return;
 
             this.system.ability.value = baseStat.attribute ?? this.system.ability.value;


### PR DESCRIPTION
`proficency.slug` is an empty string in every spellcasting entry I've checked.

Addresses resolving `@actor.system.attributes.spellDC.value` in #20034