### PR TITLE
Add weapons case to IWR

### DIFF
--- a/src/module/actor/data/iwr.ts
+++ b/src/module/actor/data/iwr.ts
@@ -203,6 +203,8 @@ abstract class IWR<TType extends IWRType> {
                 return ["item:category:unarmed"];
             case "unholy":
                 return [{ or: ["origin:action:trait:unholy", "item:trait:unholy"] }];
+            case "weapons":
+                return ["item:type:weapon", { not: "item:category:unarmed" }];
             default: {
                 if (iwrType in CONFIG.PF2E.damageTypes) {
                     return [`damage:type:${iwrType}`];


### PR DESCRIPTION
Closes #17184

In testing, I noticed even basic unarmed got marked as an item type weapon, so I added the omission for unarmed attacks.