### PR TITLE
Add base slug to Powerful Alchemy

### DIFF
--- a/packs/pf2e/class-features/powerful-alchemy.json
+++ b/packs/pf2e/class-features/powerful-alchemy.json
@@ -32,6 +32,7 @@
                     "item:trait:infused"
                 ],
                 "selector": "inline-dc",
+                "slug": "base",
                 "value": "@actor.classDCs.alchemist.mod"
             }
         ],


### PR DESCRIPTION
Powerful Alchemy was lacking a base slug which resulted in the target DC going wacky if any conditions on the actor impacted DCs. As detailed in https://github.com/foundryvtt/pf2e/issues/21091