### PR TITLE
Fix most issues with calculation of derived speeds

### DIFF
--- a/src/module/actor/character/helpers.ts
+++ b/src/module/actor/character/helpers.ts
@@ -401,25 +401,6 @@ function createShoddyPenalty(
 
 /**
  * Create a penalty for wearing armor with the "ponderous" trait
- * "You take a –5 penalty to all your Speeds (to a minimum of a 5-foot Speed). This is separate from and in addition to
- * the armor's Speed penalty, and affects you even if your Strength or an ability lets you reduce or ignore the armor's
- * Speed penalty."
- */
-function createHinderingPenalty(actor: CharacterPF2e): Modifier | null {
-    const slug = "hindering";
-    return actor.wornArmor?.traits.has(slug)
-        ? new Modifier({
-              label: "PF2E.TraitHindering",
-              type: "untyped",
-              slug,
-              modifier: -5,
-              adjustments: [],
-          })
-        : null;
-}
-
-/**
- * Create a penalty for wearing armor with the "ponderous" trait
  * "While wearing the armor, you take a –1 penalty to initiative checks. If you don't meet the armor's required Strength
  * score, this penalty increases to be equal to the armor's check penalty if it's worse."
  */
@@ -443,7 +424,6 @@ export {
     PCAttackTraitHelpers,
     WeaponAuxiliaryAction,
     createForceOpenPenalty,
-    createHinderingPenalty,
     createPonderousPenalty,
     createShoddyPenalty,
     getItemProficiencyRank,

--- a/src/module/rules/rule-element/base-speed.ts
+++ b/src/module/rules/rule-element/base-speed.ts
@@ -18,7 +18,6 @@ class BaseSpeedRuleElement extends RuleElement<BaseSpeedRuleSchema> {
         if (this.invalid) return;
 
         this.selector = this.selector.trim().replace(/-speed$/, "");
-
         if (typeof this.value !== "string" && typeof this.value !== "number" && !this.isBracketedValue(this.value)) {
             this.failValidation("A value must be a number, string, or bracketed value");
         }
@@ -54,10 +53,8 @@ class BaseSpeedRuleElement extends RuleElement<BaseSpeedRuleSchema> {
             }
             // Whether this speed is derived from the creature's land speed
             const derivedFromLand =
-                type !== "land" &&
-                typeof this.value === "string" &&
-                /attributes\.speed\.(?:value|total)/.test(this.value);
-            return { type: type, value, source: this.item.name, derivedFromLand };
+                type !== "land" && typeof this.value === "string" && this.value.includes("movement.speeds.land.value");
+            return { type: type, value, source: this.getReducedLabel(), derivedFromLand };
         };
     }
 }

--- a/src/module/system/statistic/speed.ts
+++ b/src/module/system/statistic/speed.ts
@@ -2,7 +2,7 @@ import { ActorPF2e } from "@actor";
 import { StatisticModifier } from "@actor/modifiers.ts";
 import { MovementType } from "@actor/types.ts";
 import { extractModifierAdjustments, extractModifiers } from "@module/rules/helpers.ts";
-import { ErrorPF2e } from "@util";
+import { ErrorPF2e, localizer } from "@util";
 import { BaseStatistic } from "./base.ts";
 import { BaseStatisticData, BaseStatisticTraceData } from "./data.ts";
 
@@ -48,8 +48,10 @@ class SpeedStatistic<TActor extends ActorPF2e, TType extends MovementType | "tra
     #value: number | null = null;
 
     get breakdown(): string {
-        const typeLabel = game.i18n.localize(`PF2E.Actor.Speed.Type.${this.type.capitalize()}`);
-        const baseLabel = game.i18n.format("PF2E.Actor.Speed.BaseLabel", { value: this.base, type: typeLabel });
+        const localize = localizer("PF2E.Actor.Speed");
+        const typeLabel = localize(`Type.${this.type.capitalize()}`);
+        const baseKey = this.source ? "BaseWithSource" : "BaseLabel";
+        const baseLabel = localize(baseKey, { value: this.base, type: typeLabel, source: this.source });
         const components = this.modifiers
             .filter((m) => m.enabled && m.value !== 0)
             .map((m) => `${m.label} ${m.signedValue}`);
@@ -58,15 +60,8 @@ class SpeedStatistic<TActor extends ActorPF2e, TType extends MovementType | "tra
 
     /** Derive a travel speed from this statistic. */
     extend<TType extends MovementType | "travel">(options: ExtendParams<TType>): SpeedStatistic<TActor, TType> {
-        const base = options.base ?? this.base;
-        const source = options.source ?? this.source;
-        const modifiers = [
-            options.modifiers ?? [],
-            this.modifiers
-                .filter((m) => !["all-speeds", "speed"].some((d) => m.domains.includes(d)))
-                .map((m) => m.clone()),
-        ].flat();
-        return new SpeedStatistic(this.actor, { type: options.type, base, modifiers, source });
+        const { type, base = this.value, modifiers = [], source = this.source } = options;
+        return new SpeedStatistic(this.actor, { type, base, modifiers, domains: [`${type}-speed`], source });
     }
 
     override getTraceData(): SpeedStatisticTraceData<TType> {
@@ -109,7 +104,7 @@ interface LandSpeedStatisticTraceData extends SpeedStatisticTraceData {
 }
 
 interface ExtendParams<TType extends MovementType | "travel">
-    extends Pick<SpeedStatisticData<TType>, "type" | "base" | "source" | "modifiers"> {}
+    extends Pick<SpeedStatisticData<TType>, "type" | "base" | "modifiers" | "source"> {}
 
 export { SpeedStatistic };
 export type { LandSpeedStatisticTraceData, SpeedStatisticTraceData };

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -571,6 +571,7 @@
             },
             "Speed": {
                 "BaseLabel": "{value}-Foot {type} Speed",
+                "BaseWithSource": "{value}-Foot {type} Speed ({source})",
                 "Plural": "Speeds",
                 "Label": "Speed",
                 "LabelFeet": "Speed (Feet)",


### PR DESCRIPTION
There remains an edge case: a typed bonus/penalty applied specifically to a non-land speed should get run through stacking rules against bonuses/penalties inherited from land speed. It's edgy enough to look at later, though.