### PR TITLE
Add vehicle related actions to SF2e

### DIFF
--- a/src/module/system/action-macros/index.ts
+++ b/src/module/system/action-macros/index.ts
@@ -59,8 +59,13 @@ import * as treatDisease from "./medicine/treat-disease.ts";
 import * as treatPoison from "./medicine/treat-poison.ts";
 import * as commandAnAnimal from "./nature/command-an-animal.ts";
 import * as perform from "./performance/perform.ts";
+import { drive } from "./piloting/drive.ts";
 import { navigate } from "./piloting/navigate.ts";
 import { plotCourse } from "./piloting/plot-course.ts";
+import { runOver } from "./piloting/run-over.ts";
+import { stop } from "./piloting/stop.ts";
+import { stunt } from "./piloting/stunt.ts";
+import { takeControl } from "./piloting/take-control.ts";
 import * as createForgery from "./society/create-forgery.ts";
 import { arrestAFall } from "./specialty-basic/arrest-a-fall.ts";
 import { avertGaze } from "./specialty-basic/avert-gaze.ts";
@@ -240,6 +245,21 @@ const SystemActions: Action[] = [
     tumbleThrough.action,
 ];
 
-const SF2eOnlySystemActions = [accessInfosphere, hack, operateDevice, navigate, plotCourse];
+/**
+ * Actions that are only relevant in the starfinder system and sf2e anachronism.
+ * @todo Some of these are present in pf2e as well but require more complicated handling.
+ */
+const SF2eOnlySystemActions = [
+    accessInfosphere,
+    drive,
+    hack,
+    navigate,
+    operateDevice,
+    plotCourse,
+    runOver,
+    stop,
+    stunt,
+    takeControl,
+];
 
 export { SF2eOnlySystemActions, SystemActions };

--- a/src/module/system/action-macros/piloting/drive.ts
+++ b/src/module/system/action-macros/piloting/drive.ts
@@ -1,0 +1,54 @@
+import { SingleCheckAction } from "@actor/actions/index.ts";
+
+const PREFIX = "PF2E.Actions.Drive";
+
+const drive = new SingleCheckAction({
+    description: `${PREFIX}.Description`,
+    name: `${PREFIX}.Title`,
+    rollOptions: ["action:drive"],
+    section: "skill",
+    slug: "drive",
+    statistic: "piloting",
+    traits: ["move"],
+    variants: [
+        {
+            cost: 1,
+            description: `${PREFIX}.Drive1.Description`,
+            name: `${PREFIX}.Drive1.Title`,
+            notes: [
+                { outcome: ["criticalSuccess", "success"], text: `${PREFIX}.Drive1.Notes.success` },
+                { outcome: ["failure"], text: `${PREFIX}.Drive1.Notes.failure` },
+                { outcome: ["criticalFailure"], text: `${PREFIX}.Drive1.Notes.criticalFailure` },
+            ],
+            rollOptions: ["action:drive", "action:drive:drive1"],
+            slug: "drive1",
+        },
+        {
+            cost: 2,
+            description: `${PREFIX}.Drive2.Description`,
+            name: `${PREFIX}.Drive2.Title`,
+            notes: [
+                { outcome: ["criticalSuccess", "success"], text: `${PREFIX}.Drive2.Notes.success` },
+                { outcome: ["criticalFailure", "failure"], text: `${PREFIX}.Drive2.Notes.failure` },
+            ],
+            rollOptions: ["action:drive", "action:drive:drive2"],
+            slug: "drive2",
+            traits: ["move", "reckless"],
+        },
+        {
+            cost: 3,
+            description: `${PREFIX}.Drive3.Description`,
+            modifiers: [{ label: `${PREFIX}.Drive3.Title`, modifier: -5 }],
+            name: `${PREFIX}.Drive3.Title`,
+            notes: [
+                { outcome: ["criticalSuccess", "success"], text: `${PREFIX}.Drive3.Notes.success` },
+                { outcome: ["criticalFailure", "failure"], text: `${PREFIX}.Drive3.Notes.failure` },
+            ],
+            rollOptions: ["action:drive", "action:drive:drive3"],
+            slug: "drive3",
+            traits: ["move", "reckless"],
+        },
+    ],
+});
+
+export { drive };

