### PR TITLE
Fix auto-resolving Choice Set in draconic benefactor

### DIFF
--- a/packs/pf2e/ancestryfeatures/draconic-benefactor.json
+++ b/packs/pf2e/ancestryfeatures/draconic-benefactor.json
@@ -34,7 +34,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:adamantine"
                                 ]
@@ -55,7 +55,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:barrage"
                                 ]
@@ -76,7 +76,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:bog"
                                 ]
@@ -97,7 +97,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:brine"
                                 ]
@@ -118,7 +118,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:cinder"
                                 ]
@@ -139,7 +139,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:cloud"
                                 ]
@@ -160,7 +160,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:conspirator"
                                 ]
@@ -181,7 +181,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:coral"
                                 ]
@@ -202,7 +202,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:crystal"
                                 ]
@@ -223,7 +223,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:delight"
                                 ]
@@ -244,7 +244,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:despair"
                                 ]
@@ -265,7 +265,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:diabolic"
                                 ]
@@ -286,7 +286,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:empyreal"
                                 ]
@@ -307,7 +307,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:executor"
                                 ]
@@ -328,7 +328,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:forest"
                                 ]
@@ -349,7 +349,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:fortune"
                                 ]
@@ -370,7 +370,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:horned"
                                 ]
@@ -391,7 +391,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:magma"
                                 ]
@@ -412,7 +412,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:mirage"
                                 ]
@@ -433,7 +433,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:mirage"
                                 ]
@@ -454,7 +454,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:oath"
                                 ]
@@ -475,7 +475,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:omen"
                                 ]
@@ -496,7 +496,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:phase"
                                 ]
@@ -517,7 +517,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:requiem"
                                 ]
@@ -538,7 +538,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:resurrection"
                                 ]
@@ -559,7 +559,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:rime"
                                 ]
@@ -580,7 +580,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:rune"
                                 ]
@@ -601,7 +601,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:sage"
                                 ]
@@ -622,7 +622,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:sea"
                                 ]
@@ -643,7 +643,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:sky"
                                 ]
@@ -664,7 +664,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:sovereign"
                                 ]
@@ -685,7 +685,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:stormcrown"
                                 ]
@@ -706,7 +706,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:time"
                                 ]
@@ -727,7 +727,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:umbral"
                                 ]
@@ -748,7 +748,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:underworld"
                                 ]
@@ -769,7 +769,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:vizier"
                                 ]
@@ -790,7 +790,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:vorpal"
                                 ]
@@ -811,7 +811,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:wailing"
                                 ]
@@ -832,7 +832,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:whisper"
                                 ]
@@ -853,7 +853,7 @@
                             {
                                 "or": [
                                     {
-                                        "not": "feature:draconic-benefactor"
+                                        "not": "draconic-benefactor"
                                     },
                                     "draconic-benefactor:wish"
                                 ]
@@ -871,6 +871,10 @@
                 ],
                 "flag": "draconicBenefactor",
                 "key": "ChoiceSet"
+            },
+            {
+                "key": "RollOption",
+                "option": "draconic-benefactor"
             },
             {
                 "key": "RollOption",


### PR DESCRIPTION
Turns out `feature:draconic-benefactor` is already present by the time Choice Set executes, so going with this instead