### PR TITLE
Refactor Compendium Browser to use a `Predicate` for filtering entries

### DIFF
--- a/src/module/apps/compendium-browser/components/filters/level.svelte
+++ b/src/module/apps/compendium-browser/components/filters/level.svelte
@@ -12,14 +12,10 @@
         const name = event.currentTarget.name;
         const value = Math.clamp(Number(event.currentTarget.value), level.min, level.max);
         if (name === "from") {
-            if (value > level.to) {
-                level.to = value;
-            }
+            if (value > level.to) level.to = value;
             level.from = value;
         } else if (name === "to") {
-            if (value < level.from) {
-                level.from = value;
-            }
+            if (value < level.from) level.from = value;
             level.to = value;
         }
         level.changed = level.from !== level.min || level.to !== level.max;

--- a/src/module/apps/compendium-browser/components/filters/traits.svelte
+++ b/src/module/apps/compendium-browser/components/filters/traits.svelte
@@ -11,7 +11,7 @@
         traits: TraitData;
     }
     const { traits = $bindable() }: Props = $props();
-    const exclude = $state(new SvelteSet<string>());
+    const exclude = new SvelteSet<string>();
 
     function onChangeConjunction(event: Event & { currentTarget: HTMLInputElement }): void {
         const value = event.currentTarget.value;
@@ -54,7 +54,7 @@
     selection={traitSelection}
     onChange={onChangeTraits}
     placeholder={game.i18n.localize("PF2E.SelectLabel")}
-    value={traits.selected.map((s) => s.value)}
+    value={traits.selected.map((t) => t.value)}
 />
 <div class="filter-conjunction">
     <label class="checkbox">
@@ -102,6 +102,7 @@
                 aria-label="deslect"
                 data-action="deselect"
                 use:itemAction={opt}
+                onclick={() => exclude.delete(opt.value)}
             >
                 <svg height="16" width="16" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
                     <path

--- a/src/module/apps/compendium-browser/tabs/action.ts
+++ b/src/module/apps/compendium-browser/tabs/action.ts
@@ -1,5 +1,4 @@
 import { getActionIcon } from "@module/sheet/helpers.ts";
-import { sluggify } from "@util";
 import * as R from "remeda";
 import { CompendiumBrowser } from "../browser.ts";
 import { ContentTabName } from "../data.ts";
@@ -51,23 +50,18 @@ export class CompendiumBrowserActionTab extends CompendiumBrowserTab {
                     );
                     continue;
                 }
-                const options: string[] = [];
+
                 const system = actionData.system;
                 // update icons for any passive actions
                 if (system.actionType.value === "passive") actionData.img = getActionIcon("passive");
-                options.push(`action-type:${system.actionType.value}`);
-                options.push(...system.traits.value.map((t: string) => `trait:${t.replace(/^hb_/, "")}`));
-
-                // Prepare publication source
                 const pubSource = String(system.publication?.title ?? system.source?.value ?? "").trim();
-                const sourceSlug = sluggify(pubSource);
-                if (pubSource) {
-                    publications.add(pubSource);
-                    options.push(`source:${sourceSlug}`);
-                }
-
-                options.push(`type:${actionData.type}`);
-                options.push(`category:${system.category}`);
+                const options: string[] = [
+                    `action-type:${system.actionType.value}`,
+                    ...system.traits.value.map((t: string) => `trait:${t.replace(/^hb_/, "")}`),
+                    `type:${actionData.type}`,
+                    `category:${system.category}`,
+                    this.preparePublicationSource(pubSource, publications),
+                ];
 
                 actions.push({
                     name: actionData.name,

--- a/src/module/apps/compendium-browser/tabs/action.ts
+++ b/src/module/apps/compendium-browser/tabs/action.ts
@@ -51,33 +51,30 @@ export class CompendiumBrowserActionTab extends CompendiumBrowserTab {
                     );
                     continue;
                 }
-                const options = new Set<string>();
+                const options: string[] = [];
                 const system = actionData.system;
                 // update icons for any passive actions
                 if (system.actionType.value === "passive") actionData.img = getActionIcon("passive");
-                options.add(`action-type:${system.actionType.value}`);
-
-                for (const trait of system.traits.value) {
-                    options.add(`trait:${trait.replace(/^hb_/, "")}`);
-                }
+                options.push(`action-type:${system.actionType.value}`);
+                options.push(...system.traits.value.map((t: string) => `trait:${t.replace(/^hb_/, "")}`));
 
                 // Prepare publication source
                 const pubSource = String(system.publication?.title ?? system.source?.value ?? "").trim();
                 const sourceSlug = sluggify(pubSource);
                 if (pubSource) {
                     publications.add(pubSource);
-                    options.add(`source:${sourceSlug}`);
+                    options.push(`source:${sourceSlug}`);
                 }
 
-                options.add(`type:${actionData.type}`);
-                options.add(`category:${system.category}`);
+                options.push(`type:${actionData.type}`);
+                options.push(`category:${system.category}`);
 
                 actions.push({
                     name: actionData.name,
                     originalName: actionData.originalName, // Added by Babele
                     img: actionData.img,
                     uuid: actionData.uuid,
-                    options,
+                    options: new Set(options),
                 });
             }
         }

