### PR TITLE
Link Share Hunter's Edge effects and add edge-sharing feat description addenda in Hunt Prey action

### DIFF
--- a/packs/pf2e/class-features/flurry.json
+++ b/packs/pf2e/class-features/flurry.json
@@ -55,7 +55,7 @@
                 "property": "description",
                 "value": [
                     {
-                        "text": "{item|description}"
+                        "text": "PF2E.SpecificRule.Ranger.HuntersEdge.Flurry.Description"
                     },
                     {
                         "predicate": [
@@ -96,7 +96,7 @@
                 "property": "description",
                 "value": [
                     {
-                        "text": "{item|description}"
+                        "text": "PF2E.SpecificRule.Ranger.HuntersEdge.Flurry.Description"
                     },
                     {
                         "predicate": [

--- a/packs/pf2e/class-features/flurry.json
+++ b/packs/pf2e/class-features/flurry.json
@@ -84,6 +84,47 @@
                         "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Share Hunter's Edge (Flurry, Masterful)]"
                     }
                 ]
+            },
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:hunt-prey"
+                ],
+                "priority": 130,
+                "property": "description",
+                "value": [
+                    {
+                        "text": "{item|description}"
+                    },
+                    {
+                        "predicate": [
+                            {
+                                "or": [
+                                    "feat:animal-companion-ranger",
+                                    "feat:shared-prey"
+                                ]
+                            }
+                        ],
+                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Share Hunter's Edge (Flurry)]"
+                    },
+                    {
+                        "predicate": [
+                            "feat:masterful-companion",
+                            "feature:masterful-hunter"
+                        ],
+                        "text": "PF2E.SpecificRule.Ranger.MasterfulHunter.Flurry",
+                        "title": "PF2E.SpecificRule.Ranger.MasterfulHunter.Label"
+                    },
+                    {
+                        "predicate": [
+                            "feat:masterful-companion",
+                            "feature:masterful-hunter"
+                        ],
+                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Share Hunter's Edge (Flurry, Masterful)]"
+                    }
+                ]
             }
         ],
         "traits": {

--- a/packs/pf2e/class-features/outwit.json
+++ b/packs/pf2e/class-features/outwit.json
@@ -90,6 +90,47 @@
                         "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Share Hunter's Edge (Outwit, Masterful)]"
                     }
                 ]
