### PR TITLE
Fix draw/sheathe of area weapons

### DIFF
--- a/src/module/actor/character/data.ts
+++ b/src/module/actor/character/data.ts
@@ -394,6 +394,8 @@ interface BasicAttackData {
     visible: boolean;
     auxiliaryActions: WeaponAuxiliaryAction[];
     weaponTraits: TraitViewData[];
+    /** Whether the character has sufficient hands available to wield this weapon or use this unarmed attack */
+    handsAvailable: boolean;
 }
 
 /** The full data for a character strike */
@@ -401,8 +403,6 @@ interface CharacterStrike extends StrikeData, BasicAttackData {
     item: WeaponPF2e<CharacterPF2e>;
     /** Domains/selectors from which modifiers are drawn */
     domains: string[];
-    /** Whether the character has sufficient hands available to wield this weapon or use this unarmed attack */
-    handsAvailable: boolean;
     altUsages: CharacterAttack[];
     doubleBarrel: { selected: boolean } | null;
     versatileOptions: VersatileWeaponOption[];


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/20646

The reason strikes weren't working is that it checks if the attack is ready. The strike was not ready, even though the area attack was.