### PR TITLE
Added missing traditions to Share Pain

### DIFF
--- a/packs/sf2e/spells/spells/rank-3/share-pain.json
+++ b/packs/sf2e/spells/spells/rank-3/share-pain.json
@@ -77,7 +77,10 @@
         },
         "traits": {
             "rarity": "common",
-            "traditions": [],
+            "traditions": [
+                "divine",
+                "occult"
+            ],
             "value": [
                 "concentrate",
                 "manipulate",


### PR DESCRIPTION
Noticed that the spell Share Pain didn't have any traditions listed. This PR should address that.