### PR TITLE
Allow loading untyped special ammo

### DIFF
--- a/src/module/item/ammo/document.ts
+++ b/src/module/item/ammo/document.ts
@@ -52,9 +52,7 @@ class AmmoPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Phys
         const weaponData = weapon.system.ammo;
 
         // If this is not ammo or the weapon doesn't take ammo, return
-        if (!this.system.baseItem || !weaponData || weaponData.builtIn) {
-            return false;
-        }
+        if (!weaponData || weaponData.builtIn) return false;
 
         const thisAmmoTypeData = this.system.baseItem ? CONFIG.PF2E.ammoTypes[this.system.baseItem] : null;
         const weaponAmmoTypeData = objectHasKey(CONFIG.PF2E.ammoTypes, weaponData.baseType)
@@ -65,6 +63,14 @@ class AmmoPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Phys
         const isMagazine = thisAmmoTypeData?.magazine || this.system.uses.max > 1;
 
         return (
+            // Unselected special ammo. The attach() function should lock in the ammo type after
+            (!this.system.baseItem &&
+                this.system.craftableAs &&
+                !isMagazine &&
+                !!weaponAmmoTypeData &&
+                (this.system.craftableAs.length === 0 ||
+                    !basicWeaponAmmoType ||
+                    tupleHasValue(this.system.craftableAs, basicWeaponAmmoType))) ||
             // Return true if it is an exact match
             this.system.baseItem === weaponData.baseType ||
             // Return true if this is a non-magazine and the weapon accepts anything

--- a/src/module/item/physical/document.ts
+++ b/src/module/item/physical/document.ts
@@ -482,7 +482,8 @@ abstract class PhysicalItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | n
             .deepClone(this._source.system.subitems)
             .filter((i) => i._id && !purgedItems.includes(i._id));
 
-        // Add to subitems, matching with a stackable item if stack is true
+        // Create attachment source data.
+        // If it is unattributed special ammo, lock in the time so removal doesn't re-prompt
         const validCarryTypes = ["attached", "installed"] as const;
         const attachmentSource = item.toObject();
         attachmentSource.system.quantity = quantity;
@@ -490,6 +491,11 @@ abstract class PhysicalItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | n
             carryType: validCarryTypes.find((c) => c === item.system.usage.type) ?? "attached",
             handsHeld: 0,
         };
+        if (item.isOfType("ammo") && this.isOfType("weapon") && !item.system.baseItem && item.system.craftableAs) {
+            attachmentSource.system.baseItem = this.system.ammo?.baseType ?? "arrows";
+        }
+
+        // Add to subitems, matching with a stackable item if stack is true
         const matchingId = stack ? this.subitems.contents.find((s) => s.isStackableWith(item))?.id : null;
         const matching = matchingId ? subitems.find((s) => s._id === matchingId) : null;
         if (matching) {


### PR DESCRIPTION
This allows loading special ammo without a selected input, or special ammo that was migrated while already on an actor, to be loaded onto a weapon. When it is, the baseType becomes set to the weapon it was loaded into.

Closes https://github.com/foundryvtt/pf2e/issues/20645