### PR TITLE
Remove Gecko's Grip prerequisites

### DIFF
--- a/packs/feats/ancestry/lizardfolk/geckos-grip.json
+++ b/packs/feats/ancestry/lizardfolk/geckos-grip.json
@@ -18,11 +18,7 @@
             "value": 5
         },
         "prerequisites": {
-            "value": [
-                {
-                    "value": "cliffscale lizardfolk"
-                }
-            ]
+            "value": []
         },
         "publication": {
             "license": "ORC",


### PR DESCRIPTION
These were left from the premaster version.