### PR TITLE
Fix action cost of Raised Cavalry's Trampling Charge

### DIFF
--- a/packs/claws-of-the-tyrant-bestiary/3-of-blood-and-faith/raised-cavalry.json
+++ b/packs/claws-of-the-tyrant-bestiary/3-of-blood-and-faith/raised-cavalry.json
@@ -292,7 +292,7 @@
         },
         {
             "_id": "CW2A6gvQDkEQk2gM",
-            "img": "systems/pf2e/icons/actions/TwoActions.webp",
+            "img": "systems/pf2e/icons/actions/ThreeActions.webp",
             "name": "Trampling Charge",
             "sort": 900000,
             "system": {
@@ -300,7 +300,7 @@
                     "value": "action"
                 },
                 "actions": {
-                    "value": 2
+                    "value": 3
                 },
                 "category": "offensive",
                 "description": {


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/20535