### PR TITLE
Remove Dismemberment Table's immunity to vitality damage

### DIFF
--- a/packs/crown-of-the-kobold-king-bestiary/dismemberment-table.json
+++ b/packs/crown-of-the-kobold-king-bestiary/dismemberment-table.json
@@ -184,7 +184,21 @@
                     "remaster": false,
                     "title": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "key": "ActiveEffectLike",
+                        "mode": "override",
+                        "path": "system.attributes.hp.negativeHealing",
+                        "value": true
+                    },
+                    {
+                        "key": "Immunity",
+                        "mode": "remove",
+                        "type": [
+                            "vitality"
+                        ]
+                    }
+                ],
                 "slug": null,
                 "traits": {
                     "rarity": "common",


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/20753