### PR TITLE
Update Rule Element for Gigaton Strike to use the new predicate "unstable-state"

### DIFF
--- a/packs/feats/class/inventor/gigaton-strike.json
+++ b/packs/feats/class/inventor/gigaton-strike.json
@@ -34,7 +34,7 @@
                 "key": "Note",
                 "predicate": [
                     "megaton-strike",
-                    "unstable-function"
+                    "unstable-state"
                 ],
                 "selector": "strike-damage",
                 "text": "{item|description}"


### PR DESCRIPTION
Update to the gigaton-strike.json to have the rule element use the correct predicate of 'unstable-state' rather than the deprecated value of 'unstable-function'.