### PR TITLE
Add support for spell gems in sf2e

### DIFF
--- a/packs/sf2e/equipment/consumables/spell-gems/spell-gem-10th-rank-spell.json
+++ b/packs/sf2e/equipment/consumables/spell-gems/spell-gem-10th-rank-spell.json
@@ -8,7 +8,7 @@
         "bulk": {
             "value": 0.1
         },
-        "category": "other",
+        "category": "spell-gem",
         "containerId": null,
         "damage": null,
         "description": {

--- a/packs/sf2e/equipment/consumables/spell-gems/spell-gem-1st-rank-spell.json
+++ b/packs/sf2e/equipment/consumables/spell-gems/spell-gem-1st-rank-spell.json
@@ -8,7 +8,7 @@
         "bulk": {
             "value": 0.1
         },
-        "category": "other",
+        "category": "spell-gem",
         "containerId": null,
         "damage": null,
         "description": {

--- a/packs/sf2e/equipment/consumables/spell-gems/spell-gem-2nd-rank-spell.json
+++ b/packs/sf2e/equipment/consumables/spell-gems/spell-gem-2nd-rank-spell.json
@@ -8,7 +8,7 @@
         "bulk": {
             "value": 0.1
         },
-        "category": "other",
+        "category": "spell-gem",
         "containerId": null,
         "damage": null,
         "description": {

--- a/packs/sf2e/equipment/consumables/spell-gems/spell-gem-3rd-rank-spell.json
+++ b/packs/sf2e/equipment/consumables/spell-gems/spell-gem-3rd-rank-spell.json
@@ -8,7 +8,7 @@
         "bulk": {
             "value": 0.1
         },
-        "category": "other",
+        "category": "spell-gem",
         "containerId": null,
         "damage": null,
         "description": {

--- a/packs/sf2e/equipment/consumables/spell-gems/spell-gem-4th-rank-spell.json
+++ b/packs/sf2e/equipment/consumables/spell-gems/spell-gem-4th-rank-spell.json
@@ -8,7 +8,7 @@
         "bulk": {
             "value": 0.1
         },
-        "category": "other",
+        "category": "spell-gem",
         "containerId": null,
         "damage": null,
         "description": {

--- a/packs/sf2e/equipment/consumables/spell-gems/spell-gem-5th-rank-spell.json
+++ b/packs/sf2e/equipment/consumables/spell-gems/spell-gem-5th-rank-spell.json
@@ -8,7 +8,7 @@
         "bulk": {
             "value": 0.1
         },
-        "category": "other",
+        "category": "spell-gem",
         "containerId": null,
         "damage": null,
         "description": {

--- a/packs/sf2e/equipment/consumables/spell-gems/spell-gem-6th-rank-spell.json
+++ b/packs/sf2e/equipment/consumables/spell-gems/spell-gem-6th-rank-spell.json
@@ -8,7 +8,7 @@
         "bulk": {
             "value": 0.1
         },
-        "category": "other",
+        "category": "spell-gem",
         "containerId": null,
         "damage": null,
         "description": {

--- a/packs/sf2e/equipment/consumables/spell-gems/spell-gem-7th-rank-spell.json
+++ b/packs/sf2e/equipment/consumables/spell-gems/spell-gem-7th-rank-spell.json
@@ -8,7 +8,7 @@
         "bulk": {
             "value": 0.1
         },
-        "category": "other",
+        "category": "spell-gem",
         "containerId": null,
         "damage": null,
         "description": {

--- a/packs/sf2e/equipment/consumables/spell-gems/spell-gem-8th-rank-spell.json
+++ b/packs/sf2e/equipment/consumables/spell-gems/spell-gem-8th-rank-spell.json
@@ -8,7 +8,7 @@
         "bulk": {
             "value": 0.1
         },
-        "category": "other",
+        "category": "spell-gem",
         "containerId": null,
         "damage": null,
         "description": {

--- a/packs/sf2e/equipment/consumables/spell-gems/spell-gem-9th-rank-spell.json
+++ b/packs/sf2e/equipment/consumables/spell-gems/spell-gem-9th-rank-spell.json
@@ -8,7 +8,7 @@
         "bulk": {
             "value": 0.1
         },
-        "category": "other",
+        "category": "spell-gem",
         "containerId": null,
         "damage": null,
         "description": {

--- a/src/module/actor/character/crafting/helpers.ts
+++ b/src/module/actor/character/crafting/helpers.ts
@@ -113,7 +113,7 @@ export async function craftSpellConsumable(
     actor: ActorPF2e,
 ): Promise<void> {
     const consumableType = item.category;
-    if (!(consumableType === "scroll" || consumableType === "wand")) return;
+    if (!["scroll", "wand", "spell-gem"].includes(consumableType)) return;
     const rank = (consumableType === "wand" ? Math.ceil(item.level / 2) - 1 : Math.ceil(item.level / 2)) as OneToTen;
     const validSpells = actor.itemTypes.spell
         .filter((s) => s.baseRank <= rank && !s.isCantrip && !s.isFocusSpell && !s.isRitual)

--- a/src/module/actor/creature/document.ts
+++ b/src/module/actor/creature/document.ts
@@ -284,7 +284,7 @@ abstract class CreaturePF2e<
 
         // Add spell collections from spell consumables if a matching spellcasting ability is found
         const spellConsumables = this.itemTypes.consumable.filter(
-            (c) => ["scroll", "wand"].includes(c.category) && c.isIdentified && !c.isStowed,
+            (c) => ["scroll", "wand", "spell-gem"].includes(c.category) && c.isIdentified && !c.isStowed,
         );
         for (const consumable of spellConsumables) {
             const spell = consumable.embeddedSpell;

--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -383,7 +383,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
             if (
                 currentSource.type === "consumable" &&
                 currentSource.system.spell?.system?.traits &&
-                tupleHasValue(["scroll", "wand"], currentSource.system.category) &&
+                tupleHasValue(["scroll", "spell-gem", "wand"], currentSource.system.category) &&
                 latestSource.type === "consumable" &&
                 !latestSource.system.spell
             ) {

--- a/src/module/item/consumable/document.ts
+++ b/src/module/item/consumable/document.ts
@@ -80,7 +80,7 @@ class ConsumablePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extend
             ? [game.i18n.localize(CONFIG.PF2E.consumableCategories[this.category]), true]
             : [
                   this.generateUnidentifiedName({ typeOnly: true }),
-                  !["other", "scroll", "talisman", "toolkit", "wand"].includes(this.category),
+                  !["other", "scroll", "spell-gem", "talisman", "toolkit", "wand"].includes(this.category),
               ];
 
         const usesLabel = game.i18n.localize("PF2E.Item.Consumable.Uses.Label");
@@ -131,7 +131,7 @@ class ConsumablePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extend
         if (!actor) return;
         const uses = this.uses;
 
-        if (["scroll", "wand"].includes(this.category) && this.system.spell) {
+        if (["scroll", "spell-gem", "wand"].includes(this.category) && this.system.spell) {
             if (actor.spellcasting?.canCastConsumable(this)) {
                 this.castEmbeddedSpell();
             } else if (actor.itemTypes.feat.some((feat) => feat.slug === "trick-magic-item")) {

--- a/src/module/item/consumable/sheet.ts
+++ b/src/module/item/consumable/sheet.ts
@@ -19,7 +19,7 @@ class ConsumableSheetPF2e extends PhysicalItemSheetPF2e<ConsumablePF2e> {
             !!item.system.damage &&
             ["vitality", "void", "untyped"].includes(item.system.damage.type);
         const embeddedSpell = item.actor ? item.embeddedSpell : null;
-        const shouldHaveSpell = !!embeddedSpell || ["scroll", "wand"].includes(item.system.category);
+        const shouldHaveSpell = !!embeddedSpell || ["scroll", "spell-gem", "wand"].includes(item.system.category);
 
         return {
             ...sheetData,

--- a/src/module/item/consumable/values.ts
+++ b/src/module/item/consumable/values.ts
@@ -10,6 +10,7 @@ const CONSUMABLE_CATEGORIES = new Set([
     "poison",
     "potion",
     "scroll",
+    "spell-gem",
     "snare",
     "talisman",
     "toolkit",

--- a/src/module/item/spellcasting-entry/data.ts
+++ b/src/module/item/spellcasting-entry/data.ts
@@ -71,9 +71,9 @@ interface SpellCollectionTypeData extends SpellCollectionTypeSource {
 
 export type {
     SlotKey,
-    SpellDifficultyClass,
     SpellcastingEntrySlots,
     SpellcastingEntrySource,
     SpellcastingEntrySystemData,
     SpellcastingEntrySystemSource,
+    SpellDifficultyClass,
 };

--- a/src/scripts/config/index.ts
+++ b/src/scripts/config/index.ts
@@ -764,40 +764,60 @@ export const PF2ECONFIG = {
         ritual: "PF2E.PreparationTypeRitual",
     },
 
-    spellcastingItems: {
-        scroll: {
-            name: "PF2E.Item.Consumable.Category.scroll",
-            nameTemplate: "PF2E.Item.Physical.FromSpell.Scroll",
-            compendiumUuids: {
-                1: "Compendium.pf2e.equipment-srd.Item.RjuupS9xyXDLgyIr",
-                2: "Compendium.pf2e.equipment-srd.Item.Y7UD64foDbDMV9sx",
-                3: "Compendium.pf2e.equipment-srd.Item.ZmefGBXGJF3CFDbn",
-                4: "Compendium.pf2e.equipment-srd.Item.QSQZJ5BC3DeHv153",
-                5: "Compendium.pf2e.equipment-srd.Item.tjLvRWklAylFhBHQ",
-                6: "Compendium.pf2e.equipment-srd.Item.4sGIy77COooxhQuC",
-                7: "Compendium.pf2e.equipment-srd.Item.fomEZZ4MxVVK3uVu",
-                8: "Compendium.pf2e.equipment-srd.Item.iPki3yuoucnj7bIt",
-                9: "Compendium.pf2e.equipment-srd.Item.cFHomF3tty8Wi1e5",
-                10: "Compendium.pf2e.equipment-srd.Item.o1XIHJ4MJyroAHfF",
-            },
-        },
-        wand: {
-            name: "PF2E.Item.Consumable.Category.wand",
-            nameTemplate: "PF2E.Item.Physical.FromSpell.Wand",
-            compendiumUuids: {
-                1: "Compendium.pf2e.equipment-srd.Item.UJWiN0K3jqVjxvKk",
-                2: "Compendium.pf2e.equipment-srd.Item.vJZ49cgi8szuQXAD",
-                3: "Compendium.pf2e.equipment-srd.Item.wrDmWkGxmwzYtfiA",
-                4: "Compendium.pf2e.equipment-srd.Item.Sn7v9SsbEDMUIwrO",
-                5: "Compendium.pf2e.equipment-srd.Item.5BF7zMnrPYzyigCs",
-                6: "Compendium.pf2e.equipment-srd.Item.kiXh4SUWKr166ZeM",
-                7: "Compendium.pf2e.equipment-srd.Item.nmXPj9zuMRQBNT60",
-                8: "Compendium.pf2e.equipment-srd.Item.Qs8RgNH6thRPv2jt",
-                9: "Compendium.pf2e.equipment-srd.Item.Fgv722039TVM5JTc",
-                10: null,
-            },
-        },
-    },
+    spellcastingItems:
+        SYSTEM_ID === "pf2e"
+            ? {
+                  scroll: {
+                      name: "PF2E.Item.Consumable.Category.scroll",
+                      nameTemplate: "PF2E.Item.Physical.FromSpell.Scroll",
+                      compendiumUuids: {
+                          1: "Compendium.pf2e.equipment-srd.Item.RjuupS9xyXDLgyIr",
+                          2: "Compendium.pf2e.equipment-srd.Item.Y7UD64foDbDMV9sx",
+                          3: "Compendium.pf2e.equipment-srd.Item.ZmefGBXGJF3CFDbn",
+                          4: "Compendium.pf2e.equipment-srd.Item.QSQZJ5BC3DeHv153",
+                          5: "Compendium.pf2e.equipment-srd.Item.tjLvRWklAylFhBHQ",
+                          6: "Compendium.pf2e.equipment-srd.Item.4sGIy77COooxhQuC",
+                          7: "Compendium.pf2e.equipment-srd.Item.fomEZZ4MxVVK3uVu",
+                          8: "Compendium.pf2e.equipment-srd.Item.iPki3yuoucnj7bIt",
+                          9: "Compendium.pf2e.equipment-srd.Item.cFHomF3tty8Wi1e5",
+                          10: "Compendium.pf2e.equipment-srd.Item.o1XIHJ4MJyroAHfF",
+                      },
+                  },
+                  wand: {
+                      name: "PF2E.Item.Consumable.Category.wand",
+                      nameTemplate: "PF2E.Item.Physical.FromSpell.Wand",
+                      compendiumUuids: {
+                          1: "Compendium.pf2e.equipment-srd.Item.UJWiN0K3jqVjxvKk",
+                          2: "Compendium.pf2e.equipment-srd.Item.vJZ49cgi8szuQXAD",
+                          3: "Compendium.pf2e.equipment-srd.Item.wrDmWkGxmwzYtfiA",
+                          4: "Compendium.pf2e.equipment-srd.Item.Sn7v9SsbEDMUIwrO",
+                          5: "Compendium.pf2e.equipment-srd.Item.5BF7zMnrPYzyigCs",
+                          6: "Compendium.pf2e.equipment-srd.Item.kiXh4SUWKr166ZeM",
+                          7: "Compendium.pf2e.equipment-srd.Item.nmXPj9zuMRQBNT60",
+                          8: "Compendium.pf2e.equipment-srd.Item.Qs8RgNH6thRPv2jt",
+                          9: "Compendium.pf2e.equipment-srd.Item.Fgv722039TVM5JTc",
+                          10: null,
+                      },
+                  },
+              }
+            : {
+                  "spell-gem": {
+                      name: "PF2E.Item.Consumable.Category.spell-gem",
+                      nameTemplate: "PF2E.Item.Physical.FromSpell.spell-gem",
+                      compendiumUuids: {
+                          1: "Compendium.sf2e.equipment.Item.R6LuVXimv1Hh8ehE",
+                          2: "Compendium.sf2e.equipment.Item.p5DYjh3sCSjzrBBg",
+                          3: "Compendium.sf2e.equipment.Item.Nwl7YydQ0r8cAhw7",
+                          4: "Compendium.sf2e.equipment.Item.88IBM9viOjJ0kJbm",
+                          5: "Compendium.sf2e.equipment.Item.BVCQFla90m2JDepV",
+                          6: "Compendium.sf2e.equipment.Item.9PAmdF8UqVQKXWPA",
+                          7: "Compendium.sf2e.equipment.Item.JgvLQeWK45OxFrx0",
+                          8: "Compendium.sf2e.equipment.Item.Vt6VVUXFf1boNs3P",
+                          9: "Compendium.sf2e.equipment.Item.8nNTrkf4ZCqkApNT",
+                          10: "Compendium.sf2e.equipment.Item.ulNSlan9Q5j1ozPI",
+                      },
+                  },
+              },
 
     attitude: {
         hostile: "PF2E.Attitudes.Hostile",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2075,6 +2075,7 @@
                     "elixir": "Elixir",
                     "fulu": "Fulu",
                     "gadget": "Gadget",
+                    "spell-gem": "Spell Gem",
                     "mutagen": "Mutagen",
                     "oil": "Oil",
                     "other": "Other",
@@ -2661,6 +2662,7 @@
                 "FromSpell": {
                     "CantripDeck5": "Cantrip Deck of {name} (5-pack)",
                     "Scroll": "Scroll of {name} (Rank {level})",
+                    "spell-gem": "Spell Gem of {name} (Rank {level})",
                     "Wand": "Wand of {name} (Rank {level})"
                 },
                 "GeneratedName": {


### PR DESCRIPTION
Spell gems are exactly like scrolls except they don't get the scroll trait (or any trait), some abilities refer to them specifically, and they can be embedded into equipment with the `aeon` trait.