### PR TITLE
Export module-subclassable classes

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -5,7 +5,7 @@ import type { Action } from "@actor/actions/index.ts";
 import type { AutomaticBonusProgression as ABP } from "@actor/character/automatic-bonus-progression.ts";
 import type { ElementalBlast } from "@actor/character/elemental-blast.ts";
 import type { FeatGroupData } from "@actor/character/feats/index.ts";
-import type { CheckModifier, ModifierPF2e, ModifierType, StatisticModifier } from "@actor/modifiers.ts";
+import type { CheckModifier, Modifier, ModifierType, StatisticModifier } from "@actor/modifiers.ts";
 import type { SettingConfig } from "@client/_types.d.mts";
 import type Hotbar from "@client/applications/ui/hotbar.d.mts";
 import type Config from "@client/config.d.mts";
@@ -15,7 +15,7 @@ import type { CompendiumUUID } from "@client/utils/_module.d.mts";
 import type { ImageFilePath, RollMode, UserRole } from "@common/constants.d.mts";
 import type { ItemPF2e, PhysicalItemPF2e } from "@item";
 import type { ConditionSource } from "@item/condition/data.ts";
-import type { CoinsPF2e } from "@item/physical/helpers.ts";
+import type { Coins } from "@item/physical/helpers.ts";
 import type { ActiveEffectPF2e } from "@module/active-effect.ts";
 import type {
     CompendiumBrowser,
@@ -37,7 +37,7 @@ import type { ChatMessagePF2e } from "@module/chat-message/index.ts";
 import type { ActorsPF2e } from "@module/collection/actors.ts";
 import type { CombatantPF2e, EncounterPF2e } from "@module/encounter/index.ts";
 import type { MacroPF2e } from "@module/macro.ts";
-import type { RuleElementPF2e, RuleElements } from "@module/rules/index.ts";
+import type { RuleElement, RuleElements } from "@module/rules/index.ts";
 import type { UserPF2e } from "@module/user/index.ts";
 import type {
     AmbientLightDocumentPF2e,
@@ -62,7 +62,7 @@ import type {
     xpFromEncounter,
 } from "@scripts/macros/index.ts";
 import type { remigrate } from "@scripts/system/remigrate.ts";
-import type { CheckPF2e } from "@system/check/index.ts";
+import type { Check } from "@system/check/index.ts";
 import type { ConditionManager } from "@system/conditions/manager.ts";
 import type { EffectTracker } from "@system/effect-tracker.ts";
 import type { ModuleArt } from "@system/module-art.ts";
@@ -193,16 +193,16 @@ interface GamePF2e
         variantRules: {
             AutomaticBonusProgression: typeof AutomaticBonusProgression;
         };
-        Check: typeof CheckPF2e;
+        Check: typeof Check;
         CheckModifier: typeof CheckModifier;
-        Coins: typeof CoinsPF2e;
+        Coins: typeof Coins;
         ConditionManager: typeof ConditionManager;
         Dice: typeof DicePF2e;
         ElementalBlast: typeof ElementalBlast;
-        Modifier: typeof ModifierPF2e;
+        Modifier: typeof Modifier;
         ModifierType: { [K in Uppercase<ModifierType>]: Lowercase<K> };
         Predicate: typeof Predicate;
-        RuleElement: typeof RuleElementPF2e;
+        RuleElement: typeof RuleElement;
         RuleElements: typeof RuleElements;
         StatisticModifier: typeof StatisticModifier;
         StatusEffects: typeof StatusEffects;

--- a/src/module/actor/actions/single-check.ts
+++ b/src/module/actor/actions/single-check.ts
@@ -1,5 +1,5 @@
 import { ActorPF2e } from "@actor";
-import { ModifierPF2e, RawModifier, StatisticModifier } from "@actor/modifiers.ts";
+import { Modifier, RawModifier, StatisticModifier } from "@actor/modifiers.ts";
 import { DCSlug } from "@actor/types.ts";
 import { SAVE_TYPES } from "@actor/values.ts";
 import type { ItemPF2e } from "@item";
@@ -67,7 +67,7 @@ interface ActionCheckPreview {
 
 interface SingleCheckActionUseOptions extends ActionUseOptions {
     difficultyClass: CheckDC | DCSlug | number;
-    modifiers: ModifierPF2e[];
+    modifiers: Modifier[];
     multipleAttackPenalty: number;
     notes: SingleCheckActionRollNoteData[];
     rollOptions: string[];
@@ -128,11 +128,11 @@ class SingleCheckActionVariant extends BaseActionVariant {
     }
 
     override async use(options: Partial<SingleCheckActionUseOptions> = {}): Promise<CheckResultCallback[]> {
-        const modifiers = this.modifiers.map((raw) => new ModifierPF2e(raw)).concat(options.modifiers ?? []);
+        const modifiers = this.modifiers.map((raw) => new Modifier(raw)).concat(options.modifiers ?? []);
         if (options.multipleAttackPenalty) {
             const map = options.multipleAttackPenalty;
             const modifier = map > 0 ? Math.min(2, map) * -5 : map;
-            modifiers.push(new ModifierPF2e({ label: "PF2E.MultipleAttackPenalty", modifier }));
+            modifiers.push(new Modifier({ label: "PF2E.MultipleAttackPenalty", modifier }));
         }
         const notes = (this.notes as SingleCheckActionRollNoteData[])
             .concat(options.notes ?? [])
@@ -195,10 +195,7 @@ class SingleCheckActionVariant extends BaseActionVariant {
         if (args.actor) {
             const statistic = args.actor.getStatistic(args.slug);
             if (statistic) {
-                const modifiers = [
-                    ...statistic.modifiers,
-                    ...this.modifiers.map((modifier) => new ModifierPF2e(modifier)),
-                ];
+                const modifiers = [...statistic.modifiers, ...this.modifiers.map((modifier) => new Modifier(modifier))];
                 const modifier = new StatisticModifier(
                     args.slug,
                     modifiers,

--- a/src/module/actor/army/document.ts
+++ b/src/module/actor/army/document.ts
@@ -1,7 +1,7 @@
 import { FeatGroup } from "@actor/character/feats/index.ts";
 import { Sense } from "@actor/creature/sense.ts";
 import { ActorInitiative } from "@actor/initiative.ts";
-import { ModifierPF2e } from "@actor/modifiers.ts";
+import { Modifier } from "@actor/modifiers.ts";
 import { Kingdom } from "@actor/party/kingdom/model.ts";
 import { DamageContext } from "@actor/roll-context/damage.ts";
 import type { Rolled } from "@client/dice/_module.d.mts";
@@ -109,19 +109,19 @@ class ArmyPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | nu
         this.armorClass = new ArmorStatistic(this, {
             attribute: null,
             modifiers: [
-                new ModifierPF2e({
+                new Modifier({
                     slug: "base",
                     label: "PF2E.ModifierTitle",
                     modifier: expectedAC - 10,
                 }),
                 acAdjustment &&
-                    new ModifierPF2e({
+                    new Modifier({
                         slug: "adjustment",
                         label: "PF2E.Kingmaker.Army.Adjustment",
                         modifier: acAdjustment,
                     }),
                 this.system.ac.potency &&
-                    new ModifierPF2e({ slug: "potency", label: "Potency", modifier: this.system.ac.potency }),
+                    new Modifier({ slug: "potency", label: "Potency", modifier: this.system.ac.potency }),
             ].filter(R.isTruthy),
         }).dc;
         this.system.ac.value = this.armorClass.value;
@@ -133,9 +133,9 @@ class ArmyPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | nu
             label: "PF2E.Kingmaker.Army.Scouting",
             domains: ["scouting"],
             modifiers: [
-                new ModifierPF2e({ slug: "base", label: "PF2E.ModifierTitle", modifier: baseScouting }),
+                new Modifier({ slug: "base", label: "PF2E.ModifierTitle", modifier: baseScouting }),
                 scoutAdjustment
-                    ? new ModifierPF2e({
+                    ? new Modifier({
                           slug: "adjustment",
                           label: "PF2E.Kingmaker.Army.Adjustment",
                           modifier: scoutAdjustment,
@@ -157,9 +157,9 @@ class ArmyPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | nu
                 label: `PF2E.Kingmaker.Army.Save.${saveType}`,
                 domains: ["saving-throw", saveType],
                 modifiers: [
-                    new ModifierPF2e({ slug: "base", label: "PF2E.ModifierTitle", modifier: baseValue }),
+                    new Modifier({ slug: "base", label: "PF2E.ModifierTitle", modifier: baseValue }),
                     adjustment
-                        ? new ModifierPF2e({
+                        ? new Modifier({
                               slug: "adjustment",
                               label: "PF2E.Kingmaker.Army.Adjustment",
                               modifier: adjustment,
@@ -236,7 +236,7 @@ class ArmyPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | nu
         })();
 
         const createMapModifier = (prop: "map1" | "map2") => {
-            return new ModifierPF2e({
+            return new Modifier({
                 slug: maps.slug,
                 label: maps.label,
                 modifier: maps[prop],
@@ -251,13 +251,13 @@ class ArmyPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | nu
             rollOptions: [`item:${type}`],
             check: { type: "attack-roll" },
             modifiers: [
-                new ModifierPF2e({
+                new Modifier({
                     slug: "base",
                     label: "PF2E.ModifierTitle",
                     modifier: ARMY_STATS.attack[this.level],
                 }),
-                data.potency && new ModifierPF2e({ slug: "potency", label: "Potency", modifier: data.potency }),
-                new ModifierPF2e({
+                data.potency && new Modifier({ slug: "potency", label: "Potency", modifier: data.potency }),
+                new Modifier({
                     slug: "concealed",
                     label: "PF2E.Kingmaker.Army.Condition.concealed.name",
                     type: "circumstance",

--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -30,7 +30,7 @@ import { isContainerCycle } from "@item/container/helpers.ts";
 import type { EffectFlags, EffectSource } from "@item/effect/data.ts";
 import { createDisintegrateEffect } from "@item/effect/helpers.ts";
 import { itemIsOfType } from "@item/helpers.ts";
-import { CoinsPF2e } from "@item/physical/coins.ts";
+import { Coins } from "@item/physical/coins.ts";
 import { getDefaultEquipStatus } from "@item/physical/helpers.ts";
 import { ActiveEffectPF2e } from "@module/active-effect.ts";
 import type { TokenPF2e } from "@module/canvas/index.ts";
@@ -47,7 +47,7 @@ import {
     processPreUpdateActorHooks,
 } from "@module/rules/helpers.ts";
 import type { RuleElementSynthetics } from "@module/rules/index.ts";
-import type { RuleElementPF2e } from "@module/rules/rule-element/base.ts";
+import type { RuleElement } from "@module/rules/rule-element/base.ts";
 import type { RollOptionRuleElement } from "@module/rules/rule-element/roll-option/rule-element.ts";
 import type { UserPF2e } from "@module/user/document.ts";
 import type { ScenePF2e } from "@scene/document.ts";
@@ -116,7 +116,7 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
     declare spellcasting: ActorSpellcasting<this> | null;
 
     /** Rule elements drawn from owned items */
-    declare rules: RuleElementPF2e[];
+    declare rules: RuleElement[];
 
     declare synthetics: RuleElementSynthetics;
 
@@ -905,7 +905,7 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
         this.rules = this.prepareRuleElements();
     }
 
-    protected prepareRuleElements(): RuleElementPF2e[] {
+    protected prepareRuleElements(): RuleElement[] {
         // Ensure certain ABC items go early and common temporary items go last
         // These leads to predictability with RE overrides such as auras and CreatureSize
         const sortOrder: Partial<Record<ItemType, number>> = {
@@ -985,7 +985,7 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
         value = typeof itemId === "boolean" ? itemId : (value ?? !this.rollOptions[domain]?.[option]);
 
         // Find the rule on the actor. The item id provided may be for a sub item, so we search instead of retrieving outright
-        type MaybeRollOption = RuleElementPF2e & { domain?: unknown; option?: unknown };
+        type MaybeRollOption = RuleElement & { domain?: unknown; option?: unknown };
         const rule = this.rules.find(
             (r: MaybeRollOption): r is RollOptionRuleElement =>
                 r.key === "RollOption" &&
@@ -1559,7 +1559,7 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
 
         // If this is a transaction, remove coins from the buyer and add to the seller
         if (isPurchase) {
-            const itemValue = CoinsPF2e.fromPrice(item.price, quantity);
+            const itemValue = Coins.fromPrice(item.price, quantity);
             if (await targetActor.inventory.removeCoins(itemValue)) {
                 await item.actor.inventory.addCoins(itemValue);
             } else {

--- a/src/module/actor/character/automatic-bonus-progression.ts
+++ b/src/module/actor/character/automatic-bonus-progression.ts
@@ -1,5 +1,5 @@
 import type { ActorPF2e, CharacterPF2e } from "@actor";
-import { ModifierPF2e } from "@actor/modifiers.ts";
+import { Modifier } from "@actor/modifiers.ts";
 import type { ArmorPF2e, WeaponPF2e } from "@item";
 import { ZeroToThree } from "@module/data.ts";
 import type { FlatModifierRuleElement } from "@module/rules/rule-element/flat-modifier.ts";
@@ -39,7 +39,7 @@ class AutomaticBonusProgression {
             const modifiers = (synthetics.modifiers["saving-throw"] ??= []);
             modifiers.push(
                 () =>
-                    new ModifierPF2e({
+                    new Modifier({
                         slug: "save-potency",
                         label: "PF2E.AutomaticBonusProgression.savePotency",
                         modifier: save,
@@ -52,7 +52,7 @@ class AutomaticBonusProgression {
             const modifiers = (synthetics.modifiers["ac"] ??= []);
             modifiers.push(
                 () =>
-                    new ModifierPF2e({
+                    new Modifier({
                         slug: "defense-potency",
                         label: "PF2E.AutomaticBonusProgression.defensePotency",
                         modifier: ac,
@@ -65,7 +65,7 @@ class AutomaticBonusProgression {
             const modifiers = (synthetics.modifiers["perception"] ??= []);
             modifiers.push(
                 () =>
-                    new ModifierPF2e({
+                    new Modifier({
                         slug: "perception-potency",
                         label: "PF2E.AutomaticBonusProgression.perceptionPotency",
                         modifier: perception,
@@ -81,7 +81,7 @@ class AutomaticBonusProgression {
                 const modifiers = (synthetics.modifiers["strike-attack-roll"] ??= []);
                 modifiers.push(
                     () =>
-                        new ModifierPF2e({
+                        new Modifier({
                             slug: "attack-potency",
                             label: "PF2E.AutomaticBonusProgression.attackPotency",
                             modifier: attack,

--- a/src/module/actor/character/crafting/helpers.ts
+++ b/src/module/actor/character/crafting/helpers.ts
@@ -3,7 +3,7 @@ import type { Rolled } from "@client/dice/_module.d.mts";
 import type { ConsumablePF2e, PhysicalItemPF2e, SpellPF2e } from "@item";
 import { ItemProxyPF2e } from "@item";
 import { createConsumableFromSpell } from "@item/consumable/spell-consumables.ts";
-import { CoinsPF2e } from "@item/physical/helpers.ts";
+import { Coins } from "@item/physical/helpers.ts";
 import { ChatMessagePF2e } from "@module/chat-message/index.ts";
 import { OneToTen } from "@module/data.ts";
 import { getIncomeForLevel } from "@scripts/macros/earn-income/calculate.ts";
@@ -16,10 +16,10 @@ import appv1 = foundry.appv1;
 /** Implementation of Crafting rules on https://2e.aonprd.com/Actions.aspx?ID=43 */
 
 interface Costs {
-    reductionPerDay: CoinsPF2e;
-    materials: CoinsPF2e;
-    itemPrice: CoinsPF2e;
-    lostMaterials: CoinsPF2e;
+    reductionPerDay: Coins;
+    materials: Coins;
+    itemPrice: Coins;
+    lostMaterials: Coins;
 }
 
 function calculateDaysToNoCost(costs: Costs): number {
@@ -51,10 +51,10 @@ function calculateCosts(
     degreeOfSuccess: number,
     skill: string = "crafting",
 ): Costs | null {
-    const itemPrice = CoinsPF2e.fromPrice(item.price, quantity);
+    const itemPrice = Coins.fromPrice(item.price, quantity);
     const materialCosts = itemPrice.scale(0.5);
-    const lostMaterials = new CoinsPF2e();
-    const reductionPerDay = new CoinsPF2e();
+    const lostMaterials = new Coins();
+    const reductionPerDay = new Coins();
 
     const proficiency = actor.skills[skill]?.rank;
     if (!proficiency) return null;

--- a/src/module/actor/character/elemental-blast.ts
+++ b/src/module/actor/character/elemental-blast.ts
@@ -1,7 +1,7 @@
 import type { ActorPF2e } from "@actor";
 import { AttackTraitHelpers } from "@actor/creature/helpers.ts";
 import { calculateMAPs } from "@actor/helpers.ts";
-import { ModifierPF2e, StatisticModifier } from "@actor/modifiers.ts";
+import { Modifier, StatisticModifier } from "@actor/modifiers.ts";
 import { DamageContext } from "@actor/roll-context/damage.ts";
 import type { Rolled } from "@client/dice/roll.d.mts";
 import type { ImageFilePath } from "@common/constants.d.mts";
@@ -481,14 +481,14 @@ class ElementalBlast {
         if (item.system.traits.value.includes("forceful")) {
             const diceNumber = processedDamage.dice;
             extraModifiers.push(
-                new ModifierPF2e({
+                new Modifier({
                     slug: "forceful-second",
                     label: "PF2E.Item.Weapon.Forceful.Second",
                     modifier: diceNumber,
                     type: "circumstance",
                     ignored: true,
                 }),
-                new ModifierPF2e({
+                new Modifier({
                     slug: "forceful-third",
                     label: "PF2E.Item.Weapon.Forceful.Third",
                     modifier: 2 * diceNumber,
@@ -540,7 +540,7 @@ class ElementalBlast {
         return DamagePF2e.roll(damageTemplate, damageContext);
     }
 
-    #strengthModToDamage(item: AbilityItemPF2e, domains: string[]): ModifierPF2e | null {
+    #strengthModToDamage(item: AbilityItemPF2e, domains: string[]): Modifier | null {
         if (!item.range) return null;
         const strengthModValue = this.actor.abilities.str.mod;
         const { traits } = item;
@@ -553,7 +553,7 @@ class ElementalBlast {
               : null;
 
         return typeof modifierValue === "number"
-            ? new ModifierPF2e({
+            ? new Modifier({
                   slug: "str",
                   label: CONFIG.PF2E.abilities.str,
                   ability: "str",

--- a/src/module/actor/character/helpers.ts
+++ b/src/module/actor/character/helpers.ts
@@ -1,6 +1,6 @@
 import type { ActorPF2e, CharacterPF2e } from "@actor";
 import { AttackTraitHelpers } from "@actor/creature/helpers.ts";
-import { ModifierPF2e } from "@actor/modifiers.ts";
+import { Modifier } from "@actor/modifiers.ts";
 import type { AbilityItemPF2e, ArmorPF2e, ConditionPF2e, WeaponPF2e } from "@item";
 import { EffectPF2e, ItemProxyPF2e } from "@item";
 import type { ItemCarryType } from "@item/physical/index.ts";
@@ -46,7 +46,7 @@ class PCAttackTraitHelpers extends AttackTraitHelpers {
         }
     }
 
-    static override createAttackModifiers({ item, domains }: CreateAttackModifiersParams): ModifierPF2e[] {
+    static override createAttackModifiers({ item, domains }: CreateAttackModifiersParams): Modifier[] {
         const actor = item.actor;
         if (!actor) throw ErrorPF2e("The weapon must be embedded");
 
@@ -60,7 +60,7 @@ class PCAttackTraitHelpers extends AttackTraitHelpers {
                     // (pre-remaster language)
                     // "Firing a kickback weapon gives a –2 circumstance penalty to the attack roll, but characters with
                     // 14 or more Strength ignore the penalty."
-                    return new ModifierPF2e({
+                    return new Modifier({
                         slug: unannotatedTrait,
                         label: CONFIG.PF2E.weaponTraits.kickback,
                         modifier: -2,
@@ -70,7 +70,7 @@ class PCAttackTraitHelpers extends AttackTraitHelpers {
                     });
                 }
                 case "improvised": {
-                    return new ModifierPF2e({
+                    return new Modifier({
                         slug: unannotatedTrait,
                         label: this.getLabel(trait),
                         modifier: -2,
@@ -367,10 +367,10 @@ function getWeaponProficiencyRank(actor: CharacterPF2e, weapon: WeaponPF2e, item
 }
 
 /** Create a penalty for attempting to Force Open without a crowbar or equivalent tool */
-function createForceOpenPenalty(actor: CharacterPF2e, domains: string[]): ModifierPF2e {
+function createForceOpenPenalty(actor: CharacterPF2e, domains: string[]): Modifier {
     const slug = "no-crowbar";
     const { modifierAdjustments } = actor.synthetics;
-    return new ModifierPF2e({
+    return new Modifier({
         slug,
         label: "PF2E.Actions.ForceOpen.NoCrowbarPenalty",
         type: "item",
@@ -385,12 +385,12 @@ function createShoddyPenalty(
     actor: ActorPF2e,
     item: WeaponPF2e | ArmorPF2e | null,
     domains: string[],
-): ModifierPF2e | null {
+): Modifier | null {
     if (!actor.isOfType("character") || !item?.isShoddy) return null;
 
     const slug = "shoddy";
 
-    return new ModifierPF2e({
+    return new Modifier({
         label: "PF2E.Item.Physical.OtherTag.Shoddy",
         type: "item",
         slug,
@@ -405,10 +405,10 @@ function createShoddyPenalty(
  * the armor's Speed penalty, and affects you even if your Strength or an ability lets you reduce or ignore the armor's
  * Speed penalty."
  */
-function createHinderingPenalty(actor: CharacterPF2e): ModifierPF2e | null {
+function createHinderingPenalty(actor: CharacterPF2e): Modifier | null {
     const slug = "hindering";
     return actor.wornArmor?.traits.has(slug)
-        ? new ModifierPF2e({
+        ? new Modifier({
               label: "PF2E.TraitHindering",
               type: "untyped",
               slug,
@@ -423,14 +423,14 @@ function createHinderingPenalty(actor: CharacterPF2e): ModifierPF2e | null {
  * "While wearing the armor, you take a –1 penalty to initiative checks. If you don't meet the armor's required Strength
  * score, this penalty increases to be equal to the armor's check penalty if it's worse."
  */
-function createPonderousPenalty(actor: CharacterPF2e): ModifierPF2e | null {
+function createPonderousPenalty(actor: CharacterPF2e): Modifier | null {
     const armor = actor.wornArmor;
     const slug = "ponderous";
     if (!armor?.traits.has(slug)) return null;
 
     const penaltyValue = actor.abilities.str.mod >= (armor.strength ?? -Infinity) ? -1 : armor.checkPenalty || -1;
 
-    return new ModifierPF2e({
+    return new Modifier({
         label: "PF2E.TraitPonderous",
         type: "untyped",
         slug,

--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -22,7 +22,7 @@ import { ItemPF2e, ItemProxyPF2e } from "@item";
 import { TraitToggleViewData } from "@item/ability/trait-toggles.ts";
 import { ItemSourcePF2e } from "@item/base/data/index.ts";
 import { isSpellConsumable } from "@item/consumable/spell-consumables.ts";
-import { CoinsPF2e } from "@item/physical/coins.ts";
+import { Coins } from "@item/physical/coins.ts";
 import type { MagicTradition } from "@item/spell/types.ts";
 import type { SpellcastingSheetData } from "@item/spellcasting-entry/types.ts";
 import type { BaseWeaponType, WeaponGroup } from "@item/weapon/types.ts";
@@ -486,7 +486,7 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
             item: f.item,
             dc: f.dc,
             batchSize: this.#formulaQuantities[f.uuid] ?? f.batchSize,
-            cost: CoinsPF2e.fromPrice(f.item.price, this.#formulaQuantities[f.uuid] ?? f.batchSize),
+            cost: Coins.fromPrice(f.item.price, this.#formulaQuantities[f.uuid] ?? f.batchSize),
         }));
         const knownFormulas = R.pipe(
             sheetFormulas,
@@ -1548,7 +1548,7 @@ interface FormulaSheetData {
     item: ItemPF2e;
     dc: number;
     batchSize: number;
-    cost: CoinsPF2e;
+    cost: Coins;
 }
 
 interface FormulaByLevel {

--- a/src/module/actor/creature/data.ts
+++ b/src/module/actor/creature/data.ts
@@ -12,7 +12,7 @@ import type {
     StrikeData,
 } from "@actor/data/base.ts";
 import type { ActorSizePF2e } from "@actor/data/size.ts";
-import type { ModifierPF2e, RawModifier } from "@actor/modifiers.ts";
+import type { Modifier, RawModifier } from "@actor/modifiers.ts";
 import type { AttributeString, MovementType, SaveType, SkillSlug } from "@actor/types.ts";
 import type { ImageFilePath } from "@common/constants.d.mts";
 import type { LabeledNumber, Size, ValueAndMax, ValueAndMaybeMax, ZeroToThree } from "@module/data.ts";
@@ -112,7 +112,7 @@ interface CreatureSystemData extends Omit<CreatureSystemSource, "attributes">, A
     perception: CreaturePerceptionData;
 
     /** Maps roll types -> a list of modifiers which should affect that roll type. */
-    customModifiers: Record<string, ModifierPF2e[]>;
+    customModifiers: Record<string, Modifier[]>;
 
     /** Saving throw data */
     saves: CreatureSaves;

--- a/src/module/actor/creature/document.ts
+++ b/src/module/actor/creature/document.ts
@@ -2,7 +2,7 @@ import { ActorPF2e, type PartyPF2e } from "@actor";
 import type { HitPointsSummary } from "@actor/base.ts";
 import { CORE_RESOURCES } from "@actor/character/values.ts";
 import type { CreatureSource } from "@actor/data/index.ts";
-import { MODIFIER_TYPES, ModifierPF2e, RawModifier } from "@actor/modifiers.ts";
+import { Modifier, MODIFIER_TYPES, RawModifier } from "@actor/modifiers.ts";
 import { ActorSpellcasting } from "@actor/spellcasting.ts";
 import { MovementType, SaveType, SkillSlug } from "@actor/types.ts";
 import { MOVEMENT_TYPES } from "@actor/values.ts";
@@ -347,7 +347,7 @@ abstract class CreaturePF2e<
         const customModifiers = (this.system.customModifiers ??= {});
         for (const selector of Object.keys(customModifiers)) {
             customModifiers[selector] = customModifiers[selector].map(
-                (rawModifier: RawModifier) => new ModifierPF2e(rawModifier),
+                (rawModifier: RawModifier) => new Modifier(rawModifier),
             );
         }
 
@@ -601,7 +601,7 @@ abstract class CreaturePF2e<
         const modifiers = customModifiers[stat] ?? [];
         if (!modifiers.some((m) => m.label === label)) {
             const modifierType = setHasElement(MODIFIER_TYPES, type) ? type : "untyped";
-            const modifier = new ModifierPF2e({
+            const modifier = new Modifier({
                 label,
                 modifier: value,
                 type: modifierType,
@@ -739,7 +739,7 @@ abstract class CreaturePF2e<
      * Prepare this creature's movement data
      * @param modifiers Modifiers in addition to those extracted
      */
-    prepareMovementData(modifiers: ModifierPF2e[] = []): void {
+    prepareMovementData(modifiers: Modifier[] = []): void {
         const baseSpeed = this.system.movement.speeds.land.base;
         const landSpeed = new SpeedStatistic(this, { type: "land", base: baseSpeed, modifiers });
         this.system.movement.speeds.land.value = landSpeed.value;

--- a/src/module/actor/creature/helpers.ts
+++ b/src/module/actor/creature/helpers.ts
@@ -1,6 +1,6 @@
 import type { ActorPF2e, CreaturePF2e } from "@actor";
 import { Immunity } from "@actor/data/iwr.ts";
-import { ModifierPF2e } from "@actor/modifiers.ts";
+import { Modifier } from "@actor/modifiers.ts";
 import { ImmunityType } from "@actor/types.ts";
 import type { AbilityItemPF2e, MeleePF2e, WeaponPF2e } from "@item";
 import { ConditionPF2e } from "@item";
@@ -20,7 +20,7 @@ class AttackTraitHelpers {
         return trait.replace(/-d?\d{1,3}$/, "");
     }
 
-    static createAttackModifiers({ item, domains }: CreateAttackModifiersParams): ModifierPF2e[] {
+    static createAttackModifiers({ item, domains }: CreateAttackModifiersParams): Modifier[] {
         const actor = item.actor;
         if (!actor) throw ErrorPF2e("The weapon must be embedded");
 
@@ -32,7 +32,7 @@ class AttackTraitHelpers {
                     if (!rangeIncrement) return [];
 
                     const penaltyRange = Number(/-(\d+)$/.exec(trait)![1]);
-                    return new ModifierPF2e({
+                    return new Modifier({
                         slug: unannotatedTrait,
                         label: this.getLabel(trait),
                         modifier: -2,
@@ -50,7 +50,7 @@ class AttackTraitHelpers {
                     });
                 }
                 case "sweep": {
-                    return new ModifierPF2e({
+                    return new Modifier({
                         slug: unannotatedTrait,
                         label: this.getLabel(trait),
                         modifier: 1,
@@ -59,7 +59,7 @@ class AttackTraitHelpers {
                     });
                 }
                 case "backswing": {
-                    return new ModifierPF2e({
+                    return new Modifier({
                         slug: unannotatedTrait,
                         label: this.getLabel(trait),
                         modifier: 1,

--- a/src/module/actor/familiar/data.ts
+++ b/src/module/actor/familiar/data.ts
@@ -13,7 +13,7 @@ import type {
 } from "@actor/creature/data.ts";
 import { ActorSystemModel, ActorSystemSchema } from "@actor/data/model.ts";
 import { ActorSizePF2e } from "@actor/data/size.ts";
-import type { ModifierPF2e } from "@actor/modifiers.ts";
+import type { Modifier } from "@actor/modifiers.ts";
 import type { ActorAlliance, AttributeString, SaveType } from "@actor/types.ts";
 import { ATTRIBUTE_ABBREVIATIONS } from "@actor/values.ts";
 import type {
@@ -129,7 +129,7 @@ interface FamiliarSystemData
         ModelPropsFromSchema<FamiliarSystemSchema> {
     attributes: CreatureAttributes;
     details: FamiliarDetails;
-    customModifiers: Record<string, ModifierPF2e[]>;
+    customModifiers: Record<string, Modifier[]>;
 }
 
 type FamiliarSystemSchema = ActorSystemSchema & {

--- a/src/module/actor/familiar/document.ts
+++ b/src/module/actor/familiar/document.ts
@@ -3,14 +3,14 @@ import type { ActorPF2e } from "@actor/base.ts";
 import type { CreatureSaves } from "@actor/creature/data.ts";
 import type { CreatureUpdateCallbackOptions } from "@actor/creature/index.ts";
 import { createEncounterRollOptions, setHitPointsRollOptions } from "@actor/helpers.ts";
-import { ModifierPF2e, applyStackingRules } from "@actor/modifiers.ts";
+import { Modifier, applyStackingRules } from "@actor/modifiers.ts";
 import type { SaveType } from "@actor/types.ts";
 import { SAVE_TYPES } from "@actor/values.ts";
 import type { DatabaseDeleteCallbackOptions } from "@common/abstract/_types.d.mts";
 import type { ActorUUID } from "@common/documents/_module.d.mts";
 import type { ItemType } from "@item/base/data/index.ts";
 import type { CombatantPF2e, EncounterPF2e } from "@module/encounter/index.ts";
-import type { RuleElementPF2e } from "@module/rules/index.ts";
+import type { RuleElement } from "@module/rules/index.ts";
 import type { TokenDocumentPF2e } from "@scene";
 import { Predicate } from "@system/predication.ts";
 import { ArmorStatistic, HitPointsStatistic, PerceptionStatistic, Statistic } from "@system/statistic/index.ts";
@@ -83,7 +83,7 @@ class FamiliarPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e 
     }
 
     /** Skip rule-element preparation if there is no master */
-    protected override prepareRuleElements(): RuleElementPF2e[] {
+    protected override prepareRuleElements(): RuleElement[] {
         return this.master ? super.prepareRuleElements() : [];
     }
 
@@ -92,8 +92,8 @@ class FamiliarPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e 
         const { level, master, masterAttributeModifier, system } = this;
         const attributeModifier =
             masterAttributeModifier > 2
-                ? new ModifierPF2e(`PF2E.MasterAbility.${system.master.ability}`, masterAttributeModifier, "untyped")
-                : new ModifierPF2e(`PF2E.Actor.Familiar.MinimumAttributeModifier`, 3, "untyped");
+                ? new Modifier(`PF2E.MasterAbility.${system.master.ability}`, masterAttributeModifier, "untyped")
+                : new Modifier(`PF2E.Actor.Familiar.MinimumAttributeModifier`, 3, "untyped");
 
         // Hit Points
         const hitPoints = new HitPointsStatistic(this, { baseMax: level * 5 });
@@ -102,7 +102,7 @@ class FamiliarPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e 
 
         // Armor Class
         const masterModifier = master
-            ? new ModifierPF2e({
+            ? new Modifier({
                   label: "PF2E.Actor.Familiar.Master.ArmorClass",
                   slug: "base",
                   modifier: master.armorClass.modifiers
@@ -126,7 +126,7 @@ class FamiliarPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e 
                     slug: saveType,
                     label: game.i18n.localize(CONFIG.PF2E.saves[saveType]),
                     domains: selectors,
-                    modifiers: [new ModifierPF2e(`PF2E.MasterSavingThrow.${saveType}`, totalMod, "untyped")],
+                    modifiers: [new Modifier(`PF2E.MasterSavingThrow.${saveType}`, totalMod, "untyped")],
                     check: { type: "saving-throw" },
                 });
 
@@ -144,7 +144,7 @@ class FamiliarPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e 
         this.attackStatistic = new Statistic(this, {
             slug: "attack-roll",
             label: "PF2E.Familiar.AttackRoll",
-            modifiers: [new ModifierPF2e("PF2E.MasterLevel", masterLevel, "untyped")],
+            modifiers: [new Modifier("PF2E.MasterLevel", masterLevel, "untyped")],
             check: { type: "attack-roll" },
         });
         system.attack = this.attackStatistic.getTraceData();
@@ -155,7 +155,7 @@ class FamiliarPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e 
             label: "PF2E.PerceptionLabel",
             attribute: "wis",
             domains: ["perception", "wis-based", "all"],
-            modifiers: [new ModifierPF2e("PF2E.MasterLevel", masterLevel, "untyped"), attributeModifier],
+            modifiers: [new Modifier("PF2E.MasterLevel", masterLevel, "untyped"), attributeModifier],
             check: { type: "perception-check" },
             senses: system.perception.senses,
         });
@@ -163,7 +163,7 @@ class FamiliarPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e 
 
         // Skills
         this.skills = R.mapToObj(R.entries(CONFIG.PF2E.skills), ([skill, { label, attribute }]) => {
-            const modifiers = [new ModifierPF2e("PF2E.MasterLevel", masterLevel, "untyped")];
+            const modifiers = [new Modifier("PF2E.MasterLevel", masterLevel, "untyped")];
             if (["acrobatics", "stealth"].includes(skill)) {
                 modifiers.push(attributeModifier);
             }

--- a/src/module/actor/hazard/document.ts
+++ b/src/module/actor/hazard/document.ts
@@ -3,7 +3,7 @@ import { InitiativeData } from "@actor/data/base.ts";
 import { Immunity } from "@actor/data/iwr.ts";
 import { setHitPointsRollOptions, strikeFromMeleeItem } from "@actor/helpers.ts";
 import { ActorInitiative } from "@actor/initiative.ts";
-import { ModifierPF2e } from "@actor/modifiers.ts";
+import { Modifier } from "@actor/modifiers.ts";
 import { SaveType } from "@actor/types.ts";
 import { SAVE_TYPES } from "@actor/values.ts";
 import { ConditionPF2e } from "@item";
@@ -112,7 +112,7 @@ class HazardPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | 
                 label: CONFIG.PF2E.skills.stealth.label,
                 domains: ["stealth", `dex-based`, "skill-check", `dex-skill-check`, "all"],
                 modifiers: [
-                    new ModifierPF2e({
+                    new Modifier({
                         label: "PF2E.ModifierTitle",
                         slug: "base",
                         type: "untyped",
@@ -139,7 +139,7 @@ class HazardPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | 
 
         // Armor Class
         if (this.hasDefenses) {
-            const baseModifier = new ModifierPF2e({
+            const baseModifier = new Modifier({
                 slug: "base",
                 label: "PF2E.BaseModifier",
                 modifier: system.attributes.ac.value - 10,
@@ -193,7 +193,7 @@ class HazardPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | 
                 attribute: CONFIG.PF2E.savingThrowDefaultAttributes[saveType],
                 domains: [saveType, "saving-throw"],
                 modifiers: [
-                    new ModifierPF2e({
+                    new Modifier({
                         slug: "base",
                         label: "PF2E.ModifierTitle",
                         modifier: base,

--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -18,7 +18,7 @@ import {
 import { eventToRollParams } from "@module/sheet/helpers.ts";
 import type { RegionDocumentPF2e, ScenePF2e } from "@scene";
 import type { EnvironmentRegionBehavior } from "@scene/region-behavior/types.ts";
-import { CheckCheckContext, CheckPF2e, CheckRoll } from "@system/check/index.ts";
+import { Check, CheckCheckContext, CheckRoll } from "@system/check/index.ts";
 import { DamageDamageContext, DamagePF2e } from "@system/damage/index.ts";
 import { DamageRoll } from "@system/damage/roll.ts";
 import { WeaponDamagePF2e } from "@system/damage/weapon.ts";
@@ -29,7 +29,7 @@ import * as R from "remeda";
 import { AttackTraitHelpers } from "./creature/helpers.ts";
 import type { DamageRollFunction } from "./data/base.ts";
 import type { ActorSourcePF2e } from "./data/index.ts";
-import { CheckModifier, ModifierPF2e, StatisticModifier, createAttributeModifier } from "./modifiers.ts";
+import { CheckModifier, Modifier, StatisticModifier, createAttributeModifier } from "./modifiers.ts";
 import type { NPCStrike } from "./npc/data.ts";
 import { CheckContext } from "./roll-context/check.ts";
 import { DamageContext } from "./roll-context/damage.ts";
@@ -359,7 +359,7 @@ function getStrikeAttackDomains(
             alternativeAttributeModifier,
             ...extractModifiers(weapon.actor.synthetics, domains, { resolvables: { weapon }, test: rollOptions }),
         ]
-            .filter((m): m is ModifierPF2e & { ability: AttributeString } => m?.type === "ability" && m.enabled)
+            .filter((m): m is Modifier & { ability: AttributeString } => m?.type === "ability" && m.enabled)
             .reduce((best, candidate) => (candidate.modifier > best.modifier ? candidate : best));
         domains.push(`${attributeModifier.ability}-attack`, `${attributeModifier.ability}-based`);
     }
@@ -442,7 +442,7 @@ function strikeFromMeleeItem(item: MeleePF2e<ActorPF2e>): NPCStrike {
 
     const synthetics = actor.synthetics;
     const modifiers = [
-        new ModifierPF2e({
+        new Modifier({
             slug: "base",
             label: "PF2E.ModifierTitle",
             modifier: item.attackModifier,
@@ -514,7 +514,7 @@ function strikeFromMeleeItem(item: MeleePF2e<ActorPF2e>): NPCStrike {
     // Multiple attack penalty
     const maps = calculateMAPs(item, { domains, options: initialRollOptions });
     const createMapModifier = (prop: "map1" | "map2") => {
-        return new ModifierPF2e({
+        return new Modifier({
             slug: maps.slug,
             label: maps.label,
             modifier: maps[prop],
@@ -601,7 +601,7 @@ function strikeFromMeleeItem(item: MeleePF2e<ActorPF2e>): NPCStrike {
                 dosAdjustments,
                 createMessage: params.createMessage ?? true,
             };
-            const roll = await CheckPF2e.roll(check, checkContext, params.event);
+            const roll = await Check.roll(check, checkContext, params.event);
 
             if (roll) {
                 for (const rule of context.origin.actor.rules.filter((r) => !r.ignored)) {
@@ -699,11 +699,11 @@ function calculateRangePenalty(
     increment: number | null,
     selectors: string[],
     rollOptions: Set<string>,
-): ModifierPF2e | null {
+): Modifier | null {
     if (!increment || increment === 1) return null;
 
     const slug = "range-penalty";
-    const modifier = new ModifierPF2e({
+    const modifier = new Modifier({
         label: "PF2E.RangePenalty",
         slug,
         type: "untyped",

--- a/src/module/actor/npc/data.ts
+++ b/src/module/actor/npc/data.ts
@@ -27,7 +27,7 @@ import type {
     StrikeData,
 } from "@actor/data/base.ts";
 import { InitiativeTraceData } from "@actor/initiative.ts";
-import type { ModifierPF2e, StatisticModifier } from "@actor/modifiers.ts";
+import type { Modifier, StatisticModifier } from "@actor/modifiers.ts";
 import type { ActorAlliance, SaveType, SkillSlug } from "@actor/types.ts";
 import type { MeleePF2e } from "@item";
 import type { PublicationData, ValueAndMax } from "@module/data.ts";
@@ -166,7 +166,7 @@ interface NPCSystemData extends Omit<NPCSystemSource, "attributes" | "perception
         rituals: { dc: number };
     };
 
-    customModifiers: Record<string, ModifierPF2e[]>;
+    customModifiers: Record<string, Modifier[]>;
 }
 
 interface NPCPerceptionData extends CreaturePerceptionData {

--- a/src/module/actor/npc/document.ts
+++ b/src/module/actor/npc/document.ts
@@ -4,7 +4,7 @@ import type { CreatureUpdateCallbackOptions } from "@actor/creature/index.ts";
 import { ActorSizePF2e } from "@actor/data/size.ts";
 import { setHitPointsRollOptions, strikeFromMeleeItem } from "@actor/helpers.ts";
 import { ActorInitiative } from "@actor/initiative.ts";
-import { ModifierPF2e, StatisticModifier } from "@actor/modifiers.ts";
+import { Modifier, StatisticModifier } from "@actor/modifiers.ts";
 import type { MovementType, SaveType } from "@actor/types.ts";
 import { SAVE_TYPES } from "@actor/values.ts";
 import type { UserAction } from "@common/constants.d.mts";
@@ -156,11 +156,7 @@ class NPCPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | nul
             });
             synthetics.modifiers.hp.push(
                 () =>
-                    new ModifierPF2e(
-                        "PF2E.NPC.Adjustment.EliteLabel",
-                        this.getHpAdjustment(baseLevel, "elite"),
-                        "untyped",
-                    ),
+                    new Modifier("PF2E.NPC.Adjustment.EliteLabel", this.getHpAdjustment(baseLevel, "elite"), "untyped"),
             );
         } else if (this.isWeak) {
             modifierAdjustments.all.push({
@@ -170,7 +166,7 @@ class NPCPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | nul
             });
             synthetics.modifiers.hp.push(
                 () =>
-                    new ModifierPF2e(
+                    new Modifier(
                         "PF2E.NPC.Adjustment.WeakLabel",
                         this.getHpAdjustment(baseLevel, "weak") * -1,
                         "untyped",
@@ -186,7 +182,7 @@ class NPCPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | nul
         // Hit Points
         {
             const base = system.attributes.hp.max;
-            const modifiers: ModifierPF2e[] = [
+            const modifiers: Modifier[] = [
                 extractModifiers(synthetics, ["hp"], { test: this.getRollOptions(["hp"]) }),
                 extractModifiers(synthetics, ["hp-per-level"], {
                     test: this.getRollOptions(["hp-per-level"]),
@@ -215,7 +211,7 @@ class NPCPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | nul
         // Armor Class
         const armorStatistic = new ArmorStatistic(this, {
             modifiers: [
-                new ModifierPF2e({
+                new Modifier({
                     slug: "base",
                     label: "PF2E.ModifierTitle",
                     modifier: system.attributes.ac.value - 10,
@@ -240,7 +236,7 @@ class NPCPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | nul
                 attribute: "wis",
                 domains,
                 modifiers: [
-                    new ModifierPF2e({
+                    new Modifier({
                         slug: "base",
                         label: "PF2E.ModifierTitle",
                         modifier: system.perception.mod,
@@ -297,7 +293,7 @@ class NPCPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | nul
                 label: saveName,
                 domains: domains,
                 modifiers: [
-                    new ModifierPF2e({
+                    new Modifier({
                         slug: "base",
                         label: "PF2E.ModifierTitle",
                         modifier: base,
@@ -331,7 +327,7 @@ class NPCPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | nul
                     ?.filter((v) => v.predicate?.length)
                     .map(
                         (special) =>
-                            new ModifierPF2e({
+                            new Modifier({
                                 slug: "variant",
                                 label: special.label,
                                 modifier: special.base - skill.base,
@@ -347,7 +343,7 @@ class NPCPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | nul
                 attribute,
                 domains,
                 modifiers: [
-                    new ModifierPF2e({
+                    new Modifier({
                         slug: "base",
                         label: "PF2E.ModifierTitle",
                         modifier: skill?.base ?? this.system.abilities[attribute].mod,
@@ -375,7 +371,7 @@ class NPCPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | nul
                 attribute: "int",
                 domains,
                 modifiers: [
-                    new ModifierPF2e({
+                    new Modifier({
                         slug: "base",
                         label: "PF2E.ModifierTitle",
                         modifier: loreItem.system.mod.value,

--- a/src/module/actor/npc/sheet.ts
+++ b/src/module/actor/npc/sheet.ts
@@ -1,6 +1,6 @@
 import type { NPCPF2e } from "@actor";
 import { CreatureSheetPF2e, type CreatureSheetData } from "@actor/creature/sheet.ts";
-import { ModifierPF2e } from "@actor/modifiers.ts";
+import { Modifier } from "@actor/modifiers.ts";
 import { NPCSkillsEditor } from "@actor/npc/skills-editor.ts";
 import { SheetClickActionHandlers } from "@actor/sheet/base.ts";
 import { createAbilityViewData } from "@actor/sheet/helpers.ts";
@@ -121,7 +121,7 @@ abstract class AbstractNPCSheet extends CreatureSheetPF2e<NPCPF2e> {
             const args: StatisticRollParameters = {
                 ...eventToRollParams(event, { type: "check" }),
                 modifiers: [
-                    new ModifierPF2e({
+                    new Modifier({
                         slug: "variant",
                         label: variant.label,
                         modifier: variant.base - skill.base,

--- a/src/module/actor/party/document.ts
+++ b/src/module/actor/party/document.ts
@@ -9,7 +9,7 @@ import type {
 import type { UserAction } from "@common/constants.d.mts";
 import type { ActorUUID } from "@common/documents/_module.d.mts";
 import type { ItemType } from "@item/base/data/index.ts";
-import { RuleElementPF2e } from "@module/rules/index.ts";
+import { RuleElement } from "@module/rules/index.ts";
 import type { RuleElementSchema } from "@module/rules/rule-element/data.ts";
 import type { TokenDocumentPF2e } from "@scene/index.ts";
 import type { Statistic } from "@system/statistic/index.ts";
@@ -84,7 +84,7 @@ class PartyPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
     }
 
     /** Only prepare rule elements for non-physical items (in case campaign items exist) */
-    protected override prepareRuleElements(): RuleElementPF2e<RuleElementSchema>[] {
+    protected override prepareRuleElements(): RuleElement<RuleElementSchema>[] {
         return this.items.contents
             .filter((item) => !item.isOfType("physical"))
             .flatMap((item) => item.prepareRuleElements())

--- a/src/module/actor/party/kingdom/model.ts
+++ b/src/module/actor/party/kingdom/model.ts
@@ -1,6 +1,6 @@
 import { ActorPF2e, type ArmyPF2e, type PartyPF2e } from "@actor";
 import { FeatGroup } from "@actor/character/feats/index.ts";
-import { MODIFIER_TYPES, ModifierPF2e, RawModifier, createProficiencyModifier } from "@actor/modifiers.ts";
+import { MODIFIER_TYPES, Modifier, RawModifier, createProficiencyModifier } from "@actor/modifiers.ts";
 import { CampaignFeaturePF2e, ItemPF2e } from "@item";
 import type { ItemType } from "@item/base/data/index.ts";
 import { ChatMessagePF2e } from "@module/chat-message/document.ts";
@@ -153,7 +153,7 @@ class Kingdom extends foundry.abstract.DataModel<PartySystemData, KingdomSchema>
         const modifiers = customModifiers[stat] ?? [];
         if (!modifiers.some((m) => m.label === data.label)) {
             data.type = setHasElement(MODIFIER_TYPES, data.type) ? data.type : "untyped";
-            const modifier = new ModifierPF2e({ ...data, custom: true }).toObject();
+            const modifier = new Modifier({ ...data, custom: true }).toObject();
             await this.update({ [`customModifiers.${stat}`]: [...modifiers, modifier] });
         }
     }
@@ -250,7 +250,7 @@ class Kingdom extends foundry.abstract.DataModel<PartySystemData, KingdomSchema>
         const customModifiers = (this.customModifiers ??= {});
         for (const selector of Object.keys(customModifiers)) {
             const modifiers = (customModifiers[selector] = customModifiers[selector].map(
-                (rawModifier: RawModifier) => new ModifierPF2e(rawModifier),
+                (rawModifier: RawModifier) => new Modifier(rawModifier),
             ));
             (synthetics.modifiers[selector] ??= []).push(...modifiers.map((m) => () => m));
         }
@@ -267,7 +267,7 @@ class Kingdom extends foundry.abstract.DataModel<PartySystemData, KingdomSchema>
             const modifiers = (synthetics.modifiers["control-dc"] ??= []);
             modifiers.push(
                 () =>
-                    new ModifierPF2e({
+                    new Modifier({
                         slug: "size",
                         label: "Size Modifier",
                         modifier: sizeData.controlMod,
@@ -282,7 +282,7 @@ class Kingdom extends foundry.abstract.DataModel<PartySystemData, KingdomSchema>
                 const modifiers = (synthetics.modifiers[`${ability}-based`] ??= []);
                 modifiers.push(
                     () =>
-                        new ModifierPF2e({
+                        new Modifier({
                             slug: "ruin",
                             type: "item",
                             label: KINGDOM_RUIN_LABELS[ability],
@@ -310,7 +310,7 @@ class Kingdom extends foundry.abstract.DataModel<PartySystemData, KingdomSchema>
                 }
                 for (const [selector, entries] of Object.entries(penalties.modifiers ?? {})) {
                     const modifiers = (synthetics.modifiers[selector] ??= []);
-                    modifiers.push(...entries.map((e) => () => new ModifierPF2e(e)));
+                    modifiers.push(...entries.map((e) => () => new Modifier(e)));
                 }
             }
 
@@ -319,7 +319,7 @@ class Kingdom extends foundry.abstract.DataModel<PartySystemData, KingdomSchema>
                 const modifiers = (synthetics.modifiers[`${ability}-skill-check`] ??= []);
                 modifiers.push(
                     () =>
-                        new ModifierPF2e({
+                        new Modifier({
                             slug: "invested",
                             label: "PF2E.Kingmaker.Kingdom.Invested",
                             type: "status",
@@ -336,7 +336,7 @@ class Kingdom extends foundry.abstract.DataModel<PartySystemData, KingdomSchema>
             const modifiers = (synthetics.modifiers["kingdom-check"] ??= []);
             modifiers.push(
                 () =>
-                    new ModifierPF2e({
+                    new Modifier({
                         slug: "unrest",
                         label: "PF2E.Kingmaker.Kingdom.Unrest",
                         type: "status",
@@ -386,19 +386,19 @@ class Kingdom extends foundry.abstract.DataModel<PartySystemData, KingdomSchema>
             domains: ["consumption"],
             modifiers: [
                 consumption.settlement &&
-                    new ModifierPF2e({
+                    new Modifier({
                         slug: "settlements",
                         label: "PF2E.Kingmaker.Settlement.Label",
                         modifier: consumption.settlement,
                     }),
                 consumption.army &&
-                    new ModifierPF2e({
+                    new Modifier({
                         slug: "army",
                         label: "PF2E.Kingmaker.Army.Label",
                         modifier: consumption.army,
                     }),
                 this.resources.workSites.food.value &&
-                    new ModifierPF2e({
+                    new Modifier({
                         slug: "farmland",
                         label: "PF2E.Kingmaker.WorkSites.food.Name",
                         modifier: -this.resources.workSites.food.value,
@@ -414,7 +414,7 @@ class Kingdom extends foundry.abstract.DataModel<PartySystemData, KingdomSchema>
             slug: "control",
             label: "PF2E.Kingmaker.Kingdom.ControlDC",
             domains: ["control-dc"],
-            modifiers: [new ModifierPF2e({ slug: "base", label: "PF2E.ModifierTitle", modifier: controlMod })],
+            modifiers: [new Modifier({ slug: "base", label: "PF2E.ModifierTitle", modifier: controlMod })],
         });
 
         // Calculate all kingdom skills
@@ -429,7 +429,7 @@ class Kingdom extends foundry.abstract.DataModel<PartySystemData, KingdomSchema>
                 label: KINGDOM_SKILL_LABELS[skill],
                 domains,
                 modifiers: [
-                    new ModifierPF2e({
+                    new Modifier({
                         slug: ability,
                         label: KINGDOM_ABILITY_LABELS[ability],
                         modifier: abilityMod,

--- a/src/module/actor/roll-context/types.ts
+++ b/src/module/actor/roll-context/types.ts
@@ -1,6 +1,6 @@
 import type { ActorPF2e } from "@actor";
 import type { StrikeData } from "@actor/data/base.ts";
-import type { ModifierPF2e } from "@actor/modifiers.ts";
+import type { Modifier } from "@actor/modifiers.ts";
 import type { ItemPF2e } from "@item";
 import type { AbilityTrait } from "@item/ability/types.ts";
 import type { CheckContextChatFlag } from "@module/chat-message/data.ts";
@@ -48,7 +48,7 @@ interface RollOrigin<
     /** The item used for the strike */
     item: TItem;
     /** Bonuses and penalties added at the time of a check */
-    modifiers: ModifierPF2e[];
+    modifiers: Modifier[];
 }
 
 interface RollTarget {

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -14,7 +14,7 @@ import type { ActionType, ItemSourcePF2e } from "@item/base/data/index.ts";
 import { createConsumableFromSpell } from "@item/consumable/spell-consumables.ts";
 import { isContainerCycle } from "@item/container/helpers.ts";
 import { itemIsOfType } from "@item/helpers.ts";
-import type { Coins } from "@item/physical/data.ts";
+import type { RawCoins } from "@item/physical/data.ts";
 import { sizeItemForActor } from "@item/physical/helpers.ts";
 import { DENOMINATIONS, PHYSICAL_ITEM_TYPES } from "@item/physical/values.ts";
 import { DropCanvasItemDataPF2e } from "@module/canvas/drop-canvas-data.ts";
@@ -306,7 +306,7 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends fav1.sheets.Acto
         }
     }
 
-    protected static coinsToSheetData(coins: Coins): CoinageSummary {
+    protected static coinsToSheetData(coins: RawCoins): CoinageSummary {
         return DENOMINATIONS.reduce(
             (accumulated, d) => ({
                 ...accumulated,

--- a/src/module/actor/sheet/data-types.ts
+++ b/src/module/actor/sheet/data-types.ts
@@ -8,7 +8,7 @@ import type { ActorSheetData } from "@client/appv1/sheets/actor-sheet.d.mts";
 import type { ItemUUID } from "@common/documents/_module.d.mts";
 import type { PhysicalItemPF2e } from "@item";
 import type { Frequency } from "@item/base/data/index.ts";
-import type { Coins } from "@item/physical/data.ts";
+import type { RawCoins } from "@item/physical/data.ts";
 import type { RollOptionToggle } from "@module/rules/synthetics.ts";
 import type { SheetOptions } from "@module/sheet/helpers.ts";
 
@@ -35,7 +35,7 @@ interface CoinDisplayData {
     label: string;
 }
 
-export type CoinageSummary = { [K in keyof Coins]?: CoinDisplayData };
+export type CoinageSummary = { [K in keyof RawCoins]?: CoinDisplayData };
 
 interface SheetItemList {
     label: string;
@@ -63,7 +63,7 @@ interface ActorSheetDataPF2e<TActor extends ActorPF2e> extends ActorSheetData<TA
     toggles: Record<string, RollOptionToggle[]>;
     totalCoinage: CoinageSummary;
     totalCoinageGold: string;
-    totalWealth: Coins;
+    totalWealth: RawCoins;
     totalWealthGold: string;
     traits: SheetOptions;
     user: { isGM: boolean };

--- a/src/module/actor/sheet/popups/add-coins-popup.ts
+++ b/src/module/actor/sheet/popups/add-coins-popup.ts
@@ -1,8 +1,8 @@
 import { ActorPF2e } from "@actor/base.ts";
-import { Coins } from "@item/physical/data.ts";
+import { RawCoins } from "@item/physical/data.ts";
 import appv1 = foundry.appv1;
 
-interface AddCoinsFormData extends Coins {
+interface AddCoinsFormData extends RawCoins {
     combineStacks: boolean;
 }
 

--- a/src/module/actor/sheet/popups/distribute-coins-popup.ts
+++ b/src/module/actor/sheet/popups/distribute-coins-popup.ts
@@ -1,5 +1,5 @@
 import type { ActorPF2e, CharacterPF2e } from "@actor";
-import { CoinsPF2e } from "@item/physical/helpers.ts";
+import { Coins } from "@item/physical/helpers.ts";
 import { ChatMessagePF2e } from "@module/chat-message/document.ts";
 import appv1 = foundry.appv1;
 
@@ -65,7 +65,7 @@ export class DistributeCoinsPopup extends appv1.api.FormApplication<ActorPF2e, D
             return;
         }
 
-        const coinShare = new CoinsPF2e();
+        const coinShare = new Coins();
         if (formData.breakCoins) {
             const thisActorCopperValue = thisActor.inventory.coins.copperValue;
             const copperToDistribute = Math.trunc(thisActorCopperValue / playerCount);

--- a/src/module/actor/sheet/popups/item-transfer-dialog.ts
+++ b/src/module/actor/sheet/popups/item-transfer-dialog.ts
@@ -1,6 +1,6 @@
 import type { ActorPF2e } from "@actor";
 import type { PhysicalItemPF2e } from "@item";
-import { CoinsPF2e } from "@item/physical/coins.ts";
+import { Coins } from "@item/physical/coins.ts";
 import { htmlQuery } from "@util";
 import appv1 = foundry.appv1;
 
@@ -87,7 +87,7 @@ class ItemTransferDialog extends appv1.api.FormApplication<PhysicalItemPF2e, Mov
             const getQuantity = () => Math.clamp(Number(quantityInput?.value ?? 1), 1, this.item.quantity);
             const updatePrice = () => {
                 const quantity = Math.clamp(Number(quantityInput?.value ?? 1), 1, this.item.quantity);
-                const cost = CoinsPF2e.fromPrice(this.item.price, quantity);
+                const cost = Coins.fromPrice(this.item.price, quantity);
                 priceElement.innerText = `(${cost.toString()})`;
             };
 

--- a/src/module/actor/sheet/popups/remove-coins-popup.ts
+++ b/src/module/actor/sheet/popups/remove-coins-popup.ts
@@ -1,8 +1,8 @@
 import { ActorPF2e } from "@actor";
-import { Coins } from "@item/physical/data.ts";
+import { RawCoins } from "@item/physical/data.ts";
 import appv1 = foundry.appv1;
 
-interface PopupFormData extends Coins {
+interface PopupFormData extends RawCoins {
     removeByValue: boolean;
 }
 

--- a/src/module/actor/vehicle/document.ts
+++ b/src/module/actor/vehicle/document.ts
@@ -1,6 +1,6 @@
 import { ActorSizePF2e } from "@actor/data/size.ts";
 import { setHitPointsRollOptions } from "@actor/helpers.ts";
-import { ModifierPF2e } from "@actor/modifiers.ts";
+import { Modifier } from "@actor/modifiers.ts";
 import { ActorDimensions } from "@actor/types.ts";
 import { ItemType } from "@item/base/data/index.ts";
 import { extractModifierAdjustments, extractModifiers } from "@module/rules/helpers.ts";
@@ -56,7 +56,7 @@ class VehiclePF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e |
         if (this.hasCondition("broken")) {
             for (const selector of ["ac", "saving-throw"]) {
                 const modifiers = (this.synthetics.modifiers[selector] ??= []);
-                const brokenModifier = new ModifierPF2e({
+                const brokenModifier = new Modifier({
                     slug: "broken",
                     label: "PF2E.ConditionTypeBroken",
                     modifier: -2,
@@ -76,7 +76,7 @@ class VehiclePF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e |
         // Prepare AC
         const armorStatistic = new ArmorStatistic(this, {
             modifiers: [
-                new ModifierPF2e({
+                new Modifier({
                     slug: "base",
                     label: "PF2E.ModifierTitle",
                     modifier: this.system.attributes.ac.value - 10,
@@ -96,7 +96,7 @@ class VehiclePF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e |
         const slug = "fortitude";
         const domains = [slug, "saving-throw", "all"];
         const modifiers = [
-            new ModifierPF2e({
+            new Modifier({
                 label: "PF2E.ModifierTitle",
                 slug,
                 type: "untyped",

--- a/src/module/apps/compendium-browser/tabs/equipment.ts
+++ b/src/module/apps/compendium-browser/tabs/equipment.ts
@@ -1,4 +1,4 @@
-import { CoinsPF2e } from "@item/physical/helpers.ts";
+import { Coins } from "@item/physical/helpers.ts";
 import { MAGIC_TRADITIONS } from "@item/spell/values.ts";
 import { localizer, sluggify } from "@util";
 import * as R from "remeda";
@@ -84,7 +84,7 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
                     // Store price as a number for better sorting (note: we may be dealing with old data, convert if needed)
                     const priceValue = itemData.system.price.value;
                     const priceCoins =
-                        typeof priceValue === "string" ? CoinsPF2e.fromString(priceValue) : new CoinsPF2e(priceValue);
+                        typeof priceValue === "string" ? Coins.fromString(priceValue) : new Coins(priceValue);
                     const coinValue = priceCoins.copperValue;
 
                     // Prepare publication source
@@ -215,8 +215,8 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
                 upper = upper.replaceAll(translated, english);
             }
             return {
-                min: CoinsPF2e.fromString(lower).copperValue,
-                max: CoinsPF2e.fromString(upper).copperValue,
+                min: Coins.fromString(lower).copperValue,
+                max: Coins.fromString(upper).copperValue,
                 inputMin: lower,
                 inputMax: upper,
             };

--- a/src/module/apps/roll-inspector/app.svelte
+++ b/src/module/apps/roll-inspector/app.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { DamageDicePF2e, ModifierPF2e } from "@actor/modifiers.ts";
+    import { DamageDicePF2e, Modifier } from "@actor/modifiers.ts";
     import type { RollInspectorContext } from "./app.ts";
     import * as R from "remeda";
     import { createHTMLElement, signedInteger } from "@util";
@@ -30,7 +30,7 @@
     }
 
     /** Shows the roll options for a specific modifier */
-    async function showOptionsTooltip(element: HTMLElement, object: ModifierPF2e | DamageDicePF2e) {
+    async function showOptionsTooltip(element: HTMLElement, object: Modifier | DamageDicePF2e) {
         const rollOptions = R.sortBy(object.getRollOptions().sort(), (o) => o.includes(":"));
         const content = await fa.handlebars.renderTemplate("systems/pf2e/templates/system/roll-options-tooltip.hbs", {
             description: game.i18n.localize("PF2E.ChatRollDetails.DiceRollOptionsHint"),
@@ -130,7 +130,7 @@
                         <span class="label-slug">{m.label} ({m.slug})</span>
                         <i
                             class="fa-solid fa-circle-info"
-                            onpointerenter={(evt) => showOptionsTooltip(evt.currentTarget, new ModifierPF2e(m))}
+                            onpointerenter={(evt) => showOptionsTooltip(evt.currentTarget, new Modifier(m))}
                         ></i>
                     </header>
                     <div>

--- a/src/module/apps/sidebar/chat-log.ts
+++ b/src/module/apps/sidebar/chat-log.ts
@@ -11,7 +11,7 @@ import { applyDamageFromMessage } from "@module/chat-message/helpers.ts";
 import { ChatMessagePF2e } from "@module/chat-message/index.ts";
 import { CombatantPF2e } from "@module/encounter/index.ts";
 import { TokenDocumentPF2e } from "@scene";
-import { CheckPF2e } from "@system/check/index.ts";
+import { Check } from "@system/check/index.ts";
 import { looksLikeDamageRoll } from "@system/damage/helpers.ts";
 import { DamageRoll } from "@system/damage/roll.ts";
 import { createHTMLElement, ErrorPF2e, fontAwesomeIcon, htmlClosest, htmlQuery, objectHasKey } from "@util";
@@ -525,7 +525,7 @@ class ChatLogPF2e extends fa.sidebar.tabs.ChatLog {
                 condition: canHeroPointReroll,
                 callback: (li) => {
                     const message = game.messages.get(li.dataset.messageId, { strict: true });
-                    CheckPF2e.rerollFromMessage(message, { resource: "hero-points" });
+                    Check.rerollFromMessage(message, { resource: "hero-points" });
                 },
             },
             {
@@ -534,7 +534,7 @@ class ChatLogPF2e extends fa.sidebar.tabs.ChatLog {
                 condition: canMythicPointReroll,
                 callback: (li) => {
                     const message = game.messages.get(li.dataset.messageId, { strict: true });
-                    CheckPF2e.rerollFromMessage(message, { resource: "mythic-points" });
+                    Check.rerollFromMessage(message, { resource: "mythic-points" });
                 },
             },
             {
@@ -543,7 +543,7 @@ class ChatLogPF2e extends fa.sidebar.tabs.ChatLog {
                 condition: canReroll,
                 callback: (li) => {
                     const message = game.messages.get(li.dataset.messageId, { strict: true });
-                    CheckPF2e.rerollFromMessage(message);
+                    Check.rerollFromMessage(message);
                 },
             },
             {
@@ -552,7 +552,7 @@ class ChatLogPF2e extends fa.sidebar.tabs.ChatLog {
                 condition: canReroll,
                 callback: (li) => {
                     const message = game.messages.get(li.dataset.messageId, { strict: true });
-                    CheckPF2e.rerollFromMessage(message, { keep: "lower" });
+                    Check.rerollFromMessage(message, { keep: "lower" });
                 },
             },
             {
@@ -561,7 +561,7 @@ class ChatLogPF2e extends fa.sidebar.tabs.ChatLog {
                 condition: canReroll,
                 callback: (li) => {
                     const message = game.messages.get(li.dataset.messageId, { strict: true });
-                    CheckPF2e.rerollFromMessage(message, { keep: "higher" });
+                    Check.rerollFromMessage(message, { keep: "higher" });
                 },
             },
         );

--- a/src/module/chat-message/listeners/cards.ts
+++ b/src/module/chat-message/listeners/cards.ts
@@ -5,7 +5,7 @@ import { SAVE_TYPES } from "@actor/values.ts";
 import type { Rolled } from "@client/dice/roll.d.mts";
 import { PhysicalItemPF2e, type ItemPF2e } from "@item";
 import { isSpellConsumable } from "@item/consumable/spell-consumables.ts";
-import { CoinsPF2e } from "@item/physical/helpers.ts";
+import { Coins } from "@item/physical/helpers.ts";
 import { eventToRollParams } from "@module/sheet/helpers.ts";
 import { effectTraits } from "@scripts/config/traits.ts";
 import { onRepairChatCardEvent } from "@system/action-macros/crafting/repair.ts";
@@ -222,7 +222,7 @@ class ChatCards {
                 await onRepairChatCardEvent(event, message, buttonGroup);
             } else if (physicalItem && action === "pay-crafting-costs") {
                 const quantity = Number(buttonGroup?.dataset.craftingQuantity) || 1;
-                const craftingCost = CoinsPF2e.fromPrice(physicalItem.price, quantity);
+                const craftingCost = Coins.fromPrice(physicalItem.price, quantity);
                 const coinsToRemove = button.classList.contains("full") ? craftingCost : craftingCost.scale(0.5);
                 if (!(await actor.inventory.removeCoins(coinsToRemove))) {
                     ui.notifications.warn(game.i18n.localize("PF2E.Actions.Craft.Warning.InsufficientCoins"));
@@ -264,7 +264,7 @@ class ChatCards {
                     speaker: { alias: actor.name },
                 });
             } else if (physicalItem && action === "lose-materials") {
-                const craftingCost = CoinsPF2e.fromPrice(physicalItem.price, quantity);
+                const craftingCost = Coins.fromPrice(physicalItem.price, quantity);
                 const materialCosts = craftingCost.scale(0.5);
                 const coinsToRemove = materialCosts.scale(0.1);
                 if (!(await actor.inventory.removeCoins(coinsToRemove))) {

--- a/src/module/item/ability/document.ts
+++ b/src/module/item/ability/document.ts
@@ -4,7 +4,7 @@ import type { DatabaseCreateCallbackOptions, DatabaseUpdateCallbackOptions } fro
 import { ItemPF2e } from "@item";
 import type { ActionCost, Frequency, RawItemChatData } from "@item/base/data/index.ts";
 import type { RangeData } from "@item/types.ts";
-import type { RuleElementOptions, RuleElementPF2e } from "@module/rules/index.ts";
+import type { RuleElement, RuleElementOptions } from "@module/rules/index.ts";
 import { EnrichmentOptionsPF2e } from "@system/text-editor.ts";
 import { sluggify } from "@util";
 import type { AbilitySource, AbilitySystemData } from "./data.ts";
@@ -75,7 +75,7 @@ class AbilityItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> exten
     }
 
     /** Overriden to not create rule elements when suppressed */
-    override prepareRuleElements(options?: Omit<RuleElementOptions, "parent">): RuleElementPF2e[] {
+    override prepareRuleElements(options?: Omit<RuleElementOptions, "parent">): RuleElement[] {
         if (this.suppressed) return [];
         return super.prepareRuleElements(options);
     }

--- a/src/module/item/armor/sheet.ts
+++ b/src/module/item/armor/sheet.ts
@@ -1,7 +1,7 @@
 import { AutomaticBonusProgression as ABP } from "@actor/character/automatic-bonus-progression.ts";
 import { ItemSheetOptions } from "@item/base/sheet/sheet.ts";
 import {
-    CoinsPF2e,
+    Coins,
     Grade,
     MATERIAL_DATA,
     MaterialSheetData,
@@ -39,7 +39,7 @@ class ArmorSheetPF2e extends PhysicalItemSheetPF2e<ArmorPF2e> {
             ...sheetData,
             abpEnabled: ABP.isEnabled(this.actor),
             adjustedBulkHint,
-            basePrice: new CoinsPF2e(armor._source.system.price.value),
+            basePrice: new Coins(armor._source.system.price.value),
             baseTypes: sortStringRecord(CONFIG.PF2E.baseArmorTypes),
             categories: CONFIG.PF2E.armorCategories,
             groups: sortStringRecord(CONFIG.PF2E.armorGroups),
@@ -81,7 +81,7 @@ class ArmorSheetPF2e extends PhysicalItemSheetPF2e<ArmorPF2e> {
 
 interface ArmorSheetData extends PhysicalItemSheetData<ArmorPF2e> {
     abpEnabled: boolean;
-    basePrice: CoinsPF2e;
+    basePrice: Coins;
     baseTypes: Record<BaseArmorType, string>;
     categories: Record<ArmorCategory, string>;
     groups: Record<ArmorGroup, string>;

--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -22,7 +22,7 @@ import { ChatMessagePF2e } from "@module/chat-message/document.ts";
 import { preImportJSON } from "@module/doc-helpers.ts";
 import { MigrationList, MigrationRunner } from "@module/migration/index.ts";
 import { MigrationRunnerBase } from "@module/migration/runner/base.ts";
-import { RuleElementOptions, RuleElementPF2e, RuleElementSource, RuleElements } from "@module/rules/index.ts";
+import { RuleElement, RuleElementOptions, RuleElementSource, RuleElements } from "@module/rules/index.ts";
 import { processGrantDeletions } from "@module/rules/rule-element/grant-item/helpers.ts";
 import { eventToRollMode } from "@module/sheet/helpers.ts";
 import { type EnrichmentOptionsPF2e, type RollDataPF2e, TextEditorPF2e } from "@system/text-editor.ts";
@@ -74,7 +74,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
     }
 
     /** Prepared rule elements from this item */
-    declare rules: RuleElementPF2e[];
+    declare rules: RuleElement[];
 
     /** The sluggified name of the item **/
     get slug(): string | null {
@@ -307,7 +307,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
         this.grantedBy = this.actor?.items.get(this.flags.pf2e.grantedBy?.id ?? "") ?? null;
     }
 
-    prepareRuleElements(options: Omit<RuleElementOptions, "parent"> = {}): RuleElementPF2e[] {
+    prepareRuleElements(options: Omit<RuleElementOptions, "parent"> = {}): RuleElement[] {
         if (!this.actor) throw ErrorPF2e("Rule elements may only be prepared from embedded items");
         return (this.rules = this.actor.canHostRuleElements
             ? RuleElements.fromOwnedItem({ ...options, parent: this as ItemPF2e<NonNullable<TParent>> })

--- a/src/module/item/base/sheet/rule-element-form/base.ts
+++ b/src/module/item/base/sheet/rule-element-form/base.ts
@@ -2,7 +2,7 @@ import { ActorPF2e, ActorProxyPF2e } from "@actor";
 import type { DataField, SourceFromSchema } from "@common/data/fields.d.mts";
 import { ItemPF2e, ItemProxyPF2e } from "@item";
 import { isBracketedValue } from "@module/rules/helpers.ts";
-import { RuleElements, type RuleElementPF2e, type RuleElementSource } from "@module/rules/index.ts";
+import { RuleElements, type RuleElement, type RuleElementSource } from "@module/rules/index.ts";
 import { ResolvableValueField, RuleElementSchema } from "@module/rules/rule-element/data.ts";
 import type { HTMLTagifyTagsElement } from "@system/html-elements/tagify-tags.ts";
 import type { LaxSchemaField } from "@system/schema-data-fields.ts";
@@ -11,7 +11,7 @@ import { tagify } from "@util/tags.ts";
 import * as R from "remeda";
 import type { ItemSheetPF2e } from "../index.ts";
 
-interface RuleElementFormOptions<TSource extends RuleElementSource, TObject extends RuleElementPF2e | null> {
+interface RuleElementFormOptions<TSource extends RuleElementSource, TObject extends RuleElement | null> {
     sheet: ItemSheetPF2e<ItemPF2e>;
     index: number;
     rule: TSource;
@@ -21,7 +21,7 @@ interface RuleElementFormOptions<TSource extends RuleElementSource, TObject exte
 /** Base Rule Element form handler. Form handlers intercept sheet events to support new UI */
 class RuleElementForm<
     TSource extends RuleElementSource = RuleElementSource,
-    TObject extends RuleElementPF2e | null = RuleElementPF2e | null,
+    TObject extends RuleElement | null = RuleElement | null,
 > {
     template = "systems/pf2e/templates/items/rules/default.hbs";
 
@@ -418,7 +418,7 @@ function cleanPredicate(source: { predicate?: unknown }) {
     }
 }
 
-interface RuleElementFormSheetData<TSource extends RuleElementSource, TObject extends RuleElementPF2e | null>
+interface RuleElementFormSheetData<TSource extends RuleElementSource, TObject extends RuleElement | null>
     extends Omit<RuleElementFormOptions<TSource, TObject>, "sheet"> {
     item: ItemPF2e;
     label: string;

--- a/src/module/item/condition/document.ts
+++ b/src/module/item/condition/document.ts
@@ -4,7 +4,7 @@ import type { ItemPF2e } from "@item";
 import { AbstractEffectPF2e, EffectBadge } from "@item/abstract-effect/index.ts";
 import { reduceItemName } from "@item/helpers.ts";
 import { ChatMessagePF2e } from "@module/chat-message/index.ts";
-import { RuleElementOptions, RuleElementPF2e } from "@module/rules/index.ts";
+import { RuleElement, RuleElementOptions } from "@module/rules/index.ts";
 import type { TokenDocumentPF2e } from "@scene/index.ts";
 import { DamageCategorization } from "@system/damage/helpers.ts";
 import { DamageRoll } from "@system/damage/roll.ts";
@@ -278,7 +278,7 @@ class ConditionPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends
     }
 
     /** Withhold all rule elements if this condition is inactive */
-    override prepareRuleElements(options?: Omit<RuleElementOptions, "parent">): RuleElementPF2e[] {
+    override prepareRuleElements(options?: Omit<RuleElementOptions, "parent">): RuleElement[] {
         return this.active ? super.prepareRuleElements(options) : [];
     }
 

--- a/src/module/item/effect/document.ts
+++ b/src/module/item/effect/document.ts
@@ -9,7 +9,7 @@ import { AbstractEffectPF2e } from "@item/abstract-effect/index.ts";
 import { BadgeReevaluationEventType } from "@item/abstract-effect/types.ts";
 import { reduceItemName } from "@item/helpers.ts";
 import { ChatMessagePF2e } from "@module/chat-message/index.ts";
-import type { RuleElementOptions, RuleElementPF2e } from "@module/rules/index.ts";
+import type { RuleElement, RuleElementOptions } from "@module/rules/index.ts";
 import { ErrorPF2e, sluggify } from "@util";
 import * as R from "remeda";
 import type { EffectFlags, EffectSource, EffectSystemData } from "./data.ts";
@@ -47,7 +47,7 @@ class EffectPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ab
     }
 
     /** Unless this effect is temporarily constructed, ignore rule elements if it is expired */
-    override prepareRuleElements(options?: Omit<RuleElementOptions, "parent">): RuleElementPF2e[] {
+    override prepareRuleElements(options?: Omit<RuleElementOptions, "parent">): RuleElement[] {
         if (this.isExpired && this.actor?.items.has(this.id)) {
             for (const rule of this.system.rules) {
                 rule.ignored = true;

--- a/src/module/item/feat/document.ts
+++ b/src/module/item/feat/document.ts
@@ -9,7 +9,7 @@ import { ItemPF2e, type HeritagePF2e } from "@item";
 import { getActionCostRollOptions, normalizeActionChangeData, processSanctification } from "@item/ability/helpers.ts";
 import { ActionCost, Frequency, RawItemChatData } from "@item/base/data/index.ts";
 import { Rarity } from "@module/data.ts";
-import { RuleElementOptions, RuleElementPF2e, RuleElementSource } from "@module/rules/index.ts";
+import { RuleElement, RuleElementOptions, RuleElementSource } from "@module/rules/index.ts";
 import { EnrichmentOptionsPF2e } from "@system/text-editor.ts";
 import { ErrorPF2e, objectHasKey, setHasElement, sluggify } from "@util";
 import * as R from "remeda";
@@ -293,7 +293,7 @@ class FeatPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
     }
 
     /** Overriden to not create rule elements when suppressed */
-    override prepareRuleElements(options?: Omit<RuleElementOptions, "parent">): RuleElementPF2e[] {
+    override prepareRuleElements(options?: Omit<RuleElementOptions, "parent">): RuleElement[] {
         if (this.suppressed) return [];
         return super.prepareRuleElements(options);
     }

--- a/src/module/item/kit/sheet.ts
+++ b/src/module/item/kit/sheet.ts
@@ -1,5 +1,5 @@
 import { ItemSheetDataPF2e, ItemSheetOptions, ItemSheetPF2e } from "@item/base/sheet/sheet.ts";
-import { CoinsPF2e, PhysicalItemPF2e } from "@item/physical/index.ts";
+import { Coins, PhysicalItemPF2e } from "@item/physical/index.ts";
 import { htmlClosest, htmlQueryAll } from "@util";
 import { KitEntryData } from "./data.ts";
 import { KitPF2e } from "./document.ts";
@@ -79,14 +79,14 @@ class KitSheetPF2e extends ItemSheetPF2e<KitPF2e> {
     protected override async _updateObject(event: Event, formData: Record<string, unknown>): Promise<void> {
         // Convert price from a string to an actual object
         const priceString = String(formData["system.price.value"] ?? "").trim();
-        formData["system.price.==value"] = CoinsPF2e.fromString(priceString).toObject();
+        formData["system.price.==value"] = Coins.fromString(priceString).toObject();
         delete formData["system.price.value"];
         return super._updateObject(event, formData);
     }
 }
 
 interface KitSheetData extends ItemSheetDataPF2e<KitPF2e> {
-    priceString: CoinsPF2e;
+    priceString: Coins;
     items: Record<string, KitEntrySheetData>;
 }
 

--- a/src/module/item/physical/coins.ts
+++ b/src/module/item/physical/coins.ts
@@ -1,15 +1,15 @@
 import { Size } from "@module/data.ts";
-import { Coins, PartialPrice } from "./data.ts";
+import { PartialPrice, RawCoins } from "./data.ts";
 import { DENOMINATIONS } from "./values.ts";
 
 /** Coins class that exposes methods to perform operations on coins without side effects */
-class CoinsPF2e implements Coins {
+class Coins implements RawCoins {
     declare cp: number;
     declare sp: number;
     declare gp: number;
     declare pp: number;
 
-    constructor(data?: Coins | null) {
+    constructor(data?: RawCoins | null) {
         data ??= {};
         for (const denomination of DENOMINATIONS) {
             this[denomination] = Math.max(Math.floor(Math.abs(data[denomination] ?? 0)), 0);
@@ -26,9 +26,9 @@ class CoinsPF2e implements Coins {
         return this.copperValue / 100;
     }
 
-    plus(coins: Coins): CoinsPF2e {
-        const other = new CoinsPF2e(coins);
-        return new CoinsPF2e({
+    plus(coins: RawCoins): Coins {
+        const other = new Coins(coins);
+        return new Coins({
             pp: this.pp + other.pp,
             gp: this.gp + other.gp,
             sp: this.sp + other.sp,
@@ -37,8 +37,8 @@ class CoinsPF2e implements Coins {
     }
 
     /** Multiply by a number and clean up result */
-    scale(factor: number): CoinsPF2e {
-        const result = new CoinsPF2e(this);
+    scale(factor: number): Coins {
+        const result = new Coins(this);
         result.pp *= factor;
         result.gp *= factor;
         result.sp *= factor;
@@ -60,8 +60,8 @@ class CoinsPF2e implements Coins {
     }
 
     /** Increase a price for larger physical-item sizes */
-    adjustForSize(size: Size): CoinsPF2e {
-        const basePrice = new CoinsPF2e(this);
+    adjustForSize(size: Size): Coins {
+        const basePrice = new Coins(this);
 
         switch (size) {
             case "lg": {
@@ -79,7 +79,7 @@ class CoinsPF2e implements Coins {
     }
 
     /** Returns a coins data object with all zero value denominations omitted */
-    toObject(): Coins {
+    toObject(): RawCoins {
         return DENOMINATIONS.reduce((result, denomination) => {
             if (this[denomination] !== 0) {
                 return { ...result, [denomination]: this[denomination] };
@@ -89,7 +89,7 @@ class CoinsPF2e implements Coins {
     }
 
     /** Parses a price string such as "5 gp" and returns a new CoinsPF2e object */
-    static fromString(coinString: string, quantity = 1): CoinsPF2e {
+    static fromString(coinString: string, quantity = 1): Coins {
         if (/^\s*\d+\s*$/.test(coinString)) coinString = `${coinString.trim()} gp`;
 
         // This requires preprocessing, as large gold values contain , for their value
@@ -109,12 +109,12 @@ class CoinsPF2e implements Coins {
                 const computedValue = (Number(value) || 0) * quantity;
                 return { [denomination]: computedValue };
             })
-            .reduce((first, second) => first.plus(second), new CoinsPF2e());
+            .reduce((first, second) => first.plus(second), new Coins());
     }
 
-    static fromPrice(price: PartialPrice, factor: number): CoinsPF2e {
+    static fromPrice(price: PartialPrice, factor: number): Coins {
         const per = Math.max(1, price.per ?? 1);
-        return new CoinsPF2e(price.value).scale(factor / per);
+        return new Coins(price.value).scale(factor / per);
     }
 
     /** Creates a new price string such as "5 gp" from this object */
@@ -142,4 +142,4 @@ const coinCompendiumIds = {
     cp: "lzJ8AVhRcbFul5fh",
 };
 
-export { coinCompendiumIds, CoinsPF2e };
+export { coinCompendiumIds, Coins };

--- a/src/module/item/physical/data.ts
+++ b/src/module/item/physical/data.ts
@@ -5,7 +5,7 @@ import type { Size, TraitsWithRarity, ZeroToTwo } from "@module/data.ts";
 import type { MaterialDamageEffect } from "@system/damage/types.ts";
 import type { BaseItemSourcePF2e, ItemSystemData, ItemSystemSource, TraitConfig } from "../base/data/system.ts";
 import type { ITEM_CARRY_TYPES } from "../base/data/values.ts";
-import type { CoinsPF2e } from "./helpers.ts";
+import type { Coins } from "./helpers.ts";
 import type { PhysicalItemTrait, PhysicalItemType, PreciousMaterialGrade, PreciousMaterialType } from "./types.ts";
 import type { UsageDetails } from "./usage.ts";
 
@@ -132,7 +132,7 @@ interface PhysicalItemHitPoints extends PhysicalItemHPSource {
     brokenThreshold: number;
 }
 
-type Coins = {
+type RawCoins = {
     pp?: number;
     gp?: number;
     sp?: number;
@@ -140,20 +140,19 @@ type Coins = {
 };
 
 interface PartialPrice {
-    value: Coins;
+    value: RawCoins;
     per?: number;
     /** Whether the price adjusts according to its size */
     sizeSensitive?: boolean;
 }
 
 interface Price extends Required<PartialPrice> {
-    value: CoinsPF2e;
+    value: Coins;
 }
 
 export type {
     BasePhysicalItemSource,
     BulkData,
-    Coins,
     EquippedData,
     IdentificationData,
     IdentificationStatus,
@@ -171,4 +170,5 @@ export type {
     PhysicalSystemData,
     PhysicalSystemSource,
     Price,
+    RawCoins,
 };

--- a/src/module/item/physical/helpers.ts
+++ b/src/module/item/physical/helpers.ts
@@ -8,12 +8,12 @@ import { Rarity } from "@module/data.ts";
 import { tupleHasValue } from "@util";
 import * as R from "remeda";
 import { Bulk, STACK_DEFINITIONS } from "./bulk.ts";
-import { CoinsPF2e } from "./coins.ts";
+import { Coins } from "./coins.ts";
 import { BulkData, EquippedData } from "./data.ts";
 import { getMaterialValuationData } from "./materials.ts";
 import { RUNE_DATA, getRuneValuationData } from "./runes.ts";
 
-function computePrice(item: PhysicalItemPF2e): CoinsPF2e {
+function computePrice(item: PhysicalItemPF2e): Coins {
     if (item.isOfType("treasure")) return item.price.value;
 
     // Adjust the item price according to precious material and runes
@@ -34,20 +34,20 @@ function computePrice(item: PhysicalItemPF2e): CoinsPF2e {
             : (RUNE_DATA.shield.reinforcing[item.system.runes.reinforcing]?.price ?? 0);
     const runeValue = item.isSpecific ? 0 : runesData.reduce((sum, rune) => sum + rune.price, 0) - reinforcingRuneValue;
 
-    const basePrice = materialValue > 0 || runeValue > 0 ? new CoinsPF2e() : item.price.value;
+    const basePrice = materialValue > 0 || runeValue > 0 ? new Coins() : item.price.value;
     const gradeValue = item.isSpecific ? 0 : getGradeData(item).price;
     const afterMaterialAndRunes = runeValue
-        ? new CoinsPF2e({ gp: runeValue + materialValue })
+        ? new Coins({ gp: runeValue + materialValue })
         : basePrice.plus({ gp: gradeValue + materialValue });
     const higher = afterMaterialAndRunes.copperValue > basePrice.copperValue ? afterMaterialAndRunes : basePrice;
-    const afterReinforcingRune = higher.plus(new CoinsPF2e({ gp: reinforcingRuneValue }));
+    const afterReinforcingRune = higher.plus(new Coins({ gp: reinforcingRuneValue }));
     const afterShoddy = item.isShoddy ? afterReinforcingRune.scale(0.5) : afterReinforcingRune;
 
     /** Increase the price if it is larger than medium and not magical. */
     return item.system.price.sizeSensitive ? afterShoddy.adjustForSize(item.size) : afterShoddy;
 }
 
-function computeLevelRarityPrice(item: PhysicalItemPF2e): { level: number; rarity: Rarity; price: CoinsPF2e } {
+function computeLevelRarityPrice(item: PhysicalItemPF2e): { level: number; rarity: Rarity; price: Coins } {
     // Stop here if this weapon is not a magical or precious-material item, or if it is a specific magic weapon
     const materialData = getMaterialValuationData(item);
     const price = computePrice(item);
@@ -336,7 +336,7 @@ function getDefaultEquipStatus(item: PhysicalItemPF2e): EquippedData {
 
 export { coinCompendiumIds } from "./coins.ts";
 export {
-    CoinsPF2e,
+    Coins,
     checkPhysicalItemSystemChange,
     computeLevelRarityPrice,
     generateItemName,

--- a/src/module/item/physical/runes.ts
+++ b/src/module/item/physical/runes.ts
@@ -3,9 +3,9 @@ import type { CreatureTrait } from "@actor/creature/index.ts";
 import {
     DamageDicePF2e,
     DamageDiceParameters,
+    Modifier,
     ModifierAdjustment,
     ModifierObjectParams,
-    ModifierPF2e,
 } from "@actor/modifiers.ts";
 import { ResistanceType } from "@actor/types.ts";
 import type { ArmorPF2e, MeleePF2e, PhysicalItemPF2e, WeaponPF2e } from "@item";
@@ -103,7 +103,7 @@ function getPropertyRuneDamage(
     weapon: WeaponPF2e | MeleePF2e,
     runes: WeaponPropertyRuneType[],
     options: Set<string>,
-): (DamageDicePF2e | ModifierPF2e)[] {
+): (DamageDicePF2e | Modifier)[] {
     return runes.flatMap((rune) => {
         const runeData = WEAPON_PROPERTY_RUNES[rune];
         return fu.deepClone(runeData.damage?.additional ?? []).map((data) => {
@@ -114,7 +114,7 @@ function getPropertyRuneDamage(
                     typeof data.modifier === "string"
                         ? Number(Roll.replaceFormulaData(data.modifier, resolvables)) || 0
                         : data.modifier;
-                return new ModifierPF2e({ ...data, slug, modifier: value });
+                return new Modifier({ ...data, slug, modifier: value });
             } else {
                 const dice = new DamageDicePF2e({
                     selector: "strike-damage",

--- a/src/module/item/physical/schema.ts
+++ b/src/module/item/physical/schema.ts
@@ -1,5 +1,5 @@
 import * as R from "remeda";
-import { CoinsPF2e } from "./coins.ts";
+import { Coins } from "./coins.ts";
 import type { Price } from "./index.ts";
 import { DENOMINATIONS } from "./values.ts";
 import fields = foundry.data.fields;
@@ -29,13 +29,13 @@ class PriceField extends fields.SchemaField<PriceSchema, fields.SourceFromSchema
 
     override initialize(source: fields.SourceFromSchema<PriceSchema>): Price {
         const initialized = super.initialize(source);
-        initialized.value = new CoinsPF2e(initialized.value);
+        initialized.value = new Coins(initialized.value);
         initialized.sizeSensitive ??= false;
         return initialized;
     }
 }
 
-type CoinsField = fields.SchemaField<CoinsSchema, fields.SourceFromSchema<CoinsSchema>, CoinsPF2e, true, false, true>;
+type CoinsField = fields.SchemaField<CoinsSchema, fields.SourceFromSchema<CoinsSchema>, Coins, true, false, true>;
 
 type CoinsSchema = {
     cp: fields.NumberField<number, number, false, false, false>;

--- a/src/module/item/physical/sheet.ts
+++ b/src/module/item/physical/sheet.ts
@@ -7,7 +7,7 @@ import { getAdjustment, isControlDown } from "@module/sheet/helpers.ts";
 import { TextEditorPF2e } from "@system/text-editor.ts";
 import { ErrorPF2e, htmlClosest, htmlQuery, localizer, sortStringRecord, tupleHasValue } from "@util";
 import * as R from "remeda";
-import { CoinsPF2e, MaterialValuationData } from "./index.ts";
+import { Coins, MaterialValuationData } from "./index.ts";
 import { PRECIOUS_MATERIAL_GRADES } from "./values.ts";
 
 class PhysicalItemSheetPF2e<TItem extends PhysicalItemPF2e> extends ItemSheetPF2e<TItem> {
@@ -25,7 +25,7 @@ class PhysicalItemSheetPF2e<TItem extends PhysicalItemPF2e> extends ItemSheetPF2
         const bulkAdjustment = getAdjustment(item.system.bulk.value, item._source.system.bulk.value, {
             better: "lower",
         });
-        const basePrice = new CoinsPF2e(item._source.system.price.value);
+        const basePrice = new Coins(item._source.system.price.value);
         const priceAdjustment = getAdjustment(item.system.price.value.copperValue, basePrice.copperValue);
 
         // Enrich content
@@ -54,7 +54,7 @@ class PhysicalItemSheetPF2e<TItem extends PhysicalItemPF2e> extends ItemSheetPF2
         const adjustedPriceHint = (() => {
             if (!priceAdjustment) return null;
             const baseData = item._source;
-            const basePrice = new CoinsPF2e(baseData.system.price.value).scale(baseData.system.quantity).copperValue;
+            const basePrice = new Coins(baseData.system.price.value).scale(baseData.system.quantity).copperValue;
             const derivedPrice = item.assetValue.copperValue;
             const priceLabel =
                 game.i18n.lang === "de"
@@ -201,7 +201,7 @@ class PhysicalItemSheetPF2e<TItem extends PhysicalItemPF2e> extends ItemSheetPF2
 
         // Convert price from a string to an actual object
         if ("system.price.value" in formData) {
-            formData["system.price.value"] = CoinsPF2e.fromString(String(formData["system.price.value"]));
+            formData["system.price.value"] = Coins.fromString(String(formData["system.price.value"]));
         }
 
         return super._updateObject(event, formData);
@@ -215,7 +215,7 @@ interface PhysicalItemSheetData<TItem extends PhysicalItemPF2e> extends ItemShee
     bulkAdjustment: string | null;
     adjustedBulkHint?: string | null;
     adjustedLevelHint: string | null;
-    basePrice: CoinsPF2e;
+    basePrice: Coins;
     priceAdjustment: string | null;
     adjustedPriceHint: string | null;
     attributes: typeof CONFIG.PF2E.abilities;

--- a/src/module/item/shield/sheet.ts
+++ b/src/module/item/shield/sheet.ts
@@ -1,6 +1,6 @@
 import { ItemSheetOptions } from "@item/base/sheet/sheet.ts";
 import {
-    CoinsPF2e,
+    Coins,
     MATERIAL_DATA,
     MaterialSheetData,
     PhysicalItemSheetData,
@@ -44,7 +44,7 @@ class ShieldSheetPF2e extends PhysicalItemSheetPF2e<ShieldPF2e> {
         return {
             ...sheetData,
             baseHardness: shield._source.system.hardness,
-            basePrice: new CoinsPF2e(shield._source.system.price.value),
+            basePrice: new Coins(shield._source.system.price.value),
             baseTypes: sortStringRecord(CONFIG.PF2E.baseShieldTypes),
             canChangeMaterial: !shield.isSpecific || !!shield.system.material.type,
             preciousMaterials: this.getMaterialSheetData(shield, materialData),
@@ -90,7 +90,7 @@ class ShieldSheetPF2e extends PhysicalItemSheetPF2e<ShieldPF2e> {
 
 interface ShieldSheetData extends PhysicalItemSheetData<ShieldPF2e> {
     baseHardness: number;
-    basePrice: CoinsPF2e;
+    basePrice: Coins;
     baseTypes: Record<BaseShieldType, string>;
     canChangeMaterial: boolean;
     preciousMaterials: MaterialSheetData;

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -1,5 +1,5 @@
 import type { ActorPF2e } from "@actor";
-import { DamageDicePF2e, ModifierPF2e } from "@actor/modifiers.ts";
+import { DamageDicePF2e, Modifier } from "@actor/modifiers.ts";
 import { DamageContext } from "@actor/roll-context/damage.ts";
 import type { AttributeString } from "@actor/types.ts";
 import { SAVE_TYPES } from "@actor/values.ts";
@@ -370,7 +370,7 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
         };
 
         // Add modifiers and damage die adjustments
-        const modifiers: ModifierPF2e[] = [];
+        const modifiers: Modifier[] = [];
         const damageDice: DamageDicePF2e[] = [];
         const originClone = contextData.origin.actor;
         const { damageAlterations, modifierAdjustments } = actor.synthetics;
@@ -381,7 +381,7 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
                 .filter(([, d]) => d.applyMod)
                 .map(
                     ([k, d]) =>
-                        new ModifierPF2e({
+                        new Modifier({
                             label: CONFIG.PF2E.abilities[attribute],
                             slug: `ability-${k}`,
                             // Not a restricted attribute modifier in the same way it is for checks or weapon damage

--- a/src/module/item/spellcasting-entry/document.ts
+++ b/src/module/item/spellcasting-entry/document.ts
@@ -1,5 +1,5 @@
 import type { ActorPF2e } from "@actor";
-import { ModifierPF2e } from "@actor/modifiers.ts";
+import { Modifier } from "@actor/modifiers.ts";
 import { AttributeString } from "@actor/types.ts";
 import type { DatabaseUpdateCallbackOptions } from "@common/abstract/_types.d.mts";
 import { ItemPF2e, PhysicalItemPF2e, type SpellPF2e } from "@item";
@@ -201,11 +201,11 @@ class SpellcastingEntryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null>
                 check: {
                     type: "attack-roll",
                     domains: checkDomains,
-                    modifiers: [new ModifierPF2e({ slug: "base", label: "PF2E.ModifierTitle", modifier: baseMod })],
+                    modifiers: [new Modifier({ slug: "base", label: "PF2E.ModifierTitle", modifier: baseMod })],
                 },
                 dc: {
                     domains: dcDomains,
-                    modifiers: [new ModifierPF2e({ slug: "base", label: "PF2E.ModifierTitle", modifier: baseDC - 10 })],
+                    modifiers: [new Modifier({ slug: "base", label: "PF2E.ModifierTitle", modifier: baseDC - 10 })],
                 },
             });
         } else {

--- a/src/module/migration/migrations/746-standardize-pricing.ts
+++ b/src/module/migration/migrations/746-standardize-pricing.ts
@@ -1,6 +1,6 @@
 import { ItemSourcePF2e } from "@item/base/data/index.ts";
 import { itemIsOfType } from "@item/helpers.ts";
-import { CoinsPF2e } from "@item/physical/helpers.ts";
+import { Coins } from "@item/physical/helpers.ts";
 import { TreasureSystemSource } from "@item/treasure/data.ts";
 import * as R from "remeda";
 import { MigrationBase } from "../base.ts";
@@ -12,7 +12,7 @@ export class Migration746StandardizePricing extends MigrationBase {
         if (!itemIsOfType(source, "physical") && source.type !== "kit") return;
 
         if (!R.isPlainObject(source.system.price)) {
-            source.system.price = { value: CoinsPF2e.fromString(String(source.system.price)).toObject() };
+            source.system.price = { value: Coins.fromString(String(source.system.price)).toObject() };
         }
 
         if (source.type === "treasure") {
@@ -28,7 +28,7 @@ export class Migration746StandardizePricing extends MigrationBase {
                 delete systemData.value;
             }
         } else if (!R.isPlainObject(source.system.price.value)) {
-            source.system.price.value = CoinsPF2e.fromString(String(source.system.price.value)).toObject();
+            source.system.price.value = Coins.fromString(String(source.system.price.value)).toObject();
         }
     }
 }

--- a/src/module/migration/migrations/750-fix-corrupted-price.ts
+++ b/src/module/migration/migrations/750-fix-corrupted-price.ts
@@ -1,6 +1,6 @@
 import { ItemSourcePF2e } from "@item/base/data/index.ts";
 import { itemIsOfType } from "@item/helpers.ts";
-import { CoinsPF2e } from "@item/physical/helpers.ts";
+import { Coins } from "@item/physical/helpers.ts";
 import { MigrationBase } from "../base.ts";
 
 export class Migration750FixCorruptedPrice extends MigrationBase {
@@ -10,7 +10,7 @@ export class Migration750FixCorruptedPrice extends MigrationBase {
         if (!itemIsOfType(source, "physical") && source.type !== "kit") return;
 
         if (typeof source.system.price === "string") {
-            source.system.price = { value: CoinsPF2e.fromString(source.system.price).toObject() };
+            source.system.price = { value: Coins.fromString(source.system.price).toObject() };
         }
     }
 }

--- a/src/module/notes.ts
+++ b/src/module/notes.ts
@@ -2,7 +2,7 @@ import { UserVisibility } from "@scripts/ui/user-visibility.ts";
 import { DegreeOfSuccessString } from "@system/degree-of-success.ts";
 import { Predicate, RawPredicate } from "@system/predication.ts";
 import { createHTMLElement } from "@util";
-import type { RuleElementPF2e } from "./rules/index.ts";
+import type { RuleElement } from "./rules/index.ts";
 
 class RollNotePF2e {
     /** The selector used to determine on which rolls the note will be shown for. */
@@ -18,7 +18,7 @@ class RollNotePF2e {
     /** An optional visibility restriction for the note */
     visibility: UserVisibility | null;
     /** The originating rule element of this modifier, if any: used to retrieve "parent" item roll options */
-    rule: RuleElementPF2e | null;
+    rule: RuleElement | null;
 
     constructor(params: RollNoteParams) {
         this.selector = params.selector;
@@ -88,7 +88,7 @@ interface RollNoteSource {
 }
 
 interface RollNoteParams extends RollNoteSource {
-    rule?: RuleElementPF2e | null;
+    rule?: RuleElement | null;
 }
 
 export { RollNotePF2e, type RollNoteSource };

--- a/src/module/rules/index.ts
+++ b/src/module/rules/index.ts
@@ -1,5 +1,5 @@
 import { LaxSchemaField } from "@system/schema-data-fields.ts";
-import { RuleElementPF2e } from "./rule-element/base.ts";
+import { RuleElement } from "./rule-element/base.ts";
 
 import { ActorTraitsRuleElement } from "./rule-element/actor-traits.ts";
 import { AdjustDegreeOfSuccessRuleElement } from "./rule-element/adjust-degree-of-success.ts";
@@ -50,7 +50,7 @@ export type { RuleElementSynthetics } from "./synthetics.ts";
  * @category RuleElement
  */
 class RuleElements {
-    static #builtin: Record<string, RuleElementConstructor | undefined> = Object.freeze({
+    static readonly builtin: Record<string, RuleElementConstructor | undefined> = {
         ActiveEffectLike: AELikeRuleElement,
         ActorTraits: ActorTraitsRuleElement,
         AdjustDegreeOfSuccess: AdjustDegreeOfSuccessRuleElement,
@@ -93,16 +93,16 @@ class RuleElements {
         TokenName: TokenNameRuleElement,
         Weakness: WeaknessRuleElement,
         WeaponPotency: WeaponPotencyRuleElement,
-    });
+    };
 
     static custom: Record<string, RuleElementConstructor | undefined> = {};
 
     static get all(): Record<string, RuleElementConstructor | undefined> {
-        return { ...this.#builtin, ...this.custom };
+        return { ...this.builtin, ...this.custom };
     }
 
-    static fromOwnedItem(options: RuleElementOptions): RuleElementPF2e[] {
-        const rules: RuleElementPF2e[] = [];
+    static fromOwnedItem(options: RuleElementOptions): RuleElement[] {
+        const rules: RuleElement[] = [];
         const item = options.parent;
         for (const [sourceIndex, source] of item.system.rules.entries()) {
             if (typeof source.key !== "string") {
@@ -111,7 +111,7 @@ class RuleElements {
                 );
                 continue;
             }
-            const REConstructor = this.custom[source.key] ?? this.custom[source.key] ?? this.#builtin[source.key];
+            const REConstructor = this.custom[source.key] ?? this.custom[source.key] ?? this.builtin[source.key];
             if (REConstructor) {
                 try {
                     rules.push(new REConstructor(source, { ...options, sourceIndex }));
@@ -136,6 +136,6 @@ class RuleElements {
 type RuleElementConstructor = { schema: LaxSchemaField<RuleElementSchema> } & (new (
     data: RuleElementSource,
     options: RuleElementOptions,
-) => RuleElementPF2e);
+) => RuleElement);
 
-export { RuleElementOptions, RuleElementPF2e, RuleElements, RuleElementSource };
+export { RuleElement, RuleElementOptions, RuleElements, RuleElementSource };

--- a/src/module/rules/rule-element/actor-traits.ts
+++ b/src/module/rules/rule-element/actor-traits.ts
@@ -1,10 +1,10 @@
 import type { ActorType } from "@actor/types.ts";
 import { ErrorPF2e } from "@util";
 import { ModelPropsFromRESchema } from "./data.ts";
-import { RuleElementPF2e, RuleElementSchema } from "./index.ts";
+import { RuleElement, RuleElementSchema } from "./index.ts";
 import fields = foundry.data.fields;
 
-class ActorTraitsRuleElement extends RuleElementPF2e<ActorTraitsRuleSchema> {
+class ActorTraitsRuleElement extends RuleElement<ActorTraitsRuleSchema> {
     protected static override validActorTypes: ActorType[] = ["character", "npc", "familiar", "hazard", "vehicle"];
 
     static override defineSchema(): ActorTraitsRuleSchema {
@@ -73,7 +73,7 @@ type ActorTraitsRuleSchema = RuleElementSchema & {
 };
 
 interface ActorTraitsRuleElement
-    extends RuleElementPF2e<ActorTraitsRuleSchema>,
+    extends RuleElement<ActorTraitsRuleSchema>,
         ModelPropsFromRESchema<ActorTraitsRuleSchema> {}
 
 export { ActorTraitsRuleElement };

--- a/src/module/rules/rule-element/adjust-degree-of-success.ts
+++ b/src/module/rules/rule-element/adjust-degree-of-success.ts
@@ -7,13 +7,13 @@ import {
 } from "@system/degree-of-success.ts";
 import { RecordField } from "@system/schema-data-fields.ts";
 import { ModelPropsFromRESchema } from "./data.ts";
-import { RuleElementPF2e, RuleElementSchema } from "./index.ts";
+import { RuleElement, RuleElementSchema } from "./index.ts";
 import fields = foundry.data.fields;
 
 /**
  * @category RuleElement
  */
-class AdjustDegreeOfSuccessRuleElement extends RuleElementPF2e<AdjustDegreeRuleSchema> {
+class AdjustDegreeOfSuccessRuleElement extends RuleElement<AdjustDegreeRuleSchema> {
     protected static override validActorTypes: ActorType[] = ["character", "npc"];
 
     static override defineSchema(): AdjustDegreeRuleSchema {
@@ -69,7 +69,7 @@ class AdjustDegreeOfSuccessRuleElement extends RuleElementPF2e<AdjustDegreeRuleS
 }
 
 interface AdjustDegreeOfSuccessRuleElement
-    extends RuleElementPF2e<AdjustDegreeRuleSchema>,
+    extends RuleElement<AdjustDegreeRuleSchema>,
         ModelPropsFromRESchema<AdjustDegreeRuleSchema> {
     get actor(): CharacterPF2e | NPCPF2e;
 }

--- a/src/module/rules/rule-element/adjust-modifier.ts
+++ b/src/module/rules/rule-element/adjust-modifier.ts
@@ -6,11 +6,11 @@ import { objectHasKey } from "@util";
 import * as R from "remeda";
 import { AELikeChangeMode, AELikeRuleElement } from "./ae-like.ts";
 import { ModelPropsFromRESchema, ResolvableValueField } from "./data.ts";
-import { RuleElementOptions, RuleElementPF2e, RuleElementSchema, RuleElementSource } from "./index.ts";
+import { RuleElement, RuleElementOptions, RuleElementSchema, RuleElementSource } from "./index.ts";
 import fields = foundry.data.fields;
 
 /** Adjust the value of a modifier, change its damage type (in case of damage modifiers) or suppress it entirely */
-class AdjustModifierRuleElement extends RuleElementPF2e<AdjustModifierSchema> {
+class AdjustModifierRuleElement extends RuleElement<AdjustModifierSchema> {
     constructor(source: AdjustModifierSource, options: RuleElementOptions) {
         if (source.suppress) source.mode = "override"; // Allow `suppress` as a shorthand without providing `mode`
         super(source, options);
@@ -118,7 +118,7 @@ class AdjustModifierRuleElement extends RuleElementPF2e<AdjustModifierSchema> {
 }
 
 interface AdjustModifierRuleElement
-    extends RuleElementPF2e<AdjustModifierSchema>,
+    extends RuleElement<AdjustModifierSchema>,
         ModelPropsFromRESchema<AdjustModifierSchema> {
     suppress: boolean;
     maxApplications: number;

--- a/src/module/rules/rule-element/adjust-strike.ts
+++ b/src/module/rules/rule-element/adjust-strike.ts
@@ -10,11 +10,11 @@ import { ErrorPF2e, objectHasKey, sluggify } from "@util";
 import * as R from "remeda";
 import { StrikeAdjustment } from "../synthetics.ts";
 import { AELikeChangeMode, AELikeRuleElement } from "./ae-like.ts";
-import { RuleElementOptions, RuleElementPF2e } from "./base.ts";
+import { RuleElement, RuleElementOptions } from "./base.ts";
 import { ModelPropsFromRESchema, ResolvableValueField, RuleElementSchema, RuleElementSource } from "./data.ts";
 import fields = foundry.data.fields;
 
-class AdjustStrikeRuleElement extends RuleElementPF2e<AdjustStrikeSchema> {
+class AdjustStrikeRuleElement extends RuleElement<AdjustStrikeSchema> {
     protected static override validActorTypes: ActorType[] = ["character", "familiar", "npc"];
 
     constructor(data: AdjustStrikeSource, options: RuleElementOptions) {
@@ -204,9 +204,7 @@ class AdjustStrikeRuleElement extends RuleElementPF2e<AdjustStrikeSchema> {
     }
 }
 
-interface AdjustStrikeRuleElement
-    extends RuleElementPF2e<AdjustStrikeSchema>,
-        ModelPropsFromRESchema<AdjustStrikeSchema> {}
+interface AdjustStrikeRuleElement extends RuleElement<AdjustStrikeSchema>, ModelPropsFromRESchema<AdjustStrikeSchema> {}
 
 type AdjustStrikeSchema = RuleElementSchema & {
     mode: fields.StringField<AELikeChangeMode, AELikeChangeMode, true, false, false>;

--- a/src/module/rules/rule-element/ae-like.ts
+++ b/src/module/rules/rule-element/ae-like.ts
@@ -1,5 +1,5 @@
 import * as R from "remeda";
-import { RuleElementPF2e } from "./base.ts";
+import { RuleElement } from "./base.ts";
 import { ModelPropsFromRESchema, ResolvableValueField, RuleElementSchema, RuleElementSource } from "./data.ts";
 import fields = foundry.data.fields;
 import validation = foundry.data.validation;
@@ -8,7 +8,7 @@ import validation = foundry.data.validation;
  * Make a numeric modification to an arbitrary property in a similar way as `ActiveEffect`s
  * @category RuleElement
  */
-class AELikeRuleElement<TSchema extends AELikeSchema> extends RuleElementPF2e<TSchema> {
+class AELikeRuleElement<TSchema extends AELikeSchema> extends RuleElement<TSchema> {
     static override defineSchema(): AELikeSchema {
         const baseSchema = super.defineSchema();
         const PRIORITIES: Record<string, number | undefined> = this.CHANGE_MODE_DEFAULT_PRIORITIES;
@@ -246,7 +246,7 @@ class AELikeRuleElement<TSchema extends AELikeSchema> extends RuleElementPF2e<TS
 }
 
 interface AELikeRuleElement<TSchema extends AELikeSchema>
-    extends RuleElementPF2e<TSchema>,
+    extends RuleElement<TSchema>,
         ModelPropsFromRESchema<AELikeSchema> {}
 
 interface AutoChangeEntry {

--- a/src/module/rules/rule-element/aura.ts
+++ b/src/module/rules/rule-element/aura.ts
@@ -7,7 +7,7 @@ import type { EffectTrait } from "@item/abstract-effect/types.ts";
 import { DataUnionField, LaxArrayField, PredicateField, StrictArrayField } from "@system/schema-data-fields.ts";
 import { isImageOrVideoPath, sluggify } from "@util";
 import * as R from "remeda";
-import { RuleElementOptions, RuleElementPF2e } from "./base.ts";
+import { RuleElement, RuleElementOptions } from "./base.ts";
 import {
     ModelPropsFromRESchema,
     ResolvableValueField,
@@ -19,7 +19,7 @@ import { ItemAlteration } from "./item-alteration/alteration.ts";
 import fields = foundry.data.fields;
 
 /** A Pathfinder 2e aura, capable of transmitting effects and with a visual representation on the canvas */
-class AuraRuleElement extends RuleElementPF2e<AuraSchema> {
+class AuraRuleElement extends RuleElement<AuraSchema> {
     constructor(source: AuraRuleElementSource, options: RuleElementOptions) {
         super(source, options);
         if (this.invalid) return;
@@ -358,7 +358,7 @@ class AuraRuleElement extends RuleElementPF2e<AuraSchema> {
     }
 }
 
-interface AuraRuleElement extends RuleElementPF2e<AuraSchema>, ModelPropsFromRESchema<AuraSchema> {
+interface AuraRuleElement extends RuleElement<AuraSchema>, ModelPropsFromRESchema<AuraSchema> {
     slug: string;
     effects: AuraEffectREData[];
 }

--- a/src/module/rules/rule-element/base-speed.ts
+++ b/src/module/rules/rule-element/base-speed.ts
@@ -3,14 +3,14 @@ import type { MovementType } from "@actor/types.ts";
 import { MOVEMENT_TYPES } from "@actor/values.ts";
 import { tupleHasValue } from "@util";
 import type { BaseSpeedSynthetic, DeferredMovementType } from "../synthetics.ts";
-import { RuleElementOptions, RuleElementPF2e } from "./base.ts";
+import { RuleElement, RuleElementOptions } from "./base.ts";
 import { ModelPropsFromRESchema, ResolvableValueField, RuleElementSchema, RuleElementSource } from "./data.ts";
 import fields = foundry.data.fields;
 
 /**
  * @category RuleElement
  */
-class BaseSpeedRuleElement extends RuleElementPF2e<BaseSpeedRuleSchema> {
+class BaseSpeedRuleElement extends RuleElement<BaseSpeedRuleSchema> {
     protected static override validActorTypes: ActorType[] = ["character", "familiar", "npc"];
 
     constructor(data: RuleElementSource, options: RuleElementOptions) {
@@ -63,9 +63,7 @@ class BaseSpeedRuleElement extends RuleElementPF2e<BaseSpeedRuleSchema> {
     }
 }
 
-interface BaseSpeedRuleElement
-    extends RuleElementPF2e<BaseSpeedRuleSchema>,
-        ModelPropsFromRESchema<BaseSpeedRuleSchema> {
+interface BaseSpeedRuleElement extends RuleElement<BaseSpeedRuleSchema>, ModelPropsFromRESchema<BaseSpeedRuleSchema> {
     get actor(): CreaturePF2e;
 }
 

--- a/src/module/rules/rule-element/base.ts
+++ b/src/module/rules/rule-element/base.ts
@@ -1,5 +1,5 @@
 import type { ActorPF2e, ActorType } from "@actor";
-import type { CheckModifier, DamageDicePF2e, ModifierPF2e } from "@actor/modifiers.ts";
+import type { CheckModifier, DamageDicePF2e, Modifier } from "@actor/modifiers.ts";
 import type { Rolled } from "@client/dice/roll.d.mts";
 import type {
     DatabaseCreateOperation,
@@ -25,8 +25,10 @@ import { BracketedValue, RuleElementSchema, RuleElementSource, RuleValue } from 
  *
  * @category RuleElement
  */
-abstract class RuleElementPF2e<TSchema extends RuleElementSchema = RuleElementSchema> extends foundry.abstract
-    .DataModel<ItemPF2e<ActorPF2e>, TSchema> {
+abstract class RuleElement<TSchema extends RuleElementSchema = RuleElementSchema> extends foundry.abstract.DataModel<
+    ItemPF2e<ActorPF2e>,
+    TSchema
+> {
     declare static _schema: LaxSchemaField<RuleElementSchema> | undefined;
 
     declare label: string;
@@ -416,10 +418,10 @@ abstract class RuleElementPF2e<TSchema extends RuleElementSchema = RuleElementSc
     }
 }
 
-interface RuleElementPF2e<TSchema extends RuleElementSchema>
+interface RuleElement<TSchema extends RuleElementSchema>
     extends foundry.abstract.DataModel<ItemPF2e<ActorPF2e>, TSchema>,
         ModelPropsFromSchema<RuleElementSchema> {
-    constructor: typeof RuleElementPF2e<TSchema>;
+    constructor: typeof RuleElement<TSchema>;
 
     get schema(): LaxSchemaField<TSchema>;
 
@@ -454,7 +456,7 @@ interface RuleElementPF2e<TSchema extends RuleElementSchema>
      * @param domains Applicable predication domains for pending check
      * @param rollOptions Currently accumulated roll options for the pending check
      */
-    afterRoll?(params: RuleElementPF2e.AfterRollParams): Promise<void>;
+    afterRoll?(params: RuleElement.AfterRollParams): Promise<void>;
 
     /** Runs before the rule's parent item's owning actor is updated */
     preUpdateActor?(): Promise<{ create: ItemSourcePF2e[]; delete: string[] }>;
@@ -464,14 +466,14 @@ interface RuleElementPF2e<TSchema extends RuleElementSchema>
      * alter itself before its parent item is stored on an actor; it can also alter the item source itself in the same
      * manner.
      */
-    preCreate?({ ruleSource, itemSource, pendingItems, operation }: RuleElementPF2e.PreCreateParams): Promise<void>;
+    preCreate?({ ruleSource, itemSource, pendingItems, operation }: RuleElement.PreCreateParams): Promise<void>;
 
     /**
      * Runs before this rules element's parent item is created. The item is temporarilly constructed. A rule element can
      * alter itself before its parent item is stored on an actor; it can also alter the item source itself in the same
      * manner.
      */
-    preDelete?({ pendingItems, operation }: RuleElementPF2e.PreDeleteParams): Promise<void>;
+    preDelete?({ pendingItems, operation }: RuleElement.PreDeleteParams): Promise<void>;
 
     /**
      * Runs before this rules element's parent item is updated */
@@ -512,11 +514,11 @@ interface RuleElementPF2e<TSchema extends RuleElementSchema>
     onDelete?(actorUpdates: Record<string, unknown>): void;
 
     /** An optional method for excluding damage modifiers and extra dice */
-    applyDamageExclusion?(weapon: WeaponPF2e, modifiers: (DamageDicePF2e | ModifierPF2e)[]): void;
+    applyDamageExclusion?(weapon: WeaponPF2e, modifiers: (DamageDicePF2e | Modifier)[]): void;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
-namespace RuleElementPF2e {
+namespace RuleElement {
     export interface PreCreateParams<T extends RuleElementSource = RuleElementSource> {
         /** The source partial of the rule element's parent item to be created */
         itemSource: ItemSourcePF2e;
@@ -564,4 +566,4 @@ interface RuleElementOptions extends DataModelConstructionContext<ItemPF2e<Actor
     suppressWarnings?: boolean;
 }
 
-export { RuleElementPF2e, type RuleElementOptions };
+export { RuleElement, type RuleElementOptions };

--- a/src/module/rules/rule-element/choice-set/rule-element.ts
+++ b/src/module/rules/rule-element/choice-set/rule-element.ts
@@ -22,7 +22,7 @@ import {
 import { localizer, objectHasKey, sluggify } from "@util";
 import { UUIDUtils } from "@util/uuid.ts";
 import * as R from "remeda";
-import { RuleElementOptions, RuleElementPF2e } from "../base.ts";
+import { RuleElement, RuleElementOptions } from "../base.ts";
 import { ModelPropsFromRESchema } from "../data.ts";
 import {
     AllowedDropsData,
@@ -41,7 +41,7 @@ import fields = foundry.data.fields;
  * Present a set of options to the user and assign their selection to an injectable property
  * @category RuleElement
  */
-class ChoiceSetRuleElement extends RuleElementPF2e<ChoiceSetSchema> {
+class ChoiceSetRuleElement extends RuleElement<ChoiceSetSchema> {
     declare choices: UninflatedChoiceSet;
     declare flag: string;
     declare allowedDrops: AllowedDropsData | null;
@@ -184,7 +184,7 @@ class ChoiceSetRuleElement extends RuleElementPF2e<ChoiceSetSchema> {
         itemSource,
         ruleSource,
         tempItems,
-    }: RuleElementPF2e.PreCreateParams<ChoiceSetSource>): Promise<void> {
+    }: RuleElement.PreCreateParams<ChoiceSetSource>): Promise<void> {
         if (this.selection === null && R.isObjectType(this.choices) && "query" in this.choices) {
             this.failValidation("As of FVTT version 11, choice set queries are no longer supported.");
             for (const ruleData of this.item.system.rules) {
@@ -586,6 +586,6 @@ class ChoiceSetRuleElement extends RuleElementPF2e<ChoiceSetSchema> {
     }
 }
 
-interface ChoiceSetRuleElement extends RuleElementPF2e<ChoiceSetSchema>, ModelPropsFromRESchema<ChoiceSetSchema> {}
+interface ChoiceSetRuleElement extends RuleElement<ChoiceSetSchema>, ModelPropsFromRESchema<ChoiceSetSchema> {}
 
 export { ChoiceSetRuleElement };

--- a/src/module/rules/rule-element/crafting-ability.ts
+++ b/src/module/rules/rule-element/crafting-ability.ts
@@ -3,14 +3,14 @@ import type { ItemUUID } from "@client/documents/_module.d.mts";
 import { ItemPF2e } from "@item";
 import { PredicateField } from "@system/schema-data-fields.ts";
 import { sluggify } from "@util";
-import { RuleElementOptions, RuleElementPF2e } from "./base.ts";
+import { RuleElement, RuleElementOptions } from "./base.ts";
 import { ModelPropsFromRESchema, ResolvableValueField, RuleElementSchema, RuleElementSource } from "./data.ts";
 import fields = foundry.data.fields;
 
 /**
  * @category RuleElement
  */
-class CraftingAbilityRuleElement extends RuleElementPF2e<CraftingAbilityRuleSchema> {
+class CraftingAbilityRuleElement extends RuleElement<CraftingAbilityRuleSchema> {
     protected static override validActorTypes: ActorType[] = ["character"];
 
     constructor(data: CraftingAbilityRuleSource, options: RuleElementOptions) {
@@ -143,7 +143,7 @@ class CraftingAbilityRuleElement extends RuleElementPF2e<CraftingAbilityRuleSche
 }
 
 interface CraftingAbilityRuleElement
-    extends RuleElementPF2e<CraftingAbilityRuleSchema>,
+    extends RuleElement<CraftingAbilityRuleSchema>,
         ModelPropsFromRESchema<CraftingAbilityRuleSchema> {
     readonly parent: ItemPF2e<CharacterPF2e>;
     slug: string;

--- a/src/module/rules/rule-element/creature-size.ts
+++ b/src/module/rules/rule-element/creature-size.ts
@@ -6,7 +6,7 @@ import { SIZES, Size } from "@module/data.ts";
 import { RecordField } from "@system/schema-data-fields.ts";
 import { tupleHasValue } from "@util";
 import * as R from "remeda";
-import { RuleElementOptions, RuleElementPF2e } from "./base.ts";
+import { RuleElement, RuleElementOptions } from "./base.ts";
 import { ModelPropsFromRESchema, ResolvableValueField, RuleElementSchema, RuleElementSource } from "./data.ts";
 import fields = foundry.data.fields;
 
@@ -14,7 +14,7 @@ import fields = foundry.data.fields;
  * @category RuleElement
  * Change a creature's size
  */
-class CreatureSizeRuleElement extends RuleElementPF2e<CreatureSizeRuleSchema> {
+class CreatureSizeRuleElement extends RuleElement<CreatureSizeRuleSchema> {
     protected static override validActorTypes: ActorType[] = ["character", "npc", "familiar"];
 
     constructor(data: RuleElementSource, options: RuleElementOptions) {
@@ -160,7 +160,7 @@ class CreatureSizeRuleElement extends RuleElementPF2e<CreatureSizeRuleSchema> {
 }
 
 interface CreatureSizeRuleElement
-    extends RuleElementPF2e<CreatureSizeRuleSchema>,
+    extends RuleElement<CreatureSizeRuleSchema>,
         ModelPropsFromRESchema<CreatureSizeRuleSchema> {
     get actor(): CreaturePF2e;
 }

--- a/src/module/rules/rule-element/crit-spec.ts
+++ b/src/module/rules/rule-element/crit-spec.ts
@@ -1,4 +1,4 @@
-import { DamageDicePF2e, MODIFIER_TYPES, ModifierPF2e, ModifierType } from "@actor/modifiers.ts";
+import { DamageDicePF2e, MODIFIER_TYPES, Modifier, ModifierType } from "@actor/modifiers.ts";
 import type { ActorType } from "@actor/types.ts";
 import type { MeleePF2e, WeaponPF2e } from "@item";
 import { RollNotePF2e } from "@module/notes.ts";
@@ -6,12 +6,12 @@ import { DamageCategoryUnique, DamageType } from "@system/damage/types.ts";
 import { DAMAGE_CATEGORIES_UNIQUE } from "@system/damage/values.ts";
 import * as R from "remeda";
 import { CritSpecEffect } from "../synthetics.ts";
-import { RuleElementPF2e } from "./base.ts";
+import { RuleElement } from "./base.ts";
 import { ModelPropsFromRESchema, ResolvableValueField, RuleElementSchema, RuleValue } from "./data.ts";
 import fields = foundry.data.fields;
 
 /** Substitute a pre-determined result for a check's D20 roll */
-class CritSpecRuleElement extends RuleElementPF2e<CritSpecRuleSchema> {
+class CritSpecRuleElement extends RuleElement<CritSpecRuleSchema> {
     static override validActorTypes: ActorType[] = ["character", "npc"];
 
     static override defineSchema(): CritSpecRuleSchema {
@@ -130,7 +130,7 @@ class CritSpecRuleElement extends RuleElementPF2e<CritSpecRuleSchema> {
 
         const modifier = () =>
             this.alternate && this.modifier
-                ? new ModifierPF2e({
+                ? new Modifier({
                       slug,
                       label,
                       type: this.modifier.type,
@@ -163,7 +163,7 @@ class CritSpecRuleElement extends RuleElementPF2e<CritSpecRuleSchema> {
                     : weapon.flags.pf2e.attackItemBonus;
                 const bonus =
                     bonusValue > 0
-                        ? new ModifierPF2e({
+                        ? new Modifier({
                               slug,
                               label,
                               type: "item",
@@ -177,7 +177,7 @@ class CritSpecRuleElement extends RuleElementPF2e<CritSpecRuleSchema> {
             case "pick":
                 return weapon.baseDamage.die
                     ? [
-                          new ModifierPF2e({
+                          new Modifier({
                               slug,
                               label,
                               type: "untyped",
@@ -193,7 +193,7 @@ class CritSpecRuleElement extends RuleElementPF2e<CritSpecRuleSchema> {
     }
 }
 
-interface CritSpecRuleElement extends RuleElementPF2e<CritSpecRuleSchema>, ModelPropsFromRESchema<CritSpecRuleSchema> {}
+interface CritSpecRuleElement extends RuleElement<CritSpecRuleSchema>, ModelPropsFromRESchema<CritSpecRuleSchema> {}
 
 type DamageDieFaces = 4 | 6 | 8 | 10 | 12;
 

--- a/src/module/rules/rule-element/damage-alteration/alteration.ts
+++ b/src/module/rules/rule-element/damage-alteration/alteration.ts
@@ -1,5 +1,5 @@
 import type { ActorPF2e } from "@actor";
-import { DamageDicePF2e, ModifierPF2e } from "@actor/modifiers.ts";
+import { DamageDicePF2e, Modifier } from "@actor/modifiers.ts";
 import type { ItemPF2e } from "@item";
 import { damageDieSizeToFaces, nextDamageDieSize } from "@system/damage/helpers.ts";
 import { BaseDamageData } from "@system/damage/types.ts";
@@ -27,7 +27,7 @@ class DamageAlteration {
     }
 
     getNewValue(
-        damage: BaseDamageData | DamageDicePF2e | ModifierPF2e,
+        damage: BaseDamageData | DamageDicePF2e | Modifier,
         item: ItemPF2e | null,
     ): DamageAlterationValue | null {
         const rule = this.#rule;
@@ -92,7 +92,7 @@ class DamageAlteration {
         }
     }
 
-    applyTo<TDamage extends DamageDicePF2e | ModifierPF2e>(
+    applyTo<TDamage extends DamageDicePF2e | Modifier>(
         damage: TDamage,
         options: { item: ItemPF2e<ActorPF2e>; test: string[] | Set<string> },
     ): TDamage {

--- a/src/module/rules/rule-element/damage-alteration/rule-element.ts
+++ b/src/module/rules/rule-element/damage-alteration/rule-element.ts
@@ -5,12 +5,12 @@ import { sluggify, tupleHasValue } from "@util";
 import * as R from "remeda";
 import { AELikeRuleElement, type AELikeChangeMode } from "../ae-like.ts";
 import type { ModelPropsFromRESchema, RuleElementSchema } from "../data.ts";
-import { ResolvableValueField, RuleElementPF2e } from "../index.ts";
+import { ResolvableValueField, RuleElement } from "../index.ts";
 import { DamageAlteration } from "./alteration.ts";
 import fields = foundry.data.fields;
 
 /** Alter certain aspects of individual components (modifiers and dice) of a damage roll. */
-class DamageAlterationRuleElement extends RuleElementPF2e<DamageAlterationSchema> {
+class DamageAlterationRuleElement extends RuleElement<DamageAlterationSchema> {
     static override defineSchema(): DamageAlterationSchema {
         return {
             ...super.defineSchema(),
@@ -105,7 +105,7 @@ class DamageAlterationRuleElement extends RuleElementPF2e<DamageAlterationSchema
 }
 
 interface DamageAlterationRuleElement
-    extends RuleElementPF2e<DamageAlterationSchema>,
+    extends RuleElement<DamageAlterationSchema>,
         ModelPropsFromRESchema<DamageAlterationSchema> {}
 
 type DamageAlterationProperty = "dice-faces" | "dice-number" | "damage-type" | "tags";

--- a/src/module/rules/rule-element/damage-dice.ts
+++ b/src/module/rules/rule-element/damage-dice.ts
@@ -4,11 +4,11 @@ import { DAMAGE_DIE_SIZES } from "@system/damage/values.ts";
 import { SlugField } from "@system/schema-data-fields.ts";
 import { isObject, objectHasKey, sluggify, tupleHasValue } from "@util";
 import { extractDamageAlterations } from "../helpers.ts";
-import { RuleElementOptions, RuleElementPF2e } from "./base.ts";
+import { RuleElement, RuleElementOptions } from "./base.ts";
 import { ModelPropsFromRESchema, ResolvableValueField, RuleElementSchema, RuleElementSource } from "./data.ts";
 import fields = foundry.data.fields;
 
-class DamageDiceRuleElement extends RuleElementPF2e<DamageDiceRuleSchema> {
+class DamageDiceRuleElement extends RuleElement<DamageDiceRuleSchema> {
     constructor(data: DamageDiceSource, options: RuleElementOptions) {
         super(data, options);
         if (this.invalid) return;
@@ -202,7 +202,7 @@ interface DamageDiceSource extends RuleElementSource {
 }
 
 interface DamageDiceRuleElement
-    extends RuleElementPF2e<DamageDiceRuleSchema>,
+    extends RuleElement<DamageDiceRuleSchema>,
         ModelPropsFromRESchema<DamageDiceRuleSchema> {}
 
 type DamageDiceRuleSchema = RuleElementSchema & {

--- a/src/module/rules/rule-element/dexterity-modifier-cap.ts
+++ b/src/module/rules/rule-element/dexterity-modifier-cap.ts
@@ -1,11 +1,11 @@
 import type { ActorType, CharacterPF2e, NPCPF2e } from "@actor";
-import { RuleElementPF2e } from "./base.ts";
+import { RuleElement } from "./base.ts";
 import { ModelPropsFromRESchema, ResolvableValueField, RuleElementSchema } from "./data.ts";
 
 /**
  * @category RuleElement
  */
-class DexterityModifierCapRuleElement extends RuleElementPF2e<DexterityModifierCapRuleSchema> {
+class DexterityModifierCapRuleElement extends RuleElement<DexterityModifierCapRuleSchema> {
     protected static override validActorTypes: ActorType[] = ["character", "npc"];
 
     static override defineSchema(): DexterityModifierCapRuleSchema {
@@ -31,7 +31,7 @@ class DexterityModifierCapRuleElement extends RuleElementPF2e<DexterityModifierC
 }
 
 interface DexterityModifierCapRuleElement
-    extends RuleElementPF2e<DexterityModifierCapRuleSchema>,
+    extends RuleElement<DexterityModifierCapRuleSchema>,
         ModelPropsFromRESchema<DexterityModifierCapRuleSchema> {
     get actor(): CharacterPF2e | NPCPF2e;
 }

--- a/src/module/rules/rule-element/effect-spinoff/rule-element.ts
+++ b/src/module/rules/rule-element/effect-spinoff/rule-element.ts
@@ -1,12 +1,12 @@
 import type { ActorPF2e } from "@actor";
 import type { PhysicalItemPF2e } from "@item";
 import { SlugField } from "@system/schema-data-fields.ts";
-import { RuleElementOptions, RuleElementPF2e } from "../base.ts";
+import { RuleElement, RuleElementOptions } from "../base.ts";
 import type { ModelPropsFromRESchema, RuleElementSchema, RuleElementSource } from "../data.ts";
 import { EffectSpinoff } from "./spinoff.ts";
 import fields = foundry.data.fields;
 
-class EffectSpinoffRuleElement extends RuleElementPF2e<EffectSpinoffSchema> {
+class EffectSpinoffRuleElement extends RuleElement<EffectSpinoffSchema> {
     constructor(source: RuleElementSource, options: RuleElementOptions) {
         super(source, options);
 
@@ -87,7 +87,7 @@ class EffectSpinoffRuleElement extends RuleElementPF2e<EffectSpinoffSchema> {
 }
 
 interface EffectSpinoffRuleElement
-    extends RuleElementPF2e<EffectSpinoffSchema>,
+    extends RuleElement<EffectSpinoffSchema>,
         ModelPropsFromRESchema<EffectSpinoffSchema> {
     slug: string;
 

--- a/src/module/rules/rule-element/ephemeral-effect.ts
+++ b/src/module/rules/rule-element/ephemeral-effect.ts
@@ -3,13 +3,13 @@ import type Document from "@common/abstract/document.d.mts";
 import { ItemPF2e } from "@item";
 import { ConditionSource, EffectSource } from "@item/base/data/index.ts";
 import { UUIDUtils } from "@util/uuid.ts";
-import { RuleElementPF2e } from "./base.ts";
+import { RuleElement } from "./base.ts";
 import { ModelPropsFromRESchema, RuleElementSchema } from "./data.ts";
 import { ItemAlteration, ItemAlterationSchema } from "./item-alteration/alteration.ts";
 import fields = foundry.data.fields;
 
 /** An effect that applies ephemerally during a single action, such as a strike */
-class EphemeralEffectRuleElement extends RuleElementPF2e<EphemeralEffectSchema> {
+class EphemeralEffectRuleElement extends RuleElement<EphemeralEffectSchema> {
     static override defineSchema(): EphemeralEffectSchema {
         const alterationField = new fields.EmbeddedDataField(ItemAlteration);
         return {
@@ -91,7 +91,7 @@ class EphemeralEffectRuleElement extends RuleElementPF2e<EphemeralEffectSchema> 
 }
 
 interface EphemeralEffectRuleElement
-    extends RuleElementPF2e<EphemeralEffectSchema>,
+    extends RuleElement<EphemeralEffectSchema>,
         ModelPropsFromRESchema<EphemeralEffectSchema> {}
 
 type EphemeralEffectSchema = RuleElementSchema & {

--- a/src/module/rules/rule-element/fast-healing.ts
+++ b/src/module/rules/rule-element/fast-healing.ts
@@ -2,7 +2,7 @@ import type { ActorType } from "@actor/types.ts";
 import { ChatMessagePF2e } from "@module/chat-message/index.ts";
 import { DamageRoll } from "@system/damage/roll.ts";
 import { localizeList, objectHasKey } from "@util";
-import { RuleElementPF2e } from "./base.ts";
+import { RuleElement } from "./base.ts";
 import { ModelPropsFromRESchema, ResolvableValueField, RuleElementSchema } from "./data.ts";
 import fields = foundry.data.fields;
 
@@ -11,7 +11,7 @@ import fields = foundry.data.fields;
  * Creates a chat card every round of combat.
  * @category RuleElement
  */
-class FastHealingRuleElement extends RuleElementPF2e<FastHealingRuleSchema> {
+class FastHealingRuleElement extends RuleElement<FastHealingRuleSchema> {
     static override validActorTypes: ActorType[] = ["army", "character", "npc", "familiar"];
 
     static override defineSchema(): FastHealingRuleSchema {
@@ -103,7 +103,7 @@ type FastHealingRuleSchema = RuleElementSchema & {
 };
 
 interface FastHealingRuleElement
-    extends RuleElementPF2e<FastHealingRuleSchema>,
+    extends RuleElement<FastHealingRuleSchema>,
         ModelPropsFromRESchema<FastHealingRuleSchema> {}
 
 type FastHealingType = "fast-healing" | "regeneration";

--- a/src/module/rules/rule-element/flat-modifier.ts
+++ b/src/module/rules/rule-element/flat-modifier.ts
@@ -1,4 +1,4 @@
-import { DeferredValueParams, MODIFIER_TYPES, ModifierPF2e, ModifierType } from "@actor/modifiers.ts";
+import { DeferredValueParams, MODIFIER_TYPES, Modifier, ModifierType } from "@actor/modifiers.ts";
 import { AttributeString } from "@actor/types.ts";
 import { damageCategoriesUnique } from "@scripts/config/damage.ts";
 import { DamageCategoryUnique } from "@system/damage/types.ts";
@@ -10,7 +10,7 @@ import {
     StrictStringField,
 } from "@system/schema-data-fields.ts";
 import { objectHasKey, sluggify } from "@util";
-import { RuleElementOptions, RuleElementPF2e } from "./base.ts";
+import { RuleElement, RuleElementOptions } from "./base.ts";
 import {
     ModelPropsFromRESchema,
     ResolvableValueField,
@@ -24,7 +24,7 @@ import fields = foundry.data.fields;
  * Apply a constant modifier (or penalty/bonus) to a statistic or usage thereof
  * @category RuleElement
  */
-class FlatModifierRuleElement extends RuleElementPF2e<FlatModifierSchema> {
+class FlatModifierRuleElement extends RuleElement<FlatModifierSchema> {
     constructor(source: FlatModifierSource, options: RuleElementOptions) {
         super(source, options);
         if (this.invalid) return;
@@ -137,7 +137,7 @@ class FlatModifierRuleElement extends RuleElementPF2e<FlatModifierSchema> {
         for (const selector of selectors) {
             if (selector === "null") continue;
 
-            const construct = (options: DeferredValueParams = {}): ModifierPF2e | null => {
+            const construct = (options: DeferredValueParams = {}): Modifier | null => {
                 const resolvedValue = Number(this.resolveValue(this.value, 0, options)) || 0;
                 if (this.ignored) return null;
 
@@ -161,7 +161,7 @@ class FlatModifierRuleElement extends RuleElementPF2e<FlatModifierSchema> {
                 }
                 if (this.battleForm && !this.predicate.includes("battle-form")) this.predicate.push("battle-form");
 
-                const modifier = new ModifierPF2e({
+                const modifier = new Modifier({
                     slug,
                     label,
                     modifier: finalValue,
@@ -188,7 +188,7 @@ class FlatModifierRuleElement extends RuleElementPF2e<FlatModifierSchema> {
     }
 
     /** Remove this rule element's parent item after a roll */
-    override async afterRoll({ check, rollOptions }: RuleElementPF2e.AfterRollParams): Promise<void> {
+    override async afterRoll({ check, rollOptions }: RuleElement.AfterRollParams): Promise<void> {
         if (this.ignored || !this.removeAfterRoll || !this.item.isOfType("effect")) {
             return;
         }
@@ -201,9 +201,7 @@ class FlatModifierRuleElement extends RuleElementPF2e<FlatModifierSchema> {
     }
 }
 
-interface FlatModifierRuleElement
-    extends RuleElementPF2e<FlatModifierSchema>,
-        ModelPropsFromRESchema<FlatModifierSchema> {
+interface FlatModifierRuleElement extends RuleElement<FlatModifierSchema>, ModelPropsFromRESchema<FlatModifierSchema> {
     value: RuleValue;
 }
 

--- a/src/module/rules/rule-element/grant-item/rule-element.ts
+++ b/src/module/rules/rule-element/grant-item/rule-element.ts
@@ -10,14 +10,14 @@ import { SlugField, StrictArrayField } from "@system/schema-data-fields.ts";
 import { ErrorPF2e, isObject, setHasElement, sluggify, tupleHasValue } from "@util";
 import { UUIDUtils } from "@util/uuid.ts";
 import * as R from "remeda";
-import { RuleElementOptions, RuleElementPF2e } from "../base.ts";
+import { RuleElement, RuleElementOptions } from "../base.ts";
 import type { ChoiceSetSource } from "../choice-set/data.ts";
 import { ChoiceSetRuleElement } from "../choice-set/rule-element.ts";
 import type { ModelPropsFromRESchema, RuleElementSource } from "../data.ts";
 import { ItemAlteration } from "../item-alteration/alteration.ts";
 import type { GrantItemSchema } from "./schema.ts";
 
-class GrantItemRuleElement extends RuleElementPF2e<GrantItemSchema> {
+class GrantItemRuleElement extends RuleElement<GrantItemSchema> {
     static override validActorTypes: ActorType[] = ["army", "character", "npc", "familiar"];
 
     /** The id of the granted item */
@@ -108,7 +108,7 @@ class GrantItemRuleElement extends RuleElementPF2e<GrantItemSchema> {
         }
     }
 
-    override async preCreate(args: RuleElementPF2e.PreCreateParams): Promise<void> {
+    override async preCreate(args: RuleElement.PreCreateParams): Promise<void> {
         if (this.inMemoryOnly || this.invalid) return;
 
         const { itemSource, pendingItems, itemUpdates, operation } = args;
@@ -359,7 +359,7 @@ class GrantItemRuleElement extends RuleElementPF2e<GrantItemSchema> {
 
     /** Run the preCreate callbacks of REs from the granted item */
     async #runGrantedItemPreCreates(
-        originalArgs: Omit<RuleElementPF2e.PreCreateParams, "ruleSource">,
+        originalArgs: Omit<RuleElement.PreCreateParams, "ruleSource">,
         grantedItem: ItemPF2e<ActorPF2e>,
         grantedSource: ItemSourcePF2e,
         operation: Partial<DatabaseCreateOperation<ActorPF2e | null>>,
@@ -427,7 +427,7 @@ class GrantItemRuleElement extends RuleElementPF2e<GrantItemSchema> {
     }
 }
 
-interface GrantItemRuleElement extends RuleElementPF2e<GrantItemSchema>, ModelPropsFromRESchema<GrantItemSchema> {}
+interface GrantItemRuleElement extends RuleElement<GrantItemSchema>, ModelPropsFromRESchema<GrantItemSchema> {}
 
 interface GrantItemSource extends RuleElementSource {
     uuid?: unknown;

--- a/src/module/rules/rule-element/index.ts
+++ b/src/module/rules/rule-element/index.ts
@@ -1,3 +1,3 @@
-export { RuleElementPF2e, type RuleElementOptions } from "./base.ts";
+export { RuleElement, type RuleElementOptions } from "./base.ts";
 export { ResolvableValueField } from "./data.ts";
 export type { BracketedValue, RuleElementSchema, RuleElementSource, RuleValue } from "./data.ts";

--- a/src/module/rules/rule-element/item-alteration/alteration.ts
+++ b/src/module/rules/rule-element/item-alteration/alteration.ts
@@ -3,12 +3,12 @@ import { ItemPF2e } from "@item";
 import type { ItemSourcePF2e } from "@item/base/data/index.ts";
 import * as R from "remeda";
 import { AELikeChangeMode } from "../ae-like.ts";
-import type { RuleElementPF2e } from "../base.ts";
+import type { RuleElement } from "../base.ts";
 import { ResolvableValueField } from "../data.ts";
 import { ITEM_ALTERATION_HANDLERS } from "./handlers.ts";
 import fields = foundry.data.fields;
 
-class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlterationSchema> {
+class ItemAlteration extends foundry.abstract.DataModel<RuleElement, ItemAlterationSchema> {
     static override defineSchema(): ItemAlterationSchema {
         return {
             mode: new fields.StringField({
@@ -30,7 +30,7 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
         };
     }
 
-    get rule(): RuleElementPF2e {
+    get rule(): RuleElement {
         return this.parent;
     }
 
@@ -61,7 +61,7 @@ class ItemAlteration extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlt
 }
 
 interface ItemAlteration
-    extends foundry.abstract.DataModel<RuleElementPF2e, ItemAlterationSchema>,
+    extends foundry.abstract.DataModel<RuleElement, ItemAlterationSchema>,
         fields.ModelPropsFromSchema<ItemAlterationSchema> {}
 
 type ItemAlterationSchema = {

--- a/src/module/rules/rule-element/item-alteration/handlers.ts
+++ b/src/module/rules/rule-element/item-alteration/handlers.ts
@@ -23,7 +23,7 @@ import {
 import { objectHasKey, setHasElement, tupleHasValue } from "@util";
 import * as R from "remeda";
 import { AELikeRuleElement, type AELikeChangeMode } from "../ae-like.ts";
-import { ResolvableValueField, RuleElementPF2e } from "../index.ts";
+import { ResolvableValueField, RuleElement } from "../index.ts";
 import { adjustCreatureShieldData, getNewInterval, itemHasCounterBadge } from "./helper.ts";
 import fields = foundry.data.fields;
 import validation = foundry.data.validation;
@@ -56,12 +56,12 @@ class ItemAlterationHandler<TSchema extends AlterationSchema> extends fields.Sch
      */
     isValid(data: {
         item: ItemPF2e | ItemSourcePF2e;
-        rule: RuleElementPF2e;
+        rule: RuleElement;
         fromEquipment: boolean;
         alteration: MaybeAlterationData;
     }): data is {
         item: ItemOrSource<fields.SourceFromSchema<TSchema>["itemType"]>;
-        rule: RuleElementPF2e;
+        rule: RuleElement;
         fromEquipment: boolean;
         alteration: fields.SourceFromSchema<TSchema>;
     } {
@@ -94,7 +94,7 @@ type MaybeAlterationData = { mode: string; itemType: string; value: unknown };
 
 interface AlterationApplicationData {
     item: ItemPF2e | ItemSourcePF2e;
-    rule: RuleElementPF2e;
+    rule: RuleElement;
     fromEquipment: boolean;
     alteration: MaybeAlterationData;
 }

--- a/src/module/rules/rule-element/item-alteration/rule-element.ts
+++ b/src/module/rules/rule-element/item-alteration/rule-element.ts
@@ -4,12 +4,12 @@ import type { ItemType } from "@item/base/data/index.ts";
 import { PHYSICAL_ITEM_TYPES } from "@item/physical/values.ts";
 import * as R from "remeda";
 import { AELikeRuleElement } from "../ae-like.ts";
-import { RuleElementOptions, RuleElementPF2e } from "../base.ts";
+import { RuleElement, RuleElementOptions } from "../base.ts";
 import type { ModelPropsFromRESchema, RuleElementSchema, RuleElementSource } from "../data.ts";
 import { ItemAlteration, ItemAlterationProperty, ItemAlterationSchema } from "./alteration.ts";
 import fields = foundry.data.fields;
 
-class ItemAlterationRuleElement extends RuleElementPF2e<ItemAlterationRuleSchema> {
+class ItemAlterationRuleElement extends RuleElement<ItemAlterationRuleSchema> {
     constructor(data: RuleElementSource, options: RuleElementOptions) {
         super(data, options);
 
@@ -68,7 +68,7 @@ class ItemAlterationRuleElement extends RuleElementPF2e<ItemAlterationRuleSchema
         return this.constructor.#LAZY_PROPERTIES.includes(this.property);
     }
 
-    override async preCreate({ tempItems }: RuleElementPF2e.PreCreateParams): Promise<void> {
+    override async preCreate({ tempItems }: RuleElement.PreCreateParams): Promise<void> {
         if (this.ignored) return;
 
         // Apply feature/feature alterations during pre-creation to possibly inform subsequent REs like choice sets
@@ -185,7 +185,7 @@ class ItemAlterationRuleElement extends RuleElementPF2e<ItemAlterationRuleSchema
 }
 
 interface ItemAlterationRuleElement
-    extends RuleElementPF2e<ItemAlterationRuleSchema>,
+    extends RuleElement<ItemAlterationRuleSchema>,
         ModelPropsFromRESchema<ItemAlterationRuleSchema> {
     constructor: typeof ItemAlterationRuleElement;
 }

--- a/src/module/rules/rule-element/iwr/base.ts
+++ b/src/module/rules/rule-element/iwr/base.ts
@@ -3,12 +3,12 @@ import { IWRType } from "@actor/types.ts";
 import type { Predicate } from "@system/predication.ts";
 import { DataUnionField, PredicateField, StrictArrayField, StrictStringField } from "@system/schema-data-fields.ts";
 import { AELikeChangeMode } from "../ae-like.ts";
-import { RuleElementPF2e } from "../base.ts";
+import { RuleElement } from "../base.ts";
 import { ModelPropsFromRESchema, RuleElementSchema, RuleElementSource, RuleValue } from "../data.ts";
 import fields = foundry.data.fields;
 
 /** @category RuleElement */
-abstract class IWRRuleElement<TSchema extends IWRRuleSchema> extends RuleElementPF2e<TSchema> {
+abstract class IWRRuleElement<TSchema extends IWRRuleSchema> extends RuleElement<TSchema> {
     abstract value: RuleValue | null;
 
     static get dictionary(): Record<string, string | undefined> {
@@ -124,7 +124,7 @@ abstract class IWRRuleElement<TSchema extends IWRRuleSchema> extends RuleElement
 }
 
 interface IWRRuleElement<TSchema extends IWRRuleSchema>
-    extends RuleElementPF2e<TSchema>,
+    extends RuleElement<TSchema>,
         ModelPropsFromRESchema<IWRRuleSchema> {
     constructor: typeof IWRRuleElement<TSchema>;
 }

--- a/src/module/rules/rule-element/lose-hit-points.ts
+++ b/src/module/rules/rule-element/lose-hit-points.ts
@@ -1,11 +1,11 @@
 import type { ActorType, CreaturePF2e } from "@actor";
 import type { ItemSourcePF2e } from "@item/base/data/index.ts";
-import { RuleElementPF2e } from "./base.ts";
+import { RuleElement } from "./base.ts";
 import { ModelPropsFromRESchema, ResolvableValueField, RuleElementSchema } from "./data.ts";
 import fields = foundry.data.fields;
 
 /** Reduce current hit points without applying damage */
-class LoseHitPointsRuleElement extends RuleElementPF2e<LoseHitPointsRuleSchema> {
+class LoseHitPointsRuleElement extends RuleElement<LoseHitPointsRuleSchema> {
     static override validActorTypes: ActorType[] = ["character", "familiar", "npc"];
 
     static override defineSchema(): LoseHitPointsRuleSchema {
@@ -56,7 +56,7 @@ class LoseHitPointsRuleElement extends RuleElementPF2e<LoseHitPointsRuleSchema> 
 type LoseHitPointsSource = fields.SourceFromSchema<LoseHitPointsRuleSchema>;
 
 interface LoseHitPointsRuleElement
-    extends RuleElementPF2e<LoseHitPointsRuleSchema>,
+    extends RuleElement<LoseHitPointsRuleSchema>,
         ModelPropsFromRESchema<LoseHitPointsRuleSchema> {
     get actor(): CreaturePF2e;
 }

--- a/src/module/rules/rule-element/martial-proficiency.ts
+++ b/src/module/rules/rule-element/martial-proficiency.ts
@@ -7,11 +7,11 @@ import { WEAPON_CATEGORIES } from "@item/weapon/values.ts";
 import { OneToFour } from "@module/data.ts";
 import { PredicateField } from "@system/schema-data-fields.ts";
 import { sluggify } from "@util";
-import { RuleElementOptions, RuleElementPF2e } from "./base.ts";
+import { RuleElement, RuleElementOptions } from "./base.ts";
 import { ModelPropsFromRESchema, ResolvableValueField, RuleElementSchema, RuleElementSource } from "./data.ts";
 import fields = foundry.data.fields;
 
-class MartialProficiencyRuleElement extends RuleElementPF2e<MartialProficiencySchema> {
+class MartialProficiencyRuleElement extends RuleElement<MartialProficiencySchema> {
     protected static override validActorTypes: ActorType[] = ["character"];
 
     declare slug: string;
@@ -67,7 +67,7 @@ class MartialProficiencyRuleElement extends RuleElementPF2e<MartialProficiencySc
 }
 
 interface MartialProficiencyRuleElement
-    extends RuleElementPF2e<MartialProficiencySchema>,
+    extends RuleElement<MartialProficiencySchema>,
         ModelPropsFromRESchema<MartialProficiencySchema> {
     get actor(): CharacterPF2e;
 }

--- a/src/module/rules/rule-element/multiple-attack-penalty.ts
+++ b/src/module/rules/rule-element/multiple-attack-penalty.ts
@@ -1,12 +1,12 @@
 import { MAPSynthetic } from "../synthetics.ts";
-import { RuleElementPF2e } from "./base.ts";
+import { RuleElement } from "./base.ts";
 import { ModelPropsFromRESchema, ResolvableValueField, RuleElementSchema } from "./data.ts";
 import fields = foundry.data.fields;
 
 /**
  * @category RuleElement
  */
-class MultipleAttackPenaltyRuleElement extends RuleElementPF2e<MAPRuleSchema> {
+class MultipleAttackPenaltyRuleElement extends RuleElement<MAPRuleSchema> {
     static override defineSchema(): MAPRuleSchema {
         return {
             ...super.defineSchema(),
@@ -43,9 +43,7 @@ class MultipleAttackPenaltyRuleElement extends RuleElementPF2e<MAPRuleSchema> {
     }
 }
 
-interface MultipleAttackPenaltyRuleElement
-    extends RuleElementPF2e<MAPRuleSchema>,
-        ModelPropsFromRESchema<MAPRuleSchema> {}
+interface MultipleAttackPenaltyRuleElement extends RuleElement<MAPRuleSchema>, ModelPropsFromRESchema<MAPRuleSchema> {}
 
 type MAPRuleSchema = RuleElementSchema & {
     selector: fields.StringField<string, string, true, false, false>;

--- a/src/module/rules/rule-element/roll-note.ts
+++ b/src/module/rules/rule-element/roll-note.ts
@@ -3,11 +3,11 @@ import { RollNotePF2e } from "@module/notes.ts";
 import type { UserVisibility } from "@scripts/ui/user-visibility.ts";
 import { DEGREE_OF_SUCCESS_STRINGS, DegreeOfSuccessString } from "@system/degree-of-success.ts";
 import { DataUnionField, StrictStringField } from "@system/schema-data-fields.ts";
-import { RuleElementPF2e } from "./base.ts";
+import { RuleElement } from "./base.ts";
 import { ModelPropsFromRESchema, ResolvableValueField, RuleElementSchema, RuleElementSource } from "./data.ts";
 import fields = foundry.data.fields;
 
-class RollNoteRuleElement extends RuleElementPF2e<RollNoteSchema> {
+class RollNoteRuleElement extends RuleElement<RollNoteSchema> {
     static override defineSchema(): RollNoteSchema {
         return {
             ...super.defineSchema(),
@@ -64,7 +64,7 @@ class RollNoteRuleElement extends RuleElementPF2e<RollNoteSchema> {
     }
 }
 
-interface RollNoteRuleElement extends RuleElementPF2e<RollNoteSchema>, ModelPropsFromRESchema<RollNoteSchema> {}
+interface RollNoteRuleElement extends RuleElement<RollNoteSchema>, ModelPropsFromRESchema<RollNoteSchema> {}
 
 type RollNoteSchema = RuleElementSchema & {
     /** The statistic(s) slugs of the rolls for which this note will be appended */

--- a/src/module/rules/rule-element/roll-option/rule-element.ts
+++ b/src/module/rules/rule-element/roll-option/rule-element.ts
@@ -11,7 +11,7 @@ import { ErrorPF2e, sluggify } from "@util";
 import * as R from "remeda";
 import { RollOptionToggle } from "../../synthetics.ts";
 import { AELikeRuleElement } from "../ae-like.ts";
-import { RuleElementOptions, RuleElementPF2e } from "../base.ts";
+import { RuleElement, RuleElementOptions } from "../base.ts";
 import { ModelPropsFromRESchema, ResolvableValueField, RuleElementSource } from "../data.ts";
 import { Suboption, type RollOptionSchema } from "./data.ts";
 import fields = foundry.data.fields;
@@ -20,7 +20,7 @@ import fields = foundry.data.fields;
  * Set a roll option at a specificed domain
  * @category RuleElement
  */
-class RollOptionRuleElement extends RuleElementPF2e<RollOptionSchema> {
+class RollOptionRuleElement extends RuleElement<RollOptionSchema> {
     /** True if this roll option has a suboptions configuration */
     hasSubOptions: boolean;
 
@@ -422,7 +422,7 @@ class RollOptionRuleElement extends RuleElementPF2e<RollOptionSchema> {
     }
 
     /** Remove the parent effect if configured so */
-    override async afterRoll({ domains, rollOptions }: RuleElementPF2e.AfterRollParams): Promise<void> {
+    override async afterRoll({ domains, rollOptions }: RuleElement.AfterRollParams): Promise<void> {
         const option = this.#resolveOption({ withSuboption: true });
         if (
             !this.ignored &&
@@ -438,7 +438,7 @@ class RollOptionRuleElement extends RuleElementPF2e<RollOptionSchema> {
     }
 }
 
-interface RollOptionRuleElement extends RuleElementPF2e<RollOptionSchema>, ModelPropsFromRESchema<RollOptionSchema> {
+interface RollOptionRuleElement extends RuleElement<RollOptionSchema>, ModelPropsFromRESchema<RollOptionSchema> {
     value: boolean | string;
 }
 

--- a/src/module/rules/rule-element/roll-twice.ts
+++ b/src/module/rules/rule-element/roll-twice.ts
@@ -1,10 +1,10 @@
 import { RollTwiceSynthetic } from "../synthetics.ts";
-import { RuleElementPF2e } from "./base.ts";
+import { RuleElement } from "./base.ts";
 import { ModelPropsFromRESchema, RuleElementSchema } from "./data.ts";
 import fields = foundry.data.fields;
 
 /** Roll Twice and keep either the higher or lower result */
-class RollTwiceRuleElement extends RuleElementPF2e<RollTwiceRuleSchema> {
+class RollTwiceRuleElement extends RuleElement<RollTwiceRuleSchema> {
     static override defineSchema(): RollTwiceRuleSchema {
         return {
             ...super.defineSchema(),
@@ -29,7 +29,7 @@ class RollTwiceRuleElement extends RuleElementPF2e<RollTwiceRuleSchema> {
         }
     }
 
-    override async afterRoll({ domains, roll, rollOptions }: RuleElementPF2e.AfterRollParams): Promise<void> {
+    override async afterRoll({ domains, roll, rollOptions }: RuleElement.AfterRollParams): Promise<void> {
         if (!this.actor.items.has(this.item.id)) {
             return;
         }
@@ -56,9 +56,7 @@ class RollTwiceRuleElement extends RuleElementPF2e<RollTwiceRuleSchema> {
     }
 }
 
-interface RollTwiceRuleElement
-    extends RuleElementPF2e<RollTwiceRuleSchema>,
-        ModelPropsFromRESchema<RollTwiceRuleSchema> {}
+interface RollTwiceRuleElement extends RuleElement<RollTwiceRuleSchema>, ModelPropsFromRESchema<RollTwiceRuleSchema> {}
 
 type RollTwiceRuleSchema = RuleElementSchema & {
     selector: fields.ArrayField<

--- a/src/module/rules/rule-element/sense.ts
+++ b/src/module/rules/rule-element/sense.ts
@@ -7,14 +7,14 @@ import {
     SENSE_TYPES,
 } from "@actor/creature/values.ts";
 import { tupleHasValue } from "@util";
-import { RuleElementPF2e } from "./base.ts";
+import { RuleElement } from "./base.ts";
 import { ModelPropsFromRESchema, ResolvableValueField, RuleElementSchema } from "./data.ts";
 import fields = foundry.data.fields;
 
 /**
  * @category RuleElement
  */
-class SenseRuleElement extends RuleElementPF2e<SenseRuleSchema> {
+class SenseRuleElement extends RuleElement<SenseRuleSchema> {
     protected static override validActorTypes: ActorType[] = ["character", "familiar", "npc"];
 
     static override defineSchema(): SenseRuleSchema {
@@ -51,7 +51,7 @@ class SenseRuleElement extends RuleElementPF2e<SenseRuleSchema> {
     }
 }
 
-interface SenseRuleElement extends RuleElementPF2e<SenseRuleSchema>, ModelPropsFromRESchema<SenseRuleSchema> {
+interface SenseRuleElement extends RuleElement<SenseRuleSchema>, ModelPropsFromRESchema<SenseRuleSchema> {
     get actor(): CharacterPF2e | FamiliarPF2e;
 }
 

--- a/src/module/rules/rule-element/special-resource.ts
+++ b/src/module/rules/rule-element/special-resource.ts
@@ -10,7 +10,7 @@ import type { PhysicalItemSource } from "@item/base/data/index.ts";
 import { AnyChoiceField } from "@system/schema-data-fields.ts";
 import { sluggify } from "@util";
 import { createBatchRuleElementUpdate } from "../helpers.ts";
-import { RuleElementPF2e, type RuleElementOptions } from "./base.ts";
+import { RuleElement, type RuleElementOptions } from "./base.ts";
 import {
     ModelPropsFromRESchema,
     ResolvableValueField,
@@ -21,7 +21,7 @@ import fields = foundry.data.fields;
 
 const INVALID_RESOURCES: (keyof CharacterResources)[] = [...CORE_RESOURCES, "crafting", "infusedReagents"];
 
-class SpecialResourceRuleElement extends RuleElementPF2e<SpecialResourceSchema> {
+class SpecialResourceRuleElement extends RuleElement<SpecialResourceSchema> {
     protected static override validActorTypes: ActorType[] = ["character", "npc"];
 
     constructor(source: SpecialResourceSource, options: RuleElementOptions) {
@@ -118,7 +118,7 @@ class SpecialResourceRuleElement extends RuleElementPF2e<SpecialResourceSchema> 
     }
 
     /** If an item uuid is specified, create it when this resource is first attached */
-    override async preCreate({ tempItems, pendingItems }: RuleElementPF2e.PreCreateParams): Promise<void> {
+    override async preCreate({ tempItems, pendingItems }: RuleElement.PreCreateParams): Promise<void> {
         if (!this.test()) return;
 
         if (this.itemUUID) {
@@ -218,7 +218,7 @@ class SpecialResourceRuleElement extends RuleElementPF2e<SpecialResourceSchema> 
 }
 
 interface SpecialResourceRuleElement
-    extends RuleElementPF2e<SpecialResourceSchema>,
+    extends RuleElement<SpecialResourceSchema>,
         ModelPropsFromRESchema<SpecialResourceSchema> {
     slug: string;
     max: number;

--- a/src/module/rules/rule-element/special-statistic.ts
+++ b/src/module/rules/rule-element/special-statistic.ts
@@ -1,5 +1,5 @@
 import type { CreaturePF2e } from "@actor";
-import { ModifierPF2e } from "@actor/modifiers.ts";
+import { Modifier } from "@actor/modifiers.ts";
 import type { AttributeString } from "@actor/types.ts";
 import { ATTRIBUTE_ABBREVIATIONS, SAVE_TYPES } from "@actor/values.ts";
 import type { MagicTradition } from "@item/spell/types.ts";
@@ -9,12 +9,12 @@ import { PredicateField, SlugField } from "@system/schema-data-fields.ts";
 import { Statistic, StatisticData } from "@system/statistic/index.ts";
 import { tupleHasValue } from "@util";
 import * as R from "remeda";
-import { RuleElementPF2e } from "../index.ts";
+import { RuleElement } from "../index.ts";
 import type { ModelPropsFromRESchema, RuleElementSchema } from "./data.ts";
 import fields = foundry.data.fields;
 
 /** Create a special-purpose statistic for use in checks and as a DC */
-class SpecialStatisticRuleElement extends RuleElementPF2e<SpecialStatisticSchema> {
+class SpecialStatisticRuleElement extends RuleElement<SpecialStatisticSchema> {
     static override validActorTypes = ["character", "npc"] satisfies ("character" | "npc")[];
 
     static override defineSchema(): SpecialStatisticSchema {
@@ -89,7 +89,7 @@ class SpecialStatisticRuleElement extends RuleElementPF2e<SpecialStatisticSchema
                       const slug = typeof this.baseModifier?.mod === "number" && key !== "mod" ? `base-${key}` : "base";
                       const label = "PF2E.ModifierTitle";
                       const modifier = typeof value === "number" && key === "dc" ? value - 10 : value;
-                      return typeof modifier === "number" ? [new ModifierPF2e({ slug, label, modifier })] : [];
+                      return typeof modifier === "number" ? [new Modifier({ slug, label, modifier })] : [];
                   })
                 : { mod: [], check: [], dc: [] };
 
@@ -126,7 +126,7 @@ class SpecialStatisticRuleElement extends RuleElementPF2e<SpecialStatisticSchema
 }
 
 interface SpecialStatisticRuleElement
-    extends RuleElementPF2e<SpecialStatisticSchema>,
+    extends RuleElement<SpecialStatisticSchema>,
         ModelPropsFromRESchema<SpecialStatisticSchema> {
     slug: string;
 

--- a/src/module/rules/rule-element/strike.ts
+++ b/src/module/rules/rule-element/strike.ts
@@ -14,7 +14,7 @@ import type {
 } from "@item/weapon/types.ts";
 import type { DamageDieSize, DamageType } from "@system/damage/index.ts";
 import { objectHasKey, sluggify } from "@util";
-import { RuleElementOptions, RuleElementPF2e } from "./base.ts";
+import { RuleElement, RuleElementOptions } from "./base.ts";
 import { ModelPropsFromRESchema, ResolvableValueField, RuleElementSchema, RuleElementSource } from "./data.ts";
 import fields = foundry.data.fields;
 
@@ -22,7 +22,7 @@ import fields = foundry.data.fields;
  * Create an ephemeral strike on an actor
  * @category RuleElement
  */
-class StrikeRuleElement extends RuleElementPF2e<StrikeSchema> {
+class StrikeRuleElement extends RuleElement<StrikeSchema> {
     protected static override validActorTypes: ActorType[] = ["character", "npc"];
 
     declare graspingAppendage: boolean;
@@ -300,7 +300,7 @@ class StrikeRuleElement extends RuleElementPF2e<StrikeSchema> {
     }
 }
 
-interface StrikeRuleElement extends RuleElementPF2e<StrikeSchema>, ModelPropsFromRESchema<StrikeSchema> {
+interface StrikeRuleElement extends RuleElement<StrikeSchema>, ModelPropsFromRESchema<StrikeSchema> {
     slug: string;
     fist: boolean;
     options: string[];

--- a/src/module/rules/rule-element/striking.ts
+++ b/src/module/rules/rule-element/striking.ts
@@ -1,10 +1,10 @@
 import type { ActorType } from "@actor/types.ts";
 import { StrikingSynthetic } from "../synthetics.ts";
-import { RuleElementPF2e } from "./base.ts";
+import { RuleElement } from "./base.ts";
 import { ModelPropsFromRESchema, ResolvableValueField, RuleElementSchema } from "./data.ts";
 import fields = foundry.data.fields;
 
-class StrikingRuleElement extends RuleElementPF2e<StrikingRuleSchema> {
+class StrikingRuleElement extends RuleElement<StrikingRuleSchema> {
     protected static override validActorTypes: ActorType[] = ["character", "npc"];
 
     static override defineSchema(): StrikingRuleSchema {
@@ -35,7 +35,7 @@ class StrikingRuleElement extends RuleElementPF2e<StrikingRuleSchema> {
     }
 }
 
-interface StrikingRuleElement extends RuleElementPF2e<StrikingRuleSchema>, ModelPropsFromRESchema<StrikingRuleSchema> {}
+interface StrikingRuleElement extends RuleElement<StrikingRuleSchema>, ModelPropsFromRESchema<StrikingRuleSchema> {}
 
 type StrikingRuleSchema = RuleElementSchema & {
     selector: fields.StringField<string, string, true, false, false>;

--- a/src/module/rules/rule-element/substitute-roll.ts
+++ b/src/module/rules/rule-element/substitute-roll.ts
@@ -1,11 +1,11 @@
 import { DataUnionField, PredicateField, StrictBooleanField } from "@system/schema-data-fields.ts";
 import { sluggify } from "@util";
-import { RuleElementOptions, RuleElementPF2e } from "./base.ts";
+import { RuleElement, RuleElementOptions } from "./base.ts";
 import { ModelPropsFromRESchema, ResolvableValueField, RuleElementSchema, RuleElementSource } from "./data.ts";
 import fields = foundry.data.fields;
 
 /** Substitute a pre-determined result for a check's D20 roll */
-class SubstituteRollRuleElement extends RuleElementPF2e<SubstituteRollSchema> {
+class SubstituteRollRuleElement extends RuleElement<SubstituteRollSchema> {
     constructor(source: RuleElementSource, options: RuleElementOptions) {
         super(source, options);
 
@@ -64,7 +64,7 @@ class SubstituteRollRuleElement extends RuleElementPF2e<SubstituteRollSchema> {
         });
     }
 
-    override async afterRoll(params: RuleElementPF2e.AfterRollParams): Promise<void> {
+    override async afterRoll(params: RuleElement.AfterRollParams): Promise<void> {
         if (!this.removeAfterRoll || this.ignored) return;
 
         if (this.removeAfterRoll === true) {
@@ -86,7 +86,7 @@ class SubstituteRollRuleElement extends RuleElementPF2e<SubstituteRollSchema> {
 }
 
 interface SubstituteRollRuleElement
-    extends RuleElementPF2e<SubstituteRollSchema>,
+    extends RuleElement<SubstituteRollSchema>,
         ModelPropsFromRESchema<SubstituteRollSchema> {}
 
 type SubstituteRollSchema = RuleElementSchema & {

--- a/src/module/rules/rule-element/temp-hp.ts
+++ b/src/module/rules/rule-element/temp-hp.ts
@@ -1,14 +1,14 @@
 import type { ActorType } from "@actor/types.ts";
 import { ChatMessagePF2e } from "@module/chat-message/index.ts";
 import * as R from "remeda";
-import { RuleElementPF2e } from "./base.ts";
+import { RuleElement } from "./base.ts";
 import { ModelPropsFromRESchema, ResolvableValueField, RuleElementSchema } from "./data.ts";
 import fields = foundry.data.fields;
 
 /**
  * @category RuleElement
  */
-class TempHPRuleElement extends RuleElementPF2e<TempHPRuleSchema> {
+class TempHPRuleElement extends RuleElement<TempHPRuleSchema> {
     static override validActorTypes: ActorType[] = ["character", "npc", "familiar"];
 
     static override defineSchema(): TempHPRuleSchema {
@@ -115,7 +115,7 @@ class TempHPRuleElement extends RuleElementPF2e<TempHPRuleSchema> {
     }
 }
 
-interface TempHPRuleElement extends RuleElementPF2e<TempHPRuleSchema>, ModelPropsFromRESchema<TempHPRuleSchema> {}
+interface TempHPRuleElement extends RuleElement<TempHPRuleSchema>, ModelPropsFromRESchema<TempHPRuleSchema> {}
 
 type TempHPEventsSchema = {
     /** Whether the temporary hit points are immediately applied */

--- a/src/module/rules/rule-element/token-effect-icon.ts
+++ b/src/module/rules/rule-element/token-effect-icon.ts
@@ -1,7 +1,7 @@
 import { EffectPF2e } from "@item";
 import { ActiveEffectPF2e } from "@module/active-effect.ts";
 import { isImageFilePath } from "@util";
-import { RuleElementPF2e } from "./base.ts";
+import { RuleElement } from "./base.ts";
 import { ModelPropsFromRESchema, RuleElementSchema } from "./data.ts";
 import fields = foundry.data.fields;
 
@@ -9,7 +9,7 @@ import fields = foundry.data.fields;
  * Add an effect icon to an actor's token
  * @category RuleElement
  */
-class TokenEffectIconRuleElement extends RuleElementPF2e<TokenEffectIconSchema> {
+class TokenEffectIconRuleElement extends RuleElement<TokenEffectIconSchema> {
     static override defineSchema(): TokenEffectIconSchema {
         return {
             ...super.defineSchema(),
@@ -41,7 +41,7 @@ class TokenEffectIconRuleElement extends RuleElementPF2e<TokenEffectIconSchema> 
 }
 
 interface TokenEffectIconRuleElement
-    extends RuleElementPF2e<TokenEffectIconSchema>,
+    extends RuleElement<TokenEffectIconSchema>,
         ModelPropsFromRESchema<TokenEffectIconSchema> {}
 
 type TokenEffectIconSchema = RuleElementSchema & {

--- a/src/module/rules/rule-element/token-image.ts
+++ b/src/module/rules/rule-element/token-image.ts
@@ -1,7 +1,7 @@
 import type { TextureTransitionType } from "@client/canvas/rendering/filters/transition.d.mts";
 import type { HexColorString, ImageFilePath, VideoFilePath } from "@common/constants.d.mts";
 import { isImageOrVideoPath } from "@util";
-import { RuleElementPF2e } from "./base.ts";
+import { RuleElement } from "./base.ts";
 import { ModelPropsFromRESchema, RuleElementSchema } from "./data.ts";
 import fields = foundry.data.fields;
 
@@ -9,7 +9,7 @@ import fields = foundry.data.fields;
  * Change the image representing an actor's token
  * @category RuleElement
  */
-class TokenImageRuleElement extends RuleElementPF2e<TokenImageRuleSchema> {
+class TokenImageRuleElement extends RuleElement<TokenImageRuleSchema> {
     static override defineSchema(): TokenImageRuleSchema {
         return {
             ...super.defineSchema(),
@@ -151,7 +151,7 @@ class TokenImageRuleElement extends RuleElementPF2e<TokenImageRuleSchema> {
 }
 
 interface TokenImageRuleElement
-    extends RuleElementPF2e<TokenImageRuleSchema>,
+    extends RuleElement<TokenImageRuleSchema>,
         ModelPropsFromRESchema<TokenImageRuleSchema> {}
 
 type TokenImageRuleSchema = RuleElementSchema & {

--- a/src/module/rules/rule-element/token-light.ts
+++ b/src/module/rules/rule-element/token-light.ts
@@ -1,6 +1,6 @@
 import type { LightDataSchema } from "@common/data/data.d.mts";
 import type { SchemaField } from "@common/data/fields.d.mts";
-import { RuleElementPF2e } from "./base.ts";
+import { RuleElement } from "./base.ts";
 import { ModelPropsFromRESchema, ResolvableValueField, RuleElementSchema } from "./data.ts";
 import fields = foundry.data.fields;
 
@@ -8,7 +8,7 @@ import fields = foundry.data.fields;
  * Add or change the light emitted by a token
  * @category RuleElement
  */
-class TokenLightRuleElement extends RuleElementPF2e<TokenLightRuleSchema> {
+class TokenLightRuleElement extends RuleElement<TokenLightRuleSchema> {
     static override defineSchema(): TokenLightRuleSchema {
         return {
             ...super.defineSchema(),
@@ -57,7 +57,7 @@ class TokenLightRuleElement extends RuleElementPF2e<TokenLightRuleSchema> {
 }
 
 interface TokenLightRuleElement
-    extends RuleElementPF2e<TokenLightRuleSchema>,
+    extends RuleElement<TokenLightRuleSchema>,
         ModelPropsFromRESchema<TokenLightRuleSchema> {}
 
 type TokenLightValueSchema = Omit<LightDataSchema, "bright" | "color" | "dim"> & {

--- a/src/module/rules/rule-element/token-mark/rule-element.ts
+++ b/src/module/rules/rule-element/token-mark/rule-element.ts
@@ -2,13 +2,13 @@ import { TokenDocumentPF2e } from "@scene";
 import { SlugField } from "@system/schema-data-fields.ts";
 import { ErrorPF2e } from "@util";
 import { UUIDUtils } from "@util/uuid.ts";
-import { RuleElementPF2e } from "../base.ts";
+import { RuleElement } from "../base.ts";
 import { ModelPropsFromRESchema, RuleElementSchema, RuleElementSource } from "../data.ts";
 import { MarkTargetPrompt } from "./prompt.ts";
 import fields = foundry.data.fields;
 
 /** Remember a token for later referencing */
-class TokenMarkRuleElement extends RuleElementPF2e<TokenMarkSchema> {
+class TokenMarkRuleElement extends RuleElement<TokenMarkSchema> {
     static override defineSchema(): TokenMarkSchema {
         return {
             ...super.defineSchema(),
@@ -17,7 +17,7 @@ class TokenMarkRuleElement extends RuleElementPF2e<TokenMarkSchema> {
         };
     }
 
-    override async preCreate({ ruleSource, itemSource, pendingItems }: RuleElementPF2e.PreCreateParams): Promise<void> {
+    override async preCreate({ ruleSource, itemSource, pendingItems }: RuleElement.PreCreateParams): Promise<void> {
         if (this.ignored) return;
 
         this.uuid &&= this.resolveInjectedProperties(this.uuid);
@@ -64,7 +64,7 @@ type TokenMarkSchema = Omit<RuleElementSchema, "slug"> & {
     uuid: fields.StringField<string, string, false, true, true>;
 };
 
-interface TokenMarkRuleElement extends RuleElementPF2e<TokenMarkSchema>, ModelPropsFromRESchema<TokenMarkSchema> {
+interface TokenMarkRuleElement extends RuleElement<TokenMarkSchema>, ModelPropsFromRESchema<TokenMarkSchema> {
     slug: string;
 }
 

--- a/src/module/rules/rule-element/token-name.ts
+++ b/src/module/rules/rule-element/token-name.ts
@@ -1,4 +1,4 @@
-import { RuleElementPF2e } from "./base.ts";
+import { RuleElement } from "./base.ts";
 import { ModelPropsFromRESchema, RuleElementSchema } from "./data.ts";
 import fields = foundry.data.fields;
 
@@ -6,7 +6,7 @@ import fields = foundry.data.fields;
  * Change the name representing an actor's token
  * @category RuleElement
  */
-class TokenNameRuleElement extends RuleElementPF2e<TokenNameRuleSchema> {
+class TokenNameRuleElement extends RuleElement<TokenNameRuleSchema> {
     static override defineSchema(): TokenNameRuleSchema {
         return {
             ...super.defineSchema(),
@@ -20,9 +20,7 @@ class TokenNameRuleElement extends RuleElementPF2e<TokenNameRuleSchema> {
     }
 }
 
-interface TokenNameRuleElement
-    extends RuleElementPF2e<TokenNameRuleSchema>,
-        ModelPropsFromRESchema<TokenNameRuleSchema> {}
+interface TokenNameRuleElement extends RuleElement<TokenNameRuleSchema>, ModelPropsFromRESchema<TokenNameRuleSchema> {}
 
 type TokenNameRuleSchema = RuleElementSchema & {
     value: fields.StringField<string, string, true, false, false>;

--- a/src/module/rules/rule-element/weapon-potency.ts
+++ b/src/module/rules/rule-element/weapon-potency.ts
@@ -1,7 +1,7 @@
 import { AutomaticBonusProgression as ABP } from "@actor/character/automatic-bonus-progression.ts";
 import type { ActorType } from "@actor/types.ts";
 import { PotencySynthetic } from "../synthetics.ts";
-import { RuleElementPF2e } from "./base.ts";
+import { RuleElement } from "./base.ts";
 import { ModelPropsFromRESchema, ResolvableValueField, RuleElementSchema } from "./data.ts";
 import fields = foundry.data.fields;
 
@@ -9,7 +9,7 @@ import fields = foundry.data.fields;
  * Copies potency runes from the weapon its attached to, to another weapon based on a predicate.
  * @category RuleElement
  */
-class WeaponPotencyRuleElement extends RuleElementPF2e<WeaponPotencyRuleSchema> {
+class WeaponPotencyRuleElement extends RuleElement<WeaponPotencyRuleSchema> {
     protected static override validActorTypes: ActorType[] = ["character", "npc"];
 
     static override defineSchema(): WeaponPotencyRuleSchema {
@@ -41,7 +41,7 @@ class WeaponPotencyRuleElement extends RuleElementPF2e<WeaponPotencyRuleSchema> 
 }
 
 interface WeaponPotencyRuleElement
-    extends RuleElementPF2e<WeaponPotencyRuleSchema>,
+    extends RuleElement<WeaponPotencyRuleSchema>,
         ModelPropsFromRESchema<WeaponPotencyRuleSchema> {}
 
 type WeaponPotencyRuleSchema = RuleElementSchema & {

--- a/src/module/rules/synthetics.ts
+++ b/src/module/rules/synthetics.ts
@@ -6,8 +6,8 @@ import type {
     DeferredDamageDiceOptions,
     DeferredPromise,
     DeferredValue,
+    Modifier,
     ModifierAdjustment,
-    ModifierPF2e,
 } from "@actor/modifiers.ts";
 import type { MovementType } from "@actor/types.ts";
 import type { TokenAnimationOptions } from "@client/_module.d.mts";
@@ -76,7 +76,7 @@ interface RuleElementSynthetics {
     weaponPotency: Record<string, PotencySynthetic[]>;
 }
 
-type CritSpecEffect = (DamageDicePF2e | ModifierPF2e | RollNotePF2e)[];
+type CritSpecEffect = (DamageDicePF2e | Modifier | RollNotePF2e)[];
 type CritSpecSynthetic = (weapon: WeaponPF2e | MeleePF2e, options: Set<string>) => CritSpecEffect | null;
 
 type DamageDiceSynthetics = { damage: DeferredDamageDice[] } & Record<string, DeferredDamageDice[] | undefined>;
@@ -85,7 +85,7 @@ type ModifierAdjustmentSynthetics = { all: ModifierAdjustment[]; damage: Modifie
     string,
     ModifierAdjustment[] | undefined
 >;
-type DeferredModifier = DeferredValue<ModifierPF2e>;
+type DeferredModifier = DeferredValue<Modifier>;
 type DeferredDamageDice = (args: DeferredDamageDiceOptions) => DamageDicePF2e | null;
 type DeferredMovementType = DeferredValue<BaseSpeedSynthetic | null>;
 type DeferredEphemeralEffect = DeferredPromise<EffectSource | ConditionSource | null>;

--- a/src/module/system/action-macros/ancestry/automaton/arcane-slam.ts
+++ b/src/module/system/action-macros/ancestry/automaton/arcane-slam.ts
@@ -1,5 +1,5 @@
 import { CreaturePF2e } from "@actor";
-import { ModifierPF2e } from "@actor/modifiers.ts";
+import { Modifier } from "@actor/modifiers.ts";
 import { RollNotePF2e } from "@module/notes.ts";
 import { Predicate } from "@system/predication.ts";
 import { ActionMacroHelpers, SkillActionOptions } from "../../index.ts";
@@ -18,7 +18,7 @@ export function arcaneSlam(options: SkillActionOptions): void {
                 const attackerSize = opts.actor.system.traits.size;
                 const targetSize = opts.target.system.traits.size;
                 const sizeDifference = attackerSize.difference(targetSize);
-                const sizeModifier = new ModifierPF2e(
+                const sizeModifier = new Modifier(
                     "PF2E.Actions.ArcaneSlam.Modifier.SizeDifference",
                     Math.clamp(2 * sizeDifference, -4, 4),
                     "circumstance",

--- a/src/module/system/action-macros/athletics/climb.ts
+++ b/src/module/system/action-macros/athletics/climb.ts
@@ -1,6 +1,6 @@
-import { ActionMacroHelpers, SkillActionOptions } from "../index.ts";
 import { SingleCheckAction } from "@actor/actions/index.ts";
-import { ModifierPF2e } from "@actor/modifiers.ts";
+import { Modifier } from "@actor/modifiers.ts";
+import { ActionMacroHelpers, SkillActionOptions } from "../index.ts";
 
 const PREFIX = "PF2E.Actions.Climb";
 
@@ -8,7 +8,7 @@ function climb(options: SkillActionOptions): void {
     const slug = options?.skill ?? "athletics";
     const rollOptions = ["action:climb"];
     const modifiers = (options?.modifiers ?? []).concat(
-        new ModifierPF2e({
+        new Modifier({
             slug: "climb-speed",
             label: `${PREFIX}.Modifier.ClimbSpeed`,
             modifier: 4,
@@ -69,4 +69,4 @@ const action = new SingleCheckAction({
     traits: ["move"],
 });
 
-export { climb as legacy, action };
+export { action, climb as legacy };

--- a/src/module/system/action-macros/athletics/swim.ts
+++ b/src/module/system/action-macros/athletics/swim.ts
@@ -1,6 +1,6 @@
-import { ActionMacroHelpers, SkillActionOptions } from "../index.ts";
 import { SingleCheckAction } from "@actor/actions/index.ts";
-import { ModifierPF2e } from "@actor/modifiers.ts";
+import { Modifier } from "@actor/modifiers.ts";
+import { ActionMacroHelpers, SkillActionOptions } from "../index.ts";
 
 const PREFIX = "PF2E.Actions.Swim";
 
@@ -8,7 +8,7 @@ function swim(options: SkillActionOptions): void {
     const slug = options?.skill ?? "athletics";
     const rollOptions = ["action:swim"];
     const modifiers = (options?.modifiers ?? []).concat(
-        new ModifierPF2e({
+        new Modifier({
             slug: "swim-speed",
             label: `${PREFIX}.Modifier.SwimSpeed`,
             modifier: 4,
@@ -69,4 +69,4 @@ const action = new SingleCheckAction({
     traits: ["move"],
 });
 
-export { swim as legacy, action };
+export { action, swim as legacy };

--- a/src/module/system/action-macros/athletics/trip.ts
+++ b/src/module/system/action-macros/athletics/trip.ts
@@ -1,6 +1,6 @@
 import { ActorPF2e } from "@actor";
 import { SingleCheckAction, SingleCheckActionVariant, SingleCheckActionVariantData } from "@actor/actions/index.ts";
-import { ModifierPF2e } from "@actor/modifiers.ts";
+import { Modifier } from "@actor/modifiers.ts";
 import { ItemPF2e, WeaponPF2e } from "@item";
 import { extractModifierAdjustments } from "@module/rules/helpers.ts";
 import { CheckContextData, CheckContextOptions, CheckMacroContext } from "@system/action-macros/types.ts";
@@ -32,7 +32,7 @@ function tripCheckContext<ItemType extends ItemPF2e<ActorPF2e>>(
         }
         if (item.traits.has("ranged-trip")) {
             modifiers.push(
-                new ModifierPF2e({
+                new Modifier({
                     slug: "ranged-trip",
                     adjustments: extractModifierAdjustments(
                         opts.actor.synthetics.modifierAdjustments,

--- a/src/module/system/action-macros/athletics/whirling-throw.ts
+++ b/src/module/system/action-macros/athletics/whirling-throw.ts
@@ -1,6 +1,6 @@
 import { CreaturePF2e } from "@actor";
 import { ActorSizePF2e } from "@actor/data/size.ts";
-import { ModifierPF2e } from "@actor/modifiers.ts";
+import { Modifier } from "@actor/modifiers.ts";
 import { ActionMacroHelpers, SkillActionOptions } from "../index.ts";
 
 function determineSizeBonus(actorSize: ActorSizePF2e, targetSize: ActorSizePF2e) {
@@ -21,7 +21,7 @@ export function whirlingThrow(options: SkillActionOptions): void {
             if (opts.actor instanceof CreaturePF2e && opts.target instanceof CreaturePF2e) {
                 const actorSize = opts.actor.system.traits.size;
                 const targetSize = opts.target.system.traits.size;
-                const sizeModifier = new ModifierPF2e(
+                const sizeModifier = new Modifier(
                     "Size Modifier",
                     determineSizeBonus(actorSize, targetSize),
                     "circumstance",

--- a/src/module/system/action-macros/exploration/sense-direction.ts
+++ b/src/module/system/action-macros/exploration/sense-direction.ts
@@ -1,10 +1,10 @@
-import { ActionMacroHelpers, SkillActionOptions } from "../index.ts";
-import { ModifierPF2e } from "@actor/modifiers.ts";
 import { SingleCheckAction } from "@actor/actions/index.ts";
+import { Modifier } from "@actor/modifiers.ts";
+import { ActionMacroHelpers, SkillActionOptions } from "../index.ts";
 
 function senseDirection(options: SkillActionOptions): void {
     const modifiers = [
-        new ModifierPF2e({
+        new Modifier({
             label: "PF2E.Actions.SenseDirection.Modifier.NoCompass",
             modifier: -2,
             predicate: [{ not: "compass-in-possession" }],
@@ -61,4 +61,4 @@ const action = new SingleCheckAction({
     traits: ["exploration", "secret"],
 });
 
-export { senseDirection as legacy, action };
+export { action, senseDirection as legacy };

--- a/src/module/system/action-macros/general/subsist.ts
+++ b/src/module/system/action-macros/general/subsist.ts
@@ -1,12 +1,12 @@
-import { ActionMacroHelpers, SkillActionOptions } from "../index.ts";
-import { ModifierPF2e } from "@actor/modifiers.ts";
 import {
     SingleCheckAction,
     SingleCheckActionUseOptions,
     SingleCheckActionVariant,
     SingleCheckActionVariantData,
 } from "@actor/actions/index.ts";
+import { Modifier } from "@actor/modifiers.ts";
 import { CheckResultCallback } from "@system/action-macros/types.ts";
+import { ActionMacroHelpers, SkillActionOptions } from "../index.ts";
 
 function subsist(options: SkillActionOptions): void {
     if (!options?.skill) {
@@ -14,7 +14,7 @@ function subsist(options: SkillActionOptions): void {
         return;
     }
     const modifiers = [
-        new ModifierPF2e({
+        new Modifier({
             label: "PF2E.Actions.Subsist.AfterExplorationPenalty",
             modifier: -5,
             predicate: ["action:subsist:after-exploration"],
@@ -98,4 +98,4 @@ class SubsistAction extends SingleCheckAction {
 
 const action = new SubsistAction();
 
-export { subsist as legacy, action };
+export { action, subsist as legacy };

--- a/src/module/system/action-macros/helpers.ts
+++ b/src/module/system/action-macros/helpers.ts
@@ -2,7 +2,7 @@ import type { ActorPF2e } from "@actor";
 import { AutomaticBonusProgression } from "@actor/character/automatic-bonus-progression.ts";
 import type { StrikeData } from "@actor/data/base.ts";
 import { getRangeIncrement } from "@actor/helpers.ts";
-import { CheckModifier, ModifierPF2e, ensureProficiencyOption } from "@actor/modifiers.ts";
+import { CheckModifier, Modifier, ensureProficiencyOption } from "@actor/modifiers.ts";
 import type { RollOrigin, RollTarget } from "@actor/roll-context/types.ts";
 import type { ItemPF2e, WeaponPF2e } from "@item";
 import type { AbilityTrait } from "@item/ability/types.ts";
@@ -15,7 +15,7 @@ import {
 } from "@module/rules/helpers.ts";
 import { eventToRollParams } from "@module/sheet/helpers.ts";
 import type { TokenDocumentPF2e } from "@scene";
-import { CheckPF2e, CheckType } from "@system/check/index.ts";
+import { Check, CheckType } from "@system/check/index.ts";
 import type { CheckDC, DegreeOfSuccessString } from "@system/degree-of-success.ts";
 import { CheckDCReference, Statistic } from "@system/statistic/index.ts";
 import { sluggify } from "@util";
@@ -260,7 +260,7 @@ class ActionMacroHelpers {
                     );
                     const dosAdjustments = extractDegreeOfSuccessAdjustments(actor.synthetics, domains);
 
-                    await CheckPF2e.roll(
+                    await Check.roll(
                         check,
                         {
                             actor: selfActor,
@@ -312,10 +312,10 @@ class ActionMacroHelpers {
         };
     }
 
-    static getWeaponPotencyModifier(item: WeaponPF2e<ActorPF2e>, selector: string): ModifierPF2e | null {
+    static getWeaponPotencyModifier(item: WeaponPF2e<ActorPF2e>, selector: string): Modifier | null {
         const slug = "potency";
         if (AutomaticBonusProgression.isEnabled(item.actor)) {
-            return new ModifierPF2e({
+            return new Modifier({
                 slug,
                 type: "potency",
                 label: "PF2E.AutomaticBonusProgression.attackPotency",
@@ -323,7 +323,7 @@ class ActionMacroHelpers {
                 adjustments: extractModifierAdjustments(item.actor.synthetics.modifierAdjustments, [selector], slug),
             });
         } else if (item.system.runes.potency > 0) {
-            return new ModifierPF2e({
+            return new Modifier({
                 slug,
                 type: "item",
                 label: "PF2E.Item.Weapon.Rune.Potency",

--- a/src/module/system/action-macros/intimidation/demoralize.ts
+++ b/src/module/system/action-macros/intimidation/demoralize.ts
@@ -1,12 +1,12 @@
 import { SingleCheckAction } from "@actor/actions/index.ts";
-import { ModifierPF2e } from "@actor/modifiers.ts";
+import { Modifier } from "@actor/modifiers.ts";
 import { ActionMacroHelpers, SkillActionOptions } from "../index.ts";
 
 function demoralize(options: SkillActionOptions): void {
     const slug = options?.skill ?? "intimidation";
     const rollOptions = ["action:demoralize"];
     const modifiers = [
-        new ModifierPF2e({
+        new Modifier({
             label: "PF2E.Actions.Demoralize.Unintelligible",
             modifier: -4,
             predicate: ["action:demoralize:unintelligible"],

--- a/src/module/system/action-macros/medicine/administer-first-aid.ts
+++ b/src/module/system/action-macros/medicine/administer-first-aid.ts
@@ -1,6 +1,6 @@
 import type { ActorPF2e } from "@actor";
 import { SingleCheckAction } from "@actor/actions/index.ts";
-import { ModifierPF2e } from "@actor/modifiers.ts";
+import { Modifier } from "@actor/modifiers.ts";
 import { CheckDC } from "@system/degree-of-success.ts";
 import { Statistic } from "@system/statistic/index.ts";
 import { ActionMacroHelpers, SkillActionOptions } from "../index.ts";
@@ -17,7 +17,7 @@ function stabilizeDifficultyClass(target: ActorPF2e): CheckDC | null {
     if (!dying?.value) {
         throw new Error(game.i18n.localize(`${PREFIX}.Warning.TargetNotDying`));
     }
-    const dcModifier = new ModifierPF2e({
+    const dcModifier = new Modifier({
         slug: "dying-recovery",
         label: "PF2E.ModifierTitle",
         modifier: 5 + dying.recoveryDC + dying.value - 10,

--- a/src/module/system/action-macros/society/create-forgery.ts
+++ b/src/module/system/action-macros/society/create-forgery.ts
@@ -1,13 +1,13 @@
-import { ActionMacroHelpers, SkillActionOptions } from "../index.ts";
-import { CheckResultCallback } from "@system/action-macros/types.ts";
 import { CreaturePF2e } from "@actor";
-import { RawModifier, ModifierPF2e } from "@actor/modifiers.ts";
 import {
     SingleCheckAction,
     SingleCheckActionUseOptions,
     SingleCheckActionVariant,
     SingleCheckActionVariantData,
 } from "@actor/actions/index.ts";
+import { Modifier, RawModifier } from "@actor/modifiers.ts";
+import { CheckResultCallback } from "@system/action-macros/types.ts";
+import { ActionMacroHelpers, SkillActionOptions } from "../index.ts";
 
 interface ChatMessageCheckFlags {
     context: {
@@ -29,7 +29,7 @@ async function createForgeryCallback(
                 .map((modifier) => {
                     return { ...modifier, predicate: [] };
                 })
-                .map((modifier) => new ModifierPF2e(modifier));
+                .map((modifier) => new Modifier(modifier));
             return result.actor.skills.society
                 .extend({
                     slug: result.actor.skills.society.slug,
@@ -88,7 +88,7 @@ async function createForgeryCallback(
 
 function createForgery(options: SkillActionOptions): Promise<void> {
     const modifiers = [
-        new ModifierPF2e({
+        new Modifier({
             label: "PF2E.Actions.CreateForgery.UnspecificHandwriting",
             modifier: 4,
             predicate: ["action:create-forgery:unspecific-handwriting"],
@@ -167,4 +167,4 @@ class CreateForgeryAction extends SingleCheckAction {
 
 const action = new CreateForgeryAction();
 
-export { createForgery as legacy, action };
+export { action, createForgery as legacy };

--- a/src/module/system/action-macros/thievery/steal.ts
+++ b/src/module/system/action-macros/thievery/steal.ts
@@ -1,12 +1,12 @@
-import { ActionMacroHelpers, SkillActionOptions } from "../index.ts";
-import { ModifierPF2e } from "@actor/modifiers.ts";
 import { SingleCheckAction } from "@actor/actions/index.ts";
+import { Modifier } from "@actor/modifiers.ts";
+import { ActionMacroHelpers, SkillActionOptions } from "../index.ts";
 
 const PREFIX = "PF2E.Actions.Steal";
 
 function steal(options: SkillActionOptions): void {
     const modifiers = [
-        new ModifierPF2e({
+        new Modifier({
             label: "PF2E.Actions.Steal.Pocketed",
             modifier: -5,
             predicate: ["action:steal:pocketed"],
@@ -51,4 +51,4 @@ const action = new SingleCheckAction({
     traits: ["manipulate"],
 });
 
-export { steal as legacy, action };
+export { action, steal as legacy };

--- a/src/module/system/action-macros/types.ts
+++ b/src/module/system/action-macros/types.ts
@@ -1,6 +1,6 @@
 import type { ActorPF2e } from "@actor";
 import { StrikeData } from "@actor/data/base.ts";
-import type { ModifierPF2e } from "@actor/modifiers.ts";
+import type { Modifier } from "@actor/modifiers.ts";
 import type { DCSlug } from "@actor/types.ts";
 import type { Rolled } from "@client/dice/_module.d.mts";
 import type { ItemPF2e } from "@item";
@@ -34,7 +34,7 @@ interface CheckContextOptions<TItem extends ItemPF2e<ActorPF2e>> {
 
 interface CheckContextData<TItem extends ItemPF2e<ActorPF2e>> {
     item?: TItem;
-    modifiers?: ModifierPF2e[];
+    modifiers?: Modifier[];
     rollOptions: string[];
     slug: string;
     target?: ActorPF2e | null;
@@ -43,7 +43,7 @@ interface CheckContextData<TItem extends ItemPF2e<ActorPF2e>> {
 interface CheckMacroContext<TItem extends ItemPF2e<ActorPF2e>> {
     type: CheckType;
     item?: TItem;
-    modifiers?: ModifierPF2e[];
+    modifiers?: Modifier[];
     rollOptions: string[];
     slug: string;
     statistic: Statistic | (StrikeData & { rank?: number });
@@ -87,7 +87,7 @@ interface ActionDefaultOptions {
     event?: Event | null;
     actors?: ActorPF2e | ActorPF2e[];
     glyph?: ActionGlyph;
-    modifiers?: ModifierPF2e[];
+    modifiers?: Modifier[];
     callback?: (result: CheckResultCallback) => void;
 }
 

--- a/src/module/system/check/check.ts
+++ b/src/module/system/check/check.ts
@@ -53,7 +53,7 @@ type CheckRollCallback = (
     event: Event | null,
 ) => Promise<void> | void;
 
-class CheckPF2e {
+class Check {
     /** Roll the given statistic, optionally showing the check modifier dialog if 'Shift' is held down. */
     static async roll(
         check: CheckModifier,
@@ -581,8 +581,8 @@ class CheckPF2e {
         }
 
         const renders = {
-            old: await CheckPF2e.renderReroll(oldRoll, { isOld: true, resource }),
-            new: await CheckPF2e.renderReroll(newRoll, { isOld: false, resource }),
+            old: await Check.renderReroll(oldRoll, { isOld: true, resource }),
+            new: await Check.renderReroll(newRoll, { isOld: false, resource }),
         };
 
         const rerollIcon = fontAwesomeIcon(
@@ -939,5 +939,5 @@ interface CreateTagFlavorParams {
     extraTags: string[];
 }
 
-export { CheckPF2e };
+export { Check };
 export type { CheckRollCallback };

--- a/src/module/system/check/dialog.ts
+++ b/src/module/system/check/dialog.ts
@@ -1,4 +1,4 @@
-import { MODIFIER_TYPES, ModifierPF2e, RawModifier, StatisticModifier } from "@actor/modifiers.ts";
+import { MODIFIER_TYPES, Modifier, RawModifier, StatisticModifier } from "@actor/modifiers.ts";
 import type { ApplicationV1Options } from "@client/appv1/api/application-v1.d.mts";
 import type { RollMode } from "@common/constants.d.mts";
 import type { RollSubstitution } from "@module/rules/synthetics.ts";
@@ -22,7 +22,7 @@ export class CheckModifiersDialog extends fav1.api.Application {
     isResolved = false;
 
     /** A set of originally enabled modifiers to circumvent hideIfDisabled for manual disables */
-    #originallyEnabled: Set<ModifierPF2e>;
+    #originallyEnabled: Set<Modifier>;
 
     constructor(
         check: StatisticModifier,
@@ -164,7 +164,7 @@ export class CheckModifiersDialog extends fav1.api.Application {
             if (errors.length > 0) {
                 ui.notifications.error(errors.join(" "));
             } else {
-                this.check.push(new ModifierPF2e(name, value, type));
+                this.check.push(new Modifier(name, value, type));
                 this.render();
             }
         });

--- a/src/module/system/damage/dialog.ts
+++ b/src/module/system/damage/dialog.ts
@@ -1,4 +1,4 @@
-import { DamageDicePF2e, MODIFIER_TYPES, ModifierPF2e, applyStackingRules } from "@actor/modifiers.ts";
+import { DamageDicePF2e, MODIFIER_TYPES, Modifier, applyStackingRules } from "@actor/modifiers.ts";
 import type { RollMode } from "@common/constants.d.mts";
 import { DEGREE_OF_SUCCESS, DEGREE_OF_SUCCESS_STRINGS, DegreeOfSuccessIndex } from "@system/degree-of-success.ts";
 import {
@@ -37,7 +37,7 @@ class DamageModifierDialog extends fav1.api.Application {
 
     /** A set of originally enabled modifiers and dice to circumvent hideIfDisabled for manual disables */
     #originallyEnabled: {
-        modifiers: Set<ModifierPF2e>;
+        modifiers: Set<Modifier>;
         dice: Set<DamageDicePF2e>;
     };
 
@@ -271,7 +271,7 @@ class DamageModifierDialog extends fav1.api.Application {
                 ui.notifications.error(errors.join(" "));
             } else {
                 this.formulaData.modifiers.push(
-                    new ModifierPF2e({
+                    new Modifier({
                         label,
                         modifier: value,
                         type,

--- a/src/module/system/damage/helpers.ts
+++ b/src/module/system/damage/helpers.ts
@@ -1,5 +1,5 @@
 import type { ActorPF2e } from "@actor";
-import { DamageDicePF2e, ModifierPF2e, RawDamageDice } from "@actor/modifiers.ts";
+import { DamageDicePF2e, Modifier, RawDamageDice } from "@actor/modifiers.ts";
 import type { ItemPF2e } from "@item";
 import { WeaponDamage } from "@item/weapon/data.ts";
 import { extractDamageAlterations, extractModifierAdjustments } from "@module/rules/helpers.ts";
@@ -84,7 +84,7 @@ function applyBaseDamageAlterations({ actor, item, base, domains, rollOptions }:
                     term.dice.number = damage.diceNumber;
                     term.dice.faces = damage.dieSize ? damageDieSizeToFaces(damage.dieSize) : term.dice.faces;
                 } else if (term.modifier) {
-                    const modifier = new ModifierPF2e({
+                    const modifier = new Modifier({
                         label: "PF2E.ModifierTitle",
                         slug: "base",
                         modifier: term.modifier,
@@ -376,7 +376,7 @@ function processBaseDamage(
             : null;
     const modifier =
         unprocessed.modifier !== 0
-            ? new ModifierPF2e({
+            ? new Modifier({
                   slug: "base",
                   label: "Base",
                   damageCategory,
@@ -394,7 +394,7 @@ function processBaseDamage(
                   diceNumber: unprocessed.persistent.number,
                   dieSize: `d${unprocessed.persistent.faces}`,
               })
-            : new ModifierPF2e({
+            : new Modifier({
                   slug: "base-persistent",
                   label: "Base",
                   damageCategory: "persistent",
@@ -494,9 +494,9 @@ function getDamageDiceOverrideLabel(d: DamageDicePF2e | RawDamageDice): string {
 }
 
 export {
-    DamageCategorization,
     applyBaseDamageAlterations,
     applyDamageDiceOverrides,
+    DamageCategorization,
     damageDiceIcon,
     damageDieSizeToFaces,
     deepFindTerms,

--- a/src/module/system/damage/types.ts
+++ b/src/module/system/damage/types.ts
@@ -1,4 +1,4 @@
-import type { DamageDicePF2e, ModifierPF2e } from "@actor/modifiers.ts";
+import type { DamageDicePF2e, Modifier } from "@actor/modifiers.ts";
 import type { RollOrigin, RollTarget } from "@actor/roll-context/types.ts";
 import type { ImmunityType, ResistanceType } from "@actor/types.ts";
 import type { ZeroToTwo } from "@module/data.ts";
@@ -59,7 +59,7 @@ interface DamageDamageContext extends BaseRollContext {
 interface DamageFormulaData {
     base: BaseDamageData[];
     dice: DamageDicePF2e[];
-    modifiers: ModifierPF2e[];
+    modifiers: Modifier[];
     /** Maximum number of die increases. Weapons should be set to 1 */
     maxIncreases?: number;
     bypass?: DamageIRBypassData;
@@ -133,7 +133,7 @@ interface WeaponBaseDamageData extends BaseDamageData {
 interface BaseDamageTemplate {
     name: string;
     materials: MaterialDamageEffect[];
-    modifiers?: (ModifierPF2e | DamageDicePF2e)[];
+    modifiers?: (Modifier | DamageDicePF2e)[];
 }
 
 interface WeaponDamageTemplate extends BaseDamageTemplate {

--- a/src/module/system/damage/weapon.ts
+++ b/src/module/system/damage/weapon.ts
@@ -1,5 +1,5 @@
 import { ActorPF2e } from "@actor";
-import { DamageDicePF2e, ModifierPF2e, createAttributeModifier } from "@actor/modifiers.ts";
+import { DamageDicePF2e, Modifier, createAttributeModifier } from "@actor/modifiers.ts";
 import { ATTRIBUTE_ABBREVIATIONS } from "@actor/values.ts";
 import type { MeleePF2e, WeaponPF2e } from "@item";
 import type { NPCAttackDamage } from "@item/melee/data.ts";
@@ -45,7 +45,7 @@ class WeaponDamagePF2e {
 
         // Collect damage dice and modifiers from secondary damage instances
         const damageDice: DamageDicePF2e[] = [];
-        const modifiers: ModifierPF2e[] = [];
+        const modifiers: Modifier[] = [];
         const labelFromCategory = {
             null: "",
             persistent: "",
@@ -71,7 +71,7 @@ class WeaponDamagePF2e {
             }
             if (instance.modifier) {
                 modifiers.push(
-                    new ModifierPF2e({
+                    new Modifier({
                         slug: "base",
                         label: labelFromCategory[instance.category ?? "null"],
                         modifier: instance.modifier,
@@ -158,7 +158,7 @@ class WeaponDamagePF2e {
         if (splashDamage > 0) {
             const slug = hasScatterTrait ? "scatter" : "splash";
             const label = `PF2E.Trait${sluggify(slug, { camel: "bactrian" })}`;
-            const modifier = new ModifierPF2e({
+            const modifier = new Modifier({
                 slug,
                 label,
                 modifier: splashDamage,
@@ -173,7 +173,7 @@ class WeaponDamagePF2e {
             if (weaponTraits.includes("kickback")) {
                 // For NPCs, subtract from the base damage and add back as an untype bonus
                 modifiers.push(
-                    new ModifierPF2e({
+                    new Modifier({
                         slug: "kickback",
                         label: CONFIG.PF2E.weaponTraits.kickback,
                         modifier: 1,
@@ -200,14 +200,14 @@ class WeaponDamagePF2e {
         })();
 
         if (critSpecEffect.length > 0) options.add("critical-specialization");
-        modifiers.push(...critSpecEffect.filter((e): e is ModifierPF2e => e instanceof ModifierPF2e));
+        modifiers.push(...critSpecEffect.filter((e): e is Modifier => e instanceof Modifier));
         damageDice.push(...critSpecEffect.filter((e): e is DamageDicePF2e => e instanceof DamageDicePF2e));
 
         // Property Runes
         const propertyRunes = weapon.system.runes.property;
         const runeDamage = getPropertyRuneDamage(weapon, propertyRunes, options);
         damageDice.push(...runeDamage.filter((d): d is DamageDicePF2e => "diceNumber" in d));
-        modifiers.push(...runeDamage.filter((d): d is ModifierPF2e => "modifier" in d));
+        modifiers.push(...runeDamage.filter((d): d is Modifier => "modifier" in d));
         const propertyRuneAdjustments = getPropertyRuneModifierAdjustments(propertyRunes);
 
         const irBypassData: DamageIRBypassData = {
@@ -220,7 +220,7 @@ class WeaponDamagePF2e {
 
         // Backstabber trait
         if (weaponTraits.some((t) => t === "backstabber") && options.has("target:condition:off-guard")) {
-            const modifier = new ModifierPF2e({
+            const modifier = new Modifier({
                 label: CONFIG.PF2E.weaponTraits.backstabber,
                 slug: "backstabber",
                 modifier: weaponPotency > 2 ? 2 : 1,
@@ -306,14 +306,14 @@ class WeaponDamagePF2e {
         // Forceful trait
         if (weaponTraits.some((t) => t === "forceful") && weapon.isOfType("weapon")) {
             modifiers.push(
-                new ModifierPF2e({
+                new Modifier({
                     slug: "forceful-second",
                     label: "PF2E.Item.Weapon.Forceful.Second",
                     modifier: weapon._source.system.damage.dice + strikingDice,
                     type: "circumstance",
                     ignored: true,
                 }),
-                new ModifierPF2e({
+                new Modifier({
                     slug: "forceful-third",
                     label: "PF2E.Item.Weapon.Forceful.Third",
                     modifier: 2 * (weapon._source.system.damage.dice + strikingDice),
@@ -325,7 +325,7 @@ class WeaponDamagePF2e {
 
         // Tearing trait
         if (weaponTraits.some((t) => t === "tearing")) {
-            const modifier = new ModifierPF2e({
+            const modifier = new Modifier({
                 label: CONFIG.PF2E.weaponTraits.tearing,
                 slug: "tearing",
                 modifier: strikingDice > 1 ? 2 : 1,
@@ -338,7 +338,7 @@ class WeaponDamagePF2e {
         // Twin trait
         if (weaponTraits.some((t) => t === "twin") && weapon.isOfType("weapon")) {
             modifiers.push(
-                new ModifierPF2e({
+                new Modifier({
                     slug: "twin-second",
                     label: "PF2E.Item.Weapon.Twin.SecondPlus",
                     modifier: weapon._source.system.damage.dice + strikingDice,
@@ -350,7 +350,7 @@ class WeaponDamagePF2e {
 
         // Venomous trait
         if (weaponTraits.some((t) => t === "venomous")) {
-            const modifier = new ModifierPF2e({
+            const modifier = new Modifier({
                 label: CONFIG.PF2E.weaponTraits.venomous,
                 slug: "venomous",
                 modifier: strikingDice > 1 ? 2 : 1,
@@ -547,7 +547,7 @@ interface WeaponDamageCalculateParams {
     actor: ActorPF2e;
     weaponPotency?: number;
     damageDice?: DamageDicePF2e[];
-    modifiers?: ModifierPF2e[];
+    modifiers?: Modifier[];
     context: DamageDamageContext;
 }
 
@@ -559,7 +559,7 @@ interface NPCStrikeCalculateParams {
 
 interface ExcludeDamageParams {
     actor: ActorPF2e;
-    modifiers: (DamageDicePF2e | ModifierPF2e)[];
+    modifiers: (DamageDicePF2e | Modifier)[];
     weapon: WeaponPF2e | null;
     options: Set<string>;
 }

--- a/src/module/system/rolls.ts
+++ b/src/module/system/rolls.ts
@@ -1,4 +1,4 @@
-import type { ModifierPF2e } from "@actor/modifiers.ts";
+import type { Modifier } from "@actor/modifiers.ts";
 import type { RollOrigin, RollTarget } from "@actor/roll-context/types.ts";
 import type { RollMode } from "@common/constants.d.mts";
 import type { AbilityTrait } from "@item/ability/types.ts";
@@ -28,7 +28,7 @@ interface RollParameters {
     /** Callback called when the roll occurs. */
     callback?: (roll: dice.Rolled<Roll>) => void | Promise<void>;
     /** Additional modifiers */
-    modifiers?: ModifierPF2e[];
+    modifiers?: Modifier[];
     /** Whether to create a message from the roll */
     createMessage?: boolean;
 }

--- a/src/module/system/statistic/armor-class.ts
+++ b/src/module/system/statistic/armor-class.ts
@@ -1,6 +1,6 @@
 import type { ActorPF2e, CreaturePF2e } from "@actor";
 import { createShoddyPenalty } from "@actor/character/helpers.ts";
-import { ModifierPF2e, StatisticModifier } from "@actor/modifiers.ts";
+import { Modifier, StatisticModifier } from "@actor/modifiers.ts";
 import { AttributeString } from "@actor/types.ts";
 import type { ArmorPF2e } from "@item";
 import { ZeroToFour } from "@module/data.ts";
@@ -38,12 +38,12 @@ class ArmorStatistic<TActor extends ActorPF2e = ActorPF2e> extends Statistic<TAc
     }
 
     /** If this statistic belongs to a PC, create bonuses and penalties from their worn armor */
-    #createBonusesAndPenalties(): ModifierPF2e[] {
+    #createBonusesAndPenalties(): Modifier[] {
         const actor = this.actor;
         const armor = actor.isOfType("character") ? actor.wornArmor : null;
         const armorSlug = armor?.baseType ?? armor?.slug ?? sluggify(armor?.name ?? "");
         const itemBonus = armor
-            ? new ModifierPF2e({
+            ? new Modifier({
                   label: armor.name,
                   type: "item",
                   slug: armorSlug,
@@ -60,7 +60,7 @@ class ArmorStatistic<TActor extends ActorPF2e = ActorPF2e> extends Statistic<TAc
         );
     }
 
-    #createShieldBonus(): ModifierPF2e | null {
+    #createShieldBonus(): Modifier | null {
         const { actor } = this;
         if (!actor.isOfType("character", "npc")) return null;
 
@@ -68,7 +68,7 @@ class ArmorStatistic<TActor extends ActorPF2e = ActorPF2e> extends Statistic<TAc
         const slug = "raised-shield";
 
         return shieldData.raised && !shieldData.broken
-            ? new ModifierPF2e({
+            ? new Modifier({
                   label: shieldData.name,
                   slug,
                   adjustments: extractModifierAdjustments(

--- a/src/module/system/statistic/base.ts
+++ b/src/module/system/statistic/base.ts
@@ -1,5 +1,5 @@
 import type { ActorPF2e } from "@actor";
-import { StatisticModifier, type ModifierPF2e } from "@actor/modifiers.ts";
+import { StatisticModifier, type Modifier } from "@actor/modifiers.ts";
 import { extractModifiers } from "@module/rules/helpers.ts";
 import * as R from "remeda";
 import { BaseStatisticData, BaseStatisticTraceData, StatisticData } from "./data.ts";
@@ -17,7 +17,7 @@ abstract class BaseStatistic<TActor extends ActorPF2e> {
     /** String category identifiers: used to retrieve modifiers and other synthetics as well as create roll options  */
     domains: string[];
     /** Penalties, bonuses, and actual modifiers comprising a total modifier value */
-    modifiers: ModifierPF2e[];
+    modifiers: Modifier[];
 
     constructor(actor: TActor, data: BaseStatisticData) {
         this.actor = actor;

--- a/src/module/system/statistic/data.ts
+++ b/src/module/system/statistic/data.ts
@@ -1,4 +1,4 @@
-import type { ModifierPF2e, RawModifier } from "@actor/modifiers.ts";
+import type { Modifier, RawModifier } from "@actor/modifiers.ts";
 import { AttributeString } from "@actor/types.ts";
 import { ZeroToFour } from "@module/data.ts";
 import { CheckType } from "@system/check/index.ts";
@@ -10,7 +10,7 @@ interface BaseStatisticData {
     /** Base domains for fetching actor roll options */
     domains?: string[];
     /** Modifiers not retrieved from the actor's synthetics record */
-    modifiers?: ModifierPF2e[];
+    modifiers?: Modifier[];
 }
 
 /** Used to build the actual statistic object */
@@ -23,7 +23,7 @@ interface StatisticData extends BaseStatisticData {
     check?: StatisticCheckData;
     dc?: StatisticDifficultyClassData;
     /** If given, filters all automatically acquired modifiers */
-    filter?: (m: ModifierPF2e) => boolean;
+    filter?: (m: Modifier) => boolean;
     /**
      * Any static roll options that should be added to the list of roll options.
      * This does not include actor, rank, or basic item roll options.
@@ -37,7 +37,7 @@ interface StatisticCheckData {
     /** Additional domains for fetching actor roll options */
     domains?: string[];
     /** Modifiers not retrieved from the actor's synthetics record */
-    modifiers?: ModifierPF2e[];
+    modifiers?: Modifier[];
 }
 
 interface StatisticDifficultyClassData {
@@ -45,7 +45,7 @@ interface StatisticDifficultyClassData {
     domains?: string[];
     label?: string;
     /** Modifiers not retrieved from the actor's synthetics record */
-    modifiers?: ModifierPF2e[];
+    modifiers?: Modifier[];
 }
 
 /** Defines view data for chat message and sheet rendering */

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -1,5 +1,5 @@
 import type { ActorPF2e } from "@actor";
-import { ModifierPF2e } from "@actor/modifiers.ts";
+import { Modifier } from "@actor/modifiers.ts";
 import { ActorSheetPF2e } from "@actor/sheet/base.ts";
 import { SAVE_TYPES } from "@actor/values.ts";
 import type { EnrichmentOptions } from "@client/applications/ux/text-editor.d.mts";
@@ -875,7 +875,7 @@ function getCheckDC({
             params.type === "flat"
                 ? ["inline-flat-check-dc"]
                 : ["all", "inline-dc", idDomain, slugDomain].filter(R.isTruthy);
-        const modifier = new ModifierPF2e({
+        const modifier = new Modifier({
             slug: "base",
             label: "PF2E.ModifierTitle",
             modifier: base - 10,

--- a/src/pf2e.ts
+++ b/src/pf2e.ts
@@ -2,3 +2,7 @@ import { HooksPF2e } from "@scripts/hooks/index.ts";
 import "./styles/main.scss";
 
 HooksPF2e.listen();
+
+export { AutomaticBonusProgression } from "@actor/character/automatic-bonus-progression.ts";
+export { ElementalBlast } from "@actor/character/elemental-blast.ts";
+export { RuleElement } from "@module/rules/index.ts";

--- a/src/scripts/config/index.ts
+++ b/src/scripts/config/index.ts
@@ -37,7 +37,6 @@ import { PreciousMaterialGrade } from "@item/physical/types.ts";
 import { MeleeWeaponGroup, WeaponCategory, WeaponGroup, WeaponReloadTime } from "@item/weapon/types.ts";
 import { Size, ZeroToThree } from "@module/data.ts";
 import { JournalSheetPF2e } from "@module/journal-entry/sheet.ts";
-import { RuleElementPF2e, RuleElements } from "@module/rules/index.ts";
 import { configFromLocalization, sluggify } from "@util";
 import * as R from "remeda";
 import {
@@ -804,12 +803,4 @@ export const PF2ECONFIG = {
             gmVision: 0xd1ccff,
         },
     },
-
-    RuleElement: RuleElementPF2e,
-    RuleElements,
 };
-
-Object.defineProperties(PF2ECONFIG, {
-    RuleElement: { configurable: false, writable: false },
-    RuleElements: { configurable: false },
-});

--- a/src/scripts/handlebars.ts
+++ b/src/scripts/handlebars.ts
@@ -1,5 +1,5 @@
-import type { Coins, PartialPrice } from "@item/physical/data.ts";
-import { CoinsPF2e } from "@item/physical/helpers.ts";
+import type { PartialPrice, RawCoins } from "@item/physical/data.ts";
+import { Coins } from "@item/physical/helpers.ts";
 import { getActionGlyph, ordinalString, signedInteger, sluggify } from "@util";
 import * as R from "remeda";
 
@@ -102,13 +102,13 @@ export function registerHandlebarsHelpers(): void {
         return signedInteger(number, { emptyStringZero, zeroIsNegative });
     });
 
-    Handlebars.registerHelper("coinLabel", (value: Maybe<Coins | PartialPrice>): CoinsPF2e | null => {
+    Handlebars.registerHelper("coinLabel", (value: Maybe<RawCoins | PartialPrice>): Coins | null => {
         if (!value) return null;
         if ("value" in value) {
             // todo: handle per pricing
-            return new CoinsPF2e(value.value);
+            return new Coins(value.value);
         }
-        return new CoinsPF2e(value);
+        return new Coins(value);
     });
 
     Handlebars.registerHelper("includes", (data: unknown, element: unknown): boolean => {

--- a/src/scripts/hooks/init.ts
+++ b/src/scripts/hooks/init.ts
@@ -9,6 +9,7 @@ import {
     ItemDirectoryPF2e,
 } from "@module/apps/sidebar/index.ts";
 import { setPerceptionModes } from "@module/canvas/perception/modes.ts";
+import { PF2ECONFIG } from "@scripts/config/index.ts";
 import { registerHandlebarsHelpers } from "@scripts/handlebars.ts";
 import { registerFonts } from "@scripts/register-fonts.ts";
 import { registerKeybindings } from "@scripts/register-keybindings.ts";
@@ -29,6 +30,7 @@ export const Init = {
                 delete game.system.documentTypes.Item.affliction;
             }
 
+            CONFIG.PF2E = PF2ECONFIG;
             CONFIG.debug.ruleElement ??= false;
 
             setPerceptionModes();

--- a/src/scripts/hooks/load.ts
+++ b/src/scripts/hooks/load.ts
@@ -54,7 +54,6 @@ import {
 } from "@scene/index.ts";
 import { DifficultTerrainBehaviorType } from "@scene/region-behavior/difficult-terrain.ts";
 import { PrototypeTokenConfigPF2e } from "@scene/token-document/index.ts";
-import { PF2ECONFIG } from "@scripts/config/index.ts";
 import { monkeyPatchFoundry } from "@scripts/🐵🩹.ts";
 import { CheckRoll, StrikeAttackRoll } from "@system/check/roll.ts";
 import { ClientDatabaseBackendPF2e } from "@system/client-backend.ts";
@@ -66,8 +65,6 @@ import * as R from "remeda";
 /** Not an actual hook listener but rather things to run on initial load */
 export class Load {
     static listen(): void {
-        CONFIG.PF2E = PF2ECONFIG;
-
         // Assign database backend to handle migrations
         CONFIG.DatabaseBackend = new ClientDatabaseBackendPF2e();
 

--- a/src/scripts/macros/earn-income/helpers.ts
+++ b/src/scripts/macros/earn-income/helpers.ts
@@ -1,5 +1,5 @@
 import type { CharacterPF2e } from "@actor";
-import { CoinsPF2e } from "@item/physical/helpers.ts";
+import { Coins } from "@item/physical/helpers.ts";
 import { ChatMessagePF2e } from "@module/chat-message/index.ts";
 import { OneToFour } from "@module/data.ts";
 import { calculateDC } from "@module/dc.ts";
@@ -23,7 +23,7 @@ function degreeOfSuccessLabel(degreeIndex: DegreeOfSuccessIndex): string {
     return game.i18n.localize(`PF2E.Check.Result.Degree.Check.${degreeSlug}`);
 }
 
-function coinsToString(coins: CoinsPF2e, degreeOfSuccess: DegreeOfSuccessIndex): string {
+function coinsToString(coins: Coins, degreeOfSuccess: DegreeOfSuccessIndex): string {
     if (degreeOfSuccess === 0) {
         return "none";
     } else {

--- a/src/scripts/set-game-pf2e.ts
+++ b/src/scripts/set-game-pf2e.ts
@@ -1,13 +1,13 @@
 import { Action } from "@actor/actions/index.ts";
 import { AutomaticBonusProgression } from "@actor/character/automatic-bonus-progression.ts";
 import { ElementalBlast } from "@actor/character/elemental-blast.ts";
-import { CheckModifier, ModifierPF2e, StatisticModifier } from "@actor/modifiers.ts";
-import { CoinsPF2e, generateItemName } from "@item/physical/helpers.ts";
+import { CheckModifier, Modifier, StatisticModifier } from "@actor/modifiers.ts";
+import { Coins, generateItemName } from "@item/physical/helpers.ts";
 import { CompendiumBrowser } from "@module/apps/compendium-browser/browser.ts";
 import { EffectsPanel } from "@module/apps/effects-panel.ts";
 import { WorldClock } from "@module/apps/world-clock/index.ts";
 import { StatusEffects } from "@module/canvas/status-effects.ts";
-import { RuleElementPF2e } from "@module/rules/index.ts";
+import { RuleElement, RuleElements } from "@module/rules/index.ts";
 import { DicePF2e } from "@scripts/dice.ts";
 import {
     calculateXP,
@@ -29,7 +29,7 @@ import {
 } from "@scripts/macros/index.ts";
 import { remigrate } from "@scripts/system/remigrate.ts";
 import { ActionMacros, SystemActions } from "@system/action-macros/index.ts";
-import { CheckPF2e } from "@system/check/check.ts";
+import { Check } from "@system/check/check.ts";
 import { ConditionManager } from "@system/conditions/index.ts";
 import { EffectTracker } from "@system/effect-tracker.ts";
 import { ModuleArt } from "@system/module-art.ts";
@@ -70,15 +70,17 @@ export const SetGamePF2e = {
         } as const;
 
         const initSafe: Partial<(typeof game)["pf2e"]> = {
-            Check: CheckPF2e,
+            Check: Check,
             CheckModifier,
-            Coins: CoinsPF2e,
+            Coins: Coins,
             ConditionManager,
             Dice: DicePF2e,
             ElementalBlast,
-            Modifier: ModifierPF2e,
+            Modifier: Modifier,
             ModifierType: MODIFIER_TYPE,
             Predicate: Predicate,
+            RuleElement: RuleElement,
+            RuleElements: RuleElements,
             StatisticModifier: StatisticModifier,
             StatusEffects: StatusEffects,
             TextEditor: TextEditorPF2e,
@@ -99,11 +101,7 @@ export const SetGamePF2e = {
             system: { generateItemName, moduleArt: new ModuleArt(), remigrate, sluggify },
             variantRules: { AutomaticBonusProgression },
         };
-        game.pf2e = Object.assign(game.pf2e ?? {}, initSafe);
-        Object.defineProperties(game.pf2e, {
-            RuleElement: { get: () => RuleElementPF2e },
-            RuleElements: { get: () => CONFIG.PF2E.RuleElements },
-        });
+        game.pf2e = fu.mergeObject(game.pf2e ?? {}, initSafe);
 
         const campaignType = game.settings.get("pf2e", "campaignType");
         game.pf2e.settings = {

--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -1,5 +1,5 @@
 import { ActorPF2e } from "@actor";
-import { ModifierPF2e } from "@actor/modifiers.ts";
+import { Modifier } from "@actor/modifiers.ts";
 import { SAVE_TYPES } from "@actor/values.ts";
 import type { ClientDocument } from "@client/documents/abstract/client-document.d.mts";
 import type { MeasuredTemplateType } from "@common/constants.d.mts";
@@ -261,7 +261,7 @@ export class InlineRollLinks {
                 } else if (against) {
                     const defenseStat = opposingActor?.getStatistic(against)?.clone({
                         modifiers: adjustment
-                            ? [new ModifierPF2e({ label: "PF2E.InlineCheck.DCAdjustment", modifier: adjustment })]
+                            ? [new Modifier({ label: "PF2E.InlineCheck.DCAdjustment", modifier: adjustment })]
                             : [],
                         rollOptions: [
                             item?.isOfType("action", "feat") ? `${opposingRole}:action:slug:${item.slug}` : null,


### PR DESCRIPTION
Also:
- Revert "Move `RuleElement` and `RuleElements` objects to `CONFIG.PF2E`" (ffae14a17595a25f85e37f8f11fb30bf2d3f01c3).
- Drop `PF2e` suffix from class names where unnecessary