### PR TITLE
Prevent errors when granting flat persistent damage (such as with Flames Oracle)

### DIFF
--- a/src/module/rules/rule-element/item-alteration/handlers.ts
+++ b/src/module/rules/rule-element/item-alteration/handlers.ts
@@ -726,6 +726,7 @@ const ITEM_ALTERATION_HANDLERS = {
             const pdObject = R.isPlainObject(data.alteration.value) ? data.alteration.value : { dc: NaN };
             const dc = Math.trunc(Math.abs(Number(pdObject?.dc) || 15));
             data.alteration.value = { ...pdObject, dc };
+            data.alteration = this.clean(data.alteration);
             if (this.isValid(data)) {
                 data.item.system.persistent = this.initialize(data.alteration).value;
             }


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/20486

It looks like validation testing in item alterations do not attempt to coerce the value. If someone wants to take a crack at coercing it instead, that would be handy.