### PR TITLE
Prevent multiple instances of Precise Debilitations Damage Dice from stacking

### DIFF
--- a/packs/feat-effects/effect-precise-debilitations.json
+++ b/packs/feat-effects/effect-precise-debilitations.json
@@ -27,13 +27,18 @@
             },
             {
                 "category": "precision",
-                "diceNumber": "2",
+                "diceNumber": 2,
                 "dieSize": "d6",
+                "hideIfDisabled": true,
                 "key": "DamageDice",
                 "predicate": [
-                    "target:mark:precise-debilitations"
+                    "target:mark:precise-debilitations",
+                    {
+                        "not": "parent:tag:precise-debilitations-dice-added"
+                    }
                 ],
-                "selector": "strike-damage"
+                "selector": "strike-damage",
+                "slug": "precise-debilitations"
             }
         ],
         "start": {

--- a/packs/feat-effects/effect-precise-debilitations.json
+++ b/packs/feat-effects/effect-precise-debilitations.json
@@ -37,8 +37,7 @@
                         "not": "parent:tag:precise-debilitations-dice-added"
                     }
                 ],
-                "selector": "strike-damage",
-                "slug": "precise-debilitations"
+                "selector": "strike-damage"
             }
         ],
         "start": {

--- a/packs/feats/class/rogue/precise-debilitations.json
+++ b/packs/feats/class/rogue/precise-debilitations.json
@@ -41,8 +41,7 @@
                 "predicate": [
                     "target:mark:precise-debilitations"
                 ],
-                "selector": "strike-damage",
-                "slug": "precise-debilitations"
+                "selector": "strike-damage"
             },
             {
                 "itemType": "effect",

--- a/packs/feats/class/rogue/precise-debilitations.json
+++ b/packs/feats/class/rogue/precise-debilitations.json
@@ -32,7 +32,29 @@
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [],
+        "rules": [
+            {
+                "category": "precision",
+                "diceNumber": 2,
+                "dieSize": "d6",
+                "key": "DamageDice",
+                "predicate": [
+                    "target:mark:precise-debilitations"
+                ],
+                "selector": "strike-damage",
+                "slug": "precise-debilitations"
+            },
+            {
+                "itemType": "effect",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:effect-precise-debilitations"
+                ],
+                "property": "other-tags",
+                "value": "precise-debilitations-dice-added"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [


### PR DESCRIPTION
Tag as a bandaid for current rogues not to break until we can migrate.

- Closes #20187