### PR TITLE
Remove ranged-trip from ranged-only traits

### DIFF
--- a/src/module/item/weapon/values.ts
+++ b/src/module/item/weapon/values.ts
@@ -145,7 +145,6 @@ const RANGED_ONLY_TRAITS: Set<WeaponTrait> = new Set([
     "scatter-15",
     "scatter-20",
     "splash",
-    "ranged-trip",
     "repeating",
     "thrown",
 ]);


### PR DESCRIPTION
At least one thrown melee weapon has this trait.