### PR TITLE
Add the ability to use target's initiative for effect expiration

### DIFF
--- a/src/module/item/abstract-effect/data.ts
+++ b/src/module/item/abstract-effect/data.ts
@@ -67,7 +67,7 @@ interface DurationData {
     value: number;
     unit: TimeUnit | "unlimited" | "encounter";
     expiry: EffectExpiryType | null;
-    target: boolean;
+    useTarget: boolean;
 }
 
 class EffectContextField extends fields.SchemaField<
@@ -187,7 +187,7 @@ type DurationDataSchema = {
     value: fields.NumberField<number, number, true, false, true>;
     unit: fields.StringField<TimeUnit | "unlimited" | "encounter", TimeUnit | "unlimited" | "encounter", true, false>;
     expiry: fields.StringField<EffectExpiryType, EffectExpiryType, true, true>;
-    target: fields.BooleanField<boolean, boolean, false, false>;
+    useTarget: fields.BooleanField<boolean, boolean, false, false>;
 };
 
 type EffectBadgeCounterSchema = {

--- a/src/module/item/abstract-effect/data.ts
+++ b/src/module/item/abstract-effect/data.ts
@@ -67,6 +67,7 @@ interface DurationData {
     value: number;
     unit: TimeUnit | "unlimited" | "encounter";
     expiry: EffectExpiryType | null;
+    target: boolean;
 }
 
 class EffectContextField extends fields.SchemaField<
@@ -186,6 +187,7 @@ type DurationDataSchema = {
     value: fields.NumberField<number, number, true, false, true>;
     unit: fields.StringField<TimeUnit | "unlimited" | "encounter", TimeUnit | "unlimited" | "encounter", true, false>;
     expiry: fields.StringField<EffectExpiryType, EffectExpiryType, true, true>;
+    target: fields.BooleanField<boolean, boolean, false, false>;
 };
 
 type EffectBadgeCounterSchema = {

--- a/src/module/item/abstract-effect/helpers.ts
+++ b/src/module/item/abstract-effect/helpers.ts
@@ -33,7 +33,7 @@ export function calculateRemainingDuration(
         const fightyActor = effect.actor?.isOfType("familiar") ? (effect.actor.master ?? effect.actor) : effect.actor;
         const atTurnStart = () =>
             startInitiative === currentInitiative &&
-            (combatant.actor === (effect.origin ?? fightyActor) || durationData.target);
+            (combatant.actor === (effect.origin ?? fightyActor) || durationData.useTarget);
 
         result.expired =
             expiry === "turn-start"

--- a/src/module/item/abstract-effect/helpers.ts
+++ b/src/module/item/abstract-effect/helpers.ts
@@ -32,7 +32,8 @@ export function calculateRemainingDuration(
         // A familiar won't be represented in the encounter tracker: use the master in its place
         const fightyActor = effect.actor?.isOfType("familiar") ? (effect.actor.master ?? effect.actor) : effect.actor;
         const atTurnStart = () =>
-            startInitiative === currentInitiative && combatant.actor === (effect.origin ?? fightyActor);
+            startInitiative === currentInitiative &&
+            (combatant.actor === (effect.origin ?? fightyActor) || durationData.target);
 
         result.expired =
             expiry === "turn-start"

--- a/src/module/item/affliction/data.ts
+++ b/src/module/item/affliction/data.ts
@@ -144,6 +144,7 @@ class AfflictionSystemData extends ItemSystemModel<AfflictionPF2e, AfflictionSys
                     nullable: true,
                     initial: null,
                 }),
+                target: new fields.BooleanField({ required: false, nullable: false }),
             }),
             start: new fields.SchemaField({
                 value: new fields.NumberField({ required: true, nullable: false, initial: 0 }),

--- a/src/module/item/affliction/data.ts
+++ b/src/module/item/affliction/data.ts
@@ -144,7 +144,7 @@ class AfflictionSystemData extends ItemSystemModel<AfflictionPF2e, AfflictionSys
                     nullable: true,
                     initial: null,
                 }),
