### PR TITLE
Allow treasure items to have 0 quantity

### DIFF
--- a/src/module/item/treasure/data.ts
+++ b/src/module/item/treasure/data.ts
@@ -109,7 +109,7 @@ class TreasureSystemData extends ItemSystemModel<TreasurePF2e, TreasureSystemSch
                 required: true,
                 nullable: false,
                 integer: true,
-                positive: true,
+                min: 0,
                 initial: 1,
             }),
             size: new fields.StringField({


### PR DESCRIPTION
The sheet allows items to be set to 0 quantity so there are probably quite a few of them in the wild.

Closes #20649 