### PR TITLE
Grant slinger's reload and initial deed with their respective archetype feats

### DIFF
--- a/packs/classfeatures/way-of-the-drifter.json
+++ b/packs/classfeatures/way-of-the-drifter.json
@@ -44,6 +44,18 @@
                 "mode": "upgrade",
                 "path": "system.skills.acrobatics.rank",
                 "value": 1
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.gunslinger.slingersReload",
+                "value": "Compendium.pf2e.actionspf2e.Item.Reloading Strike"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.gunslinger.initialDeed",
+                "value": "Compendium.pf2e.actionspf2e.Item.Into the Fray"
             }
         ],
         "traits": {

--- a/packs/classfeatures/way-of-the-pistolero.json
+++ b/packs/classfeatures/way-of-the-pistolero.json
@@ -60,6 +60,18 @@
                 "mode": "upgrade",
                 "path": "system.skills.{item|flags.pf2e.rulesSelections.skill}.rank",
                 "value": 1
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.gunslinger.slingersReload",
+                "value": "Compendium.pf2e.actionspf2e.Item.Raconteur's Reload"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.gunslinger.initialDeed",
+                "value": "Compendium.pf2e.actionspf2e.Item.Ten Paces"
             }
         ],
         "traits": {

--- a/packs/classfeatures/way-of-the-sniper.json
+++ b/packs/classfeatures/way-of-the-sniper.json
@@ -44,6 +44,18 @@
                 "mode": "upgrade",
                 "path": "system.skills.stealth.rank",
                 "value": 1
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.gunslinger.slingersReload",
+                "value": "Compendium.pf2e.actionspf2e.Item.Covered Reload"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.gunslinger.initialDeed",
+                "value": "Compendium.pf2e.actionspf2e.Item.One Shot, One Kill"
             }
         ],
         "traits": {

--- a/packs/classfeatures/way-of-the-triggerbrand.json
+++ b/packs/classfeatures/way-of-the-triggerbrand.json
@@ -44,6 +44,18 @@
                     "class:gunslinger"
                 ],
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Touch and Go"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.gunslinger.slingersReload",
+                "value": "Compendium.pf2e.actionspf2e.Item.Touch and Go"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.gunslinger.initialDeed",
+                "value": "Compendium.pf2e.actionspf2e.Item.Spring the Trap"
             }
         ],
         "traits": {

--- a/packs/classfeatures/way-of-the-vanguard.json
+++ b/packs/classfeatures/way-of-the-vanguard.json
@@ -44,6 +44,18 @@
                 "mode": "upgrade",
                 "path": "system.skills.athletics.rank",
                 "value": 1
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.gunslinger.slingersReload",
+                "value": "Compendium.pf2e.actionspf2e.Item.Clear a Path"
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "override",
+                "path": "flags.pf2e.gunslinger.initialDeed",
+                "value": "Compendium.pf2e.actionspf2e.Item.Living Fortification"
             }
         ],
         "traits": {

--- a/packs/feats/archetype/gunslinger/practiced-reloads.json
+++ b/packs/feats/archetype/gunslinger/practiced-reloads.json
@@ -29,7 +29,12 @@
             "remaster": true,
             "title": "Pathfinder Guns & Gears"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "GrantItem",
+                "uuid": "{actor|flags.pf2e.gunslinger.initialDeed}"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/feats/archetype/gunslinger/slingers-readiness.json
+++ b/packs/feats/archetype/gunslinger/slingers-readiness.json
@@ -29,7 +29,12 @@
             "remaster": true,
             "title": "Pathfinder Guns & Gears"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "GrantItem",
+                "uuid": "{actor|flags.pf2e.gunslinger.slingersReload}"
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [


### PR DESCRIPTION
Existing archetype slingers won't have these flags, but luckily Grant Items are silent about it in the console, so it shouldn't need a migration