### PR TITLE
Fix AdjustModifier targeting on Effect Swift Standard

### DIFF
--- a/packs/equipment-effects/effect-swift-standard.json
+++ b/packs/equipment-effects/effect-swift-standard.json
@@ -82,6 +82,7 @@
                     "swift-standard:swift-standard-greater"
                 ],
                 "selector": "land-speed",
+                "slug": "swift-standard",
                 "value": 10
             },
             {
@@ -91,6 +92,7 @@
                     "swift-standard:swift-standard-major"
                 ],
                 "selector": "land-speed",
+                "slug": "swift-standard",
                 "value": 15
             }
         ],


### PR DESCRIPTION
Currently the adjust mods have no slug target, so affect all mods.