### PR TITLE
Fix display of coinage value in the inventory

### DIFF
--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -247,6 +247,7 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends fav1.sheets.Acto
         const actorSize = new ActorSizePF2e({ value: actor.size });
         const itemSize = new ActorSizePF2e({ value: item.size });
         const sizeDifference = itemSize.difference(actorSize, { smallIsMedium: true });
+        const isCurrency = item.isOfType("treasure") && item.isCoinage;
 
         return {
             item,
@@ -269,7 +270,7 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends fav1.sheets.Acto
             itemSize: sizeDifference !== 0 ? itemSize : null,
             unitBulk: actor.isOfType("loot") ? createBulkPerLabel(item) : null,
             unitPrice: item.price.value.toString({ short: true }),
-            assetValue: item.assetValue.toString({ short: true }),
+            assetValue: item.assetValue.toString({ short: true, denomination: isCurrency ? item.denomination : null }),
             hidden: false,
         };
     }

--- a/src/module/apps/compendium-browser/tabs/equipment.ts
+++ b/src/module/apps/compendium-browser/tabs/equipment.ts
@@ -208,7 +208,11 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
             return {
                 min: minCoins.copperValue,
                 max: maxCoins.copperValue,
-                inputMin: minCoins.toString({ short: true, defaultDenomination: "cp", normalize: false }),
+                inputMin: minCoins.toString({
+                    short: true,
+                    denomination: minCoins.copperValue === 0 ? "cp" : null, // override 0 gp with 0 cp
+                    normalize: false,
+                }),
                 inputMax: maxCoins.toString({ short: true, normalize: false }),
             };
         }
@@ -219,7 +223,11 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
     protected override prepareFilterData(): EquipmentFilters {
         const defaultMinPrice = new Coins({ cp: 0 });
         const defaultMaxPrice = new Coins({ gp: 200000 });
-        const minPriceString = defaultMinPrice.toString({ short: true, defaultDenomination: "cp", normalize: false });
+        const minPriceString = defaultMinPrice.toString({
+            short: true,
+            denomination: defaultMinPrice.copperValue === 0 ? "cp" : null, // override 0 gp with 0 cp
+            normalize: false,
+        });
         const maxPriceString = defaultMaxPrice.toString({ short: true, normalize: false });
 
         return {

--- a/src/module/item/physical/coins.ts
+++ b/src/module/item/physical/coins.ts
@@ -131,10 +131,15 @@ class Coins implements RawCoins {
     }
 
     /** Creates a new price string such as "5 gp" from this object */
-    toString({ short = false, defaultDenomination = "gp", normalize = true }: CoinStringParams = {}): string {
+    toString({ short = false, denomination, normalize = true }: CoinStringParams = {}): string {
         if (SYSTEM_ID === "sf2e") {
             const value = Math.ceil(this.copperValue / 10);
             return short ? String(value) : `${value} ${game.i18n.localize("PF2E.CurrencyAbbreviations.credits")}`;
+        } else if (denomination) {
+            const divider = denomination === "cp" ? 1 : denomination === "sp" ? 10 : denomination === "gp" ? 100 : 1000;
+            const value = this.copperValue / divider;
+            const unit = game.i18n.localize(`PF2E.CurrencyAbbreviations.${denomination}`);
+            return `${value} ${unit}`;
         }
 
         // Simplify to GP if normalization is enabled
@@ -148,14 +153,14 @@ class Coins implements RawCoins {
 
         // Return 0 in the default denomination if there's nothing
         if (DENOMINATIONS.every((denomination) => !coins[denomination])) {
-            return `0 ${game.i18n.localize(`PF2E.CurrencyAbbreviations.${defaultDenomination}`)}`;
+            return `0 ${game.i18n.localize(`PF2E.CurrencyAbbreviations.gp`)}`;
         }
 
         // Display all denomations from biggest to smallest (see Adventurer's Pack)
         const parts: string[] = [];
-        for (const denomination of DENOMINATIONS) {
-            const value = coins[denomination];
-            const unit = game.i18n.localize(`PF2E.CurrencyAbbreviations.${denomination}`);
+        for (const partialDenom of DENOMINATIONS) {
+            const value = coins[partialDenom];
+            const unit = game.i18n.localize(`PF2E.CurrencyAbbreviations.${partialDenom}`);
             if (value) parts.push(`${value} ${unit}`);
         }
 
@@ -173,8 +178,8 @@ const coinCompendiumIds = {
 interface CoinStringParams {
     /** If true, indicates that space is limited. This omits displaying "credits" in sf2e */
     short?: boolean;
-    /** Sets the default denomination to display if the value is 0. No effect if SF2e. Defaults to gp */
-    defaultDenomination?: CoinDenomination;
+    /** Sets the denomination to a specific type instead of normalizing. */
+    denomination?: CoinDenomination | null;
     /** If set, normalizes currency denominations to the system's default currency. No effect if SF2e. Defaults to true */
     normalize?: boolean;
 }


### PR DESCRIPTION
Fixes silver pieces displaying as 5 gp, 2 sp instead of 52 sp in the treasure section.