### PR TITLE
Add aura to 3rd rank protection spell effect

### DIFF
--- a/packs/pf2e/spell-effects/spell-effect-protection-aura.json
+++ b/packs/pf2e/spell-effects/spell-effect-protection-aura.json
@@ -1,7 +1,7 @@
 {
-    "_id": "RawLEPwyT5CtCZ4D",
+    "_id": "Ydjj9h3EwhVLmv11",
     "img": "systems/pf2e/icons/spells/protection.webp",
-    "name": "Spell Effect: Protection",
+    "name": "Spell Effect: Protection (Aura)",
     "system": {
         "description": {
             "value": "<p>Granted by @UUID[Compendium.pf2e.spells-srd.Item.Protection].</p>\n<p>You gain a +1 status bonus to Armor Class and saving throws.</p>"
@@ -12,6 +12,7 @@
             "unit": "minutes",
             "value": 1
         },
+        "fromSpell": false,
         "level": {
             "value": 1
         },
@@ -30,23 +31,6 @@
                 ],
                 "type": "status",
                 "value": 1
-            },
-            {
-                "effects": [
-                    {
-                        "uuid": "Compendium.pf2e.spell-effects.Item.Ydjj9h3EwhVLmv11"
-                    }
-                ],
-                "key": "Aura",
-                "predicate": [
-                    {
-                        "gte": [
-                            "parent:level",
-                            3
-                        ]
-                    }
-                ],
-                "radius": 10
             }
         ],
         "start": {
@@ -57,7 +41,6 @@
             "show": true
         },
         "traits": {
-            "rarity": "common",
             "value": []
         }
     },

--- a/packs/pf2e/spell-effects/spell-effect-protection.json
+++ b/packs/pf2e/spell-effects/spell-effect-protection.json
@@ -34,7 +34,7 @@
             {
                 "effects": [
                     {
-                        "uuid": "Compendium.pf2e.spell-effects.Item.Ydjj9h3EwhVLmv11"
+                        "uuid": "Compendium.pf2e.spell-effects.Item.Spell Effect: Protection (Aura)"
                     }
                 ],
                 "key": "Aura",


### PR DESCRIPTION
I hope I did this right, and I hope this doesn't conflict with the text of the spell being:

Heightened (3rd) You **can** choose to have the benefits also affect all your allies in a 10-foot emanation around the target.

I am also not sure if this is intended to act like an aura, or to apply to everyone at the time of casting for the duration of the spell

But @InfamousSky made me make this PR, so he's at fault