### PR TITLE
Add description alteration for juvenile flight feat: The Sequel

### DIFF
--- a/packs/pf2e/feats/ancestry/strix/level-5/juvenile-flight.json
+++ b/packs/pf2e/feats/ancestry/strix/level-5/juvenile-flight.json
@@ -40,6 +40,20 @@
                 ],
                 "selector": "fly-speed",
                 "value": 10
+            },
+            {
+                "key": "ItemAlteration",
+                "mode": "add",
+                "property": "description",
+                "itemType": "feat",
+                "value": [
+                    {
+                        "text": "{item|description}"
+                    }
+                ],
+                "predicate": [
+                    "item:slug:fledgling-flight"
+                ]
             }
         ],
         "selfEffect": {


### PR DESCRIPTION
As #20971 but after the git warzone.

> In my experience people are more likely to look at the actions to refer to the rules than check the toggle at the top of their sheet and then see their speed distance for confirmation on how much flight speed they have. Thus, the description alteration.