### PR TITLE
Add short-duration panache effect and implement it with several Swashbuckler feats

### DIFF
--- a/packs/feat-effects/effect-dueling-parry.json
+++ b/packs/feat-effects/effect-dueling-parry.json
@@ -4,7 +4,7 @@
     "name": "Effect: Dueling Parry",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Extravagant Parry] or @UUID[Compendium.pf2e.feats-srd.Item.Dueling Parry]</p>\n<p>You gain a circumstance bonus to AC.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Dueling Parry]</p>\n<p>You gain a circumstance bonus to AC.</p>"
         },
         "duration": {
             "expiry": "turn-start",

--- a/packs/feat-effects/effect-dueling-parry.json
+++ b/packs/feat-effects/effect-dueling-parry.json
@@ -4,7 +4,7 @@
     "name": "Effect: Dueling Parry",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Dueling Parry]</p>\n<p>You gain a circumstance bonus to AC.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Dueling Parry]</p>\n<p>You gain a +2 circumstance bonus to AC.</p>"
         },
         "duration": {
             "expiry": "turn-start",

--- a/packs/feat-effects/effect-even-the-odds-eagle-knight.json
+++ b/packs/feat-effects/effect-even-the-odds-eagle-knight.json
@@ -1,0 +1,42 @@
+{
+    "_id": "xxkCSwizAu2wC7Fo",
+    "img": "icons/magic/life/heart-glowing-red.webp",
+    "name": "Effect: Even the Odds (Eagle Knight)",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Even the Odds (Eagle Knight)]</p>\n<p>You gain 25 temporary Hit Points.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "minutes",
+            "value": 1
+        },
+        "fromSpell": false,
+        "level": {
+            "value": 14
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Lost Omens Shining Kingdoms"
+        },
+        "rules": [
+            {
+                "key": "TempHP",
+                "value": 25
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feat-effects/effect-even-the-odds.json
+++ b/packs/feat-effects/effect-even-the-odds.json
@@ -1,30 +1,33 @@
 {
-    "_id": "xxkCSwizAu2wC7Fo",
-    "img": "icons/magic/life/heart-glowing-red.webp",
+    "_id": "58QyKgMWfsUPqZn1",
+    "img": "icons/skills/melee/maneuver-daggers-paired-orange.webp",
     "name": "Effect: Even the Odds",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Even the Odds (Eagle Knight)]</p>\n<p>You gain 25 temporary Hit Points.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Even the Odds]</p>\n<p>You gain panache.</p>"
         },
         "duration": {
-            "expiry": "turn-start",
+            "expiry": "turn-end",
             "sustained": false,
-            "unit": "minutes",
-            "value": 1
+            "unit": "rounds",
+            "value": 0
         },
         "fromSpell": false,
         "level": {
-            "value": 14
+            "value": 4
         },
         "publication": {
             "license": "ORC",
             "remaster": true,
-            "title": "Pathfinder Lost Omens Shining Kingdoms"
+            "title": "Pathfinder Player Core 2"
         },
         "rules": [
             {
-                "key": "TempHP",
-                "value": 25
+                "key": "GrantItem",
+                "onDeleteActions": {
+                    "grantee": "cascade"
+                },
+                "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Panache"
             }
         ],
         "start": {

--- a/packs/feat-effects/effect-extravagant-parry.json
+++ b/packs/feat-effects/effect-extravagant-parry.json
@@ -63,7 +63,7 @@
                 ],
                 "key": "EphemeralEffect",
                 "selectors": "strike-attack-roll",
