### PR TITLE
Priorize array fields for arrays when failing validation in DataUnionField

### DIFF
--- a/src/module/system/schema-data-fields.ts
+++ b/src/module/system/schema-data-fields.ts
@@ -293,16 +293,25 @@ class DataUnionField<
         value: unknown,
         options?: DataFieldValidationOptions | undefined,
     ): boolean | void | validation.DataModelValidationFailure {
+        const errors: { field: TField; result: validation.DataModelValidationFailure }[] = [];
         for (const field of this.fields) {
             const result = field.validate(value, options);
             if (result instanceof validation.DataModelValidationFailure) {
-                if (field === this.fields.at(-1)) return result;
-                continue;
+                errors.push({ field, result });
             } else {
                 return true;
             }
         }
-        return false;
+
+        const lastError = errors.at(-1)?.result;
+        if (!lastError) return false;
+
+        // Attempt to determine which error is the most relevant based on simple heuristics
+        if (Array.isArray(value)) {
+            return errors.findLast((e) => e.field instanceof fields.ArrayField)?.result ?? lastError;
+        } else {
+            return lastError;
+        }
     }
 
     override initialize(


### PR DESCRIPTION
The following **invalid** rule element correctly error'd, but the error message wasn't very helpful even though there was sufficient data to determine the user's intent.

```json
{
  "alwaysActive": true,
  "key": "RollOption",
  "option": "ancestral-longevity",
  "phase": "beforeDerived",
  "suboptions": [
    {
      "label": "PF2E.OracleCurses.Ancestor.Label.Martial",
      "valueWrong": "aaa"
    }
  ],
  "toggleable": true
}
```

Before:
<img width="673" height="166" alt="image" src="https://github.com/user-attachments/assets/4a452f3f-715e-47ac-87b9-2cbf9b87f4fc" />

After:
<img width="691" height="146" alt="image" src="https://github.com/user-attachments/assets/04a772ab-8b07-42b3-ab93-85b79dd6a00b" />
