### PR TITLE
Fix the extra precision damage of the item Mantis Embrace's Crushing Embrace

### DIFF
--- a/packs/equipment/mantis-embrace.json
+++ b/packs/equipment/mantis-embrace.json
@@ -57,7 +57,7 @@
             },
             {
                 "category": "precision",
-                "diceNumber": 5,
+                "diceNumber": 3,
                 "dieSize": "d6",
                 "key": "DamageDice",
                 "predicate": [


### PR DESCRIPTION
Fixes https://github.com/foundryvtt/pf2e/issues/20262

Looks like it was set to 5 because that's what Mantis Embrace Greater is