### PR TITLE
Always include action roll options in basic actions

### DIFF
--- a/src/module/actor/actions/single-check.ts
+++ b/src/module/actor/actions/single-check.ts
@@ -38,6 +38,8 @@ interface SingleCheckActionVariantData extends BaseActionVariantData {
     difficultyClass?: CheckDC | DCSlug;
     modifiers?: RawModifier[];
     notes?: SingleCheckActionRollNoteData[];
+
+    /** Additional roll options beyond the base action's and `action:${actionSlug}:${variantSlug}` */
     rollOptions?: string[];
     statistic?: string | string[];
 }
@@ -46,6 +48,8 @@ interface SingleCheckActionData extends BaseActionData<SingleCheckActionVariantD
     difficultyClass?: CheckDC | DCSlug;
     modifiers?: RawModifier[];
     notes?: SingleCheckActionRollNoteData[];
+
+    /** Additional roll options beyond `action:${slug}`, which is implicit */
     rollOptions?: string[];
     statistic: string | string[];
 }
@@ -88,8 +92,10 @@ class SingleCheckActionVariant extends BaseActionVariant {
             this.#difficultyClass = data.difficultyClass;
             this.#modifiers = data?.modifiers;
             this.#notes = data.notes ? data.notes.map(toRollNoteSource) : undefined;
-            this.#rollOptions = data.rollOptions;
             this.#statistic = data.statistic;
+            this.#rollOptions = data.slug
+                ? [`action:${action.slug}:${data.slug.trim()}`, ...(data.rollOptions ?? [])]
+                : data.rollOptions;
         }
     }
 
@@ -106,7 +112,7 @@ class SingleCheckActionVariant extends BaseActionVariant {
     }
 
     get rollOptions(): string[] {
-        return this.#rollOptions ?? this.#action.rollOptions;
+        return this.#rollOptions ? [...this.#action.rollOptions, ...this.#rollOptions] : this.#action.rollOptions;
     }
 
     get statistic(): string | string[] {
@@ -222,7 +228,7 @@ class SingleCheckAction extends BaseAction<SingleCheckActionVariantData, SingleC
         this.difficultyClass = data.difficultyClass;
         this.modifiers = data.modifiers ?? [];
         this.notes = (data.notes ?? []).map(toRollNoteSource);
-        this.rollOptions = data.rollOptions ?? [];
+        this.rollOptions = [`action:${this.slug}`, ...(data.rollOptions ?? [])];
         this.statistic = data.statistic;
     }
 

