### PR TITLE
Fix price updates when changing currency

### DIFF
--- a/src/module/item/physical/document.ts
+++ b/src/module/item/physical/document.ts
@@ -918,13 +918,16 @@ abstract class PhysicalItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | n
 
         if (operation.checkHP ?? true) handleHPChange(this, changed);
 
-        // Clear 0 price denominations and per fields with values 0 or 1
+        // Clear empty price denominations and per fields with values 0 or 1
         if (R.isPlainObject(changed.system.price)) {
             const price: Record<string, unknown> = changed.system.price;
             if (R.isPlainObject(price.value)) {
                 const coins = price.value;
+                const sourceCoins = this._source.system.price.value;
                 for (const denomination of DENOMINATIONS) {
-                    if (coins[denomination] === 0) coins[`-=${denomination}`] = null;
+                    if (!coins[denomination] && denomination in sourceCoins) {
+                        coins[`-=${denomination}`] = null;
+                    }
                 }
             }
             if ("per" in price) price.per = Math.max(1, Math.floor(Number(price.per) || 1));

--- a/src/module/item/physical/sheet.ts
+++ b/src/module/item/physical/sheet.ts
@@ -205,8 +205,7 @@ class PhysicalItemSheetPF2e<TItem extends PhysicalItemPF2e> extends ItemSheetPF2
 
         // Convert price from a string to an actual object
         if ("system.price.value" in formData) {
-            formData["system.price.==value"] = Coins.fromString(String(formData["system.price.value"])).toObject();
-            delete formData["system.price.value"];
+            formData["system.price.value"] = Coins.fromString(String(formData["system.price.value"])).toObject();
         }
 
         return super._updateObject(event, formData);


### PR DESCRIPTION
This fixes changing denominations on physical items, given that ==value does not work with pruned schema fields properly (it only works on next refresh). Migrating would also fix this, but if we can't migrate, this is what we must do instead.