### PR TITLE
Initial support for modular configurations

### DIFF
--- a/src/module/actor/character/helpers.ts
+++ b/src/module/actor/character/helpers.ts
@@ -215,7 +215,7 @@ function getWeaponAuxiliaryActions(weapon: WeaponPF2e<CharacterPF2e>): WeaponAux
     const isRealItem = actor.items.has(weapon.id);
     const traitsArray = weapon.system.traits.value;
 
-    if (weapon.system.traits.toggles.modular.options.length > 0) {
+    if (weapon.system.traits.toggles.modular) {
         auxiliaryActions.push(new WeaponAuxiliaryAction({ weapon, action: "interact", annotation: "modular" }));
     }
     if (weapon.isEquipped) {

--- a/src/module/item/affliction/data.ts
+++ b/src/module/item/affliction/data.ts
@@ -3,15 +3,16 @@ import { SAVE_TYPES } from "@actor/values.ts";
 import type { ModelPropsFromSchema, SourceFromSchema } from "@common/data/fields.d.mts";
 import type { ItemUUID } from "@common/documents/_module.d.mts";
 import { type DurationDataSchema, EffectContextField } from "@item/abstract-effect/data.ts";
-import type { EffectAuraData } from "@item/abstract-effect/index.ts";
+import type { AbstractEffectSchema, EffectAuraData } from "@item/abstract-effect/index.ts";
 import type { EffectTrait, TimeUnit } from "@item/abstract-effect/types.ts";
 import { EFFECT_TIME_UNITS } from "@item/abstract-effect/values.ts";
-import { ItemSystemModel, ItemSystemSchema } from "@item/base/data/model.ts";
+import { ItemSystemModel } from "@item/base/data/model.ts";
 import type {
     BaseItemSourcePF2e,
     ItemFlagsPF2e,
     ItemSourceFlagsPF2e,
     ItemSystemSource,
+    ItemTraitsNoRarity,
 } from "@item/base/data/system.ts";
 import type { ConditionSlug } from "@item/condition/index.ts";
 import { CONDITION_SLUGS } from "@item/condition/values.ts";
@@ -164,20 +165,9 @@ interface AfflictionSystemData
     extends ItemSystemModel<AfflictionPF2e, AfflictionSystemSchema>,
         Omit<ModelPropsFromSchema<AfflictionSystemSchema>, "description"> {}
 
-type AfflictionSystemSchema = Omit<ItemSystemSchema, "traits"> & {
+type AfflictionSystemSchema = AbstractEffectSchema & {
     level: fields.SchemaField<{
         value: fields.NumberField<number, number, true, false, true>;
-    }>;
-    traits: fields.SchemaField<{
-        otherTags: fields.ArrayField<SlugField<true, false, false>, string[], string[], true, false, true>;
-        value: fields.ArrayField<
-            fields.StringField<EffectTrait, EffectTrait, true, false, false>,
-            EffectTrait[],
-            EffectTrait[],
-            true,
-            false,
-            true
-        >;
     }>;
     save: fields.SchemaField<{
         type: fields.StringField<SaveType, SaveType, true, false, true>;
@@ -251,6 +241,7 @@ type AfflictionConditionSchema = {
 };
 
 type AfflictionSystemSource = SourceFromSchema<AfflictionSystemSchema> & {
+    traits: ItemTraitsNoRarity<EffectTrait>;
     schema?: ItemSystemSource["schema"];
 };
 

--- a/src/module/item/armor/data.ts
+++ b/src/module/item/armor/data.ts
@@ -1,4 +1,5 @@
 import { PhysicalItemSource } from "@item/base/data/index.ts";
+import type { TraitConfig } from "@item/base/data/system.ts";
 import {
     BasePhysicalItemSource,
     Investable,
@@ -68,6 +69,7 @@ type SourceOmission =
 
 interface ArmorTraits extends PhysicalItemTraits<ArmorTrait> {
     otherTags: OtherArmorTag[];
+    config: TraitConfig;
 }
 
 interface ArmorRuneData extends ArmorRuneSource {

--- a/src/module/item/base/data/model.ts
+++ b/src/module/item/base/data/model.ts
@@ -1,8 +1,11 @@
 import type { ActorPF2e } from "@actor";
+import type { ModelPropsFromSchema, SourceFromSchema } from "@common/data/fields.mjs";
+import type { WeaponTrait } from "@item/weapon/types.ts";
 import type { MigrationDataField } from "@module/data.ts";
 import { PublicationField } from "@module/model.ts";
 import type { RuleElementSource } from "@module/rules/index.ts";
-import { SlugField } from "@system/schema-data-fields.ts";
+import type { DamageType } from "@system/damage/types.ts";
+import { PrunedSchemaField, SlugField } from "@system/schema-data-fields.ts";
 import type { ItemPF2e } from "../document.ts";
 import type { ItemDescriptionData } from "./system.ts";
 import fields = foundry.data.fields;
@@ -81,4 +84,44 @@ type ItemSystemSchema = {
     _migration: MigrationDataField;
 };
 
-export { ItemSystemModel, type ItemSystemSchema };
+class TraitConfigField extends PrunedSchemaField<TraitConfigSchema> {
+    constructor() {
+        super({
+            modular: new fields.ArrayField(
+                new fields.SchemaField({
+                    damageType: new fields.StringField({
+                        required: true,
+                        nullable: false,
+                        initial: "bludgeoning" as DamageType,
+                        choices: CONFIG.PF2E.damageTypes,
+                    }),
+                    traits: new fields.ArrayField(
+                        new fields.StringField({
+                            required: true,
+                            nullable: false,
+                            choices: CONFIG.PF2E.weaponTraits,
+                        }),
+                    ),
+                }),
+                { required: false, nullable: false },
+            ),
+        });
+    }
+}
+
+type TraitConfigSchema = {
+    modular: fields.ArrayField<
+        fields.SchemaField<ModularConfigSchema>,
+        SourceFromSchema<ModularConfigSchema>[],
+        ModelPropsFromSchema<ModularConfigSchema>[],
+        false,
+        false
+    >;
+};
+
+type ModularConfigSchema = {
+    damageType: fields.StringField<DamageType, DamageType, true, false, true>;
+    traits: fields.ArrayField<fields.StringField<WeaponTrait, WeaponTrait, true, false>>;
+};
+
+export { ItemSystemModel, TraitConfigField, type ItemSystemSchema };

--- a/src/module/item/base/data/system.ts
+++ b/src/module/item/base/data/system.ts
@@ -1,6 +1,7 @@
 import type { DocumentFlags, DocumentFlagsSource } from "@common/data/_types.d.mts";
 import type * as fields from "@common/data/fields.d.mts";
 import type { EffectAreaShape, ItemType } from "@item/types.ts";
+import type { WeaponTrait } from "@item/weapon/types.ts";
 import type { MigrationRecord, OneToThree, PublicationData, Rarity } from "@module/data.ts";
 import type { RuleElementSource } from "@module/rules/index.ts";
 import type { DamageType } from "@system/damage/index.ts";
@@ -26,12 +27,18 @@ interface TraitConfig {
     capacity?: number;
     deadly?: string;
     fatal?: string;
+    modular: ModularConfig[] | undefined;
     resilient?: number;
     thrown?: number;
     tracking?: number;
     versatile?: DamageType[];
     volley?: number;
     [key: string]: unknown | undefined;
+}
+
+interface ModularConfig {
+    damageType: DamageType;
+    traits: WeaponTrait[];
 }
 
 interface ItemTraits<T extends ItemTrait = ItemTrait> {
@@ -177,6 +184,7 @@ export type {
     ItemTrait,
     ItemTraits,
     ItemTraitsNoRarity,
+    ModularConfig,
     OtherTagsOnly,
     RarityTraitAndOtherTags,
     TraitConfig,

--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -53,7 +53,7 @@ import type {
     RawItemChatData,
     TraitChatData,
 } from "./data/index.ts";
-import type { ItemDescriptionData, ItemTrait } from "./data/system.ts";
+import type { ItemDescriptionData, ItemTrait, TraitConfig } from "./data/system.ts";
 import type { ItemSheetPF2e } from "./sheet/sheet.ts";
 
 /** The basic `Item` subclass for the system */
@@ -274,7 +274,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
             const validTraits = this.constructor.validTraits;
             const original = this.system.traits.value;
             this.system.traits.value = [];
-            this.system.traits.config = {};
+            this.system.traits.config ??= {} as TraitConfig;
             for (const trait of original) {
                 if (!(trait in validTraits)) continue;
                 addOrUpgradeTrait(this.system.traits, trait);

--- a/src/module/item/effect/data.ts
+++ b/src/module/item/effect/data.ts
@@ -15,6 +15,7 @@ import type {
     ItemFlagsPF2e,
     ItemSourceFlagsPF2e,
     ItemSystemSource,
+    ItemTraitsNoRarity,
 } from "@item/base/data/system.ts";
 import { LaxArrayField, SlugField } from "@system/schema-data-fields.ts";
 import type { EffectPF2e } from "./document.ts";
@@ -214,6 +215,7 @@ type EffectFlags = ItemFlagsPF2e & {
 
 type EffectSystemSource = SourceFromSchema<EffectSystemSchema> & {
     schema?: ItemSystemSource["schema"];
+    traits: ItemTraitsNoRarity<EffectTrait>;
 };
 
 export { EffectSystemData };

--- a/src/module/item/helpers.ts
+++ b/src/module/item/helpers.ts
@@ -99,7 +99,7 @@ function addOrUpgradeTrait<TTrait extends ItemTrait>(
     // Get traits and annotations object to potentially upgrade
     const isArray = Array.isArray(traits);
     const value = isArray ? traits : traits.value;
-    const config = isArray ? null : (traits.config ??= {});
+    const config = isArray ? null : (traits.config ??= { modular: undefined });
 
     // Any special non-numerical annotated trait like area or versatile. These need special handling.
     const specialTraitRegex = /^(area|versatile)-(.*)$/;
@@ -186,6 +186,11 @@ function removeTrait<TTrait extends ItemTrait>(
         } else {
             delete config[traitBase];
         }
+    }
+
+    // Remove modular config as well if its modular. Refactor once we have a list of all configurable traits
+    if (trait === "modular") {
+        delete config?.modular;
     }
 }
 

--- a/src/module/item/melee/data.ts
+++ b/src/module/item/melee/data.ts
@@ -1,11 +1,12 @@
 import type { ModelPropsFromSchema, SourceFromSchema } from "@common/data/fields.mjs";
 import type { MeleePF2e } from "@item";
-import { ItemSystemModel, ItemSystemSchema } from "@item/base/data/model.ts";
+import { ItemSystemModel, ItemSystemSchema, TraitConfigField } from "@item/base/data/model.ts";
 import type {
     BaseItemSourcePF2e,
     ItemFlagsPF2e,
     ItemSystemSource,
     ItemTraitsNoRarity,
+    TraitConfig,
 } from "@item/base/data/system.ts";
 import type { EffectAreaShape } from "@item/types.ts";
 import { EFFECT_AREA_SHAPES } from "@item/values.ts";
@@ -55,6 +56,7 @@ class MeleeSystemData extends ItemSystemModel<MeleePF2e, NPCAttackSystemSchema> 
                         initial: undefined,
                     }),
                 ),
+                config: new TraitConfigField(),
             }),
             action: new fields.StringField({
                 choices: NPC_ATTACK_ACTIONS,
@@ -182,6 +184,7 @@ type NPCAttackSystemSchema = Omit<ItemSystemSchema, "traits"> & {
             false,
             true
         >;
+        config: TraitConfigField;
     }>;
     action: fields.StringField<NPCAttackActionType, NPCAttackActionType, true, false, true>;
     area: fields.SchemaField<
@@ -235,7 +238,7 @@ type MeleeSystemSource = fields.SourceFromSchema<NPCAttackSystemSchema> & {
 };
 
 type NPCAttackDamage = fields.SourceFromSchema<NPCAttackSystemSchema>["damageRolls"]["string"];
-type NPCAttackTraits = ItemTraitsNoRarity<NPCAttackTrait>;
+type NPCAttackTraits = ItemTraitsNoRarity<NPCAttackTrait> & { config: TraitConfig };
 
 export { MeleeSystemData };
 export type { MeleeFlags, MeleeSource, MeleeSystemSource, NPCAttackDamage, NPCAttackTraits };

--- a/src/module/item/physical/data.ts
+++ b/src/module/item/physical/data.ts
@@ -1,9 +1,9 @@
 import type { AttributeString } from "@actor/types.ts";
 import type { ImageFilePath } from "@common/constants.d.mts";
 import type { PhysicalItemSource } from "@item/base/data/index.ts";
-import type { Size, TraitsWithRarity, ZeroToTwo } from "@module/data.ts";
+import type { Size, ZeroToTwo } from "@module/data.ts";
 import type { MaterialDamageEffect } from "@system/damage/types.ts";
-import type { BaseItemSourcePF2e, ItemSystemData, ItemSystemSource, TraitConfig } from "../base/data/system.ts";
+import type { BaseItemSourcePF2e, ItemSystemData, ItemSystemSource, ItemTraits } from "../base/data/system.ts";
 import type { ITEM_CARRY_TYPES } from "../base/data/values.ts";
 import type { Coins } from "./helpers.ts";
 import type { PhysicalItemTrait, PhysicalItemType, PreciousMaterialGrade, PreciousMaterialType } from "./types.ts";
@@ -116,9 +116,8 @@ type EquippedData = {
     invested?: boolean | null;
 };
 
-interface PhysicalItemTraits<T extends PhysicalItemTrait> extends TraitsWithRarity<T> {
+interface PhysicalItemTraits<T extends PhysicalItemTrait> extends ItemTraits<T> {
     otherTags: string[];
-    config?: TraitConfig;
 }
 
 interface PhysicalItemHPSource {

--- a/src/module/item/weapon/data.ts
+++ b/src/module/item/weapon/data.ts
@@ -98,7 +98,7 @@ interface WeaponTraitsSource extends PhysicalItemTraits<WeaponTrait> {
     otherTags: OtherWeaponTag[];
     toggles?: {
         doubleBarrel?: { selected: boolean };
-        modular?: { selected: DamageType | null };
+        modular?: { selected: number | null } | null;
         versatile?: { selected: DamageType | null };
     };
 }
@@ -194,7 +194,7 @@ interface ComboWeaponMeleeUsage {
     damage: { type: DamageType; die: DamageDieSize };
     group: MeleeWeaponGroup;
     traits?: WeaponTrait[];
-    traitToggles?: { modular: DamageType | null; versatile: DamageType | null };
+    traitToggles?: { modular: number | null; versatile: DamageType | null };
 }
 
 export type {

--- a/src/module/item/weapon/document.ts
+++ b/src/module/item/weapon/document.ts
@@ -164,13 +164,14 @@ class WeaponPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
 
     /** This weapon's damage before modification by creature abilities, effects, etc. */
     get baseDamage(): WeaponDamage {
+        const traits = this.system.traits;
         return {
             ...fu.deepClone(this.system.damage),
             // Damage types from trait toggles are not applied as data mutations so as to delay it for rule elements to
             // add options
             damageType:
-                this.system.traits.toggles.versatile.selected ??
-                this.system.traits.toggles.modular.selected ??
+                traits.toggles.versatile.selected ??
+                traits.toggles.modular?.config.damageType ??
                 this.system.damage.damageType,
         };
     }
@@ -489,6 +490,14 @@ class WeaponPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
         } else {
             this.system.ammo = null;
             this.system.expend = null;
+        }
+
+        // Add traits from the current modular configuration
+        const config = traits.toggles.modular?.config;
+        if (config) {
+            for (const trait of config.traits) {
+                addOrUpgradeTrait(traits, trait);
+            }
         }
     }
 

--- a/src/module/rules/rule-element/strike.ts
+++ b/src/module/rules/rule-element/strike.ts
@@ -73,11 +73,9 @@ class StrikeRuleElement extends RuleElement<StrikeSchema> {
             ),
             traitToggles: new fields.SchemaField(
                 {
-                    modular: new fields.StringField({
+                    modular: new fields.NumberField({
                         required: true,
-                        blank: false,
                         nullable: true,
-                        choices: CONFIG.PF2E.damageTypes,
                         initial: null,
                     }),
                     versatile: new fields.StringField({
@@ -322,11 +320,11 @@ type StrikeSchema = RuleElementSchema & {
     traits: fields.ArrayField<fields.StringField<NPCAttackTrait, NPCAttackTrait, true, false, false>>;
     traitToggles: fields.SchemaField<
         {
-            modular: fields.StringField<DamageType, DamageType, true, true, true>;
+            modular: fields.NumberField<number, number, true, true, true>;
             versatile: fields.StringField<DamageType, DamageType, true, true, true>;
         },
-        { modular: DamageType | null; versatile: DamageType | null },
-        { modular: DamageType | null; versatile: DamageType | null },
+        { modular: number | null; versatile: DamageType | null },
+        { modular: number | null; versatile: DamageType | null },
         true,
         false,
         true
@@ -408,10 +406,9 @@ interface StrikeSource extends RuleElementSource {
     fist?: unknown;
 }
 
-interface UpdateToggleParams {
-    trait: "modular" | "versatile";
-    selected: DamageType | null;
-}
+type UpdateToggleParams =
+    | { trait: "modular"; selected: number | null }
+    | { trait: "versatile"; selected: DamageType | null };
 
 export { StrikeRuleElement };
 export type { StrikeSource };

--- a/src/scripts/register-templates.ts
+++ b/src/scripts/register-templates.ts
@@ -115,6 +115,7 @@ export function registerTemplates(): void {
         "items/partials/addendum.hbs",
         "items/partials/apex.hbs",
         "items/partials/duration.hbs",
+        "items/partials/modular.hbs",
         "items/partials/other-tags.hbs",
         "items/partials/self-applied-effect.hbs",
 

--- a/src/styles/item/_index.scss
+++ b/src/styles/item/_index.scss
@@ -441,6 +441,22 @@
             }
         }
 
+        .modular-configurations {
+            margin-top: 0.5rem;
+
+            .config {
+                align-items: center;
+                display: flex;
+                gap: var(--space-4);
+                margin-top: var(--space-2);
+                .tags {
+                    padding: 0;
+                    margin: 0;
+                    flex: 1;
+                }
+            }
+        }
+
         .consumable-details {
             flex: 0 0 1.5rem;
 

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -204,8 +204,11 @@ function ordinalString(value: number): string {
 }
 
 /** Localizes a list of strings into a (possibly comma-delimited) list for the current language */
-function localizeList(items: string[], { conjunction = "or" }: { conjunction?: "and" | "or" } = {}): string {
-    items = [...items].sort((a, b) => a.localeCompare(b, game.i18n.lang));
+function localizeList(
+    items: string[],
+    { conjunction = "or", sort = true }: { conjunction?: "and" | "or"; sort?: boolean } = {},
+): string {
+    items = sort ? [...items].sort((a, b) => a.localeCompare(b, game.i18n.lang)) : items;
     const parts = conjunction === "or" ? "PF2E.ListPartsOr" : "PF2E.ListPartsAnd";
 
     if (items.length === 0) return "";

--- a/static/lang/action-en.json
+++ b/static/lang/action-en.json
@@ -567,7 +567,7 @@
                     "Title": "Change Grip (2H)"
                 },
                 "Modular": {
-                    "Description": "{actor} adjusts their {weapon} to deal {damageType} damage.",
+                    "Description": "{actor} adjusts their {weapon} to {modularConfig}.",
                     "Title": "Modular"
                 },
                 "Parenthetical": "Interact {purpose}",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3032,6 +3032,9 @@
                     "Hint": "A combination weapon has a firearm form or usage and a melee weapon form or usage. Switching between the melee weapon usage and the firearm usage requires an Interact action. However, if your last action was a successful melee Strike against a foe using a combination weapon, you can make a firearm Strike with the combination weapon against that foe without fully switching to the firearm usage, firing the firearm just as you hit with the melee attack. In this case, the combination weapon returns to its melee usage after the firearm Strike.",
                     "Label": "Melee Usage"
                 },
+                "Modular": {
+                    "Title": "Modular Configurations"
+                },
                 "NoRangeMelee": "None (Melee)",
                 "RangeIncrementN": {
                     "Hint": "Ranged and thrown weapons have a range increment. Attacks with these weapons work normally up to that distance. Attack rolls beyond a weapon's range increment take a -2 penalty for each additional multiple of that increment between you and the target. Attacks beyond the sixth range increment are impossible.",
@@ -5340,7 +5343,7 @@
         "TraitMisfortuneEffects": "Misfortune Effects",
         "TraitMissive": "Missive",
         "TraitModification": "Modification",
-        "TraitModular": "Modular B, P, or S",
+        "TraitModular": "Modular",
         "TraitMonitor": "Monitor",
         "TraitMonk": "Monk",
         "TraitMorlock": "Morlock",

--- a/static/templates/items/melee-details.hbs
+++ b/static/templates/items/melee-details.hbs
@@ -29,6 +29,8 @@
     {{formGroup systemFields.range.fields.max type="number" value=item._source.system.range.max}}
 {{/unless}}
 
+{{> (resolvePath "templates/items/partials/modular.hbs")}}
+
 <ol class="form-list">
     {{#each data.damageRolls as |damageRoll key|}}
         <li class="damage-partial" data-key="{{key}}">

--- a/static/templates/items/partials/modular.hbs
+++ b/static/templates/items/partials/modular.hbs
@@ -1,0 +1,19 @@
+{{#if modularConfigs.length includeZero=true}}
+    <fieldset>
+        <legend>
+            {{localize "PF2E.Item.Weapon.Modular.Title"}}
+            {{#if editable}}<a data-action="add-modular-config"><i class="fa-solid fa-fw fa-plus" ></i></a>{{/if}}
+        </legend>
+        <div class="modular-configurations">
+            {{#each modularConfigs as |config index|}}
+                <div class="config">
+                    <select name="{{basePath}}.damageType">
+                        {{selectOptions @root.damageTypes selected=config.damageType localize=true}}
+                    </select>
+                    <tagify-tags class="tags paizo-style modular-traits" name="{{basePath}}.traits" value="{{json config.traits}}"></tagify-tags>
+                    <button type="button" class="inline-control icon fa-solid fa-trash" data-action="remove-modular-config" data-index="{{index}}"></button>
+                </div>
+            {{/each}}
+        </div>
+    </fieldset>
+{{/if}}

--- a/static/templates/items/weapon-details.hbs
+++ b/static/templates/items/weapon-details.hbs
@@ -181,6 +181,8 @@
     </fieldset>
 {{/unless}}
 
+{{> (resolvePath "templates/items/partials/modular.hbs")}}
+
 <fieldset>
     <legend>
         {{localize "PF2E.DamageLabel"}}


### PR DESCRIPTION
We will eventually need to update the rendered traits, support actually swapping configs in npc attacks, better communicate that an empty list of modular configs is BPS, and support passing modular configs into the item alteration. We may also need a migration for the current selection maybe.

I'm using a pruned schema field for the trait config currently, but I'm suspecting to support adding new annotatable traits in modules we may need TraitConfigField to instead accept a config object to generate the actual schema instead of being hardcoded. Hardcoded is likely fine for current development.