### PR TITLE
Reduce light intensity of Light spell effect

### DIFF
--- a/packs/spell-effects/spell-effect-light.json
+++ b/packs/spell-effects/spell-effect-light.json
@@ -24,7 +24,7 @@
             {
                 "key": "TokenLight",
                 "value": {
-                    "alpha": 0.2,
+                    "alpha": 0.05,
                     "animation": {
                         "intensity": 1,
                         "speed": 2,


### PR DESCRIPTION
- Closes #18174

The issue mentions other light sources, but the light cantrip is by far the most ubiquitous example of this.