### PR TITLE
Fix Cavern Troll's Furious Throw not being a reaction

### DIFF
--- a/packs/pf2e/pathfinder-monster-core-2/cavern-troll.json
+++ b/packs/pf2e/pathfinder-monster-core-2/cavern-troll.json
@@ -203,10 +203,10 @@
             "sort": 600000,
             "system": {
                 "actionType": {
-                    "value": "action"
+                    "value": "reaction"
                 },
                 "actions": {
-                    "value": 1
+                    "value": null
                 },
                 "category": "defensive",
                 "description": {


### PR DESCRIPTION
Comparing to Monster Core 2, everything else about the statistics seems to be correct