### PR TITLE
Show area fire description instead of item description

### DIFF
--- a/src/module/actor/data/base.ts
+++ b/src/module/actor/data/base.ts
@@ -225,6 +225,8 @@ interface BasicAttackAction {
     slug: string;
     label: string;
     type: string;
+    /** Action traits associated with this action */
+    traits: TraitViewData[];
     /** The glyph for this attack (how many actions it takes, reaction, etc). */
     glyph: string;
     /** A description of this attack. */
@@ -266,12 +268,6 @@ interface StrikeData extends StatisticModifier, BasicAttackAction {
     label: string;
     /** The type of action; currently just 'strike'. */
     type: "strike";
-    /** A description of what happens on a critical success. */
-    criticalSuccess: string;
-    /** A description of what happens on a success. */
-    success: string;
-    /** Action traits associated with this strike */
-    traits: TraitViewData[];
     /** Any options always applied to this strike */
     options: string[];
     /** Alias for `attack`. */

--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -704,6 +704,10 @@ function areaFireFromMeleeItem(item: MeleePF2e<ActorPF2e>): NPCAreaAttack {
         item,
         statistic,
         additionalEffects,
+        traits: [
+            ["attack"].map((t) => traitSlugToObject(t, CONFIG.PF2E.actionTraits)),
+            item.system.traits.value.map((t) => traitSlugToObject(t, CONFIG.PF2E.npcAttackTraits)),
+        ].flat(),
         variants: [
             {
                 label: game.i18n.format("PF2E.ActionWithDC", {

--- a/static/templates/actors/character/partials/strike.hbs
+++ b/static/templates/actors/character/partials/strike.hbs
@@ -109,14 +109,7 @@
 
     <div class="item-summary" hidden="hidden">
         <div class="item-description">
-            <p>{{{localize action.description}}}</p>
-            <hr />
-            <dl>
-                <dt>{{{localize "PF2E.CritSuccess"}}}</dt>
-                <dd>{{{localize action.criticalSuccess}}}</dd>
-                <dt>{{{localize "PF2E.Success"}}}</dt>
-                <dd>{{{localize action.success}}}</dd>
-            </dl>
+            {{{action.description}}}
         </div>
         <div class="item-properties tags">
             {{#each action.traits as |trait|}}


### PR DESCRIPTION
This fixes an issue where the attack descriptions weren't enriched, but that's because this feature was never supposed to show the item description. Note that despite auto fire gaining a description, auto fire is an alt usage and automatic weapons will show the strike description instead.