### PR TITLE
Show message when reloading during combat

### DIFF
--- a/static/lang/action-en.json
+++ b/static/lang/action-en.json
@@ -518,6 +518,10 @@
                     "Description": "{actor} picks up {weapon} from the ground.",
                     "Title": "Pick Up (2H)"
                 },
+                "Reload": {
+                    "Description": "{actor} loads {weapon} with {ammo}.",
+                    "Title": "Reload"
+                },
                 "Retrieve1H": {
                     "Description": "{actor} retrieves their {weapon}.",
                     "Title": "Retrieve (1H)"
@@ -719,9 +723,6 @@
                     "Title": "Change Grip (1H)"
                 },
                 "Title": "Release"
-            },
-            "Reload": {
-                "ShortTitle": "Reload"
             },
             "Repair": {
                 "Chat": {

--- a/static/templates/actors/character/partials/strike.hbs
+++ b/static/templates/actors/character/partials/strike.hbs
@@ -72,7 +72,7 @@
                     {{#if action.ammunition.remaining}}
                         <div class="empty plain">
                             <a class="name" data-action="reload" data-anchor-id="{{action.item.uuid}}-actions">
-                                <span>{{localize "PF2E.Actions.Reload.ShortTitle"}} <span class="action-glyph">{{action.ammunition.reloadGlyph}}</span></span>
+                                <span>{{localize "PF2E.Actions.Interact.Reload.Title"}} <span class="action-glyph">{{action.ammunition.reloadGlyph}}</span></span>
                             </a>
                             <span class="remaining">
                                 {{#if (gt action.ammunition.capacity 1)}}


### PR DESCRIPTION
<img width="301" height="178" alt="image" src="https://github.com/user-attachments/assets/69838ec0-2b08-4820-b0c8-b1db0595ace9" />

Closes https://github.com/foundryvtt/pf2e/issues/20656

There are two things that make me a bit queasy, but im happy to merge even if  they're not resolved:
* The message is only sent when the application is used, so it wouldn't trigger from a macro. We could maybe consider making reload an aux action, but I'm not sure how to do that without making it possible for an aux action to have a different "render type". Its likely not worth getting that sophisticated.
* There is code duplication with the send message function. Not sure if we should make a helper or where.