### PR TITLE
Show a different warning if a weapon has ammo but not enough to fire

### DIFF
--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -1537,9 +1537,8 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
                 params.consumeAmmo = weapon.system.ammo?.builtIn ? false : (params.consumeAmmo ?? expend > 0);
 
                 if (params.consumeAmmo && expend > ammoRemaining) {
-                    ui.notifications.warn(
-                        game.i18n.format("PF2E.Strike.Ranged.NoAmmo", { weapon: weapon.name, actor: this.name }),
-                    );
+                    const message = ammoRemaining ? "PF2E.Strike.Ranged.InsufficientAmmo" : "PF2E.Strike.Ranged.NoAmmo";
+                    ui.notifications.warn(game.i18n.format(message, { weapon: weapon.name, actor: this.name }));
                     return null;
                 }
                 const targetToken = params.getFormula

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -4154,6 +4154,7 @@
             "Ranged": {
                 "Description": "You attack with a weapon you're wielding, targeting one creature within range. Roll the attack roll for the weapon you are using, and compare the result to the target creature's AC to determine the effect.",
                 "NoAmmo": "No ammunition is assigned to {weapon}. Check the Actions tab of {actor}'s sheet.",
+                "InsufficientAmmo": "Not enough ammunition is left in {weapon}. Check the Actions tab of {actor}'s sheet.",
                 "Success": "You deal damage according to the weapon, including any modifiers, bonuses, and penalties you have to damage."
             },
             "Unarmed": {


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/20864. Specifically by making the configuration issue more clear. The first half of that issue is already solved in development.