### PR TITLE
Fix scene config label for Starfinder

### DIFF
--- a/src/module/scene/sheet.ts
+++ b/src/module/scene/sheet.ts
@@ -18,7 +18,7 @@ export class SceneConfigPF2e<TDocument extends ScenePF2e> extends fa.sheets.Scen
 
     static override TABS = (() => {
         const tabsConfig = super.TABS;
-        const label = SYSTEM_ID === "pf2e" ? "PF2E.Pathfinder" : "SF2E.Starfinder";
+        const label = SYSTEM_ID === "pf2e" ? "PF2E.Pathfinder" : "PF2E.Starfinder";
         tabsConfig["sheet"].tabs.push({ id: SYSTEM_ID, icon: "action-glyph", label });
         return tabsConfig;
     })();


### PR DESCRIPTION
We've moved to only having the PF2E namespace (outside of re-en.json). This is the only instance of a call to SF2E.foo remaining outside of packs.