### PR TITLE
Correct Crime Kingpin's Sneak Attack damage dice total

### DIFF
--- a/packs/pathfinder-npc-core/criminal/crime-kingpin.json
+++ b/packs/pathfinder-npc-core/criminal/crime-kingpin.json
@@ -890,7 +890,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The creature's Strikes deal an additional 3d6 precision damage to @UUID[Compendium.pf2e.conditionitems.Item.Off-Guard] creatures.</p>"
+                    "value": "<p>The crime kingpin deals an additional 3d6 precision damage to @UUID[Compendium.pf2e.conditionitems.Item.Off-Guard] creatures.</p>"
                 },
                 "publication": {
                     "license": "ORC",

--- a/packs/pathfinder-npc-core/criminal/crime-kingpin.json
+++ b/packs/pathfinder-npc-core/criminal/crime-kingpin.json
@@ -890,7 +890,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The creature's Strikes deal an additional 1d6 precision damage to @UUID[Compendium.pf2e.conditionitems.Item.Off-Guard] creatures.</p>"
+                    "value": "<p>The creature's Strikes deal an additional 3d6 precision damage to @UUID[Compendium.pf2e.conditionitems.Item.Off-Guard] creatures.</p>"
                 },
                 "publication": {
                     "license": "ORC",
@@ -900,7 +900,7 @@
                 "rules": [
                     {
                         "category": "precision",
-                        "diceNumber": 1,
+                        "diceNumber": 3,
                         "dieSize": "d6",
                         "key": "DamageDice",
                         "predicate": [


### PR DESCRIPTION
- Closes #20081