### PR TITLE
Show linked weapon in npc attack sheet and relink to compatible matches when generating attacks

### DIFF
--- a/src/module/actor/npc/sheet.ts
+++ b/src/module/actor/npc/sheet.ts
@@ -1,5 +1,6 @@
 import type { NPCPF2e } from "@actor";
 import { CreatureSheetPF2e, type CreatureSheetData } from "@actor/creature/sheet.ts";
+import { applyActorGroupUpdate, createActorGroupUpdate } from "@actor/helpers.ts";
 import { Modifier } from "@actor/modifiers.ts";
 import { NPCSkillsEditor } from "@actor/npc/skills-editor.ts";
 import { SheetClickActionHandlers } from "@actor/sheet/base.ts";
@@ -7,6 +8,7 @@ import { createAbilityViewData } from "@actor/sheet/helpers.ts";
 import { RecallKnowledgePopup } from "@actor/sheet/popups/recall-knowledge-popup.ts";
 import { ATTRIBUTE_ABBREVIATIONS, SAVE_TYPES } from "@actor/values.ts";
 import type { ActorSheetOptions } from "@client/appv1/sheets/actor-sheet.d.mts";
+import type { MeleePF2e, MeleeSource } from "@item/melee/index.ts";
 import { createNPCAttackTraitsAndTags, createTagifyTraits, eventToRollParams } from "@module/sheet/helpers.ts";
 import type { UserPF2e } from "@module/user/document.ts";
 import { DicePF2e } from "@scripts/dice.ts";
@@ -425,10 +427,36 @@ class NPCSheetPF2e extends AbstractNPCSheet {
                     }
                 }
 
+                // Create actions, and either relink to existing actions or create them
                 const attacks = item.toNPCAttacks().map((a) => a.toObject());
-                await actor.createEmbeddedDocuments("Item", attacks);
+                const missingLinks = actor.itemTypes.melee.filter((m) => !m.linkedWeapon);
+                const getComparisonSubset = (item: MeleeSource | MeleePF2e) => ({
+                    name: item.name,
+                    ...R.pick(item.system, ["action", "range"]),
+                });
+                const pairs = attacks.map((a): [MeleeSource, MeleePF2e | null] => [
+                    a,
+                    missingLinks.find(
+                        (l) =>
+                            a.flags[SYSTEM_ID].linkedWeapon &&
+                            R.isDeepEqual(getComparisonSubset(a), getComparisonSubset(l)),
+                    ) ?? null,
+                ]);
+                const update = createActorGroupUpdate({
+                    itemCreates: pairs.filter((p) => !p[1]).map((p) => p[0]),
+                    itemUpdates: pairs
+                        .filter((p): p is [MeleeSource, MeleePF2e] => !!p[1])
+                        .map(([newAction, oldAction]) => ({
+                            _id: oldAction.id,
+                            [`flags.${SYSTEM_ID}.linkedWeapon`]: newAction.flags[SYSTEM_ID].linkedWeapon,
+                        })),
+                });
+                await applyActorGroupUpdate(actor, update);
+
+                // Show correct notification based on update
+                const localizationKey = `PF2E.Actor.NPC.GenerateAttack.${update.itemCreates.length ? "Notification" : "NotificationRelink"}`;
                 ui.notifications.info(
-                    game.i18n.format("PF2E.Actor.NPC.GenerateAttack.Notification", {
+                    game.i18n.format(localizationKey, {
                         attack: attacks.at(0)?.name ?? "",
                     }),
                 );

--- a/src/module/actor/npc/sheet.ts
+++ b/src/module/actor/npc/sheet.ts
@@ -454,7 +454,7 @@ class NPCSheetPF2e extends AbstractNPCSheet {
                 await applyActorGroupUpdate(actor, update);
 
                 // Show correct notification based on update
-                const localizationKey = `PF2E.Actor.NPC.GenerateAttack.${update.itemCreates.length ? "Notification" : "NotificationRelink"}`;
+                const localizationKey = `PF2E.Actor.NPC.GenerateAttack.Notification.${update.itemCreates.length ? "New" : "Relinked"}`;
                 ui.notifications.info(
                     game.i18n.format(localizationKey, {
                         attack: attacks.at(0)?.name ?? "",

--- a/src/module/actor/npc/sheet.ts
+++ b/src/module/actor/npc/sheet.ts
@@ -455,9 +455,7 @@ class NPCSheetPF2e extends AbstractNPCSheet {
 
                 // Show correct notification based on update
                 const localizationKey = `PF2E.Actor.NPC.GenerateAttack.Notification.${update.itemCreates.length ? "New" : "Relinked"}`;
-                ui.notifications.info(
-                    game.i18n.format(localizationKey, { attack: attacks.at(0)?.name ?? "" }),
-                );
+                ui.notifications.info(game.i18n.format(localizationKey, { attack: attacks.at(0)?.name ?? "" }));
             };
         }
 

--- a/src/module/actor/npc/sheet.ts
+++ b/src/module/actor/npc/sheet.ts
@@ -456,9 +456,7 @@ class NPCSheetPF2e extends AbstractNPCSheet {
                 // Show correct notification based on update
                 const localizationKey = `PF2E.Actor.NPC.GenerateAttack.Notification.${update.itemCreates.length ? "New" : "Relinked"}`;
                 ui.notifications.info(
-                    game.i18n.format(localizationKey, {
-                        attack: attacks.at(0)?.name ?? "",
-                    }),
+                    game.i18n.format(localizationKey, { attack: attacks.at(0)?.name ?? "" }),
                 );
             };
         }

--- a/src/module/actor/npc/sheet.ts
+++ b/src/module/actor/npc/sheet.ts
@@ -1,6 +1,6 @@
 import type { NPCPF2e } from "@actor";
 import { CreatureSheetPF2e, type CreatureSheetData } from "@actor/creature/sheet.ts";
-import { applyActorGroupUpdate, createActorGroupUpdate } from "@actor/helpers.ts";
+import { applyActorGroupUpdate } from "@actor/helpers.ts";
 import { Modifier } from "@actor/modifiers.ts";
 import { NPCSkillsEditor } from "@actor/npc/skills-editor.ts";
 import { SheetClickActionHandlers } from "@actor/sheet/base.ts";
@@ -442,7 +442,7 @@ class NPCSheetPF2e extends AbstractNPCSheet {
                             R.isDeepEqual(getComparisonSubset(a), getComparisonSubset(l)),
                     ) ?? null,
                 ]);
-                const update = createActorGroupUpdate({
+                const update = {
                     itemCreates: pairs.filter((p) => !p[1]).map((p) => p[0]),
                     itemUpdates: pairs
                         .filter((p): p is [MeleeSource, MeleePF2e] => !!p[1])
@@ -450,7 +450,7 @@ class NPCSheetPF2e extends AbstractNPCSheet {
                             _id: oldAction.id,
                             [`flags.${SYSTEM_ID}.linkedWeapon`]: newAction.flags[SYSTEM_ID].linkedWeapon,
                         })),
-                });
+                };
                 await applyActorGroupUpdate(actor, update);
 
                 // Show correct notification based on update

