### PR TITLE
Add support for adding skill choices to Treat Wounds

### DIFF
--- a/packs/classfeatures/chirurgeon.json
+++ b/packs/classfeatures/chirurgeon.json
@@ -36,6 +36,12 @@
                 }
             },
             {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.treatWoundsSkills",
+                "value": "crafting"
+            },
+            {
                 "itemType": "weapon",
                 "key": "ItemAlteration",
                 "label": "PF2E.SpecificRule.Alchemist.ResearchField.FieldVials",

--- a/packs/feats/skill/natural-medicine.json
+++ b/packs/feats/skill/natural-medicine.json
@@ -39,6 +39,12 @@
                 "selector": "nature",
                 "type": "circumstance",
                 "value": 2
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.pf2e.treatWoundsSkills",
+                "value": "nature"
             }
         ],
         "traits": {

--- a/src/module/actor/character/data.ts
+++ b/src/module/actor/character/data.ts
@@ -62,6 +62,8 @@ type CharacterFlags = ActorFlagsPF2e & {
         showBasicUnarmed: boolean;
         /** The limit for each feat group that supports a custom limit. */
         featLimits: Record<string, number>;
+        /** The alternative skills available to use in Treat Wounds */
+        treatWoundsSkills: string[];
     };
 };
 

--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -243,6 +243,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
         );
         flags.pf2e.showBasicUnarmed ??= true;
         flags.pf2e.featLimits ??= {};
+        flags.pf2e.treatWoundsSkills ??= [];
 
         // Build selections: boosts and skill trainings
         const isGradual = game.pf2e.settings.variants.gab;

--- a/src/scripts/macros/treat-wounds.ts
+++ b/src/scripts/macros/treat-wounds.ts
@@ -43,11 +43,16 @@ async function treatWounds(options: ActionDefaultOptions): Promise<void> {
         return;
     }
 
+    const skills = ["medicine"].concat(...(<[]>actor.flags.pf2e.treatWoundsSkills)).sort();
     const medicineName = game.i18n.localize("PF2E.Skill.Medicine");
-    const chirurgeon = CheckFeat(actor, "chirurgeon");
-    const naturalMedicine = CheckFeat(actor, "natural-medicine");
     const domIdAppend = fu.randomID(); // Attached to element id attributes for DOM uniqueness
     const riskySurgeryChecked = actor.getRollOptions(["medicine"]).includes("risky-surgery") ? " checked" : "";
+    const skillSelectOptions = skills
+        .map(
+            (skill) =>
+                `<option value="${skill}">${game.i18n.localize("PF2E.Skill." + game.pf2e.system.sluggify(skill, { camel: "bactrian" }))}</option>`,
+        )
+        .join();
     const dialog = new foundry.appv1.api.Dialog({
         title: game.i18n.localize("PF2E.Actions.TreatWounds.Label"),
         content: `
@@ -56,10 +61,8 @@ async function treatWounds(options: ActionDefaultOptions): Promise<void> {
 <form>
 <div class="form-group">
 <label for="skill-${domIdAppend}">${game.i18n.localize("PF2E.Actions.TreatWounds.SkillSelect")}</label>
-<select id="skill-${domIdAppend}"${!chirurgeon && !naturalMedicine ? " disabled" : ""}>
-  ${chirurgeon ? `<option value="crafting">${game.i18n.localize("PF2E.Skill.Crafting")}</option>` : ``}
-  ${naturalMedicine ? `<option value="nature">${game.i18n.localize("PF2E.Skill.Nature")}</option>` : ``}
-  <option value="medicine">${medicineName}</option>
+<select id="skill-${domIdAppend}"${skills.length === 1 ? " disabled" : ""}>
+    ${skillSelectOptions}
 </select>
 </div>
 <div class="form-group">

--- a/src/scripts/macros/treat-wounds.ts
+++ b/src/scripts/macros/treat-wounds.ts
@@ -43,11 +43,11 @@ async function treatWounds(options: ActionDefaultOptions): Promise<void> {
         return;
     }
 
-    const skills = ["medicine"].concat(...(<[]>actor.flags.pf2e.treatWoundsSkills)).sort();
+    const skills = new Set(["medicine"].concat(...(<[]>actor.flags.pf2e.treatWoundsSkills)).sort());
     const medicineName = game.i18n.localize("PF2E.Skill.Medicine");
     const domIdAppend = fu.randomID(); // Attached to element id attributes for DOM uniqueness
     const riskySurgeryChecked = actor.getRollOptions(["medicine"]).includes("risky-surgery") ? " checked" : "";
-    const skillSelectOptions = skills
+    const skillSelectOptions = [...skills]
         .map(
             (skill) =>
                 `<option value="${skill}">${game.i18n.localize("PF2E.Skill." + game.pf2e.system.sluggify(skill, { camel: "bactrian" }))}</option>`,
@@ -61,7 +61,7 @@ async function treatWounds(options: ActionDefaultOptions): Promise<void> {
 <form>
 <div class="form-group">
 <label for="skill-${domIdAppend}">${game.i18n.localize("PF2E.Actions.TreatWounds.SkillSelect")}</label>
-<select id="skill-${domIdAppend}"${skills.length === 1 ? " disabled" : ""}>
+<select id="skill-${domIdAppend}"${skills.size === 1 ? " disabled" : ""}>
     ${skillSelectOptions}
 </select>
 </div>


### PR DESCRIPTION
Creates an array in flags to hold alternate skills to use for treat wounds and changes the treat wounds macro to add skills from there to its menu. This will generalize for any possible future features and homebrew additions.

May need explicit support for Chirurgeon and Natural Medicine added back to the macro unless existing features could be migrated to add the rule element to them.

<img width="409" height="213" alt="image" src="https://github.com/user-attachments/assets/a5c7b845-a3ae-45b1-99c1-82a6e6f7f338" />
