### PR TITLE
Update Yacob's Handwrap of Mighty Blows and add missing Striking Rune

### DIFF
--- a/packs/pf2e/paizo-pregens/mark-of-the-mantis/yacob.json
+++ b/packs/pf2e/paizo-pregens/mark-of-the-mantis/yacob.json
@@ -1199,6 +1199,7 @@
             "name": "Sawtooth Saber",
             "sort": 0,
             "system": {
+                "ammo": null,
                 "baseItem": "sawtooth-saber",
                 "bonus": {
                     "value": 0
@@ -1225,6 +1226,7 @@
                     "invested": null
                 },
                 "expend": null,
+                "grade": null,
                 "group": "sword",
                 "hardness": 0,
                 "hp": {
@@ -1274,98 +1276,6 @@
                 },
                 "usage": {
                     "value": "held-in-one-hand"
-                }
-            },
-            "type": "weapon"
-        },
-        {
-            "_id": "IFtZVbwoaKzz8orU",
-            "_stats": {
-                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.FNDq4NFSN0g2HKWO"
-            },
-            "img": "icons/equipment/hand/gauntlet-simple-leather-brown-gold.webp",
-            "name": "Handwraps of Mighty Blows",
-            "sort": 0,
-            "system": {
-                "baseItem": null,
-                "bonus": {
-                    "value": 1
-                },
-                "bonusDamage": {
-                    "value": 0
-                },
-                "bulk": {
-                    "value": 0
-                },
-                "category": "unarmed",
-                "containerId": null,
-                "damage": {
-                    "damageType": "bludgeoning",
-                    "dice": 1,
-                    "die": "d4"
-                },
-                "description": {
-                    "value": "<p>As you invest these embroidered strips of cloth, you must meditate and slowly wrap them around your hands. These handwraps have weapon runes etched into them to give your unarmed attacks the benefits of those runes, making your unarmed attacks work like magic weapons. For example, <em>+1 striking handwraps of mighty blows</em> would give you a +1 item bonus to attack rolls with your unarmed attacks and increase the damage of your unarmed attacks from one weapon die to two (normally 2d4 instead of 1d4, but if your fists have a different weapon damage die or you have other unarmed attacks, use two of that die size instead).</p>\n<p>You can upgrade, add, and transfer runes to and from the handwraps just as you would for a weapon, and you can attach talismans to the handwraps. Treat the handwraps as melee weapons of the brawling group with light Bulk for these purposes. Property runes apply only when they would be applicable to the unarmed attack you're using. For example, a property that must be applied to a slashing weapon wouldn't function when you attacked with a fist, but you would gain its benefits if you attacked with a claw or some other slashing unarmed attack.</p>"
-                },
-                "equipped": {
-                    "carryType": "worn",
-                    "handsHeld": 0,
-                    "inSlot": true,
-                    "invested": true
-                },
-                "expend": null,
-                "group": "brawling",
-                "hardness": 0,
-                "hp": {
-                    "max": 0,
-                    "value": 0
-                },
-                "level": {
-                    "value": 2
-                },
-                "material": {
-                    "grade": null,
-                    "type": null
-                },
-                "price": {
-                    "value": {
-                        "gp": 35
-                    }
-                },
-                "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": "Pathfinder Core Rulebook"
-                },
-                "quantity": 1,
-                "range": null,
-                "reload": {
-                    "value": null
-                },
-                "rules": [],
-                "runes": {
-                    "potency": 0,
-                    "property": [],
-                    "striking": 0
-                },
-                "size": "med",
-                "slug": "handwraps-of-mighty-blows",
-                "splashDamage": {
-                    "value": null
-                },
-                "traits": {
-                    "rarity": "common",
-                    "value": [
-                        "agile",
-                        "finesse",
-                        "invested",
-                        "magical",
-                        "nonlethal",
-                        "unarmed"
-                    ]
-                },
-                "usage": {
-                    "value": "worngloves"
                 }
             },
             "type": "weapon"
@@ -3331,6 +3241,101 @@
                 }
             },
             "type": "feat"
+        },
+        {
+            "_id": "5Di2wlXI2Rhcgl4A",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.FNDq4NFSN0g2HKWO"
+            },
+            "img": "icons/equipment/hand/gauntlet-simple-leather-brown-gold.webp",
+            "name": "Handwraps of Mighty Blows",
+            "sort": 0,
+            "system": {
+                "ammo": null,
+                "baseItem": null,
+                "bonus": {
+                    "value": 1
+                },
+                "bonusDamage": {
+                    "value": 0
+                },
+                "bulk": {
+                    "value": 0
+                },
+                "category": "unarmed",
+                "containerId": null,
+                "damage": {
+                    "damageType": "bludgeoning",
+                    "dice": 1,
+                    "die": "d4"
+                },
+                "description": {
+                    "value": "<p>As you invest these embroidered strips of cloth, you must meditate and slowly wrap them around your hands. These handwraps have weapon runes etched into them to give your unarmed attacks the benefits of those runes, making your unarmed attacks work like magic weapons. For example, <em>+1 striking handwraps of mighty blows</em> would give you a +1 item bonus to attack rolls with your unarmed attacks and increase the damage of your unarmed attacks from one weapon die to two (normally 2d4 instead of 1d4, but if your fists have a different weapon damage die or you have other unarmed attacks, use two of that die size instead).</p>\n<p>You can upgrade, add, and transfer runes to and from the handwraps just as you would for a weapon, and you can attach talismans to the handwraps. Treat the handwraps as melee weapons of the brawling group with light Bulk for these purposes. Property runes apply only when they would be applicable to the unarmed attack you're using. For example, a property that must be applied to a slashing weapon wouldn't function when you attacked with a fist, but you would gain its benefits if you attacked with a claw or some other slashing unarmed attack.</p>"
+                },
+                "equipped": {
+                    "carryType": "worn",
+                    "handsHeld": 0,
+                    "inSlot": true,
+                    "invested": true
+                },
+                "expend": null,
+                "grade": null,
+                "group": "brawling",
+                "hardness": 0,
+                "hp": {
+                    "max": 0,
+                    "value": 0
+                },
+                "level": {
+                    "value": 2
+                },
+                "material": {
+                    "grade": null,
+                    "type": null
+                },
+                "price": {
+                    "value": {
+                        "gp": 35
+                    }
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Pathfinder GM Core"
+                },
+                "quantity": 1,
+                "range": null,
+                "reload": {
+                    "value": null
+                },
+                "rules": [],
+                "runes": {
+                    "potency": 1,
+                    "property": {
+                        "0": ""
+                    },
+                    "striking": 1
+                },
+                "size": "med",
+                "slug": "handwraps-of-mighty-blows",
+                "splashDamage": {
+                    "value": 0
+                },
+                "traits": {
+                    "otherTags": [
+                        "handwraps-of-mighty-blows"
+                    ],
+                    "rarity": "common",
+                    "value": [
+                        "invested",
+                        "magical"
+                    ]
+                },
+                "usage": {
+                    "value": "worngloves"
+                }
+            },
+            "type": "weapon"
         }
     ],
     "name": "Yacob",


### PR DESCRIPTION
<img width="512" height="275" alt="image" src="https://github.com/user-attachments/assets/0462d3af-8dd2-4622-8aa8-f337c8358957" />

The original item in the actor was not adding the +1 bonus to hits, so I replaced it with the current version of the item in the compendium.