### PR TITLE
Add SF2e language file that overrides PF2e text

### DIFF
--- a/src/scripts/config/traits.ts
+++ b/src/scripts/config/traits.ts
@@ -1389,6 +1389,8 @@ const traitDescriptions = {
     "deadly-d4": "PF2E.TraitDescriptionDeadly",
     "deadly-d6": "PF2E.TraitDescriptionDeadly",
     "deadly-d8": "PF2E.TraitDescriptionDeadly",
+    "deadly-d10": "PF2E.TraitDescriptionDeadly",
+    "deadly-d12": "PF2E.TraitDescriptionDeadly",
     "deadly-2d8": "PF2E.TraitDescriptionDeadly",
     "deadly-2d10": "PF2E.TraitDescriptionDeadly",
     "deadly-2d12": "PF2E.TraitDescriptionDeadly",

--- a/static/lang/sf2e-overrides-en.json
+++ b/static/lang/sf2e-overrides-en.json
@@ -1,0 +1,5 @@
+{
+    "PF2E": {
+        "TraitDescriptionDeadly": "On a critical hit, the weapon adds a weapon damage die of the listed size. Roll this after doubling the weapon's damage. This increases to two dice for elite and ultimate grade weapons and 3 dice for paragon grade weapons. For instance, an elite nano-edge rapier deals an additional 2d8 piercing damage on a critical hit. An ability that changes the size of the weapon's normal damage dice doesn't change the size of its deadly die."
+    }
+}

--- a/system.sf2e.json
+++ b/system.sf2e.json
@@ -106,6 +106,12 @@
             "name": "Kingmaker (English)",
             "path": "lang/kingmaker-en.json",
             "flags": {}
+        },
+        {
+            "lang": "en",
+            "name": "SF2e Overrides (English)",
+            "path": "lang/sf2e-overrides-en.json",
+            "flags": {}
         }
     ],
     "packs": [


### PR DESCRIPTION
This can be used to add alternative descriptions such as for the crafting action. This file is not to be intended for sf2e actions in general, but for pf2e things that are altered in sf2e. These will not be available in sf2e anachronism.

I don't know if Ysoki would go here, it seems both ratfolk and ysoki are interchangeable traits. Even if that does cause issues for feat filtering.

