### PR TITLE
Add spell effect for Community Restoration's temporary Hit Points on self

### DIFF
--- a/packs/spell-effects/spell-effect-community-restoration.json
+++ b/packs/spell-effects/spell-effect-community-restoration.json
@@ -1,0 +1,161 @@
+{
+    "_id": "Be5TFiSqhRDvrm2J",
+    "img": "icons/magic/life/heart-hand-gold-green.webp",
+    "name": "Spell Effect: Community Restoration",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Community Restoration]</p>\n<p>You gain 2 temporary Hit Points per rank of the triggering spell.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "minutes",
+            "value": 1
+        },
+        "fromSpell": false,
+        "level": {
+            "value": 4
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core"
+        },
+        "rules": [
+            {
+                "choices": [
+                    {
+                        "label": "PF2E.SpecificRule.SpellRank.First",
+                        "value": 1
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.SpellRank.Second",
+                        "predicate": [
+                            {
+                                "gte": [
+                                    "self:level",
+                                    3
+                                ]
+                            }
+                        ],
+                        "value": 2
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.SpellRank.Third",
+                        "predicate": [
+                            {
+                                "gte": [
+                                    "self:level",
+                                    5
+                                ]
+                            }
+                        ],
+                        "value": 3
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.SpellRank.Fourth",
+                        "predicate": [
+                            {
+                                "gte": [
+                                    "self:level",
+                                    7
+                                ]
+                            }
+                        ],
+                        "value": 4
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.SpellRank.Fifth",
+                        "predicate": [
+                            {
+                                "gte": [
+                                    "self:level",
+                                    9
+                                ]
+                            }
+                        ],
+                        "value": 5
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.SpellRank.Sixth",
+                        "predicate": [
+                            {
+                                "gte": [
+                                    "self:level",
+                                    11
+                                ]
+                            }
+                        ],
+                        "value": 6
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.SpellRank.Seventh",
+                        "predicate": [
+                            {
+                                "gte": [
+                                    "self:level",
+                                    13
+                                ]
+                            }
+                        ],
+                        "value": 7
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.SpellRank.Eighth",
+                        "predicate": [
+                            {
+                                "gte": [
+                                    "self:level",
+                                    15
+                                ]
+                            }
+                        ],
+                        "value": 8
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.SpellRank.Ninth",
+                        "predicate": [
+                            {
+                                "gte": [
+                                    "self:level",
+                                    17
+                                ]
+                            }
+                        ],
+                        "value": 9
+                    },
+                    {
+                        "label": "PF2E.SpecificRule.SpellRank.Tenth",
+                        "predicate": [
+                            {
+                                "gte": [
+                                    "self:level",
+                                    19
+                                ]
+                            }
+                        ],
+                        "value": 10
+                    }
+                ],
+                "flag": "rank",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.SpellRank.Prompt"
+            },
+            {
+                "key": "TempHP",
+                "value": "2*@item.flags.pf2e.rulesSelections.rank"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/spells/focus/community-restoration.json
+++ b/packs/spells/focus/community-restoration.json
@@ -12,7 +12,7 @@
         "damage": {},
         "defense": null,
         "description": {
-            "value": "<p><strong>Trigger</strong> You Cast a Spell from a wizard spell slot, and the spell affects one or more willing allies without damaging them.</p>\n<hr />\n<p>When you use your magic to support your allies, shared strength bolsters you all. You gain 2 temporary Hit Points per rank of the triggering spell, and can grant an equal number divided as you choose among allies affected by the triggering spell. These temporary Hit Points last for 1 minute.</p>"
+            "value": "<p><strong>Trigger</strong> You Cast a Spell from a wizard spell slot, and the spell affects one or more willing allies without damaging them.</p><hr /><p>When you use your magic to support your allies, shared strength bolsters you all. You gain 2 temporary Hit Points per rank of the triggering spell, and can grant an equal number divided as you choose among allies affected by the triggering spell. These temporary Hit Points last for 1 minute.</p>\n<p>@UUID[Compendium.pf2e.spell-effects.Item.Spell Effect: Community Restoration]</p>"
         },
         "duration": {
             "sustained": false,


### PR DESCRIPTION
This doesn't handle the temporary Hit Points on allies if they're divided