### PR TITLE
Add strike rule to solar weapon to change damage dice with two hand d10 trait

### DIFF
--- a/packs/sf2e/feat-effects/effect-solar-weapon-twin-weapons.json
+++ b/packs/sf2e/feat-effects/effect-solar-weapon-twin-weapons.json
@@ -351,6 +351,29 @@
                 ]
             },
             {
+              "domain": "damage",
+              "key": "RollOption",
+              "option": "solar-weapon-two-hand",
+              "toggleable": true,
+              "value": false,
+              "predicate": [
+                "solar-weapon-trait-one:two-hand-d10"
+              ],
+              "label":"Solar Weapon 2H"
+            },
+            {
+              "key": "DamageAlteration",
+              "property": "dice-faces",
+              "value": 10,
+              "predicate": [
+                "solar-weapon-two-hand"
+              ],
+              "mode": "override",
+              "selectors": [
+                "{item|id}-damage"
+              ]
+            },
+            {
                 "itemType": "weapon",
                 "key": "ItemAlteration",
                 "mode": "add",

--- a/packs/sf2e/feat-effects/effect-solar-weapon-twin-weapons.json
+++ b/packs/sf2e/feat-effects/effect-solar-weapon-twin-weapons.json
@@ -353,20 +353,20 @@
             {
               "domain": "damage",
               "key": "RollOption",
-              "option": "solar-weapon-two-hand",
+              "option": "twin-solar-weapon-two-hand",
               "toggleable": true,
               "value": false,
               "predicate": [
-                "solar-weapon-trait-one:two-hand-d10"
+                "twin-solar-weapon-trait-one:two-hand-d10"
               ],
-              "label":"Solar Weapon 2H"
+              "label":"SF2E.SpecificRule.Solarian.SolarWeapon.TwoHandToggle.TwinLabel"
             },
             {
               "key": "DamageAlteration",
               "property": "dice-faces",
               "value": 10,
               "predicate": [
-                "solar-weapon-two-hand"
+                "twin-solar-weapon-two-hand"
               ],
               "mode": "override",
               "selectors": [

--- a/packs/sf2e/feat-effects/effect-solar-weapon.json
+++ b/packs/sf2e/feat-effects/effect-solar-weapon.json
@@ -402,9 +402,6 @@
                 "predicate": [
                     {
                         "not": "stellar-attunement:unattuned"
-                    },
-                    {
-                        "not": "solar-weapon-trait-one:two-hand-d10"
                     }
                 ],
                 "range": null,
@@ -415,29 +412,28 @@
                 ]
             },
             {
-                "category": "martial",
-                "damage": {
-                    "base": {
-                        "damageType": "{item|flags.sf2e.rulesSelections.solarWeaponDamageType}",
-                        "dice": 1,
-                        "die": "d10"
-                    }
-                },
-                "group": "{item|flags.sf2e.rulesSelections.weaponGroup}",
-                "key": "Strike",
-                "label": "SF2E.SpecificRule.Solarian.SolarWeapon.Label",
-                "predicate": [
-                    {
-                        "not": "stellar-attunement:unattuned"
-                    },
-                    "solar-weapon-trait-one:two-hand-d10"
-                ],
-                "range": null,
-                "slug": "solar-weapon",
-                "traits": [
-                    "attuned",
-                    "solarian"
-                ]
+              "domain": "damage",
+              "key": "RollOption",
+              "option": "solar-weapon-two-hand",
+              "toggleable": true,
+              "value": false,
+              "predicate": [
+                "solar-weapon-trait-one:two-hand-d10"
+              ],
+              "label":"Solar Weapon 2H"
+            },
+            {
+              "key": "DamageAlteration",
+              "property": "dice-faces",
+              "value": 10,
+              "predicate": [
+                "solar-weapon-two-hand"
+              ],
+              "label": "Solar Weapon Two Hand",
+              "mode": "override",
+              "selectors": [
+                "{item|id}-damage"
+              ]
             },
             {
                 "itemType": "weapon",

--- a/packs/sf2e/feat-effects/effect-solar-weapon.json
+++ b/packs/sf2e/feat-effects/effect-solar-weapon.json
@@ -402,7 +402,35 @@
                 "predicate": [
                     {
                         "not": "stellar-attunement:unattuned"
+                    },
+                    {
+                        "not": "solar-weapon-trait-one:two-hand-d10"
                     }
+                ],
+                "range": null,
+                "slug": "solar-weapon",
+                "traits": [
+                    "attuned",
+                    "solarian"
+                ]
+            },
+            {
+                "category": "martial",
+                "damage": {
+                    "base": {
+                        "damageType": "{item|flags.sf2e.rulesSelections.solarWeaponDamageType}",
+                        "dice": 1,
+                        "die": "d10"
+                    }
+                },
+                "group": "{item|flags.sf2e.rulesSelections.weaponGroup}",
+                "key": "Strike",
+                "label": "SF2E.SpecificRule.Solarian.SolarWeapon.Label",
+                "predicate": [
+                    {
+                        "not": "stellar-attunement:unattuned"
+                    },
+                    "solar-weapon-trait-one:two-hand-d10"
                 ],
                 "range": null,
                 "slug": "solar-weapon",

--- a/packs/sf2e/feat-effects/effect-solar-weapon.json
+++ b/packs/sf2e/feat-effects/effect-solar-weapon.json
@@ -420,7 +420,7 @@
               "predicate": [
                 "solar-weapon-trait-one:two-hand-d10"
               ],
-              "label":"Solar Weapon 2H"
+              "label":"SF2E.SpecificRule.Solarian.SolarWeapon.TwoHandToggle.Label"
             },
             {
               "key": "DamageAlteration",

--- a/packs/sf2e/feat-effects/effect-solar-weapon.json
+++ b/packs/sf2e/feat-effects/effect-solar-weapon.json
@@ -429,7 +429,6 @@
               "predicate": [
                 "solar-weapon-two-hand"
               ],
-              "label": "Solar Weapon Two Hand",
               "mode": "override",
               "selectors": [
                 "{item|id}-damage"

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -7957,7 +7957,11 @@
                     "PhotonAttuned": {
                         "Label": "Photon-Attuned"
                     },
-                    "TwinLabel": "Twin Solar Weapon"
+                    "TwinLabel": "Twin Solar Weapon",
+                    "TwoHandToggle": {
+                        "Label": "Solar Weapon — Use two hands",
+                        "TwinLabel": "Twin Solar Weapon — Use two hands"
+                    }
                 },
                 "StellarAttunement": {
                     "Graviton": "Graviton-Attuned",


### PR DESCRIPTION
My players found out that you can't change grip on strikes that were created with a strike rule element. My guess it's because it doesn't create a real item, so we can't change grip. But since when you are creating a solar weapon with two hand d10 trait, you certainly want to use it in 2h, I guess it might be okay to just add a new strike rule with d10, that will be used only with the solar weapon with this trait. Not the best approach, but it least it'll work