### PR TITLE
Remove bleed from being implicitly ignored by non-living actors

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -367,7 +367,6 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
             chaotic: traits.includes("lawful"),
             vitality: !!this.attributes.hp?.negativeHealing,
             void: !(this.modeOfBeing === "construct" || this.attributes.hp?.negativeHealing),
-            bleed: this.modeOfBeing === "living",
             spirit: !this.itemTypes.effect.some((e) => e.traits.has("possession")),
         };
         return damageIsApplicable[damageType];

--- a/src/module/actor/values.ts
+++ b/src/module/actor/values.ts
@@ -16,7 +16,7 @@ const WEAKNESS_TYPES: Set<WeaknessType> = new Set(R.keys(weaknessTypes));
 
 const RESISTANCE_TYPES: Set<ResistanceType> = new Set(R.keys(resistanceTypes));
 
-const UNAFFECTED_TYPES = new Set(["bleed", "good", "evil", "lawful", "chaotic", "spirit", "vitality", "void"] as const);
+const UNAFFECTED_TYPES = new Set(["good", "evil", "lawful", "chaotic", "spirit", "vitality", "void"] as const);
 
 /** All skill slugs that are part of the core system. Used for validation. */
 const CORE_SKILL_SLUGS = new Set([


### PR DESCRIPTION
Currently bleed damage is implicitly ignored by any non-living actors, post remaster this behavior no longer appears to be the case, with bleed immunity now being explicitly stated on stat blocks as noted in #15149.

Of note here is that the Skeleton ancestry and Zombie/Ghoul dedications are now no longer immune to bleed damage, due to their legacy content status, which may be undesirable when compared to similar monster stat-blocks.