### PR TITLE
Fix the Blood Pear Tree Splash Damage

### DIFF
--- a/packs/pf2e/stolen-fate-bestiary/book-2-the-destiny-war/blood-pear-tree.json
+++ b/packs/pf2e/stolen-fate-bestiary/book-2-the-destiny-war/blood-pear-tree.json
@@ -115,7 +115,7 @@
                     "1": {
                         "category": "splash",
                         "damage": "2d6",
-                        "damageType": "poison"
+                        "damageType": "bleed"
                     }
                 },
                 "description": {


### PR DESCRIPTION
Fixed the Blood Pear Tree splash damage from poison to bleed as reported in https://github.com/foundryvtt/pf2e/issues/14360