### PR TITLE
Automate Glorious Banner

### DIFF
--- a/packs/classfeatures/commanders-banner.json
+++ b/packs/classfeatures/commanders-banner.json
@@ -40,7 +40,10 @@
                 ],
                 "key": "Aura",
                 "predicate": [
-                    "commanders-banner"
+                    "commanders-banner",
+                    {
+                        "not": "feat:glorious-banner"
+                    }
                 ],
                 "radius": 30,
                 "slug": "commanders-banner",

--- a/packs/feat-effects/effect-commanders-banner.json
+++ b/packs/feat-effects/effect-commanders-banner.json
@@ -23,6 +23,7 @@
         },
         "rules": [
             {
+                "hideIfDisabled": true,
                 "key": "FlatModifier",
                 "predicate": [
                     "item:trait:fear"
@@ -33,8 +34,39 @@
                     "reflex-dc",
                     "will"
                 ],
+                "slug": "commanders-banner-fear",
                 "type": "status",
                 "value": 1
+            },
+            {
+                "hideIfDisabled": true,
+                "key": "FlatModifier",
+                "predicate": [
+                    "parent:tag:glorious-banner"
+                ],
+                "selector": [
+                    "reflex",
+                    "fortitude",
+                    "ac"
+                ],
+                "slug": "commanders-banner-glorious-banner",
+                "type": "status",
+                "value": 1
+            },
+            {
+                "key": "AdjustModifier",
+                "mode": "upgrade",
+                "predicate": [
+                    "parent:tag:glorious-banner"
+                ],
+                "selectors": [
+                    "ac",
+                    "fortitude-dc",
+                    "reflex-dc",
+                    "will"
+                ],
+                "slug": "commanders-banner-fear",
+                "value": 2
             }
         ],
         "start": {

--- a/packs/feat-effects/effect-glorious-banner.json
+++ b/packs/feat-effects/effect-glorious-banner.json
@@ -1,0 +1,54 @@
+{
+    "_id": "8x5T5e5Gzh3NJ86H",
+    "img": "icons/sundries/flags/banner-symbol-claw.webp",
+    "name": "Effect: Glorious Banner",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Glorious Banner]</p>\n<p>You take a –2 status penalty to Will saves as long as you can see the origin's banner.</p>"
+        },
+        "duration": {
+            "expiry": null,
+            "sustained": false,
+            "unit": "unlimited",
+            "value": -1
+        },
+        "fromSpell": false,
+        "level": {
+            "value": 20
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Battlecry!"
+        },
+        "rules": [
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Commander.GloriousBanner.ToggleLabel",
+                "option": "glorious-banner",
+                "toggleable": true,
+                "value": true
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "glorious-banner"
+                ],
+                "selector": "will",
+                "type": "status",
+                "value": -2
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feats/class/commander/glorious-banner.json
+++ b/packs/feats/class/commander/glorious-banner.json
@@ -25,7 +25,39 @@
             "remaster": true,
             "title": "Pathfinder Battlecry!"
         },
-        "rules": [],
+        "rules": [
+            {
+                "effects": [
+                    {
+                        "affects": "allies",
+                        "alterations": [
+                            {
+                                "mode": "add",
+                                "property": "other-tags",
+                                "value": "glorious-banner"
+                            }
+                        ],
+                        "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Commander's Banner"
+                    },
+                    {
+                        "affects": "enemies",
+                        "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Glorious Banner"
+                    }
+                ],
+                "key": "Aura",
+                "predicate": [
+                    "commanders-banner"
+                ],
+                "radius": 60,
+                "slug": "commanders-banner",
+                "traits": [
+                    "emotion",
+                    "mental",
+                    "visual",
+                    "aura"
+                ]
+            }
+        ],
         "subfeatures": {
             "proficiencies": {},
             "senses": {},

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -3266,6 +3266,9 @@
                 "Banner": {
                     "Label": "Commander's Banner"
                 },
+                "GloriousBanner": {
+                    "ToggleLabel": "Glorious Banner — Commander's banner in sight"
+                },
                 "Tactics": {
                     "CryHavoc": {
                         "ToggleLabel": "Cry Havoc — Participating squadmates"


### PR DESCRIPTION
- Closes #20172

Toggle on Glorious Banner effect left as true on purpose. An enemy affected by the aura will most likely be able to see the banner, but the toggle is there for the GM to be able to make calls about it.