### PR TITLE
Normalize price strings and add rudimentary credit parsing

### DIFF
--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -257,6 +257,8 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends fav1.sheets.Acto
             isSellable: editable && item.isOfType("treasure") && !item.isCoinage,
             itemSize: sizeDifference !== 0 ? itemSize : null,
             unitBulk: actor.isOfType("loot") ? createBulkPerLabel(item) : null,
+            unitPrice: item.price.value.toString({ short: true }),
+            assetValue: item.assetValue.toString({ short: true }),
             hidden: false,
         };
     }

--- a/src/module/actor/sheet/data-types.ts
+++ b/src/module/actor/sheet/data-types.ts
@@ -26,6 +26,10 @@ interface InventoryItem<TItem extends PhysicalItemPF2e = PhysicalItemPF2e> {
     heldItems?: InventoryItem[] | null;
     notifyEquip?: boolean;
     notifyInvest?: boolean;
+    /** The sale price label per sold minimum unit. For example, arrows are 1sp per 10 */
+    unitPrice: string;
+    /** Total asset value of the entire stack of the inventory item */
+    assetValue: string;
     /** Whether the item should be hidden if the user isn't the owner */
     hidden: boolean;
 }

--- a/src/module/actor/sheet/item-summary-renderer.ts
+++ b/src/module/actor/sheet/item-summary-renderer.ts
@@ -108,6 +108,7 @@ export class ItemSummaryRenderer<TActor extends ActorPF2e, TSheet extends Applic
             return `@UUID[${uuid}]{${name}}`;
         })();
 
+        const price = item.isOfType("physical", "kit") ? item.system.price : null;
         const summary = await fa.handlebars.renderTemplate("systems/pf2e/templates/actors/partials/item-summary.hbs", {
             item,
             description: chatData.description,
@@ -115,6 +116,7 @@ export class ItemSummaryRenderer<TActor extends ActorPF2e, TSheet extends Applic
             isCreature: item.actor?.isOfType("creature"),
             chatData,
             selfEffect: selfEffectLink && (await TextEditorPF2e.enrichHTML(selfEffectLink)),
+            price: !price ? null : price.per > 1 ? `${price.value.toString()} / ${price.per}` : price.value.toString(),
         });
 
         container.innerHTML = summary;

--- a/src/module/item/kit/sheet.ts
+++ b/src/module/item/kit/sheet.ts
@@ -18,7 +18,7 @@ class KitSheetPF2e extends ItemSheetPF2e<KitPF2e> {
         );
         return {
             ...(await super.getData(options)),
-            priceString: this.item.price.value,
+            priceString: this.item.price.value.toString(),
             items,
         };
     }
@@ -79,14 +79,13 @@ class KitSheetPF2e extends ItemSheetPF2e<KitPF2e> {
     protected override async _updateObject(event: Event, formData: Record<string, unknown>): Promise<void> {
         // Convert price from a string to an actual object
         const priceString = String(formData["system.price.value"] ?? "").trim();
-        formData["system.price.==value"] = Coins.fromString(priceString).toObject();
-        delete formData["system.price.value"];
+        formData["system.price.value"] = Coins.fromString(priceString).toObject();
         return super._updateObject(event, formData);
     }
 }
 
 interface KitSheetData extends ItemSheetDataPF2e<KitPF2e> {
-    priceString: Coins;
+    priceString: string;
     items: Record<string, KitEntrySheetData>;
 }
 

--- a/src/module/item/physical/document.ts
+++ b/src/module/item/physical/document.ts
@@ -265,11 +265,6 @@ abstract class PhysicalItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | n
         this.system.stackGroup ??= null;
         this.system.hp.brokenThreshold = Math.floor(this.system.hp.max / 2);
 
-        // Temporary: prevent noise from items pre migration 746
-        if (typeof this.system.price.value === "string") {
-            this.system.price.value = Coins.fromString(this.system.price.value);
-        }
-
         // Ensure infused items are always temporary
         const traits: PhysicalItemTrait[] = this.system.traits.value;
         if (traits.includes("infused")) this.system.temporary = true;
