### PR TITLE
Remove flipping of initial `unconstrainedMovement` scene control value

### DIFF
--- a/src/scripts/hooks/get-scene-control-buttons.ts
+++ b/src/scripts/hooks/get-scene-control-buttons.ts
@@ -9,11 +9,6 @@ export const GetSceneControlButtons = {
             // World Clock
             const tokenTools = controls.tokens?.tools;
             if (tokenTools) {
-                // Side adventure: flip the default of "Unconstrained Movement"
-                if (game.user.isGM && tokenTools.unconstrainedMovement) {
-                    tokenTools.unconstrainedMovement.active = true;
-                }
-
                 const settings = game.pf2e.settings.worldClock;
                 tokenTools.worldClock = {
                     name: "worldClock",


### PR DESCRIPTION
It is now a client setting.