### PR TITLE
Defer DC value computation for inline check

### DIFF
--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -1488,7 +1488,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
                     domains: attackDomains,
                     origin: { actor: this, statistic: action, item: weapon },
                     target: { token: targetToken },
-                    against: "armor",
+                    against: { slug: "armor" },
                     options: new Set([...baseOptions, ...params.options]),
                     viewOnly: params.getFormula,
                     traits: actionTraits,

--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -559,7 +559,7 @@ function strikeFromMeleeItem(item: MeleePF2e<ActorPF2e>): NPCStrike {
                 viewOnly: params.getFormula ?? false,
                 origin: { actor, statistic: strike, item },
                 target: { token: (params.target ?? game.user.targets.first())?.document ?? null },
-                against: "armor",
+                against: { slug: "armor" },
                 domains,
                 options: new Set([...baseOptions, ...params.options]),
                 traits: actionTraits,

--- a/src/module/actor/roll-context/check.ts
+++ b/src/module/actor/roll-context/check.ts
@@ -1,9 +1,10 @@
 import type { ActorPF2e } from "@actor";
 import type { StrikeData } from "@actor/data/base.ts";
 import { calculateRangePenalty } from "@actor/helpers.ts";
+import { Modifier } from "@actor/modifiers.ts";
 import type { ItemPF2e } from "@item";
 import { CheckDC } from "@system/degree-of-success.ts";
-import type { Statistic } from "@system/statistic/statistic.ts";
+import type { CheckDCReference, Statistic } from "@system/statistic/statistic.ts";
 import { RollContext } from "./base.ts";
 import { CheckContextConstructorParams, CheckContextData } from "./types.ts";
 
@@ -13,7 +14,7 @@ class CheckContext<
     TItem extends ItemPF2e<ActorPF2e> | null,
 > extends RollContext<TSelf, TStatistic, TItem> {
     /** The slug of a `Statistic` for use in building a DC */
-    against: string | null;
+    against: CheckDCReference | null;
 
     constructor(params: CheckContextConstructorParams<TSelf, TStatistic, TItem>) {
         super(params);
@@ -38,8 +39,26 @@ class CheckContext<
             const { domains, against } = this;
             if (!against) return null;
             const scope = domains.includes("attack") ? "attack" : "check";
-            const statistic = opposingActor?.getStatistic(against.replace(/-dc$/, ""))?.dc;
-            return statistic ? { scope, statistic, slug: against, value: statistic.value } : null;
+            let statistic = opposingActor?.getStatistic(against.slug.replace(/-dc$/, ""));
+            if (statistic && against.adjustment) {
+                statistic = statistic.clone({
+                    modifiers: against.adjustment
+                        ? [new Modifier({ label: "PF2E.InlineCheck.DCAdjustment", modifier: against.adjustment })]
+                        : [],
+                });
+            }
+
+            return statistic
+                ? {
+                      label:
+                          statistic.dc.label ??
+                          game.i18n.format("PF2E.InlineCheck.DCWithName", { name: statistic.label }),
+                      scope,
+                      statistic: statistic.dc,
+                      slug: against.slug,
+                      value: statistic.dc.value,
+                  }
+                : null;
         })();
 
         return { ...baseContext, dc: dcData };

--- a/src/module/actor/roll-context/types.ts
+++ b/src/module/actor/roll-context/types.ts
@@ -6,7 +6,7 @@ import type { AbilityTrait } from "@item/ability/types.ts";
 import type { CheckContextChatFlag } from "@module/chat-message/data.ts";
 import type { TokenDocumentPF2e } from "@scene";
 import type { CheckDC, DegreeOfSuccessString } from "@system/degree-of-success.ts";
-import type { Statistic } from "@system/statistic/statistic.ts";
+import type { CheckDCReference, Statistic } from "@system/statistic/statistic.ts";
 
 interface OpposingActorConstructorData<
     TActor extends ActorPF2e | null = ActorPF2e | null,
@@ -134,7 +134,7 @@ type CheckContextConstructorParams<
     TStatistic extends Statistic | StrikeData = Statistic | StrikeData,
     TItem extends ItemPF2e<ActorPF2e> | null = ItemPF2e<ActorPF2e> | null,
 > = RollContextConstructorParams<TSelf, TStatistic, TItem> & {
-    against?: string | null;
+    against?: CheckDCReference | null;
 };
 
 type DamageContextConstructorParams<

--- a/src/module/system/statistic/statistic.ts
+++ b/src/module/system/statistic/statistic.ts
@@ -461,7 +461,7 @@ class StatisticCheck<TParent extends Statistic = Statistic> {
                         token: targetToken,
                     },
                     domains,
-                    against: args.dc?.slug ?? "ac",
+                    against: args.dc?.slug ? (args.dc as CheckDCReference) : { slug: "ac" },
                     options: optionSet,
                 }).resolve();
             } else if (selfIsTarget) {
@@ -477,7 +477,7 @@ class StatisticCheck<TParent extends Statistic = Statistic> {
                         item: contextItem,
                     },
                     domains,
-                    against: args.dc?.slug ?? null,
+                    against: args.dc?.slug ? (args.dc as CheckDCReference) : null,
                     options: optionSet,
                 }).resolve();
             } else {
@@ -760,6 +760,7 @@ class StatisticDifficultyClass<TParent extends Statistic = Statistic> {
 
 interface CheckDCReference {
     slug: string;
+    adjustment?: number;
     value?: never;
 }
 

--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -1,5 +1,4 @@
 import { ActorPF2e } from "@actor";
-import { Modifier } from "@actor/modifiers.ts";
 import { SAVE_TYPES } from "@actor/values.ts";
 import type { ClientDocument } from "@client/documents/abstract/client-document.d.mts";
 import type { MeasuredTemplateType } from "@common/constants.d.mts";
@@ -11,7 +10,7 @@ import { calculateDC } from "@module/dc.ts";
 import { eventToRollParams } from "@module/sheet/helpers.ts";
 import { resolveActorAndItemFromHTML, resolveSheetDocument } from "@scripts/helpers.ts";
 import type { CheckDC } from "@system/degree-of-success.ts";
-import { Statistic, StatisticRollParameters } from "@system/statistic/index.ts";
+import { CheckDCReference, Statistic, StatisticRollParameters } from "@system/statistic/index.ts";
 import { TextEditorPF2e } from "@system/text-editor.ts";
 import { ErrorPF2e, getActionGlyph, htmlClosest, htmlQueryAll, sluggify, splitListString, tupleHasValue } from "@util";
 import { getSelectedActors } from "@util/token-actor-utils.ts";
@@ -231,7 +230,6 @@ export class InlineRollLinks {
                 : isSavingThrow
                   ? "target"
                   : "origin";
-            const opposingRole = rollerRole === "target" ? "origin" : "target";
             const targetActor =
                 against && rollerRole === "target"
                     ? rollingActor
@@ -252,31 +250,14 @@ export class InlineRollLinks {
                     ? (itemFromDoc as ItemPF2e<ActorPF2e>)
                     : null;
 
-            const dc = ((): CheckDC | null => {
+            const dc = ((): CheckDC | CheckDCReference | null => {
                 const dcValue = pf2Dc === "@self.level" ? calculateDC(rollingActor.level) : Number(pf2Dc ?? "NaN");
                 const adjustment = Number(pf2Adjustment) || 0;
 
                 if (Number.isInteger(dcValue)) {
                     return { label: pf2Label, value: dcValue + adjustment };
-                } else if (against) {
-                    const defenseStat = opposingActor?.getStatistic(against)?.clone({
-                        modifiers: adjustment
-                            ? [new Modifier({ label: "PF2E.InlineCheck.DCAdjustment", modifier: adjustment })]
-                            : [],
-                        rollOptions: [
-                            item?.isOfType("action", "feat") ? `${opposingRole}:action:slug:${item.slug}` : null,
-                        ].filter(R.isTruthy),
-                    });
-                    if (defenseStat) {
-                        return {
-                            label:
-                                defenseStat.dc.label ??
-                                game.i18n.format("PF2E.InlineCheck.DCWithName", { name: defenseStat.label }),
-                            statistic: defenseStat.dc,
-                            scope: "check",
-                            value: defenseStat.dc.value,
-                        };
-                    }
+                } else if (against && opposingActor) {
+                    return { slug: against, adjustment };
                 }
 
                 return null;
@@ -287,7 +268,7 @@ export class InlineRollLinks {
                 extraRollOptions,
                 origin: originActor,
                 dc,
-                target: dc?.statistic ? targetActor : null,
+                target: dc?.slug ? opposingActor : null,
                 item,
                 traits: abilityTraits,
             };


### PR DESCRIPTION
The main purpose of this patch is to allow `EphemeralEffect` REs to apply before the final DC is computed for inline checks using `against / defence`, eg. `@Check[athletics|against:fortitude]`.

This allows an action with a check in its description to (ephemerally) modify or create the statistic on the target before evaluation. Specifically I want to use it for the Esoteric Lore check on [Exploit Vulnerability](https://2e.aonprd.com/Actions.aspx?ID=1227). This way I can create a "level-dc" `SpecialStatistic` on it* to roll against. It is likely useful elsewhere, and this patch could even be considered a bug fix.

**Not yet, as the `baseModifier.dc` value option only takes a fixed number.*