### PR TITLE
Fix Plunderer of the Hive's Riches description in re-en.json

### DIFF
--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -4001,7 +4001,7 @@
                     },
                     "PlundererOfTheHivesRiches": {
                         "CriticalSpecialization": "When you critically succeed at a Strike, the taste of honey fills your mouth as you plunder part of your foe's vitality for yourself, gaining temporary Hit Points equal to half the creature's level that last for 1 minute.",
-                        "Description": "When you Spark Transcendence, a mass of buzzing insects fill the air around you, granting you concealment until the beginning of your next turn."
+                        "Description": "When you Spark Transcendence, a mass of buzzing insects fill the air around you, granting you @UUID[Compendium.pf2e.conditionitems.Item.DmAIPqOBomZ7H95W]{Concealment} until the beginning of your next turn."
                     },
                     "RestlessAsTheTide": {
                         "CriticalSpecialization": "When you critically succeed on a Strike, water blasts the target and those nearby. This deals bludgeoning splash damage equal to the number of weapon damage dice to the target and all creatures within 10 feet of it. This effect has the water trait.",

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -4001,7 +4001,7 @@
                     },
                     "PlundererOfTheHivesRiches": {
                         "CriticalSpecialization": "When you critically succeed at a Strike, the taste of honey fills your mouth as you plunder part of your foe's vitality for yourself, gaining temporary Hit Points equal to half the creature's level that last for 1 minute.",
-                        "Description": "When you Spark Transcendence, you gain temporary Hit Points equal to half your level as you are reinvigorated by the changing of the seasons; these temporary Hit Points last until the start of your next turn."
+                        "Description": "When you Spark Transcendence, a mass of buzzing insects fill the air around you, granting you concealment until the beginning of your next turn."
                     },
                     "RestlessAsTheTide": {
                         "CriticalSpecialization": "When you critically succeed on a Strike, water blasts the target and those nearby. This deals bludgeoning splash damage equal to the number of weapon damage dice to the target and all creatures within 10 feet of it. This effect has the water trait.",


### PR DESCRIPTION
[the description is not correct](https://2e.aonprd.com/Epithets.aspx?ID=17) according to the description of the 'item' in foundry and according to aon. 
I don't want to spoil myself if I play this AP if someone wants to verify the text from the source.