-                target: new fields.BooleanField({ required: false, nullable: false }),
+                useTarget: new fields.BooleanField({ required: false, nullable: false }),
             }),
             start: new fields.SchemaField({
                 value: new fields.NumberField({ required: true, nullable: false, initial: 0 }),

--- a/src/module/item/affliction/document.ts
+++ b/src/module/item/affliction/document.ts
@@ -85,7 +85,7 @@ class AfflictionPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extend
         const stageDuration: DurationData = {
             ...(stageData?.duration ?? { unit: "unlimited", value: -1 }),
             expiry: "turn-end",
-            target: true,
+            useTarget: true,
         };
         return calculateRemainingDuration(this, stageDuration);
     }

--- a/src/module/item/affliction/document.ts
+++ b/src/module/item/affliction/document.ts
@@ -85,6 +85,7 @@ class AfflictionPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extend
         const stageDuration: DurationData = {
             ...(stageData?.duration ?? { unit: "unlimited", value: -1 }),
             expiry: "turn-end",
+            target: true,
         };
         return calculateRemainingDuration(this, stageDuration);
     }

--- a/src/module/item/condition/data.ts
+++ b/src/module/item/condition/data.ts
@@ -85,7 +85,7 @@ class ConditionSystemData extends ItemSystemModel<ConditionPF2e, ConditionSystem
             value: -1,
             unit: "unlimited",
             expiry: null,
-            target: false,
+            useTarget: false,
         };
     }
 }

--- a/src/module/item/condition/data.ts
+++ b/src/module/item/condition/data.ts
@@ -85,6 +85,7 @@ class ConditionSystemData extends ItemSystemModel<ConditionPF2e, ConditionSystem
             value: -1,
             unit: "unlimited",
             expiry: null,
+            target: false,
         };
     }
 }

--- a/src/module/item/effect/data.ts
+++ b/src/module/item/effect/data.ts
@@ -62,6 +62,11 @@ class EffectSystemData extends ItemSystemModel<EffectPF2e, EffectSystemSchema> {
                     nullable: true,
                     initial: null,
                 }),
