### PR TITLE
Fix predicate value missing in auto-generated forms

### DIFF
--- a/static/templates/items/rules/default.hbs
+++ b/static/templates/items/rules/default.hbs
@@ -13,8 +13,10 @@
         {{/unless}}
     {{/each}}
     {{#unless (includes omittedFields "predicate")}}
-        {{formGroup fields.predicate name=(concat "system.rules." index ".predicate") value=(lookup ../rule "predicate")
-                    rootId=rootId placeholder="[]"}}
+        <div class="form-group">
+            <label class="short" for="{{rootId}}-predicate">{{localize "PF2E.RULES.Common.FIELDS.predicate.label"}}</label>
+            <input type="text" name="{{basePath}}.predicate" id="{{rootId}}-predicate" value="{{json rule.predicate}}" />
+        </div>
     {{/unless}}
 {{~else~}}
     <textarea name="system.rules.{{index}}" spellcheck="false">{{json rule}}</textarea>


### PR DESCRIPTION
Using `rule.predicate` errors, and using `json rule.predicate` shows escape characters when used with formGroup. I had to revert predicate specifically to how it is in other forms.