### PR TITLE
Remove improper `select-item` id override

### DIFF
--- a/src/module/system/action-macros/crafting/select-item.ts
+++ b/src/module/system/action-macros/crafting/select-item.ts
@@ -21,6 +21,7 @@ class SelectItemDialog extends SvelteApplicationMixin(fa.api.ApplicationV2) {
     }
 
     static override DEFAULT_OPTIONS: DeepPartial<SelectItemConfiguration> = {
+        id: "select-item-dialog",
         position: { width: 270 },
         window: {
             icon: "fa-solid fa-hammer",
@@ -30,10 +31,6 @@ class SelectItemDialog extends SvelteApplicationMixin(fa.api.ApplicationV2) {
     override root = Root;
 
     declare protected $state: SelectItemState;
-
-    override get id(): string {
-        return `select-item-dialog-${this.#action}`;
-    }
 
     override get title(): string {
         const key = sluggify(this.#action, { camel: "bactrian" });


### PR DESCRIPTION
Fixes an issue from #20939. While peaking at some other things that could be converted to AppV2, I learned the id getter should not be overridden, instead should be configured in `_initializeApplicationOptions`. In this case there isn't really a need to ensure there's only one instance of the window though.