### PR TITLE
Fix styling of description in loot sheet

### DIFF
--- a/src/styles/actor/loot/_index.scss
+++ b/src/styles/actor/loot/_index.scss
@@ -83,8 +83,11 @@
 
         .description {
             overflow: hidden;
-            :not(:has(prose-mirror[open])) {
+            .editor-content {
                 padding: var(--space-4);
+            }
+            prose-mirror.active .editor-content {
+                padding-top: 0;
             }
         }
     }


### PR DESCRIPTION
The current styling was applying to all child elements, including buttons and inline elements, but also the editor in v13 no longer has extra left padding when editing.