### PR TITLE
Skip confirmation for eject ammo if shift is held

### DIFF
--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -914,11 +914,11 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
             return item.system.traits.toggles?.update({ trait, selected: !toggle.selected });
         };
 
-        handlers["unload"] = async (_, button) => {
+        handlers["unload"] = async (event, button) => {
             const weapon = this.getAttackActionFromDOM(button)?.item;
             if (weapon) {
                 const itemId = htmlClosest(button, "[data-item-id]")?.dataset.itemId;
-                weapon.subitems.get(itemId, { strict: true }).detach();
+                weapon.subitems.get(itemId, { strict: true }).detach({ skipConfirm: event.shiftKey });
             }
         };
 

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -937,7 +937,7 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends fav1.sheets.Acto
     }
 
     protected deleteItem<TItem extends ItemPF2e>(item: TItem, event?: PointerEvent): Promise<TItem | undefined> {
-        return event?.ctrlKey ? item.delete() : item.deleteDialog();
+        return event?.ctrlKey || event?.shiftKey ? item.delete() : item.deleteDialog();
     }
 
     #onClickBrowseAbilities(anchor: HTMLElement): void {


### PR DESCRIPTION
Also sneakily includes holding shift key as an option for inventory items. We can remove CTRL key for skipping delete inventory item confirmation in a future release, maybe v14?