### PR TITLE
Tidy description formatting for Celestial Magic and Fiendish Magic

### DIFF
--- a/packs/feats/ancestry/versatile-heritages/nephilim/celestial-magic.json
+++ b/packs/feats/ancestry/versatile-heritages/nephilim/celestial-magic.json
@@ -12,7 +12,7 @@
         },
         "category": "ancestry",
         "description": {
-            "value": "<p>You possess celestial magic. Choose two of the following spells: @UUID[Compendium.pf2e.spells-srd.Item.Clear Mind], @UUID[Compendium.pf2e.spells-srd.Item.Everlight], @UUID[Compendium.pf2e.spells-srd.Item.Humanoid Form], @UUID[Compendium.pf2e.spells-srd.Item.Revealing Light], @UUID[Compendium.pf2e.spells-srd.Item.Share Life], or @UUID[Compendium.pf2e.spells-srd.Item.Sure Footing]. You can use each of the chosen spells once per day as 2nd-rank divine innate spells.</p>\n<p>Angelkin typically take clear mind and humanoid form, lawbringers typically have everlight and share life, and musetouched typically have revealing light and sure footing.</p>"
+            "value": "<p>You possess celestial magic. Choose two of the following spells: @UUID[Compendium.pf2e.spells-srd.Item.Clear Mind], @UUID[Compendium.pf2e.spells-srd.Item.Everlight], @UUID[Compendium.pf2e.spells-srd.Item.Humanoid Form], @UUID[Compendium.pf2e.spells-srd.Item.Revealing Light], @UUID[Compendium.pf2e.spells-srd.Item.Share Life], or @UUID[Compendium.pf2e.spells-srd.Item.Sure Footing]. You can use each of the chosen spells once per day as 2nd-rank divine innate spells.</p>\n<p>Angelkin typically take <em>clear mind</em> and <em>humanoid form</em>, lawbringers typically have <em>everlight</em> and <em>share life</em>, and musetouched typically have <em>revealing light</em> and <em>sure footing</em>.</p>"
         },
         "level": {
             "value": 9

--- a/packs/feats/ancestry/versatile-heritages/nephilim/fiendish-magic.json
+++ b/packs/feats/ancestry/versatile-heritages/nephilim/fiendish-magic.json
@@ -12,7 +12,7 @@
         },
         "category": "ancestry",
         "description": {
-            "value": "<p>You possess fiendish magic. Choose two of the following spells: @UUID[Compendium.pf2e.spells-srd.Item.Disguise Magic], @UUID[Compendium.pf2e.spells-srd.Item.False Vitality], @UUID[Compendium.pf2e.spells-srd.Item.Invisibility], @UUID[Compendium.pf2e.spells-srd.Item.See the Unseen], @UUID[Compendium.pf2e.spells-srd.Item.Shatter], or @UUID[Compendium.pf2e.spells-srd.Item.Paranoia]. You can use each of the chosen spells once per day as 2nd-rank divine innate spells.</p>\n<p>Grimspawn typically take false vitality and see the unseen, pitborn typically take paranoia and shatter, and hellspawn typically take invisibility and disguise.</p>"
+            "value": "<p>You possess fiendish magic. Choose two of the following spells: @UUID[Compendium.pf2e.spells-srd.Item.Disguise Magic], @UUID[Compendium.pf2e.spells-srd.Item.False Vitality], @UUID[Compendium.pf2e.spells-srd.Item.Invisibility], @UUID[Compendium.pf2e.spells-srd.Item.See the Unseen], @UUID[Compendium.pf2e.spells-srd.Item.Shatter], or @UUID[Compendium.pf2e.spells-srd.Item.Paranoia]. You can use each of the chosen spells once per day as 2nd-rank divine innate spells.</p>\n<p>Grimspawn typically take <em>false vitality</em> and <em>see the unseen</em>, pitborn typically take <em>paranoia</em> and <em>shatter</em>, and hellspawn typically take <em>invisibility</em> and <em>disguise magic</em>.</p>"
         },
         "level": {
             "value": 9


### PR DESCRIPTION
Changed "disguise" to "disguise magic"  as this seemed an obvious error