### PR TITLE
Allow Manifest Will tradition to be changed and add basic support for occult patron

### DIFF
--- a/packs/feat-effects/effect-multifaceted-will.json
+++ b/packs/feat-effects/effect-multifaceted-will.json
@@ -24,7 +24,7 @@
             {
                 "key": "FlatModifier",
                 "predicate": [
-                    "spellcasting:tradition:{item|origin.flags.pf2e.manifestWill}"
+                    "spellcasting:tradition:{item|origin.flags.pf2e.manifestWillTradition}"
                 ],
                 "selector": "saving-throw",
                 "type": "status",

--- a/packs/spell-effects/aura-manifest-will.json
+++ b/packs/spell-effects/aura-manifest-will.json
@@ -22,31 +22,89 @@
         },
         "rules": [
             {
-                "actorFlag": true,
-                "choices": [
+                "alwaysActive": true,
+                "key": "RollOption",
+                "option": "manifest-will-tradition",
+                "placement": "spellcasting",
+                "suboptions": [
                     {
                         "label": "PF2E.TraitArcane",
+                        "predicate": [
+                            {
+                                "or": [
+                                    {
+                                        "not": "parent:origin:item"
+                                    },
+                                    "parent:origin:item:tag:multifaceted-will",
+                                    "parent:spellcasting:tradition:arcane"
+                                ]
+                            }
+                        ],
                         "value": "arcane"
                     },
                     {
                         "label": "PF2E.TraitDivine",
+                        "predicate": [
+                            {
+                                "or": [
+                                    {
+                                        "not": "parent:origin:item"
+                                    },
+                                    "parent:origin:item:tag:multifaceted-will",
+                                    "parent:spellcasting:tradition:divine"
+                                ]
+                            }
+                        ],
                         "value": "divine"
                     },
                     {
                         "label": "PF2E.TraitOccult",
+                        "predicate": [
+                            {
+                                "or": [
+                                    {
+                                        "not": "parent:origin:item"
+                                    },
+                                    "parent:origin:item:tag:multifaceted-will",
+                                    "parent:spellcasting:tradition:occult"
+                                ]
+                            }
+                        ],
                         "value": "occult"
                     },
                     {
                         "label": "PF2E.TraitPrimal",
+                        "predicate": [
+                            {
+                                "or": [
+                                    {
+                                        "not": "parent:origin:item"
+                                    },
+                                    "parent:origin:item:tag:multifaceted-will",
+                                    "parent:spellcasting:tradition:primal"
+                                ]
+                            }
+                        ],
                         "value": "primal"
                     }
                 ],
-                "flag": "manifestWill",
-                "key": "ChoiceSet",
+                "toggleable": true
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.manifestWillTradition",
+                "value": "{item|flags.pf2e.rulesSelections.manifestWillTradition}"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
                 "predicate": [
-                    "parent:origin:item:tag:multifaceted-will"
+                    "item:slug:manifest-will"
                 ],
-                "prompt": "PF2E.SpecificRule.Prompt.Tradition"
+                "property": "other-tags",
+                "value": "manifest-will:{item|flags.pf2e.rulesSelections.manifestWillTradition}"
             },
             {
                 "effects": [

--- a/packs/spell-effects/spell-effect-manifest-will.json
+++ b/packs/spell-effects/spell-effect-manifest-will.json
@@ -4,7 +4,7 @@
     "name": "Spell Effect: Manifest Will",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Manifest Will]</p>\n<p>The effect depends on the patron's tradition.</p><ul><li><strong>Arcane</strong> You gain weakness to spell damage.</li><li><strong>Divine</strong> You gain temporary Hit Points.</li><li><strong>Primal</strong> You have a –10-foot status penalty to all its Speeds.</li></ul>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Manifest Will]</p>\n<p>The effect on the spell's tradition, or the tradition selected with Multifaceted Will.</p><ul><li><strong>Arcane</strong> You gain weakness to spell damage equal to the spell's rank.</li><li><strong>Divine</strong> You gain temporary Hit Points equal to twice the spell's rank.</li><li><strong>Occult</strong> You gain lesser cover.</li><li><strong>Primal</strong> You have a –10-foot status penalty to all its Speeds.</li></ul>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -28,11 +28,22 @@
                         "predicate": [
                             {
                                 "or": [
+                                    "parent:origin:item:tag:manifest-will:arcane",
+                                    {
+                                        "and": [
+                                            "parent:spellcasting:tradition:arcane",
+                                            {
+                                                "nor": [
+                                                    "parent:origin:item:tag:manifest-will:divine",
+                                                    "parent:origin:item:tag:manifest-will:occult",
+                                                    "parent:origin:item:tag:manifest-will:primal"
+                                                ]
+                                            }
+                                        ]
+                                    },
                                     {
                                         "not": "parent:origin:item"
-                                    },
-                                    "parent:spellcasting:tradition:arcane",
-                                    "parent:origin:item:tag:multifaceted-will"
+                                    }
                                 ]
                             }
                         ],
@@ -43,11 +54,48 @@
                         "predicate": [
                             {
                                 "or": [
+                                    "parent:origin:item:tag:manifest-will:divine",
+                                    {
+                                        "and": [
+                                            "parent:spellcasting:tradition:divine",
+                                            {
+                                                "nor": [
+                                                    "parent:origin:item:tag:manifest-will:arcane",
+                                                    "parent:origin:item:tag:manifest-will:occult",
+                                                    "parent:origin:item:tag:manifest-will:primal"
+                                                ]
+                                            }
+                                        ]
+                                    },
                                     {
                                         "not": "parent:origin:item"
+                                    }
+                                ]
+                            }
+                        ],
+                        "value": "divine"
+                    },
+                    {
+                        "label": "PF2E.TraitOccult",
+                        "predicate": [
+                            {
+                                "or": [
+                                    "parent:origin:item:tag:manifest-will:occult",
+                                    {
+                                        "and": [
+                                            "parent:spellcasting:tradition:occult",
+                                            {
+                                                "nor": [
+                                                    "parent:origin:item:tag:manifest-will:arcane",
+                                                    "parent:origin:item:tag:manifest-will:divine",
+                                                    "parent:origin:item:tag:manifest-will:primal"
+                                                ]
+                                            }
+                                        ]
                                     },
-                                    "parent:spellcasting:tradition:divine",
-                                    "parent:origin:item:tag:multifaceted-will"
+                                    {
+                                        "not": "parent:origin:item"
+                                    }
                                 ]
                             }
                         ],
@@ -58,11 +106,22 @@
                         "predicate": [
                             {
                                 "or": [
+                                    "parent:origin:item:tag:manifest-will:primal",
+                                    {
+                                        "and": [
+                                            "parent:spellcasting:tradition:primal",
+                                            {
+                                                "nor": [
+                                                    "parent:origin:item:tag:manifest-will:arcane",
+                                                    "parent:origin:item:tag:manifest-will:divine",
+                                                    "parent:origin:item:tag:manifest-will:occult"
+                                                ]
+                                            }
+                                        ]
+                                    },
                                     {
                                         "not": "parent:origin:item"
-                                    },
-                                    "parent:spellcasting:tradition:primal",
-                                    "parent:origin:item:tag:multifaceted-will"
+                                    }
                                 ]
                             }
                         ],
@@ -96,6 +155,16 @@
                 "selector": "all-speeds",
                 "type": "status",
                 "value": -10
+            },
+            {
+                "key": "GrantItem",
+                "onDeleteActions": {
+                    "granter": "detach"
+                },
+                "predicate": [
+                    "manifest-will:occult"
+                ],
+                "uuid": "Compendium.pf2e.other-effects.Item.Effect: Cover"
             }
         ],
         "start": {

--- a/packs/spell-effects/spell-effect-manifest-will.json
+++ b/packs/spell-effects/spell-effect-manifest-will.json
@@ -4,7 +4,7 @@
     "name": "Spell Effect: Manifest Will",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Manifest Will]</p>\n<p>The effect on the spell's tradition, or the tradition selected with Multifaceted Will.</p><ul><li><strong>Arcane</strong> You gain weakness to spell damage equal to the spell's rank.</li><li><strong>Divine</strong> You gain temporary Hit Points equal to twice the spell's rank.</li><li><strong>Occult</strong> You gain lesser cover.</li><li><strong>Primal</strong> You have a –10-foot status penalty to all its Speeds.</li></ul>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Manifest Will]</p>\n<p>You gain an effect depending on the spell's tradition, or the tradition selected with Multifaceted Will.</p><ul><li><strong>Arcane</strong> You gain weakness to spell damage equal to the spell's rank.</li><li><strong>Divine</strong> You gain temporary Hit Points equal to twice the spell's rank.</li><li><strong>Occult</strong> You gain lesser cover.</li><li><strong>Primal</strong> You have a –10-foot status penalty to all its Speeds.</li></ul>"
         },
         "duration": {
             "expiry": "turn-start",


### PR DESCRIPTION
Since the selected tradition can be changed after a Sustain, I switched the Choice Set with an always active toggle, which allows switching between traditions if the witch has Multifaceted Will.

Also added basic support for the occult option of adding lesser cover. We can't preselect non-string choices, so they still need to pick lesser cover, but I think it's still an improvement. The granted effect is detached since the cover persists beyond the normal duration.