### PR TITLE
Lower priority of Celestial Armaments' Token Light

### DIFF
--- a/packs/feat-effects/effect-celestial-armaments.json
+++ b/packs/feat-effects/effect-celestial-armaments.json
@@ -35,6 +35,7 @@
             },
             {
                 "key": "TokenLight",
+                "priority": 90,
                 "value": {
                     "alpha": 0.2,
                     "animation": {


### PR DESCRIPTION
- Closes #19611

Fixes the issue of the smaller light from Celestial Armaments overriding the larger light of the dedication, but introduces a new one when that light is halved via Aegis of the Innocent, since the aura and its light become smaller than the armament's light. At least that latter scenario should be less common due to needing another feat, but ¯\\_ (ツ)_/¯