### PR TITLE
Fix reload on attack popup

### DIFF
--- a/src/styles/actor/character/_attack-popout.scss
+++ b/src/styles/actor/character/_attack-popout.scss
@@ -1,5 +1,32 @@
 .tab {
     @import "actions";
+
+    button.inline-control {
+        background: transparent;
+        border: 1px solid transparent;
+        box-shadow: none;
+        display: flex;
+        height: var(--button-size);
+        line-height: normal;
+        margin: unset;
+        text-decoration: none;
+        transition: none;
+        width: auto;
+
+        &:hover {
+            text-shadow: 0 0 8px var(--color-shadow-primary);
+        }
+
+        &:disabled {
+            --button-text-color: var(--color-text-subtle);
+            text-shadow: none;
+        }
+    }
+
+    input {
+        border: none;
+        border-radius: 0;
+    }
 }
 
 .tab.actions {

--- a/static/templates/actors/character/partials/strike.hbs
+++ b/static/templates/actors/character/partials/strike.hbs
@@ -75,7 +75,7 @@
                     {{/each}}
                     {{#if action.ammunition.remaining}}
                         <div class="empty plain">
-                            <a class="name" data-action="reload" data-anchor-id="{{action.item.uuid}}-actions">
+                            <a class="name" data-action="reload" data-anchor-id="{{@root.options.id}}-{{action.item.uuid}}-reload">
                                 <span>{{localize "PF2E.Actions.Interact.Reload.Title"}} <span class="action-glyph">{{action.ammunition.reloadGlyph}}</span></span>
                             </a>
                             <span class="remaining">

--- a/types/foundry/client/helpers/hooks.d.mts
+++ b/types/foundry/client/helpers/hooks.d.mts
@@ -194,10 +194,10 @@ export default class Hooks {
      * Unregister a callback handler for a particular hook event
      *
      * @param hook  The unique name of the hooked event
-     * @param fn    The function that should be removed from the set of hooked callbacks
+     * @param fn    The function, or ID number for the function, that should be turned off
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    static off(hook: string, fn: (...args: any[]) => boolean | void | Promise<boolean | void>): void;
+    static off(hook: string, fn: ((...args: any[]) => boolean | void | Promise<boolean | void>) | number): void;
 
     /**
      * Call all hook listeners in the order in which they were registered


### PR DESCRIPTION
This also prevents holding onto a reference to a stale html element, and makes the re-render reposition more resilient in cases where the actor updates due to something a different user (such as the GM) did. Manual sheet re-renders are not broadcasted.

<img width="533" height="213" alt="image" src="https://github.com/user-attachments/assets/81408686-d8ca-4f9d-8649-15b7dfced908" />
