### PR TITLE
Add support for credits in currency summary

### DIFF
--- a/src/module/actor/inventory/index.ts
+++ b/src/module/actor/inventory/index.ts
@@ -6,7 +6,7 @@ import { ItemSourcePF2e, KitSource, PhysicalItemSource } from "@item/base/data/i
 import { itemIsOfType } from "@item/helpers.ts";
 import { RawCoins } from "@item/physical/data.ts";
 import { Coins } from "@item/physical/helpers.ts";
-import { DENOMINATIONS } from "@item/physical/values.ts";
+import { DENOMINATION_RATES, DENOMINATIONS } from "@item/physical/values.ts";
 import { DelegatedCollection, ErrorPF2e, groupBy } from "@util";
 import * as R from "remeda";
 import { InventoryBulk } from "./bulk.ts";
@@ -116,7 +116,7 @@ class ActorInventory<TActor extends ActorPF2e> extends DelegatedCollection<Physi
 
         if (byValue && valueToRemove) {
             // Phase 2 - remove by converting but without breaking any coins (best effort currency type maintenance)
-            for (const [denomination, rate] of R.entries(denominationValues).toReversed()) {
+            for (const [denomination, rate] of R.entries(DENOMINATION_RATES).toReversed()) {
                 const toRemove = Math.min(actorCoins[denomination], Math.floor(valueToRemove / rate));
                 if (!toRemove) continue;
                 removeResult[denomination] += toRemove;
@@ -126,7 +126,7 @@ class ActorInventory<TActor extends ActorPF2e> extends DelegatedCollection<Physi
 
             // Phase 3 - Choose quantities of each coin to remove from smallest to largest to ensure we don't end in a situation
             // where we need to break a coin that has already been "removed".
-            for (const [denomination, rate] of R.entries(R.pick(denominationValues, ["cp", "sp", "gp"]))) {
+            for (const [denomination, rate] of R.entries(R.pick(DENOMINATION_RATES, ["cp", "sp", "gp"]))) {
                 if ((valueToRemove / rate) % 10 > actorCoins[denomination]) {
                     const toRemove = (valueToRemove / rate) % 10;
                     valueToRemove += (10 - toRemove) * rate;
@@ -311,13 +311,6 @@ const coinCompendiumUuids = {
     gp: "Compendium.pf2e.equipment-srd.Item.B6B7tBWJSqOBz5zz",
     sp: "Compendium.pf2e.equipment-srd.Item.5Ew82vBF9YfaiY9f",
     cp: "Compendium.pf2e.equipment-srd.Item.lzJ8AVhRcbFul5fh",
-};
-
-const denominationValues = {
-    cp: 1,
-    sp: 10,
-    gp: 100,
-    pp: 1000,
 };
 
 type AddItemParam = AddableItemSourceOrEntry | AddableItemSourceOrEntry[];

--- a/src/module/actor/sheet/data-types.ts
+++ b/src/module/actor/sheet/data-types.ts
@@ -42,7 +42,11 @@ interface CoinDisplayData {
     label: string;
 }
 
-export type CoinageSummary = { [K in keyof RawCoins]?: CoinDisplayData };
+interface CurrencySummary {
+    units: { [K in keyof RawCoins]?: CoinDisplayData };
+    totalCurrency: string;
+    totalWealth: string;
+}
 
 interface SheetItemList {
     label: string;
@@ -68,10 +72,7 @@ interface ActorSheetDataPF2e<TActor extends ActorPF2e> extends ActorSheetData<TA
     isLootSheet: boolean;
     isTargetFlatFooted: boolean;
     toggles: Record<string, RollOptionToggle[]>;
-    totalCoinage: CoinageSummary;
-    totalCoinageGold: string;
-    totalWealth: RawCoins;
-    totalWealthGold: string;
+    currency: CurrencySummary;
     traits: SheetOptions;
     user: { isGM: boolean };
     publicationLicenses: FormSelectOption[];
@@ -98,4 +99,11 @@ interface ActorSheetRenderOptionsPF2e extends AppV1RenderOptions {
     tab?: string;
 }
 
-export type { AbilityViewData, ActorSheetDataPF2e, ActorSheetRenderOptionsPF2e, InventoryItem, SheetInventory };
+export type {
+    AbilityViewData,
+    ActorSheetDataPF2e,
+    ActorSheetRenderOptionsPF2e,
+    CurrencySummary,
+    InventoryItem,
+    SheetInventory,
+};

--- a/src/module/apps/compendium-browser/tabs/equipment.ts
+++ b/src/module/apps/compendium-browser/tabs/equipment.ts
@@ -209,12 +209,8 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
             return {
                 min: minCoins.copperValue,
                 max: maxCoins.copperValue,
-                inputMin: minCoins.toString({
-                    short: true,
-                    denomination: minCoins.copperValue === 0 ? "cp" : null, // override 0 gp with 0 cp
-                    normalize: false,
-                }),
-                inputMax: maxCoins.toString({ short: true, normalize: false }),
+                inputMin: minCoins.toString({ short: true, unit: "raw" }),
+                inputMax: maxCoins.toString({ short: true, unit: "raw" }),
             };
         }
 
@@ -224,12 +220,8 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
     protected override prepareFilterData(): EquipmentFilters {
         const defaultMinPrice = new Coins({ cp: 0 });
         const defaultMaxPrice = new Coins({ gp: 200000 });
-        const minPriceString = defaultMinPrice.toString({
-            short: true,
-            denomination: defaultMinPrice.copperValue === 0 ? "cp" : null, // override 0 gp with 0 cp
-            normalize: false,
-        });
-        const maxPriceString = defaultMaxPrice.toString({ short: true, normalize: false });
+        const minPriceString = defaultMinPrice.toString({ short: true, unit: "raw" });
+        const maxPriceString = defaultMaxPrice.toString({ short: true, unit: "raw" });
 
         return {
             checkboxes: {

--- a/src/module/item/physical/coins.ts
+++ b/src/module/item/physical/coins.ts
@@ -1,7 +1,9 @@
 import type { Size } from "@module/data.ts";
+import { tupleHasValue } from "@util";
+import * as R from "remeda";
 import type { PartialPrice, RawCoins } from "./data.ts";
 import type { CoinDenomination } from "./types.ts";
-import { DENOMINATIONS } from "./values.ts";
+import { DENOMINATION_RATES, DENOMINATIONS } from "./values.ts";
 
 /** Coins class that exposes methods to perform operations on coins without side effects */
 class Coins implements RawCoins {
@@ -10,10 +12,17 @@ class Coins implements RawCoins {
     declare gp: number;
     declare pp: number;
 
-    constructor(data?: RawCoins | null) {
-        data ??= {};
+    /**
+     * What unit to show in toString() if the value is 0 and units is "raw".
+     * This is used to maintain "0 cp" in certain min price situations like the compendium browser.
+     */
+    #givenUnit: CoinDenomination | null;
+
+    constructor(data?: RawCoins | number | null) {
+        this.#givenUnit = R.isObjectType(data) ? R.keys(data)[0] : null;
+        const object = typeof data === "number" ? { cp: data } : (data ?? {});
         for (const denomination of DENOMINATIONS) {
-            this[denomination] = Math.max(Math.floor(Math.abs(data[denomination] ?? 0)), 0);
+            this[denomination] = Math.max(Math.floor(Math.abs(object[denomination] ?? 0)), 0);
         }
     }
 
@@ -115,14 +124,18 @@ class Coins implements RawCoins {
             },
             coinString.trim().replace(/,/g, ""),
         );
-        return [...priceTag.matchAll(/(\d+)\s*([pgsc]p|credits)/g)]
-            .map((match) => {
-                const [value, denominationRaw] = match.slice(1, 3);
-                const denomination = denominationRaw === "credits" ? "sp" : denominationRaw;
-                const computedValue = (Number(value) || 0) * quantity;
-                return { [denomination]: computedValue };
-            })
-            .reduce((first, second) => first.plus(second), new Coins());
+
+        // We add to raw coins so that the base unit works if rendering with "raw"
+        const result: RawCoins = {};
+        for (const match of priceTag.matchAll(/(\d+)\s*([pgsc]p|credits)/g)) {
+            const [value, denominationRaw] = match.slice(1, 3);
+            const denomination = denominationRaw === "credits" ? "sp" : denominationRaw;
+            const computedValue = (Number(value) || 0) * quantity;
+            if (tupleHasValue(DENOMINATIONS, denomination)) {
+                result[denomination] = computedValue;
+            }
+        }
+        return new Coins(result);
     }
 
     static fromPrice(price: PartialPrice, factor: number): Coins {
@@ -131,15 +144,19 @@ class Coins implements RawCoins {
     }
 
     /** Creates a new price string such as "5 gp" from this object */
-    toString({ short = false, denomination, normalize = true }: CoinStringParams = {}): string {
-        if (SYSTEM_ID === "sf2e") {
+    toString({ short = false, unit = "primary", decimal = false }: CoinStringParams = {}): string {
+        // Convert system denomination to gp/credits. This is a single value display
+        const normalize = unit === "primary";
+
+        if (tupleHasValue(DENOMINATIONS, unit) || (SYSTEM_ID === "pf2e" && unit === "primary" && decimal)) {
+            const denomination = unit === "primary" ? "gp" : unit;
+            const divider = DENOMINATION_RATES[denomination];
+            const value = this.copperValue / divider;
+            const unitLabel = game.i18n.localize(`PF2E.CurrencyAbbreviations.${denomination}`);
+            return `${decimal ? value.toFixed(2) : value} ${unitLabel}`;
+        } else if (SYSTEM_ID === "sf2e" || unit === "credits") {
             const value = Math.ceil(this.copperValue / 10);
             return short ? String(value) : `${value} ${game.i18n.localize("PF2E.CurrencyAbbreviations.credits")}`;
-        } else if (denomination) {
-            const divider = denomination === "cp" ? 1 : denomination === "sp" ? 10 : denomination === "gp" ? 100 : 1000;
-            const value = this.copperValue / divider;
-            const unit = game.i18n.localize(`PF2E.CurrencyAbbreviations.${denomination}`);
-            return `${value} ${unit}`;
         }
 
         // Simplify to GP if normalization is enabled
@@ -153,15 +170,16 @@ class Coins implements RawCoins {
 
         // Return 0 in the default denomination if there's nothing
         if (DENOMINATIONS.every((denomination) => !coins[denomination])) {
-            return `0 ${game.i18n.localize(`PF2E.CurrencyAbbreviations.gp`)}`;
+            const zeroUnit = (unit === "raw" ? this.#givenUnit : null) ?? (SYSTEM_ID === "pf2e" ? "gp" : "credits");
+            return `0 ${game.i18n.localize(`PF2E.CurrencyAbbreviations.${zeroUnit}`)}`;
         }
 
         // Display all denomations from biggest to smallest (see Adventurer's Pack)
         const parts: string[] = [];
         for (const partialDenom of DENOMINATIONS) {
             const value = coins[partialDenom];
-            const unit = game.i18n.localize(`PF2E.CurrencyAbbreviations.${partialDenom}`);
-            if (value) parts.push(`${value} ${unit}`);
+            const unitLabel = game.i18n.localize(`PF2E.CurrencyAbbreviations.${partialDenom}`);
+            if (value) parts.push(`${value} ${unitLabel}`);
         }
 
         return parts.join(", ");
@@ -171,10 +189,15 @@ class Coins implements RawCoins {
 interface CoinStringParams {
     /** If true, indicates that space is limited. This omits displaying "credits" in sf2e */
     short?: boolean;
-    /** Sets the denomination to a specific type instead of normalizing. */
-    denomination?: CoinDenomination | null;
-    /** If set, normalizes currency denominations to the system's default currency. No effect if SF2e. Defaults to true */
-    normalize?: boolean;
+    /**
+     * Shows the value in a specific unit, or a special type. The special types are:
+     * - raw: shows the exact contained values without conversion
+     * - primary: normalizes to gp in pf2e or credits in sf2e.
+     *   If the system is pf2e and decimals is false, then 5 sp will be shown as 5 sp, but 50 sp will be shown as 5 gp.
+     */
+    unit?: CoinDenomination | "credits" | "primary" | "raw";
+    /** If enabled, the result is shown with decimals regardless of value, unless its credits */
+    decimal?: boolean;
 }
 
 export { Coins };

--- a/src/module/item/physical/values.ts
+++ b/src/module/item/physical/values.ts
@@ -39,4 +39,11 @@ const PRECIOUS_MATERIAL_GRADES = new Set(["low", "standard", "high"] as const);
 
 const DENOMINATIONS = ["pp", "gp", "sp", "cp"] as const;
 
-export { DENOMINATIONS, PHYSICAL_ITEM_TYPES, PRECIOUS_MATERIAL_GRADES, PRECIOUS_MATERIAL_TYPES };
+const DENOMINATION_RATES = {
+    cp: 1,
+    sp: 10,
+    gp: 100,
+    pp: 1000,
+};
+
+export { DENOMINATION_RATES, DENOMINATIONS, PHYSICAL_ITEM_TYPES, PRECIOUS_MATERIAL_GRADES, PRECIOUS_MATERIAL_TYPES };

--- a/src/styles/actor/_coinage.scss
+++ b/src/styles/actor/_coinage.scss
@@ -113,14 +113,16 @@
 }
 
 .wealth {
-    @include micro;
     @include button;
     align-items: center;
     background-color: var(--color-pf-inventory-header-bg);
     display: flex;
+    font-family: var(--sans-serif);
+    font-size: var(--font-size-10);
+    justify-content: flex-end;
+    letter-spacing: 0.04em;
     margin-bottom: 0.5rem;
     min-height: 1.5rem;
-    justify-content: flex-end;
     padding: 0 0.25rem;
 
     .item-name {
@@ -131,12 +133,10 @@
         font-weight: bold;
         margin: 2px 2px 0 0.25rem;
         text-shadow: 0 0 2px rgba(black, 0.75);
-        text-transform: capitalize;
 
         span {
             margin-left: 0.25rem;
             font-weight: normal;
-            text-transform: uppercase;
         }
     }
 

--- a/static/templates/actors/partials/coinage.hbs
+++ b/static/templates/actors/partials/coinage.hbs
@@ -1,8 +1,8 @@
 <div class="coinage">
     <div class="currency">
         <li class="label">{{localize "PF2E.StackGroupCoins"}}</li>
-        {{#each totalCoinage as |value denomination|}}
-            <li class="denomination {{denomination}}">
+        {{#each currency.units as |value unit|}}
+            <li class="denomination {{unit}}">
                 <div class="currency-image" data-tooltip="{{localize value.label}}"></div>
                 <span>{{value.value}}</span>
             </li>
@@ -38,12 +38,12 @@
         <div class="item-name">
             <i class="fa-solid fa-coins fa-fw"></i>
             {{localize "PF2E.TotalCoinage"}}
-            <span>{{totalCoinageGold}} {{localize "PF2E.CurrencyAbbreviations.gp"}}</span>
+            <span>{{currency.totalCurrency}}</span>
         </div>
         <div class="item-name">
             <i class="fa-solid fa-scale-unbalanced fa-fw"></i>
             {{localize "PF2E.TotalWealth"}}
-            <span>{{totalWealthGold}} {{localize "PF2E.CurrencyAbbreviations.gp"}}</span>
+            <span>{{currency.totalWealth}}</span>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Primarily, this allows us to show credits in the currency summary's total coins and total wealth. This also changes the GP in coinage to lowercase, which is the more appropriate way to show it anyways.

Internally, this also attempts to remove the coins toString()'s normalize property to replace with a new "raw" pseudo-unit. I'm willing for alternatives in how to handle that, but ideally the less properties the better. 

In summary, these are all the ways we have to render coins:
- System dependent GP with 2 decimals OR credits, such 52.50 gp (used for currency summaries)
- A specific denomination usually without decimals (used for displaying currencies in the sheet)
- A system normalized value. 15 sp is 1 gp, 5 sp. 5 cp stays 5 cp. 5 credits is 5 credits (used for price displays)
- A variant system normalized value that culls "credits", currently this is "short" (used for inventories....this is what sf2e player core does when showing items, they just show a number for the credits)
- as is with no convert. 0 cp is 0 cp. 5 gp is 5 gp. (used in compendium browser filters)

The params to reproduce are the following, in order:
- `decimals: true` (default unit "primary")
- `unit: "sp"` or `unit: "pp"` or whatever
- no parameters, this is the default (default unit "primary")
- `short: true`
- `unit: "raw"`