### PR TITLE
Fix rolling damage from chat after striking with an area fire weapon

### DIFF
--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -1218,7 +1218,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
         const handsAvailable = !weapon.system.graspingAppendage || handsReallyFree > 0;
 
         return {
-            slug: identifier,
+            slug: weaponSlug,
             type: action,
             attackRollType: actionLabel,
             label: weapon.name,

--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -693,7 +693,7 @@ function areaFireFromMeleeItem(item: MeleePF2e<ActorPF2e>): NPCAreaAttack {
     });
 
     return {
-        slug: identifier,
+        slug: attackSlug,
         type: action,
         attackRollType: NPC_ATTACK_ACTIONS[action],
         label: item.name,


### PR DESCRIPTION
This fixes retrieval of the underlying attack when the alt usage is a strike and the primary action is area fire. I decided against using the identifier as the slug, its unique, but its not quite the same sort of string as other stuff we've used as slugs.