@@ -586,6 +581,8 @@ abstract class PhysicalItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | n
 
         const thisData = this.toObject().system;
         const otherData = item.toObject().system;
+        thisData.price.value = { cp: new Coins(thisData.price.value).copperValue };
+        otherData.price.value = { cp: new Coins(otherData.price.value).copperValue };
         thisData.quantity = otherData.quantity;
         thisData.equipped = otherData.equipped;
         thisData.containerId = otherData.containerId;

--- a/src/module/item/physical/sheet.ts
+++ b/src/module/item/physical/sheet.ts
@@ -81,9 +81,13 @@ class PhysicalItemSheetPF2e<TItem extends PhysicalItemPF2e> extends ItemSheetPF2
             sidebarTemplate: "systems/pf2e/templates/items/physical-sidebar.hbs",
             bulkAdjustment,
             adjustedLevelHint,
-            basePrice,
-            priceAdjustment,
-            adjustedPriceHint,
+            price: {
+                base: new Coins(item._source.system.price.value).toString({ short: true }),
+                label: item.system.price.value.toString({ short: true }),
+                adjustment: priceAdjustment,
+                adjustmentHint: adjustedPriceHint,
+                per: item.system.price.per,
+            },
             attributes: CONFIG.PF2E.abilities,
             actionTypes: CONFIG.PF2E.actionTypes,
             bulks,
@@ -201,7 +205,8 @@ class PhysicalItemSheetPF2e<TItem extends PhysicalItemPF2e> extends ItemSheetPF2
 
         // Convert price from a string to an actual object
         if ("system.price.value" in formData) {
-            formData["system.price.value"] = Coins.fromString(String(formData["system.price.value"]));
+            formData["system.price.==value"] = Coins.fromString(String(formData["system.price.value"])).toObject();
+            delete formData["system.price.value"];
         }
 
         return super._updateObject(event, formData);
@@ -215,9 +220,13 @@ interface PhysicalItemSheetData<TItem extends PhysicalItemPF2e> extends ItemShee
     bulkAdjustment: string | null;
     adjustedBulkHint?: string | null;
     adjustedLevelHint: string | null;
-    basePrice: Coins;
-    priceAdjustment: string | null;
-    adjustedPriceHint: string | null;
+    price: {
+        label: string;
+        base: string;
+        adjustment: string | null;
+        adjustmentHint: string | null;
+        per: number | null;
+    };
     attributes: typeof CONFIG.PF2E.abilities;
     actionTypes: typeof CONFIG.PF2E.actionTypes;
     actionsNumber: typeof CONFIG.PF2E.actionsNumber;

--- a/src/module/item/weapon/sheet.ts
+++ b/src/module/item/weapon/sheet.ts
@@ -221,7 +221,6 @@ interface WeaponSheetData extends PhysicalItemSheetData<WeaponPF2e> {
     abpEnabled: boolean;
     adjustedDiceHint: string | null;
     adjustedLevelHint: string | null;
-    adjustedPriceHint: string | null;
     baseTypes: typeof CONFIG.PF2E.baseWeaponTypes;
     categories: typeof CONFIG.PF2E.weaponCategories;
     conditionTypes: typeof CONFIG.PF2E.conditionTypes;

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1184,7 +1184,8 @@
             "cp": "cp",
             "gp": "gp",
             "pp": "pp",
-            "sp": "sp"
+            "sp": "sp",
+            "credits": "credits"
         },
         "CurrencyCP": "Copper",
         "CurrencyGP": "Gold",