--- a/src/module/item/melee/sheet.ts
+++ b/src/module/item/melee/sheet.ts
@@ -33,10 +33,6 @@ export class MeleeSheetPF2e extends ItemSheetPF2e<MeleePF2e> {
                 label: game.i18n.localize(`PF2E.Actor.NPC.BonusLabel.${isCheck ? "modifier" : "save"}`),
                 value: item.system.bonus.value + (isCheck ? 0 : 10),
             },
-            linkedWeapon: {
-                selected: item.flags[SYSTEM_ID].linkedWeapon ?? null,
-                choices: R.mapToObj(item.actor?.itemTypes.weapon ?? [], (w) => [w.id, w.name]),
-            },
         };
     }
 
@@ -99,9 +95,5 @@ interface MeleeSheetData extends ItemSheetDataPF2e<MeleePF2e> {
     modifierOrSave: {
         label: string;
         value: number;
-    };
-    linkedWeapon: {
-        selected: string | null;
-        choices: Record<string, string>;
     };
 }

--- a/src/module/item/melee/sheet.ts
+++ b/src/module/item/melee/sheet.ts
@@ -33,6 +33,10 @@ export class MeleeSheetPF2e extends ItemSheetPF2e<MeleePF2e> {
                 label: game.i18n.localize(`PF2E.Actor.NPC.BonusLabel.${isCheck ? "modifier" : "save"}`),
                 value: item.system.bonus.value + (isCheck ? 0 : 10),
             },
+            linkedWeapon: {
+                selected: item.flags[SYSTEM_ID].linkedWeapon ?? null,
+                choices: R.mapToObj(item.actor?.itemTypes.weapon ?? [], (w) => [w.id, w.name]),
+            },
         };
     }
 
@@ -95,5 +99,9 @@ interface MeleeSheetData extends ItemSheetDataPF2e<MeleePF2e> {
     modifierOrSave: {
         label: string;
         value: number;
+    };
+    linkedWeapon: {
+        selected: string | null;
+        choices: Record<string, string>;
     };
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -609,7 +609,8 @@
                         "Title": "Regenerate attack"
                     },
                     "Label": "Generate Attack",
-                    "Notification": "Generated NPC attack: {attack}"
+                    "Notification": "Generated NPC attack: {attack}",
+                    "NotificationRelink": "Relinked NPC Attack: {attack}"
                 },
                 "Identification": {
                     "Skills": {
@@ -2605,7 +2606,8 @@
                 "LinkedWeapon": "Linked Weapon",
                 "Tags": {
                     "RangeN": "Range {n} Feet",
-                    "RangeIncrementN": "Range Increment {n} Feet"
+                    "RangeIncrementN": "Range Increment {n} Feet",
+                    "MagN": "Mag {n}"
                 }
             },
             "OtherTags": {
@@ -5253,17 +5255,6 @@
         "TraitLocathah": "Athamaru",
         "TraitLozenge": "Lozenge",
         "TraitMaftet": "Maftet",
-        "TraitMag1": "Mag 1",
-        "TraitMag10": "Mag 10",
-        "TraitMag2": "Mag 2",
-        "TraitMag20": "Mag 20",
-        "TraitMag3": "Mag 3",
-        "TraitMag30": "Mag 30",
-        "TraitMag4": "Mag 4",
-        "TraitMag5": "Mag 5",
-        "TraitMag6": "Mag 6",
-        "TraitMag7": "Mag 7",
-        "TraitMag8": "Mag 8",
         "TraitMagic": "Magic",
         "TraitMagical": "Magical",
         "TraitMagitech": "Magitech",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2602,6 +2602,7 @@
                         }
                     }
                 },