--- a/src/module/system/action-macros/piloting/run-over.ts
+++ b/src/module/system/action-macros/piloting/run-over.ts
@@ -1,0 +1,18 @@
+import { SingleCheckAction } from "@actor/actions/index.ts";
+
+const PREFIX = "PF2E.Actions.RunOver";
+
+// @todo this action is present in pf2e as well but requires special handling
+const runOver = new SingleCheckAction({
+    cost: 3,
+    description: `${PREFIX}.Description`,
+    name: `${PREFIX}.Title`,
+    notes: [{ outcome: ["criticalFailure", "failure"], text: `${PREFIX}.Notes.failure` }],
+    rollOptions: ["action:run-over"],
+    section: "skill",
+    slug: "run-over",
+    statistic: "piloting",
+    traits: ["move", "reckless"],
+});
+
+export { runOver };

--- a/src/module/system/action-macros/piloting/stop.ts
+++ b/src/module/system/action-macros/piloting/stop.ts
@@ -1,0 +1,14 @@
+import { SimpleAction } from "@actor/actions/index.ts";
+
+const PREFIX = "PF2E.Actions.Stop";
+
+const stop = new SimpleAction({
+    cost: 1,
+    description: `${PREFIX}.Description`,
+    name: `${PREFIX}.Title`,
+    section: "skill",
+    slug: "stop",
+    traits: ["manipulate"],
+});
+
+export { stop };

