### PR TITLE
Fix dropping actors to parties from compendium

### DIFF
--- a/static/templates/sidebar/party-document-partial.hbs
+++ b/static/templates/sidebar/party-document-partial.hbs
@@ -1,4 +1,4 @@
-<ol class="directory-list plain parties">
+<ol class="plain parties">
     {{#if activeParty~}}
         {{> partyEntry party=activeParty}}
     {{~/if}}


### PR DESCRIPTION
The changes in actor-directory.ts add the dropped actor to the party. The changes in the partial prevent the event from firing twice. So far I don't see any visual changes.