### PR TITLE
Halve the bulk of smaller items

### DIFF
--- a/src/module/item/physical/bulk.ts
+++ b/src/module/item/physical/bulk.ts
@@ -184,7 +184,7 @@ class Bulk {
                         ? new Bulk()
                         : b.value <= 1
                           ? new Bulk(0.1)
-                          : new Bulk(Math.max(0.1, Math.floor(0.1 * this.value))),
+                          : new Bulk(Math.max(0.1, Math.floor(0.5 * this.value))),
                 actorSizeIndex - itemSizeIndex,
                 this,
             );


### PR DESCRIPTION
This keeps the scaling more in line with how larger items double instead. Afterwards a Camel does not carry an absurd quantity of greatswords (but yes to longswords I guess).

This preserves the behavior of the following rule, with no changes other than 5 such items is 5xL instead of negligible
> A Large creature treats 10 items of 1 Bulk as 1 Bulk, a Huge creature treats 10 items of 2 Bulk as 1 Bulk, and so on. A Tiny creature treats 10 items of negligible Bulk as 1 Bulk.