### PR TITLE
Add support for configuring npc attacks as area/auto fire

### DIFF
--- a/src/module/item/melee/data.ts
+++ b/src/module/item/melee/data.ts
@@ -1,3 +1,4 @@
+import type { ModelPropsFromSchema, SourceFromSchema } from "@common/data/fields.mjs";
 import type { MeleePF2e } from "@item";
 import { ItemSystemModel, ItemSystemSchema } from "@item/base/data/model.ts";
 import type {
@@ -6,12 +7,15 @@ import type {
     ItemSystemSource,
     ItemTraitsNoRarity,
 } from "@item/base/data/system.ts";
+import type { EffectAreaShape } from "@item/types.ts";
+import { EFFECT_AREA_SHAPES } from "@item/values.ts";
 import type { WeaponMaterialData } from "@item/weapon/data.ts";
 import type { WeaponPropertyRuneType } from "@item/weapon/types.ts";
 import { damageCategoriesUnique } from "@scripts/config/damage.ts";
 import type { DamageCategoryUnique, DamageType } from "@system/damage/types.ts";
 import { LaxArrayField, RecordField, SlugField } from "@system/schema-data-fields.ts";
-import type { NPCAttackTrait } from "./types.ts";
+import type { NPCAttackActionType, NPCAttackTrait } from "./types.ts";
+import { NPC_ATTACK_ACTIONS } from "./values.ts";
 import fields = foundry.data.fields;
 
 type MeleeSource = BaseItemSourcePF2e<"melee", MeleeSystemSource> & {
@@ -48,6 +52,31 @@ class MeleeSystemData extends ItemSystemModel<MeleePF2e, NPCAttackSystemSchema> 
                     }),
                 ),
             }),
+            action: new fields.StringField({
+                choices: NPC_ATTACK_ACTIONS,
+                required: true,
+                nullable: false,
+                initial: "strike",
+            }),
+            area: new fields.SchemaField(
+                {
+                    type: new fields.StringField({
+                        choices: EFFECT_AREA_SHAPES,
+                        required: true,
+                        nullable: false,
+                        initial: "burst",
+                    }),
+                    value: new fields.NumberField({
+                        min: 5,
+                        max: 50,
+                        step: 5,
+                        required: true,
+                        nullable: false,
+                        initial: 5,
+                    }),
+                },
+                { required: true, nullable: true, initial: null },
+            ),
             damageRolls: new RecordField(
                 new fields.StringField({ required: true, nullable: false, blank: false, initial: undefined }),
                 new fields.SchemaField({
@@ -81,6 +110,11 @@ class MeleeSystemData extends ItemSystemModel<MeleePF2e, NPCAttackSystemSchema> 
             }),
         };
     }
+
+    override prepareBaseData(): void {
+        super.prepareBaseData();
+        if (this.action !== "strike") this.area ??= { type: "burst", value: 5 };
+    }
 }
 
 interface MeleeSystemData
@@ -99,6 +133,15 @@ type NPCAttackSystemSchema = Omit<ItemSystemSchema, "traits"> & {
             true
         >;
     }>;
+    action: fields.StringField<NPCAttackActionType, NPCAttackActionType, true, false, true>;
+    area: fields.SchemaField<
+        EffectAreaSchema,
+        SourceFromSchema<EffectAreaSchema>,
+        ModelPropsFromSchema<EffectAreaSchema>,
+        true,
+        true,
+        true
+    >;
     damageRolls: RecordField<
         fields.StringField<string, string, true, false, false>,
         fields.SchemaField<{
@@ -118,6 +161,11 @@ type NPCAttackSystemSchema = Omit<ItemSystemSchema, "traits"> & {
     attackEffects: fields.SchemaField<{
         value: fields.ArrayField<fields.StringField<string, string, true, false, false>>;
     }>;
+};
+
+type EffectAreaSchema = {
+    type: fields.StringField<EffectAreaShape, EffectAreaShape, true, false, true>;
+    value: fields.NumberField<number, number, true, false, true>;
 };
 
 type MeleeSystemSource = fields.SourceFromSchema<NPCAttackSystemSchema> & {

--- a/src/module/item/melee/types.ts
+++ b/src/module/item/melee/types.ts
@@ -1,3 +1,6 @@
-type NPCAttackTrait = keyof typeof CONFIG.PF2E.npcAttackTraits;
+import { NPC_ATTACK_ACTIONS } from "./values.ts";
 
-export type { NPCAttackTrait };
+type NPCAttackTrait = keyof typeof CONFIG.PF2E.npcAttackTraits;
+type NPCAttackActionType = keyof typeof NPC_ATTACK_ACTIONS;
+
+export type { NPCAttackActionType, NPCAttackTrait };

--- a/src/module/item/melee/values.ts
+++ b/src/module/item/melee/values.ts
@@ -1,0 +1,7 @@
+const NPC_ATTACK_ACTIONS = {
+    strike: "PF2E.Actions.Strike.Title",
+    "area-fire": "PF2E.Actions.AreaFire.Title",
+    "auto-fire": "PF2E.Actions.AutoFire.Title",
+};
+
+export { NPC_ATTACK_ACTIONS };

--- a/static/lang/action-en.json
+++ b/static/lang/action-en.json
@@ -66,12 +66,20 @@
                 },
                 "Title": "Arcane Slam"
             },
