### PR TITLE
Allow the SpecialResource rule element on npcs

### DIFF
--- a/src/module/rules/rule-element/special-resource.ts
+++ b/src/module/rules/rule-element/special-resource.ts
@@ -22,7 +22,7 @@ import fields = foundry.data.fields;
 const INVALID_RESOURCES: (keyof CharacterResources)[] = [...CORE_RESOURCES, "crafting", "infusedReagents"];
 
 class SpecialResourceRuleElement extends RuleElementPF2e<SpecialResourceSchema> {
-    protected static override validActorTypes: ActorType[] = ["character"];
+    protected static override validActorTypes: ActorType[] = ["character", "npc"];
 
     constructor(source: SpecialResourceSource, options: RuleElementOptions) {
         super({ priority: 18, ...source }, options);


### PR DESCRIPTION
Some NPCs in SF2e may have a vitality network. While it always worked, we restricted it out of caution, but its been long enough I think. There is already UI for it in the npcs.