### PR TITLE
Check if the party could roll checks they speak before short-circuiting actor selection

### DIFF
--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -154,8 +154,8 @@ export class InlineRollLinks {
                 return [sheetActor];
             }
 
-            // If the rolling actor is a party actor, return it (likely kingmaker)
-            if (parentActor?.isOfType("party")) {
+            // If the rolling actor is a party actor and has the requested statistic, return it (likely kingmaker)
+            if (parentActor?.isOfType("party") && parentActor?.getStatistic(pf2Check)) {
                 return [parentActor];
             }
 


### PR DESCRIPTION
Fixes #20568 