+                target: new fields.BooleanField({
+                    required: false,
+                    nullable: false,
+                    initial: false,
+                }),
                 sustained: new fields.BooleanField({ required: true, nullable: false, initial: false }),
             }),
             tokenIcon: new fields.SchemaField({

--- a/src/module/item/effect/data.ts
+++ b/src/module/item/effect/data.ts
@@ -62,7 +62,7 @@ class EffectSystemData extends ItemSystemModel<EffectPF2e, EffectSystemSchema> {
                     nullable: true,
                     initial: null,
                 }),
-                target: new fields.BooleanField({
+                useTarget: new fields.BooleanField({
                     required: false,
                     nullable: false,
                     initial: false,

--- a/src/module/item/effect/document.ts
+++ b/src/module/item/effect/document.ts
@@ -123,8 +123,18 @@ class EffectPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ab
         user: fd.BaseUser,
     ): Promise<boolean | void> {
         if (this.isOwned) {
-            const initiative = this.origin?.combatant?.initiative ?? game.combat?.combatant?.initiative ?? null;
-            this._source.system.start = { value: game.time.worldTime, initiative };
+            const use_target = data.system?.duration?.target ?? false;
+            const originInitiative = this.origin?.combatant?.initiative ?? game.combat?.combatant?.initiative ?? null;
+            const targetInitiative = this.actor?.combatant?.initiative ?? null;
+            const initiative = use_target ? targetInitiative : originInitiative;
+            const isTargetBefore = (targetInitiative ?? 0) > (originInitiative ?? 0);
+            const expiry = this._source.system.duration.expiry;
+            if (use_target && expiry) {
+                if (!(expiry === "turn-end" && isTargetBefore) && this._source.system.duration.value > 0) {
+                    this._source.system.duration.value -= 1;
+                }
+            }
+            this._source.system.start = { value: game.time.worldTime, initiative: initiative };
         }
 
         // If this is an immediate evaluation formula effect, pre-roll and change the badge type on creation

--- a/src/module/item/effect/document.ts
+++ b/src/module/item/effect/document.ts
@@ -123,13 +123,13 @@ class EffectPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ab
         user: fd.BaseUser,
     ): Promise<boolean | void> {
         if (this.isOwned) {
-            const use_target = data.system?.duration?.target ?? false;
+            const useTarget = data.system?.duration?.useTarget ?? false;
             const originInitiative = this.origin?.combatant?.initiative ?? game.combat?.combatant?.initiative ?? null;
             const targetInitiative = this.actor?.combatant?.initiative ?? null;
-            const initiative = use_target ? targetInitiative : originInitiative;
+            const initiative = useTarget ? targetInitiative : originInitiative;
             const isTargetBefore = (targetInitiative ?? 0) > (originInitiative ?? 0);
             const expiry = this._source.system.duration.expiry;
-            if (use_target && expiry) {
+            if (useTarget && expiry) {
                 if (!(expiry === "turn-end" && isTargetBefore) && this._source.system.duration.value > 0) {
                     this._source.system.duration.value -= 1;
                 }

--- a/src/module/rules/helpers.ts
+++ b/src/module/rules/helpers.ts
@@ -119,7 +119,13 @@ async function extractEphemeralEffects({
                     target: { actor: effectsTo.uuid, token: null },
                     roll: null,
                 };
-                effect.system.duration = { value: -1, unit: "unlimited", expiry: null, sustained: false };
+                effect.system.duration = {
+                    value: -1,
+                    unit: "unlimited",
+                    expiry: null,
+                    target: false,
+                    sustained: false,
+                };
             }
             return effect;
         });

--- a/src/module/rules/helpers.ts
+++ b/src/module/rules/helpers.ts
@@ -123,7 +123,7 @@ async function extractEphemeralEffects({
                     value: -1,
                     unit: "unlimited",
                     expiry: null,
-                    target: false,
+                    useTarget: false,
                     sustained: false,
                 };
             }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2462,7 +2462,7 @@
                     "EndOfTurn": "End of Turn",
                     "ExpiresOn": "Expires On",
                     "StartOfTurn": "Start of Turn",
-                    "Target": "Target's Turn"
+                    "UseTarget": "Target's Turn"
                 },
                 "Badge": {
                     "Add": "Add Badge",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2461,7 +2461,8 @@
                     "EndOfRound": "End of Round",
                     "EndOfTurn": "End of Turn",
                     "ExpiresOn": "Expires On",
-                    "StartOfTurn": "Start of Turn"
+                    "StartOfTurn": "Start of Turn",
+                    "Target": "Target's Turn"
                 },
                 "Badge": {
                     "Add": "Add Badge",

--- a/static/templates/items/effect-sidebar.hbs
+++ b/static/templates/items/effect-sidebar.hbs
@@ -17,9 +17,9 @@
                     {{selectOptions expiryOptions selected=data.duration.expiry localize=true}}
                 </select>
             </div>
-             <label for="{{item.uuid}}-duration-target">{{localize "PF2E.Item.Effect.Expiry.Target"}}</label>
+             <label for="{{item.uuid}}-duration-useTarget">{{localize "PF2E.Item.Effect.Expiry.UseTarget"}}</label>
             <div class="form-fields">
-                <input id="{{item.uuid}}-duration-target" type="checkbox" name="system.duration.target" {{checked data.duration.target}} />
+                <input id="{{item.uuid}}-duration-useTarget" type="checkbox" name="system.duration.useTarget" {{checked data.duration.useTarget}} />
             </div>
         </div>
     {{/unless}}

--- a/static/templates/items/effect-sidebar.hbs
+++ b/static/templates/items/effect-sidebar.hbs
@@ -17,6 +17,10 @@
                     {{selectOptions expiryOptions selected=data.duration.expiry localize=true}}
                 </select>
             </div>
+             <label for="{{item.uuid}}-duration-target">{{localize "PF2E.Item.Effect.Expiry.Target"}}</label>
+            <div class="form-fields">
+                <input id="{{item.uuid}}-duration-target" type="checkbox" name="system.duration.target" {{checked data.duration.target}} />
+            </div>
         </div>
     {{/unless}}
     <div class="form-group">


### PR DESCRIPTION
<img width="700" height="462" alt="изображение" src="https://github.com/user-attachments/assets/213b5e43-727f-487c-acdc-77f0086cc55e" />

This is somewhat a big change, so if it's not accepted, hopefully, someone will get inspired and makes a better attempt.
Adds a checkbox to the effect properties, that, when set, will use the target's initiative for the expiration of that effect.

Hopefully, closes #18990

Some considerations:
 - Due to the way durations are handled, every combination of initative order of target and origin except for one (target being earlier, end of the turn) requires the "next turn" to be a duration of 0; this is handled
 - This currently doesn't handle changing of target's initiative after the effect is applied. I think it's possible to handle, either per-effect before the expiry is checked _or_ on the initiative change; might not be worth it though
 - Having the ability to set the initiative of the effect's start manually would be nice, and probably would help with the previous point