### PR TITLE
Correct internal currency values for select items

### DIFF
--- a/packs/sf2e/equipment/grenades/flash-grenade-paragon.json
+++ b/packs/sf2e/equipment/grenades/flash-grenade-paragon.json
@@ -42,7 +42,7 @@
         },
         "price": {
             "value": {
-                "gp": 5000
+                "sp": 5000
             }
         },
         "publication": {

--- a/packs/sf2e/equipment/magic-items/divas-microphone-advanced.json
+++ b/packs/sf2e/equipment/magic-items/divas-microphone-advanced.json
@@ -27,9 +27,9 @@
         "price": {
             "value": {
                 "cp": 0,
-                "gp": 190400,
+                "gp": 0,
                 "pp": 0,
-                "sp": 0
+                "sp": 190400
             }
         },
         "publication": {

--- a/packs/sf2e/equipment/magic-items/divas-microphone-commercial.json
+++ b/packs/sf2e/equipment/magic-items/divas-microphone-commercial.json
@@ -27,9 +27,9 @@
         "price": {
             "value": {
                 "cp": 0,
-                "gp": 750,
+                "gp": 0,
                 "pp": 0,
-                "sp": 0
+                "sp": 750
             }
         },
         "publication": {

--- a/packs/sf2e/equipment/magic-items/divas-microphone-tactical.json
+++ b/packs/sf2e/equipment/magic-items/divas-microphone-tactical.json
@@ -26,7 +26,10 @@
         },
         "price": {
             "value": {
-                "gp": 9500
+                "cp": 0,
+                "gp": 0,
+                "pp": 0,
+                "sp": 9500
             }
         },
         "publication": {

--- a/packs/sf2e/equipment/medical-items/machine-mind-serum-advanced.json
+++ b/packs/sf2e/equipment/medical-items/machine-mind-serum-advanced.json
@@ -28,7 +28,7 @@
         },
         "price": {
             "value": {
-                "gp": 200
+                "sp": 200
             }
         },
         "publication": {

--- a/packs/sf2e/equipment/medical-items/machine-mind-serum-tactical.json
+++ b/packs/sf2e/equipment/medical-items/machine-mind-serum-tactical.json
@@ -28,7 +28,7 @@
         },
         "price": {
             "value": {
-                "gp": 10
+                "sp": 10
             }
         },
         "publication": {

--- a/packs/sf2e/equipment/weapons/shuriken-drone.json
+++ b/packs/sf2e/equipment/weapons/shuriken-drone.json
@@ -39,7 +39,7 @@
         },
         "price": {
             "value": {
-                "gp": 5
+                "sp": 5
             }
         },
         "publication": {


### PR DESCRIPTION
- Closes #21276

Note that Invisibility Potion is not a native item from SF2e, but was added because of typo shenanigans/links in the Detect Magic description. Those links have been removed, so the item in question could be removed.