### PR TITLE
Ensure Energized Spark's Damage Alteration occurs after other similar rules

### DIFF
--- a/packs/actions/break-free.json
+++ b/packs/actions/break-free.json
@@ -20,8 +20,15 @@
         },
         "rules": [
             {
+                "disabledIf": [
+                    {
+                        "not": "divine-spark:bands-of-imprisonment"
+                    }
+                ],
+                "disabledValue": false,
                 "key": "RollOption",
                 "option": "break-free",
+                "priority": 51,
                 "toggleable": true
             },
             {

--- a/packs/actions/flowing-spirit-strike.json
+++ b/packs/actions/flowing-spirit-strike.json
@@ -20,8 +20,15 @@
         },
         "rules": [
             {
+                "disabledIf": [
+                    {
+                        "not": "divine-spark:gleaming-blade"
+                    }
+                ],
+                "disabledValue": false,
                 "key": "RollOption",
                 "option": "flowing-spirit-strike",
+                "priority": 51,
                 "suboptions": [
                     {
                         "label": "PF2E.GenericLabel.StrikeCount.First",

--- a/packs/actions/fracture-mountains.json
+++ b/packs/actions/fracture-mountains.json
@@ -20,8 +20,15 @@
         },
         "rules": [
             {
+                "disabledIf": [
+                    {
+                        "not": "divine-spark:titans-breaker"
+                    }
+                ],
+                "disabledValue": false,
                 "key": "RollOption",
                 "option": "fracture-mountains",
+                "priority": 51,
                 "toggleable": true
             },
             {

--- a/packs/feats/class/exemplar/energized-spark.json
+++ b/packs/feats/class/exemplar/energized-spark.json
@@ -260,6 +260,7 @@
                         ]
                     }
                 ],
+                "priority": 110,
                 "property": "damage-type",
                 "selectors": [
                     "inline-damage",


### PR DESCRIPTION
Namely Flowing Spirit Strike. It eluded testing because Flowing Spirit Strike's rule element wins the priority tie breaker until the exemplar does the level up dance, at which point it goes after Energized Spark. This should ensure Energized Spark always goes after most such cases.

And disable some transcendence toggles if their ikon does not have divine spark.