### PR TITLE
Fix the DCs of coven spells for legacy hags

### DIFF
--- a/packs/pathfinder-bestiary-3/blood-hag.json
+++ b/packs/pathfinder-bestiary-3/blood-hag.json
@@ -71,8 +71,8 @@
                 "slots": {},
                 "slug": null,
                 "spelldc": {
-                    "dc": 23,
-                    "value": 15
+                    "dc": 26,
+                    "value": 18
                 },
                 "tradition": {
                     "value": "occult"

--- a/packs/pathfinder-bestiary-3/moon-hag.json
+++ b/packs/pathfinder-bestiary-3/moon-hag.json
@@ -71,8 +71,8 @@
                 "slots": {},
                 "slug": null,
                 "spelldc": {
-                    "dc": 23,
-                    "value": 15
+                    "dc": 29,
+                    "value": 21
                 },
                 "tradition": {
                     "value": "occult"

--- a/packs/pathfinder-bestiary-3/storm-hag.json
+++ b/packs/pathfinder-bestiary-3/storm-hag.json
@@ -72,9 +72,9 @@
                 "slots": {},
                 "slug": null,
                 "spelldc": {
-                    "dc": 23,
+                    "dc": 22,
                     "mod": 0,
-                    "value": 15
+                    "value": 14
                 },
                 "tradition": {
                     "value": "occult"

--- a/packs/pathfinder-bestiary-3/winter-hag.json
+++ b/packs/pathfinder-bestiary-3/winter-hag.json
@@ -71,8 +71,8 @@
                 "slots": {},
                 "slug": null,
                 "spelldc": {
-                    "dc": 23,
-                    "value": 15
+                    "dc": 25,
+                    "value": 17
                 },
                 "tradition": {
                     "value": "occult"

--- a/packs/pathfinder-bestiary/night-hag.json
+++ b/packs/pathfinder-bestiary/night-hag.json
@@ -74,9 +74,9 @@
                 "slots": {},
                 "slug": null,
                 "spelldc": {
-                    "dc": 23,
+                    "dc": 28,
                     "mod": 0,
-                    "value": 15
+                    "value": 20
                 },
                 "tradition": {
                     "value": "occult"


### PR DESCRIPTION
Addresses https://github.com/foundryvtt/pf2e/issues/20165
Specifically this fixes the DCs for coven spells of Winter Hag, Blood Hag, Moon Hag, Night Hag, and Storm Hag. 