--- a/src/module/apps/compendium-browser/tabs/action.ts
+++ b/src/module/apps/compendium-browser/tabs/action.ts
@@ -13,7 +13,7 @@ export class CompendiumBrowserActionTab extends CompendiumBrowserTab {
 
     /* MiniSearch */
     override searchFields = ["name", "originalName"];
-    override storeFields = ["type", "name", "img", "uuid", "traits", "source", "category", "actionType"];
+    override storeFields = ["name", "originalName", "img", "uuid", "options"];
 
     constructor(browser: CompendiumBrowser) {
         super(browser);
@@ -44,34 +44,41 @@ export class CompendiumBrowserActionTab extends CompendiumBrowserTab {
         )) {
             console.debug(`PF2e System | Compendium Browser | ${pack.metadata.label} - Loading`);
             for (const actionData of index) {
-                if (actionData.type === "action") {
-                    if (!this.hasAllIndexFields(actionData, indexFields)) {
-                        console.warn(
-                            `Action '${actionData.name}' does not have all required data fields. Consider unselecting pack '${pack.metadata.label}' in the compendium browser settings.`,
-                        );
-                        continue;
-                    }
-                    // update icons for any passive actions
-                    if (actionData.system.actionType.value === "passive") actionData.img = getActionIcon("passive");
-
-                    // Prepare publication source
-                    const { system } = actionData;
-                    const pubSource = String(system.publication?.title ?? system.source?.value ?? "").trim();
-                    const sourceSlug = sluggify(pubSource);
-                    if (pubSource) publications.add(pubSource);
-
-                    actions.push({
-                        type: actionData.type,
-                        name: actionData.name,
-                        originalName: actionData.originalName, // Added by Babele
-                        img: actionData.img,
-                        uuid: actionData.uuid,
-                        traits: actionData.system.traits.value.map((t: string) => t.replace(/^hb_/, "")),
-                        actionType: actionData.system.actionType.value,
-                        category: actionData.system.category,
-                        source: sourceSlug,
-                    });
+                if (actionData.type !== "action") continue;
+                if (!this.hasAllIndexFields(actionData, indexFields)) {
+                    console.warn(
+                        `Action '${actionData.name}' does not have all required data fields. Consider unselecting pack '${pack.metadata.label}' in the compendium browser settings.`,
+                    );
+                    continue;
                 }
+                const options = new Set<string>();
+                const system = actionData.system;
+                // update icons for any passive actions
+                if (system.actionType.value === "passive") actionData.img = getActionIcon("passive");
+                options.add(`action-type:${system.actionType.value}`);
+
+                for (const trait of system.traits.value) {
+                    options.add(`trait:${trait.replace(/^hb_/, "")}`);
+                }
+
+                // Prepare publication source
+                const pubSource = String(system.publication?.title ?? system.source?.value ?? "").trim();
+                const sourceSlug = sluggify(pubSource);
+                if (pubSource) {
+                    publications.add(pubSource);
+                    options.add(`source:${sourceSlug}`);
+                }
+
+                options.add(`type:${actionData.type}`);
+                options.add(`category:${system.category}`);
+
+                actions.push({
+                    name: actionData.name,
+                    originalName: actionData.originalName, // Added by Babele
+                    img: actionData.img,
+                    uuid: actionData.uuid,
+                    options,
+                });
             }
         }
 
@@ -89,27 +96,6 @@ export class CompendiumBrowserActionTab extends CompendiumBrowserTab {
         console.debug("PF2e System | Compendium Browser | Finished loading actions");
     }
 
-    protected override filterIndexData(entry: CompendiumBrowserIndexData): boolean {
-        const { checkboxes, source, traits } = this.filterData;
-
-        // Types
-        if (checkboxes.types.selected.length) {
-            if (!checkboxes.types.selected.includes(entry.actionType)) return false;
-        }
-        // Categories
-        if (checkboxes.category.selected.length) {
-            const selected = checkboxes.category.selected;
-            if (!selected.includes(entry.category)) return false;
-        }
-        // Traits
-        if (!this.filterTraits(entry.traits, traits.selected, traits.conjunction)) return false;
-        // Source
-        if (source.selected.length) {
-            if (!source.selected.includes(entry.source)) return false;
-        }
-        return true;
-    }
-
     protected override prepareFilterData(): ActionFilters {
         return {
             checkboxes: {
@@ -117,6 +103,7 @@ export class CompendiumBrowserActionTab extends CompendiumBrowserTab {
                     isExpanded: true,
                     label: "PF2E.ActionActionTypeLabel",
                     options: {},
+                    optionPrefix: "action-type",
                     selected: [],
                 },
                 category: {

--- a/src/module/apps/compendium-browser/tabs/base.svelte.ts
+++ b/src/module/apps/compendium-browser/tabs/base.svelte.ts
@@ -298,6 +298,13 @@ export abstract class CompendiumBrowserTab {
         );
     }
 
+    /** Adds the publication source to `publications` if available and returns a `source` option for convenience */
+    protected preparePublicationSource(pubSource: string, publications: Set<string>): string {
+        if (!pubSource) return "source:none";
+        publications.add(pubSource);
+        return `source:${sluggify(pubSource)}`;
+    }
+
     /** Provide a best-effort sort of an object (e.g. CONFIG.PF2E.monsterTraits) */
     protected sortedConfig(obj: Record<string, string>): Record<string, string> {
         return Object.fromEntries(

--- a/src/module/apps/compendium-browser/tabs/base.svelte.ts
+++ b/src/module/apps/compendium-browser/tabs/base.svelte.ts
@@ -1,12 +1,19 @@
 import type { CompendiumIndexData } from "@client/documents/collections/compendium-collection.d.mts";
 import type { TableResultSource } from "@common/documents/table-result.d.mts";
 import { CompendiumDirectoryPF2e } from "@module/apps/sidebar/compendium-directory.ts";
+import { Predicate, type PredicateStatement } from "@system/predication.ts";
 import { ErrorPF2e, htmlQuery, sluggify } from "@util";
 import MiniSearch from "minisearch";
 import * as R from "remeda";
 import { CompendiumBrowser, CompendiumBrowserOpenTabOptions } from "../browser.ts";
 import { BrowserTabs, ContentTabName } from "../data.ts";
-import type { BrowserFilter, CheckboxOptions, CompendiumBrowserIndexData, RangesInputData, TraitData } from "./data.ts";
+import type {
+    BrowserFilter,
+    CheckboxData,
+    CheckboxOptions,
+    CompendiumBrowserIndexData,
+    RangesInputData,
+} from "./data.ts";
 
 export abstract class CompendiumBrowserTab {
     /** A reference to the parent CompendiumBrowser */
@@ -18,11 +25,9 @@ export abstract class CompendiumBrowserTab {
         if (!this.filterData) return [];
         this.browser.resetListElement();
         const searchText = fa.ux.SearchFilter.cleanQuery(this.filterData.search.text);
-        if (searchText) {
-            const searchResult = this.searchEngine.search(searchText);
-            return this.sortResult(searchResult.filter(this.filterIndexData.bind(this)));
-        }
-        return this.sortResult(this.indexData.filter(this.filterIndexData.bind(this)));
+        const baseResults = this.sortResult(searchText ? this.searchEngine.search(searchText) : this.indexData);
+        const predicate = this.buildPredicate();
+        return baseResults.filter((i) => predicate.test(i.options));
     });
     /** The maximum number of items shown in the result list element */
     resultLimit = $state(CompendiumBrowser.RESULT_LIMIT);
@@ -141,30 +146,75 @@ export abstract class CompendiumBrowserTab {
     /** Prepare the the filterData object of this tab */
     protected abstract prepareFilterData(): this["filterData"];
 
-    /** Filter indexData */
-    protected abstract filterIndexData(entry: CompendiumBrowserIndexData): boolean;
+    /** Build a `Predicate` from the applied filters */
+    protected buildPredicate(): Predicate {
+        if (!this.filterData) {
+            throw ErrorPF2e(`Tab "${this.tabLabel}" is not initialized!`);
+        }
+        const statements: PredicateStatement[] = [];
 
-    protected filterTraits(
-        traits: string[],
-        selected: TraitData["selected"],
-        condition: TraitData["conjunction"],
-    ): boolean {
-        const selectedTraits = selected.filter((s) => !s.not).map((s) => s.value);
-        const notTraits = selected.filter((t) => t.not).map((s) => s.value);
-        if (notTraits.some((t) => traits.includes(t))) {
-            return false;
+        if ("checkboxes" in this.filterData) {
+            const checkboxes = this.filterData.checkboxes as Record<string, CheckboxData>;
+            for (const [key, checkbox] of R.entries(checkboxes)) {
+                if (checkbox.selected.length === 0) continue;
+                const prefix = checkbox.optionPrefix ?? key;
+                statements.push({ or: checkbox.selected.map((s) => `${prefix}:${s}`) });
+            }
         }
-        if (selectedTraits.length) {
-            return condition === "and"
-                ? selectedTraits.every((t) => traits.includes(t))
-                : selectedTraits.some((t) => traits.includes(t));
+
+        if ("level" in this.filterData) {
+            const level = this.filterData.level;
+            if (level.from !== level.min || level.to !== level.max) {
+                statements.push({ and: [{ gte: ["level", level.from] }, { lte: ["level", level.to] }] });
+            }
         }
-        return true;
+
+        if ("ranges" in this.filterData) {
+            const ranges = this.filterData.ranges;
+            for (const [key, range] of R.entries(ranges)) {
+                if (!range.changed) continue;
+                const prefix = range.optionPrefix ?? key;
+                const min = range.values.min;
+                const max = range.values.max;
+                statements.push({ and: [{ gte: [prefix, min] }, { lte: [prefix, max] }] });
+            }
+        }
+
+        if ("selects" in this.filterData) {
+            const selects = this.filterData.selects;
+            for (const [key, select] of R.entries(selects)) {
+                if (!select.selected) continue;
+                const prefix = select.optionPrefix ?? key;
+                statements.push(`${prefix}:${select.selected}`);
+            }
+        }
+
+        if ("source" in this.filterData) {
+            const source = this.filterData.source;
+            if (source.selected.length > 0) {
+                statements.push({ or: source.selected });
+            }
+        }
+
+        const traits = this.filterData.traits;
+        if (traits.selected.length > 0) {
+            const include = traits.selected.filter((t) => !t.not).map((t) => `trait:${t.value}`);
+            if (include.length > 0) {
+                const includeStatement = { [traits.conjunction]: include } as PredicateStatement;
+                statements.push(includeStatement);
+            }
+            const exclude = traits.selected.filter((t) => t.not).map((t) => `trait:${t.value}`);
+            if (exclude.length > 0) {
+                statements.push({ not: { or: exclude } });
+            }
+        }
+
+        return new Predicate([{ and: statements }]);
     }
 
     /** Sort result array by name, level or price */
     protected sortResult(result: CompendiumBrowserIndexData[]): CompendiumBrowserIndexData[] {
-        if (!this.filterData) return [];
+        if (!this.filterData) return result;
         const order = this.filterData.order;
         const lang = game.i18n.lang;
         const sorted = result.sort((entryA, entryB) => {
@@ -194,22 +244,22 @@ export abstract class CompendiumBrowserTab {
         };
     }
 
-    /** Check if an array includes any keys of another array */
-    protected arrayIncludes(array: string[], other: string[]): boolean {
-        return other.some((value) => array.includes(value));
-    }
-
-    /** Generates a localized and sorted CheckBoxOptions object from config data */
+    /** Generates a localized and sorted options from config data
+     * @param configData The object to convert to options
+     * @param [options] Additional options for the conversion
+     * @param [options.prefix] An additional prefix for these options. The final value will be `filterPrefix:thisPrefix:option`
+     * @param [options.sort] Wether to sort the resulting options alphabetically
+     */
     protected generateCheckboxOptions(
         configData: Record<string, string | { label: string }>,
-        sort = true,
+        { prefix, sort }: { prefix?: string; sort?: boolean } = { sort: true },
     ): CheckboxOptions {
         // Localize labels for sorting. Return localized and sorted CheckBoxOptions
         const localized = R.mapValues(configData, (v) => game.i18n.localize(R.isObjectType(v) ? v.label : v));
         return Object.entries(sort ? this.sortedConfig(localized) : localized).reduce(
             (result: CheckboxOptions, [key, label]) => ({
                 ...result,
-                [key]: {
+                [prefix ? `${prefix}:${key}` : key]: {
                     label,
                     selected: false,
                 },
@@ -220,20 +270,17 @@ export abstract class CompendiumBrowserTab {
 
     protected generateMultiselectOptions<T extends string>(
         optionsRecord: Record<T, string>,
-        sort?: boolean,
+        options?: { prefix?: string; sort?: boolean },
     ): { value: T; label: string }[];
     protected generateMultiselectOptions(
         optionsRecord: Record<string, string>,
-        sort = true,
+        { prefix, sort }: { prefix?: string; sort?: boolean } = { sort: true },
     ): { value: string; label: string }[] {
         const options = Object.entries(optionsRecord).map(([value, label]) => ({
-            value,
+            value: prefix ? `${prefix}:${value}` : value,
             label: game.i18n.localize(label),
         }));
-        if (sort) {
-            options.sort((a, b) => a.label.localeCompare(b.label, game.i18n.lang));
-        }
-
+        if (sort) options.sort((a, b) => a.label.localeCompare(b.label, game.i18n.lang));
         return options;
     }
 
@@ -242,7 +289,7 @@ export abstract class CompendiumBrowserTab {
         return [...sources].sort().reduce(
             (result: CheckboxOptions, source) => ({
                 ...result,
-                [sluggify(source)]: {
+                [`source:${sluggify(source)}`]: {
                     label: source,
                     selected: false,
                 },

--- a/src/module/apps/compendium-browser/tabs/bestiary.ts
+++ b/src/module/apps/compendium-browser/tabs/bestiary.ts
@@ -1,4 +1,3 @@
-import { sluggify } from "@util";
 import { CompendiumBrowser } from "../browser.ts";
 import { ContentTabName } from "../data.ts";
 import { CompendiumBrowserTab } from "./base.svelte.ts";
@@ -50,21 +49,18 @@ export class CompendiumBrowserBestiaryTab extends CompendiumBrowserTab {
                     );
                     continue;
                 }
-                const options: string[] = [];
+
                 const system = actorData.system;
-                // Prepare publication source
                 const details = system.details;
                 const pubSource = String(details.publication?.title ?? details.source?.value ?? "").trim();
-                const sourceSlug = sluggify(pubSource);
-                if (pubSource) {
-                    publications.add(pubSource);
-                    options.push(`source:${sourceSlug}`);
-                }
-                options.push(...system.traits.value.map((t: string) => `trait:${t.replace(/^hb_/, "")}`));
-                options.push(`level:${system.details.level.value}`);
-                options.push(`rarity:${system.traits.rarity}`);
-                options.push(`size:${system.traits.size.value}`);
-                options.push(`type:${actorData.type}`);
+                const options: string[] = [
+                    ...system.traits.value.map((t: string) => `trait:${t.replace(/^hb_/, "")}`),
+                    `level:${system.details.level.value}`,
+                    `rarity:${system.traits.rarity}`,
+                    `size:${system.traits.size.value}`,
+                    `type:${actorData.type}`,
+                    this.preparePublicationSource(pubSource, publications),
+                ];
 
                 bestiaryActors.push({
                     name: actorData.name,

--- a/src/module/apps/compendium-browser/tabs/bestiary.ts
+++ b/src/module/apps/compendium-browser/tabs/bestiary.ts
@@ -19,7 +19,7 @@ export class CompendiumBrowserBestiaryTab extends CompendiumBrowserTab {
 
     /* MiniSearch */
     override searchFields = ["name", "originalName"];
-    override storeFields = ["type", "name", "img", "uuid", "level", "actorSize", "traits", "rarity", "source"];
+    override storeFields = ["name", "originalName", "img", "uuid", "level", "rarity", "options"];
 
     constructor(browser: CompendiumBrowser) {
         super(browser);
@@ -50,24 +50,34 @@ export class CompendiumBrowserBestiaryTab extends CompendiumBrowserTab {
                     );
                     continue;
                 }
-
+                const options = new Set<string>();
+                const system = actorData.system;
                 // Prepare publication source
-                const { details } = actorData.system;
+                const details = system.details;
                 const pubSource = String(details.publication?.title ?? details.source?.value ?? "").trim();
                 const sourceSlug = sluggify(pubSource);
-                if (pubSource) publications.add(pubSource);
+                if (pubSource) {
+                    publications.add(pubSource);
+                    options.add(`source:${sourceSlug}`);
+                }
+
+                for (const trait of system.traits.value) {
+                    options.add(`trait:${trait.replace(/^hb_/, "")}`);
+                }
+
+                options.add(`level:${system.details.level.value}`);
+                options.add(`rarity:${system.traits.rarity}`);
+                options.add(`size:${system.traits.size.value}`);
+                options.add(`type:${actorData.type}`);
 
                 bestiaryActors.push({
-                    type: actorData.type,
                     name: actorData.name,
                     originalName: actorData.originalName, // Added by Babele
                     img: actorData.img,
                     uuid: actorData.uuid,
                     level: actorData.system.details.level.value,
-                    actorSize: actorData.system.traits.size.value,
-                    traits: actorData.system.traits.value.map((t: string) => t.replace(/^hb_/, "")),
                     rarity: actorData.system.traits.rarity,
-                    source: sourceSlug,
+                    options,
                 });
             }
             console.debug(`PF2e System | Compendium Browser | ${pack.metadata.label} - Loaded`);
@@ -78,37 +88,13 @@ export class CompendiumBrowserBestiaryTab extends CompendiumBrowserTab {
 
         // Filters
         this.filterData.checkboxes.sizes.options = this.generateCheckboxOptions(CONFIG.PF2E.actorSizes);
+        this.filterData.checkboxes.rarity.options = this.generateCheckboxOptions(CONFIG.PF2E.rarityTraits, {
+            sort: false,
+        });
         this.filterData.traits.options = this.generateMultiselectOptions(CONFIG.PF2E.creatureTraits);
-        this.filterData.checkboxes.rarity.options = this.generateCheckboxOptions(CONFIG.PF2E.rarityTraits, false);
         this.filterData.source.options = this.generateSourceCheckboxOptions(publications);
 
         console.debug("PF2e System | Compendium Browser | Finished loading Bestiary actors");
-    }
-
-    protected override filterIndexData(entry: CompendiumBrowserIndexData): boolean {
-        const { checkboxes, source, traits, level } = this.filterData;
-
-        // Level
-        if (!(entry.level >= level.from && entry.level <= level.to)) return false;
-
-        // Size
-        if (checkboxes.sizes.selected.length) {
-            if (!checkboxes.sizes.selected.includes(entry.actorSize)) return false;
-        }
-
-        // Traits
-        if (!this.filterTraits(entry.traits, traits.selected, traits.conjunction)) return false;
-
-        // Source
-        if (source.selected.length) {
-            if (!source.selected.includes(entry.source)) return false;
-        }
-
-        // Rarity
-        if (checkboxes.rarity.selected.length) {
-            if (!checkboxes.rarity.selected.includes(entry.rarity)) return false;
-        }
-        return true;
     }
 
     protected override prepareFilterData(): BestiaryFilters {
@@ -118,6 +104,7 @@ export class CompendiumBrowserBestiaryTab extends CompendiumBrowserTab {
                     isExpanded: true,
                     label: "PF2E.CompendiumBrowser.Filter.Sizes",
                     options: {},
+                    optionPrefix: "size",
                     selected: [],
                 },
                 rarity: {

--- a/src/module/apps/compendium-browser/tabs/bestiary.ts
+++ b/src/module/apps/compendium-browser/tabs/bestiary.ts
@@ -50,7 +50,7 @@ export class CompendiumBrowserBestiaryTab extends CompendiumBrowserTab {
                     );
                     continue;
                 }
-                const options = new Set<string>();
+                const options: string[] = [];
                 const system = actorData.system;
                 // Prepare publication source
                 const details = system.details;
@@ -58,17 +58,13 @@ export class CompendiumBrowserBestiaryTab extends CompendiumBrowserTab {
                 const sourceSlug = sluggify(pubSource);
                 if (pubSource) {
                     publications.add(pubSource);
-                    options.add(`source:${sourceSlug}`);
+                    options.push(`source:${sourceSlug}`);
                 }
-
-                for (const trait of system.traits.value) {
-                    options.add(`trait:${trait.replace(/^hb_/, "")}`);
-                }
-
-                options.add(`level:${system.details.level.value}`);
-                options.add(`rarity:${system.traits.rarity}`);
-                options.add(`size:${system.traits.size.value}`);
-                options.add(`type:${actorData.type}`);
+                options.push(...system.traits.value.map((t: string) => `trait:${t.replace(/^hb_/, "")}`));
+                options.push(`level:${system.details.level.value}`);
+                options.push(`rarity:${system.traits.rarity}`);
+                options.push(`size:${system.traits.size.value}`);
+                options.push(`type:${actorData.type}`);
 
                 bestiaryActors.push({
                     name: actorData.name,
@@ -77,7 +73,7 @@ export class CompendiumBrowserBestiaryTab extends CompendiumBrowserTab {
                     uuid: actorData.uuid,
                     level: actorData.system.details.level.value,
                     rarity: actorData.system.traits.rarity,
-                    options,
+                    options: new Set(options),
                 });
             }
             console.debug(`PF2e System | Compendium Browser | ${pack.metadata.label} - Loaded`);

--- a/src/module/apps/compendium-browser/tabs/campaign-feature.ts
+++ b/src/module/apps/compendium-browser/tabs/campaign-feature.ts
@@ -45,24 +45,21 @@ export class CompendiumBrowserCampaignFeaturesTab extends CompendiumBrowserTab {
         )) {
             console.debug(`PF2e System | Compendium Browser | ${pack.metadata.label} - ${index.size} entries found`);
             for (const featData of index.filter((i) => i.type === "campaignFeature")) {
-                const options = new Set<string>();
+                const options: string[] = [];
                 const system = featData.system;
 
-                for (const trait of system.traits.value.map((t: string) => t.replace(/^hb_/, ""))) {
-                    options.add(`trait:${trait}`);
-                }
+                options.push(...system.traits.value.map((t: string) => `trait:${t.replace(/^hb_/, "")}`));
 
                 // Prepare publication source
                 const pubSource = String(system.publication?.title ?? system.source?.value ?? "").trim();
                 const sourceSlug = sluggify(pubSource);
                 if (pubSource) {
                     publications.add(pubSource);
-                    options.add(`source:${sourceSlug}`);
+                    options.push(`source:${sourceSlug}`);
                 }
-
-                options.add(`category:${system.category}`);
-                options.add(`level:${system.level?.value ?? 0}`);
-                options.add(`rarity:${system.traits.rarity}`);
+                options.push(`category:${system.category}`);
+                options.push(`level:${system.level?.value ?? 0}`);
+                options.push(`rarity:${system.traits.rarity}`);
 
                 feats.push({
                     name: featData.name,
@@ -71,7 +68,7 @@ export class CompendiumBrowserCampaignFeaturesTab extends CompendiumBrowserTab {
                     uuid: featData.uuid,
                     level: featData.system.level?.value,
                     rarity: system.traits.rarity,
-                    options,
+                    options: new Set(options),
                 });
             }
         }

--- a/src/module/apps/compendium-browser/tabs/campaign-feature.ts
+++ b/src/module/apps/compendium-browser/tabs/campaign-feature.ts
@@ -1,5 +1,4 @@
 import { KINGMAKER_CATEGORIES } from "@item/campaign-feature/values.ts";
-import { sluggify } from "@util";
 import { CompendiumBrowser } from "../browser.ts";
 import { ContentTabName } from "../data.ts";
 import { CompendiumBrowserTab } from "./base.svelte.ts";
@@ -45,21 +44,16 @@ export class CompendiumBrowserCampaignFeaturesTab extends CompendiumBrowserTab {
         )) {
             console.debug(`PF2e System | Compendium Browser | ${pack.metadata.label} - ${index.size} entries found`);
             for (const featData of index.filter((i) => i.type === "campaignFeature")) {
-                const options: string[] = [];
                 const system = featData.system;
 
-                options.push(...system.traits.value.map((t: string) => `trait:${t.replace(/^hb_/, "")}`));
-
-                // Prepare publication source
                 const pubSource = String(system.publication?.title ?? system.source?.value ?? "").trim();
-                const sourceSlug = sluggify(pubSource);
-                if (pubSource) {
-                    publications.add(pubSource);
-                    options.push(`source:${sourceSlug}`);
-                }
-                options.push(`category:${system.category}`);
-                options.push(`level:${system.level?.value ?? 0}`);
-                options.push(`rarity:${system.traits.rarity}`);
+                const options: string[] = [
+                    ...system.traits.value.map((t: string) => `trait:${t.replace(/^hb_/, "")}`),
+                    `category:${system.category}`,
+                    `level:${system.level?.value ?? 0}`,
+                    `rarity:${system.traits.rarity}`,
+                    this.preparePublicationSource(pubSource, publications),
+                ];
 
                 feats.push({
                     name: featData.name,

--- a/src/module/apps/compendium-browser/tabs/campaign-feature.ts
+++ b/src/module/apps/compendium-browser/tabs/campaign-feature.ts
@@ -12,7 +12,7 @@ export class CompendiumBrowserCampaignFeaturesTab extends CompendiumBrowserTab {
 
     /* MiniSearch */
     override searchFields = ["name", "originalName"];
-    override storeFields = ["type", "name", "img", "uuid", "level", "category", "traits", "source"];
+    override storeFields = ["name", "originalName", "img", "uuid", "level", "rarity", "options"];
 
     constructor(browser: CompendiumBrowser) {
         super(browser);
@@ -45,26 +45,33 @@ export class CompendiumBrowserCampaignFeaturesTab extends CompendiumBrowserTab {
         )) {
             console.debug(`PF2e System | Compendium Browser | ${pack.metadata.label} - ${index.size} entries found`);
             for (const featData of index.filter((i) => i.type === "campaignFeature")) {
-                featData.filters = {};
+                const options = new Set<string>();
+                const system = featData.system;
+
+                for (const trait of system.traits.value.map((t: string) => t.replace(/^hb_/, ""))) {
+                    options.add(`trait:${trait}`);
+                }
 
                 // Prepare publication source
-                const { system } = featData;
                 const pubSource = String(system.publication?.title ?? system.source?.value ?? "").trim();
                 const sourceSlug = sluggify(pubSource);
-                if (pubSource) publications.add(pubSource);
+                if (pubSource) {
+                    publications.add(pubSource);
+                    options.add(`source:${sourceSlug}`);
+                }
 
-                // Only store essential data
+                options.add(`category:${system.category}`);
+                options.add(`level:${system.level?.value ?? 0}`);
+                options.add(`rarity:${system.traits.rarity}`);
+
                 feats.push({
-                    type: featData.type,
                     name: featData.name,
                     originalName: featData.originalName, // Added by Babele
                     img: featData.img,
                     uuid: featData.uuid,
                     level: featData.system.level?.value,
-                    category: featData.system.category,
-                    traits: featData.system.traits.value.map((t: string) => t.replace(/^hb_/, "")),
-                    rarity: featData.system.traits.rarity,
-                    source: sourceSlug,
+                    rarity: system.traits.rarity,
+                    options,
                 });
             }
         }
@@ -79,34 +86,6 @@ export class CompendiumBrowserCampaignFeaturesTab extends CompendiumBrowserTab {
         this.filterData.traits.options = this.generateMultiselectOptions(CONFIG.PF2E.kingmakerTraits);
 
         console.debug("PF2e System | Compendium Browser | Finished loading feats");
-    }
-
-    protected override filterIndexData(entry: CompendiumBrowserIndexData): boolean {
-        const { checkboxes, source, traits, level } = this.filterData;
-
-        const entryLevel = entry.level ?? 0;
-
-        // Level
-        if (!(entryLevel >= level.from && entryLevel <= level.to)) {
-            return false;
-        }
-        // Campaign category type
-        if (checkboxes.category.selected.length) {
-            if (!checkboxes.category.selected.includes(entry.category)) return false;
-        }
-        // Traits
-        if (!this.filterTraits(entry.traits, traits.selected, traits.conjunction)) {
-            return false;
-        }
-        // Source
-        if (source.selected.length) {
-            if (!source.selected.includes(entry.source)) return false;
-        }
-        // Rarity
-        if (checkboxes.rarity.selected.length) {
-            if (!checkboxes.rarity.selected.includes(entry.rarity)) return false;
-        }
-        return true;
     }
 
     protected override prepareFilterData(): CampaignFeatureFilters {

--- a/src/module/apps/compendium-browser/tabs/data.ts
+++ b/src/module/apps/compendium-browser/tabs/data.ts
@@ -6,7 +6,7 @@ import { KingmakerTrait } from "@item/campaign-feature/types.ts";
 import { FeatTrait } from "@item/feat/types.ts";
 import { PhysicalItemTrait } from "@item/physical/data.ts";
 import type { SearchResult } from "minisearch";
-import { SortDirection } from "../data.ts";
+import type { SortDirection } from "../data.ts";
 
 interface CheckboxOption {
     label: string;
@@ -19,6 +19,8 @@ interface CheckboxData {
     isExpanded: boolean;
     label: string;
     options: CheckboxOptions;
+    /** Defaults to the object key of this filter */
+    optionPrefix?: string;
     selected: string[];
 }
 
@@ -31,6 +33,8 @@ interface TraitData<T extends string = string> {
 interface SelectData {
     label: string;
     options: Record<string, string>;
+    /** Defaults to the object key of this filter */
+    optionPrefix?: string;
     selected: string;
 }
 
@@ -54,6 +58,8 @@ interface RangesInputData {
         inputMax: string;
     };
     label: string;
+    /** Defaults to the object key of this filter */
+    optionPrefix?: string;
 }
 
 interface LevelData {
@@ -70,7 +76,7 @@ interface BaseFilterData {
     search: {
         text: string;
     };
-    traits: TraitData<string>;
+    traits: TraitData;
 }
 
 interface ActionFilters extends BaseFilterData {

--- a/src/module/apps/compendium-browser/tabs/equipment.ts
+++ b/src/module/apps/compendium-browser/tabs/equipment.ts
@@ -15,20 +15,7 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
 
     /* MiniSearch */
     override searchFields = ["name", "originalName"];
-    override storeFields = [
-        "type",
-        "name",
-        "img",
-        "uuid",
-        "level",
-        "category",
-        "group",
-        "price",
-        "priceInCopper",
-        "traits",
-        "rarity",
-        "source",
-    ];
+    override storeFields = ["name", "originalName", "img", "uuid", "level", "price", "rarity", "options"];
 
     constructor(browser: CompendiumBrowser) {
         super(browser);
@@ -40,7 +27,7 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
     protected override async loadData(): Promise<void> {
         console.debug("PF2e System | Compendium Browser | Started loading inventory items");
 
-        const inventoryItems: CompendiumBrowserIndexData[] = [];
+        const equipment: CompendiumBrowserIndexData[] = [];
         const itemTypes = [...PHYSICAL_ITEM_TYPES, "kit"];
         // Define index fields for different types of equipment
 
@@ -79,18 +66,23 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
                         );
                         continue;
                     }
+                    const options = new Set<string>();
 
                     // Store price as a number for better sorting (note: we may be dealing with old data, convert if needed)
                     const priceValue = itemData.system.price.value;
                     const priceCoins =
                         typeof priceValue === "string" ? Coins.fromString(priceValue) : new Coins(priceValue);
                     const coinValue = priceCoins.copperValue;
+                    options.add(`price:${coinValue}`);
 
                     // Prepare publication source
-                    const { system } = itemData;
+                    const system = itemData.system;
                     const pubSource = String(system.publication?.title ?? system.source?.value ?? "").trim();
                     const sourceSlug = sluggify(pubSource);
-                    if (pubSource) publications.add(pubSource);
+                    if (pubSource) {
+                        publications.add(pubSource);
+                        options.add(`source:${sourceSlug}`);
+                    }
 
                     // Infer magical trait from runes
                     const traits = itemData.system.traits.value ?? [];
@@ -103,40 +95,41 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
                     ) {
                         traits.push("magical");
                     }
+                    for (const trait of R.unique(traits)) {
+                        options.add(`trait:${trait}`);
+                    }
+                    options.add(`level:${itemData.system.level?.value ?? 0}`);
+                    options.add(`type:category:${itemData.system.category ?? "none"}`);
+                    options.add(`type:group:${itemData.system.group ?? "none"}`);
+                    options.add(`rarity:${itemData.system.traits.rarity}`);
+                    options.add(`type:${itemData.type}`);
 
-                    inventoryItems.push({
-                        type: itemData.type,
+                    equipment.push({
                         name: itemData.name,
                         originalName: itemData.originalName, // Added by Babele
                         img: itemData.img,
                         uuid: itemData.uuid,
                         level: itemData.system.level?.value ?? 0,
-                        category: itemData.system.category ?? "",
-                        group: itemData.system.group ?? "",
                         price: priceCoins,
-                        priceInCopper: coinValue,
-                        traits: R.unique(itemData.system.traits.value),
                         rarity: itemData.system.traits.rarity,
-                        source: sourceSlug,
+                        options,
                     });
                 }
             }
         }
 
         // Set indexData
-        this.indexData = inventoryItems;
+        this.indexData = equipment;
 
         // Filters
-        this.filterData.checkboxes.armorTypes.options = this.generateCheckboxOptions(CONFIG.PF2E.armorCategories);
-        fu.mergeObject(
-            this.filterData.checkboxes.armorTypes.options,
-            this.generateCheckboxOptions(CONFIG.PF2E.armorGroups),
-        );
-        this.filterData.checkboxes.weaponTypes.options = this.generateCheckboxOptions(CONFIG.PF2E.weaponCategories);
-        fu.mergeObject(
-            this.filterData.checkboxes.weaponTypes.options,
-            this.generateCheckboxOptions(CONFIG.PF2E.weaponGroups),
-        );
+        this.filterData.checkboxes.armorTypes.options = {
+            ...this.generateCheckboxOptions(CONFIG.PF2E.armorCategories, { prefix: "category" }),
+            ...this.generateCheckboxOptions(CONFIG.PF2E.armorGroups, { prefix: "group" }),
+        };
+        this.filterData.checkboxes.weaponTypes.options = {
+            ...this.generateCheckboxOptions(CONFIG.PF2E.weaponCategories, { prefix: "category" }),
+            ...this.generateCheckboxOptions(CONFIG.PF2E.weaponGroups, { prefix: "group" }),
+        };
 
         this.filterData.traits.options = this.generateMultiselectOptions({
             ...CONFIG.PF2E.armorTraits,
@@ -157,49 +150,12 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
             backpack: "TYPES.Item.backpack",
             kit: "TYPES.Item.kit",
         });
-        this.filterData.checkboxes.rarity.options = this.generateCheckboxOptions(CONFIG.PF2E.rarityTraits, false);
+        this.filterData.checkboxes.rarity.options = this.generateCheckboxOptions(CONFIG.PF2E.rarityTraits, {
+            sort: false,
+        });
         this.filterData.source.options = this.generateSourceCheckboxOptions(publications);
 
         console.debug("PF2e System | Compendium Browser | Finished loading inventory items");
-    }
-
-    protected override filterIndexData(entry: CompendiumBrowserIndexData): boolean {
-        const { checkboxes, source, traits, ranges, level } = this.filterData;
-
-        // Level
-        if (!(entry.level >= level.from && entry.level <= level.to)) return false;
-        // Price
-        if (!(entry.priceInCopper >= ranges.price.values.min && entry.priceInCopper <= ranges.price.values.max))
-            return false;
-        // Item type
-        if (checkboxes.itemTypes.selected.length > 0 && !checkboxes.itemTypes.selected.includes(entry.type)) {
-            return false;
-        }
-        // Armor
-        if (
-            checkboxes.armorTypes.selected.length > 0 &&
-            !this.arrayIncludes(checkboxes.armorTypes.selected, [entry.category, entry.group])
-        ) {
-            return false;
-        }
-        // Weapon categories
-        if (
-            checkboxes.weaponTypes.selected.length > 0 &&
-            !this.arrayIncludes(checkboxes.weaponTypes.selected, [entry.category, entry.group])
-        ) {
-            return false;
-        }
-        // Traits
-        if (!this.filterTraits(entry.traits, traits.selected, traits.conjunction)) return false;
-        // Source
-        if (source.selected.length > 0 && !source.selected.includes(entry.source)) {
-            return false;
-        }
-        // Rarity
-        if (checkboxes.rarity.selected.length > 0 && !checkboxes.rarity.selected.includes(entry.rarity)) {
-            return false;
-        }
-        return true;
     }
 
     override parseRangeFilterInput(name: string, lower: string, upper: string): RangesInputData["values"] {
@@ -229,6 +185,7 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
                     isExpanded: true,
                     label: "PF2E.CompendiumBrowser.Filter.InventoryTypes",
                     options: {},
+                    optionPrefix: "type",
                     selected: [],
                 },
                 rarity: {
@@ -241,12 +198,14 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
                     isExpanded: false,
                     label: "PF2E.CompendiumBrowser.Filter.ArmorFilters",
                     options: {},
+                    optionPrefix: "type",
                     selected: [],
                 },
                 weaponTypes: {
                     isExpanded: false,
                     label: "PF2E.CompendiumBrowser.Filter.WeaponFilters",
                     options: {},
+                    optionPrefix: "type",
                     selected: [],
                 },
             },

--- a/src/module/apps/compendium-browser/tabs/equipment.ts
+++ b/src/module/apps/compendium-browser/tabs/equipment.ts
@@ -66,14 +66,14 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
                         );
                         continue;
                     }
-                    const options = new Set<string>();
+                    const options: string[] = [];
 
                     // Store price as a number for better sorting (note: we may be dealing with old data, convert if needed)
                     const priceValue = itemData.system.price.value;
                     const priceCoins =
                         typeof priceValue === "string" ? Coins.fromString(priceValue) : new Coins(priceValue);
                     const coinValue = priceCoins.copperValue;
-                    options.add(`price:${coinValue}`);
+                    options.push(`price:${coinValue}`);
 
                     // Prepare publication source
                     const system = itemData.system;
@@ -81,11 +81,11 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
                     const sourceSlug = sluggify(pubSource);
                     if (pubSource) {
                         publications.add(pubSource);
-                        options.add(`source:${sourceSlug}`);
+                        options.push(`source:${sourceSlug}`);
                     }
 
                     // Infer magical trait from runes
-                    const traits = itemData.system.traits.value ?? [];
+                    const traits: string[] = itemData.system.traits.value ?? [];
                     const runes = itemData.system.runes;
                     const traditionTraits: Set<string> = MAGIC_TRADITIONS;
                     if (
@@ -95,14 +95,12 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
                     ) {
                         traits.push("magical");
                     }
-                    for (const trait of R.unique(traits)) {
-                        options.add(`trait:${trait}`);
-                    }
-                    options.add(`level:${itemData.system.level?.value ?? 0}`);
-                    options.add(`type:category:${itemData.system.category ?? "none"}`);
-                    options.add(`type:group:${itemData.system.group ?? "none"}`);
-                    options.add(`rarity:${itemData.system.traits.rarity}`);
-                    options.add(`type:${itemData.type}`);
+                    options.push(...traits.map((t) => `trait:${t.replace(/^hb_/, "")}`));
+                    options.push(`level:${itemData.system.level?.value ?? 0}`);
+                    options.push(`type:category:${itemData.system.category ?? "none"}`);
+                    options.push(`type:group:${itemData.system.group ?? "none"}`);
+                    options.push(`rarity:${itemData.system.traits.rarity}`);
+                    options.push(`type:${itemData.type}`);
 
                     equipment.push({
                         name: itemData.name,
@@ -112,7 +110,7 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
                         level: itemData.system.level?.value ?? 0,
                         price: priceCoins,
                         rarity: itemData.system.traits.rarity,
-                        options,
+                        options: new Set(options),
                     });
                 }
             }

--- a/src/module/apps/compendium-browser/tabs/equipment.ts
+++ b/src/module/apps/compendium-browser/tabs/equipment.ts
@@ -1,7 +1,6 @@
 import { Coins } from "@item/physical/helpers.ts";
 import { PHYSICAL_ITEM_TYPES } from "@item/physical/values.ts";
 import { MAGIC_TRADITIONS } from "@item/spell/values.ts";
-import { sluggify } from "@util";
 import * as R from "remeda";
 import { CompendiumBrowser } from "../browser.ts";
 import { ContentTabName } from "../data.ts";
@@ -66,23 +65,7 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
                         );
                         continue;
                     }
-                    const options: string[] = [];
-
-                    // Store price as a number for better sorting (note: we may be dealing with old data, convert if needed)
-                    const priceValue = itemData.system.price.value;
-                    const priceCoins =
-                        typeof priceValue === "string" ? Coins.fromString(priceValue) : new Coins(priceValue);
-                    const coinValue = priceCoins.copperValue;
-                    options.push(`price:${coinValue}`);
-
-                    // Prepare publication source
                     const system = itemData.system;
-                    const pubSource = String(system.publication?.title ?? system.source?.value ?? "").trim();
-                    const sourceSlug = sluggify(pubSource);
-                    if (pubSource) {
-                        publications.add(pubSource);
-                        options.push(`source:${sourceSlug}`);
-                    }
 
                     // Infer magical trait from runes
                     const traits: string[] = itemData.system.traits.value ?? [];
@@ -95,12 +78,24 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
                     ) {
                         traits.push("magical");
                     }
-                    options.push(...traits.map((t) => `trait:${t.replace(/^hb_/, "")}`));
-                    options.push(`level:${itemData.system.level?.value ?? 0}`);
-                    options.push(`type:category:${itemData.system.category ?? "none"}`);
-                    options.push(`type:group:${itemData.system.group ?? "none"}`);
-                    options.push(`rarity:${itemData.system.traits.rarity}`);
-                    options.push(`type:${itemData.type}`);
+
+                    // Store price as a number for better sorting (note: we may be dealing with old data, convert if needed)
+                    const priceValue = system.price.value;
+                    const priceCoins =
+                        typeof priceValue === "string" ? Coins.fromString(priceValue) : new Coins(priceValue);
+                    const coinValue = priceCoins.copperValue;
+
+                    const pubSource = String(system.publication?.title ?? system.source?.value ?? "").trim();
+                    const options: string[] = [
+                        ...traits.map((t) => `trait:${t.replace(/^hb_/, "")}`),
+                        `price:${coinValue}`,
+                        `level:${itemData.system.level?.value ?? 0}`,
+                        `type:category:${itemData.system.category ?? "none"}`,
+                        `type:group:${itemData.system.group ?? "none"}`,
+                        `rarity:${itemData.system.traits.rarity}`,
+                        `type:${itemData.type}`,
+                        this.preparePublicationSource(pubSource, publications),
+                    ];
 
                     equipment.push({
                         name: itemData.name,

--- a/src/module/apps/compendium-browser/tabs/feat.ts
+++ b/src/module/apps/compendium-browser/tabs/feat.ts
@@ -61,7 +61,7 @@ export class CompendiumBrowserFeatTab extends CompendiumBrowserTab {
                     );
                     continue;
                 }
-                const options = new Set<string>();
+                const options: string[] = [];
                 const system = featData.system;
 
                 // Accommodate deprecated featType objects
@@ -87,35 +87,28 @@ export class CompendiumBrowserFeatTab extends CompendiumBrowserTab {
                         }
                     }
                 }
-
-                for (const skill of skills) {
-                    options.add(`skill:${skill}`);
-                }
+                options.push(...skills.map((s) => `skill:${s}`));
 
                 const category = system.category;
                 const type = featData.type;
                 const traits: string[] = system.traits.value;
                 // Tag ancestry items without an ancestry trait
                 if (category === "ancestry" && !traits.some((t) => t in this.#creatureTraits)) {
-                    options.add("trait:ancestry:universal");
+                    options.push("trait:ancestry:universal");
                 }
-                options.add(`category:${category}`);
-                options.add(`type:${type}`);
-
-                for (const trait of traits) {
-                    options.add(`trait:${trait.replace(/^hb_/, "")}`);
-                }
+                options.push(`category:${category}`);
+                options.push(`type:${type}`);
+                options.push(...traits.map((t: string) => `trait:${t.replace(/^hb_/, "")}`));
 
                 // Prepare source
                 const pubSource = system.publication?.title ?? system.source?.value ?? "";
                 const sourceSlug = sluggify(pubSource);
                 if (pubSource) {
                     publications.add(pubSource);
-                    options.add(`source:${sourceSlug}`);
+                    options.push(`source:${sourceSlug}`);
                 }
-
-                options.add(`level:${system.level.value}`);
-                options.add(`rarity:${system.traits.rarity}`);
+                options.push(`level:${system.level.value}`);
+                options.push(`rarity:${system.traits.rarity}`);
 
                 feats.push({
                     name: featData.name,
@@ -124,7 +117,7 @@ export class CompendiumBrowserFeatTab extends CompendiumBrowserTab {
                     uuid: featData.uuid,
                     level: featData.system.level.value,
                     rarity: featData.system.traits.rarity,
-                    options,
+                    options: new Set(options),
                 });
             }
         }

--- a/src/module/apps/compendium-browser/tabs/feat.ts
+++ b/src/module/apps/compendium-browser/tabs/feat.ts
@@ -3,7 +3,7 @@ import * as R from "remeda";
 import { CompendiumBrowser } from "../browser.ts";
 import { ContentTabName } from "../data.ts";
 import { CompendiumBrowserTab } from "./base.svelte.ts";
-import { CompendiumBrowserIndexData, FeatFilters, TraitData } from "./data.ts";
+import { CompendiumBrowserIndexData, FeatFilters } from "./data.ts";
 
 export class CompendiumBrowserFeatTab extends CompendiumBrowserTab {
     tabName: ContentTabName = "feat";
@@ -12,7 +12,7 @@ export class CompendiumBrowserFeatTab extends CompendiumBrowserTab {
 
     /* MiniSearch */
     override searchFields = ["name", "originalName"];
-    override storeFields = ["type", "name", "img", "uuid", "level", "category", "skills", "traits", "rarity", "source"];
+    override storeFields = ["name", "originalName", "img", "uuid", "level", "rarity", "options"];
 
     #creatureTraits = CONFIG.PF2E.creatureTraits;
 
@@ -47,66 +47,85 @@ export class CompendiumBrowserFeatTab extends CompendiumBrowserTab {
         )) {
             console.debug(`PF2e System | Compendium Browser | ${pack.metadata.label} - ${index.size} entries found`);
             for (const featData of index) {
-                if (featData.type === "feat") {
-                    featData.filters = {};
-                    // Check separately for one of "system.category or "system.featType.value" to provide backward
-                    // compatible support for unmigrated feats in non-system compendiums.
-                    const categoryPaths = ["system.category", "system.featType.value"];
-                    const nonCategoryPaths = indexFields.filter((f) => !categoryPaths.includes(f));
-                    const categoryPathFound = categoryPaths.some((p) => fu.hasProperty(featData, p));
+                if (featData.type !== "feat") continue;
+                // Check separately for one of "system.category or "system.featType.value" to provide backward
+                // compatible support for unmigrated feats in non-system compendiums.
+                const categoryPaths = ["system.category", "system.featType.value"];
+                const nonCategoryPaths = indexFields.filter((f) => !categoryPaths.includes(f));
+                const categoryPathFound = categoryPaths.some((p) => fu.hasProperty(featData, p));
 
-                    if (!this.hasAllIndexFields(featData, nonCategoryPaths) || !categoryPathFound) {
-                        console.warn(
-                            `Feat "${featData.name}" does not have all required data fields.`,
-                            `Consider unselecting pack "${pack.metadata.label}" in the compendium browser settings.`,
-                        );
-                        continue;
-                    }
-
-                    // Accommodate deprecated featType objects
-                    const featType: unknown = featData.system.featType;
-                    if (R.isPlainObject(featType) && "value" in featType && typeof featType.value === "string") {
-                        featData.system.category = featType.value;
-                        delete featData.system.featType;
-                    }
-
-                    // Prerequisites are strings that could contain translated skill names
-                    const prereqs: { value: string }[] = featData.system.prerequisites.value;
-                    const prerequisitesArr = prereqs.map((prerequisite) =>
-                        prerequisite?.value ? prerequisite.value.toLowerCase() : "",
+                if (!this.hasAllIndexFields(featData, nonCategoryPaths) || !categoryPathFound) {
+                    console.warn(
+                        `Feat "${featData.name}" does not have all required data fields.`,
+                        `Consider unselecting pack "${pack.metadata.label}" in the compendium browser settings.`,
                     );
-                    const skills: Set<string> = new Set();
-                    for (const prereq of prerequisitesArr) {
-                        for (const [key, value] of Object.entries(CONFIG.PF2E.skills)) {
-                            // Check the string for the english translation key or a translated skill name
-                            const translated = game.i18n.localize(value.label).toLocaleLowerCase(game.i18n.lang);
-                            if (prereq.includes(key) || prereq.includes(translated)) {
-                                // Alawys record the translation key to enable filtering
-                                skills.add(key);
-                            }
+                    continue;
+                }
+                const options = new Set<string>();
+                const system = featData.system;
+
+                // Accommodate deprecated featType objects
+                const featType: unknown = system.featType;
+                if (R.isPlainObject(featType) && "value" in featType && typeof featType.value === "string") {
+                    system.category = featType.value;
+                    delete system.featType;
+                }
+
+                // Prerequisites are strings that could contain translated skill names
+                const prereqs: { value: string }[] = system.prerequisites.value;
+                const prerequisitesArr = prereqs.map((prerequisite) =>
+                    prerequisite?.value ? prerequisite.value.toLowerCase() : "",
+                );
+                const skills: Set<string> = new Set();
+                for (const prereq of prerequisitesArr) {
+                    for (const [key, value] of Object.entries(CONFIG.PF2E.skills)) {
+                        // Check the string for the english translation key or a translated skill name
+                        const translated = game.i18n.localize(value.label).toLocaleLowerCase(game.i18n.lang);
+                        if (prereq.includes(key) || prereq.includes(translated)) {
+                            // Alawys record the translation key to enable filtering
+                            skills.add(key);
                         }
                     }
-
-                    // Prepare source
-                    const pubSource = featData.system.publication?.title ?? featData.system.source?.value ?? "";
-                    const sourceSlug = sluggify(pubSource);
-                    if (pubSource) publications.add(pubSource);
-
-                    // Only store essential data
-                    feats.push({
-                        type: featData.type,
-                        name: featData.name,
-                        originalName: featData.originalName, // Added by Babele
-                        img: featData.img,
-                        uuid: featData.uuid,
-                        level: featData.system.level.value,
-                        category: featData.system.category,
-                        skills: [...skills],
-                        traits: featData.system.traits.value.map((t: string) => t.replace(/^hb_/, "")),
-                        rarity: featData.system.traits.rarity,
-                        source: sourceSlug,
-                    });
                 }
+
+                for (const skill of skills) {
+                    options.add(`skill:${skill}`);
+                }
+
+                const category = system.category;
+                const type = featData.type;
+                const traits: string[] = system.traits.value;
+                // Tag ancestry items without an ancestry trait
+                if (category === "ancestry" && !traits.some((t) => t in this.#creatureTraits)) {
+                    options.add("trait:ancestry:universal");
+                }
+                options.add(`category:${category}`);
+                options.add(`type:${type}`);
+
+                for (const trait of traits) {
+                    options.add(`trait:${trait.replace(/^hb_/, "")}`);
+                }
+
+                // Prepare source
+                const pubSource = system.publication?.title ?? system.source?.value ?? "";
+                const sourceSlug = sluggify(pubSource);
+                if (pubSource) {
+                    publications.add(pubSource);
+                    options.add(`source:${sourceSlug}`);
+                }
+
+                options.add(`level:${system.level.value}`);
+                options.add(`rarity:${system.traits.rarity}`);
+
+                feats.push({
+                    name: featData.name,
+                    originalName: featData.originalName, // Added by Babele
+                    img: featData.img,
+                    uuid: featData.uuid,
+                    level: featData.system.level.value,
+                    rarity: featData.system.traits.rarity,
+                    options,
+                });
             }
         }
 
@@ -123,48 +142,6 @@ export class CompendiumBrowserFeatTab extends CompendiumBrowserTab {
         console.debug("PF2e System | Compendium Browser | Finished loading feats");
     }
 
-    protected override filterTraits(
-        traits: string[],
-        selected: TraitData["selected"],
-        condition: TraitData["conjunction"],
-    ): boolean {
-        // Pre-filter the selected traits if the current ancestry item has no ancestry traits
-        if (
-            this.filterData.checkboxes.category.selected.includes("ancestry") &&
-            !traits.some((t) => t in this.#creatureTraits)
-        ) {
-            const withoutAncestryTraits = selected.filter((t) => !(t.value in this.#creatureTraits));
-            return super.filterTraits(traits, withoutAncestryTraits, condition);
-        }
-        return super.filterTraits(traits, selected, condition);
-    }
-
-    protected override filterIndexData(entry: CompendiumBrowserIndexData): boolean {
-        const { checkboxes, source, traits, level } = this.filterData;
-
-        // Level
-        if (!(entry.level >= level.from && entry.level <= level.to)) return false;
-        // Feat types
-        if (checkboxes.category.selected.length) {
-            if (!checkboxes.category.selected.includes(entry.category)) return false;
-        }
-        // Skills
-        if (checkboxes.skills.selected.length) {
-            if (!this.arrayIncludes(checkboxes.skills.selected, entry.skills)) return false;
-        }
-        // Traits
-        if (!this.filterTraits(entry.traits, traits.selected, traits.conjunction)) return false;
-        // Source
-        if (source.selected.length) {
-            if (!source.selected.includes(entry.source)) return false;
-        }
-        // Rarity
-        if (checkboxes.rarity.selected.length) {
-            if (!checkboxes.rarity.selected.includes(entry.rarity)) return false;
-        }
-        return true;
-    }
-
     protected override prepareFilterData(): FeatFilters {
         return {
             checkboxes: {
@@ -178,6 +155,7 @@ export class CompendiumBrowserFeatTab extends CompendiumBrowserTab {
                     isExpanded: false,
                     label: "PF2E.SkillsLabel",
                     options: {},
+                    optionPrefix: "skill",
                     selected: [],
                 },
                 rarity: {

--- a/src/module/apps/compendium-browser/tabs/feat.ts
+++ b/src/module/apps/compendium-browser/tabs/feat.ts
@@ -1,4 +1,3 @@
-import { sluggify } from "@util";
 import * as R from "remeda";
 import { CompendiumBrowser } from "../browser.ts";
 import { ContentTabName } from "../data.ts";
@@ -61,7 +60,6 @@ export class CompendiumBrowserFeatTab extends CompendiumBrowserTab {
                     );
                     continue;
                 }
-                const options: string[] = [];
                 const system = featData.system;
 
                 // Accommodate deprecated featType objects
@@ -87,28 +85,24 @@ export class CompendiumBrowserFeatTab extends CompendiumBrowserTab {
                         }
                     }
                 }
-                options.push(...skills.map((s) => `skill:${s}`));
-
                 const category = system.category;
                 const type = featData.type;
                 const traits: string[] = system.traits.value;
+                const pubSource = system.publication?.title ?? system.source?.value ?? "";
+                const options: string[] = [
+                    ...traits.map((t: string) => `trait:${t.replace(/^hb_/, "")}`),
+                    ...skills.map((s) => `skill:${s}`),
+                    `category:${category}`,
+                    `type:${type}`,
+                    `level:${system.level.value}`,
+                    `rarity:${system.traits.rarity}`,
+                    this.preparePublicationSource(pubSource, publications),
+                ];
+
                 // Tag ancestry items without an ancestry trait
                 if (category === "ancestry" && !traits.some((t) => t in this.#creatureTraits)) {
                     options.push("trait:ancestry:universal");
                 }
-                options.push(`category:${category}`);
-                options.push(`type:${type}`);
-                options.push(...traits.map((t: string) => `trait:${t.replace(/^hb_/, "")}`));
-
-                // Prepare source
-                const pubSource = system.publication?.title ?? system.source?.value ?? "";
-                const sourceSlug = sluggify(pubSource);
-                if (pubSource) {
-                    publications.add(pubSource);
-                    options.push(`source:${sourceSlug}`);
-                }
-                options.push(`level:${system.level.value}`);
-                options.push(`rarity:${system.traits.rarity}`);
 
                 feats.push({
                     name: featData.name,

--- a/src/module/apps/compendium-browser/tabs/hazard.ts
+++ b/src/module/apps/compendium-browser/tabs/hazard.ts
@@ -46,26 +46,22 @@ export class CompendiumBrowserHazardTab extends CompendiumBrowserTab {
                     );
                     continue;
                 }
-                const options = new Set<string>();
+                const options: string[] = [];
                 const system = actorData.system;
 
-                for (const trait of system.traits.value) {
-                    options.add(`trait:${trait}`);
-                }
-
+                options.push(...system.traits.value.map((t: string) => `trait:${t.replace(/^hb_/, "")}`));
                 // Prepare publication source
                 const details = system.details;
                 const pubSource = String(details.publication?.title ?? details.source?.value ?? "").trim();
                 const sourceSlug = sluggify(pubSource);
                 if (pubSource) {
                     publications.add(pubSource);
-                    options.add(`source:${sourceSlug}`);
+                    options.push(`source:${sourceSlug}`);
                 }
-
-                options.add(`complexity:${system.details.isComplex ? "complex" : "simple"}`);
-                options.add(`level:${system.details.level.value}`);
-                options.add(`rarity:${system.traits.rarity}`);
-                options.add(`type:${actorData.type}`);
+                options.push(`complexity:${system.details.isComplex ? "complex" : "simple"}`);
+                options.push(`level:${system.details.level.value}`);
+                options.push(`rarity:${system.traits.rarity}`);
+                options.push(`type:${actorData.type}`);
 
                 hazardActors.push({
                     name: actorData.name,
@@ -74,7 +70,7 @@ export class CompendiumBrowserHazardTab extends CompendiumBrowserTab {
                     uuid: actorData.uuid,
                     level: actorData.system.details.level.value,
                     rarity: actorData.system.traits.rarity,
-                    options,
+                    options: new Set(options),
                 });
             }
             console.debug(`PF2e System | Compendium Browser | ${pack.metadata.label} - Loaded`);

--- a/src/module/apps/compendium-browser/tabs/hazard.ts
+++ b/src/module/apps/compendium-browser/tabs/hazard.ts
@@ -1,4 +1,3 @@
-import { sluggify } from "@util";
 import { CompendiumBrowser } from "../browser.ts";
 import { ContentTabName } from "../data.ts";
 import { CompendiumBrowserTab } from "./base.svelte.ts";
@@ -46,22 +45,17 @@ export class CompendiumBrowserHazardTab extends CompendiumBrowserTab {
                     );
                     continue;
                 }
-                const options: string[] = [];
                 const system = actorData.system;
-
-                options.push(...system.traits.value.map((t: string) => `trait:${t.replace(/^hb_/, "")}`));
-                // Prepare publication source
                 const details = system.details;
                 const pubSource = String(details.publication?.title ?? details.source?.value ?? "").trim();
-                const sourceSlug = sluggify(pubSource);
-                if (pubSource) {
-                    publications.add(pubSource);
-                    options.push(`source:${sourceSlug}`);
-                }
-                options.push(`complexity:${system.details.isComplex ? "complex" : "simple"}`);
-                options.push(`level:${system.details.level.value}`);
-                options.push(`rarity:${system.traits.rarity}`);
-                options.push(`type:${actorData.type}`);
+                const options: string[] = [
+                    ...system.traits.value.map((t: string) => `trait:${t.replace(/^hb_/, "")}`),
+                    `complexity:${system.details.isComplex ? "complex" : "simple"}`,
+                    `level:${system.details.level.value}`,
+                    `rarity:${system.traits.rarity}`,
+                    `type:${actorData.type}`,
+                    this.preparePublicationSource(pubSource, publications),
+                ];
 
                 hazardActors.push({
                     name: actorData.name,

--- a/src/module/apps/compendium-browser/tabs/hazard.ts
+++ b/src/module/apps/compendium-browser/tabs/hazard.ts
@@ -11,7 +11,7 @@ export class CompendiumBrowserHazardTab extends CompendiumBrowserTab {
 
     /* MiniSearch */
     override searchFields = ["name", "originalName"];
-    override storeFields = ["type", "name", "img", "uuid", "level", "complexity", "traits", "rarity", "source"];
+    override storeFields = ["name", "originalName", "img", "uuid", "level", "rarity", "options"];
 
     protected index = ["img", "system.details.level.value", "system.details.isComplex", "system.traits"];
 
@@ -46,24 +46,35 @@ export class CompendiumBrowserHazardTab extends CompendiumBrowserTab {
                     );
                     continue;
                 }
+                const options = new Set<string>();
+                const system = actorData.system;
+
+                for (const trait of system.traits.value) {
+                    options.add(`trait:${trait}`);
+                }
 
                 // Prepare publication source
-                const { details } = actorData.system;
+                const details = system.details;
                 const pubSource = String(details.publication?.title ?? details.source?.value ?? "").trim();
                 const sourceSlug = sluggify(pubSource);
-                if (pubSource) publications.add(pubSource);
+                if (pubSource) {
+                    publications.add(pubSource);
+                    options.add(`source:${sourceSlug}`);
+                }
+
+                options.add(`complexity:${system.details.isComplex ? "complex" : "simple"}`);
+                options.add(`level:${system.details.level.value}`);
+                options.add(`rarity:${system.traits.rarity}`);
+                options.add(`type:${actorData.type}`);
 
                 hazardActors.push({
-                    type: actorData.type,
                     name: actorData.name,
                     originalName: actorData.originalName, // Added by Babele
                     img: actorData.img,
                     uuid: actorData.uuid,
                     level: actorData.system.details.level.value,
-                    complexity: actorData.system.details.isComplex ? "complex" : "simple",
-                    traits: actorData.system.traits.value,
                     rarity: actorData.system.traits.rarity,
-                    source: sourceSlug,
+                    options,
                 });
             }
             console.debug(`PF2e System | Compendium Browser | ${pack.metadata.label} - Loaded`);
@@ -78,35 +89,15 @@ export class CompendiumBrowserHazardTab extends CompendiumBrowserTab {
                 simple: "PF2E.Actor.Hazard.Simple",
                 complex: "PF2E.TraitComplex",
             },
-            false,
+            { sort: false },
         );
+        this.filterData.checkboxes.rarity.options = this.generateCheckboxOptions(CONFIG.PF2E.rarityTraits, {
+            sort: false,
+        });
         this.filterData.traits.options = this.generateMultiselectOptions(CONFIG.PF2E.hazardTraits);
-        this.filterData.checkboxes.rarity.options = this.generateCheckboxOptions(CONFIG.PF2E.rarityTraits, false);
         this.filterData.source.options = this.generateSourceCheckboxOptions(publications);
 
         console.debug("PF2e System | Compendium Browser | Finished loading Hazard actors");
-    }
-
-    protected override filterIndexData(entry: CompendiumBrowserIndexData): boolean {
-        const { checkboxes, source, traits, level } = this.filterData;
-
-        // Level
-        if (!(entry.level >= level.from && entry.level <= level.to)) return false;
-        // Complexity
-        if (checkboxes.complexity.selected.length) {
-            if (!checkboxes.complexity.selected.includes(entry.complexity)) return false;
-        }
-        // Traits
-        if (!this.filterTraits(entry.traits, traits.selected, traits.conjunction)) return false;
-        // Source
-        if (source.selected.length) {
-            if (!source.selected.includes(entry.source)) return false;
-        }
-        // Rarity
-        if (checkboxes.rarity.selected.length) {
-            if (!checkboxes.rarity.selected.includes(entry.rarity)) return false;
-        }
-        return true;
     }
 
     protected override prepareFilterData(): HazardFilters {

--- a/src/module/apps/compendium-browser/tabs/spell.ts
+++ b/src/module/apps/compendium-browser/tabs/spell.ts
@@ -43,7 +43,6 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
             console.debug(`PF2e System | Compendium Browser | ${pack.metadata.label} - ${index.size} entries found`);
             for (const spellData of index) {
                 if (spellData.type !== "spell") continue;
-                const options: string[] = [];
 
                 if ("system" in spellData && R.isPlainObject(spellData.system)) {
                     spellData.system.ritual ??= null;
@@ -70,10 +69,17 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
                     isFocusSpell ? "focus" : null,
                     isRitual ? "ritual" : null,
                 ].filter(R.isTruthy);
-                options.push(...categories.map((c) => `category:${c}`));
-                options.push(...system.traits.value.map((t: string) => `trait:${t.replace(/^hb_/, "")}`));
-                // format casting time (before value is sluggified)
-                const actionGlyph = getActionGlyph(system.time.value);
+
+                const pubSource = String(system.publication?.title ?? system.source?.value ?? "").trim();
+                const options: string[] = [
+                    ...system.traits.value.map((t: string) => `trait:${t.replace(/^hb_/, "")}`),
+                    ...system.traits.traditions.map((t: string) => `tradition:${t}`),
+                    ...categories.map((c) => `category:${c}`),
+                    `rank:${system.level.value}`,
+                    `rarity:${system.traits.rarity}`,
+                    "type:spell",
+                    this.preparePublicationSource(pubSource, publications),
+                ];
 
                 // Casting time
                 const time: unknown = system.time.value;
@@ -86,27 +92,13 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
                     options.push(`time:${normalizedTime}`);
                 }
 
-                options.push(...system.traits.traditions.map((t: string) => `tradition:${t}`));
-                options.push(...system.traits.value.map((t: string) => `trait:${t.replace(/^hb_/, "")}`));
-
-                // Publication Source
-                const pubSource = String(system.publication?.title ?? system.source?.value ?? "").trim();
-                const sourceSlug = sluggify(pubSource);
-                if (pubSource) {
-                    publications.add(pubSource);
-                    options.push(`source:${sourceSlug}`);
-                }
-                options.push(`rank:${system.level.value}`);
-                options.push(`rarity:${system.traits.rarity}`);
-                options.push("type:spell");
-
                 spells.push({
                     name: spellData.name,
                     originalName: spellData.originalName, // Added by Babele
                     img: spellData.img,
                     uuid: spellData.uuid,
                     rank: system.level.value,
-                    actionGlyph,
+                    actionGlyph: getActionGlyph(system.time.value),
                     rarity: system.traits.rarity,
                     options: new Set(options),
                 });

--- a/src/module/apps/compendium-browser/tabs/spell.ts
+++ b/src/module/apps/compendium-browser/tabs/spell.ts
@@ -43,7 +43,7 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
             console.debug(`PF2e System | Compendium Browser | ${pack.metadata.label} - ${index.size} entries found`);
             for (const spellData of index) {
                 if (spellData.type !== "spell") continue;
-                const options = new Set<string>();
+                const options: string[] = [];
 
                 if ("system" in spellData && R.isPlainObject(spellData.system)) {
                     spellData.system.ritual ??= null;
@@ -55,13 +55,14 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
                     );
                     continue;
                 }
+                const system = spellData.system;
 
                 // Category
-                const isCantrip = spellData.system.traits.value.includes("cantrip");
+                const isCantrip = system.traits.value.includes("cantrip");
                 const isFocusSpell =
-                    spellData.system.traits.value.includes("focus") ||
-                    (isCantrip && (spellData.system.traits.traditions ?? []).length === 0);
-                const isRitual = !!spellData.system.ritual;
+                    system.traits.value.includes("focus") ||
+                    (isCantrip && (system.traits.traditions ?? []).length === 0);
+                const isRitual = !!system.ritual;
                 const isSpell = !isCantrip && !isFocusSpell && !isRitual;
                 const categories = [
                     isSpell ? "spell" : null,
@@ -69,64 +70,45 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
                     isFocusSpell ? "focus" : null,
                     isRitual ? "ritual" : null,
                 ].filter(R.isTruthy);
-                for (const category of categories) {
-                    options.add(`category:${category}`);
-                }
-
+                options.push(...categories.map((c) => `category:${c}`));
+                options.push(...system.traits.value.map((t: string) => `trait:${t.replace(/^hb_/, "")}`));
                 // format casting time (before value is sluggified)
-                const actionGlyph = getActionGlyph(spellData.system.time.value);
+                const actionGlyph = getActionGlyph(system.time.value);
 
                 // Casting time
-                const time: unknown = spellData.system.time.value;
+                const time: unknown = system.time.value;
                 if (time && typeof time === "string") {
                     const normalizedTime = time.toLocaleLowerCase("en").includes("reaction")
                         ? "reaction"
                         : sluggify(time);
                     times.add(normalizedTime);
-                    spellData.system.time.value = normalizedTime;
-                    options.add(`time:${normalizedTime}`);
+                    system.time.value = normalizedTime;
+                    options.push(`time:${normalizedTime}`);
                 }
 
-                for (const tradition of spellData.system.traits.traditions) {
-                    options.add(`tradition:${tradition}`);
-                }
-
-                for (const trait of spellData.system.traits.value) {
-                    options.add(`trait:${trait.replace(/^hb_/, "")}`);
-                }
-
-                const defense = spellData.system.defense;
-                if (defense?.save) {
-                    if (defense.save.basic) options.add(`defense:save:basic`);
-                    options.add(`defense:save:${defense.save.statistic}`);
-                }
-                if (defense?.passive) options.add(`defense:passive:${defense.passive.statistic.split("-")[0]}`);
-                if (!defense && options.has(`trait:attack`) && !options.has("category:ritual")) {
-                    options.add(`defense:passive:armor`);
-                }
+                options.push(...system.traits.traditions.map((t: string) => `tradition:${t}`));
+                options.push(...system.traits.value.map((t: string) => `trait:${t.replace(/^hb_/, "")}`));
 
                 // Publication Source
-                const system = spellData.system;
                 const pubSource = String(system.publication?.title ?? system.source?.value ?? "").trim();
                 const sourceSlug = sluggify(pubSource);
                 if (pubSource) {
                     publications.add(pubSource);
-                    options.add(`source:${sourceSlug}`);
+                    options.push(`source:${sourceSlug}`);
                 }
-
-                options.add(`rank:${spellData.system.level.value}`);
-                options.add(`rarity:${spellData.system.traits.rarity}`);
-                options.add("type:spell");
+                options.push(`rank:${system.level.value}`);
+                options.push(`rarity:${system.traits.rarity}`);
+                options.push("type:spell");
 
                 spells.push({
                     name: spellData.name,
                     originalName: spellData.originalName, // Added by Babele
                     img: spellData.img,
                     uuid: spellData.uuid,
-                    rank: spellData.system.level.value,
+                    rank: system.level.value,
                     actionGlyph,
-                    rarity: spellData.system.traits.rarity,
-                    options,
+                    rarity: system.traits.rarity,
+                    options: new Set(options),
                 });
             }
         }

--- a/src/module/apps/compendium-browser/tabs/spell.ts
+++ b/src/module/apps/compendium-browser/tabs/spell.ts
@@ -2,9 +2,9 @@ import { MAGIC_TRADITIONS } from "@item/spell/values.ts";
 import { getActionGlyph, ordinalString, sluggify } from "@util";
 import * as R from "remeda";
 import { CompendiumBrowser } from "../browser.ts";
-import { ContentTabName } from "../data.ts";
+import type { ContentTabName } from "../data.ts";
 import { CompendiumBrowserTab } from "./base.svelte.ts";
-import { CompendiumBrowserIndexData, SpellFilters } from "./data.ts";
+import type { CompendiumBrowserIndexData, SpellFilters } from "./data.ts";
 
 export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
     tabName: ContentTabName = "spell";
@@ -13,19 +13,7 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
 
     /* MiniSearch */
     override searchFields = ["name", "originalName"];
-    override storeFields = [
-        "type",
-        "name",
-        "img",
-        "uuid",
-        "rank",
-        "time",
-        "traditions",
-        "traits",
-        "categories",
-        "rarity",
-        "source",
-    ];
+    override storeFields = ["name", "originalName", "img", "uuid", "rank", "rarity", "actionGlyph", "options"];
 
     constructor(browser: CompendiumBrowser) {
         super(browser);
@@ -54,71 +42,92 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
         for await (const { pack, index } of data) {
             console.debug(`PF2e System | Compendium Browser | ${pack.metadata.label} - ${index.size} entries found`);
             for (const spellData of index) {
-                spellData.filters = {};
+                if (spellData.type !== "spell") continue;
+                const options = new Set<string>();
 
-                if (spellData.type === "spell") {
-                    if ("system" in spellData && R.isPlainObject(spellData.system)) {
-                        spellData.system.ritual ??= null;
-                    }
-
-                    if (!this.hasAllIndexFields(spellData, indexFields)) {
-                        console.warn(
-                            `Item '${spellData.name}' does not have all required data fields. Consider unselecting pack '${pack.metadata.label}' in the compendium browser settings.`,
-                        );
-                        continue;
-                    }
-
-                    const isCantrip = spellData.system.traits.value.includes("cantrip");
-                    const isFocusSpell =
-                        spellData.system.traits.value.includes("focus") ||
-                        (isCantrip && (spellData.system.traits.traditions ?? []).length === 0);
-                    const isRitual = !!spellData.system.ritual;
-                    const isSpell = !isCantrip && !isFocusSpell && !isRitual;
-                    const categories = [
-                        isSpell ? "spell" : null,
-                        isCantrip ? "cantrip" : null,
-                        isFocusSpell ? "focus" : null,
-                        isRitual ? "ritual" : null,
-                    ].filter(R.isTruthy);
-
-                    // format casting time (before value is sluggified)
-                    const actionGlyph = getActionGlyph(spellData.system.time.value);
-
-                    // recording casting times
-                    const maybeTime: unknown = spellData.system.time.value;
-                    const time = ((): string | null => {
-                        if (maybeTime && typeof maybeTime === "string") {
-                            const normalizedTime = maybeTime.toLocaleLowerCase("en").includes("reaction")
-                                ? "reaction"
-                                : sluggify(maybeTime);
-                            times.add(normalizedTime);
-                            return normalizedTime;
-                        }
-                        return null;
-                    })();
-
-                    // Prepare publication source
-                    const { system } = spellData;
-                    const pubSource = String(system.publication?.title ?? system.source?.value ?? "").trim();
-                    const sourceSlug = sluggify(pubSource);
-                    if (pubSource) publications.add(pubSource);
-
-                    spells.push({
-                        type: spellData.type,
-                        name: spellData.name,
-                        originalName: spellData.originalName, // Added by Babele
-                        img: spellData.img,
-                        uuid: spellData.uuid,
-                        rank: spellData.system.level.value,
-                        categories,
-                        time,
-                        actionGlyph,
-                        traditions: spellData.system.traits.traditions,
-                        traits: spellData.system.traits.value.map((t: string) => t.replace(/^hb_/, "")),
-                        rarity: spellData.system.traits.rarity,
-                        source: sourceSlug,
-                    });
+                if ("system" in spellData && R.isPlainObject(spellData.system)) {
+                    spellData.system.ritual ??= null;
                 }
+
+                if (!this.hasAllIndexFields(spellData, indexFields)) {
+                    console.warn(
+                        `Item '${spellData.name}' does not have all required data fields. Consider unselecting pack '${pack.metadata.label}' in the compendium browser settings.`,
+                    );
+                    continue;
+                }
+
+                // Category
+                const isCantrip = spellData.system.traits.value.includes("cantrip");
+                const isFocusSpell =
+                    spellData.system.traits.value.includes("focus") ||
+                    (isCantrip && (spellData.system.traits.traditions ?? []).length === 0);
+                const isRitual = !!spellData.system.ritual;
+                const isSpell = !isCantrip && !isFocusSpell && !isRitual;
+                const categories = [
+                    isSpell ? "spell" : null,
+                    isCantrip ? "cantrip" : null,
+                    isFocusSpell ? "focus" : null,
+                    isRitual ? "ritual" : null,
+                ].filter(R.isTruthy);
+                for (const category of categories) {
+                    options.add(`category:${category}`);
+                }
+
+                // format casting time (before value is sluggified)
+                const actionGlyph = getActionGlyph(spellData.system.time.value);
+
+                // Casting time
+                const time: unknown = spellData.system.time.value;
+                if (time && typeof time === "string") {
+                    const normalizedTime = time.toLocaleLowerCase("en").includes("reaction")
+                        ? "reaction"
+                        : sluggify(time);
+                    times.add(normalizedTime);
+                    spellData.system.time.value = normalizedTime;
+                    options.add(`time:${normalizedTime}`);
+                }
+
+                for (const tradition of spellData.system.traits.traditions) {
+                    options.add(`tradition:${tradition}`);
+                }
+
+                for (const trait of spellData.system.traits.value) {
+                    options.add(`trait:${trait.replace(/^hb_/, "")}`);
+                }
+
+                const defense = spellData.system.defense;
+                if (defense?.save) {
+                    if (defense.save.basic) options.add(`defense:save:basic`);
+                    options.add(`defense:save:${defense.save.statistic}`);
+                }
+                if (defense?.passive) options.add(`defense:passive:${defense.passive.statistic.split("-")[0]}`);
+                if (!defense && options.has(`trait:attack`) && !options.has("category:ritual")) {
+                    options.add(`defense:passive:armor`);
+                }
+
+                // Publication Source
+                const system = spellData.system;
+                const pubSource = String(system.publication?.title ?? system.source?.value ?? "").trim();
+                const sourceSlug = sluggify(pubSource);
+                if (pubSource) {
+                    publications.add(pubSource);
+                    options.add(`source:${sourceSlug}`);
+                }
+
+                options.add(`rank:${spellData.system.level.value}`);
+                options.add(`rarity:${spellData.system.traits.rarity}`);
+                options.add("type:spell");
+
+                spells.push({
+                    name: spellData.name,
+                    originalName: spellData.originalName, // Added by Babele
+                    img: spellData.img,
+                    uuid: spellData.uuid,
+                    rank: spellData.system.level.value,
+                    actionGlyph,
+                    rarity: spellData.system.traits.rarity,
+                    options,
+                });
             }
         }
         // Set indexData
@@ -133,7 +142,10 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
                 selected: false,
             };
         }
-        this.filterData.checkboxes.rarity.options = this.generateCheckboxOptions(CONFIG.PF2E.rarityTraits, false);
+
+        this.filterData.checkboxes.rarity.options = this.generateCheckboxOptions(CONFIG.PF2E.rarityTraits, {
+            sort: false,
+        });
         this.filterData.traits.options = this.generateMultiselectOptions(
             R.omit(CONFIG.PF2E.spellTraits, Array.from(MAGIC_TRADITIONS)),
         );
@@ -145,7 +157,7 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
                 focus: "PF2E.TraitFocus",
                 ritual: "PF2E.Item.Spell.Ritual.Label",
             },
-            false,
+            { sort: false },
         );
 
         this.filterData.selects.timefilter.options = [...times].sort().reduce(
@@ -157,54 +169,6 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
         );
 
         console.debug("PF2e System | Compendium Browser | Finished loading spells");
-    }
-
-    protected override filterIndexData(indexData: CompendiumBrowserIndexData): boolean {
-        const { checkboxes, source, traits, selects } = this.filterData;
-
-        // Rank
-        if (checkboxes.rank.selected.length > 0) {
-            const ranks = checkboxes.rank.selected.map((r) => Number(r));
-            if (!ranks.includes(indexData.rank)) return false;
-        }
-
-        // Categories
-        if (
-            checkboxes.category.selected.length > 0 &&
-            !R.isShallowEqual([...checkboxes.category.selected].sort(), indexData.categories.sort())
-        ) {
-            return false;
-        }
-
-        // Casting time
-        if (selects.timefilter.selected) {
-            if (!(selects.timefilter.selected === indexData.time)) return false;
-        }
-
-        // Traditions
-        if (
-            checkboxes.traditions.selected.length > 0 &&
-            R.intersection(checkboxes.traditions.selected, indexData.traditions).length === 0
-        ) {
-            return false;
-        }
-
-        // Traits
-        if (!this.filterTraits(indexData.traits, traits.selected, traits.conjunction)) {
-            return false;
-        }
-
-        // Rarity
-        if (checkboxes.rarity.selected.length > 0) {
-            if (!checkboxes.rarity.selected.includes(indexData.rarity)) return false;
-        }
-
-        // Source
-        if (source.selected.length > 0) {
-            if (!source.selected.includes(indexData.source)) return false;
-        }
-
-        return true;
     }
 
     protected override prepareFilterData(): SpellFilters {
@@ -220,6 +184,7 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
                     isExpanded: true,
                     label: "PF2E.CompendiumBrowser.Filter.Traditions",
                     options: {},
+                    optionPrefix: "tradition",
                     selected: [],
                 },
                 rank: {
@@ -250,6 +215,7 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
                 timefilter: {
                     label: "PF2E.CompendiumBrowser.Filter.CastingTime",
                     options: {},
+                    optionPrefix: "time",
                     selected: "",
                 },
             },


### PR DESCRIPTION
I finally had some more time to work on this. Pulled out from #20282

This PR only includes the switch to predication and no other additions or UI changes. If this is approved I can start to pull out the other changes from the old PR.

Current filter:
<img width="188" height="22" alt="Current" src="https://github.com/user-attachments/assets/c3dee832-5fb3-49fc-a174-394276dc9f12" />

Predicate filter:
<img width="266" height="20" alt="CachedPredicate" src="https://github.com/user-attachments/assets/5795d425-5f92-45ad-8891-bc190a4271c8" />

