### PR TITLE
Automates physical resistance for Inspire Heroics (Defense) effects

### DIFF
--- a/packs/pf2e/spell-effects/spell-effect-inspire-heroics-defense-2.json
+++ b/packs/pf2e/spell-effects/spell-effect-inspire-heroics-defense-2.json
@@ -1,10 +1,10 @@
 {
     "_id": "Chol7ExtoN2T36mP",
     "img": "systems/pf2e/icons/spells/inspire-heroics.webp",
-    "name": "Spell Effect: Inspire Heroics (Defense, +2)",
+    "name": "Spell Effect: Inspire Heroics (Rallying, +2)",
     "system": {
         "description": {
-            "value": "<p>Granted by succeeding on @UUID[Compendium.pf2e.spells-srd.Item.Fortissimo Composition] to enhance @UUID[Compendium.pf2e.spells-srd.Item.Rallying Anthem].</p>\n<p>You inspire your allies to protect themselves more effectively. You and all allies in the area gain a +2 status bonus to AC and saving throws, as well as resistance equal to half the spell's rank to physical damage.</p>\n<p><em>Note: resistance is not automatically added.</em></p>"
+            "value": "<p>Granted by succeeding on @UUID[Compendium.pf2e.spells-srd.Item.Fortissimo Composition] to enhance @UUID[Compendium.pf2e.spells-srd.Item.Rallying Anthem].</p>\n<p>You inspire your allies to protect themselves more effectively. You and all allies in the area gain a +2 status bonus to AC and saving throws, as well as resistance equal to half the spell's rank to physical damage.</p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -23,13 +23,18 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Inspire Defense",
+                "label": "Rallying Anthem",
                 "selector": [
                     "ac",
                     "saving-throw"
                 ],
                 "type": "status",
                 "value": 2
+            },
+            {
+                "key": "Resistance",
+                "type": "physical",
+                "value": "floor(( @item.level ) / 2 )"
             }
         ],
         "start": {

--- a/packs/pf2e/spell-effects/spell-effect-inspire-heroics-defense-2.json
+++ b/packs/pf2e/spell-effects/spell-effect-inspire-heroics-defense-2.json
@@ -1,7 +1,7 @@
 {
     "_id": "Chol7ExtoN2T36mP",
     "img": "systems/pf2e/icons/spells/inspire-heroics.webp",
-    "name": "Spell Effect: Inspire Heroics (Defense, +2)",
+    "name": "Spell Effect: Inspire Heroics (Rallying, +2)",
     "system": {
         "description": {
             "value": "<p>Granted by succeeding on @UUID[Compendium.pf2e.spells-srd.Item.Fortissimo Composition] to enhance @UUID[Compendium.pf2e.spells-srd.Item.Rallying Anthem].</p>\n<p>You inspire your allies to protect themselves more effectively. You and all allies in the area gain a +2 status bonus to AC and saving throws, as well as resistance equal to half the spell's rank to physical damage.</p>"
@@ -23,6 +23,7 @@
         "rules": [
             {
                 "key": "FlatModifier",
+                "label": "Rallying Anthem",
                 "selector": [
                     "ac",
                     "saving-throw"

--- a/packs/pf2e/spell-effects/spell-effect-inspire-heroics-defense-2.json
+++ b/packs/pf2e/spell-effects/spell-effect-inspire-heroics-defense-2.json
@@ -1,7 +1,7 @@
 {
     "_id": "Chol7ExtoN2T36mP",
     "img": "systems/pf2e/icons/spells/inspire-heroics.webp",
-    "name": "Spell Effect: Inspire Heroics (Rallying, +2)",
+    "name": "Spell Effect: Inspire Heroics (Defense, +2)",
     "system": {
         "description": {
             "value": "<p>Granted by succeeding on @UUID[Compendium.pf2e.spells-srd.Item.Fortissimo Composition] to enhance @UUID[Compendium.pf2e.spells-srd.Item.Rallying Anthem].</p>\n<p>You inspire your allies to protect themselves more effectively. You and all allies in the area gain a +2 status bonus to AC and saving throws, as well as resistance equal to half the spell's rank to physical damage.</p>"
@@ -23,7 +23,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Rallying Anthem",
                 "selector": [
                     "ac",
                     "saving-throw"

--- a/packs/pf2e/spell-effects/spell-effect-inspire-heroics-defense-3.json
+++ b/packs/pf2e/spell-effects/spell-effect-inspire-heroics-defense-3.json
@@ -1,7 +1,7 @@
 {
     "_id": "BKam63zT98iWMJH7",
     "img": "systems/pf2e/icons/spells/inspire-heroics.webp",
-    "name": "Spell Effect: Inspire Heroics (Defense, +3)",
+    "name": "Spell Effect: Inspire Heroics (Rallying, +3)",
     "system": {
         "description": {
             "value": "<p>Granted by critically succeeding on @UUID[Compendium.pf2e.spells-srd.Item.Fortissimo Composition] to enhance @UUID[Compendium.pf2e.spells-srd.Item.Rallying Anthem].</p>\n<p>You inspire your allies to protect themselves more effectively. You and all allies in the area gain a +3 status bonus to AC and saving throws, as well as resistance equal to half the spell's rank to physical damage.</p>"
@@ -23,6 +23,7 @@
         "rules": [
             {
                 "key": "FlatModifier",
+                "label": "Rallying Anthem",
                 "selector": [
                     "ac",
                     "saving-throw"

--- a/packs/pf2e/spell-effects/spell-effect-inspire-heroics-defense-3.json
+++ b/packs/pf2e/spell-effects/spell-effect-inspire-heroics-defense-3.json
@@ -1,7 +1,7 @@
 {
     "_id": "BKam63zT98iWMJH7",
     "img": "systems/pf2e/icons/spells/inspire-heroics.webp",
-    "name": "Spell Effect: Inspire Heroics (Rallying, +3)",
+    "name": "Spell Effect: Inspire Heroics (Defense, +3)",
     "system": {
         "description": {
             "value": "<p>Granted by critically succeeding on @UUID[Compendium.pf2e.spells-srd.Item.Fortissimo Composition] to enhance @UUID[Compendium.pf2e.spells-srd.Item.Rallying Anthem].</p>\n<p>You inspire your allies to protect themselves more effectively. You and all allies in the area gain a +3 status bonus to AC and saving throws, as well as resistance equal to half the spell's rank to physical damage.</p>"
@@ -23,7 +23,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Rallying Anthem",
                 "selector": [
                     "ac",
                     "saving-throw"

--- a/packs/pf2e/spell-effects/spell-effect-inspire-heroics-defense-3.json
+++ b/packs/pf2e/spell-effects/spell-effect-inspire-heroics-defense-3.json
@@ -1,10 +1,10 @@
 {
     "_id": "BKam63zT98iWMJH7",
     "img": "systems/pf2e/icons/spells/inspire-heroics.webp",
-    "name": "Spell Effect: Inspire Heroics (Defense, +3)",
+    "name": "Spell Effect: Inspire Heroics (Rallying, +3)",
     "system": {
         "description": {
-            "value": "<p>Granted by critically succeeding on @UUID[Compendium.pf2e.spells-srd.Item.Fortissimo Composition] to enhance @UUID[Compendium.pf2e.spells-srd.Item.Rallying Anthem].</p>\n<p>You inspire your allies to protect themselves more effectively. You and all allies in the area gain a +3 status bonus to AC and saving throws, as well as resistance equal to half the spell's rank to physical damage.</p>\n<p><em>Note: resistance is not automatically added.</em></p>"
+            "value": "<p>Granted by critically succeeding on @UUID[Compendium.pf2e.spells-srd.Item.Fortissimo Composition] to enhance @UUID[Compendium.pf2e.spells-srd.Item.Rallying Anthem].</p>\n<p>You inspire your allies to protect themselves more effectively. You and all allies in the area gain a +3 status bonus to AC and saving throws, as well as resistance equal to half the spell's rank to physical damage.</p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -23,13 +23,18 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Inspire Defense",
+                "label": "Rallying Anthem",
                 "selector": [
                     "ac",
                     "saving-throw"
                 ],
                 "type": "status",
                 "value": 3
+            },
+            {
+                "key": "Resistance",
+                "type": "physical",
+                "value": "floor(( @item.level ) / 2 )"
             }
         ],
         "start": {


### PR DESCRIPTION
Adds resistance rules elements to Inspire Heroics (Defense) spell effects.
Renames effects and labels to match remastered name Rallying Anthem.
Updates descriptions to reflect added rules element.