+            },
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:hunt-prey"
+                ],
+                "priority": 130,
+                "property": "description",
+                "value": [
+                    {
+                        "text": "{item|description}"
+                    },
+                    {
+                        "predicate": [
+                            {
+                                "or": [
+                                    "feat:animal-companion-ranger",
+                                    "feat:shared-prey"
+                                ]
+                            }
+                        ],
+                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Share Hunter's Edge (Outwit)]"
+                    },
+                    {
+                        "predicate": [
+                            "feat:masterful-companion",
+                            "feature:masterful-hunter"
+                        ],
+                        "text": "PF2E.SpecificRule.Ranger.MasterfulHunter.Outwit",
+                        "title": "PF2E.SpecificRule.Ranger.MasterfulHunter.Label"
+                    },
+                    {
+                        "predicate": [
+                            "feat:masterful-companion",
+                            "feature:masterful-hunter"
+                        ],
+                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Share Hunter's Edge (Outwit, Masterful)]"
+                    }
+                ]
             }
         ],
         "traits": {

--- a/packs/pf2e/class-features/outwit.json
+++ b/packs/pf2e/class-features/outwit.json
@@ -61,7 +61,7 @@
                 "property": "description",
                 "value": [
                     {
-                        "text": "{item|description}"
+                        "text": "PF2E.SpecificRule.Ranger.HuntersEdge.Outwit.Description"
                     },
                     {
                         "predicate": [
@@ -102,7 +102,7 @@
                 "property": "description",
                 "value": [
                     {
-                        "text": "{item|description}"
+                        "text": "PF2E.SpecificRule.Ranger.HuntersEdge.Outwit.Description"
                     },
                     {
                         "predicate": [

--- a/packs/pf2e/class-features/precision.json
+++ b/packs/pf2e/class-features/precision.json
@@ -95,6 +95,47 @@
                         "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Share Hunter's Edge (Precision, Masterful)]"
                     }
                 ]
+            },
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:hunt-prey"
+                ],
+                "priority": 130,
+                "property": "description",
+                "value": [
+                    {
+                        "text": "{item|description}"
+                    },
+                    {
+                        "predicate": [
+                            {
+                                "or": [
+                                    "feat:animal-companion-ranger",
+                                    "feat:shared-prey"
+                                ]
+                            }
+                        ],
+                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Share Hunter's Edge (Precision)]"
+                    },
+                    {
+                        "predicate": [
+                            "feat:masterful-companion",
+                            "feature:masterful-hunter"
+                        ],
+                        "text": "PF2E.SpecificRule.Ranger.MasterfulHunter.Precision",
+                        "title": "PF2E.SpecificRule.Ranger.MasterfulHunter.Label"
+                    },
+                    {
+                        "predicate": [
+                            "feat:masterful-companion",
+                            "feature:masterful-hunter"
+                        ],
+                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Share Hunter's Edge (Precision, Masterful)]"
+                    }
+                ]
             }
         ],
         "traits": {

--- a/packs/pf2e/class-features/precision.json
+++ b/packs/pf2e/class-features/precision.json
@@ -66,7 +66,7 @@
                 "property": "description",
                 "value": [
                     {
-                        "text": "{item|description}"
+                        "text": "PF2E.SpecificRule.Ranger.HuntersEdge.Precision.Description"
                     },
                     {
                         "predicate": [
@@ -107,7 +107,7 @@
                 "property": "description",
                 "value": [
                     {
-                        "text": "{item|description}"
+                        "text": "PF2E.SpecificRule.Ranger.HuntersEdge.Precision.Description"
                     },
                     {
                         "predicate": [

--- a/packs/pf2e/class-features/vindicator.json
+++ b/packs/pf2e/class-features/vindicator.json
@@ -240,7 +240,7 @@
                                 ]
                             }
                         ],
-                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Share Hunter's Edge (Vindicator)]"
+                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Share Hunter's Edge (Vindication)]"
                     }
                 ]
             },

--- a/packs/pf2e/class-features/vindicator.json
+++ b/packs/pf2e/class-features/vindicator.json
@@ -229,7 +229,7 @@
                 "property": "description",
                 "value": [
                     {
-                        "text": "{item|description}"
+                        "text": "PF2E.SpecificRule.Ranger.Vindicator.BenefitsAddendum"
                     },
                     {
                         "predicate": [

--- a/packs/pf2e/class-features/vindicator.json
+++ b/packs/pf2e/class-features/vindicator.json
@@ -219,6 +219,32 @@
                 ]
             },
             {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:hunt-prey"
+                ],
+                "priority": 130,
+                "property": "description",
+                "value": [
+                    {
+                        "text": "{item|description}"
+                    },
+                    {
+                        "predicate": [
+                            {
+                                "or": [
+                                    "feat:animal-companion-ranger",
+                                    "feat:shared-prey"
+                                ]
+                            }
+                        ],
+                        "text": "@UUID[Compendium.pf2e.feat-effects.Item.Effect: Share Hunter's Edge (Vindicator)]"
+                    }
+                ]
+            },
+            {
                 "definition": [
                     "item:deity-favored",
                     "item:category:advanced"

--- a/packs/pf2e/feats/class/ranger/level-1/animal-companion-ranger.json
+++ b/packs/pf2e/feats/class/ranger/level-1/animal-companion-ranger.json
@@ -25,7 +25,25 @@
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:hunt-prey",
+                    {
+                        "not": "feat:masterful-companion"
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Ranger.AnimalCompanion.HuntPreyAddendum"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "otherTags": [
                 "hunters-edge-sharing"

--- a/packs/pf2e/feats/class/ranger/level-1/monster-hunter.json
+++ b/packs/pf2e/feats/class/ranger/level-1/monster-hunter.json
@@ -25,22 +25,7 @@
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [
-            {
-                "itemType": "action",
-                "key": "ItemAlteration",
-                "mode": "add",
-                "predicate": [
-                    "item:slug:hunt-prey"
-                ],
-                "property": "description",
-                "value": [
-                    {
-                        "text": "{item|description}"
-                    }
-                ]
-            }
-        ],
+        "rules": [],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/pf2e/feats/class/ranger/level-1/monster-hunter.json
+++ b/packs/pf2e/feats/class/ranger/level-1/monster-hunter.json
@@ -25,7 +25,22 @@
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:hunt-prey"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "{item|description}"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/pf2e/feats/class/ranger/level-12/double-prey.json
+++ b/packs/pf2e/feats/class/ranger/level-12/double-prey.json
@@ -25,7 +25,25 @@
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:hunt-prey",
+                    {
+                        "not": "feat:triple-threat"
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "{item|description}"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/pf2e/feats/class/ranger/level-12/double-prey.json
+++ b/packs/pf2e/feats/class/ranger/level-12/double-prey.json
@@ -39,7 +39,7 @@
                 "property": "description",
                 "value": [
                     {
-                        "text": "{item|description}"
+                        "text": "PF2E.SpecificRule.Ranger.DoublePrey.HuntPreyAddendum"
                     }
                 ]
             }

--- a/packs/pf2e/feats/class/ranger/level-14/shared-prey.json
+++ b/packs/pf2e/feats/class/ranger/level-14/shared-prey.json
@@ -46,7 +46,7 @@
                 "property": "description",
                 "value": [
                     {
-                        "text": "{item|description}"
+                        "text": "PF2E.SpecificRule.Ranger.SharedPrey.HuntPreyAddendum"
                     }
                 ]
             }

--- a/packs/pf2e/feats/class/ranger/level-14/shared-prey.json
+++ b/packs/pf2e/feats/class/ranger/level-14/shared-prey.json
@@ -32,7 +32,25 @@
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:hunt-prey",
+                    {
+                        "not": "feat:triple-threat"
+                    }
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "{item|description}"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "otherTags": [
                 "hunters-edge-sharing"

--- a/packs/pf2e/feats/class/ranger/level-18/masterful-companion.json
+++ b/packs/pf2e/feats/class/ranger/level-18/masterful-companion.json
@@ -32,7 +32,22 @@
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:hunt-prey"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "PF2E.SpecificRule.Ranger.MasterfulCompanion.HuntPreyAddendum"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/pf2e/feats/class/ranger/level-20/triple-threat.json
+++ b/packs/pf2e/feats/class/ranger/level-20/triple-threat.json
@@ -40,7 +40,7 @@
                 "property": "description",
                 "value": [
                     {
-                        "text": "{item|description}"
+                        "text": "PF2E.SpecificRule.Ranger.TripleThreat.HuntPreyAddendum"
                     }
                 ]
             }

--- a/packs/pf2e/feats/class/ranger/level-20/triple-threat.json
+++ b/packs/pf2e/feats/class/ranger/level-20/triple-threat.json
@@ -29,7 +29,22 @@
             "remaster": true,
             "title": "Pathfinder Player Core"
         },
-        "rules": [],
+        "rules": [
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:slug:hunt-prey"
+                ],
+                "property": "description",
+                "value": [
+                    {
+                        "text": "{item|description}"
+                    }
+                ]
+            }
+        ],
         "traits": {
             "otherTags": [
                 "hunters-edge-sharing"

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -5864,6 +5864,12 @@
                 }
             },
             "Ranger": {
+                "AnimalCompanion": {
+                    "HuntPreyAddendum": "When you Hunt Prey, your animal companion gains the action's benefits and your hunter's edge benefit if you have one."
+                },
+                "DoublePrey": {
+                    "HuntPreyAddendum": "When you use the Hunt Prey action, you can pick two creatures as your prey."
+                },
                 "FocusSpells": {
                     "GravityWeapon": {
                         "RollOptionLabel": "Gravity Weapon — First weapon Strike this round"
@@ -5887,15 +5893,24 @@
                     },
                     "Prompt": "Select a hunter's edge."
                 },
+                "MasterfulCompanion": {
+                    "HuntPreyAddendum": "When you Hunt Prey, your animal companion gains the masterful hunter benefit associated with your hunter's edge, rather than just your original hunter's edge benefit."
+                },
                 "MasterfulHunter": {
                     "Flurry": "If you have master proficiency with your weapon, your multiple attack penalty for attacks against your hunted prey is –2 (–1 with an agile weapon) on your second attack of the turn, and –4 (–2 with an agile weapon) on your third and subsequent attacks of the turn.",
                     "Label": "Masterful Hunter",
                     "Outwit": "Your mastery of skills allows you to overwhelm your prey. If you have master proficiency in Deception, Intimidation, Stealth, or the skill you use to Recall Knowledge about your prey, increase the circumstance bonus against the prey with that skill from +2 to +4. If you have master proficiency with your armor, increase the circumstance bonus to AC against the prey from +1 to +2.",
                     "Precision": "Your weapon mastery allows you to hit your prey's vital areas multiple times. The second time in a round you hit your hunted prey, you also deal 1d8 precision damage. At 19th level, your second hit in a round against your hunted prey deals 2d8 precision damage, and your third hit in a round against your hunted prey deals 1d8 precision damage."
                 },
+                "SharedPrey": {
+                    "HuntPreyAddendum": "When you use Hunt Prey and select only one prey, you can grant your Hunt Prey benefits and hunter's edge to an ally in addition to gaining them yourself. The ally retains these benefits until you use Hunt Prey again."
+                },
                 "TheHarderTheyFall": {
                     "CriticalSuccess": "On a critical success, your target takes @Damage[(ternary(gte(@actor.system.skills.athletics.rank,3),4,2))d8[bludgeoning]] damage.",
                     "Success": "On a success, your target takes @Damage[(ternary(gte(@actor.system.skills.athletics.rank,3),2,1))d8[bludgeoning]] damage."
+                },
+                "TripleThreat": {
+                    "HuntPreyAddendum": "When you use Hunt Prey, you can designate three creatures as prey, designate two creatures as prey and share the effect with one ally (as Shared Prey), or designate one creature as prey and share the effect with two allies."
                 },
                 "Vindicator": {
                     "BenefitsAddendum": "You gain a +1 status bonus to your spell attack rolls against your hunted prey, and they take a –1 status penalty to their saving throws against divine spells you cast.",

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -5882,12 +5882,15 @@
                 "HuntersEdge": {
                     "FirstAttack": "First attack on hunted prey this round",
                     "Flurry": {
+                        "Description": "Your multiple attack penalty for attacks against your hunted prey is –3 (–2 with an agile attack) on your second attack of the turn instead of –5, and –6 (–4 with an agile attack) on your third or subsequent attack of the turn, instead of –10.",
                         "Label": "Flurry"
                     },
                     "Outwit": {
+                        "Description": "You gain a +1 circumstance bonus to AC against your prey's attacks and a +2 circumstance bonus to Deception checks, Intimidation checks, Stealth checks, and any checks to Recall Knowledge about the prey.",
                         "Label": "Outwit"
                     },
                     "Precision": {
+                        "Description": "The first time you hit your hunted prey in a round, you also deal 1d8 additional precision damage. At 11th level, the extra damage increases to 2d8 precision damage, and at 19th level, the extra damage increases to 3d8 precision damage.",
                         "Label": "Precision",
                         "ToggleLabel": "Precision — Hit against Hunted Prey"
                     },
@@ -5899,8 +5902,8 @@
                 "MasterfulHunter": {
                     "Flurry": "If you have master proficiency with your weapon, your multiple attack penalty for attacks against your hunted prey is –2 (–1 with an agile weapon) on your second attack of the turn, and –4 (–2 with an agile weapon) on your third and subsequent attacks of the turn.",
                     "Label": "Masterful Hunter",
-                    "Outwit": "Your mastery of skills allows you to overwhelm your prey. If you have master proficiency in Deception, Intimidation, Stealth, or the skill you use to Recall Knowledge about your prey, increase the circumstance bonus against the prey with that skill from +2 to +4. If you have master proficiency with your armor, increase the circumstance bonus to AC against the prey from +1 to +2.",
-                    "Precision": "Your weapon mastery allows you to hit your prey's vital areas multiple times. The second time in a round you hit your hunted prey, you also deal 1d8 precision damage. At 19th level, your second hit in a round against your hunted prey deals 2d8 precision damage, and your third hit in a round against your hunted prey deals 1d8 precision damage."
+                    "Outwit": "If you have master proficiency in Deception, Intimidation, Stealth, or the skill you use to Recall Knowledge about your prey, increase the circumstance bonus against the prey with that skill from +2 to +4. If you have master proficiency with your armor, increase the circumstance bonus to AC against the prey from +1 to +2.",
+                    "Precision": "The second time in a round you hit your hunted prey, you also deal 1d8 precision damage. At 19th level, your second hit in a round against your hunted prey deals 2d8 precision damage, and your third hit in a round against your hunted prey deals 1d8 precision damage."
                 },
                 "SharedPrey": {
                     "HuntPreyAddendum": "When you use Hunt Prey and select only one prey, you can grant your Hunt Prey benefits and hunter's edge to an ally in addition to gaining them yourself. The ally retains these benefits until you use Hunt Prey again."


### PR DESCRIPTION
It gets quite long at high levels, so I've localized shortened, fluff-free versions of the descriptions to make it more bearable. Worth noting that, as of now, these alterations don't show up on self-applied effects. But it should help with getting easier access to these effects normally linked within their own feats.

<img width="296" height="1080" alt="image" src="https://github.com/user-attachments/assets/2fbdbd78-a766-400d-8aac-df0cc980bd6d" />