--- a/static/templates/actors/partials/item-line.hbs
+++ b/static/templates/actors/partials/item-line.hbs
@@ -29,12 +29,12 @@
                 {{#if (or item.isIdentified @root.user.isGM)}}
                     <span data-visibility="{{#if item.isIdentified}}all{{else}}gm{{/if}}">
                         {{#if @root.inventory.showUnitBulkPrice}}
-                            {{item.price.value}}
+                            {{unitPrice}}
                             {{#if (gt item.price.per 1)}}
-                                / {{item.price.per}}
+                                <span class="per">/ {{item.price.per}}</span>
                             {{/if}}
                         {{else}}
-                            {{item.assetValue}}
+                            {{assetValue}}
                         {{/if}}
                     </span>
                 {{/if}}

--- a/static/templates/actors/partials/item-summary.hbs
+++ b/static/templates/actors/partials/item-summary.hbs
@@ -17,10 +17,10 @@
     {{/if}}
     {{#if chatData.levelLabel}}<div class="level">{{chatData.levelLabel}}</div>{{/if}}
 
-    {{#if item.price}}
+    {{#if price}}
         <section>
             <div>{{localize "PF2E.Item.Physical.LevelLabel" level=item.level}}</div>
-            <div>{{localize "PF2E.Item.Physical.PriceLabel" price=item.price.value}}</div>
+            <div>{{localize "PF2E.Item.Physical.PriceLabel" price=price}}</div>
         </section>
     {{/if}}
 {{/if}}

--- a/static/templates/items/physical-sidebar.hbs
+++ b/static/templates/items/physical-sidebar.hbs
@@ -48,21 +48,21 @@
     <div class="form-group price">
         <label for="{{fieldIdPrefix}}price">
             {{localize "PF2E.PriceLabel"}}
-            {{#if adjustedPriceHint}}<i class="fa-solid fa-circle-info" data-tooltip="{{adjustedPriceHint}}"></i>{{/if}}
+            {{#if price.adjustmentHint}}<i class="fa-solid fa-circle-info" data-tooltip="{{adjustedPriceHint}}"></i>{{/if}}
         </label>
         <div class="form-fields">
             <input
                 type="text"
-                {{#if priceAdjustment}}class="{{priceAdjustment}}"{{/if}}
+                {{#if price.adjustment}}class="{{price.adjustment}}"{{/if}}
                 id="{{fieldIdPrefix}}price"
-                value="{{item.system.price.value}}"
+                value="{{price.label}}"
                 data-property="system.price.value"
-                data-value-base="{{basePrice}}"
+                data-value-base="{{price.base}}"
                 spellcheck="false"
             />
             {{#if (eq item.type "consumable")}}
                 <span class="slash">/</span>
-                <input type="number" class="per" name="system.price.per" value="{{item.system.price.per}}" />
+                <input type="number" class="per" name="system.price.per" value="{{price.per}}" />
             {{/if}}
         </div>
     </div>

--- a/types/foundry/common/utils/helpers.d.mts
+++ b/types/foundry/common/utils/helpers.d.mts
@@ -155,6 +155,13 @@ export function diffObject<T extends Record<string, unknown> = Record<string, un
 ): T;
 
 /**
+ * Recurse through an object, applying all special keys.
+ * Deletion keys ("-=") are removed.
+ * Forced replacement keys ("==") are assigned.
+ */
+export function applySpecialKeys<T>(obj: T): T;
+
+/**
  * Test if two objects contain the same enumerable keys and values.
  * @param a  The first object.
  * @param b  The second object.


### PR DESCRIPTION
This causes all items in pf2e to prioritize displaying in gp, regardless of its from sf2e or not. The idea is to force everything to display as credits in the sf2e system. Credits are also able to be parsed as a denomination (remapped to silver pieces).

Unless we decide on a field in CONFIG or in game.pf2e, we can't really allow the sf2e anachronism module to show as credits. We're kinda waiting on the system split to use `game.system.id` or `SYSTEM_ID` instead. 

We also can't replace coins internally until we're able to migrate kits somehow. I considered doing it in migrateData() manually but it didn't really stick. Luckily we don't really need to.