-                "uuid": "Compendium.pf2e.feat-effects.Item.fJD0yIkVPMwdNjLy"
+                "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Panache (Ephemeral Note)"
             }
         ],
         "start": {

--- a/packs/feat-effects/effect-extravagant-parry.json
+++ b/packs/feat-effects/effect-extravagant-parry.json
@@ -1,0 +1,81 @@
+{
+    "_id": "FkouUFpwUrPjhMNw",
+    "img": "icons/weapons/swords/sword-machete-white.webp",
+    "name": "Effect: Extravagant Parry",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Extravagant Parry]</p>\n<p>You gain a +1 circumstance bonus to AC until the start of your next turn, or a +2 circumstance bonus if you have a free hand or are wielding a weapon with the parry trait.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "fromSpell": false,
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core 2"
+        },
+        "rules": [
+            {
+                "adjustName": false,
+                "choices": [
+                    {
+                        "label": "PF2E.UI.RuleElements.ChoiceSet.YesLabel",
+                        "value": 2
+                    },
+                    {
+                        "label": "PF2E.UI.RuleElements.ChoiceSet.NoLabel",
+                        "value": 1
+                    }
+                ],
+                "flag": "bonus",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Swashbuckler.ExtravagantParry.Prompt"
+            },
+            {
+                "key": "FlatModifier",
+                "selector": [
+                    "ac"
+                ],
+                "slug": "extravagant-parry",
+                "type": "circumstance",
+                "value": "@item.flags.pf2e.rulesSelections.bonus"
+            },
+            {
+                "affects": "origin",
+                "alterations": [
+                    {
+                        "mode": "add",
+                        "property": "other-tags",
+                        "value": "failure-note"
+                    },
+                    {
+                        "mode": "add",
+                        "property": "other-tags",
+                        "value": "critical-failure-note"
+                    }
+                ],
+                "key": "EphemeralEffect",
+                "selectors": "strike-attack-roll",
+                "uuid": "Compendium.pf2e.feat-effects.Item.fJD0yIkVPMwdNjLy"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feat-effects/effect-panache-ephemeral-note.json
+++ b/packs/feat-effects/effect-panache-ephemeral-note.json
@@ -1,0 +1,66 @@
+{
+    "_id": "fJD0yIkVPMwdNjLy",
+    "img": "icons/commodities/treasure/crown-gold-laurel-wreath.webp",
+    "name": "Effect: Panache (Ephemeral Note)",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Flashy Dodge], @UUID[Compendium.pf2e.feats-srd.Item.Extravagant Parry] via Ephemeral Effect.</p>\n<p>If your Strike misses, the origin gains panache.</p>"
+        },
+        "duration": {
+            "expiry": null,
+            "sustained": false,
+            "unit": "unlimited",
+            "value": -1
+        },
+        "fromSpell": false,
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core 2"
+        },
+        "rules": [
+            {
+                "key": "Note",
+                "outcome": [
+                    "failure"
+                ],
+                "predicate": [
+                    "parent:tag:failure-note"
+                ],
+                "selector": [
+                    "strike-attack-roll"
+                ],
+                "text": "PF2E.SpecificRule.Swashbuckler.PanacheFailure",
+                "title": "PF2E.Check.Result.Degree.Check.failure"
+            },
+            {
+                "key": "Note",
+                "outcome": [
+                    "criticalFailure"
+                ],
+                "predicate": [
+                    "parent:tag:critical-failure-note"
+                ],
+                "selector": [
+                    "strike-attack-roll"
+                ],
+                "text": "PF2E.SpecificRule.Swashbuckler.PanacheFailure",
+                "title": "PF2E.Check.Result.Degree.Check.criticalFailure"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feat-effects/effect-panache-temporary.json
+++ b/packs/feat-effects/effect-panache-temporary.json
@@ -25,7 +25,7 @@
             {
                 "key": "GrantItem",
                 "onDeleteActions": {
-                    "grantee": "restrict"
+                    "grantee": "cascade"
                 },
                 "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Panache"
             }

--- a/packs/feat-effects/effect-panache-temporary.json
+++ b/packs/feat-effects/effect-panache-temporary.json
@@ -1,0 +1,45 @@
+{
+    "_id": "paKKHPds77fq5VTH",
+    "img": "icons/commodities/treasure/crown-gold-laurel-wreath.webp",
+    "name": "Effect: Panache (Temporary)",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Flashy Dodge], @UUID[Compendium.pf2e.feats-srd.Item.Extravagant Parry], @UUID[Compendium.pf2e.feats-srd.Item.Elegant Buckler], @UUID[Compendium.pf2e.feats-srd.Item.Charmed Life], @UUID[Compendium.pf2e.feats-srd.Item.Guardian's Deflection (Swashbuckler)]{Guardian's Deflection}, and bravado actions on a failure.</p>\n<p>You gain panache.</p>"
+        },
+        "duration": {
+            "expiry": "turn-end",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "fromSpell": false,
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core 2"
+        },
+        "rules": [
+            {
+                "key": "GrantItem",
+                "onDeleteActions": {
+                    "grantee": "restrict"
+                },
+                "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Panache"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": false
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feat-effects/effect-panache.json
+++ b/packs/feat-effects/effect-panache.json
@@ -4,12 +4,12 @@
     "name": "Effect: Panache",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.classfeatures.Item.Panache]</p>\n<p>You gain panache by performing actions that have the bravado trait.</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.classfeatures.Item.Panache]</p>\n<p>You gain panache.</p>"
         },
         "duration": {
             "expiry": null,
             "sustained": false,
-            "unit": "unlimited",
+            "unit": "encounter",
             "value": -1
         },
         "level": {

--- a/packs/feats/archetype/eagle-knight/even-the-odds-eagle-knight.json
+++ b/packs/feats/archetype/eagle-knight/even-the-odds-eagle-knight.json
@@ -12,7 +12,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p><strong>Frequency</strong> once per day</p><hr /><p>Even when overpowered, Eagle Knights hold out hope. If your next action is to use @UUID[Compendium.pf2e.feats-srd.Item.Commitment to Equality], you roll the Diplomacy check twice and take the higher result. If you succeed, the target also gains 25 temporary Hit Points that last for 1 minute.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Even the Odds]</p>"
+            "value": "<p><strong>Frequency</strong> once per day</p><hr /><p>Even when overpowered, Eagle Knights hold out hope. If your next action is to use @UUID[Compendium.pf2e.feats-srd.Item.Commitment to Equality], you roll the Diplomacy check twice and take the higher result. If you succeed, the target also gains 25 temporary Hit Points that last for 1 minute.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Even the Odds (Eagle Knight)]</p>"
         },
         "frequency": {
             "max": 1,

--- a/packs/feats/class/swashbuckler/charmed-life.json
+++ b/packs/feats/class/swashbuckler/charmed-life.json
@@ -12,7 +12,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p><strong>Trigger</strong> You attempt a saving throw, but you haven't rolled yet.</p><hr /><p>When danger calls, you have a strange knack for coming out on top. You gain a +2 circumstance bonus to the triggering save. If you succeed on the triggering saving throw, you gain @UUID[Compendium.pf2e.feat-effects.Item.Effect: Panache]{Panache} until the end of your next turn.</p>"
+            "value": "<p><strong>Trigger</strong> You attempt a saving throw, but you haven't rolled yet.</p><hr /><p>When danger calls, you have a strange knack for coming out on top. You gain a +2 circumstance bonus to the triggering save. If you succeed on the triggering saving throw, you gain @UUID[Compendium.pf2e.feat-effects.Item.Effect: Panache]{Panache} until the end of your next turn.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Panache (Temporary)]</p>"
         },
         "level": {
             "value": 2

--- a/packs/feats/class/swashbuckler/charmed-life.json
+++ b/packs/feats/class/swashbuckler/charmed-life.json
@@ -12,7 +12,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p><strong>Trigger</strong> You attempt a saving throw, but you haven't rolled yet.</p><hr /><p>When danger calls, you have a strange knack for coming out on top. You gain a +2 circumstance bonus to the triggering save. If you succeed on the triggering saving throw, you gain @UUID[Compendium.pf2e.feat-effects.Item.Effect: Panache]{Panache} until the end of your next turn.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Panache (Temporary)]</p>"
+            "value": "<p><strong>Trigger</strong> You attempt a saving throw, but you haven't rolled yet.</p><hr /><p>When danger calls, you have a strange knack for coming out on top. You gain a +2 circumstance bonus to the triggering save. If you succeed on the triggering saving throw, you gain panache until the end of your next turn.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Panache (Temporary)]</p>"
         },
         "level": {
             "value": 2

--- a/packs/feats/class/swashbuckler/elegant-buckler.json
+++ b/packs/feats/class/swashbuckler/elegant-buckler.json
@@ -12,7 +12,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>You've learned a flexible way to position your @UUID[Compendium.pf2e.equipment-srd.Item.Buckler] to provide more protection. When you @UUID[Compendium.pf2e.actionspf2e.Item.Raise a Shield] to gain a circumstance bonus to AC from a buckler, increase the bonus from +1 to +2.</p>\n<p>While you have a buckler raised, if a creature critically misses you with a Strike, you gain panache until the end of your next turn.</p>"
+            "value": "<p>You've learned a flexible way to position your @UUID[Compendium.pf2e.equipment-srd.Item.Buckler] to provide more protection. When you @UUID[Compendium.pf2e.actionspf2e.Item.Raise a Shield] to gain a circumstance bonus to AC from a buckler, increase the bonus from +1 to +2.</p>\n<p>While you have a buckler raised, if a creature critically misses you with a Strike, you gain panache until the end of your next turn.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Panache (Temporary)]</p>"
         },
         "level": {
             "value": 1
@@ -27,11 +27,36 @@
         },
         "rules": [
             {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Swashbuckler.ElegantBuckler.RollOptionLabel",
+                "option": "elegant-buckler",
+                "toggleable": true
+            },
+            {
                 "key": "AdjustModifier",
                 "mode": "upgrade",
+                "predicate": [
+                    "elegant-buckler"
+                ],
                 "selector": "ac",
                 "slug": "raised-shield",
                 "value": 2
+            },
+            {
+                "affects": "origin",
+                "alterations": [
+                    {
+                        "mode": "add",
+                        "property": "other-tags",
+                        "value": "critical-failure-note"
+                    }
+                ],
+                "key": "EphemeralEffect",
+                "predicate": [
+                    "elegant-buckler"
+                ],
+                "selectors": "strike-attack-roll",
+                "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Panache (Ephemeral Note)"
             }
         ],
         "traits": {

--- a/packs/feats/class/swashbuckler/elegant-buckler.json
+++ b/packs/feats/class/swashbuckler/elegant-buckler.json
@@ -53,7 +53,8 @@
                 ],
                 "key": "EphemeralEffect",
                 "predicate": [
-                    "elegant-buckler"
+                    "elegant-buckler",
+                    "self:shield:raised"
                 ],
                 "selectors": "strike-attack-roll",
                 "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Panache (Ephemeral Note)"

