### PR TITLE
When reloading ammo, grey out and sort empty batteries to the bottom

### DIFF
--- a/src/module/item/weapon/apps/weapon-reloader/app.svelte
+++ b/src/module/item/weapon/apps/weapon-reloader/app.svelte
@@ -12,7 +12,7 @@
         {game.i18n.localize("PF2E.Item.Weapon.Reloader.EmptyMessage")}
     {/if}
     {#each data.compatible as ammo}
-        <div class="choice">
+        <div class="choice" class:depleted={ammo.depleted}>
             <button
                 type="button"
                 class="icon fa-solid fa-check select"
@@ -74,6 +74,11 @@
         gap: var(--space-8);
         padding: var(--space-4) var(--space-8);
         width: 100%;
+
+        &.depleted {
+            opacity: 0.8;
+            filter: grayscale(0.85);
+        }
 
         /* Make Icon White */
         button,

--- a/src/module/item/weapon/apps/weapon-reloader/app.ts
+++ b/src/module/item/weapon/apps/weapon-reloader/app.ts
@@ -86,11 +86,15 @@ class WeaponReloader extends SvelteApplicationMixin<
                     max: weapon.system.ammo?.capacity ?? 1,
                 },
                 weapon: getBasePhysicalItemViewData(weapon),
-                compatible: compatible.map((c) => ({
-                    ...getBasePhysicalItemViewData(c),
-                    quantity: c.quantity,
-                    uses: c.isOfType("ammo") && c.uses.max > 1 ? c.uses : null,
-                })),
+                compatible: R.sortBy(
+                    compatible.map((c) => ({
+                        ...getBasePhysicalItemViewData(c),
+                        quantity: c.quantity,
+                        uses: c.isOfType("ammo") && c.uses.max > 1 ? c.uses : null,
+                        depleted: c.quantity === 0 || (c.isOfType("ammo") && c.uses.value === 0),
+                    })),
+                    (c) => (c.depleted ? 1 : 0),
+                ),
             },
         };
     }
@@ -212,6 +216,7 @@ interface ReloadWeaponContext extends SvelteApplicationRenderContext {
 interface AmmoChoiceViewData extends BasePhysicalItemViewData {
     quantity: number;
     uses: ValueAndMax | null;
+    depleted: boolean;
 }
 
 export { WeaponReloader };


### PR DESCRIPTION
Unfortunately we can't really handle multiple stacks of empty batteries until we change the meaning of stacks of consumables.

<img width="458" height="288" alt="image" src="https://github.com/user-attachments/assets/b1ded410-79f0-4472-b89c-bc631d7fac8d" />