### PR TITLE
Use core color vars in `svelecte-pf2e' and abc picker

### DIFF
--- a/src/module/actor/character/apps/abc-picker/app.svelte
+++ b/src/module/actor/character/apps/abc-picker/app.svelte
@@ -88,7 +88,7 @@
         justify-content: start;
         padding: var(--space-8) var(--space-8) 0;
         input::placeholder {
-            color: var(--color-light-5);
+            color: var(--color-form-hint);
         }
     }
 


### PR DESCRIPTION
Closes #21095 

Also adds functionality to sync the detached dropdown theme with changes to foundry theme without reopening apps.

Before:
<img width="357" height="144" alt="Screenshot 2025-12-29 at 1 19 16 PM" src="https://github.com/user-attachments/assets/0e937209-df58-4497-bbe8-7221148b2f8a" />
<img width="255" height="144" alt="Screenshot 2025-12-29 at 1 19 44 PM" src="https://github.com/user-attachments/assets/d019cd4a-151e-4765-ac63-abe654b827b5" />


After:
<img width="349" height="140" alt="Screenshot 2025-12-29 at 1 19 26 PM" src="https://github.com/user-attachments/assets/78e7916e-9592-4393-b143-616c6bfff9c1" />
<img width="263" height="147" alt="Screenshot 2025-12-29 at 1 20 03 PM" src="https://github.com/user-attachments/assets/8e881410-8367-45bd-94ed-9a004fc926a3" />