--- a/src/module/system/action-macros/piloting/stunt.ts
+++ b/src/module/system/action-macros/piloting/stunt.ts
@@ -1,0 +1,110 @@
+import { SingleCheckAction } from "@actor/actions/index.ts";
+
+const PREFIX = "PF2E.Actions.Stunt";
+
+const stunt = new SingleCheckAction({
+    cost: 1,
+    description: `${PREFIX}.Description`,
+    name: `${PREFIX}.Title`,
+    notes: [{ outcome: ["criticalFailure", "failure"], text: `${PREFIX}.Notes.failure` }],
+    rollOptions: ["action:stunt"],
+    section: "skill",
+    slug: "stunt",
+    statistic: "piloting",
+    traits: ["manipulate", "move", "reckless"],
+    variants: [
+        {
+            modifiers: [
+                { label: `${PREFIX}.BackOff.Title`, modifier: -1 },
+                { label: `${PREFIX}.Modifiers.RecklessPiloting`, modifier: -5, predicate: ["reckless-piloting"] },
+            ],
+            name: `${PREFIX}.BackOff.Title`,
+            notes: [
+                { outcome: ["criticalSuccess", "success"], text: `${PREFIX}.BackOff.Notes.success` },
+                { outcome: ["criticalFailure", "failure"], text: `${PREFIX}.Notes.failure` },
+            ],
+            rollOptions: ["action:stunt", "action:stunt:back-off"],
+            slug: "back-off",
+        },
+        {
+            modifiers: [
+                { label: `${PREFIX}.Evade.Title`, modifier: -1 },
+                { label: `${PREFIX}.Modifiers.RecklessPiloting`, modifier: -5, predicate: ["reckless-piloting"] },
+            ],
+            name: `${PREFIX}.Evade.Title`,
+            notes: [
+                { outcome: ["criticalSuccess", "success"], text: `${PREFIX}.Evade.Notes.success` },
+                { outcome: ["criticalFailure", "failure"], text: `${PREFIX}.Notes.failure` },
+            ],
+            rollOptions: ["action:stunt", "action:stunt:evade"],
+            slug: "evade",
+        },
+        {
+            modifiers: [
+                { label: `${PREFIX}.FlipAndBurn.Title`, modifier: -1 },
+                { label: `${PREFIX}.Modifiers.RecklessPiloting`, modifier: -5, predicate: ["reckless-piloting"] },
+            ],
+            name: `${PREFIX}.FlipAndBurn.Title`,
+            notes: [
+                { outcome: ["criticalSuccess", "success"], text: `${PREFIX}.FlipAndBurn.Notes.success` },
+                { outcome: ["criticalFailure", "failure"], text: `${PREFIX}.Notes.failure` },
+            ],
+            rollOptions: ["action:stunt", "action:stunt:flip-and-burn"],
+            slug: "flip-and-burn",
+        },
+        {
+            modifiers: [
+                { label: `${PREFIX}.BarrelRoll.Title`, modifier: -2 },
+                { label: `${PREFIX}.Modifiers.RecklessPiloting`, modifier: -5, predicate: ["reckless-piloting"] },
+            ],
+            name: `${PREFIX}.BarrelRoll.Title`,
+            notes: [
+                { outcome: ["criticalSuccess", "success"], text: `${PREFIX}.BarrelRoll.Notes.success` },
+                { outcome: ["criticalFailure", "failure"], text: `${PREFIX}.Notes.failure` },
+            ],
+            rollOptions: ["action:stunt", "action:stunt:barrel-roll"],
+            slug: "barrel-roll",
+        },
+        {
+            modifiers: [
+                { label: `${PREFIX}.Flyby.Title`, modifier: -2 },
+                { label: `${PREFIX}.Modifiers.RecklessPiloting`, modifier: -5, predicate: ["reckless-piloting"] },
+            ],
+            name: `${PREFIX}.Flyby.Title`,
+            notes: [
+                { outcome: ["criticalSuccess", "success"], text: `${PREFIX}.Flyby.Notes.success` },
+                { outcome: ["criticalFailure", "failure"], text: `${PREFIX}.Notes.failure` },
+            ],
+            rollOptions: ["action:stunt", "action:stunt:flyby"],
+            slug: "flyby",
+        },
+        {
+            modifiers: [
+                { label: `${PREFIX}.Drift.Title`, modifier: -2 },
+                { label: `${PREFIX}.Modifiers.RecklessPiloting`, modifier: -5, predicate: ["reckless-piloting"] },
+            ],
+            name: `${PREFIX}.Drift.Title`,
+            notes: [
+                { outcome: ["criticalSuccess", "success"], text: `${PREFIX}.Drift.Notes.success` },
+                { outcome: ["criticalFailure", "failure"], text: `${PREFIX}.Notes.failure` },
+            ],
+            rollOptions: ["action:stunt", "action:stunt:drift"],
+            slug: "drift",
+        },
+        {
+            modifiers: [
+                { label: `${PREFIX}.TurnInPlace.Title`, modifier: -2 },
+                { label: `${PREFIX}.Modifiers.RecklessPiloting`, modifier: -5, predicate: ["reckless-piloting"] },
+            ],
+            name: `${PREFIX}.TurnInPlace.Title`,
+            notes: [
+                { outcome: ["criticalSuccess", "success"], text: `${PREFIX}.TurnInPlace.Notes.success` },
+                { outcome: ["criticalFailure", "failure"], text: `${PREFIX}.Notes.failure` },
+            ],
+            rollOptions: ["action:stunt", "action:stunt:turn-in-place"],
+            slug: "turn-in-place",
+        },
+    ],
+});
+
+export { stunt };

--- a/src/module/system/action-macros/piloting/take-control.ts
+++ b/src/module/system/action-macros/piloting/take-control.ts
@@ -1,0 +1,18 @@
+import { SingleCheckAction } from "@actor/actions/index.ts";
+
+const PREFIX = "PF2E.Actions.TakeControl";
+
+// @todo this action is present in pf2e as well but requires special handling
+const takeControl = new SingleCheckAction({
+    cost: 1,
+    description: `${PREFIX}.Description`,
+    name: `${PREFIX}.Title`,
+    notes: [{ outcome: ["criticalSuccess", "success"], text: `${PREFIX}.Notes.success` }],
+    rollOptions: ["action:take-control"],
+    section: "skill",
+    slug: "take-control",
+    statistic: "piloting",
+    traits: ["manipulate"],
+});
+
+export { takeControl };


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/21285. The localization entries already exist in our DB, though the stop action has weird behavior because there is no check, so the card is blank. I'm not too motivated adding an exception case for the stop action to show the description when others don't. drive1/drive2/drive3 is a bit strange though.

While most of these actions are also in pf2e, we don't include them for that system because "piloting checks" in that system are a more complicated affair based on the checks required to pilot a specific vehicle, with feats able to allow certain lore skills to apply to all vehicles.