### PR TITLE
Fix Strike RE with max but not increment getting set to range increment 5

### DIFF
--- a/src/module/item/melee/document.ts
+++ b/src/module/item/melee/document.ts
@@ -60,7 +60,7 @@ class MeleePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
         // If this changes, the melee sheet and range item alterations must be changed in response
         const data = this.system.range;
         return data?.max
-            ? (data as RangeData) // typescript fails to detect that data.max is not null and so we must cast
+            ? { increment: null, max: data.max }
             : data?.increment
               ? { increment: data.increment, max: data.increment * 6 }
               : null;


### PR DESCRIPTION
Strike RE's have a default range increment of 5 (not null) if range is set, and this is very old behavior. Rather than change this, which might break something, melee now does what weapon does (ignore increment if max is set)