### PR TITLE
Rework add/remove coins to use batched updates

### DIFF
--- a/src/module/item/physical/coins.ts
+++ b/src/module/item/physical/coins.ts
@@ -168,13 +168,6 @@ class Coins implements RawCoins {
     }
 }
 
-const coinCompendiumIds = {
-    pp: "JuNPeK5Qm1w6wpb4",
-    gp: "B6B7tBWJSqOBz5zz",
-    sp: "5Ew82vBF9YfaiY9f",
-    cp: "lzJ8AVhRcbFul5fh",
-};
-
 interface CoinStringParams {
     /** If true, indicates that space is limited. This omits displaying "credits" in sf2e */
     short?: boolean;
@@ -184,4 +177,4 @@ interface CoinStringParams {
     normalize?: boolean;
 }
 
-export { coinCompendiumIds, Coins };
+export { Coins };

--- a/src/module/item/physical/helpers.ts
+++ b/src/module/item/physical/helpers.ts
@@ -336,7 +336,6 @@ function getDefaultEquipStatus(item: PhysicalItemPF2e): EquippedData {
     return equipStatus;
 }
 
-export { coinCompendiumIds } from "./coins.ts";
 export {
     Coins,
     checkPhysicalItemSystemChange,


### PR DESCRIPTION
This update does three different things:
* Batches addCoins() into a single render-once group update, and removeCoins() into one or two.
* Adds a new simplification step where adds and removes are cancelled out before we hit the DB
* Attempts to remove existing denominations by value *before* engaging into the break coins chain. This will allow credits to be used to buy things that cost gp without weird behavior.

I separated it from the credits work since it will be hard to read the credit-specific changes if there is also this going on. And I'd like to get some more testing on this as well beyond what I did the last hour.