### PR TITLE
Automate Consume Power

### DIFF
--- a/packs/feat-effects/effect-consume-power.json
+++ b/packs/feat-effects/effect-consume-power.json
@@ -1,0 +1,51 @@
+{
+    "_id": "m5kXngVAHiprZea1",
+    "img": "icons/magic/fire/barrier-shield-explosion-yellow.webp",
+    "name": "Effect: Consume Power",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Consume Power]</p>\n<p>You gain a status bonus equal to half your level to the damage of your metal impulse.</p>"
+        },
+        "duration": {
+            "expiry": "turn-end",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 1
+        },
+        "fromSpell": false,
+        "level": {
+            "value": 6
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": true,
+            "title": "Pathfinder Rage of Elements"
+        },
+        "rules": [
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "item:trait:metal",
+                    "item:trait:impulse"
+                ],
+                "selector": [
+                    "inline-damage",
+                    "impulse-damage"
+                ],
+                "type": "status",
+                "value": "floor(@actor.level/2 )"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/feats/class/kineticist/consume-power.json
+++ b/packs/feats/class/kineticist/consume-power.json
@@ -12,7 +12,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p><strong>Trigger</strong> You would take acid, electricity, fire, or sonic damage.</p>\n<hr />\n<p>You absorb energy and hold it in your kinetic gate. You gain resistance equal to your level to the triggering damage—choose one eligible type of resistance. If this reaction prevents any damage, you gain a status bonus equal to half your level to the damage roll of the next metal impulse you use before the end of your next turn.</p>"
+            "value": "<p><strong>Trigger</strong> You would take acid, electricity, fire, or sonic damage.</p><hr /><p>You absorb energy and hold it in your kinetic gate. You gain resistance equal to your level to the triggering damage—choose one eligible type of resistance. If this reaction prevents any damage, you gain a status bonus equal to half your level to the damage roll of the next metal impulse you use before the end of your next turn.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Consume Power]</p>"
         },
         "level": {
             "value": 6
@@ -25,7 +25,41 @@
             "remaster": true,
             "title": "Pathfinder Rage of Elements"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Kineticist.ConsumePower.ResistanceToggle",
+                "option": "consume-power",
+                "suboptions": [
+                    {
+                        "label": "PF2E.TraitAcid",
+                        "value": "acid"
+                    },
+                    {
+                        "label": "PF2E.TraitElectricity",
+                        "value": "electricity"
+                    },
+                    {
+                        "label": "PF2E.TraitFire",
+                        "value": "fire"
+                    },
+                    {
+                        "label": "PF2E.TraitSonic",
+                        "value": "sonic"
+                    }
+                ],
+                "toggleable": true
+            },
+            {
+                "key": "Resistance",
+                "predicate": [
+                    "consume-power"
+                ],
+                "type": "{item|flags.pf2e.rulesSelections.consumePower}",
+                "value": "@actor.level"
+            }
+        ],
+        "selfEffect": null,
         "traits": {
             "rarity": "common",
             "value": [

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -4913,6 +4913,7 @@
             "Kineticist": {
                 "ConsumePower": {
                     "ResistanceToggle": "Consume Power — Resistance"
+                },
                 "DesertWind": {
                     "DamageToggle": "Desert Wind — Extra damage"
                 },

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -4907,6 +4907,9 @@
                 "Trigger": "Your prey is within reach and attempts to move away from you."
             },
             "Kineticist": {
+                "ConsumePower": {
+                    "ResistanceToggle": "Consume Power — Resistance"
+                },
                 "ExtendedKinesis": {
                     "Proliferate": {
                         "Title": "Proliferate",


### PR DESCRIPTION
Not a self effect to avoid ambiguity with the resistance