### PR TITLE
Fix clearing targets in TokenMark RE prompt

### DIFF
--- a/src/module/rules/rule-element/token-mark/prompt.ts
+++ b/src/module/rules/rule-element/token-mark/prompt.ts
@@ -19,7 +19,7 @@ class MarkTargetPrompt {
     }
 
     async resolveTarget(): Promise<Maybe<TokenDocumentPF2e | null>> {
-        game.user.targets.clear();
+        canvas.tokens.setTargets([]);
         this.activateListeners();
         ui.notifications.info(this.prompt, { localize: true });
 

--- a/src/module/rules/rule-element/token-mark/rule-element.ts
+++ b/src/module/rules/rule-element/token-mark/rule-element.ts
@@ -27,10 +27,11 @@ class TokenMarkRuleElement extends RuleElementPF2e<TokenMarkSchema> {
             return;
         }
 
+        const loneTarget = game.user.targets.size === 1 ? game.user.targets.first() : null;
         const token =
             fromUuidSync(this.uuid ?? "") ??
-            (game.user.targets.size === 1
-                ? Array.from(game.user.targets)[0].document
+            (loneTarget?.actor && loneTarget.actor.uuid !== this.actor.uuid
+                ? loneTarget.document
                 : await new MarkTargetPrompt({ prompt: null, requirements: null }).resolveTarget());
         if (!(token instanceof TokenDocumentPF2e)) {
             // No token was targeted: abort creating item


### PR DESCRIPTION
- Closes #20163 