### PR TITLE
Fix ternary expression for Scales of Steel ancestry feat

### DIFF
--- a/packs/pf2e/feats/ancestry/dragonet/level-1/scales-of-steel.json
+++ b/packs/pf2e/feats/ancestry/dragonet/level-1/scales-of-steel.json
@@ -47,7 +47,7 @@
                 ],
                 "slug": "scales-of-steel",
                 "type": "item",
-                "value": "ternary(gte(@actor.level,5)2,1)"
+                "value": "ternary(gte(@actor.level,5),2,1)"
             },
             {
                 "key": "AdjustModifier",
@@ -66,7 +66,7 @@
                 ],
                 "relabel": "{item|name}",
                 "selector": "ac",
-                "value": "ternary(gte(@actor.level,5)2,1)"
+                "value": "ternary(gte(@actor.level,5),2,1)"
             }
         ],
         "subfeatures": {


### PR DESCRIPTION
This PR fixes an incorrect ternary in `Scales of Steel` feat for Dragonet ancestry.