### PR TITLE
Remove clearing exploration activities from characters without parties

### DIFF
--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -402,11 +402,6 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
 
         // PC level is never a derived number, so it can be set early
         this.rollOptions.all[`self:level:${this.level}`] = true;
-
-        // If there are no parties, clear the exploration activities list
-        if (!this.parties.size) {
-            this.system.exploration = [];
-        }
     }
 
     /** After AE-likes have been applied, set numeric roll options */

--- a/static/templates/actors/partials/action.hbs
+++ b/static/templates/actors/partials/action.hbs
@@ -41,7 +41,7 @@
         </div>
     {{/if}}
 
-    {{#if (and action.exploration @root.document.parties.size)}}
+    {{#if (and action.exploration (or action.exploration.active @root.document.parties.size))}}
         <button type="button" class="activate {{#if action.exploration.active}}active{{/if}}" data-action="toggle-exploration">
             {{localize "PF2E.Actor.Character.Active"}}
         </button>


### PR DESCRIPTION
Fixes exploration activities getting cleared during on restarts. I considered renaming the PR that by saying "fix clearing in specific case" with a PR that removes it in all cases felt icky even for me.

The sheet blocks activating new ones if you're not in a party, but allows deactivating existing ones.