### PR TITLE
Add trait annotations logging

### DIFF
--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -1169,7 +1169,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
         {
             const grade = weapon.system.grade;
             const potencyRune = weapon.system.runes.potency;
-            const trackingMod = Number(weaponTraits.find((t) => /^tracking-[123]$/.test(t))?.slice(-1)) || 0;
+            const trackingMod = weapon.system.traits.config.tracking || 0;
 
             // Get all weapon potency synthetics. These don't work for sf2e unless the type is potency (ABP)
             const potencySynthetics = attackDomains

--- a/src/module/item/base/data/system.ts
+++ b/src/module/item/base/data/system.ts
@@ -20,10 +20,17 @@ interface ActionCost {
     value: OneToThree | null;
 }
 
+interface TraitConfig {
+    volley?: number;
+    tracking?: number;
+    [key: string]: number | undefined;
+}
+
 interface ItemTraits<T extends ItemTrait = ItemTrait> {
     value: T[];
     rarity: Rarity;
     otherTags: string[];
+    config?: TraitConfig;
 }
 
 interface ItemTraitsNoRarity<T extends ItemTrait = ItemTrait> extends Omit<ItemTraits<T>, "rarity"> {
@@ -34,12 +41,14 @@ interface RarityTraitAndOtherTags {
     rarity: Rarity;
     otherTags: string[];
     value?: never;
+    config?: never;
 }
 
 interface OtherTagsOnly {
     otherTags: string[];
     value?: never;
     rarity?: never;
+    config?: never;
 }
 
 type ItemFlagsPF2e = DocumentFlags & {
@@ -162,4 +171,5 @@ export type {
     ItemTraitsNoRarity,
     OtherTagsOnly,
     RarityTraitAndOtherTags,
+    TraitConfig,
 };

--- a/src/module/item/helpers.ts
+++ b/src/module/item/helpers.ts
@@ -3,7 +3,9 @@ import { createHTMLElement, setHasElement } from "@util";
 import type { Converter } from "showdown";
 import { processSanctification } from "./ability/helpers.ts";
 import type { ItemSourcePF2e, ItemType } from "./base/data/index.ts";
+import { ItemTraits, ItemTraitsNoRarity } from "./base/data/system.ts";
 import type { ItemPF2e } from "./base/document.ts";
+import { ItemTrait } from "./base/types.ts";
 import type { PhysicalItemPF2e } from "./physical/document.ts";
 import { PHYSICAL_ITEM_TYPES } from "./physical/values.ts";
 import type { ItemInstances } from "./types.ts";
@@ -74,4 +76,66 @@ function markdownToHTML(markdown: string): string {
         .innerHTML.trim();
 }
 
-export { itemIsOfType, markdownToHTML, performLatePreparation, reduceItemName };
+/**
+ * Add a trait to an array of traits--unless it matches an existing trait except by annotation. Replace the trait if
+ * the new trait is an upgrade, or otherwise do nothing. Note: the array is mutated as part of this process.
+ */
+function addOrUpgradeTrait<TTrait extends ItemTrait>(
+    traits: ItemTraits<TTrait> | ItemTraitsNoRarity<TTrait> | TTrait[],
+    newTrait: TTrait,
+): void {
+    // Get traits and annotations object to potentially upgrade
+    const isArray = Array.isArray(traits);
+    const value = isArray ? traits : traits.value;
+    const config = isArray ? null : (traits.config ??= {});
+
+    // Check first if its not an annotated trait
+    const annotatedTraitMatch = newTrait.match(/^([a-z][-a-z]+)-(\d*d?\d+)$/);
+    if (!annotatedTraitMatch) {
+        if (!value.includes(newTrait)) value.push(newTrait);
+        return;
+    }
+
+    // If annotated, log it and potentially upgrade it
+    const traitBase = annotatedTraitMatch[1];
+    const upgradeAnnotation = annotatedTraitMatch[2];
+    const traitPattern = new RegExp(String.raw`${traitBase}-(\d*d?\d*)`);
+    const existingTrait = value.find((t) => traitPattern.test(t));
+    const existingAnnotation = existingTrait?.match(traitPattern)?.at(1);
+    if (!(existingTrait && existingAnnotation)) {
+        if (!value.includes(newTrait)) value.push(newTrait);
+        if (config) config[traitBase] = Number(upgradeAnnotation);
+    } else if (_expectedValueOf(upgradeAnnotation) > _expectedValueOf(existingAnnotation)) {
+        value.splice(value.indexOf(existingTrait), 1, newTrait);
+        if (config) config[traitBase] = Number(upgradeAnnotation);
+    }
+}
+
+/**
+ * Removes the trait from the traits object, and also updates the annotation if relevant
+ * @param traits the traits object to update
+ * @param trait the trait being removed, either the full one or an unannotated variant (like "volley")
+ */
+function removeTrait<TTrait extends ItemTrait>(
+    traits: ItemTraits<TTrait> | ItemTraitsNoRarity<TTrait>,
+    trait: string,
+): void {
+    const idx = traits.value.findIndex((t) => t === trait);
+    if (idx < 0) return;
+
+    traits.value.splice(idx, 1);
+    const annotatedTraitMatch = trait.match(/^([a-z][-a-z]+)-(\d*d?\d+)$/);
+    if (annotatedTraitMatch && traits.config) {
+        const traitBase = annotatedTraitMatch[1];
+        delete traits.config[traitBase];
+    }
+}
+
+function _expectedValueOf(annotation: string): number {
+    const traitValueMatch = annotation.match(/(\d*)d(\d+)/);
+    return traitValueMatch
+        ? Number(traitValueMatch[1] || 1) * ((Number(traitValueMatch[2]) + 1) / 2)
+        : Number(annotation);
+}
+
+export { addOrUpgradeTrait, itemIsOfType, markdownToHTML, performLatePreparation, reduceItemName, removeTrait };

--- a/src/module/item/physical/data.ts
+++ b/src/module/item/physical/data.ts
@@ -3,7 +3,7 @@ import type { ImageFilePath } from "@common/constants.d.mts";
 import type { PhysicalItemSource } from "@item/base/data/index.ts";
 import type { Size, TraitsWithRarity, ZeroToTwo } from "@module/data.ts";
 import type { MaterialDamageEffect } from "@system/damage/types.ts";
-import type { BaseItemSourcePF2e, ItemSystemData, ItemSystemSource } from "../base/data/system.ts";
+import type { BaseItemSourcePF2e, ItemSystemData, ItemSystemSource, TraitConfig } from "../base/data/system.ts";
 import type { ITEM_CARRY_TYPES } from "../base/data/values.ts";
 import type { CoinsPF2e } from "./helpers.ts";
 import type { PhysicalItemTrait, PhysicalItemType, PreciousMaterialGrade, PreciousMaterialType } from "./types.ts";
@@ -120,6 +120,7 @@ type EquippedData = {
 
 interface PhysicalItemTraits<T extends PhysicalItemTrait> extends TraitsWithRarity<T> {
     otherTags: string[];
+    config?: TraitConfig;
 }
 
 interface PhysicalItemHPSource {

--- a/src/module/item/weapon/data.ts
+++ b/src/module/item/weapon/data.ts
@@ -1,6 +1,6 @@
 import { AttributeString } from "@actor/types.ts";
 import type { PhysicalItemSource } from "@item/base/data/index.ts";
-import { ItemFlagsPF2e } from "@item/base/data/system.ts";
+import { ItemFlagsPF2e, TraitConfig } from "@item/base/data/system.ts";
 import type {
     BasePhysicalItemSource,
     Grade,
@@ -167,6 +167,7 @@ type WeaponUsageDetails = UsageDetails & Required<WeaponSystemSource["usage"]>;
 interface WeaponTraits extends WeaponTraitsSource {
     otherTags: OtherWeaponTag[];
     toggles: WeaponTraitToggles;
+    config: TraitConfig;
 }
 
 interface WeaponMaterialData extends ItemMaterialData {

--- a/src/module/item/weapon/document.ts
+++ b/src/module/item/weapon/document.ts
@@ -8,7 +8,7 @@ import type { ConsumablePF2e, MeleePF2e, ShieldPF2e } from "@item";
 import { ItemProxyPF2e, PhysicalItemPF2e } from "@item";
 import { createActionRangeLabel } from "@item/ability/helpers.ts";
 import type { ItemSourcePF2e, MeleeSource, RawItemChatData } from "@item/base/data/index.ts";
-import { performLatePreparation } from "@item/helpers.ts";
+import { addOrUpgradeTrait, performLatePreparation } from "@item/helpers.ts";
 import type { NPCAttackDamage } from "@item/melee/data.ts";
 import type { NPCAttackTrait } from "@item/melee/types.ts";
 import type { PhysicalItemConstructionContext } from "@item/physical/document.ts";
@@ -465,22 +465,8 @@ class WeaponPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
         if (magicTrait) traits.value.push(magicTrait);
 
         // Add traits from weapon grade
-        if (gradeData.tracking > 0) traits.value.push(`tracking-${gradeData.tracking as OneToThree}`);
-        // Ensure presence of only one tracking trait
-        const trackingPattern = /^tracking-\d$/;
-        const highestTracking =
-            traits.value
-                .filter((t) => trackingPattern.test(t))
-                .map((t) => Number(t.slice(-1)))
-                .sort((a, b) => b - a)
-                .at(0) ?? 0;
-        if (highestTracking > 0) {
-            for (const trait of [...traits.value]) {
-                if (trackingPattern.test(trait) && trait !== `tracking-${highestTracking}`) {
-                    traits.value.splice(traits.value.indexOf(trait), 1);
-                }
-            }
-        }
+        if (gradeData.tracking > 0) addOrUpgradeTrait(traits, `tracking-${gradeData.tracking as OneToThree}`);
+        const highestTracking = traits.config.tracking || 0;
 
         traits.value = R.unique(traits.value).sort();
         this.flags.pf2e.attackItemBonus = Math.max(runes.potency, highestTracking, this.system.bonus.value, 0);

--- a/src/module/item/weapon/helpers.ts
+++ b/src/module/item/weapon/helpers.ts
@@ -15,38 +15,6 @@ function upgradeWeaponTrait(trait: string): string {
     return trait;
 }
 
-/**
- * Add a trait to an array of traits--unless it matches an existing trait except by annotation. Replace the trait if
- * the new trait is an upgrade, or otherwise do nothing. Note: the array is mutated as part of this process.
- */
-function addOrUpgradeTrait<TTrait extends string>(traits: TTrait[], newTrait: TTrait): TTrait[] {
-    const annotatedTraitMatch = newTrait.match(/^([a-z][-a-z]+)-(\d*d?\d+)$/);
-    if (!annotatedTraitMatch) {
-        if (!traits.includes(newTrait)) traits.push(newTrait);
-        return traits;
-    }
-    const traitBase = annotatedTraitMatch[1];
-    const upgradeAnnotation = annotatedTraitMatch[2];
-    const traitPattern = new RegExp(String.raw`${traitBase}-(\d*d?\d*)`);
-    const existingTrait = traits.find((t) => traitPattern.test(t));
-    const existingAnnotation = existingTrait?.match(traitPattern)?.at(1);
-    if (!(existingTrait && existingAnnotation)) {
-        if (!traits.includes(newTrait)) traits.push(newTrait);
-        return traits;
-    }
-    if (_expectedValueOf(upgradeAnnotation) > _expectedValueOf(existingAnnotation)) {
-        traits.splice(traits.indexOf(existingTrait), 1, newTrait);
-    }
-    return traits;
-}
-
-function _expectedValueOf(annotation: string): number {
-    const traitValueMatch = annotation.match(/(\d*)d(\d+)/);
-    return traitValueMatch
-        ? Number(traitValueMatch[1] || 1) * ((Number(traitValueMatch[2]) + 1) / 2)
-        : Number(annotation);
-}
-
 /** Apply a two-hand trait to a weapon's damage dice. */
 function processTwoHandTrait(weapon: WeaponPF2e): void {
     const traits = weapon.system.traits;
@@ -57,4 +25,4 @@ function processTwoHandTrait(weapon: WeaponPF2e): void {
     }
 }
 
-export { addOrUpgradeTrait, processTwoHandTrait, upgradeWeaponTrait };
+export { processTwoHandTrait, upgradeWeaponTrait };

--- a/src/module/rules/rule-element/adjust-strike.ts
+++ b/src/module/rules/rule-element/adjust-strike.ts
@@ -1,8 +1,8 @@
 import type { ActorType } from "@actor/types.ts";
 import type { MeleePF2e, WeaponPF2e } from "@item";
 import { AbilityTrait } from "@item/ability/types.ts";
+import { addOrUpgradeTrait, removeTrait } from "@item/helpers.ts";
 import { RUNE_DATA, prunePropertyRunes } from "@item/physical/runes.ts";
-import { addOrUpgradeTrait } from "@item/weapon/helpers.ts";
 import { WeaponRangeIncrement } from "@item/weapon/types.ts";
 import { MaterialDamageEffect } from "@system/damage/index.ts";
 import { PredicateField } from "@system/schema-data-fields.ts";
@@ -150,7 +150,7 @@ class AdjustStrikeRuleElement extends RuleElementPF2e<AdjustStrikeSchema> {
                                 return;
                             }
 
-                            const traits: { value: string[] } = weapon.system.traits;
+                            const traits = weapon.system.traits;
 
                             // If the weapon's base damage type is the same as a modular or versatile damage type, skip
                             // adding the trait
@@ -163,9 +163,9 @@ class AdjustStrikeRuleElement extends RuleElementPF2e<AdjustStrikeSchema> {
                             }
 
                             if (this.mode === "add") {
-                                traits.value = addOrUpgradeTrait(traits.value, change);
-                            } else if (traits.value.includes(change)) {
-                                traits.value.splice(traits.value.indexOf(change), 1);
+                                addOrUpgradeTrait(traits, change);
+                            } else {
+                                removeTrait(traits, change);
                             }
                         },
                     };

--- a/src/module/rules/rule-element/item-alteration/handlers.ts
+++ b/src/module/rules/rule-element/item-alteration/handlers.ts
@@ -3,10 +3,9 @@ import { ItemPF2e, WeaponPF2e } from "@item";
 import type { ItemSourcePF2e, ItemType } from "@item/base/data/index.ts";
 import type { ItemTrait } from "@item/base/types.ts";
 import { PersistentDamageValueSchema } from "@item/condition/data.ts";
-import { itemIsOfType } from "@item/helpers.ts";
+import { addOrUpgradeTrait, itemIsOfType, removeTrait } from "@item/helpers.ts";
 import { prepareBulkData } from "@item/physical/helpers.ts";
 import { PHYSICAL_ITEM_TYPES, PRECIOUS_MATERIAL_TYPES } from "@item/physical/values.ts";
-import { addOrUpgradeTrait } from "@item/weapon/helpers.ts";
 import { WeaponRangeIncrement } from "@item/weapon/types.ts";
 import { MANDATORY_RANGED_GROUPS } from "@item/weapon/values.ts";
 import { RARITIES, ZeroToFour, ZeroToThree } from "@module/data.ts";
@@ -994,12 +993,12 @@ const ITEM_ALTERATION_HANDLERS = {
             if (newValue instanceof validation.DataModelValidationFailure) {
                 throw newValue.asError();
             }
-            const traits: string[] = data.item.system.traits.value ?? [];
-            if (data.alteration.mode === "add") {
-                addOrUpgradeTrait(traits, newValue);
-            } else if (["subtract", "remove"].includes(data.alteration.mode)) {
-                const index = traits.indexOf(newValue);
-                if (index >= 0) traits.splice(index, 1);
+            if (data.item.system.traits.value) {
+                if (data.alteration.mode === "add") {
+                    addOrUpgradeTrait(data.item.system.traits, newValue);
+                } else if (["subtract", "remove"].includes(data.alteration.mode)) {
+                    removeTrait(data.item.system.traits, newValue);
+                }
             }
         },
     }),


### PR DESCRIPTION
This resurrects the traits config with a different implementation. This will (in combination with #20070) allow the implementation of soldier's Widen Area as well as a correct implementation of Area Fire itself.

I considered allowing removeTrait() to support unannotated traits (allowing "volley" to remove any volley), however we would need to relax validation of item alteration to do that. If we want to keep that validation we would need to register a list of annotate-able traits somewhere.