--- a/src/module/system/action-macros/acrobatics/balance.ts
+++ b/src/module/system/action-macros/acrobatics/balance.ts
@@ -39,7 +39,6 @@ const action = new SingleCheckAction({
         { outcome: ["failure"], text: `${PREFIX}.Notes.failure` },
         { outcome: ["criticalFailure"], text: `${PREFIX}.Notes.criticalFailure` },
     ],
-    rollOptions: ["action:balance"],
     sampleTasks: {
         untrained: `${PREFIX}.SampleTasks.Untrained`,
         trained: `${PREFIX}.SampleTasks.Trained`,

--- a/src/module/system/action-macros/acrobatics/maneuver-in-flight.ts
+++ b/src/module/system/action-macros/acrobatics/maneuver-in-flight.ts
@@ -38,7 +38,6 @@ const action = new SingleCheckAction({
         { outcome: ["failure"], text: `${PREFIX}.Notes.failure` },
         { outcome: ["criticalFailure"], text: `${PREFIX}.Notes.criticalFailure` },
     ],
-    rollOptions: ["action:maneuver-in-flight"],
     sampleTasks: {
         trained: `${PREFIX}.SampleTasks.Trained`,
         expert: `${PREFIX}.SampleTasks.Expert`,

--- a/src/module/system/action-macros/acrobatics/squeeze.ts
+++ b/src/module/system/action-macros/acrobatics/squeeze.ts
@@ -36,7 +36,6 @@ const action = new SingleCheckAction({
         { outcome: ["success"], text: `${PREFIX}.Notes.success` },
         { outcome: ["criticalFailure"], text: `${PREFIX}.Notes.criticalFailure` },
     ],
-    rollOptions: ["action:squeeze"],
     sampleTasks: {
         trained: `${PREFIX}.SampleTasks.Trained`,
         master: `${PREFIX}.SampleTasks.Master`,

--- a/src/module/system/action-macros/acrobatics/tumble-through.ts
+++ b/src/module/system/action-macros/acrobatics/tumble-through.ts
@@ -36,7 +36,6 @@ const action = new SingleCheckAction({
         { outcome: ["success", "criticalSuccess"], text: `${PREFIX}.Notes.success` },
         { outcome: ["failure", "criticalFailure"], text: `${PREFIX}.Notes.failure` },
     ],
-    rollOptions: ["action:tumble-through"],
     section: "skill",
     slug: "tumble-through",
     statistic: "acrobatics",

--- a/src/module/system/action-macros/athletics/climb.ts
+++ b/src/module/system/action-macros/athletics/climb.ts
@@ -55,7 +55,6 @@ const action = new SingleCheckAction({
         { outcome: ["success"], text: `${PREFIX}.Notes.success` },
         { outcome: ["criticalFailure"], text: `${PREFIX}.Notes.criticalFailure` },
     ],
-    rollOptions: ["action:climb"],
     sampleTasks: {
         untrained: `${PREFIX}.SampleTasks.Untrained`,
         trained: `${PREFIX}.SampleTasks.Trained`,

--- a/src/module/system/action-macros/athletics/disarm.ts
+++ b/src/module/system/action-macros/athletics/disarm.ts
@@ -71,7 +71,6 @@ class DisarmAction extends SingleCheckAction {
                 { outcome: ["success"], text: `${PREFIX}.Notes.success` },
                 { outcome: ["criticalFailure"], text: `${PREFIX}.Notes.criticalFailure` },
             ],
-            rollOptions: ["action:disarm"],
             section: "skill",
             slug: "disarm",
             statistic: "athletics",

--- a/src/module/system/action-macros/athletics/force-open.ts
+++ b/src/module/system/action-macros/athletics/force-open.ts
@@ -37,7 +37,6 @@ const action = new SingleCheckAction({
         { outcome: ["success"], text: `${PREFIX}.Notes.success` },
         { outcome: ["criticalFailure"], text: `${PREFIX}.Notes.criticalFailure` },
     ],
-    rollOptions: ["action:force-open"],
     sampleTasks: {
         untrained: `${PREFIX}.SampleTasks.Untrained`,
         trained: `${PREFIX}.SampleTasks.Trained`,

--- a/src/module/system/action-macros/athletics/grapple.ts
+++ b/src/module/system/action-macros/athletics/grapple.ts
@@ -73,7 +73,6 @@ class GrappleAction extends SingleCheckAction {
                 { outcome: ["failure"], text: `${PREFIX}.Notes.failure` },
                 { outcome: ["criticalFailure"], text: `${PREFIX}.Notes.criticalFailure` },
             ],
-            rollOptions: ["action:grapple"],
             section: "skill",
             slug: "grapple",
             statistic: "athletics",

--- a/src/module/system/action-macros/athletics/high-jump.ts
+++ b/src/module/system/action-macros/athletics/high-jump.ts
@@ -40,7 +40,7 @@ const action = new SingleCheckAction({
         { outcome: ["failure"], text: `${PREFIX}.Notes.failure` },
         { outcome: ["criticalFailure"], text: `${PREFIX}.Notes.criticalFailure` },
     ],
-    rollOptions: ["action:stride", "action:leap", "action:high-jump"],
+    rollOptions: ["action:stride", "action:leap"],
     section: "skill",
     slug: "high-jump",
     statistic: "athletics",

--- a/src/module/system/action-macros/athletics/long-jump.ts
+++ b/src/module/system/action-macros/athletics/long-jump.ts
@@ -38,7 +38,7 @@ const action = new SingleCheckAction({
         { outcome: ["failure"], text: `${PREFIX}.Notes.failure` },
         { outcome: ["criticalFailure"], text: `${PREFIX}.Notes.criticalFailure` },
     ],
-    rollOptions: ["action:stride", "action:leap", "action:long-jump"],
+    rollOptions: ["action:stride", "action:leap"],
     section: "skill",
     slug: "long-jump",
     statistic: "athletics",

--- a/src/module/system/action-macros/athletics/reposition.ts
+++ b/src/module/system/action-macros/athletics/reposition.ts
@@ -40,7 +40,7 @@ const action = new SingleCheckAction({
         { outcome: ["success"], text: `${PREFIX}.Notes.success` },
         { outcome: ["criticalFailure"], text: `${PREFIX}.Notes.criticalFailure` },
     ],
-    rollOptions: ["action:reposition", "forced-movement"],
+    rollOptions: ["forced-movement"],
     section: "skill",
     slug: "reposition",
     statistic: "athletics",

--- a/src/module/system/action-macros/athletics/shove.ts
+++ b/src/module/system/action-macros/athletics/shove.ts
@@ -71,7 +71,7 @@ class ShoveAction extends SingleCheckAction {
                 { outcome: ["success"], text: `${PREFIX}.Notes.success` },
                 { outcome: ["criticalFailure"], text: `${PREFIX}.Notes.criticalFailure` },
             ],
-            rollOptions: ["action:shove", "forced-movement"],
+            rollOptions: ["forced-movement"],
             section: "skill",
             slug: "shove",
             statistic: "athletics",

--- a/src/module/system/action-macros/athletics/swim.ts
+++ b/src/module/system/action-macros/athletics/swim.ts
@@ -55,7 +55,6 @@ const action = new SingleCheckAction({
         { outcome: ["success"], text: `${PREFIX}.Notes.success` },
         { outcome: ["criticalFailure"], text: `${PREFIX}.Notes.criticalFailure` },
     ],
-    rollOptions: ["action:swim"],
     sampleTasks: {
         untrained: `${PREFIX}.SampleTasks.Untrained`,
         trained: `${PREFIX}.SampleTasks.Trained`,

--- a/src/module/system/action-macros/athletics/trip.ts
+++ b/src/module/system/action-macros/athletics/trip.ts
@@ -97,7 +97,7 @@ class TripAction extends SingleCheckAction {
                 { outcome: ["success"], text: "PF2E.Actions.Trip.Notes.success" },
                 { outcome: ["criticalFailure"], text: "PF2E.Actions.Trip.Notes.criticalFailure" },
             ],
-            rollOptions: ["action:trip", "inflicts:prone"],
+            rollOptions: ["inflicts:prone"],
             section: "skill",
             slug: "trip",
             statistic: "athletics",

--- a/src/module/system/action-macros/basic/aid.ts
+++ b/src/module/system/action-macros/basic/aid.ts
@@ -46,7 +46,6 @@ class AidAction extends SingleCheckAction {
                     title: "PF2E.Check.Result.Degree.Check.success",
                 },
             ],
-            rollOptions: ["action:aid"],
             section: "basic",
             slug: "aid",
             statistic: "",

--- a/src/module/system/action-macros/basic/escape.ts
+++ b/src/module/system/action-macros/basic/escape.ts
@@ -179,7 +179,6 @@ class EscapeAction extends SingleCheckAction {
                 { outcome: ["success"], text: "PF2E.Actions.Escape.Notes.success" },
                 { outcome: ["criticalFailure"], text: "PF2E.Actions.Escape.Notes.criticalFailure" },
             ],
-            rollOptions: ["action:escape"],
             section: "basic",
             slug: "escape",
             statistic: ["unarmed", "acrobatics", "athletics"],

--- a/src/module/system/action-macros/basic/seek.ts
+++ b/src/module/system/action-macros/basic/seek.ts
@@ -33,7 +33,6 @@ const action = new SingleCheckAction({
         { outcome: ["criticalSuccess"], text: "PF2E.Actions.Seek.Notes.criticalSuccess" },
         { outcome: ["success"], text: "PF2E.Actions.Seek.Notes.success" },
     ],
-    rollOptions: ["action:seek"],
     section: "basic",
     slug: "seek",
     statistic: "perception",

--- a/src/module/system/action-macros/basic/sense-motive.ts
+++ b/src/module/system/action-macros/basic/sense-motive.ts
@@ -38,7 +38,6 @@ const action = new SingleCheckAction({
         { outcome: ["failure"], text: "PF2E.Actions.SenseMotive.Notes.failure" },
         { outcome: ["criticalFailure"], text: "PF2E.Actions.SenseMotive.Notes.criticalFailure" },
     ],
-    rollOptions: ["action:sense-motive"],
     section: "basic",
     slug: "sense-motive",
     statistic: "perception",

--- a/src/module/system/action-macros/crafting/identify-alchemy.ts
+++ b/src/module/system/action-macros/crafting/identify-alchemy.ts
@@ -10,7 +10,6 @@ const action = new SingleCheckAction({
         { outcome: ["failure"], text: `${PREFIX}.Notes.failure` },
         { outcome: ["criticalFailure"], text: `${PREFIX}.Notes.criticalFailure` },
     ],
-    rollOptions: ["action:identify-alchemy"],
     section: "skill",
     slug: "identify-alchemy",
     statistic: "crafting",

--- a/src/module/system/action-macros/deception/create-a-diversion.ts
+++ b/src/module/system/action-macros/deception/create-a-diversion.ts
@@ -74,19 +74,16 @@ const action = new SingleCheckAction({
     variants: [
         {
             name: `${PREFIX}.DistractingWords.Title`,
-            rollOptions: ["action:create-a-diversion", "action:create-a-diversion:distracting-words"],
             slug: "distracting-words",
             traits: ["auditory", "linguistic", "mental"],
         },
         {
             name: `${PREFIX}.Gesture.Title`,
-            rollOptions: ["action:create-a-diversion", "action:create-a-diversion:gesture"],
             slug: "gesture",
             traits: ["manipulate", "mental"],
         },
         {
             name: `${PREFIX}.Trick.Title`,
-            rollOptions: ["action:create-a-diversion", "action:create-a-diversion:trick"],
             slug: "trick",
             traits: ["manipulate", "mental"],
         },

--- a/src/module/system/action-macros/deception/feint.ts
+++ b/src/module/system/action-macros/deception/feint.ts
@@ -38,7 +38,6 @@ const action = new SingleCheckAction({
         { outcome: ["success"], text: `${PREFIX}.Notes.success` },
         { outcome: ["criticalFailure"], text: `${PREFIX}.Notes.criticalFailure` },
     ],
-    rollOptions: ["action:feint"],
     section: "skill",
     slug: "feint",
     statistic: "deception",

--- a/src/module/system/action-macros/deception/impersonate.ts
+++ b/src/module/system/action-macros/deception/impersonate.ts
@@ -37,7 +37,6 @@ const action = new SingleCheckAction({
         { outcome: ["failure"], text: `${PREFIX}.Notes.failure` },
         { outcome: ["criticalFailure"], text: `${PREFIX}.Notes.criticalFailure` },
     ],
-    rollOptions: ["action:impersonate"],
     section: "skill",
     slug: "impersonate",
     statistic: "deception",

--- a/src/module/system/action-macros/deception/lie.ts
+++ b/src/module/system/action-macros/deception/lie.ts
@@ -35,7 +35,6 @@ const action = new SingleCheckAction({
         { outcome: ["success", "criticalSuccess"], text: `${PREFIX}.Notes.success` },
         { outcome: ["failure", "criticalFailure"], text: `${PREFIX}.Notes.failure` },
     ],
-    rollOptions: ["action:lie"],
     section: "skill",
     slug: "lie",
     statistic: "deception",

--- a/src/module/system/action-macros/diplomacy/gather-information.ts
+++ b/src/module/system/action-macros/diplomacy/gather-information.ts
@@ -34,7 +34,6 @@ const action = new SingleCheckAction({
         { outcome: ["criticalSuccess", "success"], text: `${PREFIX}.Notes.success` },
         { outcome: ["criticalFailure"], text: `${PREFIX}.Notes.criticalFailure` },
     ],
-    rollOptions: ["action:gather-information"],
     sampleTasks: {
         untrained: `${PREFIX}.SampleTasks.Untrained`,
         trained: `${PREFIX}.SampleTasks.Trained`,

--- a/src/module/system/action-macros/diplomacy/make-an-impression.ts
+++ b/src/module/system/action-macros/diplomacy/make-an-impression.ts
@@ -37,7 +37,6 @@ const action = new SingleCheckAction({
         { outcome: ["success"], text: `${PREFIX}.Notes.success` },
         { outcome: ["criticalFailure"], text: `${PREFIX}.Notes.criticalFailure` },
     ],
-    rollOptions: ["action:make-an-impression"],
     section: "skill",
     slug: "make-an-impression",
     statistic: "diplomacy",

--- a/src/module/system/action-macros/diplomacy/request.ts
+++ b/src/module/system/action-macros/diplomacy/request.ts
@@ -39,7 +39,6 @@ const action = new SingleCheckAction({
         { outcome: ["failure"], text: `${PREFIX}.Notes.failure` },
         { outcome: ["criticalFailure"], text: `${PREFIX}.Notes.criticalFailure` },
     ],
-    rollOptions: ["action:request"],
     section: "skill",
     slug: "request",
     statistic: "diplomacy",

--- a/src/module/system/action-macros/exploration/avoid-notice.ts
+++ b/src/module/system/action-macros/exploration/avoid-notice.ts
@@ -32,7 +32,6 @@ const action = new SingleCheckAction({
         { outcome: ["criticalSuccess"], text: "PF2E.Actions.AvoidNotice.Notes.criticalSuccess" },
         { outcome: ["success"], text: "PF2E.Actions.AvoidNotice.Notes.success" },
     ],
-    rollOptions: ["action:avoid-notice"],
     slug: "avoid-notice",
     statistic: "stealth",
     traits: ["exploration"],

--- a/src/module/system/action-macros/exploration/sense-direction.ts
+++ b/src/module/system/action-macros/exploration/sense-direction.ts
@@ -48,7 +48,6 @@ const action = new SingleCheckAction({
         { outcome: ["criticalSuccess"], text: "PF2E.Actions.SenseDirection.Notes.criticalSuccess" },
         { outcome: ["success"], text: "PF2E.Actions.SenseDirection.Notes.success" },
     ],
-    rollOptions: ["action:sense-direction"],
     sampleTasks: {
         untrained: "PF2E.Actions.SenseDirection.SampleTasks.Untrained",
         trained: "PF2E.Actions.SenseDirection.SampleTasks.Trained",

--- a/src/module/system/action-macros/exploration/track.ts
+++ b/src/module/system/action-macros/exploration/track.ts
@@ -34,7 +34,6 @@ const action = new SingleCheckAction({
         { outcome: ["failure"], text: "PF2E.Actions.Track.Notes.failure" },
         { outcome: ["criticalFailure"], text: "PF2E.Actions.Track.Notes.criticalFailure" },
     ],
-    rollOptions: ["action:track"],
     sampleTasks: {
         untrained: "PF2E.Actions.Track.SampleTasks.Untrained",
         trained: "PF2E.Actions.Track.SampleTasks.Trained",

--- a/src/module/system/action-macros/general/decipher-writing.ts
+++ b/src/module/system/action-macros/general/decipher-writing.ts
@@ -64,7 +64,6 @@ class DecipherWritingAction extends SingleCheckAction {
                 { outcome: ["failure"], text: "PF2E.Actions.DecipherWriting.Notes.failure" },
                 { outcome: ["criticalFailure"], text: "PF2E.Actions.DecipherWriting.Notes.criticalFailure" },
             ],
-            rollOptions: ["action:decipher-writing"],
             sampleTasks: {
                 trained: "PF2E.Actions.DecipherWriting.SampleTasks.Trained",
                 expert: "PF2E.Actions.DecipherWriting.SampleTasks.Expert",

--- a/src/module/system/action-macros/general/identify-magic.ts
+++ b/src/module/system/action-macros/general/identify-magic.ts
@@ -35,7 +35,6 @@ class IdentifyMagicAction extends SingleCheckAction {
                 { outcome: ["failure"], text: `${PREFIX}.Notes.failure` },
                 { outcome: ["criticalFailure"], text: `${PREFIX}.Notes.criticalFailure` },
             ],
-            rollOptions: ["action:identify-magic"],
             section: "skill",
             slug: "identify-magic",
             statistic: ["arcana", "nature", "occultism", "religion"],

--- a/src/module/system/action-macros/general/learn-a-spell.ts
+++ b/src/module/system/action-macros/general/learn-a-spell.ts
@@ -33,7 +33,6 @@ class LearnASpellAction extends SingleCheckAction {
                 { outcome: ["failure"], text: `${PREFIX}.Notes.failure` },
                 { outcome: ["criticalFailure"], text: `${PREFIX}.Notes.criticalFailure` },
             ],
-            rollOptions: ["action:learn-a-spell"],
             section: "skill",
             slug: "learn-a-spell",
             statistic: ["arcana", "nature", "occultism", "religion"],

--- a/src/module/system/action-macros/general/recall-knowledge.ts
+++ b/src/module/system/action-macros/general/recall-knowledge.ts
@@ -62,7 +62,6 @@ class RecallKnowledgeAction extends SingleCheckAction {
                 { outcome: ["success"], text: `${PREFIX}.Notes.success` },
                 { outcome: ["criticalFailure"], text: `${PREFIX}.Notes.criticalFailure` },
             ],
-            rollOptions: ["action:recall-knowledge"],
             sampleTasks: {
                 untrained: `${PREFIX}.SampleTasks.Untrained`,
                 trained: `${PREFIX}.SampleTasks.Trained`,

--- a/src/module/system/action-macros/general/subsist.ts
+++ b/src/module/system/action-macros/general/subsist.ts
@@ -76,7 +76,6 @@ class SubsistAction extends SingleCheckAction {
                 { outcome: ["failure"], text: "PF2E.Actions.Subsist.Notes.failure" },
                 { outcome: ["criticalFailure"], text: "PF2E.Actions.Subsist.Notes.criticalFailure" },
             ],
-            rollOptions: ["action:subsist"],
             sampleTasks: {
                 untrained: "PF2E.Actions.Subsist.SampleTasks.Untrained",
                 trained: "PF2E.Actions.Subsist.SampleTasks.Trained",

--- a/src/module/system/action-macros/intimidation/coerce.ts
+++ b/src/module/system/action-macros/intimidation/coerce.ts
@@ -37,7 +37,6 @@ const action = new SingleCheckAction({
         { outcome: ["failure"], text: "PF2E.Actions.Coerce.Notes.failure" },
         { outcome: ["criticalFailure"], text: "PF2E.Actions.Coerce.Notes.criticalFailure" },
     ],
-    rollOptions: ["action:coerce"],
     section: "skill",
     slug: "coerce",
     statistic: "intimidation",

--- a/src/module/system/action-macros/intimidation/demoralize.ts
+++ b/src/module/system/action-macros/intimidation/demoralize.ts
@@ -50,7 +50,6 @@ const action = new SingleCheckAction({
         { outcome: ["criticalSuccess"], text: "PF2E.Actions.Demoralize.Notes.criticalSuccess" },
         { outcome: ["success"], text: "PF2E.Actions.Demoralize.Notes.success" },
     ],
-    rollOptions: ["action:demoralize"],
     section: "skill",
     slug: "demoralize",
     statistic: "intimidation",

--- a/src/module/system/action-macros/medicine/treat-disease.ts
+++ b/src/module/system/action-macros/medicine/treat-disease.ts
@@ -34,7 +34,6 @@ const action = new SingleCheckAction({
         { outcome: ["success"], text: "PF2E.Actions.TreatDisease.Notes.success" },
         { outcome: ["criticalFailure"], text: "PF2E.Actions.TreatDisease.Notes.criticalFailure" },
     ],
-    rollOptions: ["action:treat-disease"],
     section: "skill",
     slug: "treat-disease",
     statistic: "medicine",

--- a/src/module/system/action-macros/medicine/treat-poison.ts
+++ b/src/module/system/action-macros/medicine/treat-poison.ts
@@ -35,7 +35,6 @@ const action = new SingleCheckAction({
         { outcome: ["success"], text: "PF2E.Actions.TreatPoison.Notes.success" },
         { outcome: ["criticalFailure"], text: "PF2E.Actions.TreatPoison.Notes.criticalFailure" },
     ],
-    rollOptions: ["action:treat-poison"],
     section: "skill",
     slug: "treat-poison",
     statistic: "medicine",

--- a/src/module/system/action-macros/nature/command-an-animal.ts
+++ b/src/module/system/action-macros/nature/command-an-animal.ts
@@ -38,7 +38,6 @@ const action = new SingleCheckAction({
         { outcome: ["failure"], text: `${PREFIX}.Notes.failure` },
         { outcome: ["criticalFailure"], text: `${PREFIX}.Notes.criticalFailure` },
     ],
-    rollOptions: ["action:command-an-animal"],
     section: "skill",
     slug: "command-an-animal",
     statistic: "nature",

--- a/src/module/system/action-macros/performance/perform.ts
+++ b/src/module/system/action-macros/performance/perform.ts
@@ -74,55 +74,46 @@ const action = new SingleCheckAction({
     variants: [
         {
             name: `${PREFIX}.Acting.Title`,
-            rollOptions: ["action:perform", "action:perform:acting"],
             slug: "acting",
             traits: ["auditory", "concentrate", "linguistic", "visual"],
         },
         {
             name: `${PREFIX}.Comedy.Title`,
-            rollOptions: ["action:perform", "action:perform:comedy"],
             slug: "comedy",
             traits: ["auditory", "concentrate", "linguistic", "visual"],
         },
         {
             name: `${PREFIX}.Dance.Title`,
-            rollOptions: ["action:perform", "action:perform:dance"],
             slug: "dance",
             traits: ["concentrate", "move", "visual"],
         },
         {
             name: `${PREFIX}.Keyboards.Title`,
-            rollOptions: ["action:perform", "action:perform:keyboards"],
             slug: "keyboards",
             traits: ["auditory", "concentrate", "manipulate"],
         },
         {
             name: `${PREFIX}.Oratory.Title`,
-            rollOptions: ["action:perform", "action:perform:oratory"],
             slug: "oratory",
             traits: ["auditory", "concentrate", "linguistic"],
         },
         {
             name: `${PREFIX}.Percussion.Title`,
-            rollOptions: ["action:perform", "action:perform:percussion"],
             slug: "percussion",
             traits: ["auditory", "concentrate", "manipulate"],
         },
         {
             name: `${PREFIX}.Singing.Title`,
-            rollOptions: ["action:perform", "action:perform:singing"],
             slug: "singing",
             traits: ["auditory", "concentrate", "linguistic"],
         },
         {
             name: `${PREFIX}.Strings.Title`,
-            rollOptions: ["action:perform", "action:perform:strings"],
             slug: "strings",
             traits: ["auditory", "concentrate", "manipulate"],
         },
         {
             name: `${PREFIX}.Winds.Title`,
-            rollOptions: ["action:perform", "action:perform:winds"],
             slug: "winds",
             traits: ["auditory", "concentrate", "manipulate"],
         },

--- a/src/module/system/action-macros/society/create-forgery.ts
+++ b/src/module/system/action-macros/society/create-forgery.ts
@@ -152,7 +152,6 @@ class CreateForgeryAction extends SingleCheckAction {
                 { outcome: ["failure"], text: "PF2E.Actions.CreateForgery.Notes.failure" },
                 { outcome: ["criticalFailure"], text: "PF2E.Actions.CreateForgery.Notes.criticalFailure" },
             ],
-            rollOptions: ["action:create-forgery"],
             section: "skill",
             slug: "create-forgery",
             statistic: "society",

--- a/src/module/system/action-macros/specialty-basic/arrest-a-fall.ts
+++ b/src/module/system/action-macros/specialty-basic/arrest-a-fall.ts
@@ -6,7 +6,6 @@ const arrestAFall = new SingleCheckAction({
     difficultyClass: { value: 15 },
     name: "PF2E.Actions.ArrestAFall.Title",
     notes: [{ outcome: ["success", "criticalSuccess"], text: "PF2E.Actions.ArrestAFall.Notes.success" }],
-    rollOptions: ["action:arrest-a-fall"],
     section: "specialty-basic",
     slug: "arrest-a-fall",
     statistic: ["reflex", "acrobatics"],

--- a/src/module/system/action-macros/specialty-basic/grab-an-edge.ts
+++ b/src/module/system/action-macros/specialty-basic/grab-an-edge.ts
@@ -11,7 +11,6 @@ const grabAnEdge = new SingleCheckAction({
         { outcome: ["success"], text: `${PREFIX}.Notes.success` },
         { outcome: ["criticalFailure"], text: `${PREFIX}.Notes.criticalFailure` },
     ],
-    rollOptions: ["action:grab-an-edge"],
     section: "specialty-basic",
     slug: "grab-an-edge",
     statistic: ["reflex", "acrobatics"],

--- a/src/module/system/action-macros/stealth/conceal-an-object.ts
+++ b/src/module/system/action-macros/stealth/conceal-an-object.ts
@@ -36,7 +36,6 @@ const action = new SingleCheckAction({
         { outcome: ["success", "criticalSuccess"], text: `${PREFIX}.Notes.success` },
         { outcome: ["failure", "criticalFailure"], text: `${PREFIX}.Notes.failure` },
     ],
-    rollOptions: ["action:conceal-an-object"],
     section: "skill",
     slug: "conceal-an-object",
     statistic: "stealth",

--- a/src/module/system/action-macros/stealth/hide.ts
+++ b/src/module/system/action-macros/stealth/hide.ts
@@ -32,7 +32,6 @@ const action = new SingleCheckAction({
     img: "systems/pf2e/icons/conditions/hidden.webp",
     name: `${PREFIX}.Title`,
     notes: [{ outcome: ["success", "criticalSuccess"], text: `${PREFIX}.Notes.success` }],
-    rollOptions: ["action:hide"],
     section: "skill",
     slug: "hide",
     statistic: "stealth",

--- a/src/module/system/action-macros/stealth/sneak.ts
+++ b/src/module/system/action-macros/stealth/sneak.ts
@@ -38,7 +38,6 @@ const action = new SingleCheckAction({
         { outcome: ["failure"], text: `${PREFIX}.Notes.failure` },
         { outcome: ["criticalFailure"], text: `${PREFIX}.Notes.criticalFailure` },
     ],
-    rollOptions: ["action:sneak"],
     section: "skill",
     slug: "sneak",
     statistic: "stealth",

--- a/src/module/system/action-macros/thievery/disable-device.ts
+++ b/src/module/system/action-macros/thievery/disable-device.ts
@@ -35,7 +35,7 @@ const action = new SingleCheckAction({
         { outcome: ["success"], text: "PF2E.Actions.DisableDevice.Notes.success" },
         { outcome: ["criticalFailure"], text: "PF2E.Actions.DisableDevice.Notes.criticalFailure" },
     ],
-    rollOptions: ["action:disable-a-device", "action:disable-device"],
+    rollOptions: ["action:disable-a-device"],
     section: "skill",
     slug: "disable-device",
     statistic: "thievery",

--- a/src/module/system/action-macros/thievery/palm-an-object.ts
+++ b/src/module/system/action-macros/thievery/palm-an-object.ts
@@ -36,7 +36,6 @@ const action = new SingleCheckAction({
         { outcome: ["success", "criticalSuccess"], text: `${PREFIX}.Notes.success` },
         { outcome: ["failure", "criticalFailure"], text: `${PREFIX}.Notes.failure` },
     ],
-    rollOptions: ["action:palm-an-object"],
     section: "skill",
     slug: "palm-an-object",
     statistic: "thievery",

--- a/src/module/system/action-macros/thievery/pick-a-lock.ts
+++ b/src/module/system/action-macros/thievery/pick-a-lock.ts
@@ -35,7 +35,6 @@ const action = new SingleCheckAction({
         { outcome: ["success"], text: "PF2E.Actions.PickALock.Notes.success" },
         { outcome: ["criticalFailure"], text: "PF2E.Actions.PickALock.Notes.criticalFailure" },
     ],
-    rollOptions: ["action:pick-a-lock"],
     section: "skill",
     slug: "pick-a-lock",
     statistic: "thievery",

--- a/src/module/system/action-macros/thievery/steal.ts
+++ b/src/module/system/action-macros/thievery/steal.ts
@@ -44,7 +44,6 @@ const action = new SingleCheckAction({
         { outcome: ["success", "criticalSuccess"], text: `${PREFIX}.Notes.success` },
         { outcome: ["failure", "criticalFailure"], text: `${PREFIX}.Notes.failure` },
     ],
-    rollOptions: ["action:steal"],
     section: "skill",
     slug: "steal",
     statistic: "thievery",


### PR DESCRIPTION
Action checks should have the roll option `action:${actionSlug}`, and if it is a named variant, also `action:${actionSlug}:${variantSlug}`.

Every single action with a check roll that exists now has these options, except the non-legacy administer first aid action (the legacy action has it).

Since all actions with check rolls have or should have these options, have them added automatically in the SingleCheckAction and SingleCheckActionVariant constructors.

The rollOptions field in the action data is then documented to be the additional options added beyond the standard ones.