### PR TITLE
Automate Equitable Defense

### DIFF
--- a/packs/feat-effects/effect-equitable-defense.json
+++ b/packs/feat-effects/effect-equitable-defense.json
@@ -1,0 +1,54 @@
+{
+    "_id": "w0k59TPWUZ9Me4yF",
+    "img": "icons/skills/ranged/arrow-strike-glowing-teal.webp",
+    "name": "Effect: Equitable Defense",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Equitable Defense]</p>\n<p>You gain a +1 circumstance bonus on the next Strike you make against the marked creature.</p>"
+        },
+        "duration": {
+            "expiry": "turn-end",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "fromSpell": false,
+        "level": {
+            "value": 8
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": "Pathfinder Lost Omens Impossible Lands"
+        },
+        "rules": [
+            {
+                "key": "TokenMark",
+                "slug": "equitable-defense"
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "target:mark:equitable-defense"
+                ],
+                "removeAfterRoll": "if-enabled",
+                "selector": [
+                    "strike-attack-roll"
+                ],
+                "type": "circumstance",
+                "value": 1
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feats/archetype/shieldmarshal/equitable-defense.json
+++ b/packs/feats/archetype/shieldmarshal/equitable-defense.json
@@ -12,7 +12,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p><strong>Trigger</strong> You take damage from a critical hit.</p>\n<hr />\n<p>Gritting your teeth through the pain, you position yourself to counterattack. You gain resistance to the damage from the critical hit equal to half your level. As long as you're still conscious after the attack, you can Interact to reload a weapon you currently wield or Stand. You gain a +1 circumstance bonus on the next Strike you make against the creature who critically hit you, provided you make it before the end of your next turn.</p>"
+            "value": "<p><strong>Trigger</strong> You take damage from a critical hit.</p><hr /><p>Gritting your teeth through the pain, you position yourself to counterattack. You gain resistance to the damage from the critical hit equal to half your level. As long as you're still conscious after the attack, you can Interact to reload a weapon you currently wield or Stand.</p>\n<p>You gain a +1 circumstance bonus on the next Strike you make against the creature who critically hit you, provided you make it before the end of your next turn.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Equitable Defense]</p>"
         },
         "frequency": {
             "max": 1,
@@ -33,7 +33,22 @@
             "remaster": false,
             "title": "Pathfinder Lost Omens Impossible Lands"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "RollOption",
+                "label": "PF2E.NPCAbility.Shieldmarshal.EquitableDefense.ResistanceToggle",
+                "option": "equitable-defense",
+                "toggleable": true
+            },
+            {
+                "key": "Resistance",
+                "predicate": [
+                    "equitable-defense"
+                ],
+                "type": "critical-hits",
+                "value": "floor(@actor.level/2)"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -1407,6 +1407,9 @@
                 "CriticalHit": "Shell Broken by a Critical Hit"
             },
             "Shieldmarshal": {
+                "EquitableDefense": {
+                    "ResistanceToggle": "Equitable Defense — Critical Hit Resistance"
+                },
                 "LawbringerSpeedLabel": "Lawbringer — Moving Toward Target"
             },
             "ShockerLizard": {


### PR DESCRIPTION
Purposefully not a self-applied effect since, despite the toggle, it could be ambiguous as to whether it applies the resistance or the attack bonus.