### PR TITLE
Move SF2e Actions check to correct location

### DIFF
--- a/static/lang/action-en.json
+++ b/static/lang/action-en.json
@@ -1175,6 +1175,7 @@
             "acrobatics": "Acrobatics Check",
             "arcana": "Arcana Check",
             "athletics": "Athletics Check",
+            "computers": "Computers Check",
             "crafting": "Crafting Check",
             "deception": "Deception Check",
             "diplomacy": "Diplomacy Check",
@@ -1185,6 +1186,7 @@
             "occultism": "Occultism Check",
             "perception": "Perception Check",
             "performance": "Performance Check",
+            "piloting": "Piloting Check",
             "reflex": "Reflex Saving Throw",
             "religion": "Religion Check",
             "society": "Society Check",
@@ -1194,8 +1196,8 @@
             "thievery": "Thievery Check",
             "unarmed": "Unarmed Attack Roll",
             "will": "Will Saving Throw",
-            "x": "{type} Check",
-            "x-attack-roll": "{type} Attack Roll"
+            "x-attack-roll": "{type} Attack Roll",
+            "x": "{type} Check"
         },
         "ActionsSampleTasks": {
             "Title": "Sample {action} Tasks"

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -6781,10 +6781,6 @@
         }
     },
     "SF2E": {
-        "ActionsCheck": {
-            "computers": "Computers Check",
-            "piloting": "Piloting Check"
-        },
         "Actor": {
             "Creature": {
                 "Language": {


### PR DESCRIPTION
Statistic relies on the action check being in a certain place for it to work.