### PR TITLE
Add roll data to consumable damage rolls

### DIFF
--- a/src/module/item/consumable/document.ts
+++ b/src/module/item/consumable/document.ts
@@ -191,7 +191,11 @@ class ConsumablePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extend
 
             if (this.system.damage) {
                 const { formula, type, kind } = this.system.damage;
-                new DamageRoll(`(${formula})[${type},${kind}]`).toMessage({ speaker, flavor: content, flags });
+                new DamageRoll(`(${formula})[${type},${kind}]`, this.getRollData()).toMessage({
+                    speaker,
+                    flavor: content,
+                    flags,
+                });
             } else {
                 ChatMessage.create({ speaker, content, flags });
             }


### PR DESCRIPTION
When rolling a consumable's damage roll, e.g. a healing potion, the damage roll isn't supplied the roll data.  Add that.

This way something like `@actor.abilities.con.mod` can be used in the damage roll.  This already works in an inline roll in the item's description, as that is supplied the data.