--- a/packs/feats/class/swashbuckler/even-the-odds.json
+++ b/packs/feats/class/swashbuckler/even-the-odds.json
@@ -12,7 +12,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p><strong>Frequency</strong> once per 10 minutes</p>\n<p><strong>Trigger</strong> Your turn begins.</p>\n<p><strong>Requirements</strong> You are being flanked.</p><hr /><p>You shine brightest in desperate moments. You flash a confident smile or pose, and you gain @UUID[Compendium.pf2e.feat-effects.Item.Effect: Panache]{Panache} until the end of your turn.</p>"
+            "value": "<p><strong>Frequency</strong> once per 10 minutes</p>\n<p><strong>Trigger</strong> Your turn begins.</p>\n<p><strong>Requirements</strong> You are being flanked.</p><hr /><p>You shine brightest in desperate moments. You flash a confident smile or pose, and you gain @UUID[Compendium.pf2e.classfeatures.Item.Panache] until the end of your turn.</p>"
         },
         "frequency": {
             "max": 1,
@@ -30,6 +30,10 @@
             "title": "Pathfinder Player Core 2"
         },
         "rules": [],
+        "selfEffect": {
+            "name": "Effect: Even the Odds",
+            "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Even the Odds"
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/class/swashbuckler/extravagant-parry.json
+++ b/packs/feats/class/swashbuckler/extravagant-parry.json
@@ -12,7 +12,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p><strong>Requirements</strong> You're wielding one or more one-handed weapons</p><hr /><p>You use one-handed weapons to parry with style. You gain a +1 circumstance bonus to AC until the start of your next turn, or a +2 circumstance bonus if you have a free hand or are wielding a weapon with the parry trait. You lose this circumstance bonus if you no longer meet this feat's requirement. If a creature misses you with a Strike while you have this bonus, you gain panache until the end of your next turn.</p>"
+            "value": "<p><strong>Requirements</strong> You're wielding one or more one-handed weapons</p><hr /><p>You use one-handed weapons to parry with style. You gain a +1 circumstance bonus to AC until the start of your next turn, or a +2 circumstance bonus if you have a free hand or are wielding a weapon with the parry trait. You lose this circumstance bonus if you no longer meet this feat's requirement. If a creature misses you with a Strike while you have this bonus, you gain panache until the end of your next turn.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Panache (Temporary)]</p>"
         },
         "level": {
             "value": 1
@@ -25,35 +25,10 @@
             "remaster": true,
             "title": "Pathfinder Player Core 2"
         },
