### PR TITLE
Corrected crafting crit success daily reduction

### DIFF
--- a/src/module/actor/character/crafting/helpers.ts
+++ b/src/module/actor/character/crafting/helpers.ts
@@ -61,9 +61,9 @@ function calculateCosts(
     const REWARDS = EarnIncomeDialog.REWARDS_BY_LEVEL;
     const level = Math.clamp(actor.level, 0, 20) as keyof typeof REWARDS;
     if (degreeOfSuccess === DegreeOfSuccess.CRITICAL_SUCCESS) {
-        Object.assign(reductionPerDay, REWARDS[level].rewards[proficiency]);
-    } else if (degreeOfSuccess === DegreeOfSuccess.SUCCESS) {
         Object.assign(reductionPerDay, REWARDS[(level + 1) as keyof typeof REWARDS].rewards[proficiency]);
+    } else if (degreeOfSuccess === DegreeOfSuccess.SUCCESS) {
+        Object.assign(reductionPerDay, REWARDS[level].rewards[proficiency]);
     } else if (degreeOfSuccess === DegreeOfSuccess.CRITICAL_FAILURE) {
         Object.assign(lostMaterials, materialCosts.scale(0.1));
     }


### PR DESCRIPTION
Regular success was giving the level + 1 amount as a crit success, and vice versa.