### PR TITLE
Include piloting and computers actions if sf2e-anachronism is enabled

### DIFF
--- a/src/module/system/action-macros/index.ts
+++ b/src/module/system/action-macros/index.ts
@@ -240,8 +240,6 @@ const SystemActions: Action[] = [
     tumbleThrough.action,
 ];
 
-if (SYSTEM_ID === "sf2e") {
-    SystemActions.push(accessInfosphere, hack, operateDevice, navigate, plotCourse);
-}
+const SF2eOnlySystemActions = [accessInfosphere, hack, operateDevice, navigate, plotCourse];
 
-export { SystemActions };
+export { SF2eOnlySystemActions, SystemActions };

--- a/src/scripts/set-game-pf2e.ts
+++ b/src/scripts/set-game-pf2e.ts
@@ -27,7 +27,7 @@ import {
     xpFromEncounter,
 } from "@scripts/macros/index.ts";
 import { remigrate } from "@scripts/system/remigrate.ts";
-import { ActionMacros, SystemActions } from "@system/action-macros/index.ts";
+import { ActionMacros, SF2eOnlySystemActions, SystemActions } from "@system/action-macros/index.ts";
 import { Check } from "@system/check/check.ts";
 import { ConditionManager } from "@system/conditions/index.ts";
 import { EffectTracker } from "@system/effect-tracker.ts";
@@ -45,6 +45,11 @@ export const SetGamePF2e = {
         const actions = new Collection<string, Action>(
             SystemActions.map((action) => [action.slug, action]),
         ) as ActionCollection;
+        if (SYSTEM_ID === "sf2e" || game.modules.get("sf2e-anachronism")?.active) {
+            for (const sf2eAction of SF2eOnlySystemActions) {
+                actions.set(sf2eAction.slug, sf2eAction);
+            }
+        }
         // keep the old action functions around until everything has been converted
         for (const [name, action] of Object.entries({
             encouragingWords,


### PR DESCRIPTION
Because we don't want computers/piloting in pf2e, these actions are not included in the build. But sf2e-anachronism adds those skills. Because of the timing of homebrew data imports and global data initialization though, I don't think we can simply check if computers and piloting exist in the collection.

This will let us remove code from the module on the next pf2e update.

Alternatively we can always let those actions exist and allow chaos if someone tries to access the infosphere when computers doesn't exist. Our code maybe falls back fine enough?