### PR TITLE
Fix Spirit Body and Ghostly Swoop resistance to be double vs. non-magical

### DIFF
--- a/packs/blood-lords-bestiary/book-1-zombie-feast/granite-vulture.json
+++ b/packs/blood-lords-bestiary/book-1-zombie-feast/granite-vulture.json
@@ -167,8 +167,9 @@
                     "value": null
                 },
                 "category": "defensive",
+                "deathNote": true,
                 "description": {
-                    "value": "<p>When the vulture reaches 0 Hit Points, their spirit dissipates. If their vessel remains intact, the vulture re-forms within it after [[/br 2d4 #Days]]{2d4 days}, fully healed. If the vessel is broken, their receptacle reconstitutes the vessel in [[/br 2d4 #Days]]{2d4 days}, and the vulture re-forms within it in another [[/br 2d4 #Days]]{2d4 days}. In the meantime, the vulture's consciousness inhabits their spirit receptacle. If both their vessel and receptacle are destroyed, the vulture is instantly slain and can't reconstitute.</p>"
+                    "value": "<p>When the vulture reaches 0 Hit Points, their spirit dissipates. If their vessel remains intact, the vulture re-forms within it after [[/gmr 2d4 #Days]]{2d4 days}, fully healed. If the vessel is broken, their receptacle reconstitutes the vessel in 2d4 days, and the vulture re-forms within it in another 2d4 days. In the meantime, the vulture's consciousness inhabits their spirit receptacle. If both their vessel and receptacle are destroyed, the vulture is instantly slain and can't reconstitute.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -230,14 +231,42 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The vulture touches and melds with their bonded vessel, bringing the statue to life. They can cease Inhabiting their Vessel by spending a single action, which has the concentrate trait. While Inhabiting the Vessel, they gain Immunities healing, nonlethal; Resistances physical 3 (except bludgeoning); and the following Strike.</p>"
+                    "value": "<p>The vulture touches and melds with their bonded vessel, bringing the statue to life. They can cease Inhabiting their Vessel by spending a single action, which has the concentrate trait. While Inhabiting the Vessel, they gain <strong>Immunities</strong> healing, nonlethal; <strong>Resistances</strong> physical 3 (except bludgeoning); and the following Strike.</p>"
                 },
                 "publication": {
                     "license": "OGL",
                     "remaster": false,
                     "title": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "key": "RollOption",
+                        "option": "inhabit-vessel",
+                        "priority": 50,
+                        "toggleable": true
+                    },
+                    {
+                        "key": "Immunity",
+                        "predicate": [
+                            "inhabit-vessel"
+                        ],
+                        "type": [
+                            "healing",
+                            "nonlethal-attacks"
+                        ]
+                    },
+                    {
+                        "exceptions": [
+                            "bludgeoning"
+                        ],
+                        "key": "Resistance",
+                        "predicate": [
+                            "inhabit-vessel"
+                        ],
+                        "type": "physical",
+                        "value": 3
+                    }
+                ],
                 "slug": null,
                 "traits": {
                     "rarity": "common",
@@ -262,14 +291,53 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>When not Inhabiting their vessel or receptacle, the vulture is incorporeal, is @UUID[Compendium.pf2e.conditionitems.Item.Slowed]{Slowed 1}, and gains resistance 3 to all damage (except force damage and damage from Strikes with the <em>ghost touch</em> property rune; double resistance against non-magical).</p>"
+                    "value": "<p>When not Inhabiting their vessel or receptacle, the vulture is incorporeal, is @UUID[Compendium.pf2e.conditionitems.Item.Slowed]{Slowed 1}, and gains resistance 3 to all damage (except force damage and damage from Strikes with the <em>@UUID[Compendium.pf2e.equipment-srd.Item.Ghost Touch]</em> property rune; double resistance against non-magical).</p>"
                 },
                 "publication": {
                     "license": "OGL",
                     "remaster": false,
                     "title": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "add": [
+                            "incorporeal"
+                        ],
+                        "key": "ActorTraits",
+                        "predicate": [
+                            {
+                                "not": "inhabit-vessel"
+                            }
+                        ]
+                    },
+                    {
+                        "inMemoryOnly": true,
+                        "key": "GrantItem",
+                        "predicate": [
+                            {
+                                "not": "inhabit-vessel"
+                            }
+                        ],
+                        "uuid": "Compendium.pf2e.conditionitems.Item.Slowed"
+                    },
+                    {
+                        "doubleVs": [
+                            "non-magical"
+                        ],
+                        "exceptions": [
+                            "force",
+                            "ghost-touch"
+                        ],
+                        "key": "Resistance",
+                        "predicate": [
+                            {
+                                "not": "inhabit-vessel"
+                            }
+                        ],
+                        "type": "all-damage",
+                        "value": 3
+                    }
+                ],
                 "slug": null,
                 "traits": {
                     "rarity": "common",

--- a/packs/blood-lords-bestiary/book-1-zombie-feast/granite-vulture.json
+++ b/packs/blood-lords-bestiary/book-1-zombie-feast/granite-vulture.json
@@ -242,7 +242,6 @@
                     {
                         "key": "RollOption",
                         "option": "inhabit-vessel",
-                        "priority": 50,
                         "toggleable": true
                     },
                     {

--- a/packs/book-of-the-dead-bestiary/queen-sluagh.json
+++ b/packs/book-of-the-dead-bestiary/queen-sluagh.json
@@ -740,7 +740,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The queen sluagh becomes incorporeal until the start of their next turn, and Flies up to their fly Speed. While incorporeal, they are immune to precision damage, and have resistance 10 to all damage (except force, ghost touch, or vitality); this resistance is doubled against non-magical damage.</p>\n<p>After using Ghostly Swoop, the queen sluagh can't use it again for [[/gmr 1d4 #Recharge]]{1d4 rounds}.</p>"
+                    "value": "<p>The queen sluagh becomes incorporeal until the start of their next turn, and Flies up to their fly Speed. While incorporeal, they are immune to precision damage, and have resistance 10 to all damage (except force, <em>@UUID[Compendium.pf2e.equipment-srd.Item.Ghost Touch]</em>, or vitality); this resistance is doubled against non-magical damage.</p>\n<p>After using Ghostly Swoop, the queen sluagh can't use it again for [[/gmr 1d4 #Recharge Ghostly Swoop]]{1d4 rounds}.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -754,6 +754,25 @@
                         "toggleable": true
                     },
                     {
+                        "add": [
+                            "incorporeal"
+                        ],
+                        "key": "ActorTraits",
+                        "predicate": [
+                            "ghostly-swoop"
+                        ]
+                    },
+                    {
+                        "key": "Immunity",
+                        "predicate": [
+                            "ghostly-swoop"
+                        ],
+                        "type": "precision"
+                    },
+                    {
+                        "doubleVs": [
+                            "non-magical"
+                        ],
                         "exceptions": [
                             "force",
                             "ghost-touch",

--- a/packs/book-of-the-dead-bestiary/sluagh-reaper.json
+++ b/packs/book-of-the-dead-bestiary/sluagh-reaper.json
@@ -404,7 +404,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The sluagh reaper becomes incorporeal until the start of their next turn, and Flies up to their fly Speed. While incorporeal, they are immune to precision damage, and have resistance 10 to all damage (except force, ghost touch, or vitality); this resistance is doubled against non-magical damage.</p>\n<p>After using Ghostly Swoop, the sluagh reaper can't use it again for [[/gmr 1d4 #Recharge]]{1d4 rounds}.</p>"
+                    "value": "<p>The sluagh reaper becomes incorporeal until the start of their next turn, and Flies up to their fly Speed. While incorporeal, they are immune to precision damage, and have resistance 10 to all damage (except force, <em>@UUID[Compendium.pf2e.equipment-srd.Item.Ghost Touch]</em>, or vitality); this resistance is doubled against non-magical damage.</p>\n<p>After using Ghostly Swoop, the sluagh reaper can't use it again for [[/gmr 1d4 #Recharge Ghostly Swoop]]{1d4 rounds}.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -418,6 +418,25 @@
                         "toggleable": true
                     },
                     {
+                        "add": [
+                            "incorporeal"
+                        ],
+                        "key": "ActorTraits",
+                        "predicate": [
+                            "ghostly-swoop"
+                        ]
+                    },
+                    {
+                        "key": "Immunity",
+                        "predicate": [
+                            "ghostly-swoop"
+                        ],
+                        "type": "precision"
+                    },
+                    {
+                        "doubleVs": [
+                            "non-magical"
+                        ],
                         "exceptions": [
                             "force",
                             "ghost-touch",

--- a/packs/pathfinder-bestiary-3/elder-sphinx.json
+++ b/packs/pathfinder-bestiary-3/elder-sphinx.json
@@ -1222,6 +1222,14 @@
                         "toggleable": true
                     },
                     {
+                        "inMemoryOnly": true,
+                        "key": "GrantItem",
+                        "predicate": [
+                            "guardian-monolith"
+                        ],
+                        "uuid": "Compendium.pf2e.conditionitems.Item.Paralyzed"
+                    },
+                    {
                         "key": "ActiveEffectLike",
                         "mode": "override",
                         "path": "system.attributes.hardness.value",

--- a/packs/pathfinder-bestiary-3/stone-lion-cub.json
+++ b/packs/pathfinder-bestiary-3/stone-lion-cub.json
@@ -304,7 +304,6 @@
                     {
                         "key": "RollOption",
                         "option": "inhabit-vessel",
-                        "priority": 50,
                         "toggleable": true
                     },
                     {

--- a/packs/pathfinder-bestiary-3/stone-lion-cub.json
+++ b/packs/pathfinder-bestiary-3/stone-lion-cub.json
@@ -261,7 +261,7 @@
                 "category": "defensive",
                 "deathNote": true,
                 "description": {
-                    "value": "<p>When the cub reaches 0 Hit Points, its spirit dissipates. If its bonded vessel is intact, the cub re-forms in this vessel after [[/br 2d4 #Reconstitution]]{2d4 days}, fully healed. If the vessel is broken, it must first be @UUID[Compendium.pf2e.actionspf2e.Item.Repair]{Repaired}, after which the cub reforms in [[/br 3d4 #Reconstitution]]{3d4 days}.</p>"
+                    "value": "<p>When the cub reaches 0 Hit Points, its spirit dissipates. If its bonded vessel is intact, the cub re-forms in this vessel after [[/gmr 2d4 #Reconstitution]]{2d4 days}, fully healed. If the vessel is broken, it must first be @UUID[Compendium.pf2e.actionspf2e.Item.Repair]{Repaired}, after which the cub reforms in [[/gmr 3d4 #Reconstitution]]{3d4 days}.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -409,6 +409,20 @@
                 },
                 "rules": [
                     {
+                        "add": [
+                            "incorporeal"
+                        ],
+                        "key": "ActorTraits",
+                        "predicate": [
+                            {
+                                "not": "inhabit-vessel"
+                            }
+                        ]
+                    },
+                    {
+                        "doubleVs": [
+                            "non-magical"
+                        ],
                         "exceptions": [
                             "force",
                             "ghost-touch"

--- a/packs/pathfinder-bestiary-3/stone-lion.json
+++ b/packs/pathfinder-bestiary-3/stone-lion.json
@@ -334,7 +334,7 @@
                 "category": "defensive",
                 "deathNote": true,
                 "description": {
-                    "value": "<p>When the lion reaches 0 Hit Points, its spirit dissipates. If its bonded vessel is intact, the lion re-forms in this vessel after [[/br 2d4 #Reconstitution]]{2d4 days}, fully healed. If the vessel is broken, it must first be @UUID[Compendium.pf2e.actionspf2e.Item.Repair]{Repaired}, after which the lion reforms in [[/br 3d4 #Reconstitution]]{3d4 days}.</p>"
+                    "value": "<p>When the lion reaches 0 Hit Points, its spirit dissipates. If its bonded vessel is intact, the lion re-forms in this vessel after [[/gmr 2d4 #Reconstitution]]{2d4 days}, fully healed. If the vessel is broken, it must first be @UUID[Compendium.pf2e.actionspf2e.Item.Repair]{Repaired}, after which the lion reforms in [[/gmr 3d4 #Reconstitution]]{3d4 days}.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -537,6 +537,20 @@
                 },
                 "rules": [
                     {
+                        "add": [
+                            "incorporeal"
+                        ],
+                        "key": "ActorTraits",
+                        "predicate": [
+                            {
+                                "not": "inhabit-vessel"
+                            }
+                        ]
+                    },
+                    {
+                        "doubleVs": [
+                            "non-magical"
+                        ],
                         "exceptions": [
                             "force",
                             "ghost-touch"

--- a/packs/pathfinder-bestiary-3/stone-lion.json
+++ b/packs/pathfinder-bestiary-3/stone-lion.json
@@ -413,7 +413,6 @@
                     {
                         "key": "RollOption",
                         "option": "inhabit-vessel",
-                        "priority": 50,
                         "toggleable": true
                     },
                     {

--- a/packs/pathfinder-monster-core-2/stone-lion-cub.json
+++ b/packs/pathfinder-monster-core-2/stone-lion-cub.json
@@ -402,6 +402,20 @@
                 },
                 "rules": [
                     {
+                        "add": [
+                            "incorporeal"
+                        ],
+                        "key": "ActorTraits",
+                        "predicate": [
+                            {
+                                "not": "inhabit-vessel"
+                            }
+                        ]
+                    },
+                    {
+                        "doubleVs": [
+                            "non-magical"
+                        ],
                         "exceptions": [
                             "force",
                             "ghost-touch"

--- a/packs/pathfinder-monster-core-2/stone-lion-cub.json
+++ b/packs/pathfinder-monster-core-2/stone-lion-cub.json
@@ -298,7 +298,6 @@
                     {
                         "key": "RollOption",
                         "option": "inhabit-vessel",
-                        "priority": 50,
                         "toggleable": true
                     },
                     {

--- a/packs/pathfinder-monster-core-2/stone-lion.json
+++ b/packs/pathfinder-monster-core-2/stone-lion.json
@@ -150,7 +150,7 @@
                 "category": "defensive",
                 "deathNote": true,
                 "description": {
-                    "value": "<p>When the lion reaches 0 Hit Points, its spirit dissipates. If its bonded vessel is intact, the lion re-forms in this vessel after [[/br 2d4 #Reconstitution]]{2d4 days}, fully healed. If the vessel is broken, it must first be @UUID[Compendium.pf2e.actionspf2e.Item.Repair]{Repaired}, after which the lion reforms in [[/br 3d4 #Reconstitution]]{3d4 days}.</p>"
+                    "value": "<p>When the lion reaches 0 Hit Points, its spirit dissipates. If its bonded vessel is intact, the lion re-forms in this vessel after [[/gmr 2d4 #Reconstitution]]{2d4 days}, fully healed. If the vessel is broken, it must first be @UUID[Compendium.pf2e.actionspf2e.Item.Repair]{Repaired}, after which the lion reforms in [[/gmr 3d4 #Reconstitution]]{3d4 days}.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -350,6 +350,20 @@
                 },
                 "rules": [
                     {
+                        "add": [
+                            "incorporeal"
+                        ],
+                        "key": "ActorTraits",
+                        "predicate": [
+                            {
+                                "not": "inhabit-vessel"
+                            }
+                        ]
+                    },
+                    {
+                        "doubleVs": [
+                            "non-magical"
+                        ],
                         "exceptions": [
                             "force",
                             "ghost-touch"

--- a/packs/pathfinder-monster-core-2/stone-lion.json
+++ b/packs/pathfinder-monster-core-2/stone-lion.json
@@ -227,7 +227,6 @@
                     {
                         "key": "RollOption",
                         "option": "inhabit-vessel",
-                        "priority": 50,
                         "toggleable": true
                     },
                     {

--- a/packs/season-of-ghosts-bestiary/book-1-the-summer-that-never-was/stone-spider.json
+++ b/packs/season-of-ghosts-bestiary/book-1-the-summer-that-never-was/stone-spider.json
@@ -330,8 +330,9 @@
                     "value": null
                 },
                 "category": "defensive",
+                "deathNote": true,
                 "description": {
-                    "value": "<p>When the stone spider reaches 0 Hit Points, its spirit dissipates. If its bonded vessel is intact, the stone spider re-forms in this vessel after [[/br 2d4 #days]]{2d4 days}, fully healed. If the vessel is broken, it must first be Repaired, after which the stone spider re-forms in [[/br 3d4 #days]]{3d4 days}.</p>"
+                    "value": "<p>When the stone spider reaches 0 Hit Points, its spirit dissipates. If its bonded vessel is intact, the stone spider re-forms in this vessel after [[/gmr 2d4 #days]]{2d4 days}, fully healed. If the vessel is broken, it must first be Repaired, after which the stone spider re-forms in [[/gmr 3d4 #days]]{3d4 days}.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -362,7 +363,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The spider touches and melds with its bonded vessel, bringing it to life. It can cease Inhabiting its Vessel by spending a single action, which has the concentrate trait. While Inhabiting the Vessel, it loses its fly Speed and gains</p>\n<p><strong>Immunities</strong> healing, nonlethal</p>\n<p><strong>Resistances</strong> physical 6 (except bludgeoning)</p>\n<p><strong>Speed</strong> 25 feet, climb 25 feet</p>\n<p>and the following Strike.</p>\n<ul>\n<li>Melee <span class=\"action-glyph\">1</span> stone fangs +14 (finesse), Damage 2d8+7 piercing</li>\n</ul>"
+                    "value": "<p>The spider touches and melds with its bonded vessel, bringing it to life. It can cease Inhabiting its Vessel by spending a single action, which has the concentrate trait. While Inhabiting the Vessel, it loses its fly Speed and gains</p>\n<p><strong>Immunities</strong> healing, nonlethal</p>\n<p><strong>Resistances</strong> physical 6 (except bludgeoning)</p>\n<p><strong>Speed</strong> 25 feet, climb 25 feet</p>\n<p>and the following Strike.</p><ul><li><strong>Melee</strong> <span class=\"action-glyph\">1</span> stone fangs +14 (finesse), <strong>Damage</strong> 2d8+7 piercing</li></ul>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -466,7 +467,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>When not Inhabiting its Vessel, the stone spider is incorporeal and gains resistance 6 to all damage (except force damage and ghost touch; double resistance against non-magical).</p>"
+                    "value": "<p>When not Inhabiting its Vessel, the stone spider is incorporeal and gains resistance 6 to all damage (except force damage and <em>@UUID[Compendium.pf2e.equipment-srd.Item.Ghost Touch]</em>; double resistance against non-magical).</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -474,6 +475,17 @@
                     "title": ""
                 },
                 "rules": [
+                    {
+                        "add": [
+                            "incorporeal"
+                        ],
+                        "key": "ActorTraits",
+                        "predicate": [
+                            {
+                                "not": "inhabit-vessel"
+                            }
+                        ]
+                    },
                     {
                         "doubleVs": [
                             "non-magical"

--- a/packs/wardens-of-wildwood-bestiary/book-2-severed-at-the-root/drinesh.json
+++ b/packs/wardens-of-wildwood-bestiary/book-2-severed-at-the-root/drinesh.json
@@ -529,7 +529,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The sluagh reaper becomes incorporeal until the start of their next turn, and Flies up to their fly Speed. While incorporeal, they are immune to precision damage, and have resistance 10 to all damage (except force, ghost touch, or vitality); this resistance is doubled against non-magical damage.</p>\n<p>After using Ghostly Swoop, the sluagh reaper can't use it again for [[/gmr 1d4 #Recharge]]{1d4 rounds}.</p>"
+                    "value": "<p>The sluagh reaper becomes incorporeal until the start of their next turn, and Flies up to their fly Speed. While incorporeal, they are immune to precision damage, and have resistance 10 to all damage (except force, <em>@UUID[Compendium.pf2e.equipment-srd.Item.Ghost Touch]</em>, or vitality); this resistance is doubled against non-magical damage.</p>\n<p>After using Ghostly Swoop, the sluagh reaper can't use it again for [[/gmr 1d4 #Recharge Ghostly Swoop]]{1d4 rounds}.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -543,6 +543,25 @@
                         "toggleable": true
                     },
                     {
+                        "add": [
+                            "incorporeal"
+                        ],
+                        "key": "ActorTraits",
+                        "predicate": [
+                            "ghostly-swoop"
+                        ]
+                    },
+                    {
+                        "key": "Immunity",
+                        "predicate": [
+                            "ghostly-swoop"
+                        ],
+                        "type": "precision"
+                    },
+                    {
+                        "doubleVs": [
+                            "non-magical"
+                        ],
                         "exceptions": [
                             "force",
                             "ghost-touch",


### PR DESCRIPTION
Update Spirit Body and Ghostly Swoop to add incorporeal trait
Add precision immunity to Ghostly Swoop
Ensure Reconstitution is deathNote
Remove RollOption priority that's equal to default
Add some automation to Granite Vulture
Update Elder Sphinx's Guardian Monolith to grant Paralyzed
Update some `br` to `gmr`
Tidy some formatting