### PR TITLE
Set scale for drag-measurement waypoint labels to counter `HeadsUpDisplayContainer`'s

### DIFF
--- a/src/module/canvas/token/ruler.ts
+++ b/src/module/canvas/token/ruler.ts
@@ -1,5 +1,28 @@
 import { TokenPF2e } from "./index.ts";
 
-export class TokenRulerPF2e extends fc.placeables.tokens.TokenRuler<TokenPF2e> {
+export class TokenRulerPF2e extends foundry.canvas.placeables.tokens.TokenRuler<TokenPF2e> {
     static override WAYPOINT_LABEL_TEMPLATE = "systems/pf2e/templates/scene/token/waypoint-label.hbs";
+
+    static #hudContainerObserver = new MutationObserver(() => {
+        TokenRulerPF2e.#counterAlign();
+    });
+
+    /** The scale value opposing the one for the HeadsUpDisplayContainer */
+    static get #counterScale() {
+        return canvas.stage.scale.x * 1.75;
+    }
+
+    /** Observe changes to the attributes of the HeadsUpDisplayContainer's element. */
+    static observeHudContainer(): void {
+        TokenRulerPF2e.#hudContainerObserver.disconnect();
+        TokenRulerPF2e.#hudContainerObserver.observe(canvas.hud.element, { attributes: true });
+        TokenRulerPF2e.#counterAlign();
+    }
+
+    /** Recalculate the counter-scale. */
+    static #counterAlign(): void {
+        document
+            .getElementById("measurement")
+            ?.style.setProperty("--counter-scale", TokenRulerPF2e.#counterScale.toFixed(4));
+    }
 }

--- a/src/scripts/hooks/canvas-ready.ts
+++ b/src/scripts/hooks/canvas-ready.ts
@@ -1,3 +1,4 @@
+import { TokenRulerPF2e } from "@module/canvas/token/ruler.ts";
 import { toggleClearTemplatesButton } from "@module/chat-message/helpers.ts";
 
 /** This runs after game data has been requested and loaded from the servers, so entities exist */
@@ -46,6 +47,8 @@ export const CanvasReady = {
             for (const message of game.messages.contents.slice((-1 * CONFIG.ChatMessage.batchSize) / 2)) {
                 toggleClearTemplatesButton(message);
             }
+
+            TokenRulerPF2e.observeHudContainer();
         });
     },
 };

--- a/src/styles/canvas/_index.scss
+++ b/src/styles/canvas/_index.scss
@@ -1,0 +1,1 @@
+@import "token";

--- a/src/styles/canvas/token/_index.scss
+++ b/src/styles/canvas/token/_index.scss
@@ -1,0 +1,1 @@
+@import "ruler";

--- a/src/styles/canvas/token/_ruler.scss
+++ b/src/styles/canvas/token/_ruler.scss
@@ -1,0 +1,6 @@
+#measurement {
+    --counter-scale: 1;
+    .waypoint-label {
+        transform: scale(calc(var(--ui-scale) / var(--counter-scale))) translate(var(--transformX), var(--transformY));
+    }
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -17,6 +17,8 @@
     "item",
     // Scene and scene-object sheets
     "scene",
+    // HTML rendered on the Canvas
+    "canvas",
     // PF2E Settings Applications
     "settings",
     // PF2E System Applications

--- a/types/foundry/client/canvas/placeables/tokens/ruler.d.mts
+++ b/types/foundry/client/canvas/placeables/tokens/ruler.d.mts
@@ -41,7 +41,10 @@ export default class TokenRuler<TObject extends Token> extends BaseTokenRuler<TO
     /**
      * Get the context used to render a ruler waypoint label.
      */
-    protected _getWaypointLabelContext(waypoint: DeepReadonly<TokenRulerWaypoint>, state: object): object | void;
+    protected _getWaypointLabelContext(
+        waypoint: DeepReadonly<TokenRulerWaypoint>,
+        state: object,
+    ): WaypointRenderContext | void;
 
     /**
      * Get the style of the waypoint at the given waypoint.
@@ -85,4 +88,6 @@ export interface WaypointRenderContext {
     units: string;
     uiScale: number;
     position: { x: number; y: number };
+    distance: { total: string };
+    cost: { total: string; units: string };
 }


### PR DESCRIPTION


Results in showing the labels at a constant scale, regardless of canvas zoom level