### PR TITLE
Replace `CompendiumBrowser` checkbox filters with a tri-state filter component

### DIFF
--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -1289,11 +1289,10 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
         }
 
         // Assign categories
-        const category = filter.checkboxes.category;
+        const category = filter.chips.category;
         for (const value of featFilters.categories ?? []) {
             category.isExpanded = true;
-            category.options[value].selected = true;
-            category.selected.push(value);
+            category.selected.push({ value });
         }
 
         // Assign traits
@@ -1302,6 +1301,13 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
             (featFilters?.traits ?? []).map((trait) => ({ trait, not: false })),
             (featFilters?.omitTraits ?? []).map((trait) => ({ trait, not: true })),
         ].flat();
+        // Add a trait filter entry for ancestry items without ancestry traits
+        if (category.selected.some((c) => c.value === "ancestry")) {
+            filterTraits.push({
+                trait: "ancestry:universal",
+                not: true,
+            });
+        }
         for (const { trait, not } of filterTraits) {
             const data = traits.options.find((t) => t.value === trait);
             if (data) {

--- a/src/module/actor/party/kingdom/sheet.ts
+++ b/src/module/actor/party/kingdom/sheet.ts
@@ -454,9 +454,8 @@ class KingdomSheetPF2e extends ActorSheetPF2e<PartyPF2e> {
                 levels.isExpanded = levels.to !== levels.max;
 
                 // Set category
-                filter.checkboxes.category.options["kingdom-feat"].selected = true;
-                filter.checkboxes.category.selected.push("kingdom-feat");
-                filter.checkboxes.category.isExpanded = true;
+                filter.chips.category.selected.push({ value: "kingdom-feat" });
+                filter.chips.category.isExpanded = true;
 
                 compendiumTab.open({ filter });
             });

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -947,14 +947,13 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends fav1.sheets.Acto
         const levelString = element.dataset.level;
         const tab = game.pf2e.compendiumBrowser.tabs.equipment;
         const filter = await tab.getFilterData();
-        const checkboxes = filter.checkboxes;
+        const chipsFilters = filter.chips;
 
         for (const itemType of checkboxesFilterCodes) {
-            const checkbox = checkboxes.itemTypes;
-            if (objectHasKey(checkbox.options, itemType)) {
-                checkbox.options[itemType].selected = true;
-                checkbox.selected.push(itemType);
-                checkbox.isExpanded = true;
+            const chips = chipsFilters.itemTypes;
+            if (chips.options.some((o) => o.value === itemType)) {
+                chips.selected.push({ value: itemType });
+                chips.isExpanded = true;
             }
         }
 

--- a/src/module/apps/compendium-browser/components/filters/chips.svelte
+++ b/src/module/apps/compendium-browser/components/filters/chips.svelte
@@ -1,0 +1,131 @@
+<script lang="ts">
+    import { slide } from "svelte/transition";
+    import type { ChipsData, LabeledValue } from "../../tabs/data.ts";
+    import FilterContainer from "./filter-container.svelte";
+
+    interface Props {
+        chipsKey: string;
+        chips: ChipsData;
+    }
+    const { chips = $bindable(), chipsKey }: Props = $props();
+
+    function onClickChips(event: MouseEvent, option: LabeledValue): void {
+        const selected = chips.selected.find((s) => s.value === option.value);
+        if (event.button === 0) {
+            if (selected) {
+                if (selected.exclude) {
+                    chips.selected.findSplice((s) => s.value === selected.value);
+                } else {
+                    selected.exclude = true;
+                }
+            } else {
+                chips.selected.push({ value: option.value, exclude: event.shiftKey });
+            }
+        } else if (event.button === 2 && selected) {
+            chips.selected.findSplice((s) => s.value === selected.value);
+        }
+    }
+
+    function onChangeConjunction(event: Event & { currentTarget: HTMLInputElement }): void {
+        const value = event.currentTarget.value;
+        if (value !== "and" && value !== "or") return;
+        chips.conjunction = value;
+    }
+
+    function clear(): void {
+        chips.selected.length = 0;
+        const defaultFilter = game.pf2e.compendiumBrowser.activeTab.defaultFilterData;
+        const defaultValue = fu.getProperty(defaultFilter, `chips.${chipsKey}.conjunction`) as "and" | "or" | undefined;
+        if (!defaultValue)
+            return console.error(`Failed to retrieve default conjunction value for chips filter: ${chipsKey}!`);
+        chips.conjunction = defaultValue;
+    }
+</script>
+
+<FilterContainer
+    bind:isExpanded={chips.isExpanded}
+    clearButton={{
+        options: { visible: chips.selected.length > 0 },
+        clear,
+    }}
+    label={chips.label}
+>
+    <div transition:slide>
+        <div class="chips">
+            {#each chips.options as option}
+                {@const selected = chips.selected.find((s) => s.value === option.value)}
+                {@const exclude = !!selected?.exclude}
+                <button
+                    class="chip"
+                    onclick={(event) => onClickChips(event, option)}
+                    oncontextmenu={(event) => onClickChips(event, option)}
+                >
+                    {#if exclude}
+                        <i class="fa-solid fa-duotone fa-circle-xmark fa-lg active" class:exclude></i>
+                    {:else}
+                        <i class="fa-solid fa-duotone fa-circle-check fa-lg" class:active={!!selected}></i>
+                    {/if}
+                    {option.label}
+                </button>
+            {/each}
+        </div>
+        {#if chips.showConjunction}
+            <div class="filter-conjunction">
+                <label class="checkbox">
+                    <input
+                        type="radio"
+                        value="and"
+                        checked={chips.conjunction === "and"}
+                        onchange={onChangeConjunction}
+                    />
+                    {game.i18n.localize("PF2E.CompendiumBrowser.Filter.Conjunction.AndLabel")}
+                </label>
+                <label class="checkbox">
+                    <input
+                        type="radio"
+                        value="or"
+                        checked={chips.conjunction === "or"}
+                        onchange={onChangeConjunction}
+                    />
+                    {game.i18n.localize("PF2E.CompendiumBrowser.Filter.Conjunction.OrLabel")}
+                </label>
+            </div>
+        {/if}
+    </div>
+</FilterContainer>
+
+<style lang="scss">
+    .chips {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin: 0.35rem;
+
+        .chip {
+            font-size: var(--font-size-14);
+            border-radius: 999px;
+            gap: 0.35rem;
+
+            i {
+                --fa-secondary-opacity: 1;
+
+                &.active {
+                    --fa-secondary-color: #009988;
+                }
+
+                &:not(.active) {
+                    --fa-primary-opacity: 0.5;
+                    --fa-secondary-opacity: 0;
+                }
+
+                &.exclude {
+                    --fa-secondary-color: #cc3311;
+                }
+            }
+        }
+    }
+
+    .filter-conjunction {
+        display: flex;
+    }
+</style>

--- a/src/module/apps/compendium-browser/components/filters/filter-container.svelte
+++ b/src/module/apps/compendium-browser/components/filters/filter-container.svelte
@@ -10,15 +10,15 @@
             clear: () => void;
         };
         isExpanded?: boolean;
+        notExpandable?: boolean;
         label: string;
     }
-    const props: Props = $props();
-    let isExpanded = $state(props.isExpanded);
+    let { isExpanded = $bindable(), ...props }: Props = $props();
 </script>
 
 <fieldset>
     <legend>
-        {#if "isExpanded" in props}
+        {#if !props.notExpandable}
             <button
                 type="button"
                 class="flat expand-section"
@@ -75,7 +75,7 @@
 
             button.clear-filter {
                 &:not(:hover) {
-                    background-color: var(--background);
+                    background: var(--background);
                 }
                 line-height: 1.5em;
                 position: absolute;

--- a/src/module/apps/compendium-browser/components/filters/level.svelte
+++ b/src/module/apps/compendium-browser/components/filters/level.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import * as R from "remeda";
     import { slide } from "svelte/transition";
+    import FilterContainer from "./filter-container.svelte";
     import type { LevelData } from "../../tabs/data.ts";
 
     interface Props {
@@ -12,35 +13,46 @@
         const name = event.currentTarget.name;
         const value = Math.clamp(Number(event.currentTarget.value), level.min, level.max);
         if (name === "from") {
-            if (value > level.to) {
-                level.to = value;
-            }
+            if (value > level.to) level.to = value;
             level.from = value;
         } else if (name === "to") {
-            if (value < level.from) {
-                level.from = value;
-            }
+            if (value < level.from) level.from = value;
             level.to = value;
         }
         level.changed = level.from !== level.min || level.to !== level.max;
     }
+
+    function clear(): void {
+        level.from = level.min;
+        level.to = level.max;
+        level.changed = false;
+    }
 </script>
 
-<div class="levels-container" transition:slide>
-    <div class="inputs">
-        <select name="from" value={level.from} onchange={onChangeLevel}>
-            {#each R.range(level.min, level.max + 1) as n}
-                <option value={n}>{n}</option>
-            {/each}
-        </select>
-        -
-        <select name="to" value={level.to} onchange={onChangeLevel}>
-            {#each R.range(level.min, level.max + 1) as n}
-                <option value={n}>{n}</option>
-            {/each}
-        </select>
+<FilterContainer
+    isExpanded={level.isExpanded}
+    clearButton={{
+        options: { visible: level.changed },
+        clear,
+    }}
+    label="PF2E.CompendiumBrowser.Filter.Levels"
+>
+    <div class="levels-container" transition:slide>
+        <div class="inputs">
+            <select name="from" value={level.from} onchange={onChangeLevel}>
+                {#each R.range(level.min, level.max + 1) as n}
+                    <option value={n}>{n}</option>
+                {/each}
+            </select>
+            -
+            <select name="to" value={level.to} onchange={onChangeLevel}>
+                {#each R.range(level.min, level.max + 1) as n}
+                    <option value={n}>{n}</option>
+                {/each}
+            </select>
+        </div>
     </div>
-</div>
+</FilterContainer>
 
 <style lang="scss">
     .levels-container {

--- a/src/module/apps/compendium-browser/components/filters/ranges.svelte
+++ b/src/module/apps/compendium-browser/components/filters/ranges.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { slide } from "svelte/transition";
+    import FilterContainer from "./filter-container.svelte";
     import type { RangesInputData } from "../../tabs/data.ts";
 
     const { name, range = $bindable() }: { name: string; range: RangesInputData } = $props();
@@ -16,29 +17,45 @@
         }
         range.changed = true;
     }
+
+    function clear(): void {
+        const activeTab = game.pf2e.compendiumBrowser.activeTab;
+        if (!activeTab) return;
+        range.values = activeTab.parseRangeFilterInput(name, range.defaultMin, range.defaultMax);
+        range.changed = false;
+    }
 </script>
 
-<div class="ranges-container" transition:slide>
-    <div class="inputs">
-        <input
-            type="text"
-            autocomplete="off"
-            name="lowerBound"
-            placeholder={range.defaultMin}
-            bind:value={range.values.inputMin}
-            onchange={onChangeRange}
-        />
-        -
-        <input
-            type="text"
-            autocomplete="off"
-            name="upperBound"
-            placeholder={range.defaultMax}
-            bind:value={range.values.inputMax}
-            onchange={onChangeRange}
-        />
+<FilterContainer
+    isExpanded={range.isExpanded}
+    clearButton={{
+        options: { visible: range.changed },
+        clear,
+    }}
+    label={range.label}
+>
+    <div class="ranges-container" transition:slide>
+        <div class="inputs">
+            <input
+                type="text"
+                autocomplete="off"
+                name="lowerBound"
+                placeholder={range.defaultMin}
+                bind:value={range.values.inputMin}
+                onchange={onChangeRange}
+            />
+            -
+            <input
+                type="text"
+                autocomplete="off"
+                name="upperBound"
+                placeholder={range.defaultMax}
+                bind:value={range.values.inputMax}
+                onchange={onChangeRange}
+            />
+        </div>
     </div>
-</div>
+</FilterContainer>
 
 <style lang="scss">
     .ranges-container {

--- a/src/module/apps/compendium-browser/components/filters/traits.svelte
+++ b/src/module/apps/compendium-browser/components/filters/traits.svelte
@@ -2,6 +2,7 @@
     import { onMount } from "svelte";
     import type { Action } from "svelte/action";
     import { SvelteSet } from "svelte/reactivity";
+    import FilterContainer from "./filter-container.svelte";
     import TraitsSelect from "./partials/traits-select.svelte";
     import type { TraitData } from "../../tabs/data.ts";
 
@@ -11,7 +12,7 @@
         traits: TraitData;
     }
     const { traits = $bindable() }: Props = $props();
-    const exclude = $state(new SvelteSet<string>());
+    const exclude = new SvelteSet<string>();
 
     function onChangeConjunction(event: Event & { currentTarget: HTMLInputElement }): void {
         const value = event.currentTarget.value;
@@ -45,39 +46,41 @@
     });
 </script>
 
-<TraitsSelect
-    options={traits.options}
-    multiple
-    closeAfterSelect
-    clearable
-    creatable={false}
-    selection={traitSelection}
-    onChange={onChangeTraits}
-    placeholder={game.i18n.localize("PF2E.SelectLabel")}
-    value={traits.selected.map((s) => s.value)}
-/>
-<div class="filter-conjunction">
-    <label class="checkbox">
-        <input
-            type="radio"
-            name="filter-conjunction-and"
-            value="and"
-            checked={traits.conjunction === "and"}
-            onchange={onChangeConjunction}
-        />
-        {game.i18n.localize("PF2E.CompendiumBrowser.Filter.Conjunction.AndLabel")}
-    </label>
-    <label class="checkbox">
-        <input
-            type="radio"
-            name="filter-conjunction-or"
-            value="or"
-            checked={traits.conjunction === "or"}
-            onchange={onChangeConjunction}
-        />
-        {game.i18n.localize("PF2E.CompendiumBrowser.Filter.Conjunction.OrLabel")}
-    </label>
-</div>
+<FilterContainer label="PF2E.Traits" notExpandable={true}>
+    <TraitsSelect
+        options={traits.options}
+        multiple
+        closeAfterSelect
+        clearable
+        creatable={false}
+        selection={traitSelection}
+        onChange={onChangeTraits}
+        placeholder={game.i18n.localize("PF2E.SelectLabel")}
+        value={traits.selected.map((t) => t.value)}
+    />
+    <div class="filter-conjunction">
+        <label class="checkbox">
+            <input
+                type="radio"
+                name="filter-conjunction-and"
+                value="and"
+                checked={traits.conjunction === "and"}
+                onchange={onChangeConjunction}
+            />
+            {game.i18n.localize("PF2E.CompendiumBrowser.Filter.Conjunction.AndLabel")}
+        </label>
+        <label class="checkbox">
+            <input
+                type="radio"
+                name="filter-conjunction-or"
+                value="or"
+                checked={traits.conjunction === "or"}
+                onchange={onChangeConjunction}
+            />
+            {game.i18n.localize("PF2E.CompendiumBrowser.Filter.Conjunction.OrLabel")}
+        </label>
+    </div>
+</FilterContainer>
 
 {#snippet traitSelection(options: TraitOption[], itemAction: Action<HTMLElement, TraitOption>)}
     {#each options as opt, index (opt.value)}
@@ -102,6 +105,7 @@
                 aria-label="deslect"
                 data-action="deselect"
                 use:itemAction={opt}
+                onclick={() => exclude.delete(opt.value)}
             >
                 <svg height="16" width="16" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
                     <path

--- a/src/module/apps/compendium-browser/components/result-item.svelte
+++ b/src/module/apps/compendium-browser/components/result-item.svelte
@@ -17,7 +17,7 @@
                 buyPhysicalItem(uuid);
                 break;
             case "open-sheet":
-                (await fromUuid(uuid))?.sheet.render(true);
+                (await fromUuid(uuid))?.sheet?.render(true);
                 break;
             case "take-item":
                 takePhysicalItem(uuid);
@@ -42,7 +42,7 @@
         event.dataTransfer.setData(
             "text/plain",
             JSON.stringify({
-                type: fu.parseUuid(uuid).documentType,
+                type: fu.parseUuid(uuid)?.documentType,
                 uuid: uuid,
             }),
         );

--- a/src/module/apps/compendium-browser/tabs/data.ts
+++ b/src/module/apps/compendium-browser/tabs/data.ts
@@ -2,35 +2,46 @@ import { CreatureTrait } from "@actor/creature/types.ts";
 import { HazardTrait } from "@actor/hazard/types.ts";
 import type { CompendiumIndexData } from "@client/documents/collections/compendium-collection.d.mts";
 import { AbilityTrait } from "@item/ability/index.ts";
+import { ActionType } from "@item/base/data/index.ts";
 import { KingmakerTrait } from "@item/campaign-feature/types.ts";
 import { FeatTrait } from "@item/feat/types.ts";
 import { PhysicalItemTrait } from "@item/physical/data.ts";
 import type { SearchResult } from "minisearch";
-import { SortDirection } from "../data.ts";
+import type { SortDirection } from "../data.ts";
 
-interface CheckboxOption {
-    label: string;
-    selected: boolean;
-}
-
-type CheckboxOptions = Record<string, CheckboxOption>;
+type LabeledValue<T extends string = string> = { label: string; value: T };
 
 interface CheckboxData {
     isExpanded: boolean;
     label: string;
-    options: CheckboxOptions;
+    options: LabeledValue[];
+    /** Defaults to the object key of this filter */
+    optionPrefix?: string;
     selected: string[];
+}
+
+interface ChipsData<T extends string = string> {
+    conjunction: "and" | "or";
+    isExpanded: boolean;
+    label: string;
+    options: LabeledValue<T>[];
+    /** Defaults to the object key of this filter */
+    optionPrefix?: string;
+    selected: { exclude?: boolean; value: string }[];
+    showConjunction?: boolean;
 }
 
 interface TraitData<T extends string = string> {
     conjunction: "and" | "or";
-    options: { label: string; value: T }[];
-    selected: { label: string; not?: boolean; value: T }[];
+    options: LabeledValue<T>[];
+    selected: { label: string; not?: boolean; value: string }[];
 }
 
 interface SelectData {
     label: string;
-    options: Record<string, string>;
+    options: LabeledValue[];
+    /** Defaults to the object key of this filter */
+    optionPrefix?: string;
     selected: string;
 }
 
@@ -54,6 +65,8 @@ interface RangesInputData {
         inputMax: string;
     };
     label: string;
+    /** Defaults to the object key of this filter */
+    optionPrefix?: string;
 }
 
 interface LevelData {
@@ -70,22 +83,22 @@ interface BaseFilterData {
     search: {
         text: string;
     };
-    traits: TraitData<string>;
+    traits: TraitData;
 }
 
 interface ActionFilters extends BaseFilterData {
-    checkboxes: {
-        types: CheckboxData;
-        category: CheckboxData;
+    chips: {
+        types: ChipsData<ActionType>;
+        category: ChipsData;
     };
     source: CheckboxData;
     traits: TraitData<AbilityTrait>;
 }
 
 interface BestiaryFilters extends BaseFilterData {
-    checkboxes: {
-        rarity: CheckboxData;
-        sizes: CheckboxData;
+    chips: {
+        rarity: ChipsData;
+        sizes: ChipsData;
     };
     source: CheckboxData;
     level: LevelData;
@@ -93,18 +106,18 @@ interface BestiaryFilters extends BaseFilterData {
 }
 
 interface CampaignFeatureFilters extends BaseFilterData {
-    checkboxes: Record<"category" | "rarity", CheckboxData>;
+    chips: Record<"category" | "rarity", ChipsData>;
     level: LevelData;
     source: CheckboxData;
     traits: TraitData<KingmakerTrait>;
 }
 
 interface EquipmentFilters extends BaseFilterData {
-    checkboxes: {
-        armorTypes: CheckboxData;
-        itemTypes: CheckboxData;
-        rarity: CheckboxData;
-        weaponTypes: CheckboxData;
+    chips: {
+        armorTypes: ChipsData;
+        itemTypes: ChipsData;
+        rarity: ChipsData;
+        weaponTypes: ChipsData;
     };
     ranges: {
         price: RangesInputData;
@@ -114,17 +127,19 @@ interface EquipmentFilters extends BaseFilterData {
     traits: TraitData<PhysicalItemTrait>;
 }
 
+type AdditionalFeatTrait = "ancestry:universal";
+
 interface FeatFilters extends BaseFilterData {
-    checkboxes: Record<"category" | "skills" | "rarity", CheckboxData>;
+    chips: Record<"category" | "skills" | "rarity", ChipsData>;
     level: LevelData;
     source: CheckboxData;
-    traits: TraitData<FeatTrait>;
+    traits: TraitData<FeatTrait | AdditionalFeatTrait>;
 }
 
 interface HazardFilters extends BaseFilterData {
-    checkboxes: {
-        complexity: CheckboxData;
-        rarity: CheckboxData;
+    chips: {
+        complexity: ChipsData;
+        rarity: ChipsData;
     };
     level: LevelData;
     source: CheckboxData;
@@ -132,11 +147,12 @@ interface HazardFilters extends BaseFilterData {
 }
 
 interface SpellFilters extends BaseFilterData {
-    checkboxes: {
-        category: CheckboxData;
-        rank: CheckboxData;
-        rarity: CheckboxData;
-        traditions: CheckboxData;
+    chips: {
+        category: ChipsData;
+        rank: ChipsData;
+        rarity: ChipsData;
+        defense: ChipsData;
+        traditions: ChipsData;
     };
     selects: {
         timefilter: SelectData;
@@ -171,12 +187,12 @@ export type {
     BrowserFilterData,
     CampaignFeatureFilters,
     CheckboxData,
-    CheckboxOption,
-    CheckboxOptions,
+    ChipsData,
     CompendiumBrowserIndexData,
     EquipmentFilters,
     FeatFilters,
     HazardFilters,
+    LabeledValue,
     LevelData,
     RangesInputData,
     RenderResultListOptions,

--- a/src/module/apps/compendium-browser/tabs/feat.ts
+++ b/src/module/apps/compendium-browser/tabs/feat.ts
@@ -3,7 +3,7 @@ import * as R from "remeda";
 import { CompendiumBrowser } from "../browser.ts";
 import { ContentTabName } from "../data.ts";
 import { CompendiumBrowserTab } from "./base.svelte.ts";
-import { CompendiumBrowserIndexData, FeatFilters, TraitData } from "./data.ts";
+import { CompendiumBrowserIndexData, FeatFilters } from "./data.ts";
 
 export class CompendiumBrowserFeatTab extends CompendiumBrowserTab {
     tabName: ContentTabName = "feat";
@@ -12,7 +12,7 @@ export class CompendiumBrowserFeatTab extends CompendiumBrowserTab {
 
     /* MiniSearch */
     override searchFields = ["name", "originalName"];
-    override storeFields = ["type", "name", "img", "uuid", "level", "category", "skills", "traits", "rarity", "source"];
+    override storeFields = ["name", "originalName", "img", "uuid", "level", "rarity", "domains"];
 
     #creatureTraits = CONFIG.PF2E.creatureTraits;
 
@@ -47,66 +47,85 @@ export class CompendiumBrowserFeatTab extends CompendiumBrowserTab {
         )) {
             console.debug(`PF2e System | Compendium Browser | ${pack.metadata.label} - ${index.size} entries found`);
             for (const featData of index) {
-                if (featData.type === "feat") {
-                    featData.filters = {};
-                    // Check separately for one of "system.category or "system.featType.value" to provide backward
-                    // compatible support for unmigrated feats in non-system compendiums.
-                    const categoryPaths = ["system.category", "system.featType.value"];
-                    const nonCategoryPaths = indexFields.filter((f) => !categoryPaths.includes(f));
-                    const categoryPathFound = categoryPaths.some((p) => fu.hasProperty(featData, p));
+                if (featData.type !== "feat") continue;
+                // Check separately for one of "system.category or "system.featType.value" to provide backward
+                // compatible support for unmigrated feats in non-system compendiums.
+                const categoryPaths = ["system.category", "system.featType.value"];
+                const nonCategoryPaths = indexFields.filter((f) => !categoryPaths.includes(f));
+                const categoryPathFound = categoryPaths.some((p) => fu.hasProperty(featData, p));
 
-                    if (!this.hasAllIndexFields(featData, nonCategoryPaths) || !categoryPathFound) {
-                        console.warn(
-                            `Feat "${featData.name}" does not have all required data fields.`,
-                            `Consider unselecting pack "${pack.metadata.label}" in the compendium browser settings.`,
-                        );
-                        continue;
-                    }
-
-                    // Accommodate deprecated featType objects
-                    const featType: unknown = featData.system.featType;
-                    if (R.isPlainObject(featType) && "value" in featType && typeof featType.value === "string") {
-                        featData.system.category = featType.value;
-                        delete featData.system.featType;
-                    }
-
-                    // Prerequisites are strings that could contain translated skill names
-                    const prereqs: { value: string }[] = featData.system.prerequisites.value;
-                    const prerequisitesArr = prereqs.map((prerequisite) =>
-                        prerequisite?.value ? prerequisite.value.toLowerCase() : "",
+                if (!this.hasAllIndexFields(featData, nonCategoryPaths) || !categoryPathFound) {
+                    console.warn(
+                        `Feat "${featData.name}" does not have all required data fields.`,
+                        `Consider unselecting pack "${pack.metadata.label}" in the compendium browser settings.`,
                     );
-                    const skills: Set<string> = new Set();
-                    for (const prereq of prerequisitesArr) {
-                        for (const [key, value] of Object.entries(CONFIG.PF2E.skills)) {
-                            // Check the string for the english translation key or a translated skill name
-                            const translated = game.i18n.localize(value.label).toLocaleLowerCase(game.i18n.lang);
-                            if (prereq.includes(key) || prereq.includes(translated)) {
-                                // Alawys record the translation key to enable filtering
-                                skills.add(key);
-                            }
+                    continue;
+                }
+                const domains = new Set<string>();
+                const system = featData.system;
+
+                // Accommodate deprecated featType objects
+                const featType: unknown = system.featType;
+                if (R.isPlainObject(featType) && "value" in featType && typeof featType.value === "string") {
+                    system.category = featType.value;
+                    delete system.featType;
+                }
+
+                // Prerequisites are strings that could contain translated skill names
+                const prereqs: { value: string }[] = system.prerequisites.value;
+                const prerequisitesArr = prereqs.map((prerequisite) =>
+                    prerequisite?.value ? prerequisite.value.toLowerCase() : "",
+                );
+                const skills: Set<string> = new Set();
+                for (const prereq of prerequisitesArr) {
+                    for (const [key, value] of Object.entries(CONFIG.PF2E.skills)) {
+                        // Check the string for the english translation key or a translated skill name
+                        const translated = game.i18n.localize(value.label).toLocaleLowerCase(game.i18n.lang);
+                        if (prereq.includes(key) || prereq.includes(translated)) {
+                            // Alawys record the translation key to enable filtering
+                            skills.add(key);
                         }
                     }
-
-                    // Prepare source
-                    const pubSource = featData.system.publication?.title ?? featData.system.source?.value ?? "";
-                    const sourceSlug = sluggify(pubSource);
-                    if (pubSource) publications.add(pubSource);
-
-                    // Only store essential data
-                    feats.push({
-                        type: featData.type,
-                        name: featData.name,
-                        originalName: featData.originalName, // Added by Babele
-                        img: featData.img,
-                        uuid: featData.uuid,
-                        level: featData.system.level.value,
-                        category: featData.system.category,
-                        skills: [...skills],
-                        traits: featData.system.traits.value.map((t: string) => t.replace(/^hb_/, "")),
-                        rarity: featData.system.traits.rarity,
-                        source: sourceSlug,
-                    });
                 }
+
+                for (const skill of skills) {
+                    domains.add(`skill:${skill}`);
+                }
+
+                const category = system.category;
+                const type = featData.type;
+                const traits: string[] = system.traits.value;
+                // Tag ancestry items without an ancestry trait
+                if (category === "ancestry" && !traits.some((t) => t in this.#creatureTraits)) {
+                    domains.add("trait:ancestry:universal");
+                }
+                domains.add(`category:${category}`);
+                domains.add(`type:${type}`);
+
+                for (const trait of traits) {
+                    domains.add(`trait:${trait.replace(/^hb_/, "")}`);
+                }
+
+                // Prepare source
+                const pubSource = system.publication?.title ?? system.source?.value ?? "";
+                const sourceSlug = sluggify(pubSource);
+                if (pubSource) {
+                    publications.add(pubSource);
+                    domains.add(`source:${sourceSlug}`);
+                }
+
+                domains.add(`level:${system.level.value}`);
+                domains.add(`rarity:${system.traits.rarity}`);
+
+                feats.push({
+                    name: featData.name,
+                    originalName: featData.originalName, // Added by Babele
+                    img: featData.img,
+                    uuid: featData.uuid,
+                    level: featData.system.level.value,
+                    rarity: featData.system.traits.rarity,
+                    domains,
+                });
             }
         }
 
@@ -114,83 +133,51 @@ export class CompendiumBrowserFeatTab extends CompendiumBrowserTab {
         this.indexData = feats;
 
         // Filters
-        this.filterData.checkboxes.category.options = this.generateCheckboxOptions(CONFIG.PF2E.featCategories);
-        this.filterData.checkboxes.skills.options = this.generateCheckboxOptions(CONFIG.PF2E.skills);
-        this.filterData.checkboxes.rarity.options = this.generateCheckboxOptions(CONFIG.PF2E.rarityTraits);
+        this.filterData.chips.category.options = this.generateOptions(CONFIG.PF2E.featCategories);
+        this.filterData.chips.skills.options = this.generateOptions(CONFIG.PF2E.skills);
+        this.filterData.chips.rarity.options = this.generateOptions(CONFIG.PF2E.rarityTraits);
         this.filterData.source.options = this.generateSourceCheckboxOptions(publications);
         this.filterData.traits.options = this.generateMultiselectOptions(CONFIG.PF2E.featTraits);
+
+        // Allow filtering of ancestry items without an ancestry trait
+        this.filterData.traits.options.push({
+            label: game.i18n.localize("PF2E.CompendiumBrowser.Filter.ExtraTraits.UniversalAncestry"),
+            value: "ancestry:universal",
+        });
 
         console.debug("PF2e System | Compendium Browser | Finished loading feats");
     }
 
-    protected override filterTraits(
-        traits: string[],
-        selected: TraitData["selected"],
-        condition: TraitData["conjunction"],
-    ): boolean {
-        // Pre-filter the selected traits if the current ancestry item has no ancestry traits
-        if (
-            this.filterData.checkboxes.category.selected.includes("ancestry") &&
-            !traits.some((t) => t in this.#creatureTraits)
-        ) {
-            const withoutAncestryTraits = selected.filter((t) => !(t.value in this.#creatureTraits));
-            return super.filterTraits(traits, withoutAncestryTraits, condition);
-        }
-        return super.filterTraits(traits, selected, condition);
-    }
-
-    protected override filterIndexData(entry: CompendiumBrowserIndexData): boolean {
-        const { checkboxes, source, traits, level } = this.filterData;
-
-        // Level
-        if (!(entry.level >= level.from && entry.level <= level.to)) return false;
-        // Feat types
-        if (checkboxes.category.selected.length) {
-            if (!checkboxes.category.selected.includes(entry.category)) return false;
-        }
-        // Skills
-        if (checkboxes.skills.selected.length) {
-            if (!this.arrayIncludes(checkboxes.skills.selected, entry.skills)) return false;
-        }
-        // Traits
-        if (!this.filterTraits(entry.traits, traits.selected, traits.conjunction)) return false;
-        // Source
-        if (source.selected.length) {
-            if (!source.selected.includes(entry.source)) return false;
-        }
-        // Rarity
-        if (checkboxes.rarity.selected.length) {
-            if (!checkboxes.rarity.selected.includes(entry.rarity)) return false;
-        }
-        return true;
-    }
-
     protected override prepareFilterData(): FeatFilters {
         return {
-            checkboxes: {
+            chips: {
                 category: {
+                    conjunction: "or",
                     isExpanded: false,
                     label: "PF2E.CompendiumBrowser.Filter.Categories",
-                    options: {},
+                    options: [],
                     selected: [],
                 },
                 skills: {
+                    conjunction: "or",
                     isExpanded: false,
                     label: "PF2E.SkillsLabel",
-                    options: {},
+                    options: [],
+                    optionPrefix: "skill",
                     selected: [],
                 },
                 rarity: {
+                    conjunction: "or",
                     isExpanded: false,
                     label: "PF2E.CompendiumBrowser.Filter.Rarities",
-                    options: {},
+                    options: [],
                     selected: [],
                 },
             },
             source: {
                 isExpanded: false,
                 label: "PF2E.CompendiumBrowser.Filter.Source",
-                options: {},
+                options: [],
                 selected: [],
             },
             traits: {

--- a/src/module/apps/compendium-browser/tabs/spell.ts
+++ b/src/module/apps/compendium-browser/tabs/spell.ts
@@ -2,9 +2,9 @@ import { MAGIC_TRADITIONS } from "@item/spell/values.ts";
 import { getActionGlyph, ordinalString, sluggify } from "@util";
 import * as R from "remeda";
 import { CompendiumBrowser } from "../browser.ts";
-import { ContentTabName } from "../data.ts";
+import type { ContentTabName } from "../data.ts";
 import { CompendiumBrowserTab } from "./base.svelte.ts";
-import { CompendiumBrowserIndexData, SpellFilters } from "./data.ts";
+import type { CompendiumBrowserIndexData, SpellFilters } from "./data.ts";
 
 export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
     tabName: ContentTabName = "spell";
@@ -13,19 +13,7 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
 
     /* MiniSearch */
     override searchFields = ["name", "originalName"];
-    override storeFields = [
-        "type",
-        "name",
-        "img",
-        "uuid",
-        "rank",
-        "time",
-        "traditions",
-        "traits",
-        "categories",
-        "rarity",
-        "source",
-    ];
+    override storeFields = ["name", "originalName", "img", "uuid", "rank", "rarity", "actionGlyph", "domains"];
 
     constructor(browser: CompendiumBrowser) {
         super(browser);
@@ -42,6 +30,7 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
         const publications = new Set<string>();
         const indexFields = [
             "img",
+            "system.defense",
             "system.level.value",
             "system.time",
             "system.traits",
@@ -54,188 +43,186 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
         for await (const { pack, index } of data) {
             console.debug(`PF2e System | Compendium Browser | ${pack.metadata.label} - ${index.size} entries found`);
             for (const spellData of index) {
-                spellData.filters = {};
+                if (spellData.type !== "spell") continue;
+                const domains = new Set<string>();
 
-                if (spellData.type === "spell") {
-                    if ("system" in spellData && R.isPlainObject(spellData.system)) {
-                        spellData.system.ritual ??= null;
-                    }
-
-                    if (!this.hasAllIndexFields(spellData, indexFields)) {
-                        console.warn(
-                            `Item '${spellData.name}' does not have all required data fields. Consider unselecting pack '${pack.metadata.label}' in the compendium browser settings.`,
-                        );
-                        continue;
-                    }
-
-                    const isCantrip = spellData.system.traits.value.includes("cantrip");
-                    const isFocusSpell =
-                        spellData.system.traits.value.includes("focus") ||
-                        (isCantrip && (spellData.system.traits.traditions ?? []).length === 0);
-                    const isRitual = !!spellData.system.ritual;
-                    const isSpell = !isCantrip && !isFocusSpell && !isRitual;
-                    const categories = [
-                        isSpell ? "spell" : null,
-                        isCantrip ? "cantrip" : null,
-                        isFocusSpell ? "focus" : null,
-                        isRitual ? "ritual" : null,
-                    ].filter(R.isTruthy);
-
-                    // format casting time (before value is sluggified)
-                    const actionGlyph = getActionGlyph(spellData.system.time.value);
-
-                    // recording casting times
-                    const time: unknown = spellData.system.time.value;
-                    if (time && typeof time === "string") {
-                        const normalizedTime = time.toLocaleLowerCase("en").includes("reaction")
-                            ? "reaction"
-                            : sluggify(time);
-                        times.add(normalizedTime);
-                        spellData.system.time.value = normalizedTime;
-                    }
-
-                    // Prepare publication source
-                    const { system } = spellData;
-                    const pubSource = String(system.publication?.title ?? system.source?.value ?? "").trim();
-                    const sourceSlug = sluggify(pubSource);
-                    if (pubSource) publications.add(pubSource);
-
-                    spells.push({
-                        type: spellData.type,
-                        name: spellData.name,
-                        originalName: spellData.originalName, // Added by Babele
-                        img: spellData.img,
-                        uuid: spellData.uuid,
-                        rank: spellData.system.level.value,
-                        categories,
-                        time: spellData.system.time,
-                        actionGlyph,
-                        traditions: spellData.system.traits.traditions,
-                        traits: spellData.system.traits.value.map((t: string) => t.replace(/^hb_/, "")),
-                        rarity: spellData.system.traits.rarity,
-                        source: sourceSlug,
-                    });
+                if ("system" in spellData && R.isPlainObject(spellData.system)) {
+                    spellData.system.ritual ??= null;
                 }
+
+                if (!this.hasAllIndexFields(spellData, indexFields)) {
+                    console.warn(
+                        `Item '${spellData.name}' does not have all required data fields. Consider unselecting pack '${pack.metadata.label}' in the compendium browser settings.`,
+                    );
+                    continue;
+                }
+
+                // Category
+                const isCantrip = spellData.system.traits.value.includes("cantrip");
+                const isFocusSpell =
+                    spellData.system.traits.value.includes("focus") ||
+                    (isCantrip && (spellData.system.traits.traditions ?? []).length === 0);
+                const isRitual = !!spellData.system.ritual;
+                const isSpell = !isCantrip && !isFocusSpell && !isRitual;
+                const categories = [
+                    isSpell ? "spell" : null,
+                    isCantrip ? "cantrip" : null,
+                    isFocusSpell ? "focus" : null,
+                    isRitual ? "ritual" : null,
+                ].filter(R.isTruthy);
+                for (const category of categories) {
+                    domains.add(`category:${category}`);
+                }
+
+                // format casting time (before value is sluggified)
+                const actionGlyph = getActionGlyph(spellData.system.time.value);
+
+                // Casting time
+                const time: unknown = spellData.system.time.value;
+                if (time && typeof time === "string") {
+                    const normalizedTime = time.toLocaleLowerCase("en").includes("reaction")
+                        ? "reaction"
+                        : sluggify(time);
+                    times.add(normalizedTime);
+                    spellData.system.time.value = normalizedTime;
+                    domains.add(`time:${normalizedTime}`);
+                }
+
+                for (const tradition of spellData.system.traits.traditions) {
+                    domains.add(`tradition:${tradition}`);
+                }
+
+                for (const trait of spellData.system.traits.value) {
+                    domains.add(`trait:${trait.replace(/^hb_/, "")}`);
+                }
+
+                const defense = spellData.system.defense;
+                if (defense?.save) {
+                    if (defense.save.basic) domains.add(`defense:save:basic`);
+                    domains.add(`defense:save:${defense.save.statistic}`);
+                }
+                if (defense?.passive) domains.add(`defense:passive:${defense.passive.statistic.split("-")[0]}`);
+                if (!defense && domains.has(`trait:attack`) && !domains.has("category:ritual")) {
+                    domains.add(`defense:passive:armor`);
+                }
+
+                // Publication Source
+                const system = spellData.system;
+                const pubSource = String(system.publication?.title ?? system.source?.value ?? "").trim();
+                const sourceSlug = sluggify(pubSource);
+                if (pubSource) {
+                    publications.add(pubSource);
+                    domains.add(`source:${sourceSlug}`);
+                }
+
+                domains.add(`rank:${spellData.system.level.value}`);
+                domains.add(`rarity:${spellData.system.traits.rarity}`);
+                domains.add("type:spell");
+
+                spells.push({
+                    name: spellData.name,
+                    originalName: spellData.originalName, // Added by Babele
+                    img: spellData.img,
+                    uuid: spellData.uuid,
+                    rank: spellData.system.level.value,
+                    actionGlyph,
+                    rarity: spellData.system.traits.rarity,
+                    domains,
+                });
             }
         }
         // Set indexData
         this.indexData = spells;
 
         // Filters
-        this.filterData.checkboxes.traditions.options = this.generateCheckboxOptions(CONFIG.PF2E.magicTraditions);
+        this.filterData.chips.traditions.options = this.generateOptions(CONFIG.PF2E.magicTraditions);
         // Special case for spell ranks
         for (let rank = 1; rank <= 10; rank++) {
-            this.filterData.checkboxes.rank.options[rank] = {
-                label: game.i18n.format("PF2E.Item.Spell.Rank.Ordinal", { rank: ordinalString(rank) }),
-                selected: false,
-            };
+            this.filterData.chips.rank.options.push({
+                label: ordinalString(rank),
+                value: `${rank}`,
+            });
         }
-        this.filterData.checkboxes.rarity.options = this.generateCheckboxOptions(CONFIG.PF2E.rarityTraits, false);
+        this.filterData.chips.rarity.options = this.generateOptions(CONFIG.PF2E.rarityTraits, { sort: false });
+        this.filterData.chips.defense.options = [
+            {
+                label: game.i18n.localize("PF2E.Item.Spell.Defense.BasicSave"),
+                value: "save:basic",
+            },
+            ...this.generateOptions(CONFIG.PF2E.saves, { prefix: "save" }),
+            ...this.generateOptions(R.pick(CONFIG.PF2E.checkDCs.Specific, ["armor", "fortitude", "reflex", "will"]), {
+                prefix: "passive",
+            }),
+        ];
         this.filterData.traits.options = this.generateMultiselectOptions(
             R.omit(CONFIG.PF2E.spellTraits, Array.from(MAGIC_TRADITIONS)),
         );
         this.filterData.source.options = this.generateSourceCheckboxOptions(publications);
-        this.filterData.checkboxes.category.options = this.generateCheckboxOptions(
+        this.filterData.chips.category.options = this.generateOptions(
             {
                 spell: "TYPES.Item.spell",
                 cantrip: "PF2E.TraitCantrip",
                 focus: "PF2E.TraitFocus",
                 ritual: "PF2E.Item.Spell.Ritual.Label",
             },
-            false,
+            { sort: false },
         );
 
-        this.filterData.selects.timefilter.options = [...times].sort().reduce(
-            (result, time) => ({
-                ...result,
-                [sluggify(time)]: time,
-            }),
-            {} as Record<string, string>,
-        );
+        this.filterData.selects.timefilter.options = [...times].sort().map((label) => ({
+            label,
+            value: sluggify(label),
+        }));
 
         console.debug("PF2e System | Compendium Browser | Finished loading spells");
     }
 
-    protected override filterIndexData(indexData: CompendiumBrowserIndexData): boolean {
-        const { checkboxes, source, traits, selects } = this.filterData;
-
-        // Rank
-        if (checkboxes.rank.selected.length > 0) {
-            const ranks = checkboxes.rank.selected.map((r) => Number(r));
-            if (!ranks.includes(indexData.rank)) return false;
-        }
-
-        // Categories
-        if (
-            checkboxes.category.selected.length > 0 &&
-            !R.isShallowEqual([...checkboxes.category.selected].sort(), indexData.categories.sort())
-        ) {
-            return false;
-        }
-
-        // Casting time
-        if (selects.timefilter.selected) {
-            if (!(selects.timefilter.selected === indexData.time.value)) return false;
-        }
-
-        // Traditions
-        if (
-            checkboxes.traditions.selected.length > 0 &&
-            R.intersection(checkboxes.traditions.selected, indexData.traditions).length === 0
-        ) {
-            return false;
-        }
-
-        // Traits
-        if (!this.filterTraits(indexData.traits, traits.selected, traits.conjunction)) {
-            return false;
-        }
-
-        // Rarity
-        if (checkboxes.rarity.selected.length > 0) {
-            if (!checkboxes.rarity.selected.includes(indexData.rarity)) return false;
-        }
-
-        // Source
-        if (source.selected.length > 0) {
-            if (!source.selected.includes(indexData.source)) return false;
-        }
-
-        return true;
-    }
-
     protected override prepareFilterData(): SpellFilters {
         return {
-            checkboxes: {
+            chips: {
                 category: {
+                    conjunction: "and",
                     isExpanded: true,
                     label: "PF2E.CompendiumBrowser.Filter.Categories",
-                    options: {},
+                    options: [],
                     selected: [],
+                    showConjunction: true,
                 },
                 traditions: {
+                    conjunction: "and",
                     isExpanded: true,
                     label: "PF2E.CompendiumBrowser.Filter.Traditions",
-                    options: {},
+                    options: [],
+                    optionPrefix: "tradition",
                     selected: [],
+                    showConjunction: true,
                 },
                 rank: {
+                    conjunction: "or",
                     isExpanded: true,
                     label: "PF2E.Item.Spell.Rank.Plural",
-                    options: {},
+                    options: [],
                     selected: [],
                 },
+                defense: {
+                    conjunction: "or",
+                    isExpanded: false,
+                    label: "PF2E.Item.Spell.Defense.Label",
+                    options: [],
+                    selected: [],
+                    showConjunction: true,
+                },
                 rarity: {
+                    conjunction: "or",
                     isExpanded: false,
                     label: "PF2E.CompendiumBrowser.Filter.Rarities",
-                    options: {},
+                    options: [],
                     selected: [],
                 },
             },
             source: {
                 isExpanded: false,
                 label: "PF2E.CompendiumBrowser.Filter.Source",
-                options: {},
+                options: [],
                 selected: [],
             },
             traits: {
@@ -246,7 +233,8 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
             selects: {
                 timefilter: {
                     label: "PF2E.CompendiumBrowser.Filter.CastingTime",
-                    options: {},
+                    options: [],
+                    optionPrefix: "time",
                     selected: "",
                 },
             },

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1025,6 +1025,9 @@
                     "AndLabel": "All of above",
                     "OrLabel": "Any of above"
                 },
+                "ExtraTraits": {
+                    "UniversalAncestry": "Universal Ancestry"
+                },
                 "FilterSources": "Filter Sources",
                 "InventoryTypes": "Inventory Types",
                 "Levels": "Levels",


### PR DESCRIPTION
This one has grown a bit bigger than I anticipated so I'm pushing this up for review before adding any more to it. The browser should overall work the same as before but there might be some filter edge cases that are not covered.

- Adds a tri-state (neutral, include, exclude) chip filter to make it possible to exclude certain options from searches.
  - The first click includes the option, the second click excludes the options, the third click clears the option.
  - A right clicks clears the option immediately.
  - Shift left click excludes the option immediately.
- Replaces the custom filter implementation with a filter based on a `Predicate` which should make it even easier to implement new filter options.
- Updates all filter options to use arrays of labeled values instead of objects, eliminating the need for conversion before iteration.
- Adds a `Defense` filter to the spell tab that allows filtering by save, AC, basic save, etc.
- Introduces the concept of a custom trait filter that is not based on an actual trait to solve the problem of showing ancestry items that have no ancestry trait:
<img width="388" height="173" alt="image" src="https://github.com/user-attachments/assets/34c6506f-6d88-426e-829f-b4442d2c8f5b" />

- Moves the `FilterContainer` wrapper to the indiviudal filters to remove the need for the `getClearFunction` function.
  
  
<img width="1214" height="1067" alt="image" src="https://github.com/user-attachments/assets/2e5267c2-5102-40d8-9d50-485151327376" />