### PR TITLE
Prevent editing backpacks with items and split the stack when adding contents

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -1916,7 +1916,7 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
         userId: string,
     ): void {
         super._onUpdateDescendantDocuments(parent, collection, documents, changes, options, userId);
-        if (this !== parent || collection !== "items") return;
+        if (this !== parent || collection !== "items" || game.user.id !== userId) return;
 
         // Ensure the items being updated are all permanent character building options.
         // These updates should not occur due to temporary changes from something like drained
@@ -1932,6 +1932,29 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
                 this.update({ "system.attributes.hp.value": newHitPoints }, { allowHPOverage: true });
             }
         }
+
+        // Check through changes for any containerId updates.
+        // If items have been moved into backpacks, and the quantity exceeds 1, it splits it
+        const containersToCheck: string[] = [];
+        for (const change of changes) {
+            if (!R.isPlainObject(change)) continue;
+            const expanded = fu.expandObject(change);
+            if (R.isPlainObject(expanded.system) && expanded.system.containerId) {
+                containersToCheck.push(String(expanded.system.containerId));
+            }
+        }
+        const updates = createActorGroupUpdate();
+        for (const containerId of R.unique(containersToCheck)) {
+            const container = this.items.get(containerId);
+            if (container?.isOfType("backpack") && container.system.quantity > 1 && container.contents.size > 0) {
+                const clone = container.toObject(true);
+                clone._id = null;
+                clone.system.quantity = container.system.quantity - 1;
+                updates.itemCreates.push(clone);
+                updates.itemUpdates.push({ _id: container.id, "system.quantity": 1 });
+            }
+        }
+        applyActorGroupUpdate(this, updates); // no-ops if empty
     }
 
     protected override _onUpdate(

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -259,6 +259,7 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends fav1.sheets.Acto
                 return isAmmo ? 3 : i.isOfType("weapon") ? 0 : isEquipment ? 1 : 2;
             }),
             canBeEquipped: !item.isStowed,
+            canEditQuantity: !(item.isOfType("backpack") && item.contents.size > 0),
             hasCharges:
                 (item.isOfType("consumable") && item.system.uses.max > 0) ||
                 (item.isOfType("ammo") && item.system.uses.max > 1),

--- a/src/module/actor/sheet/data-types.ts
+++ b/src/module/actor/sheet/data-types.ts
@@ -19,6 +19,8 @@ interface InventoryItem<TItem extends PhysicalItemPF2e = PhysicalItemPF2e> {
     itemSize?: ActorSizePF2e | null;
     isContainer: boolean;
     canBeEquipped: boolean;
+    /** If true, the quantity cannot be edited, and the controls should be hidden. Used for containers and cred sticks */
+    canEditQuantity: boolean;
     /** Bulk for each item is shown on an individual basis from merchant sheets */
     unitBulk: string | null;
     isInvestable: boolean;

--- a/static/templates/actors/partials/item-line.hbs
+++ b/static/templates/actors/partials/item-line.hbs
@@ -41,7 +41,7 @@
             </span>
         {{/if}}
         <span class="quantity">
-            {{#if (and @root.editable (not isSubitem))}}
+            {{#if (and canEditQuantity @root.editable (not isSubitem))}}
                 <a
                     class="decrease"
                     data-action="decrease-quantity"
@@ -49,7 +49,7 @@
                 >&ndash;</a>
             {{/if}}
             <span>{{item.quantity}}</span>
-            {{#if (and @root.editable (not isSubitem))}}
+            {{#if (and canEditQuantity @root.editable (not isSubitem))}}
                 <a
                     class="increase"
                     data-action="increase-quantity"


### PR DESCRIPTION
I started on credsticks, which should be locked to 1 quantity, but I remembered that backpacks should also be locked to 1 quantity and I gave it a crack.