### PR TITLE
Show default modular configuration if none are set

### DIFF
--- a/src/styles/item/_index.scss
+++ b/src/styles/item/_index.scss
@@ -455,6 +455,10 @@
                     flex: 1;
                 }
             }
+
+            .empty {
+                height: 1.5em;
+            }
         }
 
         .consumable-details {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3044,6 +3044,7 @@
                     "Label": "Melee Usage"
                 },
                 "Modular": {
+                    "Default": "B, P, or S",
                     "Title": "Modular Configurations"
                 },
                 "NoRangeMelee": "None (Melee)",

--- a/static/templates/items/partials/modular.hbs
+++ b/static/templates/items/partials/modular.hbs
@@ -13,6 +13,8 @@
                     <tagify-tags class="tags paizo-style modular-traits" name="{{basePath}}.traits" value="{{json config.traits}}"></tagify-tags>
                     <button type="button" class="inline-control icon fa-solid fa-trash" data-action="remove-modular-config" data-index="{{index}}"></button>
                 </div>
+            {{else}}
+                <div class="empty">{{localize "PF2E.Item.Weapon.Modular.Default"}}</div>
             {{/each}}
         </div>
     </fieldset>


### PR DESCRIPTION
<img width="709" height="466" alt="image" src="https://github.com/user-attachments/assets/74eda368-17dd-4b10-954e-836e2fceb971" />

Before the box was empty, so despite it actually adding the B/P/S variants in prepared data, it wasn't obvious.