### PR TITLE
Replace Energy Shot Choice Set with Roll Option dropdown

### DIFF
--- a/packs/feat-effects/effect-energy-shot.json
+++ b/packs/feat-effects/effect-energy-shot.json
@@ -22,7 +22,10 @@
         },
         "rules": [
             {
-                "choices": [
+                "alwaysActive": true,
+                "key": "RollOption",
+                "option": "energy-shot",
+                "suboptions": [
                     {
                         "label": "PF2E.TraitAcid",
                         "value": "acid"
@@ -40,22 +43,15 @@
                         "value": "fire"
                     }
                 ],
-                "flag": "energyShot",
-                "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.Prompt.EnergyType"
+                "toggleable": true
             },
             {
                 "damageType": "{item|flags.pf2e.rulesSelections.energyShot}",
                 "key": "FlatModifier",
-                "predicate": [
-                    {
-                        "or": [
-                            "item:group:firearm",
-                            "item:group:crossbow"
-                        ]
-                    }
+                "selector": [
+                    "crossbow-weapon-group-damage",
+                    "firearm-weapon-group-damage"
                 ],
-                "selector": "strike-damage",
                 "value": "@weapon.system.damage.dice"
             }
         ],


### PR DESCRIPTION
> You unleash a small surge of magical energy into your weapon, shrouding the bullet with potential energy and granting it the ability to deal energy damage to your foes to exploit their weaknesses. You can Interact to draw a ranged weapon. On your first three Strikes of this encounter with a firearm or crossbow, you deal an additional 1 acid, cold, fire or electricity damage per weapon damage die. **You choose which damage type to deal as part of making each Strike.**

(emphasis mine)