-        "rules": [
-            {
-                "key": "AdjustModifier",
-                "mode": "upgrade",
-                "predicate": [
-                    {
-                        "or": [
-                            {
-                                "gte": [
-                                    "hands-free",
-                                    1
-                                ]
-                            },
-                            "parry-bonus-upgrade:yes"
-                        ]
-                    }
-                ],
-                "selector": "ac",
-                "slug": "parry-bonus",
-                "value": 2
-            },
-            {
-                "key": "RollOption",
-                "option": "weapon-parry"
-            }
-        ],
+        "rules": [],
         "selfEffect": {
-            "name": "Effect: Parry",
-            "uuid": "Compendium.pf2e.equipment-effects.Item.Effect: Parry"
+            "name": "Effect: Extravagant Parry",
+            "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Extravagant Parry"
         },
         "traits": {
             "rarity": "common",

--- a/packs/feats/class/swashbuckler/flashy-dodge.json
+++ b/packs/feats/class/swashbuckler/flashy-dodge.json
@@ -12,7 +12,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p><strong>Trigger</strong> A creature you can see targets you with an attack.</p>\n<p><strong>Requirements</strong> You aren't encumbered.</p><hr /><p>You deftly dodge out of the way, gaining a +2 circumstance bonus to AC against the triggering attack. If the Strike misses, you gain panache until the end of your next turn</p>"
+            "value": "<p><strong>Trigger</strong> A creature you can see targets you with an attack.</p>\n<p><strong>Requirements</strong> You aren't @UUID[Compendium.pf2e.conditionitems.Item.Encumbered].</p><hr /><p>You deftly dodge out of the way, gaining a +2 circumstance bonus to AC against the triggering attack. If the Strike misses, you gain panache until the end of your next turn.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Panache (Temporary)]</p>"
         },
         "level": {
             "value": 1
@@ -27,7 +27,6 @@
         },
         "rules": [
             {
-                "domain": "ac",
                 "key": "RollOption",
                 "option": "flashy-dodge",
                 "toggleable": true
@@ -40,6 +39,27 @@
                 "selector": "ac",
                 "type": "circumstance",
                 "value": 2
+            },
+            {
+                "affects": "origin",
+                "alterations": [
+                    {
+                        "mode": "add",
+                        "property": "other-tags",
+                        "value": "failure-note"
+                    },
+                    {
+                        "mode": "add",
+                        "property": "other-tags",
+                        "value": "critical-failure-note"
+                    }
+                ],
+                "key": "EphemeralEffect",
+                "predicate": [
+                    "flashy-dodge"
+                ],
+                "selectors": "strike-attack-roll",
+                "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Panache (Ephemeral Note)"
             }
         ],
         "traits": {

--- a/packs/feats/class/swashbuckler/guardians-deflection-swashbuckler.json
+++ b/packs/feats/class/swashbuckler/guardians-deflection-swashbuckler.json
@@ -12,7 +12,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p><strong>Trigger</strong> An ally within your melee reach is hit by an attack, you can see the attacker, and a +2 circumstance bonus to AC would turn the critical hit into a hit or the hit into a miss.</p>\n<p><strong>Requirements</strong> You are wielding a single one-handed melee weapon and have your other hand or hands free.</p><hr /><p>You use your weapon to deflect the attack against your ally, granting a +2 circumstance bonus to their AC against the triggering attack. This turns the triggering critical hit into a hit, or the triggering hit into a miss. You gain Panache until the end of your next turn.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Guardian's Deflection]</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Panache (Temporary)]</p>"
+            "value": "<p><strong>Trigger</strong> An ally within your melee reach is hit by an attack, you can see the attacker, and a +2 circumstance bonus to AC would turn the critical hit into a hit or the hit into a miss.</p>\n<p><strong>Requirements</strong> You are wielding a single one-handed melee weapon and have your other hand or hands free.</p><hr /><p>You use your weapon to deflect the attack against your ally, granting a +2 circumstance bonus to their AC against the triggering attack. This turns the triggering critical hit into a hit, or the triggering hit into a miss. You gain panache until the end of your next turn.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Guardian's Deflection]</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Panache (Temporary)]</p>"
         },
         "level": {
             "value": 4

--- a/packs/feats/class/swashbuckler/guardians-deflection-swashbuckler.json
+++ b/packs/feats/class/swashbuckler/guardians-deflection-swashbuckler.json
@@ -12,7 +12,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p><strong>Trigger</strong> An ally within your melee reach is hit by an attack, you can see the attacker, and a +2 circumstance bonus to AC would turn the critical hit into a hit or the hit into a miss.</p>\n<p><strong>Requirements</strong> You are wielding a single one-handed melee weapon and have your other hand or hands free.</p><hr /><p>You use your weapon to deflect the attack against your ally, granting a +2 circumstance bonus to their AC against the triggering attack. This turns the triggering critical hit into a hit, or the triggering hit into a miss. You gain @UUID[Compendium.pf2e.feat-effects.Item.Effect: Panache]{Panache} until the end of your next turn.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Guardian's Deflection]</p>"
+            "value": "<p><strong>Trigger</strong> An ally within your melee reach is hit by an attack, you can see the attacker, and a +2 circumstance bonus to AC would turn the critical hit into a hit or the hit into a miss.</p>\n<p><strong>Requirements</strong> You are wielding a single one-handed melee weapon and have your other hand or hands free.</p><hr /><p>You use your weapon to deflect the attack against your ally, granting a +2 circumstance bonus to their AC against the triggering attack. This turns the triggering critical hit into a hit, or the triggering hit into a miss. You gain Panache until the end of your next turn.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Guardian's Deflection]</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Panache (Temporary)]</p>"
         },
         "level": {
             "value": 4

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -6653,6 +6653,12 @@
                 "RuptureDamage": "If the monster takes piercing or slashing damage equaling or exceeding the listed Rupture value from a single attack or spell, the swallowed creature cuts itself free."
             },
             "Swashbuckler": {
+                "ElegantBuckler": {
+                    "RollOptionLabel": "Elegant Buckler — Using a buckler"
+                },
+                "ExtravagantParry": {
+                    "Prompt": "Do you have a free hand or wield a parry weapon?"
+                },
                 "Finisher": {
                     "Basic": "Basic",
                     "Bleeding": "Bleeding",
@@ -6679,7 +6685,7 @@
                     "Note": "On a successful Feint, the target take a -2 circumstance penalty to attack rolls against you instead of any other effects that you would gain when you Feint. @UUID[Compendium.pf2e.feat-effects.Item.rflbFzV44Fd6aBLE]{Effect: Goading Feint}"
                 },
                 "Panache": "You gain @UUID[Compendium.pf2e.feat-effects.Item.uBJsxCzNhje8m8jj]{Panache}.",
-                "PanacheFailure": "You gain panache until the end of your next turn @UUID[Compendium.pf2e.feat-effects.Item.uBJsxCzNhje8m8jj]{Effect: Panache}",
+                "PanacheFailure": "You gain panache until the end of your next turn @UUID[Compendium.pf2e.feat-effects.Item.paKKHPds77fq5VTH]{Effect: Panache (Temporary)}",
                 "Style": {
                     "Prompt": "Select a style."
                 },


### PR DESCRIPTION
- Added generic shorter-duration panache effect which grants panache until the end your of next turn for use in several swashbuckler feats as well as any bravado effect on a failure.
- Added Even the Odds effect, which grants panache until the end of the current turn. Diff is weird, but I also renamed the Eagle Knight's effect of the same name to use a parenthesis.
- Added ephemeral note panache effect which appends a note for this short-duration panache effect for use in Flashy Dodge, Extravagant Parry, and Elegant Buckler.
  - In order to implement this, Extravagant Parry needed its own effect, so it's been separated from the generic parry effect (and by RAW, it *is* supposed to be its own thing anyway).
- Updated base panache effect duration to end of encounter.