### PR TITLE
Update more system ui localization for Starfinder 2e

### DIFF
--- a/src/module/scene/sheet.ts
+++ b/src/module/scene/sheet.ts
@@ -18,8 +18,7 @@ export class SceneConfigPF2e<TDocument extends ScenePF2e> extends fa.sheets.Scen
 
     static override TABS = (() => {
         const tabsConfig = super.TABS;
-        const label = SYSTEM_ID === "pf2e" ? "PF2E.Pathfinder" : "PF2E.Starfinder";
-        tabsConfig["sheet"].tabs.push({ id: SYSTEM_ID, icon: "action-glyph", label });
+        tabsConfig["sheet"].tabs.push({ id: SYSTEM_ID, icon: "action-glyph", label: "PF2E.SystemNameShort" });
         return tabsConfig;
     })();
 

--- a/src/module/user/sheet.ts
+++ b/src/module/user/sheet.ts
@@ -16,7 +16,7 @@ class UserConfigPF2e extends fa.sheets.UserConfig<UserPF2e> {
         primary: {
             tabs: [
                 { id: "core", icon: "fa-solid fa-user", label: "PACKAGECONFIG.Core" },
-                { id: "pf2e", icon: "action-glyph", label: "PF2E.Pathfinder" },
+                { id: "pf2e", icon: "action-glyph", label: "PF2E.SystemNameShort" },
             ],
             initial: "core",
         },

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3731,7 +3731,7 @@
                     "Name": "Remove Expired Effects"
                 },
                 "RulesBasedVision": {
-                    "Hint": "Apply vision mechanics that are a best-effort attempt to capture Pathfinder Second Edition rules. Enabling this setting will remove the ability to configure Unrestricted Global Vision as well as Token Sight radii.",
+                    "Hint": "Apply vision mechanics that are a best-effort attempt to capture game rules. Enabling this setting will remove the ability to configure Unrestricted Global Vision as well as Token Sight radii.",
                     "ManagedBy": "Managed by rules-based vision.",
                     "Name": "Rules-Based Vision",
                     "ViewWorldSetting": "View World Setting"
@@ -3793,15 +3793,15 @@
             },
             "Homebrew": {
                 "ArmorGroups": {
-                    "Hint": "The mid level of Pathfinder 2e armor taxonomy (e.g, Plate, Chain)",
+                    "Hint": "The mid level of armor taxonomy (e.g, Plate, Chain)",
                     "Name": "Armor Groups"
                 },
                 "BaseArmors": {
-                    "Hint": "The bottom level of Pathfinder 2e armor taxonomy (e.g, Full Plate, Chain Mail)",
+                    "Hint": "The bottom level of armor taxonomy (e.g, Full Plate, Chain Mail)",
                     "Name": "Armor Base Types"
                 },
                 "BaseWeapons": {
-                    "Hint": "The bottom level of Pathfinder 2e weapon taxonomy (e.g, Heavy Crossbow, Longsword)",
+                    "Hint": "The bottom level of weapon taxonomy (e.g, Heavy Crossbow, Longsword)",
                     "Name": "Weapon Base Types"
                 },
                 "ConfirmDelete": {
@@ -3870,11 +3870,11 @@
                     "Traits": "Traits"
                 },
                 "WeaponCategories": {
-                    "Hint": "The top level of Pathfinder 2e weapon taxonomy (e.g., Simple, Martial)",
+                    "Hint": "The top level of weapon taxonomy (e.g., Simple, Martial)",
                     "Name": "Weapon Categories"
                 },
                 "WeaponGroups": {
-                    "Hint": "The mid level of Pathfinder 2e weapon taxonomy (e.g, Crossbow, Sword)",
+                    "Hint": "The mid level of weapon taxonomy (e.g, Crossbow, Sword)",
                     "Name": "Weapon Groups"
                 },
                 "WeaponTraits": {
@@ -4065,7 +4065,7 @@
                 }
             },
             "WorldSchemaVersion": {
-                "Hint": "Records the schema version for documents in the PF2e system (don't modify this unless you know what you are doing).",
+                "Hint": "Records the schema version for documents in the system (don't modify this unless you know what you are doing).",
                 "Name": "World Schema Version"
             },
             "critFumbleCardButtons": {
@@ -4243,6 +4243,7 @@
         "StrikesLabel": "Strikes",
         "StrikingRuneLabel": "Striking Rune",
         "Success": "<strong>Success</strong>",
+        "SystemNameShort": "Pathfinder",
         "TabActionsDowntimeLabel": "Downtime",
         "TabActionsEncounterLabel": "Encounter",
         "TabActionsExplorationLabel": "Exploration",

--- a/static/lang/sf2e-overrides-en.json
+++ b/static/lang/sf2e-overrides-en.json
@@ -6,6 +6,24 @@
                 "rules": "<p>You feel ill. Sickened always includes a value. You take a status penalty equal to this value on all your checks and DCs. You can't willingly ingest anything—including serums—while sickened.</p>\n<p>You can spend a single action retching in an attempt to recover, which lets you immediately attempt a @Check[fortitude] save against the DC of the effect that made you sickened. On a success, you reduce your sickened value by 1 (or by 2 on a critical success).</p>"
             }
         },
+        "Actor": {
+            "NPC": {
+                "Identification": {
+                    "Skills": {
+                        "Tooltip": "\"The skill used to identify a creature usually depends on that creature's trait, as shown on the Creature Identification Skills table, but you have leeway on which skills apply.\" — Starfinder GM Core pg. 54-55"
+                    },
+                    "Lore": {
+                        "Tooltip": "\"Using the applicable Lore usually has an easy or very easy DC (before adjusting for rarity).\" — Starfinder GM Core pg. 54"
+                    }
+                }
+            }
+        },
+        "Scene": {
+            "HearingRange": {
+                "Hint": "Limit the range* creatures can hear in this scene as a representation of \"an environment that distorts the sense, such as a noisy room\" (Starfinder Player Core pg. 424). Requires rules-based vision to be enabled."
+            }
+        },
+        "SystemNameShort": "Starfinder",
         "TraitDescriptionDeadly": "On a critical hit, the weapon adds a weapon damage die of the listed size. Roll this after doubling the weapon's damage. This increases to two dice for elite and ultimate grade weapons and 3 dice for paragon grade weapons. For instance, an elite nano-edge rapier deals an additional 2d8 piercing damage on a critical hit. An ability that changes the size of the weapon's normal damage dice doesn't change the size of its deadly die."
     }
 }


### PR DESCRIPTION
In instances where the system can be trivially inferred, I removed the explicit system name. In areas where we are referring to the rulebook, I added an override.