### PR TITLE
Prevent item transfer from triggering multiple times with multiple GMs present

### DIFF
--- a/src/module/actor/item-transfer.ts
+++ b/src/module/actor/item-transfer.ts
@@ -47,7 +47,7 @@ export class ItemTransfer implements ItemTransferData {
     }
 
     async request(): Promise<void> {
-        const gamemaster = game.users.find((u) => u.isGM && u.active);
+        const gamemaster = game.users.activeGM;
         if (!gamemaster) {
             const source = this.#getSource();
             const target = this.#getTarget();

--- a/src/module/actor/party/helpers.ts
+++ b/src/module/actor/party/helpers.ts
@@ -2,7 +2,7 @@ import { ActorPF2e } from "@actor";
 
 /** Create the first party actor in this (typically new) world */
 async function createFirstParty(): Promise<void> {
-    if (game.user !== game.users.activeGM || game.settings.get(SYSTEM_ID, "createdFirstParty")) {
+    if (!game.user.isActiveGM || game.settings.get(SYSTEM_ID, "createdFirstParty")) {
         return;
     }
 

--- a/src/scripts/hooks/ready.ts
+++ b/src/scripts/hooks/ready.ts
@@ -55,7 +55,7 @@ export const Ready = {
             // Save the current world schema version if hasn't before.
             storeInitialWorldVersions().then(async () => {
                 // Ensure only a single GM will run migrations if multiple are logged in
-                if (game.user !== game.users.activeGM) return;
+                if (!game.user.isActiveGM) return;
 
                 // 🎉
                 await createFirstParty();

--- a/src/scripts/socket.ts
+++ b/src/scripts/socket.ts
@@ -8,7 +8,7 @@ function activateSocketListener(): void {
         const sender = game.users.get(userId, { strict: true });
         switch (message.request) {
             case "itemTransfer":
-                if (game.user.isGM) {
+                if (game.user.isActiveGM) {
                     console.debug(`PF2e System | Received item-transfer request from ${sender.name}`);
                     const transfer = new ItemTransfer(message.data);
                     transfer.enact(sender);


### PR DESCRIPTION
The key change here is in socket.ts, where the check was true for all connected GMs (that is, all GMs and Assistant GMs). Changed to a core helper property designed to guarantee that only one active GM as valid.

Also replaced other occurrences of active GM checks with isActiveGM where I thought appropriate, but it shouldn't cause any observable changes.

Should be enough to close https://github.com/foundryvtt/pf2e/issues/20858