+            "AreaFire": {
+                "Description": "You hit each creature in the designated area with a range equal to the weapon's range increment (for cone or line) or the designated radius of the explosion (for burst). For burst, you can position the center point anywhere within your first range increment. Any creatures in the area must succeed at a basic reflex save against your class DC plus the tracking value of the weapon. This damage is area damage. Creatures who critically fail this save are subject to effects that occur on a critical hit with this weapon, including the weapon's critical specialization effect. Area Fire has an expend equal to the value listed on the weapon.",
+                "Title": "Area Fire"
+            },
             "ArrestAFall": {
                 "Description": "<p><strong>Trigger</strong> You fall.</p><p><strong>Requirements</strong> You have a fly Speed.</p><hr><p>You attempt your choice of an Acrobatics check or Reflex save to slow your fall. The DC is typically 15, but it might be higher due to air turbulence or other circumstances.</p><p><strong>Success</strong> You take no damage from the fall.</p>",
                 "Notes": {
                     "success": "<strong>Success</strong> You take no damage from the fall."
                 },
                 "Title": "Arrest A Fall"
+            },
+            "AutoFire": {
+                "Description": "You hit each creature in a cone with a range equal to half the weapon's range increment without making an attack roll. Any creatures in the area take damage equal to the weapon's damage (basic reflex save against your class DC plus the tracking value of the weapon). This damage is area damage. Creatures that critically fail this save are subject to effects that occur on a critical hit with this weapon, including the weapon's critical specialization effect. Automatic Fire has an expend equal to the number of targets in the area × 2.",
+                "Title": "Auto-Fire"
             },
             "AvertGaze": {
                 "Description": "<p>You avert your gaze from danger, such as a medusa's gaze. You gain a +2 circumstance bonus to saves against visual abilities that require you to look at a creature or object, such as a medusa's petrifying gaze. Your gaze remains averted until the start of your next turn.</p>",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -585,6 +585,10 @@
                 }
             },
             "NPC": {
+                "BonusLabel": {
+                    "modifier": "Attack Modifier",
+                    "save": "Save DC"
+                },
                 "Configure": {
                     "Lootable": {
                         "DefaultLootable": "Global Default (Lootable)",
@@ -3149,7 +3153,6 @@
         "NPCNotesTitle": "Write any notes for this NPC here.",
         "NPCWeaponAddDamage": "Add Damage Partial",
         "NPCWeaponAttackEffect": "Additional Attack Effects",
-        "NPCWeaponAttackLabel": "Attack Modifier",
         "NPCWeaponDamageLabel": "Damage Formula",
         "Nationality": "Nationality",
         "NewLabel": "New",

--- a/static/templates/items/melee-details.hbs
+++ b/static/templates/items/melee-details.hbs
@@ -1,6 +1,29 @@
+{{#developMode}}
+    {{formGroup systemFields.action label=(localize "PF2E.ActionTypeAction") value=data.action choices=attackActions}}
+
+    {{#unless (eq data.action "strike")}}
+        <div class="form-group">
+            <label for="{{fieldIdPrefix}}area-size">{{localize "PF2E.Area.InFeet"}}</label>
+            <div class="details-container-two-columns">
+                <input
+                    id="{{fieldIdPrefix}}area-size"
+                    type="number"
+                    data-property="system.area.value"
+                    min="5"
+                    step="5"
+                    value="{{data.area.value}}"
+                />
+                <select id="{{fieldIdPrefix}}area-type" name="system.area.type">
+                    {{selectOptions areaShapes selected=data.area.type blank="" localize=true}}
+                </select>
+            </div>
+        </div>
+    {{/unless}}
+{{/developMode}}
+
 <div class="form-group attack-modifier">
-    <label>{{localize "PF2E.NPCWeaponAttackLabel"}}</label>
-    <input type="number" name="system.bonus.value" value="{{data.bonus.value}}" />
+    <label>{{modifierOrSave.label}}</label>
+    <input type="number" name="system.bonus.value" value="{{modifierOrSave.value}}" />
 </div>
 
 <ol class="form-list">


### PR DESCRIPTION
No actual support yet, they're still interpreted as strikes. The actual implementation will be kinda hairy, and it might be best to separate the guaranteed parts first. Setting it is dev only for now.