### PR TITLE
Add versatile to trait config, fix deadly/fatal, and use for roll options

### DIFF
--- a/src/module/item/base/data/system.ts
+++ b/src/module/item/base/data/system.ts
@@ -3,6 +3,7 @@ import type * as fields from "@common/data/fields.d.mts";
 import type { EffectAreaShape, ItemType } from "@item/types.ts";
 import type { MigrationRecord, OneToThree, PublicationData, Rarity } from "@module/data.ts";
 import type { RuleElementSource } from "@module/rules/index.ts";
+import type { DamageType } from "@system/damage/index.ts";
 import type { Predicate } from "@system/predication.ts";
 import type { ItemTrait } from "../types.ts";
 
@@ -21,10 +22,13 @@ interface ActionCost {
 }
 
 interface TraitConfig {
-    volley?: number;
-    tracking?: number;
-    resilient?: number;
     area?: { type: EffectAreaShape; value: number | null };
+    deadly?: string;
+    fatal?: string;
+    resilient?: number;
+    tracking?: number;
+    versatile?: DamageType[];
+    volley?: number;
     [key: string]: unknown | undefined;
 }
 

--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -158,18 +158,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
     getRollOptions(prefix = this.type, { includeGranter = true } = {}): string[] {
         if (prefix.length === 0) throw ErrorPF2e("`prefix` must be at least one character long");
 
-        const { value: traits = [], rarity = null, otherTags } = this.system.traits;
-        const traitOptions = ((): string[] => {
-            // Additionally include annotated traits without their annotations
-            const damageType = Object.keys(CONFIG.PF2E.damageTypes).join("|");
-            const diceOrNumber = /-(?:[0-9]*d)?[0-9]+(?:-min)?$/;
-            const versatile = new RegExp(`-(?:b|p|s|${damageType})$`);
-            const deannotated = traits
-                .filter((t) => diceOrNumber.test(t) || versatile.test(t))
-                .map((t) => t.replace(diceOrNumber, "").replace(versatile, ""));
-            return [traits, deannotated].flat().map((t) => `trait:${t}`);
-        })();
-
+        const { value: traits = [], rarity = null, otherTags, config = {} } = this.system.traits;
         const slug = this.slug ?? sluggify(this.name);
         const granterOptions = includeGranter
             ? (this.grantedBy?.getRollOptions("granter", { includeGranter: false }).map((o) => `${prefix}:${o}`) ?? [])
@@ -181,8 +170,9 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
             `${prefix}:slug:${slug}`,
             ...granterOptions,
             ...Array.from(this.specialOptions).map((o) => `${prefix}:${o}`),
-            ...traitOptions.map((t) => `${prefix}:${t}`),
             ...otherTags.map((t) => `${prefix}:tag:${t}`),
+            ...traits.map((t) => `${prefix}:trait:${t}`),
+            ...Object.keys(config).map((k) => `${prefix}:trait:${k}`),
         ];
 
         if (rarity) {

--- a/src/module/item/helpers.ts
+++ b/src/module/item/helpers.ts
@@ -2,7 +2,8 @@ import type { ActorPF2e } from "@actor";
 import { MeasuredTemplateType } from "@common/constants.mjs";
 import { MeasuredTemplatePF2e } from "@module/canvas/measured-template.ts";
 import { ChatMessagePF2e } from "@module/chat-message/document.ts";
-import { createHTMLElement, ErrorPF2e, setHasElement, tupleHasValue } from "@util";
+import type { DamageType } from "@system/damage/types.ts";
+import { createHTMLElement, ErrorPF2e, objectHasKey, setHasElement, tupleHasValue } from "@util";
 import type { Converter } from "showdown";
 import { processSanctification } from "./ability/helpers.ts";
 import type { ItemSourcePF2e } from "./base/data/index.ts";
@@ -80,6 +81,12 @@ function markdownToHTML(markdown: string): string {
         .innerHTML.trim();
 }
 
+const VERSATILE_DAMAGE_TYPES: Record<string, DamageType | undefined> = {
+    b: "bludgeoning",
+    p: "piercing",
+    s: "slashing",
+};
+
 /**
  * Add a trait to an array of traits--unless it matches an existing trait except by annotation. Replace the trait if
  * the new trait is an upgrade, or otherwise do nothing. Note: the array is mutated as part of this process.
@@ -94,28 +101,39 @@ function addOrUpgradeTrait<TTrait extends ItemTrait>(
     const value = isArray ? traits : traits.value;
     const config = isArray ? null : (traits.config ??= {});
 
-    // Check if its an SF2e area trait, which has special handling
-    const areaRegexp = /^area-([\w]+)(?:-(\d+))?$/;
-    const areaMatch = newTrait.match(areaRegexp);
-    if (areaMatch) {
+    // Any special non-numerical annotated trait like area or versatile. These need special handling.
+    const specialTraitRegex = /^(area|versatile)-(.*)$/;
+    const [_, specialTraitBase, specialTraitValue] = newTrait.match(specialTraitRegex) ?? [null, null, null];
+    if (specialTraitBase === "versatile" && config) {
+        config.versatile ??= [];
+        const damageType = VERSATILE_DAMAGE_TYPES[specialTraitValue ?? ""] ?? specialTraitValue;
+        if (objectHasKey(CONFIG.PF2E.damageTypes, damageType) && !config.versatile.includes(damageType)) {
+            config.versatile.push(damageType);
+            value.push(newTrait);
+        }
+        return;
+    } else if (specialTraitBase === "area") {
+        const areaMatch = specialTraitValue?.match(/^([\w]+)(?:-(\d+))?/) ?? [];
         const type = areaMatch.at(1);
         const range = areaMatch.at(2) ? Number(areaMatch.at(2)) : null;
         if (!tupleHasValue(EFFECT_AREA_SHAPES, type)) {
             console.error(`Unexpected area shape ${type}`);
             return;
         }
-        if (
-            mode === "upgrade" &&
-            range &&
-            config?.area?.type === type &&
-            (!config.area.value || range > config.area.value)
-        ) {
-            config.area.value = range;
-        } else {
+
+        const performUpdate =
+            mode === "override" ||
+            !config?.area ||
+            config.area.type !== type ||
+            (range && config.area.value && range > config.area.value);
+        if (performUpdate) {
             if (config) config.area = { type, value: range };
-            const existing = value.find((t) => t.match(areaRegexp));
-            if (existing) value.splice(value.indexOf(existing), 1, newTrait);
-            value.push(newTrait);
+            const existing = value.find((t) => t.startsWith("area-"));
+            if (existing) {
+                value.splice(value.indexOf(existing), 1, newTrait);
+            } else {
+                value.push(newTrait);
+            }
         }
         return;
     }
@@ -133,32 +151,41 @@ function addOrUpgradeTrait<TTrait extends ItemTrait>(
     const traitPattern = new RegExp(String.raw`${traitBase}-(\d*d?\d*)`);
     const existingTrait = value.find((t) => traitPattern.test(t));
     const existingAnnotation = existingTrait?.match(traitPattern)?.at(1);
+    const configValue = ["deadly", "fatal"].includes(traitBase) ? upgradeAnnotation : Number(upgradeAnnotation);
     if (!(existingTrait && existingAnnotation)) {
         if (!value.includes(newTrait)) value.push(newTrait);
-        if (config) config[traitBase] = Number(upgradeAnnotation);
+        if (config) config[traitBase] = configValue;
     } else if (mode === "override" || _expectedValueOf(upgradeAnnotation) > _expectedValueOf(existingAnnotation)) {
         value.splice(value.indexOf(existingTrait), 1, newTrait);
-        if (config) config[traitBase] = Number(upgradeAnnotation);
+        if (config) config[traitBase] = configValue;
     }
 }
 
 /**
  * Removes the trait from the traits object, and also updates the annotation if relevant
  * @param traits the traits object to update
- * @param trait the trait being removed, either the full one or an unannotated variant (like "volley")
+ * @param trait the trait being removed
  */
 function removeTrait<TTrait extends ItemTrait>(
     traits: Pick<ItemTraits<TTrait>, "value" | "config">,
     trait: string,
 ): void {
+    const config = traits.config;
     const idx = traits.value.findIndex((t) => t === trait);
     if (idx < 0) return;
 
     traits.value.splice(idx, 1);
-    const annotatedTraitMatch = trait.match(/^([a-z][-a-z]+)-(\d*d?\d+)$/);
-    if (annotatedTraitMatch && traits.config) {
+    const annotatedTraitMatch = trait.match(/^([a-z][-a-z]+)-(\d*d?\d+)$/) ?? trait.match(/^(area|versatile)-(.*)$/);
+    if (annotatedTraitMatch && config) {
         const traitBase = annotatedTraitMatch[1];
-        delete traits.config[traitBase];
+        if (traitBase === "versatile" && config.versatile) {
+            const value = annotatedTraitMatch[2];
+            const damageType = VERSATILE_DAMAGE_TYPES[value ?? ""] ?? value;
+            config.versatile = config.versatile.filter((d) => d !== damageType);
+            if (config.versatile.length === 0) delete config.versatile;
+        } else {
+            delete config[traitBase];
+        }
     }
 }
 


### PR DESCRIPTION
This fixes soldier critical specialization with area weapons, which predicates on `item:trait:area`. This uses the trait config to determine the un-annotated traits, but we needed to expand the trait config for that to work.