### PR TITLE
Fix buying items from merchants using credits

### DIFF
--- a/src/module/item/physical/coins.ts
+++ b/src/module/item/physical/coins.ts
@@ -160,7 +160,7 @@ class Coins implements RawCoins {
         }
 
         // Simplify to GP if normalization is enabled
-        const coins = normalize ? this.#normalized() : this;
+        const coins = normalize ? this.normalized() : this;
 
         // Return 0 in the default denomination if there's nothing
         if (CURRENCY_TYPES.every((denomination) => !coins[denomination])) {
@@ -179,8 +179,12 @@ class Coins implements RawCoins {
         return parts.join(", ");
     }
 
-    /** Internal helper to normalize to GP */
-    #normalized() {
+    /** Returns the coins normalized to the system currency */
+    normalized(): Coins {
+        if (SYSTEM_ID === "sf2e") {
+            return new Coins({ credits: Math.ceil(this.copperValue / 10) });
+        }
+
         const coins = new Coins({ cp: this.copperValue });
         coins.sp = Math.floor(coins.cp / 10);
         coins.cp = coins.cp % 10;

--- a/src/module/item/physical/document.ts
+++ b/src/module/item/physical/document.ts
@@ -271,7 +271,7 @@ abstract class PhysicalItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | n
         if (traits.includes("infused")) this.system.temporary = true;
 
         // Normalize and fill price data
-        this.system.price.value = new Coins(this.system.temporary ? {} : this.system.price.value);
+        this.system.price.value = new Coins(this.system.temporary ? {} : this.system.price.value).normalized();
         this.system.price.per = Math.max(1, this.system.price.per ?? 1);
         this.system.price.sizeSensitive ??= true;
 


### PR DESCRIPTION
Internally this makes all item prices convert "sp" to "credits", so that addCurrency() calls don't explode in normal cases.

I'm willing to entertain a different name for the function, though it should remain a function in case we ever need to add a custom round up or round down. Selling would round down, buying would round up *I think*.