+                "LinkedWeapon": "Linked Weapon",
                 "Tags": {
                     "RangeN": "Range {n} Feet",
                     "RangeIncrementN": "Range Increment {n} Feet"

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -609,8 +609,10 @@
                         "Title": "Regenerate attack"
                     },
                     "Label": "Generate Attack",
-                    "Notification": "Generated NPC attack: {attack}",
-                    "NotificationRelink": "Relinked NPC Attack: {attack}"
+                    "Notification": {
+                        "New": "Generated NPC attack: {attack}",
+                        "Relinked": "Relinked NPC Attack: {attack}"
+                    }
                 },
                 "Identification": {
                     "Skills": {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2606,8 +2606,7 @@
                 "LinkedWeapon": "Linked Weapon",
                 "Tags": {
                     "RangeN": "Range {n} Feet",
-                    "RangeIncrementN": "Range Increment {n} Feet",
-                    "MagN": "Mag {n}"
+                    "RangeIncrementN": "Range Increment {n} Feet"
                 }
             },
             "OtherTags": {
@@ -5255,6 +5254,17 @@
         "TraitLocathah": "Athamaru",
         "TraitLozenge": "Lozenge",
         "TraitMaftet": "Maftet",
+        "TraitMag1": "Mag 1",
+        "TraitMag10": "Mag 10",
+        "TraitMag2": "Mag 2",
+        "TraitMag20": "Mag 20",
+        "TraitMag3": "Mag 3",
+        "TraitMag30": "Mag 30",
+        "TraitMag4": "Mag 4",
+        "TraitMag5": "Mag 5",
+        "TraitMag6": "Mag 6",
+        "TraitMag7": "Mag 7",
+        "TraitMag8": "Mag 8",
         "TraitMagic": "Magic",
         "TraitMagical": "Magical",
         "TraitMagitech": "Magitech",

--- a/static/templates/items/melee-details.hbs
+++ b/static/templates/items/melee-details.hbs
@@ -63,6 +63,15 @@
     </li>
 </ol>
 
+<div class="form-group">
+    <label>{{localize "PF2E.Item.NPCAttack.LinkedWeapon"}}</label>
+    <div class="form-fields">
+        <select name="{{concat "flags." systemId ".linkedWeapon"}}" data-dtype="String">
+            {{selectOptions linkedWeapon.choices selected=linkedWeapon.selected blank=""}}
+        </select>
+    </div>
+</div>
+
 <div class="form-group stacked">
     <label>
         {{localize "PF2E.NPCWeaponAttackEffect"}}

--- a/static/templates/items/melee-details.hbs
+++ b/static/templates/items/melee-details.hbs
@@ -63,16 +63,18 @@
     </li>
 </ol>
 
-<div class="form-group">
-    <label>{{localize "PF2E.Item.NPCAttack.LinkedWeapon"}}</label>
-    <div class="form-fields">
-        {{#if document.linkedWeapon}}
-            {{document.linkedWeapon.name}}
-        {{else}}
-            {{localize "PF2E.NoneOption"}}
-        {{/if}}
+{{#if document.actor}}
+    <div class="form-group">
+        <label>{{localize "PF2E.Item.NPCAttack.LinkedWeapon"}}</label>
+        <div class="form-fields">
+            {{#if document.linkedWeapon}}
+                {{document.linkedWeapon.name}}
+            {{else}}
+                {{localize "PF2E.NoneOption"}}
+            {{/if}}
+        </div>
     </div>
-</div>
+{{/if}}
 
 <div class="form-group stacked">
     <label>

--- a/static/templates/items/melee-details.hbs
+++ b/static/templates/items/melee-details.hbs
@@ -66,9 +66,11 @@
 <div class="form-group">
     <label>{{localize "PF2E.Item.NPCAttack.LinkedWeapon"}}</label>
     <div class="form-fields">
-        <select name="{{concat "flags." systemId ".linkedWeapon"}}" data-dtype="String">
-            {{selectOptions linkedWeapon.choices selected=linkedWeapon.selected blank=""}}
-        </select>
+        {{#if document.linkedWeapon}}
+            {{document.linkedWeapon.name}}
+        {{else}}
+            {{localize "PF2E.NoneOption"}}
+        {{/if}}
     </div>
 </div>
 


### PR DESCRIPTION
If changing it is a no go, I can change it just displaying the linked weapon.