### PR TITLE
Fix the magic immunities for the Flickerwisp

### DIFF
--- a/packs/abomination-vaults-bestiary/book-1-ruins-of-gauntlight/flickerwisp.json
+++ b/packs/abomination-vaults-bestiary/book-1-ruins-of-gauntlight/flickerwisp.json
@@ -152,7 +152,31 @@
                     "remaster": false,
                     "title": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "exceptions": [
+                            {
+                                "definition": [
+                                    "item:type:spell",
+                                    {
+                                        "or": [
+                                            "item:slug:gust-of-wind",
+                                            "item:slug:magic-missile",
+                                            "item:slug:maze",
+                                            "item:slug:faerie-fire",
+                                            "item:slug:force-barrage",
+                                            "item:slug:quandary",
+                                            "item:slug:revealing-light"
+                                        ]
+                                    }
+                                ],
+                                "label": "PF2E.IWR.Custom.WispVulnerabilities"
+                            }
+                        ],
+                        "key": "Immunity",
+                        "type": "magic"
+                    }
+                ],
                 "slug": null,
                 "traits": {
                     "rarity": "common",


### PR DESCRIPTION
Fixes https://github.com/foundryvtt/pf2e/issues/20252

Updated to exclude Gust of Wind, Magic Missile (Force Barrage), Faerie Fire (Revealing Light), and Maze (Quandary) 

Per AoN:
<img width="1173" height="568" alt="image" src="https://github.com/user-attachments/assets/24e5fba3-bb12-4577-8880-f7375a560647" />
