### PR TITLE
Add `tech` trait to consumables and refresh physical items and spells for all SF2e actors

### DIFF
--- a/packs/sf2e/alien-core-bestiary/abysium-dragon-adult-spellcaster.json
+++ b/packs/sf2e/alien-core-bestiary/abysium-dragon-adult-spellcaster.json
@@ -195,6 +195,9 @@
         },
         {
             "_id": "dHRXj0jAlU98R1gj",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.BHWG0rQPTgBF5Ye1"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/blue-rocket-thrusters.webp",
             "name": "Rocket Dash",
@@ -278,6 +281,9 @@
         },
         {
             "_id": "7Acucq3f39JJOD25",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.a02hsymtiVRQvh3i"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/purple-eruption.webp",
             "name": "Slice Reality",
@@ -362,6 +368,9 @@
         },
         {
             "_id": "eCnER9CLFs0yzKih",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.DPP4TW5FxE85XPKZ"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/blue-piercing-energy.webp",
             "name": "X-Ray Vision",
@@ -421,6 +430,9 @@
         },
         {
             "_id": "oQD8CxVO1Frvdjxv",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.7WtiWJRYZhT6a9Ey"
+            },
             "folder": "NQpcS2TwtjNNq1Qy",
             "img": "systems/sf2e/icons/abilities/purple-tentacle.webp",
             "name": "Control Machine",
@@ -485,6 +497,9 @@
         },
         {
             "_id": "xkvPvtgwooJFv36P",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5cMDrC3jX1yrxOzh"
+            },
             "folder": "NQpcS2TwtjNNq1Qy",
             "img": "systems/sf2e/icons/abilities/blue-heroic-lightning-symbol.webp",
             "name": "Overload Systems",
@@ -571,6 +586,9 @@
         },
         {
             "_id": "7AHWmq8eVI6qNEhV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.MlpbeZ61Euhl0d60"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "icons/creatures/slimes/slime-movement-splash-green.webp",
             "name": "Toxic Cloud",
@@ -627,7 +645,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -659,6 +677,9 @@
         },
         {
             "_id": "YIUYBK8r8wmHUt6o",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.LiGbewa9pO0yjbsY"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "systems/sf2e/icons/spells/confusion.webp",
             "name": "Confusion",
@@ -702,7 +723,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -734,6 +755,9 @@
         },
         {
             "_id": "ebjuXO7WUpxG4axx",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VlNcjmYyu95vOUe8"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/magic/symbols/ring-circle-smoke-blue.webp",
             "name": "Translocate",
@@ -772,7 +796,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -803,6 +827,9 @@
         },
         {
             "_id": "quaqknesdm4HOw5K",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.aqRYNoSvxsVfqglH"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/equipment/feet/boots-leather-laced-brown.webp",
             "name": "Unfettered Movement",
@@ -832,7 +859,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -863,6 +890,9 @@
         },
         {
             "_id": "K6fKujFAT3FvLTeM",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.V8wXOsoejQhe6CyG"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "systems/sf2e/icons/spells/gaseous-form.webp",
             "name": "Vapor Form",
@@ -891,7 +921,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -924,6 +954,9 @@
         },
         {
             "_id": "NjOsDIxDq9inDGp1",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VosLNn2M8S7JH67D"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/skills/wounds/injury-eyes-blood-red.webp",
             "name": "Blindness",
@@ -957,7 +990,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -990,6 +1023,9 @@
         },
         {
             "_id": "A7qU3w6XTrv0xX7p",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.sxQZ6yqTn0czJxVd"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/fire/projectile-fireball-orange-yellow.webp",
             "name": "Fireball",
@@ -1045,7 +1081,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -1076,6 +1112,9 @@
         },
         {
             "_id": "tXQck7637wv63XGS",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.sxQZ6yqTn0czJxVd"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/fire/projectile-fireball-orange-yellow.webp",
             "name": "Fireball",
@@ -1132,7 +1171,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -1163,6 +1202,9 @@
         },
         {
             "_id": "LYYiZ5rLiLxOHNSl",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.o6YCGx4lycsYpww4"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "systems/sf2e/icons/spells/haste.webp",
             "name": "Haste",
@@ -1201,7 +1243,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1232,6 +1274,9 @@
         },
         {
             "_id": "5pW3Ot3n8RVkYYJx",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.WsUwpfmhKrKwoIe3"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/time/hourglass-tilted-gray.webp",
             "name": "Slow",
@@ -1275,7 +1320,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1306,6 +1351,9 @@
         },
         {
             "_id": "bY8b1GfVU5gW63Hj",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.9XHmC2JgTUIQ1CCm"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/magic/air/fog-gas-smoke-dense-white.webp",
             "name": "Mist",
@@ -1337,7 +1385,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -1368,6 +1416,9 @@
         },
         {
             "_id": "5oeItviQmNTQnNxI",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jwK43yKsHTkJQvQ9"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/see-invisibility.webp",
             "name": "See the Unseen",
@@ -1396,7 +1447,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1428,6 +1479,9 @@
         },
         {
             "_id": "1gBKtPHCyHoae5tk",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Et8RSCLx8w7uOLvo"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/wholeness-of-body.webp",
             "name": "Sound Body",
@@ -1456,7 +1510,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -1489,6 +1543,9 @@
         },
         {
             "_id": "Kcnxl3Pln8nNd9r8",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.NkvRoN33RbDg3fl9"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/pink-target-sign.webp",
             "name": "Analyze Target",
@@ -1502,7 +1559,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The circumstance bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The circumstance bonus increases to +3, and you can target any number of creatures.</p>"
+                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The status bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The status bonus increases to +3, and you can target any number of creatures.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -1551,6 +1608,9 @@
         },
         {
             "_id": "EY3EzuuEqQXJVEHD",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.thAHF1zxNplLCJPO"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/acid/orb-bubble-smoke-drip.webp",
             "name": "Caustic Blast",
@@ -1606,7 +1666,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1638,6 +1698,9 @@
         },
         {
             "_id": "9GscdSBUqPVXFXjQ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.aIHY2DArKFweIrpf"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/command.webp",
             "name": "Command",
@@ -1681,7 +1744,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1715,6 +1778,9 @@
         },
         {
             "_id": "ZR4y006sR2oAv5xs",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -1731,7 +1797,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -1746,7 +1812,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1780,6 +1846,9 @@
         },
         {
             "_id": "dp42P1bxynqqvKWV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Wu0xFpewMKRK3HG8"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/grease.webp",
             "name": "Grease",
@@ -1813,7 +1882,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1843,6 +1912,9 @@
         },
         {
             "_id": "ckLEubyjcfUWfiN7",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.6DfLZBl8wKIV03Iq"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/fire/explosion-embers-evade-silhouette.webp",
             "name": "Ignition",
@@ -1891,7 +1963,9 @@
                         "_id": "eOCNn2ohYAvsYZjn",
                         "overlayType": "override",
                         "sort": 1,
-                        "system": {}
+                        "system": {
+                            "defense": null
+                        }
                     },
                     "xYyA7CV1GaFTRjBQ": {
                         "_id": "xYyA7CV1GaFTRjBQ",
@@ -1904,6 +1978,7 @@
                                     "formula": "2d6"
                                 }
                             },
+                            "defense": null,
                             "heightening": {
                                 "damage": {
                                     "cQDyW0QpjJ38MlSi": "1d6"
@@ -1918,7 +1993,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1951,6 +2026,9 @@
         },
         {
             "_id": "tOK2j5XmxAv2XkAV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.bBQ83xDvjQS3W1CG"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/blue-thermometer.webp",
             "name": "Measure",
@@ -2014,6 +2092,9 @@
         },
         {
             "_id": "cRNDullKGldNqzFJ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Qw3fnUlaUbnn7ipC"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/symbols/runes-triangle-blue.webp",
             "name": "Prestidigitation",
@@ -2042,7 +2123,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "10 feet"
@@ -2075,6 +2156,9 @@
         },
         {
             "_id": "ZWdMdftldSh7nV30",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.OhD2Z6rIGGD5ocZA"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/light/explosion-star-glow-silhouette.webp",
             "name": "Read Aura",
@@ -2118,7 +2202,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -2152,8 +2236,11 @@
         },
         {
             "_id": "CyvkBL0N1Vg6sEsr",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.o4lRVTwSxnOOn5vl"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
-            "img": "systems/sf2e/icons/spells/sleep.webp",
+            "img": "icons/magic/control/sleep-bubble-purple.webp",
             "name": "Sleep",
             "sort": 3000000,
             "system": {
@@ -2173,7 +2260,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>Each creature in the area becomes drowsy and might fall asleep. A creature that falls @UUID[Compendium.sf2e.conditions.Item.Unconscious] from this spell doesn't fall @UUID[Compendium.sf2e.conditions.Item.Prone] or release what it's holding. This spell doesn't prevent creatures from waking up due to a successful Perception check, limiting its utility in combat.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature is unaffected.</p>\n<p><strong>Success</strong> The creature takes a -1 status penalty to Perception checks for 1 round.</p>\n<p><strong>Failure</strong> The creature falls Unconscious. If it's still Unconscious after 1 minute, it wakes up automatically.</p>\n<p><strong>Critical Failure</strong> The creature falls Unconscious. If it's still Unconscious after 1 hour, it wakes up automatically.</p>\n<hr />\n<p><strong>Heightened (4th)</strong> The creatures fall Unconscious for 1 round on a failure or 1 minute on a critical failure. They fall Prone and release what they're holding, and they can't attempt Perception checks to wake up. When the duration ends, the creature is sleeping normally instead of automatically waking up.</p>"
+                    "value": "<p>Each creature in the area becomes drowsy, possibly nodding off. A creature that falls @UUID[Compendium.sf2e.conditions.Item.Unconscious] from this spell doesn't fall @UUID[Compendium.sf2e.conditions.Item.Prone] or release what it's holding. This spell doesn't prevent creatures from waking up due to a successful Perception check, limiting its utility in combat.</p><hr /><p><strong>Critical Success</strong> The creature is unaffected.</p>\n<p><strong>Success</strong> The creature takes a –1 status penalty to Perception checks for 1 round.</p>\n<p><strong>Failure</strong> The creature falls unconscious. If it's still unconscious after 1 minute, it wakes up automatically.</p>\n<p><strong>Critical Failure</strong> The creature falls unconscious. If it's still unconscious after 1 hour, it wakes up automatically.</p><hr /><p><strong>Heightened (4th)</strong> The creatures fall unconscious for 1 round on a failure or 1 minute on a critical failure. They fall prone and release what they're holding, and they can't attempt Perception checks to wake up. When the duration ends, the creature is sleeping normally instead of automatically waking up.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -2188,7 +2275,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"

--- a/packs/sf2e/alien-core-bestiary/abysium-dragon-adult.json
+++ b/packs/sf2e/alien-core-bestiary/abysium-dragon-adult.json
@@ -49,6 +49,9 @@
         },
         {
             "_id": "dHRXj0jAlU98R1gj",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.BHWG0rQPTgBF5Ye1"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/blue-rocket-thrusters.webp",
             "name": "Rocket Dash",
@@ -132,6 +135,9 @@
         },
         {
             "_id": "7AHWmq8eVI6qNEhV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.MlpbeZ61Euhl0d60"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "icons/creatures/slimes/slime-movement-splash-green.webp",
             "name": "Toxic Cloud",
@@ -188,7 +194,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -220,6 +226,9 @@
         },
         {
             "_id": "quaqknesdm4HOw5K",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.aqRYNoSvxsVfqglH"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/equipment/feet/boots-leather-laced-brown.webp",
             "name": "Unfettered Movement",
@@ -249,7 +258,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -280,6 +289,9 @@
         },
         {
             "_id": "tXQck7637wv63XGS",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.sxQZ6yqTn0czJxVd"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/fire/projectile-fireball-orange-yellow.webp",
             "name": "Fireball",
@@ -336,7 +348,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -367,6 +379,9 @@
         },
         {
             "_id": "ZR4y006sR2oAv5xs",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -383,7 +398,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -398,7 +413,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -432,6 +447,9 @@
         },
         {
             "_id": "ckLEubyjcfUWfiN7",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.6DfLZBl8wKIV03Iq"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/fire/explosion-embers-evade-silhouette.webp",
             "name": "Ignition",
@@ -480,7 +498,9 @@
                         "_id": "eOCNn2ohYAvsYZjn",
                         "overlayType": "override",
                         "sort": 1,
-                        "system": {}
+                        "system": {
+                            "defense": null
+                        }
                     },
                     "xYyA7CV1GaFTRjBQ": {
                         "_id": "xYyA7CV1GaFTRjBQ",
@@ -493,6 +513,7 @@
                                     "formula": "2d6"
                                 }
                             },
+                            "defense": null,
                             "heightening": {
                                 "damage": {
                                     "cQDyW0QpjJ38MlSi": "1d6"
@@ -507,7 +528,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"

--- a/packs/sf2e/alien-core-bestiary/abysium-dragon-ancient-spellcaster.json
+++ b/packs/sf2e/alien-core-bestiary/abysium-dragon-ancient-spellcaster.json
@@ -227,6 +227,9 @@
         },
         {
             "_id": "3T73Y3X4lhwNsrfu",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.UnWaP06SVi3jRN0M"
+            },
             "folder": "DWZvpqhX0tWHYZOh",
             "img": "systems/sf2e/icons/abilities/orange-mushroom-cloud.webp",
             "name": "Atomic Blast",
@@ -269,7 +272,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You magically split an atom, creating an explosion with radioactive fallout. All targets in the area take 5d12 bludgeoning damage and 5d12 fire damage, and they're exposed to extreme radiation that uses your spellcasting DC as the @Check[fortitude]{Fortitude DC} for radiation sickness incurred by exposure to this radiation. The onset and frequency of this magical radiation is 1 round, and the area remains radioactive for 10 minutes.</p><hr /><p><strong>Critical Success</strong> The target is unaffected by the initial damage.</p>\n<p><strong>Success</strong> The target takes half damage and is @UUID[Compendium.sf2e.conditions.Item.Dazzled] for 1 minute.</p>\n<p><strong>Failure</strong> The target takes full damage and is @UUID[Compendium.sf2e.conditions.Item.Blinded] for 1 minute.</p>\n<p><strong>Critical Failure</strong> As failure, and the target takes double damage.</p>"
+                    "value": "<p>You magically split an atom, creating an explosion with radioactive fallout. All creatures in the area take 5d12 bludgeoning damage and 5d12 fire damage, and they're exposed to extreme radiation that uses your spellcasting DC as the @Check[fortitude]{Fortitude DC} for radiation sickness incurred by exposure to this radiation. The onset and frequency of this magical radiation is 1 round, and the area remains radioactive for 10 minutes.</p><hr /><p><strong>Critical Success</strong> The target is unaffected by the initial damage.</p>\n<p><strong>Success</strong> The target takes half damage and is @UUID[Compendium.sf2e.conditions.Item.Dazzled] for 1 minute.</p>\n<p><strong>Failure</strong> The target takes full damage and is @UUID[Compendium.sf2e.conditions.Item.Blinded] for 1 minute.</p>\n<p><strong>Critical Failure</strong> As failure, and the target takes double damage.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -317,6 +320,9 @@
         },
         {
             "_id": "zJ0dQNiMoxxiNcDF",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.x7SPrsRxGb2Vy2nu"
+            },
             "folder": "IfuYSF4ymX48CZnm",
             "img": "systems/sf2e/icons/spells/earthquake.webp",
             "name": "Earthquake",
@@ -379,7 +385,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -410,6 +416,9 @@
         },
         {
             "_id": "WaWdaFW2F8LVxGCh",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gLOelTMvex2OgBqV"
+            },
             "folder": "uIyg7rfbXLT1OSXC",
             "img": "systems/sf2e/icons/abilities/purple-black-hole.webp",
             "name": "Gravity Field",
@@ -473,6 +482,9 @@
         },
         {
             "_id": "MxN5SRvDzNQBmqe3",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.m2xFMNyQiUKQDRaj"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "icons/magic/defensive/shield-barrier-glowing-blue.webp",
             "name": "Energy Aegis",
@@ -501,7 +513,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -533,6 +545,9 @@
         },
         {
             "_id": "qFYKttZkXUg0d6sC",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.fRT0T9sbd8zWc1q9"
+            },
             "folder": "MNWDEVo1eeM3A3Ec",
             "img": "systems/sf2e/icons/abilities/alien-cube-in-space.webp",
             "name": "Wall of Steel",
@@ -592,6 +607,9 @@
         },
         {
             "_id": "aNZOU3Ol7O6m8yR8",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.BHWG0rQPTgBF5Ye1"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/blue-rocket-thrusters.webp",
             "name": "Rocket Dash",
@@ -675,6 +693,9 @@
         },
         {
             "_id": "7Acucq3f39JJOD25",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.a02hsymtiVRQvh3i"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/purple-eruption.webp",
             "name": "Slice Reality",
@@ -759,6 +780,9 @@
         },
         {
             "_id": "fYoEAx8wt3fPSDfd",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.dRP4Imw3RJNQqEgc"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/yellow-energy-star.webp",
             "name": "Wall of Plasma",
@@ -850,6 +874,9 @@
         },
         {
             "_id": "eCnER9CLFs0yzKih",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.DPP4TW5FxE85XPKZ"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/blue-piercing-energy.webp",
             "name": "X-Ray Vision",
@@ -909,6 +936,9 @@
         },
         {
             "_id": "oQD8CxVO1Frvdjxv",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.7WtiWJRYZhT6a9Ey"
+            },
             "folder": "NQpcS2TwtjNNq1Qy",
             "img": "systems/sf2e/icons/abilities/purple-tentacle.webp",
             "name": "Control Machine",
@@ -973,6 +1003,9 @@
         },
         {
             "_id": "xkvPvtgwooJFv36P",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5cMDrC3jX1yrxOzh"
+            },
             "folder": "NQpcS2TwtjNNq1Qy",
             "img": "systems/sf2e/icons/abilities/blue-heroic-lightning-symbol.webp",
             "name": "Overload Systems",
@@ -1059,6 +1092,9 @@
         },
         {
             "_id": "DeJSszc9Ih7y9t1A",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.MlpbeZ61Euhl0d60"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "icons/creatures/slimes/slime-movement-splash-green.webp",
             "name": "Toxic Cloud",
@@ -1115,7 +1151,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -1147,6 +1183,9 @@
         },
         {
             "_id": "YIUYBK8r8wmHUt6o",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.LiGbewa9pO0yjbsY"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "systems/sf2e/icons/spells/confusion.webp",
             "name": "Confusion",
@@ -1190,7 +1229,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1222,6 +1261,9 @@
         },
         {
             "_id": "yVisEMsKGHxOpdSt",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.YrzBLPLd3r9m6t1p"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/magic/fire/barrier-shield-explosion-yellow.webp",
             "name": "Fire Shield (Constant)",
@@ -1269,7 +1311,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1300,6 +1342,9 @@
         },
         {
             "_id": "ebjuXO7WUpxG4axx",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VlNcjmYyu95vOUe8"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/magic/symbols/ring-circle-smoke-blue.webp",
             "name": "Translocate",
@@ -1338,7 +1383,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -1369,6 +1414,9 @@
         },
         {
             "_id": "LLxmAf6tbm6ZPziB",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.aqRYNoSvxsVfqglH"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/equipment/feet/boots-leather-laced-brown.webp",
             "name": "Unfettered Movement",
@@ -1398,7 +1446,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -1429,6 +1477,9 @@
         },
         {
             "_id": "K6fKujFAT3FvLTeM",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.V8wXOsoejQhe6CyG"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "systems/sf2e/icons/spells/gaseous-form.webp",
             "name": "Vapor Form",
@@ -1457,7 +1508,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -1490,6 +1541,9 @@
         },
         {
             "_id": "NjOsDIxDq9inDGp1",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VosLNn2M8S7JH67D"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/skills/wounds/injury-eyes-blood-red.webp",
             "name": "Blindness",
@@ -1523,7 +1577,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1556,6 +1610,9 @@
         },
         {
             "_id": "A7qU3w6XTrv0xX7p",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.sxQZ6yqTn0czJxVd"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/fire/projectile-fireball-orange-yellow.webp",
             "name": "Fireball",
@@ -1611,7 +1668,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -1642,6 +1699,9 @@
         },
         {
             "_id": "Vy10PAgGBwduvO9y",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.sxQZ6yqTn0czJxVd"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/fire/projectile-fireball-orange-yellow.webp",
             "name": "Fireball",
@@ -1698,7 +1758,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -1729,6 +1789,9 @@
         },
         {
             "_id": "LYYiZ5rLiLxOHNSl",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.o6YCGx4lycsYpww4"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "systems/sf2e/icons/spells/haste.webp",
             "name": "Haste",
@@ -1767,7 +1830,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1798,6 +1861,9 @@
         },
         {
             "_id": "5pW3Ot3n8RVkYYJx",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.WsUwpfmhKrKwoIe3"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/time/hourglass-tilted-gray.webp",
             "name": "Slow",
@@ -1841,7 +1907,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1872,6 +1938,9 @@
         },
         {
             "_id": "bY8b1GfVU5gW63Hj",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.9XHmC2JgTUIQ1CCm"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/magic/air/fog-gas-smoke-dense-white.webp",
             "name": "Mist",
@@ -1903,7 +1972,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -1934,6 +2003,9 @@
         },
         {
             "_id": "5oeItviQmNTQnNxI",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jwK43yKsHTkJQvQ9"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/see-invisibility.webp",
             "name": "See the Unseen",
@@ -1962,7 +2034,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1994,6 +2066,9 @@
         },
         {
             "_id": "1gBKtPHCyHoae5tk",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Et8RSCLx8w7uOLvo"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/wholeness-of-body.webp",
             "name": "Sound Body",
@@ -2022,7 +2097,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -2055,6 +2130,9 @@
         },
         {
             "_id": "Kcnxl3Pln8nNd9r8",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.NkvRoN33RbDg3fl9"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/pink-target-sign.webp",
             "name": "Analyze Target",
@@ -2068,7 +2146,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The circumstance bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The circumstance bonus increases to +3, and you can target any number of creatures.</p>"
+                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The status bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The status bonus increases to +3, and you can target any number of creatures.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -2117,6 +2195,9 @@
         },
         {
             "_id": "EY3EzuuEqQXJVEHD",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.thAHF1zxNplLCJPO"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/acid/orb-bubble-smoke-drip.webp",
             "name": "Caustic Blast",
@@ -2172,7 +2253,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -2204,6 +2285,9 @@
         },
         {
             "_id": "9GscdSBUqPVXFXjQ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.aIHY2DArKFweIrpf"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/command.webp",
             "name": "Command",
@@ -2247,7 +2331,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -2281,6 +2365,9 @@
         },
         {
             "_id": "ZR4y006sR2oAv5xs",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -2297,7 +2384,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -2312,7 +2399,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -2346,6 +2433,9 @@
         },
         {
             "_id": "dp42P1bxynqqvKWV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Wu0xFpewMKRK3HG8"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/grease.webp",
             "name": "Grease",
@@ -2379,7 +2469,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -2409,6 +2499,9 @@
         },
         {
             "_id": "ckLEubyjcfUWfiN7",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.6DfLZBl8wKIV03Iq"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/fire/explosion-embers-evade-silhouette.webp",
             "name": "Ignition",
@@ -2457,7 +2550,9 @@
                         "_id": "eOCNn2ohYAvsYZjn",
                         "overlayType": "override",
                         "sort": 1,
-                        "system": {}
+                        "system": {
+                            "defense": null
+                        }
                     },
                     "xYyA7CV1GaFTRjBQ": {
                         "_id": "xYyA7CV1GaFTRjBQ",
@@ -2470,6 +2565,7 @@
                                     "formula": "2d6"
                                 }
                             },
+                            "defense": null,
                             "heightening": {
                                 "damage": {
                                     "cQDyW0QpjJ38MlSi": "1d6"
@@ -2484,7 +2580,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -2517,6 +2613,9 @@
         },
         {
             "_id": "tOK2j5XmxAv2XkAV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.bBQ83xDvjQS3W1CG"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/blue-thermometer.webp",
             "name": "Measure",
@@ -2580,6 +2679,9 @@
         },
         {
             "_id": "cRNDullKGldNqzFJ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Qw3fnUlaUbnn7ipC"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/symbols/runes-triangle-blue.webp",
             "name": "Prestidigitation",
@@ -2608,7 +2710,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "10 feet"
@@ -2641,6 +2743,9 @@
         },
         {
             "_id": "ZWdMdftldSh7nV30",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.OhD2Z6rIGGD5ocZA"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/light/explosion-star-glow-silhouette.webp",
             "name": "Read Aura",
@@ -2684,7 +2789,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -2718,8 +2823,11 @@
         },
         {
             "_id": "CyvkBL0N1Vg6sEsr",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.o4lRVTwSxnOOn5vl"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
-            "img": "systems/sf2e/icons/spells/sleep.webp",
+            "img": "icons/magic/control/sleep-bubble-purple.webp",
             "name": "Sleep",
             "sort": 3700000,
             "system": {
@@ -2739,7 +2847,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>Each creature in the area becomes drowsy and might fall asleep. A creature that falls @UUID[Compendium.sf2e.conditions.Item.Unconscious] from this spell doesn't fall @UUID[Compendium.sf2e.conditions.Item.Prone] or release what it's holding. This spell doesn't prevent creatures from waking up due to a successful Perception check, limiting its utility in combat.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature is unaffected.</p>\n<p><strong>Success</strong> The creature takes a -1 status penalty to Perception checks for 1 round.</p>\n<p><strong>Failure</strong> The creature falls Unconscious. If it's still Unconscious after 1 minute, it wakes up automatically.</p>\n<p><strong>Critical Failure</strong> The creature falls Unconscious. If it's still Unconscious after 1 hour, it wakes up automatically.</p>\n<hr />\n<p><strong>Heightened (4th)</strong> The creatures fall Unconscious for 1 round on a failure or 1 minute on a critical failure. They fall Prone and release what they're holding, and they can't attempt Perception checks to wake up. When the duration ends, the creature is sleeping normally instead of automatically waking up.</p>"
+                    "value": "<p>Each creature in the area becomes drowsy, possibly nodding off. A creature that falls @UUID[Compendium.sf2e.conditions.Item.Unconscious] from this spell doesn't fall @UUID[Compendium.sf2e.conditions.Item.Prone] or release what it's holding. This spell doesn't prevent creatures from waking up due to a successful Perception check, limiting its utility in combat.</p><hr /><p><strong>Critical Success</strong> The creature is unaffected.</p>\n<p><strong>Success</strong> The creature takes a –1 status penalty to Perception checks for 1 round.</p>\n<p><strong>Failure</strong> The creature falls unconscious. If it's still unconscious after 1 minute, it wakes up automatically.</p>\n<p><strong>Critical Failure</strong> The creature falls unconscious. If it's still unconscious after 1 hour, it wakes up automatically.</p><hr /><p><strong>Heightened (4th)</strong> The creatures fall unconscious for 1 round on a failure or 1 minute on a critical failure. They fall prone and release what they're holding, and they can't attempt Perception checks to wake up. When the duration ends, the creature is sleeping normally instead of automatically waking up.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -2754,7 +2862,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"

--- a/packs/sf2e/alien-core-bestiary/abysium-dragon-ancient.json
+++ b/packs/sf2e/alien-core-bestiary/abysium-dragon-ancient.json
@@ -53,6 +53,9 @@
         },
         {
             "_id": "3T73Y3X4lhwNsrfu",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.UnWaP06SVi3jRN0M"
+            },
             "folder": "DWZvpqhX0tWHYZOh",
             "img": "systems/sf2e/icons/abilities/orange-mushroom-cloud.webp",
             "name": "Atomic Blast",
@@ -95,7 +98,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You magically split an atom, creating an explosion with radioactive fallout. All targets in the area take 5d12 bludgeoning damage and 5d12 fire damage, and they're exposed to extreme radiation that uses your spellcasting DC as the @Check[fortitude]{Fortitude DC} for radiation sickness incurred by exposure to this radiation. The onset and frequency of this magical radiation is 1 round, and the area remains radioactive for 10 minutes.</p><hr /><p><strong>Critical Success</strong> The target is unaffected by the initial damage.</p>\n<p><strong>Success</strong> The target takes half damage and is @UUID[Compendium.sf2e.conditions.Item.Dazzled] for 1 minute.</p>\n<p><strong>Failure</strong> The target takes full damage and is @UUID[Compendium.sf2e.conditions.Item.Blinded] for 1 minute.</p>\n<p><strong>Critical Failure</strong> As failure, and the target takes double damage.</p>"
+                    "value": "<p>You magically split an atom, creating an explosion with radioactive fallout. All creatures in the area take 5d12 bludgeoning damage and 5d12 fire damage, and they're exposed to extreme radiation that uses your spellcasting DC as the @Check[fortitude]{Fortitude DC} for radiation sickness incurred by exposure to this radiation. The onset and frequency of this magical radiation is 1 round, and the area remains radioactive for 10 minutes.</p><hr /><p><strong>Critical Success</strong> The target is unaffected by the initial damage.</p>\n<p><strong>Success</strong> The target takes half damage and is @UUID[Compendium.sf2e.conditions.Item.Dazzled] for 1 minute.</p>\n<p><strong>Failure</strong> The target takes full damage and is @UUID[Compendium.sf2e.conditions.Item.Blinded] for 1 minute.</p>\n<p><strong>Critical Failure</strong> As failure, and the target takes double damage.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -143,6 +146,9 @@
         },
         {
             "_id": "aNZOU3Ol7O6m8yR8",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.BHWG0rQPTgBF5Ye1"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/blue-rocket-thrusters.webp",
             "name": "Rocket Dash",
@@ -226,6 +232,9 @@
         },
         {
             "_id": "fYoEAx8wt3fPSDfd",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.dRP4Imw3RJNQqEgc"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/yellow-energy-star.webp",
             "name": "Wall of Plasma",
@@ -317,6 +326,9 @@
         },
         {
             "_id": "DeJSszc9Ih7y9t1A",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.MlpbeZ61Euhl0d60"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "icons/creatures/slimes/slime-movement-splash-green.webp",
             "name": "Toxic Cloud",
@@ -373,7 +385,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -405,6 +417,9 @@
         },
         {
             "_id": "yVisEMsKGHxOpdSt",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.YrzBLPLd3r9m6t1p"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/magic/fire/barrier-shield-explosion-yellow.webp",
             "name": "Fire Shield (Constant)",
@@ -452,7 +467,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -483,6 +498,9 @@
         },
         {
             "_id": "LLxmAf6tbm6ZPziB",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.aqRYNoSvxsVfqglH"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/equipment/feet/boots-leather-laced-brown.webp",
             "name": "Unfettered Movement",
@@ -512,7 +530,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -543,6 +561,9 @@
         },
         {
             "_id": "Vy10PAgGBwduvO9y",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.sxQZ6yqTn0czJxVd"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/fire/projectile-fireball-orange-yellow.webp",
             "name": "Fireball",
@@ -599,7 +620,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -630,6 +651,9 @@
         },
         {
             "_id": "ZR4y006sR2oAv5xs",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -646,7 +670,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -661,7 +685,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -695,6 +719,9 @@
         },
         {
             "_id": "ckLEubyjcfUWfiN7",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.6DfLZBl8wKIV03Iq"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/fire/explosion-embers-evade-silhouette.webp",
             "name": "Ignition",
@@ -743,7 +770,9 @@
                         "_id": "eOCNn2ohYAvsYZjn",
                         "overlayType": "override",
                         "sort": 1,
-                        "system": {}
+                        "system": {
+                            "defense": null
+                        }
                     },
                     "xYyA7CV1GaFTRjBQ": {
                         "_id": "xYyA7CV1GaFTRjBQ",
@@ -756,6 +785,7 @@
                                     "formula": "2d6"
                                 }
                             },
+                            "defense": null,
                             "heightening": {
                                 "damage": {
                                     "cQDyW0QpjJ38MlSi": "1d6"
@@ -770,7 +800,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"

--- a/packs/sf2e/alien-core-bestiary/abysium-dragon-young-spellcaster.json
+++ b/packs/sf2e/alien-core-bestiary/abysium-dragon-young-spellcaster.json
@@ -170,6 +170,9 @@
         },
         {
             "_id": "cG9bbaA5Y4mYNPZx",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.MlpbeZ61Euhl0d60"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "icons/creatures/slimes/slime-movement-splash-green.webp",
             "name": "Toxic Cloud",
@@ -226,7 +229,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -258,6 +261,9 @@
         },
         {
             "_id": "YIUYBK8r8wmHUt6o",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.LiGbewa9pO0yjbsY"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "systems/sf2e/icons/spells/confusion.webp",
             "name": "Confusion",
@@ -301,7 +307,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -333,6 +339,9 @@
         },
         {
             "_id": "ebjuXO7WUpxG4axx",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VlNcjmYyu95vOUe8"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/magic/symbols/ring-circle-smoke-blue.webp",
             "name": "Translocate",
@@ -371,7 +380,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -402,6 +411,9 @@
         },
         {
             "_id": "QoGbZOHnMwrz1P4i",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.aqRYNoSvxsVfqglH"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/equipment/feet/boots-leather-laced-brown.webp",
             "name": "Unfettered Movement",
@@ -431,7 +443,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -462,6 +474,9 @@
         },
         {
             "_id": "K6fKujFAT3FvLTeM",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.V8wXOsoejQhe6CyG"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "systems/sf2e/icons/spells/gaseous-form.webp",
             "name": "Vapor Form",
@@ -490,7 +505,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -523,6 +538,9 @@
         },
         {
             "_id": "NjOsDIxDq9inDGp1",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VosLNn2M8S7JH67D"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/skills/wounds/injury-eyes-blood-red.webp",
             "name": "Blindness",
@@ -556,7 +574,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -589,6 +607,9 @@
         },
         {
             "_id": "3E7qkVExffkDtFSR",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.sxQZ6yqTn0czJxVd"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/fire/projectile-fireball-orange-yellow.webp",
             "name": "Fireball",
@@ -645,7 +666,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -676,6 +697,9 @@
         },
         {
             "_id": "A7qU3w6XTrv0xX7p",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.sxQZ6yqTn0czJxVd"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/fire/projectile-fireball-orange-yellow.webp",
             "name": "Fireball",
@@ -731,7 +755,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -762,6 +786,9 @@
         },
         {
             "_id": "LYYiZ5rLiLxOHNSl",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.o6YCGx4lycsYpww4"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "systems/sf2e/icons/spells/haste.webp",
             "name": "Haste",
@@ -800,7 +827,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -831,6 +858,9 @@
         },
         {
             "_id": "5pW3Ot3n8RVkYYJx",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.WsUwpfmhKrKwoIe3"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/time/hourglass-tilted-gray.webp",
             "name": "Slow",
@@ -874,7 +904,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -905,6 +935,9 @@
         },
         {
             "_id": "bY8b1GfVU5gW63Hj",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.9XHmC2JgTUIQ1CCm"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/magic/air/fog-gas-smoke-dense-white.webp",
             "name": "Mist",
@@ -936,7 +969,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -967,6 +1000,9 @@
         },
         {
             "_id": "5oeItviQmNTQnNxI",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jwK43yKsHTkJQvQ9"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/see-invisibility.webp",
             "name": "See the Unseen",
@@ -995,7 +1031,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1027,6 +1063,9 @@
         },
         {
             "_id": "1gBKtPHCyHoae5tk",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Et8RSCLx8w7uOLvo"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/wholeness-of-body.webp",
             "name": "Sound Body",
@@ -1055,7 +1094,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -1088,6 +1127,9 @@
         },
         {
             "_id": "Kcnxl3Pln8nNd9r8",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.NkvRoN33RbDg3fl9"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/pink-target-sign.webp",
             "name": "Analyze Target",
@@ -1101,7 +1143,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The circumstance bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The circumstance bonus increases to +3, and you can target any number of creatures.</p>"
+                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The status bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The status bonus increases to +3, and you can target any number of creatures.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -1150,6 +1192,9 @@
         },
         {
             "_id": "EY3EzuuEqQXJVEHD",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.thAHF1zxNplLCJPO"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/acid/orb-bubble-smoke-drip.webp",
             "name": "Caustic Blast",
@@ -1205,7 +1250,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1237,6 +1282,9 @@
         },
         {
             "_id": "9GscdSBUqPVXFXjQ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.aIHY2DArKFweIrpf"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/command.webp",
             "name": "Command",
@@ -1280,7 +1328,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1314,6 +1362,9 @@
         },
         {
             "_id": "ZR4y006sR2oAv5xs",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -1330,7 +1381,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -1345,7 +1396,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1379,6 +1430,9 @@
         },
         {
             "_id": "dp42P1bxynqqvKWV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Wu0xFpewMKRK3HG8"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/grease.webp",
             "name": "Grease",
@@ -1412,7 +1466,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1442,6 +1496,9 @@
         },
         {
             "_id": "ckLEubyjcfUWfiN7",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.6DfLZBl8wKIV03Iq"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/fire/explosion-embers-evade-silhouette.webp",
             "name": "Ignition",
@@ -1490,7 +1547,9 @@
                         "_id": "eOCNn2ohYAvsYZjn",
                         "overlayType": "override",
                         "sort": 1,
-                        "system": {}
+                        "system": {
+                            "defense": null
+                        }
                     },
                     "xYyA7CV1GaFTRjBQ": {
                         "_id": "xYyA7CV1GaFTRjBQ",
@@ -1503,6 +1562,7 @@
                                     "formula": "2d6"
                                 }
                             },
+                            "defense": null,
                             "heightening": {
                                 "damage": {
                                     "cQDyW0QpjJ38MlSi": "1d6"
@@ -1517,7 +1577,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1550,6 +1610,9 @@
         },
         {
             "_id": "tOK2j5XmxAv2XkAV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.bBQ83xDvjQS3W1CG"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/blue-thermometer.webp",
             "name": "Measure",
@@ -1613,6 +1676,9 @@
         },
         {
             "_id": "cRNDullKGldNqzFJ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Qw3fnUlaUbnn7ipC"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/symbols/runes-triangle-blue.webp",
             "name": "Prestidigitation",
@@ -1641,7 +1707,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "10 feet"
@@ -1674,6 +1740,9 @@
         },
         {
             "_id": "ZWdMdftldSh7nV30",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.OhD2Z6rIGGD5ocZA"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/light/explosion-star-glow-silhouette.webp",
             "name": "Read Aura",
@@ -1717,7 +1786,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1751,8 +1820,11 @@
         },
         {
             "_id": "CyvkBL0N1Vg6sEsr",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.o4lRVTwSxnOOn5vl"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
-            "img": "systems/sf2e/icons/spells/sleep.webp",
+            "img": "icons/magic/control/sleep-bubble-purple.webp",
             "name": "Sleep",
             "sort": 2500000,
             "system": {
@@ -1772,7 +1844,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>Each creature in the area becomes drowsy and might fall asleep. A creature that falls @UUID[Compendium.sf2e.conditions.Item.Unconscious] from this spell doesn't fall @UUID[Compendium.sf2e.conditions.Item.Prone] or release what it's holding. This spell doesn't prevent creatures from waking up due to a successful Perception check, limiting its utility in combat.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature is unaffected.</p>\n<p><strong>Success</strong> The creature takes a -1 status penalty to Perception checks for 1 round.</p>\n<p><strong>Failure</strong> The creature falls Unconscious. If it's still Unconscious after 1 minute, it wakes up automatically.</p>\n<p><strong>Critical Failure</strong> The creature falls Unconscious. If it's still Unconscious after 1 hour, it wakes up automatically.</p>\n<hr />\n<p><strong>Heightened (4th)</strong> The creatures fall Unconscious for 1 round on a failure or 1 minute on a critical failure. They fall Prone and release what they're holding, and they can't attempt Perception checks to wake up. When the duration ends, the creature is sleeping normally instead of automatically waking up.</p>"
+                    "value": "<p>Each creature in the area becomes drowsy, possibly nodding off. A creature that falls @UUID[Compendium.sf2e.conditions.Item.Unconscious] from this spell doesn't fall @UUID[Compendium.sf2e.conditions.Item.Prone] or release what it's holding. This spell doesn't prevent creatures from waking up due to a successful Perception check, limiting its utility in combat.</p><hr /><p><strong>Critical Success</strong> The creature is unaffected.</p>\n<p><strong>Success</strong> The creature takes a –1 status penalty to Perception checks for 1 round.</p>\n<p><strong>Failure</strong> The creature falls unconscious. If it's still unconscious after 1 minute, it wakes up automatically.</p>\n<p><strong>Critical Failure</strong> The creature falls unconscious. If it's still unconscious after 1 hour, it wakes up automatically.</p><hr /><p><strong>Heightened (4th)</strong> The creatures fall unconscious for 1 round on a failure or 1 minute on a critical failure. They fall prone and release what they're holding, and they can't attempt Perception checks to wake up. When the duration ends, the creature is sleeping normally instead of automatically waking up.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -1787,7 +1859,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"

--- a/packs/sf2e/alien-core-bestiary/abysium-dragon-young.json
+++ b/packs/sf2e/alien-core-bestiary/abysium-dragon-young.json
@@ -49,6 +49,9 @@
         },
         {
             "_id": "cG9bbaA5Y4mYNPZx",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.MlpbeZ61Euhl0d60"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "icons/creatures/slimes/slime-movement-splash-green.webp",
             "name": "Toxic Cloud",
@@ -105,7 +108,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -137,6 +140,9 @@
         },
         {
             "_id": "QoGbZOHnMwrz1P4i",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.aqRYNoSvxsVfqglH"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/equipment/feet/boots-leather-laced-brown.webp",
             "name": "Unfettered Movement",
@@ -166,7 +172,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -197,6 +203,9 @@
         },
         {
             "_id": "3E7qkVExffkDtFSR",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.sxQZ6yqTn0czJxVd"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/fire/projectile-fireball-orange-yellow.webp",
             "name": "Fireball",
@@ -253,7 +262,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -284,6 +293,9 @@
         },
         {
             "_id": "ZR4y006sR2oAv5xs",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -300,7 +312,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -315,7 +327,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -349,6 +361,9 @@
         },
         {
             "_id": "ckLEubyjcfUWfiN7",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.6DfLZBl8wKIV03Iq"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/fire/explosion-embers-evade-silhouette.webp",
             "name": "Ignition",
@@ -397,7 +412,9 @@
                         "_id": "eOCNn2ohYAvsYZjn",
                         "overlayType": "override",
                         "sort": 1,
-                        "system": {}
+                        "system": {
+                            "defense": null
+                        }
                     },
                     "xYyA7CV1GaFTRjBQ": {
                         "_id": "xYyA7CV1GaFTRjBQ",
@@ -410,6 +427,7 @@
                                     "formula": "2d6"
                                 }
                             },
+                            "defense": null,
                             "heightening": {
                                 "damage": {
                                     "cQDyW0QpjJ38MlSi": "1d6"
@@ -424,7 +442,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"

--- a/packs/sf2e/alien-core-bestiary/aeon-guard-commander.json
+++ b/packs/sf2e/alien-core-bestiary/aeon-guard-commander.json
@@ -183,12 +183,18 @@
         },
         {
             "_id": "fe2dgqRm38MnKtz0",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.BmJARyq7RrMXQezF"
+            },
             "folder": "1zLXGqhSgBIthlcs",
             "img": "systems/sf2e/icons/equipment/weapons/grenade-hand.webp",
             "name": "Frag Grenade (Tactical)",
             "sort": 300000,
             "system": {
-                "ammo": null,
+                "ammo": {
+                    "baseType": null,
+                    "builtIn": false
+                },
                 "baseItem": "grenade",
                 "bonus": {
                     "value": 0
@@ -228,9 +234,6 @@
                 },
                 "price": {
                     "value": {
-                        "cp": 0,
-                        "gp": 0,
-                        "pp": 0,
                         "sp": 80
                     }
                 },
@@ -340,6 +343,9 @@
         },
         {
             "_id": "6CQqznvn9KKwCp3D",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.7psnMwQ95uO5apQz"
+            },
             "folder": "cTmXSS0L1MClVGP3",
             "img": "systems/sf2e/icons/abilities/purple-third-eye.webp",
             "name": "Darkvision Visor",
@@ -355,6 +361,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -395,13 +402,16 @@
                     ]
                 },
                 "usage": {
-                    "value": "other"
+                    "value": "installed-in-armor"
                 }
             },
             "type": "equipment"
         },
         {
             "_id": "uUhyyAiJ2ZT9RUSq",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.5PS5ESGpnQfJNOdg"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/blue-battery.webp",
             "name": "Battery (Tactical)",
@@ -417,7 +427,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -432,6 +443,7 @@
                     "type": null
                 },
                 "price": {
+                    "per": 1,
                     "value": {
                         "sp": 20
                     }
@@ -450,7 +462,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 20,
                     "value": 20
                 }

--- a/packs/sf2e/alien-core-bestiary/aeon-guard-trooper.json
+++ b/packs/sf2e/alien-core-bestiary/aeon-guard-trooper.json
@@ -101,7 +101,10 @@
             "name": "Frag Grenade (Commercial)",
             "sort": 200000,
             "system": {
-                "ammo": null,
+                "ammo": {
+                    "baseType": null,
+                    "builtIn": false
+                },
                 "baseItem": "grenade",
                 "bonus": {
                     "value": 0
@@ -174,6 +177,7 @@
                     ]
                 },
                 "usage": {
+                    "canBeAmmo": false,
                     "value": "held-in-one-hand"
                 }
             },

--- a/packs/sf2e/alien-core-bestiary/aeon-guard-trooper.json
+++ b/packs/sf2e/alien-core-bestiary/aeon-guard-trooper.json
@@ -96,6 +96,9 @@
         },
         {
             "_id": "HQQO7nTQ7KaSWyx5",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.SzGr78zdpnnrorre"
+            },
             "folder": "1zLXGqhSgBIthlcs",
             "img": "systems/sf2e/icons/equipment/weapons/grenade-hand.webp",
             "name": "Frag Grenade (Commercial)",
@@ -177,7 +180,6 @@
                     ]
                 },
                 "usage": {
-                    "canBeAmmo": false,
                     "value": "held-in-one-hand"
                 }
             },
@@ -346,6 +348,9 @@
         },
         {
             "_id": "39KaQMvhcprhNQx6",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.7psnMwQ95uO5apQz"
+            },
             "folder": "cTmXSS0L1MClVGP3",
             "img": "systems/sf2e/icons/abilities/purple-third-eye.webp",
             "name": "Darkvision Visor",
@@ -361,6 +366,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -401,13 +407,16 @@
                     ]
                 },
                 "usage": {
-                    "value": "other"
+                    "value": "installed-in-armor"
                 }
             },
             "type": "equipment"
         },
         {
             "_id": "9ZygTbQqMYFYe0vK",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -423,7 +432,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -438,6 +448,7 @@
                     "type": null
                 },
                 "price": {
+                    "per": 1,
                     "value": {
                         "sp": 10
                     }
@@ -456,7 +467,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 10,
                     "value": 10
                 }

--- a/packs/sf2e/alien-core-bestiary/akashic-dragon-adult-spellcaster.json
+++ b/packs/sf2e/alien-core-bestiary/akashic-dragon-adult-spellcaster.json
@@ -176,6 +176,9 @@
         },
         {
             "_id": "mdIGB9kjmEzFiA0k",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5bTt2CvYHPvaR7QQ"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "icons/magic/lightning/bolt-strike-explosion-purple.webp",
             "name": "Interplanar Teleport (at will; self only; to and from Akashic Record and the Universe only)",
@@ -204,7 +207,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "5 feet"
@@ -237,6 +240,9 @@
         },
         {
             "_id": "rpXtMK3mqEdJwbPA",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uqlxMQQeSGWEVjki"
+            },
             "folder": "zDlxATrLAlbYA2Mv",
             "img": "systems/sf2e/icons/spells/true-seeing.webp",
             "name": "Truesight",
@@ -266,7 +272,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -299,6 +305,9 @@
         },
         {
             "_id": "NqAQIx0tQIhD06ZU",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Ek5XI0aEdZhBgm21"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/prying-eye.webp",
             "name": "Scouting Eye",
@@ -327,7 +336,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "see text"
@@ -359,6 +368,9 @@
         },
         {
             "_id": "ggctam4rElwmWAoi",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.CptKtBneM7od45nc"
+            },
             "folder": "NQpcS2TwtjNNq1Qy",
             "img": "systems/sf2e/icons/abilities/blue-hex-field-dispersed.webp",
             "name": "Subjective Reality",
@@ -416,6 +428,9 @@
         },
         {
             "_id": "390EZpNqD6Mjnps4",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.SwUiVavHKMWG7t5K"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/tongues.webp",
             "name": "Truespeech",
@@ -444,7 +459,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -475,6 +490,9 @@
         },
         {
             "_id": "eYBqQOPyzJnG5GSq",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.zvKWclOZ7A53DObE"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "systems/sf2e/icons/spells/clairvoyance.webp",
             "name": "Clairvoyance",
@@ -504,7 +522,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -535,6 +553,9 @@
         },
         {
             "_id": "JtT8k9zKaTxeU13s",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.zvKWclOZ7A53DObE"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "systems/sf2e/icons/spells/clairvoyance.webp",
             "name": "Clairvoyance",
@@ -563,7 +584,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -594,6 +615,9 @@
         },
         {
             "_id": "lbWt8IpYmGvjDzqf",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.LiGbewa9pO0yjbsY"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "systems/sf2e/icons/spells/confusion.webp",
             "name": "Confusion",
@@ -638,7 +662,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -670,6 +694,9 @@
         },
         {
             "_id": "VECj8v3fenmG2bW4",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jyrxfWeeCsrkhNit"
+            },
             "folder": "NuBKgFiv0GJhsx3c",
             "img": "icons/magic/unholy/beam-ringed-impact-purple.webp",
             "name": "Eldritch Wrath",
@@ -756,6 +783,9 @@
         },
         {
             "_id": "QXmbGOtTnAlNRlhH",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.7Ib3qxIC0bFD3ued"
+            },
             "folder": "NuBKgFiv0GJhsx3c",
             "img": "icons/magic/time/clock-stopwatch-white-blue.webp",
             "name": "Weight of Ages",
@@ -849,6 +879,9 @@
         },
         {
             "_id": "VSFPTc2QgOHyes1F",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.HXhWYJviWalN5tQ2"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/light/orb-hand-green.webp",
             "name": "Clairaudience",
@@ -877,7 +910,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -908,6 +941,9 @@
         },
         {
             "_id": "1ZRXC7hDu80pjRrE",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.o6YCGx4lycsYpww4"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "systems/sf2e/icons/spells/haste.webp",
             "name": "Haste",
@@ -946,7 +982,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -977,6 +1013,9 @@
         },
         {
             "_id": "7UXnawJOYU6TL2oq",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ZYoC630tNGutgbE0"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/light/orb-lightbulb-gray.webp",
             "name": "Hypercognition",
@@ -1005,7 +1044,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1033,6 +1072,9 @@
         },
         {
             "_id": "IEoSblBFAe2OhTnZ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.KHnhPHL4x1AQHfbC"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "systems/sf2e/icons/spells/mind-reading.webp",
             "name": "Mind Reading",
@@ -1067,7 +1109,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1099,6 +1141,9 @@
         },
         {
             "_id": "GubPB1Zi89dn63OY",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.2qGqa33E4GPUCbMV"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/humanoid-form.webp",
             "name": "Humanoid Form",
@@ -1127,7 +1172,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1159,6 +1204,9 @@
         },
         {
             "_id": "NHRMAZYf3UfZv7UE",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.CQb8HtQ1BPeZmu9h"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/feeblemind.webp",
             "name": "Stupefy",
@@ -1192,7 +1240,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1223,6 +1271,9 @@
         },
         {
             "_id": "28WwnbtcIINKc6As",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.vTQvfYu2llKQedmY"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/comprehend-language.webp",
             "name": "Translate",
@@ -1261,7 +1312,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1292,6 +1343,9 @@
         },
         {
             "_id": "fPRg27BqEAJ6Md6V",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VynaowCerc7B4yvI"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/sundries/books/book-embossed-jewel-silver-green.webp",
             "name": "Akashic Download (at will)",
@@ -1350,6 +1404,9 @@
         },
         {
             "_id": "dCLHXJdjs5T1W5zq",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.NkvRoN33RbDg3fl9"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/pink-target-sign.webp",
             "name": "Analyze Target",
@@ -1363,7 +1420,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The circumstance bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The circumstance bonus increases to +3, and you can target any number of creatures.</p>"
+                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The status bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The status bonus increases to +3, and you can target any number of creatures.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -1412,6 +1469,9 @@
         },
         {
             "_id": "UlLIH5Fl67pj0Brp",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4gBIw4IDrSfFHik4"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/daze.webp",
             "name": "Daze",
@@ -1463,7 +1523,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "60 feet"
@@ -1497,6 +1557,9 @@
         },
         {
             "_id": "M8zIWmXPQsHSjL0x",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.yXD9uU8w8uFD2OBQ"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/cerulean-circular-sign.webp",
             "name": "Delete",
@@ -1555,6 +1618,9 @@
         },
         {
             "_id": "vJfGZxnoLjBLTtUX",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -1571,7 +1637,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -1586,7 +1652,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1620,6 +1686,9 @@
         },
         {
             "_id": "eIZTpJE3CBhjXgQV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.PRrZ7anETWPm90YY"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/magic-aura.webp",
             "name": "Disguise Magic",
@@ -1652,7 +1721,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1683,6 +1752,9 @@
         },
         {
             "_id": "r9KM7Z5njtO5btRc",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.OhD2Z6rIGGD5ocZA"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/light/explosion-star-glow-silhouette.webp",
             "name": "Read Aura",
@@ -1726,7 +1798,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1760,6 +1832,9 @@
         },
         {
             "_id": "f3QMKMjDqPG034xZ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.TVKNbcgTee19PXZR"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/shield.webp",
             "name": "Shield",
@@ -1788,7 +1863,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1820,6 +1895,9 @@
         },
         {
             "_id": "nkvmvdWpUwEz8eO3",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Gb7SeieEvd0pL2Eh"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/skills/melee/strike-blade-scimitar-gray-red.webp",
             "name": "Sure Strike",
@@ -1848,7 +1926,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""

--- a/packs/sf2e/alien-core-bestiary/akashic-dragon-adult.json
+++ b/packs/sf2e/alien-core-bestiary/akashic-dragon-adult.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "mdIGB9kjmEzFiA0k",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5bTt2CvYHPvaR7QQ"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "icons/magic/lightning/bolt-strike-explosion-purple.webp",
             "name": "Interplanar Teleport (at will; self only; to and from Akashic Record and the Universe only)",
@@ -72,7 +75,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "5 feet"
@@ -105,6 +108,9 @@
         },
         {
             "_id": "rpXtMK3mqEdJwbPA",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uqlxMQQeSGWEVjki"
+            },
             "folder": "zDlxATrLAlbYA2Mv",
             "img": "systems/sf2e/icons/spells/true-seeing.webp",
             "name": "Truesight",
@@ -134,7 +140,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -167,6 +173,9 @@
         },
         {
             "_id": "eYBqQOPyzJnG5GSq",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.zvKWclOZ7A53DObE"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "systems/sf2e/icons/spells/clairvoyance.webp",
             "name": "Clairvoyance",
@@ -196,7 +205,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -227,6 +236,9 @@
         },
         {
             "_id": "lbWt8IpYmGvjDzqf",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.LiGbewa9pO0yjbsY"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "systems/sf2e/icons/spells/confusion.webp",
             "name": "Confusion",
@@ -271,7 +283,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -303,6 +315,9 @@
         },
         {
             "_id": "IEoSblBFAe2OhTnZ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.KHnhPHL4x1AQHfbC"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "systems/sf2e/icons/spells/mind-reading.webp",
             "name": "Mind Reading",
@@ -337,7 +352,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -369,6 +384,9 @@
         },
         {
             "_id": "fPRg27BqEAJ6Md6V",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VynaowCerc7B4yvI"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/sundries/books/book-embossed-jewel-silver-green.webp",
             "name": "Akashic Download (at will)",

--- a/packs/sf2e/alien-core-bestiary/akashic-dragon-ancient-spellcaster.json
+++ b/packs/sf2e/alien-core-bestiary/akashic-dragon-ancient-spellcaster.json
@@ -215,6 +215,9 @@
         },
         {
             "_id": "kHlIt8T1DkNyhi88",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.qsNeG9KZpODSACMq"
+            },
             "folder": "fi1AYNmuCRvoT15b",
             "img": "icons/magic/perception/orb-eye-scrying.webp",
             "name": "Foresight",
@@ -244,7 +247,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -277,6 +280,9 @@
         },
         {
             "_id": "ZR3TqszHXX7xbXNq",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.64DDZxOrmr4ddqs2"
+            },
             "folder": "DWZvpqhX0tWHYZOh",
             "img": "systems/sf2e/icons/abilities/yellow-fist.webp",
             "name": "Telekinetic Tantrum",
@@ -341,6 +347,9 @@
         },
         {
             "_id": "jAk9QVBYI8xupbtG",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.wfleiawxsfhpRRwf"
+            },
             "folder": "IfuYSF4ymX48CZnm",
             "img": "systems/sf2e/icons/spells/disapperance.webp",
             "name": "Disappearance",
@@ -369,7 +378,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -400,6 +409,9 @@
         },
         {
             "_id": "PbyW3zRQ6ll9xPwT",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.CeSh8QcVnqP5OlLj"
+            },
             "folder": "IfuYSF4ymX48CZnm",
             "img": "icons/environment/settlement/watchtower-cliff.webp",
             "name": "Pinpoint",
@@ -428,7 +440,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "unlimited"
@@ -460,6 +472,9 @@
         },
         {
             "_id": "1wGpIyObOOSmXMTY",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5bTt2CvYHPvaR7QQ"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "icons/magic/lightning/bolt-strike-explosion-purple.webp",
             "name": "Interplanar Teleport",
@@ -488,7 +503,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "5 feet"
@@ -521,6 +536,9 @@
         },
         {
             "_id": "mdIGB9kjmEzFiA0k",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5bTt2CvYHPvaR7QQ"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "icons/magic/lightning/bolt-strike-explosion-purple.webp",
             "name": "Interplanar Teleport (at will; self only; to and from Akashic Record and the Universe only)",
@@ -550,7 +568,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "5 feet"
@@ -583,6 +601,9 @@
         },
         {
             "_id": "EDgbMWWHF6gkDusJ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.XZE4BawIlTf88Yl9"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "systems/sf2e/icons/spells/dimensional-lock.webp",
             "name": "Planar Seal",
@@ -614,7 +635,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -645,6 +666,9 @@
         },
         {
             "_id": "U2it5EteklS2ck0v",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.rsZ5c0AUyywe5yoK"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "icons/magic/lightning/projectile-tendrils-red.webp",
             "name": "Retrocognition",
@@ -673,7 +697,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -702,6 +726,9 @@
         },
         {
             "_id": "lretap3ckZobRGhf",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5BbU1V6wGSGbrmRD"
+            },
             "folder": "zDlxATrLAlbYA2Mv",
             "img": "systems/sf2e/icons/spells/feeblemind.webp",
             "name": "Never Mind",
@@ -735,7 +762,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -768,6 +795,9 @@
         },
         {
             "_id": "agYfKMr3zScPp4v8",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.r784cIz17eWujtQj"
+            },
             "folder": "zDlxATrLAlbYA2Mv",
             "img": "systems/sf2e/icons/spells/scrying.webp",
             "name": "Scrying",
@@ -801,7 +831,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "planetary"
@@ -832,6 +862,9 @@
         },
         {
             "_id": "ml24ZYHcvg6oEAqM",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uqlxMQQeSGWEVjki"
+            },
             "folder": "zDlxATrLAlbYA2Mv",
             "img": "systems/sf2e/icons/spells/true-seeing.webp",
             "name": "Truesight",
@@ -861,7 +894,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -894,6 +927,9 @@
         },
         {
             "_id": "ial8IXQYHegsSaA1",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uqlxMQQeSGWEVjki"
+            },
             "folder": "zDlxATrLAlbYA2Mv",
             "img": "systems/sf2e/icons/spells/true-seeing.webp",
             "name": "Truesight",
@@ -922,7 +958,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -955,6 +991,9 @@
         },
         {
             "_id": "NqAQIx0tQIhD06ZU",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Ek5XI0aEdZhBgm21"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/prying-eye.webp",
             "name": "Scouting Eye",
@@ -983,7 +1022,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "see text"
@@ -1015,6 +1054,9 @@
         },
         {
             "_id": "ggctam4rElwmWAoi",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.CptKtBneM7od45nc"
+            },
             "folder": "NQpcS2TwtjNNq1Qy",
             "img": "systems/sf2e/icons/abilities/blue-hex-field-dispersed.webp",
             "name": "Subjective Reality",
@@ -1072,6 +1114,9 @@
         },
         {
             "_id": "390EZpNqD6Mjnps4",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.SwUiVavHKMWG7t5K"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/tongues.webp",
             "name": "Truespeech",
@@ -1100,7 +1145,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -1131,6 +1176,9 @@
         },
         {
             "_id": "Lg2ybzOtvv8Vi0XW",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.SwUiVavHKMWG7t5K"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/tongues.webp",
             "name": "Truespeech (constant)",
@@ -1160,7 +1208,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -1191,6 +1239,9 @@
         },
         {
             "_id": "JtT8k9zKaTxeU13s",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.zvKWclOZ7A53DObE"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "systems/sf2e/icons/spells/clairvoyance.webp",
             "name": "Clairvoyance",
@@ -1219,7 +1270,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -1250,6 +1301,9 @@
         },
         {
             "_id": "4MXP0ywszpfP7zsY",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.zvKWclOZ7A53DObE"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "systems/sf2e/icons/spells/clairvoyance.webp",
             "name": "Clairvoyance",
@@ -1279,7 +1333,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -1310,6 +1364,9 @@
         },
         {
             "_id": "ko3X9CkHc2vakW1P",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.LiGbewa9pO0yjbsY"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "systems/sf2e/icons/spells/confusion.webp",
             "name": "Confusion",
@@ -1354,7 +1411,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1386,6 +1443,9 @@
         },
         {
             "_id": "VECj8v3fenmG2bW4",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jyrxfWeeCsrkhNit"
+            },
             "folder": "NuBKgFiv0GJhsx3c",
             "img": "icons/magic/unholy/beam-ringed-impact-purple.webp",
             "name": "Eldritch Wrath",
@@ -1472,6 +1532,9 @@
         },
         {
             "_id": "QXmbGOtTnAlNRlhH",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.7Ib3qxIC0bFD3ued"
+            },
             "folder": "NuBKgFiv0GJhsx3c",
             "img": "icons/magic/time/clock-stopwatch-white-blue.webp",
             "name": "Weight of Ages",
@@ -1565,6 +1628,9 @@
         },
         {
             "_id": "VSFPTc2QgOHyes1F",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.HXhWYJviWalN5tQ2"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/light/orb-hand-green.webp",
             "name": "Clairaudience",
@@ -1593,7 +1659,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -1624,6 +1690,9 @@
         },
         {
             "_id": "1ZRXC7hDu80pjRrE",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.o6YCGx4lycsYpww4"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "systems/sf2e/icons/spells/haste.webp",
             "name": "Haste",
@@ -1662,7 +1731,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1693,6 +1762,9 @@
         },
         {
             "_id": "7UXnawJOYU6TL2oq",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ZYoC630tNGutgbE0"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/light/orb-lightbulb-gray.webp",
             "name": "Hypercognition",
@@ -1721,7 +1793,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1749,6 +1821,9 @@
         },
         {
             "_id": "3PjTY88LxbSXWQ4P",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.KHnhPHL4x1AQHfbC"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "systems/sf2e/icons/spells/mind-reading.webp",
             "name": "Mind Reading",
@@ -1783,7 +1858,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1815,6 +1890,9 @@
         },
         {
             "_id": "GubPB1Zi89dn63OY",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.2qGqa33E4GPUCbMV"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/humanoid-form.webp",
             "name": "Humanoid Form",
@@ -1843,7 +1921,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1875,6 +1953,9 @@
         },
         {
             "_id": "NHRMAZYf3UfZv7UE",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.CQb8HtQ1BPeZmu9h"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/feeblemind.webp",
             "name": "Stupefy",
@@ -1908,7 +1989,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1939,6 +2020,9 @@
         },
         {
             "_id": "28WwnbtcIINKc6As",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.vTQvfYu2llKQedmY"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/comprehend-language.webp",
             "name": "Translate",
@@ -1977,7 +2061,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -2008,6 +2092,9 @@
         },
         {
             "_id": "fPRg27BqEAJ6Md6V",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VynaowCerc7B4yvI"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/sundries/books/book-embossed-jewel-silver-green.webp",
             "name": "Akashic Download (at will)",
@@ -2066,6 +2153,9 @@
         },
         {
             "_id": "dCLHXJdjs5T1W5zq",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.NkvRoN33RbDg3fl9"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/pink-target-sign.webp",
             "name": "Analyze Target",
@@ -2079,7 +2169,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The circumstance bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The circumstance bonus increases to +3, and you can target any number of creatures.</p>"
+                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The status bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The status bonus increases to +3, and you can target any number of creatures.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -2128,6 +2218,9 @@
         },
         {
             "_id": "UlLIH5Fl67pj0Brp",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4gBIw4IDrSfFHik4"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/daze.webp",
             "name": "Daze",
@@ -2179,7 +2272,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "60 feet"
@@ -2213,6 +2306,9 @@
         },
         {
             "_id": "M8zIWmXPQsHSjL0x",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.yXD9uU8w8uFD2OBQ"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/cerulean-circular-sign.webp",
             "name": "Delete",
@@ -2271,6 +2367,9 @@
         },
         {
             "_id": "vJfGZxnoLjBLTtUX",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -2287,7 +2386,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -2302,7 +2401,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -2336,6 +2435,9 @@
         },
         {
             "_id": "eIZTpJE3CBhjXgQV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.PRrZ7anETWPm90YY"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/magic-aura.webp",
             "name": "Disguise Magic",
@@ -2368,7 +2470,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -2399,6 +2501,9 @@
         },
         {
             "_id": "r9KM7Z5njtO5btRc",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.OhD2Z6rIGGD5ocZA"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/light/explosion-star-glow-silhouette.webp",
             "name": "Read Aura",
@@ -2442,7 +2547,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -2476,6 +2581,9 @@
         },
         {
             "_id": "f3QMKMjDqPG034xZ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.TVKNbcgTee19PXZR"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/shield.webp",
             "name": "Shield",
@@ -2504,7 +2612,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -2536,6 +2644,9 @@
         },
         {
             "_id": "nkvmvdWpUwEz8eO3",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Gb7SeieEvd0pL2Eh"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/skills/melee/strike-blade-scimitar-gray-red.webp",
             "name": "Sure Strike",
@@ -2564,7 +2675,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""

--- a/packs/sf2e/alien-core-bestiary/akashic-dragon-ancient.json
+++ b/packs/sf2e/alien-core-bestiary/akashic-dragon-ancient.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "kHlIt8T1DkNyhi88",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.qsNeG9KZpODSACMq"
+            },
             "folder": "fi1AYNmuCRvoT15b",
             "img": "icons/magic/perception/orb-eye-scrying.webp",
             "name": "Foresight",
@@ -73,7 +76,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -106,6 +109,9 @@
         },
         {
             "_id": "ZR3TqszHXX7xbXNq",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.64DDZxOrmr4ddqs2"
+            },
             "folder": "DWZvpqhX0tWHYZOh",
             "img": "systems/sf2e/icons/abilities/yellow-fist.webp",
             "name": "Telekinetic Tantrum",
@@ -170,6 +176,9 @@
         },
         {
             "_id": "mdIGB9kjmEzFiA0k",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5bTt2CvYHPvaR7QQ"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "icons/magic/lightning/bolt-strike-explosion-purple.webp",
             "name": "Interplanar Teleport (at will; self only; to and from Akashic Record and the Universe only)",
@@ -199,7 +208,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "5 feet"
@@ -232,6 +241,9 @@
         },
         {
             "_id": "ml24ZYHcvg6oEAqM",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uqlxMQQeSGWEVjki"
+            },
             "folder": "zDlxATrLAlbYA2Mv",
             "img": "systems/sf2e/icons/spells/true-seeing.webp",
             "name": "Truesight",
@@ -261,7 +273,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -294,6 +306,9 @@
         },
         {
             "_id": "Lg2ybzOtvv8Vi0XW",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.SwUiVavHKMWG7t5K"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/tongues.webp",
             "name": "Truespeech (constant)",
@@ -323,7 +338,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -354,6 +369,9 @@
         },
         {
             "_id": "4MXP0ywszpfP7zsY",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.zvKWclOZ7A53DObE"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "systems/sf2e/icons/spells/clairvoyance.webp",
             "name": "Clairvoyance",
@@ -383,7 +401,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -414,6 +432,9 @@
         },
         {
             "_id": "ko3X9CkHc2vakW1P",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.LiGbewa9pO0yjbsY"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "systems/sf2e/icons/spells/confusion.webp",
             "name": "Confusion",
@@ -458,7 +479,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -490,6 +511,9 @@
         },
         {
             "_id": "3PjTY88LxbSXWQ4P",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.KHnhPHL4x1AQHfbC"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "systems/sf2e/icons/spells/mind-reading.webp",
             "name": "Mind Reading",
@@ -524,7 +548,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -556,6 +580,9 @@
         },
         {
             "_id": "fPRg27BqEAJ6Md6V",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VynaowCerc7B4yvI"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/sundries/books/book-embossed-jewel-silver-green.webp",
             "name": "Akashic Download (at will)",

--- a/packs/sf2e/alien-core-bestiary/akashic-dragon-young-spellcaster.json
+++ b/packs/sf2e/alien-core-bestiary/akashic-dragon-young-spellcaster.json
@@ -148,6 +148,9 @@
         },
         {
             "_id": "mdIGB9kjmEzFiA0k",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5bTt2CvYHPvaR7QQ"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "icons/magic/lightning/bolt-strike-explosion-purple.webp",
             "name": "Interplanar Teleport (at will; self only; to and from Akashic Record and the Universe only)",
@@ -176,7 +179,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "5 feet"
@@ -209,6 +212,9 @@
         },
         {
             "_id": "eYBqQOPyzJnG5GSq",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.zvKWclOZ7A53DObE"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "systems/sf2e/icons/spells/clairvoyance.webp",
             "name": "Clairvoyance",
@@ -238,7 +244,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -269,6 +275,9 @@
         },
         {
             "_id": "lbWt8IpYmGvjDzqf",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.LiGbewa9pO0yjbsY"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "systems/sf2e/icons/spells/confusion.webp",
             "name": "Confusion",
@@ -313,7 +322,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -345,6 +354,9 @@
         },
         {
             "_id": "VSFPTc2QgOHyes1F",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.HXhWYJviWalN5tQ2"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/light/orb-hand-green.webp",
             "name": "Clairaudience",
@@ -373,7 +385,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -404,6 +416,9 @@
         },
         {
             "_id": "1ZRXC7hDu80pjRrE",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.o6YCGx4lycsYpww4"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "systems/sf2e/icons/spells/haste.webp",
             "name": "Haste",
@@ -442,7 +457,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -473,6 +488,9 @@
         },
         {
             "_id": "7UXnawJOYU6TL2oq",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ZYoC630tNGutgbE0"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/light/orb-lightbulb-gray.webp",
             "name": "Hypercognition",
@@ -501,7 +519,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -529,6 +547,9 @@
         },
         {
             "_id": "GubPB1Zi89dn63OY",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.2qGqa33E4GPUCbMV"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/humanoid-form.webp",
             "name": "Humanoid Form",
@@ -557,7 +578,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -589,6 +610,9 @@
         },
         {
             "_id": "NHRMAZYf3UfZv7UE",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.CQb8HtQ1BPeZmu9h"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/feeblemind.webp",
             "name": "Stupefy",
@@ -622,7 +646,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -653,6 +677,9 @@
         },
         {
             "_id": "28WwnbtcIINKc6As",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.vTQvfYu2llKQedmY"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/comprehend-language.webp",
             "name": "Translate",
@@ -691,7 +718,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -722,6 +749,9 @@
         },
         {
             "_id": "fPRg27BqEAJ6Md6V",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VynaowCerc7B4yvI"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/sundries/books/book-embossed-jewel-silver-green.webp",
             "name": "Akashic Download (at will)",
@@ -780,6 +810,9 @@
         },
         {
             "_id": "dCLHXJdjs5T1W5zq",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.NkvRoN33RbDg3fl9"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/pink-target-sign.webp",
             "name": "Analyze Target",
@@ -793,7 +826,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The circumstance bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The circumstance bonus increases to +3, and you can target any number of creatures.</p>"
+                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The status bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The status bonus increases to +3, and you can target any number of creatures.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -842,6 +875,9 @@
         },
         {
             "_id": "UlLIH5Fl67pj0Brp",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4gBIw4IDrSfFHik4"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/daze.webp",
             "name": "Daze",
@@ -893,7 +929,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "60 feet"
@@ -927,6 +963,9 @@
         },
         {
             "_id": "M8zIWmXPQsHSjL0x",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.yXD9uU8w8uFD2OBQ"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/cerulean-circular-sign.webp",
             "name": "Delete",
@@ -985,6 +1024,9 @@
         },
         {
             "_id": "vJfGZxnoLjBLTtUX",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -1001,7 +1043,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -1016,7 +1058,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1050,6 +1092,9 @@
         },
         {
             "_id": "eIZTpJE3CBhjXgQV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.PRrZ7anETWPm90YY"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/magic-aura.webp",
             "name": "Disguise Magic",
@@ -1082,7 +1127,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1113,6 +1158,9 @@
         },
         {
             "_id": "r9KM7Z5njtO5btRc",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.OhD2Z6rIGGD5ocZA"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/light/explosion-star-glow-silhouette.webp",
             "name": "Read Aura",
@@ -1156,7 +1204,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1190,6 +1238,9 @@
         },
         {
             "_id": "f3QMKMjDqPG034xZ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.TVKNbcgTee19PXZR"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/shield.webp",
             "name": "Shield",
@@ -1218,7 +1269,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1250,6 +1301,9 @@
         },
         {
             "_id": "nkvmvdWpUwEz8eO3",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Gb7SeieEvd0pL2Eh"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/skills/melee/strike-blade-scimitar-gray-red.webp",
             "name": "Sure Strike",
@@ -1278,7 +1332,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""

--- a/packs/sf2e/alien-core-bestiary/akashic-dragon-young.json
+++ b/packs/sf2e/alien-core-bestiary/akashic-dragon-young.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "mdIGB9kjmEzFiA0k",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5bTt2CvYHPvaR7QQ"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "icons/magic/lightning/bolt-strike-explosion-purple.webp",
             "name": "Interplanar Teleport (at will; self only; to and from Akashic Record and the Universe only)",
@@ -72,7 +75,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "5 feet"
@@ -105,6 +108,9 @@
         },
         {
             "_id": "eYBqQOPyzJnG5GSq",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.zvKWclOZ7A53DObE"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "systems/sf2e/icons/spells/clairvoyance.webp",
             "name": "Clairvoyance",
@@ -134,7 +140,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -165,6 +171,9 @@
         },
         {
             "_id": "lbWt8IpYmGvjDzqf",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.LiGbewa9pO0yjbsY"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "systems/sf2e/icons/spells/confusion.webp",
             "name": "Confusion",
@@ -209,7 +218,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -241,6 +250,9 @@
         },
         {
             "_id": "fPRg27BqEAJ6Md6V",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VynaowCerc7B4yvI"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/sundries/books/book-embossed-jewel-silver-green.webp",
             "name": "Akashic Download (at will)",

--- a/packs/sf2e/alien-core-bestiary/arqsheth.json
+++ b/packs/sf2e/alien-core-bestiary/arqsheth.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "RIjTFgkgkCNInH0l",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.SwUiVavHKMWG7t5K"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/tongues.webp",
             "name": "Truespeech (Constant)",
@@ -73,7 +76,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -104,6 +107,9 @@
         },
         {
             "_id": "HasYa2qKz3JTG65H",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VlNcjmYyu95vOUe8"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/magic/symbols/ring-circle-smoke-blue.webp",
             "name": "Translocate (At Will)",
@@ -143,7 +149,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -174,6 +180,9 @@
         },
         {
             "_id": "S9Z4wrq23h063w70",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.0qaqksrGGDj74HXE"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/glitterdust.webp",
             "name": "Revealing Light",
@@ -214,7 +223,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -247,6 +256,9 @@
         },
         {
             "_id": "jTEfP8Sk1HXV6Lcd",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.vLzFcIaSXs7YTIqJ"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/message.webp",
             "name": "Message",
@@ -285,7 +297,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -321,6 +333,9 @@
         },
         {
             "_id": "46IbVW4uWtGVHvAn",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Gb7SeieEvd0pL2Eh"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/skills/melee/strike-blade-scimitar-gray-red.webp",
             "name": "Sure Strike (At Will)",
@@ -350,7 +365,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""

--- a/packs/sf2e/alien-core-bestiary/asteray.json
+++ b/packs/sf2e/alien-core-bestiary/asteray.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "NcuIW0E4bEr0WkaM",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.LiGbewa9pO0yjbsY"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "systems/sf2e/icons/spells/confusion.webp",
             "name": "Confusion",
@@ -88,7 +91,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -120,6 +123,9 @@
         },
         {
             "_id": "npngbYe3FwL1MGbc",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.rBh2PjtbDGAjbcu6"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/equipment/other/yellow-battery.webp",
             "name": "Discharge",
@@ -185,6 +191,9 @@
         },
         {
             "_id": "1AjVnj5jrqrgX09U",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.EoKBlgf6Smt8opaU"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/environment/settlement/lighthouse-rock-red.webp",
             "name": "Veil of Privacy",
@@ -214,7 +223,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -245,6 +254,9 @@
         },
         {
             "_id": "OqQmIZXPX0LfpmOq",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.f8SBoXiXQjlCKqly"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/creatures/magical/spirit-undead-winged-ghost.webp",
             "name": "Illusory Creature",
@@ -274,7 +286,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -308,6 +320,9 @@
         },
         {
             "_id": "BXchrJubbH2PcObV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.vLA0q0WOK2YPuJs6"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/charm.webp",
             "name": "Charm",
@@ -352,7 +367,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -387,6 +402,9 @@
         },
         {
             "_id": "rm4SF5FOOnB6kHGr",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.2oH5IufzdESuYxat"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/illusory-object.webp",
             "name": "Illusory Object (At Will)",
@@ -419,7 +437,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"

--- a/packs/sf2e/alien-core-bestiary/barachius-angel.json
+++ b/packs/sf2e/alien-core-bestiary/barachius-angel.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "xAhuUFxKPOhdSnGJ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5bTt2CvYHPvaR7QQ"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "icons/magic/lightning/bolt-strike-explosion-purple.webp",
             "name": "Interplanar Teleport (Self Only)",
@@ -72,7 +75,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "5 feet"
@@ -105,6 +108,9 @@
         },
         {
             "_id": "oAOb38ORVRhVNdgg",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.SwUiVavHKMWG7t5K"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/tongues.webp",
             "name": "Truespeech (Constant)",
@@ -133,7 +139,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -164,6 +170,9 @@
         },
         {
             "_id": "auELSpISk602w8Wb",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jyrxfWeeCsrkhNit"
+            },
             "folder": "NuBKgFiv0GJhsx3c",
             "img": "icons/magic/unholy/beam-ringed-impact-purple.webp",
             "name": "Eldritch Wrath",
@@ -251,6 +260,9 @@
         },
         {
             "_id": "f5c57sf5bbXJbroa",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.eHiWtMiXoI1d48A7"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/purple-alien-brain.webp",
             "name": "Holographic Memory",
@@ -316,6 +328,9 @@
         },
         {
             "_id": "b2wVUOxpwi5ZDVHx",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.EhN3GjdjXChMdiFk"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/purple-neurons.webp",
             "name": "Share Pain",
@@ -353,7 +368,7 @@
                 },
                 "heightening": {
                     "levels": {
-                        "4": {
+                        "6": {
                             "damage": {
                                 "dIvEREAgyIVyanqT": {
                                     "applyMod": false,
@@ -399,7 +414,10 @@
                 },
                 "traits": {
                     "rarity": "common",
-                    "traditions": [],
+                    "traditions": [
+                        "divine",
+                        "occult"
+                    ],
                     "value": [
                         "concentrate",
                         "manipulate",
@@ -411,6 +429,9 @@
         },
         {
             "_id": "xb8SiK50pmQHyhRS",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VIKDSgBRR3Wd1mQx"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/green-chart.webp",
             "name": "Doom Scroll",
@@ -481,6 +502,9 @@
         },
         {
             "_id": "1AjqOerqeoHxEl4k",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.HPHr5aoLMH4eVwaw"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/yellow-hand.webp",
             "name": "Soul Surge",
@@ -562,6 +586,9 @@
         },
         {
             "_id": "XtHSPqSmYFlKCNEQ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.NkvRoN33RbDg3fl9"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/pink-target-sign.webp",
             "name": "Analyze Target",
@@ -575,7 +602,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The circumstance bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The circumstance bonus increases to +3, and you can target any number of creatures.</p>"
+                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The status bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The status bonus increases to +3, and you can target any number of creatures.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -685,6 +712,9 @@
         },
         {
             "_id": "eHCYmwTSs3HJlPES",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.sXnWQOcGG2ELcxXb"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-galaxy.webp",
             "name": "Ricochet",

--- a/packs/sf2e/alien-core-bestiary/botnib.json
+++ b/packs/sf2e/alien-core-bestiary/botnib.json
@@ -41,6 +41,9 @@
         },
         {
             "_id": "YeLRNo8qdJca4Hsq",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.yXD9uU8w8uFD2OBQ"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/cerulean-circular-sign.webp",
             "name": "Delete",
@@ -100,6 +103,9 @@
         },
         {
             "_id": "JFWXpZ6yZyP1cWK2",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.kBhaPuzLUSwS6vVf"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/lightning/bolt-strike-forked-blue.webp",
             "name": "Electric Arc",
@@ -151,7 +157,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -183,6 +189,9 @@
         },
         {
             "_id": "OmqiU8uv0fmOcpds",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.0zU8CPejjQFnhZFI"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/ghost-sound.webp",
             "name": "Figment",
@@ -211,7 +220,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -244,6 +253,9 @@
         },
         {
             "_id": "6jJaRGnNd6JX2mo4",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5y70IWhVV6bVjC9N"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-battery-gauge.webp",
             "name": "Recharge Weapon",
@@ -303,6 +315,9 @@
         },
         {
             "_id": "sif2FjmWrHSW3C73",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.zDJS8E66UI0himqV"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/shocking-grasp.webp",
             "name": "Thunderstrike",
@@ -366,7 +381,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"

--- a/packs/sf2e/alien-core-bestiary/civusdaemon.json
+++ b/packs/sf2e/alien-core-bestiary/civusdaemon.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "m7OEfI3d8SeEFvC2",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Uqj344bezBq3ESdq"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/magic/control/encase-creature-spider-hold.webp",
             "name": "Nightmare",
@@ -77,7 +80,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "planetary"
@@ -109,6 +112,9 @@
         },
         {
             "_id": "PtYdVNeAVqF39SMC",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.qwlh6aDgi86U3Q7H"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "systems/sf2e/icons/spells/suggestion.webp",
             "name": "Suggestion",
@@ -152,7 +158,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -186,6 +192,9 @@
         },
         {
             "_id": "W5jIe0jF5kpgVGjA",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.HXhWYJviWalN5tQ2"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/light/orb-hand-green.webp",
             "name": "Clairaudience",
@@ -215,7 +224,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -246,6 +255,9 @@
         },
         {
             "_id": "nowW8egIBSapyN47",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.KHnhPHL4x1AQHfbC"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "systems/sf2e/icons/spells/mind-reading.webp",
             "name": "Mind Reading",
@@ -280,7 +292,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -312,6 +324,9 @@
         },
         {
             "_id": "FJsxjXLWZbdzvlwP",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.L6Gww2b2YVM3q0ZQ"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/cerulean-alien-soldier.webp",
             "name": "Selective Invisibility (At Will)",
@@ -372,6 +387,9 @@
         },
         {
             "_id": "HBEc723GchJGYxc2",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.EhN3GjdjXChMdiFk"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/purple-neurons.webp",
             "name": "Share Pain",
@@ -409,7 +427,7 @@
                 },
                 "heightening": {
                     "levels": {
-                        "4": {
+                        "6": {
                             "damage": {
                                 "dIvEREAgyIVyanqT": {
                                     "applyMod": false,
@@ -455,7 +473,10 @@
                 },
                 "traits": {
                     "rarity": "common",
-                    "traditions": [],
+                    "traditions": [
+                        "divine",
+                        "occult"
+                    ],
                     "value": [
                         "concentrate",
                         "manipulate",
@@ -467,6 +488,9 @@
         },
         {
             "_id": "rkztuT1DY8azhdny",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.qOLMHvkAGsVYLhtn"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "icons/magic/perception/third-eye-blue-red.webp",
             "name": "Detect Thoughts",
@@ -481,13 +505,7 @@
                 },
                 "counteraction": false,
                 "damage": {},
-                "defense": {
-                    "passive": null,
-                    "save": {
-                        "basic": false,
-                        "statistic": "will"
-                    }
-                },
+                "defense": null,
                 "description": {
                     "value": "<p>You sense the presence of thinking creatures around you. You detect the presence or absence of thoughts from conscious creatures that have Intelligence modifiers of –3 or higher. You can choose to ignore the thoughts of creatures you're familiar with so they don't interfere with your detection of other thoughts. The spell can penetrate some barriers, but 3 feet of dirt or wood, 1 foot of stone, 1 inch of metal, a thin sheet of lead, or any force barrier blocks it. Creatures who are immune to mental effects are immune to detection by this spell.</p><hr /><p><strong>Heightened (4th)</strong> You detect the number of thinking minds and whether or not the creatures are telepathic. Creatures with telepathy have louder thoughts than creatures who don't have telepathy and might be able to sense your intrusion, at the GM's discretion.</p>"
                 },
@@ -536,6 +554,9 @@
         },
         {
             "_id": "oaHRIhX1FIPkn6ih",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VIKDSgBRR3Wd1mQx"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/green-chart.webp",
             "name": "Doom Scroll (At Will)",
@@ -606,6 +627,9 @@
         },
         {
             "_id": "kDLTQdRPO81zRbta",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.NkvRoN33RbDg3fl9"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/pink-target-sign.webp",
             "name": "Analyze Target",
@@ -619,7 +643,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The circumstance bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The circumstance bonus increases to +3, and you can target any number of creatures.</p>"
+                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The status bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The status bonus increases to +3, and you can target any number of creatures.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -668,6 +692,9 @@
         },
         {
             "_id": "50Lv2it4pxICJ8MC",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -684,7 +711,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -699,7 +726,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -733,6 +760,9 @@
         },
         {
             "_id": "M5qlI1HNnj6j7wDd",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.sNUvbMoMeLTnYJm8"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/blue-energy-alien-hand.webp",
             "name": "Injury Echo",
@@ -786,7 +816,7 @@
                                 "damage": {
                                     "X6aUcgmF4twJh5gL": "1d8"
                                 },
-                                "interval": 1,
+                                "interval": 2,
                                 "type": "interval"
                             }
                         }
@@ -813,7 +843,7 @@
                                 "damage": {
                                     "2kU3mhyAecpOrFci": "1d8"
                                 },
-                                "interval": 1,
+                                "interval": 2,
                                 "type": "interval"
                             }
                         }
@@ -840,7 +870,7 @@
                                 "damage": {
                                     "EotUm3XBubhQrtWi": "1d8"
                                 },
-                                "interval": 1,
+                                "interval": 2,
                                 "type": "interval"
                             }
                         }

--- a/packs/sf2e/alien-core-bestiary/clangit.json
+++ b/packs/sf2e/alien-core-bestiary/clangit.json
@@ -41,6 +41,9 @@
         },
         {
             "_id": "H9nQRaG6Qpk6oDvS",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.XXqE1eY3w3z6xJCB"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/creatures/magical/construct-stone-earth-gray.webp",
             "name": "Invisibility",
@@ -70,7 +73,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -101,6 +104,9 @@
         },
         {
             "_id": "1Q3GZuPtxqzH3s4c",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.h7IhypLwItepwhou"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/tentacle-drone.webp",
             "name": "Adhere",
@@ -161,6 +167,9 @@
         },
         {
             "_id": "yDqDQFdaigEBYfYJ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.kBhaPuzLUSwS6vVf"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/lightning/bolt-strike-forked-blue.webp",
             "name": "Electric Arc",
@@ -212,7 +221,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -244,6 +253,9 @@
         },
         {
             "_id": "eQja5hjzLUhjXt1V",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.0zU8CPejjQFnhZFI"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/ghost-sound.webp",
             "name": "Figment",
@@ -272,7 +284,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -305,6 +317,9 @@
         },
         {
             "_id": "F9yWJv2cUjyXfy4O",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.2oH5IufzdESuYxat"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/illusory-object.webp",
             "name": "Illusory Object",
@@ -337,7 +352,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -369,6 +384,9 @@
         },
         {
             "_id": "x9I5xlxgPxoFrMbi",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.wOjoJjl2ndZKTuFJ"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/orange-timer-fire.webp",
             "name": "Overheat",
@@ -453,6 +471,9 @@
         },
         {
             "_id": "OxayOVXMFclYr03B",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5y70IWhVV6bVjC9N"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-battery-gauge.webp",
             "name": "Recharge Weapon",

--- a/packs/sf2e/alien-core-bestiary/corpse-fleet-infantry.json
+++ b/packs/sf2e/alien-core-bestiary/corpse-fleet-infantry.json
@@ -343,6 +343,9 @@
         },
         {
             "_id": "9VIeKl4wrdFmExNi",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -358,7 +361,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -373,6 +377,7 @@
                     "type": null
                 },
                 "price": {
+                    "per": 1,
                     "value": {
                         "sp": 10
                     }
@@ -391,7 +396,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 10,
                     "value": 10
                 }
@@ -400,6 +405,9 @@
         },
         {
             "_id": "NZxGxTNCkJzCYebG",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -415,7 +423,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/alien-core-bestiary/corpse-fleet-officer.json
+++ b/packs/sf2e/alien-core-bestiary/corpse-fleet-officer.json
@@ -252,6 +252,9 @@
         },
         {
             "_id": "lqHlHaFP7gMyYfRs",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -267,7 +270,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -282,6 +286,7 @@
                     "type": null
                 },
                 "price": {
+                    "per": 1,
                     "value": {
                         "sp": 10
                     }
@@ -300,7 +305,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 10,
                     "value": 10
                 }
@@ -309,6 +314,9 @@
         },
         {
             "_id": "qEOlhXqyNfmpAIep",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -324,7 +332,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -339,6 +348,7 @@
                     "type": null
                 },
                 "price": {
+                    "per": 1,
                     "value": {
                         "sp": 10
                     }
@@ -357,7 +367,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 10,
                     "value": 10
                 }

--- a/packs/sf2e/alien-core-bestiary/corpse-fleet-recruiter.json
+++ b/packs/sf2e/alien-core-bestiary/corpse-fleet-recruiter.json
@@ -1623,6 +1623,9 @@
         },
         {
             "_id": "ZCYqku3Zx1TT35wA",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.5PS5ESGpnQfJNOdg"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/blue-battery.webp",
             "name": "Battery (Tactical)",
@@ -1638,7 +1641,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -1653,6 +1657,7 @@
                     "type": null
                 },
                 "price": {
+                    "per": 1,
                     "value": {
                         "sp": 20
                     }
@@ -1671,7 +1676,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 20,
                     "value": 20
                 }
@@ -1680,6 +1685,9 @@
         },
         {
             "_id": "MrjeBtotNv5Nlowg",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.5PS5ESGpnQfJNOdg"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/blue-battery.webp",
             "name": "Battery (Tactical)",
@@ -1695,7 +1703,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -1710,6 +1719,7 @@
                     "type": null
                 },
                 "price": {
+                    "per": 1,
                     "value": {
                         "sp": 20
                     }
@@ -1728,7 +1738,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 20,
                     "value": 20
                 }

--- a/packs/sf2e/alien-core-bestiary/corpse-fleet-recruiter.json
+++ b/packs/sf2e/alien-core-bestiary/corpse-fleet-recruiter.json
@@ -1433,6 +1433,9 @@
         },
         {
             "_id": "JuRYafRJ4UvuIvWH",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.sTe6qQmJ1lC1xDfC"
+            },
             "folder": "V89RPpe7fyCFC6NS",
             "img": "icons/equipment/hand/gauntlet-armored-leather-steel-blue.webp",
             "name": "Integrated Shock Pad",
@@ -1522,6 +1525,9 @@
         },
         {
             "_id": "NUckU1mEqJQI5FNr",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.O3QRrXVfhNpF0XyY"
+            },
             "folder": "V89RPpe7fyCFC6NS",
             "img": "systems/sf2e/icons/abilities/blue-aura-charged-gun.webp",
             "name": "Integrated Zero Pistol",
@@ -1595,17 +1601,6 @@
                 },
                 "size": "tiny",
                 "slug": "zero-pistol",
-                "specific": {
-                    "material": {
-                        "grade": null,
-                        "type": null
-                    },
-                    "runes": {
-                        "potency": 0,
-                        "property": [],
-                        "striking": 0
-                    }
-                },
                 "splashDamage": {
                     "value": 0
                 },

--- a/packs/sf2e/alien-core-bestiary/corpse-fleet-recruiter.json
+++ b/packs/sf2e/alien-core-bestiary/corpse-fleet-recruiter.json
@@ -57,6 +57,9 @@
         },
         {
             "_id": "N2JUWFfjhC3DKuRb",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.GUeRTriJkMlMlVrk"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "systems/sf2e/icons/spells/bind-undead.webp",
             "name": "Bind Undead",
@@ -86,7 +89,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -117,6 +120,9 @@
         },
         {
             "_id": "yFin88B3JF1qZFLM",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.kR5A0h2a9hY41wav"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/purple-dimension-rift.webp",
             "name": "Entropy Strike",
@@ -237,6 +243,9 @@
         },
         {
             "_id": "5tYpwMGeMWXrgLQF",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.MfsxPjshwZJZuNpN"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/hazard-emblem.webp",
             "name": "Irradiate",
@@ -302,6 +311,9 @@
         },
         {
             "_id": "KzN6ooNC5rmIQD9U",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.N1Z1oLPdBxaSgrEE"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "systems/sf2e/icons/spells/vampiric-touch.webp",
             "name": "Vampiric Feast",
@@ -354,7 +366,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -387,6 +399,9 @@
         },
         {
             "_id": "WMuFRGHlVFuCZJhB",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.c3b6LdLlQDPngNIb"
+            },
             "folder": "6JF73zNhT8zbp1qC",
             "img": "systems/sf2e/icons/spells/create-undead.webp",
             "name": "Create Undead (doesn't require secondary casters)",
@@ -400,7 +415,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You transform the target into an undead creature with a level up to that allowed in the Creature Creation Rituals table. There are many versions of this ritual, each specific to a particular type of undead (one ritual for all zombies, one for skeletons, one for ghouls, and so on), and the rituals that create rare undead are also rare. Some forms of undead, such as liches, form using their own unique methods and can't be created with a version of <em>create undead</em>.</p><hr /><p><strong>Critical Success</strong> The target becomes an undead creature of the appropriate type. If it's at least 4 levels lower than you, you can make it a minion. This gives it the minion trait, meaning it can use 2 actions when you command it, and commanding it is a single action that has the auditory and concentrate traits. You can have a maximum of four minions under your control. If it's intelligent and doesn't become a minion, the undead is helpful to you for awakening it, though it's still a horrid and evil creature. If it's unintelligent and doesn't become a minion, you can give it one simple command. It pursues that goal single-mindedly, ignoring any of your subsequent commands.</p>\n<p><strong>Success</strong> As critical success, except an intelligent undead that doesn't become your minion is only friendly to you, and an unintelligent undead that doesn't become your minion leaves you alone unless you attack it. It marauds the local area rather than following your command.</p>\n<p><strong>Failure</strong> You fail to create the undead.</p>\n<p><strong>Critical Failure</strong> You create the undead, but its soul, tortured by your foul necromancy, is full of nothing but hatred for you. It attempts to destroy you.</p><h2>Creatures Creation Rituals</h2><table class=\"sf2e remaster\"><thead><tr><th>Creature Level</th><th>Spell Rank Required</th><th>Cost</th></tr></thead><tbody><tr><td>-1 or 0</td><td>2</td><td>15 gp</td></tr><tr><td>1</td><td>2</td><td>60 gp</td></tr><tr><td>2</td><td>3</td><td>105 gp</td></tr><tr><td>3</td><td>3</td><td>180 gp</td></tr><tr><td>4</td><td>4</td><td>300 gp</td></tr><tr><td>5</td><td>4</td><td>480 gp</td></tr><tr><td>6</td><td>5</td><td>750 gp</td></tr><tr><td>7</td><td>5</td><td>1,080 gp</td></tr><tr><td>8</td><td>6</td><td>1,500 gp</td></tr><tr><td>9</td><td>6</td><td>2,100 gp</td></tr><tr><td>10</td><td>7</td><td>3,000 gp</td></tr><tr><td>11</td><td>7</td><td>4,200 gp</td></tr><tr><td>12</td><td>8</td><td>6,000 gp</td></tr><tr><td>13</td><td>8</td><td>9,000 gp</td></tr><tr><td>14</td><td>9</td><td>13,500 gp</td></tr><tr><td>15</td><td>9</td><td>19,500 gp</td></tr><tr><td>16</td><td>10</td><td>30,000 gp</td></tr><tr><td>17</td><td>10</td><td>45,000 gp</td></tr></tbody></table>"
+                    "value": "<p>You transform the target into an undead creature with a level up to that allowed in the Creature Creation Rituals table. There are many versions of this ritual, each specific to a particular type of undead (one ritual for all zombies, one for skeletons, one for ghouls, and so on), and the rituals that create rare undead are also rare. Some forms of undead, such as liches, form using their own unique methods and can't be created with a version of <em>create undead</em>.</p><hr /><p><strong>Critical Success</strong> The target becomes an undead creature of the appropriate type. If it's at least 4 levels lower than you, you can make it a minion. This gives it the minion trait, meaning it can use 2 actions when you command it, and commanding it is a single action that has the auditory and concentrate traits. You can have a maximum of four minions under your control. If it's intelligent and doesn't become a minion, the undead is helpful to you for awakening it, though it's still a horrid and evil creature. If it's unintelligent and doesn't become a minion, you can give it one simple command. It pursues that goal single-mindedly, ignoring any of your subsequent commands.</p>\n<p><strong>Success</strong> As critical success, except an intelligent undead that doesn't become your minion is only friendly to you, and an unintelligent undead that doesn't become your minion leaves you alone unless you attack it. It marauds the local area rather than following your command.</p>\n<p><strong>Failure</strong> You fail to create the undead.</p>\n<p><strong>Critical Failure</strong> You create the undead, but its soul, tortured by your foul necromancy, is full of nothing but hatred for you. It attempts to destroy you.</p><h2>Creatures Creation Rituals</h2><table class=\"pf2e remaster\"><thead><tr><th>Creature Level</th><th>Spell Rank Required</th><th>Cost</th></tr></thead><tbody><tr><td>-1 or 0</td><td>2</td><td>15 gp</td></tr><tr><td>1</td><td>2</td><td>60 gp</td></tr><tr><td>2</td><td>3</td><td>105 gp</td></tr><tr><td>3</td><td>3</td><td>180 gp</td></tr><tr><td>4</td><td>4</td><td>300 gp</td></tr><tr><td>5</td><td>4</td><td>480 gp</td></tr><tr><td>6</td><td>5</td><td>750 gp</td></tr><tr><td>7</td><td>5</td><td>1,080 gp</td></tr><tr><td>8</td><td>6</td><td>1,500 gp</td></tr><tr><td>9</td><td>6</td><td>2,100 gp</td></tr><tr><td>10</td><td>7</td><td>3,000 gp</td></tr><tr><td>11</td><td>7</td><td>4,200 gp</td></tr><tr><td>12</td><td>8</td><td>6,000 gp</td></tr><tr><td>13</td><td>8</td><td>9,000 gp</td></tr><tr><td>14</td><td>9</td><td>13,500 gp</td></tr><tr><td>15</td><td>9</td><td>19,500 gp</td></tr><tr><td>16</td><td>10</td><td>30,000 gp</td></tr><tr><td>17</td><td>10</td><td>45,000 gp</td></tr></tbody></table>"
                 },
                 "duration": {
                     "sustained": false,
@@ -415,7 +430,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "10 feet"
@@ -450,6 +465,9 @@
         },
         {
             "_id": "S207MrhdwB5xsJo0",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4GE2ZdODgIQtg51c"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/darkness.webp",
             "name": "Darkness",
@@ -482,7 +500,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -515,6 +533,9 @@
         },
         {
             "_id": "26o01G5lEiaXruf5",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Fr58LDSrbndgld9n"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/magic/defensive/shield-barrier-deflect-teal.webp",
             "name": "Resist Energy",
@@ -559,7 +580,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -591,6 +612,9 @@
         },
         {
             "_id": "juNVP6cTNRLnqVYL",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.thAHF1zxNplLCJPO"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/acid/orb-bubble-smoke-drip.webp",
             "name": "Caustic Blast",
@@ -646,7 +670,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -678,6 +702,9 @@
         },
         {
             "_id": "zIcplXhyv4NzNgEb",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -694,7 +721,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -709,7 +736,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -743,6 +770,9 @@
         },
         {
             "_id": "J8tfvksvz8C55SuF",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.kBhaPuzLUSwS6vVf"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/lightning/bolt-strike-forked-blue.webp",
             "name": "Electric Arc",
@@ -794,7 +824,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -826,6 +856,9 @@
         },
         {
             "_id": "LFPfieBxQRIu4cdv",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.k34hDOfIIMAxNL4a"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/grim-tendrils.webp",
             "name": "Grim Tendrils",
@@ -881,7 +914,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1105,6 +1138,9 @@
         },
         {
             "_id": "FLCaXsQHxvV9b4zO",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.OhD2Z6rIGGD5ocZA"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/light/explosion-star-glow-silhouette.webp",
             "name": "Read Aura",
@@ -1148,7 +1184,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1182,6 +1218,9 @@
         },
         {
             "_id": "gTODowC5nBd5wXfF",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.9WGeBwIIbbUuWKq0"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/animate-dead.webp",
             "name": "Summon Undead",
@@ -1211,7 +1250,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1243,6 +1282,9 @@
         },
         {
             "_id": "1yap8Ca5HRjFSueI",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.9WGeBwIIbbUuWKq0"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/animate-dead.webp",
             "name": "Summon Undead",
@@ -1272,7 +1314,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1304,6 +1346,9 @@
         },
         {
             "_id": "uBDdDmo9mwnB1g6N",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.mAMEt4FFbdqoRnkN"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/chill-touch.webp",
             "name": "Void Warp",
@@ -1355,7 +1400,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"

--- a/packs/sf2e/alien-core-bestiary/cosmic-dragon-adult-spellcaster.json
+++ b/packs/sf2e/alien-core-bestiary/cosmic-dragon-adult-spellcaster.json
@@ -196,6 +196,9 @@
         },
         {
             "_id": "ImHPje7uuTyH88N8",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.0jadeyQIItIuRgeH"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "systems/sf2e/icons/spells/eclipse-burst.webp",
             "name": "Eclipse Burst",
@@ -263,7 +266,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -297,6 +300,9 @@
         },
         {
             "_id": "Tk4FHr6Tzm0yPhRt",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.a3aQxCpoj1q1NQxC"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "systems/sf2e/icons/spells/sunburst.webp",
             "name": "Sunburst",
@@ -353,7 +359,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -386,6 +392,9 @@
         },
         {
             "_id": "mQURgcDXwAZwKmUx",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.yrZA4k2VAqEP8xx7"
+            },
             "folder": "zDlxATrLAlbYA2Mv",
             "img": "icons/magic/air/wind-vortex-swirl-blue-purple.webp",
             "name": "Repulsion",
@@ -419,7 +428,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "emanation up to 40-feet"
@@ -452,6 +461,9 @@
         },
         {
             "_id": "vbReB4NSOqREiCQf",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uqlxMQQeSGWEVjki"
+            },
             "folder": "zDlxATrLAlbYA2Mv",
             "img": "systems/sf2e/icons/spells/true-seeing.webp",
             "name": "Truesight",
@@ -480,7 +492,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -513,6 +525,9 @@
         },
         {
             "_id": "AypGYwWg6xV9yaIJ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.DPP4TW5FxE85XPKZ"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/blue-piercing-energy.webp",
             "name": "X-Ray Vision",
@@ -572,6 +587,9 @@
         },
         {
             "_id": "7ROUVlDkDJBq5ucC",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.bay4AfSu2iIozNNW"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/banishment.webp",
             "name": "Banishment",
@@ -615,7 +633,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -648,6 +666,9 @@
         },
         {
             "_id": "gqJOfGmhjY2anPYG",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.R9xqCBblkS5KE4y7"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/sending.webp",
             "name": "Sending",
@@ -677,7 +698,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "planetary"
@@ -709,6 +730,9 @@
         },
         {
             "_id": "i6Jq8QEjJrOhiNnB",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.R9xqCBblkS5KE4y7"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/sending.webp",
             "name": "Sending",
@@ -737,7 +761,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "planetary"
@@ -769,6 +793,9 @@
         },
         {
             "_id": "wW3iG2EYMceB91E4",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.SwUiVavHKMWG7t5K"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/tongues.webp",
             "name": "Truespeech (constant)",
@@ -798,7 +825,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -829,6 +856,9 @@
         },
         {
             "_id": "6tCPTdtjINVblo2O",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ksLCg62cLOojw3gN"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/equipment/shield/heater-steel-segmented-purple.webp",
             "name": "Planar Tether",
@@ -862,7 +892,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -893,6 +923,9 @@
         },
         {
             "_id": "slV05LbytTZKHyBN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.KqvqNAfGIE5a9wSv"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/life/ankh-gold-blue.webp",
             "name": "Heroism",
@@ -921,7 +954,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -952,6 +985,9 @@
         },
         {
             "_id": "WKbjdRL8LmfP69IO",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ShwUELLERVMtdjwE"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/blue-heart-in-a-circle.webp",
             "name": "Life Seal (at will)",
@@ -1010,6 +1046,9 @@
         },
         {
             "_id": "jZkFz75hxo0Xx3Io",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.b515AZlB0sridKSq"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/creatures/abilities/wolf-heads-swirl-purple.webp",
             "name": "Calm",
@@ -1046,7 +1085,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -1079,6 +1118,9 @@
         },
         {
             "_id": "frBdtFW6ranhzsHB",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.SUKaxVZW2TlM8lu0"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/consumables/fruit/berry-clustered-white.webp",
             "name": "Cleanse Affliction",
@@ -1107,7 +1149,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -1139,6 +1181,9 @@
         },
         {
             "_id": "JMHQT1i21aT4mXwY",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.EfFMLVbmkBWmzoLF"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/detect-alignment.webp",
             "name": "Clear Mind",
@@ -1167,7 +1212,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -1200,6 +1245,9 @@
         },
         {
             "_id": "P4x9CHihLRnTslIF",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5esP2GVzvxWsMgaX"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/endure-elements.webp",
             "name": "Environmental Endurance",
@@ -1228,7 +1276,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -1259,6 +1307,9 @@
         },
         {
             "_id": "96bdE1cKbJDt34X6",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Fr58LDSrbndgld9n"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/magic/defensive/shield-barrier-deflect-teal.webp",
             "name": "Resist Energy",
@@ -1302,7 +1353,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -1334,6 +1385,9 @@
         },
         {
             "_id": "eHRZpSTn8Z8ecZk0",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jwK43yKsHTkJQvQ9"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/see-invisibility.webp",
             "name": "See the Unseen",
@@ -1362,7 +1416,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1394,6 +1448,9 @@
         },
         {
             "_id": "RxvXto0EnJgdnv7z",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.HTou8cG05yuSkesj"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/magic/perception/orb-eye-scrying.webp",
             "name": "Status",
@@ -1435,7 +1492,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -1467,6 +1524,9 @@
         },
         {
             "_id": "m0UbRt3DB2EOQQvy",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.vTQvfYu2llKQedmY"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/comprehend-language.webp",
             "name": "Translate",
@@ -1505,7 +1565,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1536,6 +1596,9 @@
         },
         {
             "_id": "r32DBKWmbkGTf8vq",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -1552,7 +1615,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -1567,7 +1630,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1601,6 +1664,9 @@
         },
         {
             "_id": "ScXLHFH9zC0suPEF",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.RA7VKcen3p56rVyZ"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/forbidding-ward.webp",
             "name": "Forbidding Ward",
@@ -1629,7 +1695,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1660,6 +1726,9 @@
         },
         {
             "_id": "iplG9bV5LxJFr3cL",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.izcxFQFwf3woCnFs"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/guidance.webp",
             "name": "Guidance",
@@ -1688,7 +1757,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1719,6 +1788,9 @@
         },
         {
             "_id": "1KCCaqk4fDUeL6O5",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.rfZpqmj0AIIdkVIs"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/life/cross-worn-green.webp",
             "name": "Heal",
@@ -1882,7 +1954,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "varies"
@@ -1913,6 +1985,9 @@
         },
         {
             "_id": "iwuEEOb4SoYKJtF4",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.2iQKhCQBijhj5Rf3"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/weapons/swords/sword-gold-holy.webp",
             "name": "Infuse Vitality",
@@ -1945,7 +2020,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1975,6 +2050,9 @@
         },
         {
             "_id": "cP78lDt8jKUGFIy2",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.t0oFlhMhNOHbb6rG"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/blue-emblem-generic.webp",
             "name": "Reorient",
@@ -2035,6 +2113,9 @@
         },
         {
             "_id": "hejvqXVmBY7dVseH",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.8xRzLhwGL7Dgy3EZ"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/sanctuary.webp",
             "name": "Sanctuary",
@@ -2063,7 +2144,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -2093,6 +2174,9 @@
         },
         {
             "_id": "xA2injvwWUj79OxD",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.yHujiDQPdtXW797e"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/control/energy-stream-link-teal.webp",
             "name": "Spirit Link",
@@ -2139,7 +2223,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -2171,6 +2255,9 @@
         },
         {
             "_id": "YGXrLTQ1g2KQUPvb",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.SnjhtQYexDtNDdEg"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/control/debuff-energy-hold-yellow.webp",
             "name": "Stabilize",
@@ -2199,7 +2286,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"

--- a/packs/sf2e/alien-core-bestiary/cosmic-dragon-adult.json
+++ b/packs/sf2e/alien-core-bestiary/cosmic-dragon-adult.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "ImHPje7uuTyH88N8",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.0jadeyQIItIuRgeH"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "systems/sf2e/icons/spells/eclipse-burst.webp",
             "name": "Eclipse Burst",
@@ -111,7 +114,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -145,6 +148,9 @@
         },
         {
             "_id": "Tk4FHr6Tzm0yPhRt",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.a3aQxCpoj1q1NQxC"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "systems/sf2e/icons/spells/sunburst.webp",
             "name": "Sunburst",
@@ -201,7 +207,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -234,6 +240,9 @@
         },
         {
             "_id": "gqJOfGmhjY2anPYG",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.R9xqCBblkS5KE4y7"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/sending.webp",
             "name": "Sending",
@@ -263,7 +272,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "planetary"
@@ -295,6 +304,9 @@
         },
         {
             "_id": "wW3iG2EYMceB91E4",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.SwUiVavHKMWG7t5K"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/tongues.webp",
             "name": "Truespeech (constant)",
@@ -324,7 +336,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -355,6 +367,9 @@
         },
         {
             "_id": "WKbjdRL8LmfP69IO",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ShwUELLERVMtdjwE"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/blue-heart-in-a-circle.webp",
             "name": "Life Seal (at will)",

--- a/packs/sf2e/alien-core-bestiary/cosmic-dragon-ancient-spellcaster.json
+++ b/packs/sf2e/alien-core-bestiary/cosmic-dragon-ancient-spellcaster.json
@@ -238,6 +238,9 @@
         },
         {
             "_id": "L2VxasLREfuC7xZT",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.J3zMwmhIVgI2yzxm"
+            },
             "folder": "DWZvpqhX0tWHYZOh",
             "img": "systems/sf2e/icons/abilities/energy-reaction-2.webp",
             "name": "Call Cosmos",
@@ -357,6 +360,9 @@
         },
         {
             "_id": "bprFeIDSpE5rgwme",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.qsNeG9KZpODSACMq"
+            },
             "folder": "fi1AYNmuCRvoT15b",
             "img": "icons/magic/perception/orb-eye-scrying.webp",
             "name": "Foresight",
@@ -385,7 +391,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -418,6 +424,9 @@
         },
         {
             "_id": "5xXvBY1idB3icyBq",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.aPZMapuunaNpxubp"
+            },
             "folder": "uIyg7rfbXLT1OSXC",
             "img": "systems/sf2e/icons/abilities/pink-portal.webp",
             "name": "Singularity Seed",
@@ -496,6 +505,9 @@
         },
         {
             "_id": "ImHPje7uuTyH88N8",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.0jadeyQIItIuRgeH"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "systems/sf2e/icons/spells/eclipse-burst.webp",
             "name": "Eclipse Burst",
@@ -563,7 +575,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -597,6 +609,9 @@
         },
         {
             "_id": "5geGWysyK63hrlv8",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.m2xFMNyQiUKQDRaj"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "icons/magic/defensive/shield-barrier-glowing-blue.webp",
             "name": "Energy Aegis",
@@ -625,7 +640,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -657,6 +672,9 @@
         },
         {
             "_id": "RJ3fHm0QAxaAFXhX",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5bTt2CvYHPvaR7QQ"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "icons/magic/lightning/bolt-strike-explosion-purple.webp",
             "name": "Interplanar Teleport",
@@ -685,7 +703,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "5 feet"
@@ -718,6 +736,9 @@
         },
         {
             "_id": "Tk4FHr6Tzm0yPhRt",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.a3aQxCpoj1q1NQxC"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "systems/sf2e/icons/spells/sunburst.webp",
             "name": "Sunburst",
@@ -774,7 +795,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -807,6 +828,9 @@
         },
         {
             "_id": "mQURgcDXwAZwKmUx",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.yrZA4k2VAqEP8xx7"
+            },
             "folder": "zDlxATrLAlbYA2Mv",
             "img": "icons/magic/air/wind-vortex-swirl-blue-purple.webp",
             "name": "Repulsion",
@@ -840,7 +864,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "emanation up to 40-feet"
@@ -873,6 +897,9 @@
         },
         {
             "_id": "euuRUhQz6U5KV5FT",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.69L70wKfGDY66Mk9"
+            },
             "folder": "zDlxATrLAlbYA2Mv",
             "img": "systems/sf2e/icons/spells/teleport.webp",
             "name": "Teleport",
@@ -901,7 +928,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "100 miles"
@@ -932,6 +959,9 @@
         },
         {
             "_id": "vbReB4NSOqREiCQf",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uqlxMQQeSGWEVjki"
+            },
             "folder": "zDlxATrLAlbYA2Mv",
             "img": "systems/sf2e/icons/spells/true-seeing.webp",
             "name": "Truesight",
@@ -960,7 +990,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -993,6 +1023,9 @@
         },
         {
             "_id": "AypGYwWg6xV9yaIJ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.DPP4TW5FxE85XPKZ"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/blue-piercing-energy.webp",
             "name": "X-Ray Vision",
@@ -1052,6 +1085,9 @@
         },
         {
             "_id": "7ROUVlDkDJBq5ucC",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.bay4AfSu2iIozNNW"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/banishment.webp",
             "name": "Banishment",
@@ -1095,7 +1131,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1128,6 +1164,9 @@
         },
         {
             "_id": "gqJOfGmhjY2anPYG",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.R9xqCBblkS5KE4y7"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/sending.webp",
             "name": "Sending",
@@ -1157,7 +1196,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "planetary"
@@ -1189,6 +1228,9 @@
         },
         {
             "_id": "i6Jq8QEjJrOhiNnB",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.R9xqCBblkS5KE4y7"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/sending.webp",
             "name": "Sending",
@@ -1217,7 +1259,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "planetary"
@@ -1249,6 +1291,9 @@
         },
         {
             "_id": "wW3iG2EYMceB91E4",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.SwUiVavHKMWG7t5K"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/tongues.webp",
             "name": "Truespeech (constant)",
@@ -1278,7 +1323,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -1309,6 +1354,9 @@
         },
         {
             "_id": "6tCPTdtjINVblo2O",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ksLCg62cLOojw3gN"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/equipment/shield/heater-steel-segmented-purple.webp",
             "name": "Planar Tether",
@@ -1342,7 +1390,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1373,6 +1421,9 @@
         },
         {
             "_id": "slV05LbytTZKHyBN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.KqvqNAfGIE5a9wSv"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/life/ankh-gold-blue.webp",
             "name": "Heroism",
@@ -1401,7 +1452,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -1432,6 +1483,9 @@
         },
         {
             "_id": "WKbjdRL8LmfP69IO",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ShwUELLERVMtdjwE"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/blue-heart-in-a-circle.webp",
             "name": "Life Seal (at will)",
@@ -1490,6 +1544,9 @@
         },
         {
             "_id": "jZkFz75hxo0Xx3Io",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.b515AZlB0sridKSq"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/creatures/abilities/wolf-heads-swirl-purple.webp",
             "name": "Calm",
@@ -1526,7 +1583,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -1559,6 +1616,9 @@
         },
         {
             "_id": "frBdtFW6ranhzsHB",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.SUKaxVZW2TlM8lu0"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/consumables/fruit/berry-clustered-white.webp",
             "name": "Cleanse Affliction",
@@ -1587,7 +1647,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -1619,6 +1679,9 @@
         },
         {
             "_id": "JMHQT1i21aT4mXwY",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.EfFMLVbmkBWmzoLF"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/detect-alignment.webp",
             "name": "Clear Mind",
@@ -1647,7 +1710,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -1680,6 +1743,9 @@
         },
         {
             "_id": "rhioSldK0lyxZjdx",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.EfFMLVbmkBWmzoLF"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/detect-alignment.webp",
             "name": "Clear Mind",
@@ -1708,7 +1774,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -1741,6 +1807,9 @@
         },
         {
             "_id": "AqiqqMVo8Dpshwiy",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.9HpwDN4MYQJnW0LG"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/dispel-magic.webp",
             "name": "Dispel Magic",
@@ -1769,7 +1838,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -1801,6 +1870,9 @@
         },
         {
             "_id": "P4x9CHihLRnTslIF",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5esP2GVzvxWsMgaX"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/endure-elements.webp",
             "name": "Environmental Endurance",
@@ -1829,7 +1901,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -1860,6 +1932,9 @@
         },
         {
             "_id": "96bdE1cKbJDt34X6",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Fr58LDSrbndgld9n"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/magic/defensive/shield-barrier-deflect-teal.webp",
             "name": "Resist Energy",
@@ -1903,7 +1978,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -1935,6 +2010,9 @@
         },
         {
             "_id": "eHRZpSTn8Z8ecZk0",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jwK43yKsHTkJQvQ9"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/see-invisibility.webp",
             "name": "See the Unseen",
@@ -1963,7 +2041,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1995,6 +2073,9 @@
         },
         {
             "_id": "MUcRkjmXlsztcKUu",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Et8RSCLx8w7uOLvo"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/wholeness-of-body.webp",
             "name": "Sound Body",
@@ -2023,7 +2104,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -2056,6 +2137,9 @@
         },
         {
             "_id": "RxvXto0EnJgdnv7z",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.HTou8cG05yuSkesj"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/magic/perception/orb-eye-scrying.webp",
             "name": "Status",
@@ -2097,7 +2181,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -2129,6 +2213,9 @@
         },
         {
             "_id": "m0UbRt3DB2EOQQvy",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.vTQvfYu2llKQedmY"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/comprehend-language.webp",
             "name": "Translate",
@@ -2167,7 +2254,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -2198,6 +2285,9 @@
         },
         {
             "_id": "r32DBKWmbkGTf8vq",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -2214,7 +2304,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -2229,7 +2319,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -2263,6 +2353,9 @@
         },
         {
             "_id": "ScXLHFH9zC0suPEF",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.RA7VKcen3p56rVyZ"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/forbidding-ward.webp",
             "name": "Forbidding Ward",
@@ -2291,7 +2384,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -2322,6 +2415,9 @@
         },
         {
             "_id": "iplG9bV5LxJFr3cL",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.izcxFQFwf3woCnFs"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/guidance.webp",
             "name": "Guidance",
@@ -2350,7 +2446,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -2381,6 +2477,9 @@
         },
         {
             "_id": "1KCCaqk4fDUeL6O5",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.rfZpqmj0AIIdkVIs"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/life/cross-worn-green.webp",
             "name": "Heal",
@@ -2544,7 +2643,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "varies"
@@ -2575,6 +2674,9 @@
         },
         {
             "_id": "iwuEEOb4SoYKJtF4",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.2iQKhCQBijhj5Rf3"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/weapons/swords/sword-gold-holy.webp",
             "name": "Infuse Vitality",
@@ -2607,7 +2709,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -2637,6 +2739,9 @@
         },
         {
             "_id": "cP78lDt8jKUGFIy2",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.t0oFlhMhNOHbb6rG"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/blue-emblem-generic.webp",
             "name": "Reorient",
@@ -2697,6 +2802,9 @@
         },
         {
             "_id": "hejvqXVmBY7dVseH",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.8xRzLhwGL7Dgy3EZ"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/sanctuary.webp",
             "name": "Sanctuary",
@@ -2725,7 +2833,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -2755,6 +2863,9 @@
         },
         {
             "_id": "xA2injvwWUj79OxD",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.yHujiDQPdtXW797e"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/control/energy-stream-link-teal.webp",
             "name": "Spirit Link",
@@ -2801,7 +2912,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -2833,6 +2944,9 @@
         },
         {
             "_id": "YGXrLTQ1g2KQUPvb",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.SnjhtQYexDtNDdEg"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/control/debuff-energy-hold-yellow.webp",
             "name": "Stabilize",
@@ -2861,7 +2975,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"

--- a/packs/sf2e/alien-core-bestiary/cosmic-dragon-ancient.json
+++ b/packs/sf2e/alien-core-bestiary/cosmic-dragon-ancient.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "L2VxasLREfuC7xZT",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.J3zMwmhIVgI2yzxm"
+            },
             "folder": "DWZvpqhX0tWHYZOh",
             "img": "systems/sf2e/icons/abilities/energy-reaction-2.webp",
             "name": "Call Cosmos",
@@ -163,6 +166,9 @@
         },
         {
             "_id": "ImHPje7uuTyH88N8",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.0jadeyQIItIuRgeH"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "systems/sf2e/icons/spells/eclipse-burst.webp",
             "name": "Eclipse Burst",
@@ -230,7 +236,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -264,6 +270,9 @@
         },
         {
             "_id": "Tk4FHr6Tzm0yPhRt",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.a3aQxCpoj1q1NQxC"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "systems/sf2e/icons/spells/sunburst.webp",
             "name": "Sunburst",
@@ -320,7 +329,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -353,6 +362,9 @@
         },
         {
             "_id": "gqJOfGmhjY2anPYG",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.R9xqCBblkS5KE4y7"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/sending.webp",
             "name": "Sending",
@@ -382,7 +394,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "planetary"
@@ -414,6 +426,9 @@
         },
         {
             "_id": "wW3iG2EYMceB91E4",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.SwUiVavHKMWG7t5K"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/tongues.webp",
             "name": "Truespeech (constant)",
@@ -443,7 +458,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -474,6 +489,9 @@
         },
         {
             "_id": "WKbjdRL8LmfP69IO",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ShwUELLERVMtdjwE"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/blue-heart-in-a-circle.webp",
             "name": "Life Seal (at will)",

--- a/packs/sf2e/alien-core-bestiary/cosmic-dragon-young-spellcaster.json
+++ b/packs/sf2e/alien-core-bestiary/cosmic-dragon-young-spellcaster.json
@@ -165,6 +165,9 @@
         },
         {
             "_id": "gqJOfGmhjY2anPYG",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.R9xqCBblkS5KE4y7"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/sending.webp",
             "name": "Sending",
@@ -194,7 +197,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "planetary"
@@ -226,6 +229,9 @@
         },
         {
             "_id": "wW3iG2EYMceB91E4",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.SwUiVavHKMWG7t5K"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/tongues.webp",
             "name": "Truespeech (constant)",
@@ -255,7 +261,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -286,6 +292,9 @@
         },
         {
             "_id": "6tCPTdtjINVblo2O",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ksLCg62cLOojw3gN"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/equipment/shield/heater-steel-segmented-purple.webp",
             "name": "Planar Tether",
@@ -319,7 +328,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -350,6 +359,9 @@
         },
         {
             "_id": "Aqnr4d6sl5Kp9gQh",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.KqvqNAfGIE5a9wSv"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/life/ankh-gold-blue.webp",
             "name": "Heroism",
@@ -378,7 +390,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -409,6 +421,9 @@
         },
         {
             "_id": "WKbjdRL8LmfP69IO",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ShwUELLERVMtdjwE"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/blue-heart-in-a-circle.webp",
             "name": "Life Seal (at will)",
@@ -467,6 +482,9 @@
         },
         {
             "_id": "jZkFz75hxo0Xx3Io",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.b515AZlB0sridKSq"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/creatures/abilities/wolf-heads-swirl-purple.webp",
             "name": "Calm",
@@ -503,7 +521,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -536,6 +554,9 @@
         },
         {
             "_id": "frBdtFW6ranhzsHB",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.SUKaxVZW2TlM8lu0"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/consumables/fruit/berry-clustered-white.webp",
             "name": "Cleanse Affliction",
@@ -564,7 +585,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -596,6 +617,9 @@
         },
         {
             "_id": "JMHQT1i21aT4mXwY",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.EfFMLVbmkBWmzoLF"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/detect-alignment.webp",
             "name": "Clear Mind",
@@ -624,7 +648,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -657,6 +681,9 @@
         },
         {
             "_id": "P4x9CHihLRnTslIF",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5esP2GVzvxWsMgaX"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/endure-elements.webp",
             "name": "Environmental Endurance",
@@ -685,7 +712,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -716,6 +743,9 @@
         },
         {
             "_id": "eHRZpSTn8Z8ecZk0",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jwK43yKsHTkJQvQ9"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/see-invisibility.webp",
             "name": "See the Unseen",
@@ -744,7 +774,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -776,6 +806,9 @@
         },
         {
             "_id": "RxvXto0EnJgdnv7z",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.HTou8cG05yuSkesj"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/magic/perception/orb-eye-scrying.webp",
             "name": "Status",
@@ -817,7 +850,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -849,6 +882,9 @@
         },
         {
             "_id": "m0UbRt3DB2EOQQvy",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.vTQvfYu2llKQedmY"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/comprehend-language.webp",
             "name": "Translate",
@@ -887,7 +923,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -918,6 +954,9 @@
         },
         {
             "_id": "r32DBKWmbkGTf8vq",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -934,7 +973,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -949,7 +988,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -983,6 +1022,9 @@
         },
         {
             "_id": "ScXLHFH9zC0suPEF",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.RA7VKcen3p56rVyZ"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/forbidding-ward.webp",
             "name": "Forbidding Ward",
@@ -1011,7 +1053,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1042,6 +1084,9 @@
         },
         {
             "_id": "iplG9bV5LxJFr3cL",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.izcxFQFwf3woCnFs"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/guidance.webp",
             "name": "Guidance",
@@ -1070,7 +1115,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1101,6 +1146,9 @@
         },
         {
             "_id": "1KCCaqk4fDUeL6O5",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.rfZpqmj0AIIdkVIs"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/life/cross-worn-green.webp",
             "name": "Heal",
@@ -1264,7 +1312,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "varies"
@@ -1295,6 +1343,9 @@
         },
         {
             "_id": "iwuEEOb4SoYKJtF4",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.2iQKhCQBijhj5Rf3"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/weapons/swords/sword-gold-holy.webp",
             "name": "Infuse Vitality",
@@ -1327,7 +1378,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1357,6 +1408,9 @@
         },
         {
             "_id": "cP78lDt8jKUGFIy2",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.t0oFlhMhNOHbb6rG"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/blue-emblem-generic.webp",
             "name": "Reorient",
@@ -1417,6 +1471,9 @@
         },
         {
             "_id": "hejvqXVmBY7dVseH",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.8xRzLhwGL7Dgy3EZ"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/sanctuary.webp",
             "name": "Sanctuary",
@@ -1445,7 +1502,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -1475,6 +1532,9 @@
         },
         {
             "_id": "xA2injvwWUj79OxD",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.yHujiDQPdtXW797e"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/control/energy-stream-link-teal.webp",
             "name": "Spirit Link",
@@ -1521,7 +1581,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1553,6 +1613,9 @@
         },
         {
             "_id": "YGXrLTQ1g2KQUPvb",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.SnjhtQYexDtNDdEg"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/control/debuff-energy-hold-yellow.webp",
             "name": "Stabilize",
@@ -1581,7 +1644,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"

--- a/packs/sf2e/alien-core-bestiary/cosmic-dragon-young.json
+++ b/packs/sf2e/alien-core-bestiary/cosmic-dragon-young.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "gqJOfGmhjY2anPYG",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.R9xqCBblkS5KE4y7"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/sending.webp",
             "name": "Sending",
@@ -73,7 +76,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "planetary"
@@ -105,6 +108,9 @@
         },
         {
             "_id": "wW3iG2EYMceB91E4",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.SwUiVavHKMWG7t5K"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/tongues.webp",
             "name": "Truespeech (constant)",
@@ -134,7 +140,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -165,6 +171,9 @@
         },
         {
             "_id": "WKbjdRL8LmfP69IO",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ShwUELLERVMtdjwE"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/blue-heart-in-a-circle.webp",
             "name": "Life Seal (at will)",

--- a/packs/sf2e/alien-core-bestiary/cybernetic-zombie.json
+++ b/packs/sf2e/alien-core-bestiary/cybernetic-zombie.json
@@ -94,6 +94,9 @@
         },
         {
             "_id": "HeaIERqr3jb1Dw1x",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -109,7 +112,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -143,7 +147,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 10,
                     "value": 10
                 }

--- a/packs/sf2e/alien-core-bestiary/cybernetic-zombie.json
+++ b/packs/sf2e/alien-core-bestiary/cybernetic-zombie.json
@@ -4,6 +4,9 @@
     "items": [
         {
             "_id": "3W7vk1aqhkW3eMYv",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.qIgcUV22LaDCzmb2"
+            },
             "folder": "V89RPpe7fyCFC6NS",
             "img": "systems/sf2e/icons/equipment/weapons/pistol.webp",
             "name": "Integrated Commercial Laser Pistol",

--- a/packs/sf2e/alien-core-bestiary/deh-nolo.json
+++ b/packs/sf2e/alien-core-bestiary/deh-nolo.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "C0EZvOHzCJ4LkBi0",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.nbIGKNr7eyiTqKwS"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/green-energy-wave.webp",
             "name": "Corrosive Haze",
@@ -142,6 +145,9 @@
         },
         {
             "_id": "6mOKqBMnGgECwA3z",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.xS4bqHnbodCwjpqI"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/blue-planet-pillar-of-light.webp",
             "name": "Promession",
@@ -171,7 +177,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You flash freeze a target then send subsonic waves through it, potentially reducing it into fine powder. Make a spell attack against the target. If you hit a target, the target takes 6d8 cold damage and must attempt a Fortitude save. If you critically hit, the target gets a result one degree of success worse than it rolled on its Fortitude save. A creature reduced to 0 Hit Points is blasted to fine powder; its gear remains.</p><hr /><p><strong>Critical Success</strong> The target is unaffected by further damage.</p>\n<p><strong>Success</strong> The target takes an additional 3d8 sonic damage.</p>\n<p><strong>Failure</strong> The target takes an additional 6d8 sonic damage.</p>\n<p><strong>Critical Failure</strong> The target takes an additional 12d8 sonic damage.</p><hr /><p><strong>Heightened (+1)</strong> The cold and sonic damage each increase by 1d8.</p>"
+                    "value": "<p>You flash freeze a target then send subsonic waves through it, potentially reducing it into fine powder. Make a spell attack against the target. If you hit a target, the target takes 6d8 cold damage and must attempt a Fortitude save. If you critically hit, the target gets a result one degree of success worse than it rolled on its Fortitude save. A creature reduced to 0 Hit Points is blasted to fine powder; its gear remains.</p><hr /><p><strong>Critical Success</strong> The target is unaffected by further damage.</p>\n<p><strong>Success</strong> The target takes an additional @Damage[((@item.level -3)d8)[sonic]] damage.</p>\n<p><strong>Failure</strong> The target takes an additional @Damage[((@item.level)d8)[sonic]] damage.</p>\n<p><strong>Critical Failure</strong> The target takes an additional @Damage[((@item.level +6)d8)[sonic]] damage.</p><hr /><p><strong>Heightened (+1)</strong> The cold and sonic damage each increase by 1d8.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -234,6 +240,9 @@
         },
         {
             "_id": "uxWoGG8bzruhLrNd",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5cMDrC3jX1yrxOzh"
+            },
             "folder": "NQpcS2TwtjNNq1Qy",
             "img": "systems/sf2e/icons/abilities/blue-heroic-lightning-symbol.webp",
             "name": "Overload Systems",
@@ -321,6 +330,9 @@
         },
         {
             "_id": "YNHacRQho5SPmw9Y",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.BilnTGuXrof9Dt9D"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "icons/magic/fire/barrier-shield-explosion-yellow.webp",
             "name": "Synaptic Pulse",
@@ -358,7 +370,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -389,6 +401,9 @@
         },
         {
             "_id": "UsH5Qzcd6Q00Rw0Z",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VlNcjmYyu95vOUe8"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/magic/symbols/ring-circle-smoke-blue.webp",
             "name": "Translocate (at will)",
@@ -428,7 +443,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -459,6 +474,9 @@
         },
         {
             "_id": "8A2hLzLP4h7wjJwJ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.rBh2PjtbDGAjbcu6"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/equipment/other/yellow-battery.webp",
             "name": "Discharge (at will)",
@@ -524,6 +542,9 @@
         },
         {
             "_id": "mB8ahBPHmLsQhAss",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.mnoTqz0gjRmuc4oR"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/purple-tentacle.webp",
             "name": "Instant Virus (at will)",

--- a/packs/sf2e/alien-core-bestiary/demolition-class-assassin-robot.json
+++ b/packs/sf2e/alien-core-bestiary/demolition-class-assassin-robot.json
@@ -151,6 +151,9 @@
         },
         {
             "_id": "OKTMYWJxAifoe98h",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -166,7 +169,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/alien-core-bestiary/demolition-class-assassin-robot.json
+++ b/packs/sf2e/alien-core-bestiary/demolition-class-assassin-robot.json
@@ -4,6 +4,9 @@
     "items": [
         {
             "_id": "KzIfuVKIqH0u0W4H",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.qRg7totm2jOAWd4c"
+            },
             "folder": "V89RPpe7fyCFC6NS",
             "img": "icons/weapons/guns/gun-green.webp",
             "name": "Integrated Breaching Gun",

--- a/packs/sf2e/alien-core-bestiary/dreamer.json
+++ b/packs/sf2e/alien-core-bestiary/dreamer.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "fH4UXGOZjDE9Z0xv",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.LiGbewa9pO0yjbsY"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "systems/sf2e/icons/spells/confusion.webp",
             "name": "Confusion",
@@ -88,7 +91,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -120,6 +123,9 @@
         },
         {
             "_id": "y6Svsf5hDDVZbRS1",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jyrxfWeeCsrkhNit"
+            },
             "folder": "NuBKgFiv0GJhsx3c",
             "img": "icons/magic/unholy/beam-ringed-impact-purple.webp",
             "name": "Eldritch Wrath",
@@ -207,6 +213,9 @@
         },
         {
             "_id": "9ihg1eVGv8ZCIg5g",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.KHnhPHL4x1AQHfbC"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "systems/sf2e/icons/spells/mind-reading.webp",
             "name": "Mind Reading",
@@ -241,7 +250,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -273,6 +282,9 @@
         },
         {
             "_id": "bHpxMyVjiMPdsxcM",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.WsUwpfmhKrKwoIe3"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/time/hourglass-tilted-gray.webp",
             "name": "Slow",
@@ -317,7 +329,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -348,6 +360,9 @@
         },
         {
             "_id": "zOxPyXLxXZPK2RVu",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.GdlG9a4o0ax0F2HT"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/purple-hourglass.webp",
             "name": "Time's Edge",
@@ -434,6 +449,9 @@
         },
         {
             "_id": "OWVCd9t4fYlfPKrp",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.qkehzRdn7JeGrR6E"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/alien-skull.webp",
             "name": "Void Whispers",
@@ -502,6 +520,9 @@
         },
         {
             "_id": "wfFiZUF64IZxiIy5",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.41TZEjhO6D1nWw2X"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/augury.webp",
             "name": "Augury",
@@ -531,7 +552,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -562,6 +583,9 @@
         },
         {
             "_id": "NwhcU3zRrLU6PoWM",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.qOLMHvkAGsVYLhtn"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "icons/magic/perception/third-eye-blue-red.webp",
             "name": "Detect Thoughts",
@@ -576,13 +600,7 @@
                 },
                 "counteraction": false,
                 "damage": {},
-                "defense": {
-                    "passive": null,
-                    "save": {
-                        "basic": false,
-                        "statistic": "will"
-                    }
-                },
+                "defense": null,
                 "description": {
                     "value": "<p>You sense the presence of thinking creatures around you. You detect the presence or absence of thoughts from conscious creatures that have Intelligence modifiers of –3 or higher. You can choose to ignore the thoughts of creatures you're familiar with so they don't interfere with your detection of other thoughts. The spell can penetrate some barriers, but 3 feet of dirt or wood, 1 foot of stone, 1 inch of metal, a thin sheet of lead, or any force barrier blocks it. Creatures who are immune to mental effects are immune to detection by this spell.</p><hr /><p><strong>Heightened (4th)</strong> You detect the number of thinking minds and whether or not the creatures are telepathic. Creatures with telepathy have louder thoughts than creatures who don't have telepathy and might be able to sense your intrusion, at the GM's discretion.</p>"
                 },
@@ -631,6 +649,9 @@
         },
         {
             "_id": "ysyeUIQb1ox9pkcz",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.tVTJS07cKDA5rNgc"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/purple-hex-field.webp",
             "name": "Sift the Sphere",
@@ -688,6 +709,9 @@
         },
         {
             "_id": "sGiKHjzd85KumAWu",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.wRNRWwCEbmSxbHDl"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/yellow-person-silhouette.webp",
             "name": "Vibe Check",
@@ -764,6 +788,9 @@
         },
         {
             "_id": "WSl31lu2CrGtfio1",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VynaowCerc7B4yvI"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/sundries/books/book-embossed-jewel-silver-green.webp",
             "name": "Akashic Download",
@@ -822,6 +849,9 @@
         },
         {
             "_id": "5HXmL0hcX32R7wZB",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4gBIw4IDrSfFHik4"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/daze.webp",
             "name": "Daze",
@@ -873,7 +903,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "60 feet"
@@ -907,6 +937,9 @@
         },
         {
             "_id": "N4wX3GqwkIAZA7GR",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ZrFj6ktotd0pBnqO"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/environment/settlement/palast.webp",
             "name": "Dream of Home",
@@ -964,7 +997,8 @@
                     "value": [
                         "concentrate",
                         "manipulate",
-                        "mental"
+                        "mental",
+                        "subtle"
                     ]
                 }
             },
@@ -972,6 +1006,9 @@
         },
         {
             "_id": "4FiOyyApVxkUXXey",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.FEaM1B4WuiqFO7Uk"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "icons/magic/unholy/projectile-bolts-salvo-pink.webp",
             "name": "Eldritch Lance",
@@ -1052,6 +1089,9 @@
         },
         {
             "_id": "HrPkay717PSqsnym",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uBo6g5aW087cLSJR"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/magic/light/explosion-impact-purple.webp",
             "name": "Mind Skewer",
@@ -1136,6 +1176,9 @@
         },
         {
             "_id": "iZ2wRQ0DkzReYJW8",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.D442XMADp01qJ7Cs"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/mindlink.webp",
             "name": "Mindlink",
@@ -1165,7 +1208,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -1196,6 +1239,9 @@
         },
         {
             "_id": "nSJPNtHQfQFv3qvY",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.TVKNbcgTee19PXZR"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/shield.webp",
             "name": "Shield",
@@ -1224,7 +1270,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""

--- a/packs/sf2e/alien-core-bestiary/driftdead-crasher.json
+++ b/packs/sf2e/alien-core-bestiary/driftdead-crasher.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "sax1p9lfULaGvMql",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.qkehzRdn7JeGrR6E"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/alien-skull.webp",
             "name": "Void Whispers",
@@ -111,6 +114,9 @@
         },
         {
             "_id": "G1isQef5kAq7V0VR",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4GE2ZdODgIQtg51c"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/darkness.webp",
             "name": "Darkness",
@@ -143,7 +149,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -176,6 +182,9 @@
         },
         {
             "_id": "Nj4rh7h2wIsMYRbN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ZrFj6ktotd0pBnqO"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/environment/settlement/palast.webp",
             "name": "Dream of Home",
@@ -233,7 +242,8 @@
                     "value": [
                         "concentrate",
                         "manipulate",
-                        "mental"
+                        "mental",
+                        "subtle"
                     ]
                 }
             },
@@ -241,6 +251,9 @@
         },
         {
             "_id": "uLiat6fdBw3g0S5G",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4koZzrnMXhhosn0D"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/fear.webp",
             "name": "Fear",
@@ -285,7 +298,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -320,6 +333,9 @@
         },
         {
             "_id": "ApHKReZ9WdmitCyK",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.0zU8CPejjQFnhZFI"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/ghost-sound.webp",
             "name": "Figment",
@@ -348,7 +364,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -381,6 +397,9 @@
         },
         {
             "_id": "PMGeQir9Bx2481WL",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.IxhGEKl63R4QBvkj"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/movement/trail-streak-impact-blue.webp",
             "name": "Frostbite",
@@ -432,7 +451,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "60 feet"
@@ -464,6 +483,9 @@
         },
         {
             "_id": "nEMZudE3KBRoFpeW",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uBo6g5aW087cLSJR"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/magic/light/explosion-impact-purple.webp",
             "name": "Mind Skewer",
@@ -548,6 +570,9 @@
         },
         {
             "_id": "FMrDByE3v80eZphN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.sXnWQOcGG2ELcxXb"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-galaxy.webp",
             "name": "Ricochet",
@@ -669,6 +694,9 @@
         },
         {
             "_id": "TXYd02NU52S4xWvH",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.3VucgRc8FRPGy9NI"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/yellow-star-with-purple-aura.webp",
             "name": "Seek the Stars",

--- a/packs/sf2e/alien-core-bestiary/elimination-class-assassin-robot.json
+++ b/packs/sf2e/alien-core-bestiary/elimination-class-assassin-robot.json
@@ -4,6 +4,9 @@
     "items": [
         {
             "_id": "0Qt2dqS8FwJWPa85",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.VkepQ6oX9SYeQrTt"
+            },
             "folder": "V89RPpe7fyCFC6NS",
             "img": "systems/sf2e/icons/equipment/weapons/rapier.webp",
             "name": "Integrated Advanced Nano-edge Rapier",
@@ -93,6 +96,9 @@
         },
         {
             "_id": "MwA6fv2MlCFf7Aqs",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.K0xFwEC6Zv7ghVFa"
+            },
             "folder": "V89RPpe7fyCFC6NS",
             "img": "systems/sf2e/icons/equipment/weapons/pictol-wrapped.webp",
             "name": "Integrated Advanced Semi-Auto Pistol",
@@ -183,6 +189,9 @@
         },
         {
             "_id": "TsFnNZLI1xbu3Xyq",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.LTYzHdOOhCjtb79T"
+            },
             "folder": "V89RPpe7fyCFC6NS",
             "img": "systems/sf2e/icons/equipment/weapons/rifle-scoped.webp",
             "name": "Shirren-eye Rifle",
@@ -208,7 +217,7 @@
                 "damage": {
                     "damageType": "piercing",
                     "dice": 1,
-                    "die": "d10"
+                    "die": "d8"
                 },
                 "description": {
                     "value": "<p><strong>Upgrades:</strong> 1</p><hr /><p>This sniper rifle comes with a compound technological scope that allows snipers to adjust focus and magnification with natural eye movements instead of using moving parts that might disrupt their aim.</p>"
@@ -263,7 +272,7 @@
                     "rarity": "common",
                     "value": [
                         "analog",
-                        "deadly-d12",
+                        "deadly-d10",
                         "kickback",
                         "unwieldy",
                         "volley-30"

--- a/packs/sf2e/alien-core-bestiary/elimination-class-assassin-robot.json
+++ b/packs/sf2e/alien-core-bestiary/elimination-class-assassin-robot.json
@@ -277,6 +277,9 @@
         },
         {
             "_id": "Nk8v8cGgj2UA8ArU",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -292,7 +295,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -337,6 +341,9 @@
         },
         {
             "_id": "lKrhTu02ejb2uUnf",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -352,7 +359,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/alien-core-bestiary/elindrian-acolyte.json
+++ b/packs/sf2e/alien-core-bestiary/elindrian-acolyte.json
@@ -77,6 +77,9 @@
         },
         {
             "_id": "7YCesvey26FOOnrf",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4gBIw4IDrSfFHik4"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/daze.webp",
             "name": "Daze",
@@ -128,7 +131,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "60 feet"
@@ -162,6 +165,9 @@
         },
         {
             "_id": "JctvnEZGPDSiIoWV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.J7Y7tl0bbdz7TcCc"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/ray-of-enfeeblement.webp",
             "name": "Enfeeble",
@@ -195,7 +201,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -226,6 +232,9 @@
         },
         {
             "_id": "qnodptip75AC2Ofb",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gKKqvLohtrSJj3BM"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/magic-missile.webp",
             "name": "Force Barrage",
@@ -266,7 +275,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -297,6 +306,9 @@
         },
         {
             "_id": "SJC59nXwWuwmtNA3",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.sNUvbMoMeLTnYJm8"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/blue-energy-alien-hand.webp",
             "name": "Injury Echo",
@@ -350,7 +362,7 @@
                                 "damage": {
                                     "X6aUcgmF4twJh5gL": "1d8"
                                 },
-                                "interval": 1,
+                                "interval": 2,
                                 "type": "interval"
                             }
                         }
@@ -377,7 +389,7 @@
                                 "damage": {
                                     "2kU3mhyAecpOrFci": "1d8"
                                 },
-                                "interval": 1,
+                                "interval": 2,
                                 "type": "interval"
                             }
                         }
@@ -404,7 +416,7 @@
                                 "damage": {
                                     "EotUm3XBubhQrtWi": "1d8"
                                 },
-                                "interval": 1,
+                                "interval": 2,
                                 "type": "interval"
                             }
                         }
@@ -444,6 +456,9 @@
         },
         {
             "_id": "iCuJZ01idVkhZX9M",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uBo6g5aW087cLSJR"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/magic/light/explosion-impact-purple.webp",
             "name": "Mind Skewer",
@@ -527,6 +542,9 @@
         },
         {
             "_id": "Qg7RNZCgRhdxlRU1",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.OhD2Z6rIGGD5ocZA"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/light/explosion-star-glow-silhouette.webp",
             "name": "Read Aura",
@@ -570,7 +588,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -604,6 +622,9 @@
         },
         {
             "_id": "uhuf3jZAsUkWXrXG",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.3VucgRc8FRPGy9NI"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/yellow-star-with-purple-aura.webp",
             "name": "Seek the Stars",
@@ -664,6 +685,9 @@
         },
         {
             "_id": "QNhXgP6ZNyHkEOSX",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.mAMEt4FFbdqoRnkN"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/chill-touch.webp",
             "name": "Void Warp",
@@ -715,7 +739,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"

--- a/packs/sf2e/alien-core-bestiary/elindrian-queen.json
+++ b/packs/sf2e/alien-core-bestiary/elindrian-queen.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "snZo4qYzIv0RBY7E",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.J3zMwmhIVgI2yzxm"
+            },
             "folder": "DWZvpqhX0tWHYZOh",
             "img": "systems/sf2e/icons/abilities/energy-reaction-2.webp",
             "name": "Call Cosmos",
@@ -162,6 +165,9 @@
         },
         {
             "_id": "Gq72Fs7EFEC20vlO",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.10VcmSYNBrvBphu1"
+            },
             "folder": "fi1AYNmuCRvoT15b",
             "img": "systems/sf2e/icons/spells/massacre.webp",
             "name": "Massacre",
@@ -194,7 +200,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You unleash a wave of death to snuff out the life force of those in its path. Each living creature of 17th level or lower in the line must attempt a Fortitude save. If the damage from massacre reduces a creature to 0 Hit Points, that creature dies instantly. If massacre doesn't kill even a single creature, the void energy hungrily turns backward toward you, dealing an additional 30 void damage to every living creature in the line (even those above 17th level) and 30 void damage to you.</p>\n<hr />\n<p><strong>Critical Success</strong> The creature is unaffected.</p>\n<p><strong>Success</strong> The creature takes 9d6 void damage.</p>\n<p><strong>Failure</strong> The creature takes 100 void damage.</p>\n<p><strong>Critical Failure</strong> The creature dies.</p>\n<hr />\n<p><strong>Heightened (10th)</strong> The spell can affect living creatures up to 19th level. Increase the damage to 10d6 on a success, and to 115 on a failure.</p>"
+                    "value": "<p>You unleash a wave of death to snuff out the life force of those in its path. Each living creature of 17th level or lower in the line must attempt a Fortitude save. If the damage from <em>massacre</em> reduces a creature to 0 Hit Points, that creature dies instantly. If <em>massacre</em> doesn't kill even a single creature, the void energy hungrily turns backward toward you, dealing an additional @Damage[30[void]] damage to every living creature in the line (even those above 17th level) and 30 void damage to you.</p><hr /><p><strong>Critical Success</strong> The creature is unaffected.</p>\n<p><strong>Success</strong> The creature takes 9d6 void damage.</p>\n<p><strong>Failure</strong> The creature takes @Damage[(ternary(gte(@item.rank,10),115,100))[void]] damage.</p>\n<p><strong>Critical Failure</strong> The creature dies.</p><hr /><p><strong>Heightened (10th)</strong> The spell can affect living creatures up to 19th level. Increase the damage to 10d6 on a success, and to 115 on a failure.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -225,7 +231,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -258,6 +264,9 @@
         },
         {
             "_id": "iCGnu22fIK9QyIGC",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.M0jQlpQYUr0pp2Sv"
+            },
             "folder": "IfuYSF4ymX48CZnm",
             "img": "systems/sf2e/icons/spells/horrid-wilting.webp",
             "name": "Desiccate",
@@ -309,7 +318,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -340,6 +349,9 @@
         },
         {
             "_id": "SE1TvhF4zpBHlkHr",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4MOew29Z1oCX8O28"
+            },
             "folder": "IfuYSF4ymX48CZnm",
             "img": "systems/sf2e/icons/spells/moment-of-renewal.webp",
             "name": "Moment of Renewal",
@@ -368,7 +380,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -399,6 +411,9 @@
         },
         {
             "_id": "rBHXLaFd16Z9FSVT",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.aPZMapuunaNpxubp"
+            },
             "folder": "uIyg7rfbXLT1OSXC",
             "img": "systems/sf2e/icons/abilities/pink-portal.webp",
             "name": "Singularity Seed",
@@ -478,6 +493,9 @@
         },
         {
             "_id": "s5jdvyz7QAJ2Ve8g",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Z9OrRXKgAPv6Hn5l"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "icons/magic/unholy/hand-claw-fog-green.webp",
             "name": "Execute (at will)",
@@ -560,7 +578,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -592,6 +610,9 @@
         },
         {
             "_id": "Hbujcj0OvYaahWAX",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.kqhPt9344UkcGVYO"
+            },
             "folder": "6JF73zNhT8zbp1qC",
             "img": "systems/sf2e/icons/spells/resurrect.webp",
             "name": "Resurrect (elindrians only; up to 10 elindrians with one casting and a cast time of only 10 minutes if they perished within the last hour)",
@@ -620,7 +641,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "10 feet"

--- a/packs/sf2e/alien-core-bestiary/emissar-angel.json
+++ b/packs/sf2e/alien-core-bestiary/emissar-angel.json
@@ -41,6 +41,9 @@
         },
         {
             "_id": "PZ2qTENruDaFfVcn",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.qOLMHvkAGsVYLhtn"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "icons/magic/perception/third-eye-blue-red.webp",
             "name": "Detect Thoughts",
@@ -55,13 +58,7 @@
                 },
                 "counteraction": false,
                 "damage": {},
-                "defense": {
-                    "passive": null,
-                    "save": {
-                        "basic": false,
-                        "statistic": "will"
-                    }
-                },
+                "defense": null,
                 "description": {
                     "value": "<p>You sense the presence of thinking creatures around you. You detect the presence or absence of thoughts from conscious creatures that have Intelligence modifiers of –3 or higher. You can choose to ignore the thoughts of creatures you're familiar with so they don't interfere with your detection of other thoughts. The spell can penetrate some barriers, but 3 feet of dirt or wood, 1 foot of stone, 1 inch of metal, a thin sheet of lead, or any force barrier blocks it. Creatures who are immune to mental effects are immune to detection by this spell.</p><hr /><p><strong>Heightened (4th)</strong> You detect the number of thinking minds and whether or not the creatures are telepathic. Creatures with telepathy have louder thoughts than creatures who don't have telepathy and might be able to sense your intrusion, at the GM's discretion.</p>"
                 },
@@ -110,6 +107,9 @@
         },
         {
             "_id": "QqwhI1nxRMCo5Qir",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VIKDSgBRR3Wd1mQx"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/green-chart.webp",
             "name": "Doom Scroll",
@@ -180,6 +180,9 @@
         },
         {
             "_id": "4prUUDjag2sLdl70",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.wRNRWwCEbmSxbHDl"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/yellow-person-silhouette.webp",
             "name": "Vibe Check",
@@ -256,6 +259,9 @@
         },
         {
             "_id": "2C2Kwdt8Ae6LIJni",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.NkvRoN33RbDg3fl9"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/pink-target-sign.webp",
             "name": "Analyze Target",
@@ -269,7 +275,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The circumstance bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The circumstance bonus increases to +3, and you can target any number of creatures.</p>"
+                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The status bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The status bonus increases to +3, and you can target any number of creatures.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -379,6 +385,9 @@
         },
         {
             "_id": "sgYmvC0Ftueu2SXX",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.rfZpqmj0AIIdkVIs"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/life/cross-worn-green.webp",
             "name": "Heal",
@@ -543,7 +552,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "varies"
@@ -574,6 +583,9 @@
         },
         {
             "_id": "6mUNh2lVdfJqy4sg",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.vLzFcIaSXs7YTIqJ"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/message.webp",
             "name": "Message",
@@ -612,7 +624,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -648,6 +660,9 @@
         },
         {
             "_id": "jdaADl24yBc7QPTB",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5ZZca1GGJs44OxC8"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/battery-pack.webp",
             "name": "Motivating Ringtone",
@@ -734,6 +749,9 @@
         },
         {
             "_id": "nF0gJTsGVUkUKoEV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.t0oFlhMhNOHbb6rG"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/blue-emblem-generic.webp",
             "name": "Reorient",
@@ -794,6 +812,9 @@
         },
         {
             "_id": "p64pQczzyNooGJ1q",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.yvs1zN5Pai5U4CJX"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/summon-instrument.webp",
             "name": "Summon Instrument",
@@ -807,7 +828,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You materialize a handheld musical instrument in your grasp. The instrument is typical for its type, but it plays only for you. It vanishes when the spell ends. If you cast <em>summon instrument</em> again, any instrument you previously summoned disappears.</p>\n<hr />\n<p><strong>Heightened (5th)</strong> The instrument is instead a The instrument is instead a tactical handheld instrument.</p>"
+                    "value": ""
                 },
                 "duration": {
                     "sustained": false,
@@ -822,7 +843,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""

--- a/packs/sf2e/alien-core-bestiary/emissary-class-infiltrator-robot.json
+++ b/packs/sf2e/alien-core-bestiary/emissary-class-infiltrator-robot.json
@@ -181,6 +181,9 @@
         },
         {
             "_id": "WCBfB684LJwYti5n",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.dk4qkf4BF7wCPV4u"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/battery-large.webp",
             "name": "Hacking Toolkit (Advanced)",
@@ -196,6 +199,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -248,6 +252,9 @@
         },
         {
             "_id": "eNs4z6uiWmRf7QLq",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.ao5MC3I1b4Gx9LNC"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "icons/tools/hand/lockpicks-steel-grey.webp",
             "name": "Infiltrator's Toolkit (Tactical)",
@@ -263,6 +270,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -318,6 +326,9 @@
         },
         {
             "_id": "D0Nlu2OWL6Gw8hTy",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -333,7 +344,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/alien-core-bestiary/emvermod.json
+++ b/packs/sf2e/alien-core-bestiary/emvermod.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "kdCRn1cxL4csIXrl",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.SwUiVavHKMWG7t5K"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/tongues.webp",
             "name": "Truespeech (Constant)",
@@ -72,7 +75,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -103,6 +106,9 @@
         },
         {
             "_id": "0KmhOiF42MXrBSQ6",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.NkvRoN33RbDg3fl9"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/pink-target-sign.webp",
             "name": "Analyze Target",
@@ -116,7 +122,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The circumstance bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The circumstance bonus increases to +3, and you can target any number of creatures.</p>"
+                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The status bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The status bonus increases to +3, and you can target any number of creatures.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -165,6 +171,9 @@
         },
         {
             "_id": "SnBMZMdz8xVaOpqx",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4gBIw4IDrSfFHik4"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/daze.webp",
             "name": "Daze",
@@ -216,7 +225,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "60 feet"
@@ -250,6 +259,9 @@
         },
         {
             "_id": "3PuUtfjiAJF9Si1c",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.yXD9uU8w8uFD2OBQ"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/cerulean-circular-sign.webp",
             "name": "Delete (At Will)",
@@ -309,6 +321,9 @@
         },
         {
             "_id": "KUsYtR6PcbYbCkr5",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ZBeKxBcUOsXrfMRo"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/purple-insignia.webp",
             "name": "Implant Data",
@@ -368,6 +383,9 @@
         },
         {
             "_id": "xTilzxTyTxvvvKgk",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5ZZca1GGJs44OxC8"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/battery-pack.webp",
             "name": "Motivating Ringtone",

--- a/packs/sf2e/alien-core-bestiary/emvermod.json
+++ b/packs/sf2e/alien-core-bestiary/emvermod.json
@@ -559,6 +559,9 @@
         },
         {
             "_id": "cG2EqrP64RPE30ns",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.fClhrG92Zi4k14Hq"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/walkie-talkie.webp",
             "name": "Comm Unit",
@@ -650,6 +653,9 @@
         },
         {
             "_id": "bQMhwFu9YeGUrhCL",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -665,7 +671,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -680,6 +687,7 @@
                     "type": null
                 },
                 "price": {
+                    "per": 1,
                     "value": {
                         "sp": 10
                     }
@@ -698,7 +706,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 10,
                     "value": 10
                 }

--- a/packs/sf2e/alien-core-bestiary/erabryth.json
+++ b/packs/sf2e/alien-core-bestiary/erabryth.json
@@ -41,6 +41,9 @@
         },
         {
             "_id": "4R1D1GyohBQpkcRa",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.qOLMHvkAGsVYLhtn"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "icons/magic/perception/third-eye-blue-red.webp",
             "name": "Detect Thoughts",
@@ -55,13 +58,7 @@
                 },
                 "counteraction": false,
                 "damage": {},
-                "defense": {
-                    "passive": null,
-                    "save": {
-                        "basic": false,
-                        "statistic": "will"
-                    }
-                },
+                "defense": null,
                 "description": {
                     "value": "<p>You sense the presence of thinking creatures around you. You detect the presence or absence of thoughts from conscious creatures that have Intelligence modifiers of –3 or higher. You can choose to ignore the thoughts of creatures you're familiar with so they don't interfere with your detection of other thoughts. The spell can penetrate some barriers, but 3 feet of dirt or wood, 1 foot of stone, 1 inch of metal, a thin sheet of lead, or any force barrier blocks it. Creatures who are immune to mental effects are immune to detection by this spell.</p><hr /><p><strong>Heightened (4th)</strong> You detect the number of thinking minds and whether or not the creatures are telepathic. Creatures with telepathy have louder thoughts than creatures who don't have telepathy and might be able to sense your intrusion, at the GM's discretion.</p>"
                 },
@@ -109,6 +106,9 @@
         },
         {
             "_id": "2f9jMSQfqTP2oWKt",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.XXqE1eY3w3z6xJCB"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/creatures/magical/construct-stone-earth-gray.webp",
             "name": "Invisibility (at will; self only)",
@@ -138,7 +138,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -169,6 +169,9 @@
         },
         {
             "_id": "eNiP6JNgGLq8CpcB",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.0qaqksrGGDj74HXE"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/glitterdust.webp",
             "name": "Revealing Light",
@@ -206,7 +209,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -239,6 +242,9 @@
         },
         {
             "_id": "Z4jvi9PZ1exuLTiE",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.v2S6tlilNbA4uGdM"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/blue-circuit-board.webp",
             "name": "Skim Data",
@@ -298,6 +304,9 @@
         },
         {
             "_id": "EEgE7pN52JnWTRnn",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.yXD9uU8w8uFD2OBQ"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/cerulean-circular-sign.webp",
             "name": "Delete",
@@ -357,6 +366,9 @@
         },
         {
             "_id": "YKm1P9XoCBwsES6A",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ZBeKxBcUOsXrfMRo"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/purple-insignia.webp",
             "name": "Implant Data",

--- a/packs/sf2e/alien-core-bestiary/excuba.json
+++ b/packs/sf2e/alien-core-bestiary/excuba.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "eYSNACkAPlsgVxkS",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.SwUiVavHKMWG7t5K"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/tongues.webp",
             "name": "Truespeech (constant)",
@@ -72,7 +75,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -103,6 +106,9 @@
         },
         {
             "_id": "QflsdSiqfxzR4iLQ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.GB1RVtoFPwyH1B9G"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/green-acid-sprayer.webp",
             "name": "Caustic Conversion",
@@ -194,6 +200,9 @@
         },
         {
             "_id": "oswNHts4Rgnc1jXf",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ZofLZ5Zs8NN5yDPJ"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/blue-comet.webp",
             "name": "Inject Nanobots",
@@ -273,6 +282,9 @@
         },
         {
             "_id": "Syx02TRJsDTbFTXy",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.v2S6tlilNbA4uGdM"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/blue-circuit-board.webp",
             "name": "Skim Data (at will)",
@@ -332,6 +344,9 @@
         },
         {
             "_id": "2OPVkWNfIvt8rB57",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.NkvRoN33RbDg3fl9"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/pink-target-sign.webp",
             "name": "Analyze Target",
@@ -345,7 +360,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The circumstance bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The circumstance bonus increases to +3, and you can target any number of creatures.</p>"
+                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The status bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The status bonus increases to +3, and you can target any number of creatures.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -394,6 +409,9 @@
         },
         {
             "_id": "7nn84vvQEGPADiOl",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.yXD9uU8w8uFD2OBQ"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/cerulean-circular-sign.webp",
             "name": "Delete",
@@ -453,6 +471,9 @@
         },
         {
             "_id": "IQUGoTf6dGBsJXrt",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ZrFj6ktotd0pBnqO"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/environment/settlement/palast.webp",
             "name": "Dream of Home",
@@ -510,7 +531,8 @@
                     "value": [
                         "concentrate",
                         "manipulate",
-                        "mental"
+                        "mental",
+                        "subtle"
                     ]
                 }
             },
@@ -518,6 +540,9 @@
         },
         {
             "_id": "rkllSWDSzDpwc78A",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ZBeKxBcUOsXrfMRo"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/purple-insignia.webp",
             "name": "Implant Data",
@@ -577,6 +602,9 @@
         },
         {
             "_id": "EVRqeNqoN8iTSWXp",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.3VucgRc8FRPGy9NI"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/yellow-star-with-purple-aura.webp",
             "name": "Seek the Stars",

--- a/packs/sf2e/alien-core-bestiary/free-captain-gunner.json
+++ b/packs/sf2e/alien-core-bestiary/free-captain-gunner.json
@@ -187,6 +187,9 @@
         },
         {
             "_id": "Q05mysJoIZHpnzaM",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.7fIZAOxTqKohRhVv"
+            },
             "folder": "L1vkq5i6BuC4zDci",
             "img": "icons/equipment/shield/heater-steel-grey.webp",
             "name": "Carbon Shield",
@@ -317,6 +320,9 @@
         },
         {
             "_id": "KJjq9pUcQ8GpKLMh",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -332,7 +338,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/alien-core-bestiary/free-captain-knave.json
+++ b/packs/sf2e/alien-core-bestiary/free-captain-knave.json
@@ -254,6 +254,9 @@
         },
         {
             "_id": "YmzXEezpXLQdT0kn",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -269,7 +272,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -303,7 +307,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 10,
                     "value": 10
                 }

--- a/packs/sf2e/alien-core-bestiary/free-captain.json
+++ b/packs/sf2e/alien-core-bestiary/free-captain.json
@@ -314,6 +314,9 @@
         },
         {
             "_id": "flIhaBcaq1RGlXmM",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -329,7 +332,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -363,7 +367,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 10,
                     "value": 10
                 }
@@ -372,6 +376,9 @@
         },
         {
             "_id": "3jcCyxhWIeZUWC56",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.5PS5ESGpnQfJNOdg"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/blue-battery.webp",
             "name": "Battery (Tactical)",
@@ -387,7 +394,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -402,6 +410,7 @@
                     "type": null
                 },
                 "price": {
+                    "per": 1,
                     "value": {
                         "sp": 20
                     }
@@ -420,7 +429,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 20,
                     "value": 20
                 }

--- a/packs/sf2e/alien-core-bestiary/gnackle.json
+++ b/packs/sf2e/alien-core-bestiary/gnackle.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "MRB3Bcri3I6cW4p6",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.KHnhPHL4x1AQHfbC"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/spells/mind-reading.webp",
             "name": "Mind Reading",
@@ -110,6 +113,9 @@
         },
         {
             "_id": "d5U7lzJwjXuGL5vg",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.QiW8VNdBf0SFUq69"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-dna-helix.webp",
             "name": "Cellular Stimulant",
@@ -180,6 +186,9 @@
         },
         {
             "_id": "DlnNd7LS8cAtJ4wA",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4gBIw4IDrSfFHik4"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/spells/daze.webp",
             "name": "Daze",
@@ -265,6 +274,9 @@
         },
         {
             "_id": "lET5Cr6I1czufO8N",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.V1cojmrEOWkJ1yPF"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-emblem.webp",
             "name": "Glow Up",
@@ -327,6 +339,9 @@
         },
         {
             "_id": "DWiDSpM3pczRkWe7",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.i35dpZFI7jZcRoBo"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/spells/illusory-disguise.webp",
             "name": "Illusory Disguise",
@@ -388,6 +403,9 @@
         },
         {
             "_id": "477tT54I1SXmJtmw",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.sXnWQOcGG2ELcxXb"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-galaxy.webp",
             "name": "Ricochet",

--- a/packs/sf2e/alien-core-bestiary/gubbin.json
+++ b/packs/sf2e/alien-core-bestiary/gubbin.json
@@ -41,6 +41,9 @@
         },
         {
             "_id": "MWpPfKygOCcakjIn",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.mnoTqz0gjRmuc4oR"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/purple-tentacle.webp",
             "name": "Instant Virus",
@@ -103,6 +106,9 @@
         },
         {
             "_id": "J3OsW8fLW5IATM8F",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.yXD9uU8w8uFD2OBQ"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/cerulean-circular-sign.webp",
             "name": "Delete (at will)",
@@ -162,6 +168,9 @@
         },
         {
             "_id": "DzHYXc5RB8RyVKFD",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ZBeKxBcUOsXrfMRo"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/purple-insignia.webp",
             "name": "Implant Data",

--- a/packs/sf2e/alien-core-bestiary/gwereiad-queen.json
+++ b/packs/sf2e/alien-core-bestiary/gwereiad-queen.json
@@ -113,6 +113,9 @@
         },
         {
             "_id": "hRm8CCLR18oz5I9d",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.0pl80qKToraH4dvO"
+            },
             "folder": "2cuzA13JVJ0A8JrW",
             "img": "systems/sf2e/icons/abilities/purple-energy-star.webp",
             "name": "Event Horizon",
@@ -200,6 +203,9 @@
         },
         {
             "_id": "D9A4dFyHd6NqtzPw",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.J3zMwmhIVgI2yzxm"
+            },
             "folder": "DWZvpqhX0tWHYZOh",
             "img": "systems/sf2e/icons/abilities/energy-reaction-2.webp",
             "name": "Call Cosmos",
@@ -319,6 +325,9 @@
         },
         {
             "_id": "eYZTZ8IMEuVkAD8g",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4WS7HrFjwNvTn8T2"
+            },
             "folder": "fi1AYNmuCRvoT15b",
             "img": "systems/sf2e/icons/spells/implosion.webp",
             "name": "Implosion",
@@ -371,7 +380,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -401,6 +410,9 @@
         },
         {
             "_id": "YreQXJ8qmrj1zfhe",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.64DDZxOrmr4ddqs2"
+            },
             "folder": "DWZvpqhX0tWHYZOh",
             "img": "systems/sf2e/icons/abilities/yellow-fist.webp",
             "name": "Telekinetic Tantrum",
@@ -465,6 +477,9 @@
         },
         {
             "_id": "pYpyHvWyvkk42ESW",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gLOelTMvex2OgBqV"
+            },
             "folder": "uIyg7rfbXLT1OSXC",
             "img": "systems/sf2e/icons/abilities/purple-black-hole.webp",
             "name": "Gravity Field",
@@ -528,6 +543,9 @@
         },
         {
             "_id": "PMgmBb4F3Agci5gH",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.aPZMapuunaNpxubp"
+            },
             "folder": "uIyg7rfbXLT1OSXC",
             "img": "systems/sf2e/icons/abilities/pink-portal.webp",
             "name": "Singularity Seed",
@@ -607,6 +625,9 @@
         },
         {
             "_id": "yIMu1ZyoStZPETE7",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.0jadeyQIItIuRgeH"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "systems/sf2e/icons/spells/eclipse-burst.webp",
             "name": "Eclipse Burst",
@@ -674,7 +695,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -708,6 +729,9 @@
         },
         {
             "_id": "A3rzVvDj1t2IUV6V",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Z9OrRXKgAPv6Hn5l"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "icons/magic/unholy/hand-claw-fog-green.webp",
             "name": "Execute",
@@ -790,7 +814,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -822,6 +846,9 @@
         },
         {
             "_id": "PX1kbHCMzwRFn61F",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.x21WInzhprQHMyKT"
+            },
             "folder": "MNWDEVo1eeM3A3Ec",
             "img": "systems/sf2e/icons/abilities/purple-gas-cloud.webp",
             "name": "Void Scour",
@@ -910,6 +937,9 @@
         },
         {
             "_id": "2VLU2NbLhbAW5od1",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.WPXzPl7YbMEIGWfi"
+            },
             "folder": "zDlxATrLAlbYA2Mv",
             "img": "systems/sf2e/icons/spells/mislead.webp",
             "name": "Mislead",
@@ -939,7 +969,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -970,6 +1000,9 @@
         },
         {
             "_id": "XbnpWtmD3XTYlHJM",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ITzIb93GBvyX8UbJ"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/pink-portal.webp",
             "name": "Pocket Vacuum",
@@ -1057,6 +1090,9 @@
         },
         {
             "_id": "ER19VmdCPxr5aD2F",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.xS4bqHnbodCwjpqI"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/blue-planet-pillar-of-light.webp",
             "name": "Promession",
@@ -1086,7 +1122,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You flash freeze a target then send subsonic waves through it, potentially reducing it into fine powder. Make a spell attack against the target. If you hit a target, the target takes 6d8 cold damage and must attempt a Fortitude save. If you critically hit, the target gets a result one degree of success worse than it rolled on its Fortitude save. A creature reduced to 0 Hit Points is blasted to fine powder; its gear remains.</p><hr /><p><strong>Critical Success</strong> The target is unaffected by further damage.</p>\n<p><strong>Success</strong> The target takes an additional 3d8 sonic damage.</p>\n<p><strong>Failure</strong> The target takes an additional 6d8 sonic damage.</p>\n<p><strong>Critical Failure</strong> The target takes an additional 12d8 sonic damage.</p><hr /><p><strong>Heightened (+1)</strong> The cold and sonic damage each increase by 1d8.</p>"
+                    "value": "<p>You flash freeze a target then send subsonic waves through it, potentially reducing it into fine powder. Make a spell attack against the target. If you hit a target, the target takes 6d8 cold damage and must attempt a Fortitude save. If you critically hit, the target gets a result one degree of success worse than it rolled on its Fortitude save. A creature reduced to 0 Hit Points is blasted to fine powder; its gear remains.</p><hr /><p><strong>Critical Success</strong> The target is unaffected by further damage.</p>\n<p><strong>Success</strong> The target takes an additional @Damage[((@item.level -3)d8)[sonic]] damage.</p>\n<p><strong>Failure</strong> The target takes an additional @Damage[((@item.level)d8)[sonic]] damage.</p>\n<p><strong>Critical Failure</strong> The target takes an additional @Damage[((@item.level +6)d8)[sonic]] damage.</p><hr /><p><strong>Heightened (+1)</strong> The cold and sonic damage each increase by 1d8.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -1149,6 +1185,9 @@
         },
         {
             "_id": "oKNhisdrgfGRvAzZ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.kTzbLqmqPcZwOa5F"
+            },
             "folder": "NQpcS2TwtjNNq1Qy",
             "img": "systems/sf2e/icons/abilities/yellow-warning-sign.webp",
             "name": "Wave of Warning",
@@ -1236,6 +1275,9 @@
         },
         {
             "_id": "7ZMoG0oQ8YzxMwLP",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.HAaRcHfN4g83eSEC"
+            },
             "folder": "NuBKgFiv0GJhsx3c",
             "img": "icons/magic/earth/construct-stone-long-arms.webp",
             "name": "Cairn Form",
@@ -1296,6 +1338,9 @@
         },
         {
             "_id": "qVCJmJM2E5VRe1S8",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.zvKWclOZ7A53DObE"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "systems/sf2e/icons/spells/clairvoyance.webp",
             "name": "Clairvoyance",
@@ -1324,7 +1369,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -1355,6 +1400,9 @@
         },
         {
             "_id": "enOw5kFbdeP4N27A",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Cbj7tDkb2ZTp10Cg"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/blue-twin-lightning-streaks.webp",
             "name": "Electrotether",
@@ -1437,6 +1485,9 @@
         },
         {
             "_id": "j189lX62ld4EbOCe",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.o6YCGx4lycsYpww4"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "systems/sf2e/icons/spells/haste.webp",
             "name": "Haste",
@@ -1476,7 +1527,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1507,6 +1558,9 @@
         },
         {
             "_id": "YH5z7oMMV3ZFavXW",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.0mNmVi9CLXor3McX"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/green-upper-left-arrow.webp",
             "name": "Personal Gravity (Constant)",
@@ -1567,6 +1621,9 @@
         },
         {
             "_id": "enXyGlHpXz7JIAft",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.GdlG9a4o0ax0F2HT"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/purple-hourglass.webp",
             "name": "Time's Edge",
@@ -1653,6 +1710,9 @@
         },
         {
             "_id": "i5IZCXawo8sh2wFK",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4GE2ZdODgIQtg51c"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/darkness.webp",
             "name": "Darkness",
@@ -1685,7 +1745,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -1718,6 +1778,9 @@
         },
         {
             "_id": "rx5hRTs0XZi0qy1U",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.vLA0q0WOK2YPuJs6"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/charm.webp",
             "name": "Charm",
@@ -1762,7 +1825,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1797,6 +1860,9 @@
         },
         {
             "_id": "HAKUY5zhDknKqpgn",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.aIHY2DArKFweIrpf"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/command.webp",
             "name": "Command",
@@ -1841,7 +1907,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1875,6 +1941,9 @@
         },
         {
             "_id": "c3IkMm56IlnVv8JH",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -1891,7 +1960,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -1906,7 +1975,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1940,6 +2009,9 @@
         },
         {
             "_id": "dJXxLEXVPg0hehwN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4koZzrnMXhhosn0D"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/fear.webp",
             "name": "Fear",
@@ -1984,7 +2056,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -2019,6 +2091,9 @@
         },
         {
             "_id": "2BiYSBC0U8uWJbVT",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.V1cojmrEOWkJ1yPF"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-emblem.webp",
             "name": "Glow Up",
@@ -2081,6 +2156,9 @@
         },
         {
             "_id": "56e4ywzCFuoMiNz2",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.izcxFQFwf3woCnFs"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/guidance.webp",
             "name": "Guidance",
@@ -2109,7 +2187,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -2140,6 +2218,9 @@
         },
         {
             "_id": "xbxCZ85yDCZpLRq7",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Qw3fnUlaUbnn7ipC"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/symbols/runes-triangle-blue.webp",
             "name": "Prestidigitation",
@@ -2168,7 +2249,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "10 feet"
@@ -2201,6 +2282,9 @@
         },
         {
             "_id": "Um08qJZriRIRK8xl",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.nf8q0zvJDnnkzANe"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/blue-broadcast-signal.webp",
             "name": "Scan Environment",
@@ -2252,6 +2336,7 @@
                     "value": [
                         "cantrip",
                         "concentrate",
+                        "exploration",
                         "manipulate"
                     ]
                 }
@@ -2260,6 +2345,9 @@
         },
         {
             "_id": "5kuEyzSfGzWZip05",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.3VucgRc8FRPGy9NI"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/yellow-star-with-purple-aura.webp",
             "name": "Seek the Stars",
@@ -2320,6 +2408,9 @@
         },
         {
             "_id": "gZDCJpxS0FbKFTrw",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jgN33YSYXB8iIHTw"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "icons/skills/movement/figure-running-gray.webp",
             "name": "Stumble",

--- a/packs/sf2e/alien-core-bestiary/gwereiad.json
+++ b/packs/sf2e/alien-core-bestiary/gwereiad.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "iwsf02hS1Tq4lF6r",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gLOelTMvex2OgBqV"
+            },
             "folder": "uIyg7rfbXLT1OSXC",
             "img": "systems/sf2e/icons/abilities/purple-black-hole.webp",
             "name": "Gravity Field",
@@ -107,6 +110,9 @@
         },
         {
             "_id": "tu29QHvmMjM7PgWa",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Cbj7tDkb2ZTp10Cg"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/blue-twin-lightning-streaks.webp",
             "name": "Electrotether",
@@ -188,6 +194,9 @@
         },
         {
             "_id": "wQy9ojr4tNVUfWrC",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.0mNmVi9CLXor3McX"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/green-upper-left-arrow.webp",
             "name": "Personal Gravity (Constant)",
@@ -248,6 +257,9 @@
         },
         {
             "_id": "l8uAAgwHu5lqKqB0",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4koZzrnMXhhosn0D"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/fear.webp",
             "name": "Fear",
@@ -292,7 +304,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -327,6 +339,9 @@
         },
         {
             "_id": "CQOBvj2tBJe1q1oB",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.V1cojmrEOWkJ1yPF"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-emblem.webp",
             "name": "Glow Up",
@@ -389,6 +404,9 @@
         },
         {
             "_id": "XX2W1OXUD1AEDDhQ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jgN33YSYXB8iIHTw"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "icons/skills/movement/figure-running-gray.webp",
             "name": "Stumble",

--- a/packs/sf2e/alien-core-bestiary/haeshi-shaa-haeshi-form.json
+++ b/packs/sf2e/alien-core-bestiary/haeshi-shaa-haeshi-form.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "OhTRrNh4NukS0ZVd",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4koZzrnMXhhosn0D"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/fear.webp",
             "name": "Fear",
@@ -92,7 +95,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -127,6 +130,9 @@
         },
         {
             "_id": "U19URI7ZSi7OKpcB",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gKKqvLohtrSJj3BM"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/magic-missile.webp",
             "name": "Force Barrage (at will)",
@@ -168,7 +174,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -199,6 +205,9 @@
         },
         {
             "_id": "B1XXitNFAXWKGlbc",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uBo6g5aW087cLSJR"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/magic/light/explosion-impact-purple.webp",
             "name": "Mind Skewer",

--- a/packs/sf2e/alien-core-bestiary/haeshi-shaa-shaa-form.json
+++ b/packs/sf2e/alien-core-bestiary/haeshi-shaa-shaa-form.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "kKB5nmWouTFKoSJR",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Y3egStSTzL8k86qc"
+            },
             "folder": "uIyg7rfbXLT1OSXC",
             "img": "systems/sf2e/icons/abilities/spaceship-thruster.webp",
             "name": "Phantasmal Fleet",
@@ -123,6 +126,9 @@
         },
         {
             "_id": "pJRsHLCZtrRCrOd7",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uqlxMQQeSGWEVjki"
+            },
             "folder": "zDlxATrLAlbYA2Mv",
             "img": "systems/sf2e/icons/spells/true-seeing.webp",
             "name": "Truesight",
@@ -152,7 +158,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -185,6 +191,9 @@
         },
         {
             "_id": "jpODDybpYqSH4erj",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.9BnhadUO8FMLmeZ3"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/mind-probe.webp",
             "name": "Mind Probe (at will)",
@@ -219,7 +228,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -251,6 +260,9 @@
         },
         {
             "_id": "Ck09OMrZbxONUbOm",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.BilnTGuXrof9Dt9D"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "icons/magic/fire/barrier-shield-explosion-yellow.webp",
             "name": "Synaptic Pulse",
@@ -292,7 +304,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -323,6 +335,9 @@
         },
         {
             "_id": "QhHyOOCQsIvX5BQT",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.SUKaxVZW2TlM8lu0"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/consumables/fruit/berry-clustered-white.webp",
             "name": "Cleanse Affliction",
@@ -356,7 +371,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -388,6 +403,9 @@
         },
         {
             "_id": "hyAu17FEMDtJteGR",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4koZzrnMXhhosn0D"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/fear.webp",
             "name": "Fear (at will)",
@@ -432,7 +450,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -467,6 +485,9 @@
         },
         {
             "_id": "y3POZHG5uqsd6tHQ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.rfZpqmj0AIIdkVIs"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/life/cross-worn-green.webp",
             "name": "Heal",
@@ -635,7 +656,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "varies"

--- a/packs/sf2e/alien-core-bestiary/hardlight-scamp.json
+++ b/packs/sf2e/alien-core-bestiary/hardlight-scamp.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "iCoOnksytvwJov0S",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.3JG1t3T4mWn6vTke"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/blur.webp",
             "name": "Blur",
@@ -72,7 +75,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -104,6 +107,9 @@
         },
         {
             "_id": "iIrB5rCvGw6iAFKF",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.0zU8CPejjQFnhZFI"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/ghost-sound.webp",
             "name": "Figment",
@@ -132,7 +138,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -165,6 +171,9 @@
         },
         {
             "_id": "cneqHdvN0JSfYQoR",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.sXnWQOcGG2ELcxXb"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-galaxy.webp",
             "name": "Ricochet",

--- a/packs/sf2e/alien-core-bestiary/heliad-queen.json
+++ b/packs/sf2e/alien-core-bestiary/heliad-queen.json
@@ -109,6 +109,9 @@
         },
         {
             "_id": "thFEQZ6z2qqCmghl",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.m2xFMNyQiUKQDRaj"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "icons/magic/defensive/shield-barrier-glowing-blue.webp",
             "name": "Energy Aegis",
@@ -137,7 +140,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -169,6 +172,9 @@
         },
         {
             "_id": "3BUOYVfJSMuR02wi",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.a3aQxCpoj1q1NQxC"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "systems/sf2e/icons/spells/sunburst.webp",
             "name": "Sunburst",
@@ -224,7 +230,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -257,6 +263,9 @@
         },
         {
             "_id": "RuIhI7X76aKisv5M",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.x5rGOmhDRDVQPrnW"
+            },
             "folder": "zDlxATrLAlbYA2Mv",
             "img": "icons/magic/life/heart-area-circle-red-green.webp",
             "name": "Field of Life",
@@ -328,7 +337,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -360,6 +369,9 @@
         },
         {
             "_id": "EOaOxYnePItuBe9I",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.dRP4Imw3RJNQqEgc"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/yellow-energy-star.webp",
             "name": "Wall of Plasma",
@@ -451,6 +463,9 @@
         },
         {
             "_id": "crNVQvBmtxxfvq7J",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.1K6AYGisvo9gqdhs"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/elemental-form.webp",
             "name": "Elemental Form",
@@ -480,7 +495,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -511,6 +526,9 @@
         },
         {
             "_id": "XWTi3U9kl2laR9Nx",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.TUj8eugNqAvB1vVR"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/commodities/wood/log-cut-cherry-brown.webp",
             "name": "Creation",
@@ -539,7 +557,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "0 feet"
@@ -569,6 +587,9 @@
         },
         {
             "_id": "cG4ohZQmL8bfOUI4",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.YrzBLPLd3r9m6t1p"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/magic/fire/barrier-shield-explosion-yellow.webp",
             "name": "Fire Shield",
@@ -616,7 +637,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -647,6 +668,9 @@
         },
         {
             "_id": "NnqvvuF6717UAusl",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.IarZrgCeaiUqOuRu"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/magic/fire/flame-burning-campfire-rocks.webp",
             "name": "Wall of Fire",
@@ -693,7 +717,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -724,6 +748,9 @@
         },
         {
             "_id": "dwxYc9vvMs4xxOQE",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.IarZrgCeaiUqOuRu"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/magic/fire/flame-burning-campfire-rocks.webp",
             "name": "Wall of Fire",
@@ -771,7 +798,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -802,6 +829,9 @@
         },
         {
             "_id": "0IwKu0lBlfxM338X",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Cbj7tDkb2ZTp10Cg"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/blue-twin-lightning-streaks.webp",
             "name": "Electrotether",
@@ -884,6 +914,9 @@
         },
         {
             "_id": "VaiuBr1TOppt9sjo",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.IihxWhRfpsBgQ5jS"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "systems/sf2e/icons/spells/enthrall.webp",
             "name": "Enthrall",
@@ -917,7 +950,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -949,6 +982,9 @@
         },
         {
             "_id": "Z4l3ul0QBO456pga",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.sxQZ6yqTn0czJxVd"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/fire/projectile-fireball-orange-yellow.webp",
             "name": "Fireball",
@@ -1005,7 +1041,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -1036,6 +1072,9 @@
         },
         {
             "_id": "xpcgu8DQNHEsg01A",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.sxQZ6yqTn0czJxVd"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/fire/projectile-fireball-orange-yellow.webp",
             "name": "Fireball",
@@ -1092,7 +1131,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -1123,6 +1162,9 @@
         },
         {
             "_id": "Q5AnM5TS8xLyYZCS",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.MfsxPjshwZJZuNpN"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/hazard-emblem.webp",
             "name": "Irradiate",
@@ -1308,6 +1350,9 @@
         },
         {
             "_id": "3CJ8kopqN6gVxglt",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ynm8JIU3sc3qUMpa"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/magic/light/torch-fire-orange.webp",
             "name": "Everlight",
@@ -1337,7 +1382,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -1370,6 +1415,9 @@
         },
         {
             "_id": "vA7guOT2Y0Kldq9q",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.HPHr5aoLMH4eVwaw"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/yellow-hand.webp",
             "name": "Soul Surge",
@@ -1451,6 +1499,9 @@
         },
         {
             "_id": "HNAptcBZnaJHVbe5",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.y6rAdMK6EFlV6U0t"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/dragon-breath.webp",
             "name": "Breathe Fire",
@@ -1506,7 +1557,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1537,6 +1588,9 @@
         },
         {
             "_id": "RbdyQFBbdHgiSV3i",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.vLA0q0WOK2YPuJs6"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/charm.webp",
             "name": "Charm",
@@ -1581,7 +1635,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1616,6 +1670,9 @@
         },
         {
             "_id": "wJsfN8Cci2EeAVOQ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.V1cojmrEOWkJ1yPF"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-emblem.webp",
             "name": "Glow Up",
@@ -1678,6 +1735,9 @@
         },
         {
             "_id": "oTFcIB02Bcic791r",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.izcxFQFwf3woCnFs"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/guidance.webp",
             "name": "Guidance",
@@ -1706,7 +1766,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1737,6 +1797,9 @@
         },
         {
             "_id": "WBIf2feg4HTKR1Uj",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.6DfLZBl8wKIV03Iq"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/fire/explosion-embers-evade-silhouette.webp",
             "name": "Ignition",
@@ -1785,7 +1848,9 @@
                         "_id": "eOCNn2ohYAvsYZjn",
                         "overlayType": "override",
                         "sort": 1,
-                        "system": {}
+                        "system": {
+                            "defense": null
+                        }
                     },
                     "xYyA7CV1GaFTRjBQ": {
                         "_id": "xYyA7CV1GaFTRjBQ",
@@ -1798,6 +1863,7 @@
                                     "formula": "2d6"
                                 }
                             },
+                            "defense": null,
                             "heightening": {
                                 "damage": {
                                     "cQDyW0QpjJ38MlSi": "1d6"
@@ -1812,7 +1878,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1845,6 +1911,9 @@
         },
         {
             "_id": "WL3XNx12yTypbUGM",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.WBmvzNDfpwka3qT4"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/light.webp",
             "name": "Light",
@@ -1873,7 +1942,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -1907,6 +1976,9 @@
         },
         {
             "_id": "y5rNGW9CAwOOwXkK",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.WBmvzNDfpwka3qT4"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/light.webp",
             "name": "Light",
@@ -1935,7 +2007,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -1969,6 +2041,9 @@
         },
         {
             "_id": "DBMmmtDvaeSBrH8p",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.wOjoJjl2ndZKTuFJ"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/orange-timer-fire.webp",
             "name": "Overheat",
@@ -2053,6 +2128,9 @@
         },
         {
             "_id": "Yva6Bts9LlEIEBfK",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Qw3fnUlaUbnn7ipC"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/symbols/runes-triangle-blue.webp",
             "name": "Prestidigitation",
@@ -2081,7 +2159,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "10 feet"

--- a/packs/sf2e/alien-core-bestiary/heliad.json
+++ b/packs/sf2e/alien-core-bestiary/heliad.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "Sz7zVPSiqrEdeR1M",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.dRP4Imw3RJNQqEgc"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/yellow-energy-star.webp",
             "name": "Wall of Plasma",
@@ -134,6 +137,9 @@
         },
         {
             "_id": "YPbUVAd8T5DfkMPS",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.YrzBLPLd3r9m6t1p"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/magic/fire/barrier-shield-explosion-yellow.webp",
             "name": "Fire Shield",
@@ -181,7 +187,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -212,6 +218,9 @@
         },
         {
             "_id": "vm5hIULmrCdS8e9Y",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.sxQZ6yqTn0czJxVd"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/fire/projectile-fireball-orange-yellow.webp",
             "name": "Fireball",
@@ -268,7 +277,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -420,6 +429,9 @@
         },
         {
             "_id": "8Zh0Ms7fxar9V6fL",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.vLA0q0WOK2YPuJs6"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/charm.webp",
             "name": "Charm",
@@ -464,7 +476,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -499,6 +511,9 @@
         },
         {
             "_id": "5jP5f1tmUQ8ow0Un",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.V1cojmrEOWkJ1yPF"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-emblem.webp",
             "name": "Glow Up",
@@ -561,6 +576,9 @@
         },
         {
             "_id": "2p0C8MRcJd5IOiwn",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.WBmvzNDfpwka3qT4"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/light.webp",
             "name": "Light",
@@ -589,7 +607,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -623,6 +641,9 @@
         },
         {
             "_id": "ukXKPu49AoGiNHbg",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.wOjoJjl2ndZKTuFJ"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/orange-timer-fire.webp",
             "name": "Overheat",

--- a/packs/sf2e/alien-core-bestiary/hellknight-armiger.json
+++ b/packs/sf2e/alien-core-bestiary/hellknight-armiger.json
@@ -91,12 +91,18 @@
         },
         {
             "_id": "r7vadhNlSwPB9Qwr",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.BmJARyq7RrMXQezF"
+            },
             "folder": "1zLXGqhSgBIthlcs",
             "img": "systems/sf2e/icons/equipment/weapons/grenade-hand.webp",
             "name": "Frag Grenade (Tactical)",
             "sort": 200000,
             "system": {
-                "ammo": null,
+                "ammo": {
+                    "baseType": null,
+                    "builtIn": false
+                },
                 "baseItem": "grenade",
                 "bonus": {
                     "value": 0
@@ -136,9 +142,6 @@
                 },
                 "price": {
                     "value": {
-                        "cp": 0,
-                        "gp": 0,
-                        "pp": 0,
                         "sp": 80
                     }
                 },
@@ -179,12 +182,18 @@
         },
         {
             "_id": "jwCS3VWTMq6pKuJ1",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.TrS4puy7wfjbDJIA"
+            },
             "folder": "1zLXGqhSgBIthlcs",
             "img": "systems/sf2e/icons/equipment/weapons/grenade.webp",
             "name": "Incendiary Grenade (Tactical)",
             "sort": 300000,
             "system": {
-                "ammo": null,
+                "ammo": {
+                    "baseType": null,
+                    "builtIn": false
+                },
                 "baseItem": "grenade",
                 "bonus": {
                     "value": 0
@@ -224,9 +233,6 @@
                 },
                 "price": {
                     "value": {
-                        "cp": 0,
-                        "gp": 0,
-                        "pp": 0,
                         "sp": 80
                     }
                 },
@@ -429,6 +435,9 @@
         },
         {
             "_id": "0nd6OgLsJ6N1nJ48",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -444,7 +453,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -478,7 +488,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 10,
                     "value": 10
                 }

--- a/packs/sf2e/alien-core-bestiary/hellknight-signifer.json
+++ b/packs/sf2e/alien-core-bestiary/hellknight-signifer.json
@@ -1932,6 +1932,9 @@
         },
         {
             "_id": "boNJgzYxRfGqz7K9",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.rcoxWcmLV9G7HKG0"
+            },
             "folder": "cTmXSS0L1MClVGP3",
             "img": "systems/sf2e/icons/abilities/purple-energy-thrusters.webp",
             "name": "Jump Jets",
@@ -1947,6 +1950,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -1982,13 +1986,16 @@
                     ]
                 },
                 "usage": {
-                    "value": "other"
+                    "value": "installed-in-armor"
                 }
             },
             "type": "equipment"
         },
         {
             "_id": "0NrJPA9IxtWsGn4g",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.5PS5ESGpnQfJNOdg"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/blue-battery.webp",
             "name": "Battery (Tactical)",
@@ -2004,7 +2011,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -2019,6 +2027,7 @@
                     "type": null
                 },
                 "price": {
+                    "per": 1,
                     "value": {
                         "sp": 20
                     }
@@ -2037,7 +2046,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 20,
                     "value": 20
                 }

--- a/packs/sf2e/alien-core-bestiary/hellknight-signifer.json
+++ b/packs/sf2e/alien-core-bestiary/hellknight-signifer.json
@@ -54,6 +54,9 @@
         },
         {
             "_id": "xhLMfUaIKGBVcZz3",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.DyiD239dNS7RIxZE"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "systems/sf2e/icons/spells/searing-light.webp",
             "name": "Holy Light",
@@ -101,7 +104,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -146,6 +149,9 @@
         },
         {
             "_id": "gPcdTYVRhf8MJ83j",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.EhN3GjdjXChMdiFk"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/purple-neurons.webp",
             "name": "Share Pain",
@@ -183,7 +189,7 @@
                 },
                 "heightening": {
                     "levels": {
-                        "4": {
+                        "6": {
                             "damage": {
                                 "dIvEREAgyIVyanqT": {
                                     "applyMod": false,
@@ -229,7 +235,10 @@
                 },
                 "traits": {
                     "rarity": "common",
-                    "traditions": [],
+                    "traditions": [
+                        "divine",
+                        "occult"
+                    ],
                     "value": [
                         "concentrate",
                         "manipulate",
@@ -241,6 +250,9 @@
         },
         {
             "_id": "wzBoLFWtCcjXjViq",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.9HpwDN4MYQJnW0LG"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/dispel-magic.webp",
             "name": "Dispel Magic",
@@ -270,7 +282,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -302,6 +314,9 @@
         },
         {
             "_id": "03gsDJ4MELh7N2wc",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.wzLkNU3AAqOSKFPR"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/magic/fire/orb-vortex.webp",
             "name": "Noise Blast",
@@ -358,7 +373,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -390,6 +405,9 @@
         },
         {
             "_id": "cCFtvKr588eAthUo",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Fr58LDSrbndgld9n"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/magic/defensive/shield-barrier-deflect-teal.webp",
             "name": "Resist Energy",
@@ -434,7 +452,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -466,6 +484,9 @@
         },
         {
             "_id": "xvmSE125TaG2mbKi",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.XSujb7EsSwKl19Uu"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/bless.webp",
             "name": "Bless",
@@ -498,7 +519,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -530,6 +551,9 @@
         },
         {
             "_id": "gSB9LrWCqsCs0ySL",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -546,7 +570,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -561,7 +585,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -658,6 +682,9 @@
         },
         {
             "_id": "MTSsx74MPAISg67Y",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.J7Y7tl0bbdz7TcCc"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/ray-of-enfeeblement.webp",
             "name": "Enfeeble",
@@ -692,7 +719,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -916,6 +943,9 @@
         },
         {
             "_id": "4btbBFQ7U2OZAbP7",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.rfZpqmj0AIIdkVIs"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/life/cross-worn-green.webp",
             "name": "Heal",
@@ -1080,7 +1110,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "varies"
@@ -1111,6 +1141,9 @@
         },
         {
             "_id": "aJlMDySv5bgEgKMN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.rfZpqmj0AIIdkVIs"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/life/cross-worn-green.webp",
             "name": "Heal",
@@ -1275,7 +1308,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "varies"
@@ -1306,6 +1339,9 @@
         },
         {
             "_id": "OBhv1MGKwrVyufSM",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.6DfLZBl8wKIV03Iq"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/fire/explosion-embers-evade-silhouette.webp",
             "name": "Ignition",
@@ -1354,7 +1390,9 @@
                         "_id": "eOCNn2ohYAvsYZjn",
                         "overlayType": "override",
                         "sort": 1,
-                        "system": {}
+                        "system": {
+                            "defense": null
+                        }
                     },
                     "xYyA7CV1GaFTRjBQ": {
                         "_id": "xYyA7CV1GaFTRjBQ",
@@ -1367,6 +1405,7 @@
                                     "formula": "2d6"
                                 }
                             },
+                            "defense": null,
                             "heightening": {
                                 "damage": {
                                     "cQDyW0QpjJ38MlSi": "1d6"
@@ -1381,7 +1420,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1414,6 +1453,9 @@
         },
         {
             "_id": "Kdo3y3kKDnxaq1q3",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.WBmvzNDfpwka3qT4"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/light.webp",
             "name": "Light",
@@ -1442,7 +1484,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -1476,6 +1518,9 @@
         },
         {
             "_id": "sslHtfgPTWqMf0Rc",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.sXnWQOcGG2ELcxXb"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-galaxy.webp",
             "name": "Ricochet",
@@ -1597,6 +1642,9 @@
         },
         {
             "_id": "pb1g3agFNKuQfpKe",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.TVKNbcgTee19PXZR"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/shield.webp",
             "name": "Shield",
@@ -1625,7 +1673,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1657,6 +1705,9 @@
         },
         {
             "_id": "OXc7YDFVOXFJb9Zu",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Sqo1uzSmebVWpqoT"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-comet-swirling.webp",
             "name": "Wisp Ally",

--- a/packs/sf2e/alien-core-bestiary/host-dragon-adult-spellcaster.json
+++ b/packs/sf2e/alien-core-bestiary/host-dragon-adult-spellcaster.json
@@ -133,6 +133,9 @@
         },
         {
             "_id": "wHZEp1afHwNtKYO0",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.n5a3t5Qnx5AU8auy"
+            },
             "folder": "NQpcS2TwtjNNq1Qy",
             "img": "icons/creatures/fish/crab-blue-purple.webp",
             "name": "Carcinization",
@@ -196,6 +199,9 @@
         },
         {
             "_id": "IhYAttGNMGsmFH5U",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.MlpbeZ61Euhl0d60"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "icons/creatures/slimes/slime-movement-splash-green.webp",
             "name": "Toxic Cloud",
@@ -251,7 +257,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -283,6 +289,9 @@
         },
         {
             "_id": "gQTybmLZ4eUa9yOM",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.kOa055FIrO9Smnya"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "icons/commodities/stone/paver-brick-brown.webp",
             "name": "Wall of Stone",
@@ -311,7 +320,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -342,6 +351,9 @@
         },
         {
             "_id": "lgosz3UM8zZ3GtCI",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.aqRYNoSvxsVfqglH"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/equipment/feet/boots-leather-laced-brown.webp",
             "name": "Unfettered Movement",
@@ -370,7 +382,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -401,6 +413,9 @@
         },
         {
             "_id": "dHB6G9KDKsrKj8jK",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gPvtmKMRpg9I9D7H"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/earth/barrier-stone-explosion-debris.webp",
             "name": "Earthbind",
@@ -434,7 +449,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -465,6 +480,9 @@
         },
         {
             "_id": "AIWf6XPOjCRq4Bxv",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ShwUELLERVMtdjwE"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/blue-heart-in-a-circle.webp",
             "name": "Life Seal",
@@ -522,6 +540,9 @@
         },
         {
             "_id": "k8BS1KdBuga7hk5m",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.it4ZsAi6XgvGcodc"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/air/fog-gas-smoke-swirling-white.webp",
             "name": "Wall of Wind",
@@ -555,7 +576,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -586,6 +607,9 @@
         },
         {
             "_id": "nlsp6YiS7m6PRyRh",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.J6vNvrUT3b1hx2iA"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/magic/nature/root-vines-grow-brown.webp",
             "name": "Entangling Flora",
@@ -623,7 +647,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -655,6 +679,9 @@
         },
         {
             "_id": "jI1pkAJKTMFKHXMa",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5esP2GVzvxWsMgaX"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/endure-elements.webp",
             "name": "Environmental Endurance",
@@ -683,7 +710,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -714,6 +741,9 @@
         },
         {
             "_id": "RbbAZfdfHhQEELA2",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.BBvV7qoXGdw09q1C"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/creatures/mammals/ox-buffalo-horned-green.webp",
             "name": "Speak with Animals",
@@ -742,7 +772,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -771,6 +801,9 @@
         },
         {
             "_id": "cQNH5ollC1ThgkLy",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.MZGkMsPBztFN0pUO"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/magic/water/elemental-water.webp",
             "name": "Water Breathing",
@@ -799,7 +832,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -831,6 +864,9 @@
         },
         {
             "_id": "xpVIF2e8zVzaJjA7",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.X9dkmh23lFwMjrYd"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/creatures/invertebrates/ant-strength-green.webp",
             "name": "Ant Haul",
@@ -859,7 +895,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -889,6 +925,9 @@
         },
         {
             "_id": "PAB1qu2z4CTEZiPF",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.thAHF1zxNplLCJPO"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/acid/orb-bubble-smoke-drip.webp",
             "name": "Caustic Blast",
@@ -944,7 +983,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -976,6 +1015,9 @@
         },
         {
             "_id": "avYlQgNJRyxMuVnr",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -992,7 +1034,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -1007,7 +1049,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1041,6 +1083,9 @@
         },
         {
             "_id": "c4oHsyCkEeCv2Ma4",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.QqxwHeYEVylkYjsO"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/light/explosion-glow-spiral-teal.webp",
             "name": "Detect Poison",
@@ -1069,7 +1114,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1100,6 +1145,9 @@
         },
         {
             "_id": "e8H94bptnEsB1ubW",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4koZzrnMXhhosn0D"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/fear.webp",
             "name": "Fear",
@@ -1143,7 +1191,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1178,6 +1226,9 @@
         },
         {
             "_id": "5PR6dP2iFRKXGJsh",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.3VucgRc8FRPGy9NI"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/yellow-star-with-purple-aura.webp",
             "name": "Seek the Stars",
@@ -1238,6 +1289,9 @@
         },
         {
             "_id": "pj2fZczuh0tHhfgW",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jgN33YSYXB8iIHTw"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "icons/skills/movement/figure-running-gray.webp",
             "name": "Stumble",
@@ -1302,6 +1356,9 @@
         },
         {
             "_id": "cSNbCtsmIDmIhPSN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uZK2BYzPnxUBnDjr"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/nature/root-vine-entangled-hand.webp",
             "name": "Tangle Vine",
@@ -1330,7 +1387,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"

--- a/packs/sf2e/alien-core-bestiary/host-dragon-ancient-spellcaster.json
+++ b/packs/sf2e/alien-core-bestiary/host-dragon-ancient-spellcaster.json
@@ -155,6 +155,9 @@
         },
         {
             "_id": "mOD0iRYauycLydMX",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.m2xFMNyQiUKQDRaj"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "icons/magic/defensive/shield-barrier-glowing-blue.webp",
             "name": "Energy Aegis",
@@ -183,7 +186,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -215,6 +218,9 @@
         },
         {
             "_id": "rK5tqFUVg2e0vSCj",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.2Vkd1IxylPceUAAF"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "icons/magic/life/cross-beam-green.webp",
             "name": "Regenerate",
@@ -243,7 +249,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -275,6 +281,9 @@
         },
         {
             "_id": "un38xPHnDbNPPWEv",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ZhQWnQ0500AAtjDb"
+            },
             "folder": "MNWDEVo1eeM3A3Ec",
             "img": "systems/sf2e/icons/abilities/green-energy-streak.webp",
             "name": "Root of all Pain",
@@ -339,6 +348,9 @@
         },
         {
             "_id": "blfxzeuFnJU2KdAC",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.x5rGOmhDRDVQPrnW"
+            },
             "folder": "zDlxATrLAlbYA2Mv",
             "img": "icons/magic/life/heart-area-circle-red-green.webp",
             "name": "Field of Life",
@@ -409,7 +421,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -441,6 +453,9 @@
         },
         {
             "_id": "wHZEp1afHwNtKYO0",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.n5a3t5Qnx5AU8auy"
+            },
             "folder": "NQpcS2TwtjNNq1Qy",
             "img": "icons/creatures/fish/crab-blue-purple.webp",
             "name": "Carcinization",
@@ -504,6 +519,9 @@
         },
         {
             "_id": "IhYAttGNMGsmFH5U",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.MlpbeZ61Euhl0d60"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "icons/creatures/slimes/slime-movement-splash-green.webp",
             "name": "Toxic Cloud",
@@ -559,7 +577,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -591,6 +609,9 @@
         },
         {
             "_id": "gQTybmLZ4eUa9yOM",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.kOa055FIrO9Smnya"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "icons/commodities/stone/paver-brick-brown.webp",
             "name": "Wall of Stone",
@@ -619,7 +640,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -650,6 +671,9 @@
         },
         {
             "_id": "lgosz3UM8zZ3GtCI",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.aqRYNoSvxsVfqglH"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/equipment/feet/boots-leather-laced-brown.webp",
             "name": "Unfettered Movement",
@@ -678,7 +702,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -709,6 +733,9 @@
         },
         {
             "_id": "dHB6G9KDKsrKj8jK",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gPvtmKMRpg9I9D7H"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/earth/barrier-stone-explosion-debris.webp",
             "name": "Earthbind",
@@ -742,7 +769,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -773,6 +800,9 @@
         },
         {
             "_id": "AIWf6XPOjCRq4Bxv",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ShwUELLERVMtdjwE"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/blue-heart-in-a-circle.webp",
             "name": "Life Seal",
@@ -830,6 +860,9 @@
         },
         {
             "_id": "k8BS1KdBuga7hk5m",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.it4ZsAi6XgvGcodc"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/air/fog-gas-smoke-swirling-white.webp",
             "name": "Wall of Wind",
@@ -863,7 +896,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -894,6 +927,9 @@
         },
         {
             "_id": "nlsp6YiS7m6PRyRh",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.J6vNvrUT3b1hx2iA"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/magic/nature/root-vines-grow-brown.webp",
             "name": "Entangling Flora",
@@ -931,7 +967,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -963,6 +999,9 @@
         },
         {
             "_id": "jI1pkAJKTMFKHXMa",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5esP2GVzvxWsMgaX"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/endure-elements.webp",
             "name": "Environmental Endurance",
@@ -991,7 +1030,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -1022,6 +1061,9 @@
         },
         {
             "_id": "RbbAZfdfHhQEELA2",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.BBvV7qoXGdw09q1C"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/creatures/mammals/ox-buffalo-horned-green.webp",
             "name": "Speak with Animals",
@@ -1050,7 +1092,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1079,6 +1121,9 @@
         },
         {
             "_id": "cQNH5ollC1ThgkLy",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.MZGkMsPBztFN0pUO"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/magic/water/elemental-water.webp",
             "name": "Water Breathing",
@@ -1107,7 +1152,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1139,6 +1184,9 @@
         },
         {
             "_id": "xpVIF2e8zVzaJjA7",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.X9dkmh23lFwMjrYd"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/creatures/invertebrates/ant-strength-green.webp",
             "name": "Ant Haul",
@@ -1167,7 +1215,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -1197,6 +1245,9 @@
         },
         {
             "_id": "PAB1qu2z4CTEZiPF",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.thAHF1zxNplLCJPO"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/acid/orb-bubble-smoke-drip.webp",
             "name": "Caustic Blast",
@@ -1252,7 +1303,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1284,6 +1335,9 @@
         },
         {
             "_id": "avYlQgNJRyxMuVnr",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -1300,7 +1354,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -1315,7 +1369,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1349,6 +1403,9 @@
         },
         {
             "_id": "c4oHsyCkEeCv2Ma4",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.QqxwHeYEVylkYjsO"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/light/explosion-glow-spiral-teal.webp",
             "name": "Detect Poison",
@@ -1377,7 +1434,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1408,6 +1465,9 @@
         },
         {
             "_id": "e8H94bptnEsB1ubW",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4koZzrnMXhhosn0D"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/fear.webp",
             "name": "Fear",
@@ -1451,7 +1511,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1486,6 +1546,9 @@
         },
         {
             "_id": "5PR6dP2iFRKXGJsh",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.3VucgRc8FRPGy9NI"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/yellow-star-with-purple-aura.webp",
             "name": "Seek the Stars",
@@ -1546,6 +1609,9 @@
         },
         {
             "_id": "pj2fZczuh0tHhfgW",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jgN33YSYXB8iIHTw"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "icons/skills/movement/figure-running-gray.webp",
             "name": "Stumble",
@@ -1610,6 +1676,9 @@
         },
         {
             "_id": "cSNbCtsmIDmIhPSN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uZK2BYzPnxUBnDjr"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/nature/root-vine-entangled-hand.webp",
             "name": "Tangle Vine",
@@ -1638,7 +1707,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"

--- a/packs/sf2e/alien-core-bestiary/host-dragon-young-spellcaster.json
+++ b/packs/sf2e/alien-core-bestiary/host-dragon-young-spellcaster.json
@@ -108,6 +108,9 @@
         },
         {
             "_id": "dHB6G9KDKsrKj8jK",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gPvtmKMRpg9I9D7H"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/earth/barrier-stone-explosion-debris.webp",
             "name": "Earthbind",
@@ -141,7 +144,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -172,6 +175,9 @@
         },
         {
             "_id": "AIWf6XPOjCRq4Bxv",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ShwUELLERVMtdjwE"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/blue-heart-in-a-circle.webp",
             "name": "Life Seal",
@@ -229,6 +235,9 @@
         },
         {
             "_id": "k8BS1KdBuga7hk5m",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.it4ZsAi6XgvGcodc"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/air/fog-gas-smoke-swirling-white.webp",
             "name": "Wall of Wind",
@@ -262,7 +271,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -293,6 +302,9 @@
         },
         {
             "_id": "nlsp6YiS7m6PRyRh",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.J6vNvrUT3b1hx2iA"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/magic/nature/root-vines-grow-brown.webp",
             "name": "Entangling Flora",
@@ -330,7 +342,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -362,6 +374,9 @@
         },
         {
             "_id": "jI1pkAJKTMFKHXMa",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5esP2GVzvxWsMgaX"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/endure-elements.webp",
             "name": "Environmental Endurance",
@@ -390,7 +405,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -421,6 +436,9 @@
         },
         {
             "_id": "RbbAZfdfHhQEELA2",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.BBvV7qoXGdw09q1C"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/creatures/mammals/ox-buffalo-horned-green.webp",
             "name": "Speak with Animals",
@@ -449,7 +467,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -478,6 +496,9 @@
         },
         {
             "_id": "cQNH5ollC1ThgkLy",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.MZGkMsPBztFN0pUO"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/magic/water/elemental-water.webp",
             "name": "Water Breathing",
@@ -506,7 +527,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -538,6 +559,9 @@
         },
         {
             "_id": "xpVIF2e8zVzaJjA7",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.X9dkmh23lFwMjrYd"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/creatures/invertebrates/ant-strength-green.webp",
             "name": "Ant Haul",
@@ -566,7 +590,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -596,6 +620,9 @@
         },
         {
             "_id": "PAB1qu2z4CTEZiPF",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.thAHF1zxNplLCJPO"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/acid/orb-bubble-smoke-drip.webp",
             "name": "Caustic Blast",
@@ -651,7 +678,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -683,6 +710,9 @@
         },
         {
             "_id": "avYlQgNJRyxMuVnr",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -699,7 +729,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -714,7 +744,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -748,6 +778,9 @@
         },
         {
             "_id": "c4oHsyCkEeCv2Ma4",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.QqxwHeYEVylkYjsO"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/light/explosion-glow-spiral-teal.webp",
             "name": "Detect Poison",
@@ -776,7 +809,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -807,6 +840,9 @@
         },
         {
             "_id": "e8H94bptnEsB1ubW",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4koZzrnMXhhosn0D"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/fear.webp",
             "name": "Fear",
@@ -850,7 +886,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -885,6 +921,9 @@
         },
         {
             "_id": "5PR6dP2iFRKXGJsh",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.3VucgRc8FRPGy9NI"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/yellow-star-with-purple-aura.webp",
             "name": "Seek the Stars",
@@ -945,6 +984,9 @@
         },
         {
             "_id": "pj2fZczuh0tHhfgW",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jgN33YSYXB8iIHTw"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "icons/skills/movement/figure-running-gray.webp",
             "name": "Stumble",
@@ -1009,6 +1051,9 @@
         },
         {
             "_id": "cSNbCtsmIDmIhPSN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uZK2BYzPnxUBnDjr"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/nature/root-vine-entangled-hand.webp",
             "name": "Tangle Vine",
@@ -1037,7 +1082,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"

--- a/packs/sf2e/alien-core-bestiary/ichor-lord.json
+++ b/packs/sf2e/alien-core-bestiary/ichor-lord.json
@@ -101,6 +101,9 @@
         },
         {
             "_id": "brXYNPxug3STVkEk",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.pkcOby5prOausy1k"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/sundries/gaming/playing-cards-black.webp",
             "name": "Read Omens",
@@ -129,7 +132,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -160,6 +163,9 @@
         },
         {
             "_id": "VTvmoxICJ0beTElg",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.kR5A0h2a9hY41wav"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/purple-dimension-rift.webp",
             "name": "Entropy Strike",
@@ -280,6 +286,9 @@
         },
         {
             "_id": "epOaGun5mxnKCx00",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.0mNmVi9CLXor3McX"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/green-upper-left-arrow.webp",
             "name": "Personal Gravity",
@@ -340,6 +349,9 @@
         },
         {
             "_id": "2RVVKoMvQqk6Nf7i",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.EhN3GjdjXChMdiFk"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/purple-neurons.webp",
             "name": "Share Pain",
@@ -377,7 +389,7 @@
                 },
                 "heightening": {
                     "levels": {
-                        "4": {
+                        "6": {
                             "damage": {
                                 "dIvEREAgyIVyanqT": {
                                     "applyMod": false,
@@ -423,7 +435,10 @@
                 },
                 "traits": {
                     "rarity": "common",
-                    "traditions": [],
+                    "traditions": [
+                        "divine",
+                        "occult"
+                    ],
                     "value": [
                         "concentrate",
                         "manipulate",
@@ -435,6 +450,9 @@
         },
         {
             "_id": "8Vs9mL5P3NQb3LLf",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.qkehzRdn7JeGrR6E"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/alien-skull.webp",
             "name": "Void Whispers",
@@ -503,6 +521,9 @@
         },
         {
             "_id": "eWVu13BSwCejijTX",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.41TZEjhO6D1nWw2X"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/augury.webp",
             "name": "Augury",
@@ -532,7 +553,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -563,6 +584,9 @@
         },
         {
             "_id": "8uNSBRbDqDVQ0wP8",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.41TZEjhO6D1nWw2X"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/augury.webp",
             "name": "Augury",
@@ -592,7 +616,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -623,6 +647,9 @@
         },
         {
             "_id": "IB1U7IAEcANXNANA",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.3JG1t3T4mWn6vTke"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/blur.webp",
             "name": "Blur",
@@ -652,7 +679,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -684,6 +711,9 @@
         },
         {
             "_id": "E0Yjfw4NkWGdHw2Z",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.qOLMHvkAGsVYLhtn"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "icons/magic/perception/third-eye-blue-red.webp",
             "name": "Detect Thoughts",
@@ -698,13 +728,7 @@
                 },
                 "counteraction": false,
                 "damage": {},
-                "defense": {
-                    "passive": null,
-                    "save": {
-                        "basic": false,
-                        "statistic": "will"
-                    }
-                },
+                "defense": null,
                 "description": {
                     "value": "<p>You sense the presence of thinking creatures around you. You detect the presence or absence of thoughts from conscious creatures that have Intelligence modifiers of –3 or higher. You can choose to ignore the thoughts of creatures you're familiar with so they don't interfere with your detection of other thoughts. The spell can penetrate some barriers, but 3 feet of dirt or wood, 1 foot of stone, 1 inch of metal, a thin sheet of lead, or any force barrier blocks it. Creatures who are immune to mental effects are immune to detection by this spell.</p><hr /><p><strong>Heightened (4th)</strong> You detect the number of thinking minds and whether or not the creatures are telepathic. Creatures with telepathy have louder thoughts than creatures who don't have telepathy and might be able to sense your intrusion, at the GM's discretion.</p>"
                 },
@@ -753,6 +777,9 @@
         },
         {
             "_id": "oB748thJIyEXmzE5",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jwK43yKsHTkJQvQ9"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/see-invisibility.webp",
             "name": "See the Unseen (Constant)",
@@ -782,7 +809,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -814,6 +841,9 @@
         },
         {
             "_id": "icp5yKfVvBv4Omfp",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.7ZinJNzxq0XF0oMx"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/bane.webp",
             "name": "Bane",
@@ -851,7 +881,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -883,6 +913,9 @@
         },
         {
             "_id": "lQdMXjm0ABe5DEKC",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4gBIw4IDrSfFHik4"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/daze.webp",
             "name": "Daze",
@@ -934,7 +967,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "60 feet"
@@ -968,6 +1001,9 @@
         },
         {
             "_id": "OYGsWbkR8J4IOlos",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -984,7 +1020,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -999,7 +1035,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1033,6 +1069,9 @@
         },
         {
             "_id": "kX6RcMwwnmtiLcc0",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.FEaM1B4WuiqFO7Uk"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "icons/magic/unholy/projectile-bolts-salvo-pink.webp",
             "name": "Eldritch Lance",
@@ -1113,6 +1152,9 @@
         },
         {
             "_id": "Yw7GnjiO5o4fPMjV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.J7Y7tl0bbdz7TcCc"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/ray-of-enfeeblement.webp",
             "name": "Enfeeble",
@@ -1147,7 +1189,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1178,6 +1220,9 @@
         },
         {
             "_id": "CvqB9NrfHrr6h2Vp",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4koZzrnMXhhosn0D"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/fear.webp",
             "name": "Fear",
@@ -1222,7 +1267,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1257,6 +1302,9 @@
         },
         {
             "_id": "OZ4YEsuxRCAEP6AG",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uBo6g5aW087cLSJR"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/magic/light/explosion-impact-purple.webp",
             "name": "Mind Skewer",
@@ -1341,6 +1389,9 @@
         },
         {
             "_id": "hMmzENYtPMk3Rb5U",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.pwzdSlJgYqN7bs2w"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/mage-hand.webp",
             "name": "Telekinetic Hand",
@@ -1389,7 +1440,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1420,6 +1471,9 @@
         },
         {
             "_id": "gWlaut2J1Xrv0P65",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.mAMEt4FFbdqoRnkN"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/chill-touch.webp",
             "name": "Void Warp",
@@ -1471,7 +1525,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"

--- a/packs/sf2e/alien-core-bestiary/illumantula.json
+++ b/packs/sf2e/alien-core-bestiary/illumantula.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "6s9kr17VBUjxUyc7",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.0pl80qKToraH4dvO"
+            },
             "folder": "2cuzA13JVJ0A8JrW",
             "img": "systems/sf2e/icons/abilities/purple-energy-star.webp",
             "name": "Event Horizon",
@@ -132,6 +135,9 @@
         },
         {
             "_id": "IZjIPeOpFaNRZggb",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.UnWaP06SVi3jRN0M"
+            },
             "folder": "DWZvpqhX0tWHYZOh",
             "img": "systems/sf2e/icons/abilities/orange-mushroom-cloud.webp",
             "name": "Atomic Blast",
@@ -174,7 +180,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You magically split an atom, creating an explosion with radioactive fallout. All targets in the area take 5d12 bludgeoning damage and 5d12 fire damage, and they're exposed to extreme radiation that uses your spellcasting DC as the @Check[fortitude]{Fortitude DC} for radiation sickness incurred by exposure to this radiation. The onset and frequency of this magical radiation is 1 round, and the area remains radioactive for 10 minutes.</p><hr /><p><strong>Critical Success</strong> The target is unaffected by the initial damage.</p>\n<p><strong>Success</strong> The target takes half damage and is @UUID[Compendium.sf2e.conditions.Item.Dazzled] for 1 minute.</p>\n<p><strong>Failure</strong> The target takes full damage and is @UUID[Compendium.sf2e.conditions.Item.Blinded] for 1 minute.</p>\n<p><strong>Critical Failure</strong> As failure, and the target takes double damage.</p>"
+                    "value": "<p>You magically split an atom, creating an explosion with radioactive fallout. All creatures in the area take 5d12 bludgeoning damage and 5d12 fire damage, and they're exposed to extreme radiation that uses your spellcasting DC as the @Check[fortitude]{Fortitude DC} for radiation sickness incurred by exposure to this radiation. The onset and frequency of this magical radiation is 1 round, and the area remains radioactive for 10 minutes.</p><hr /><p><strong>Critical Success</strong> The target is unaffected by the initial damage.</p>\n<p><strong>Success</strong> The target takes half damage and is @UUID[Compendium.sf2e.conditions.Item.Dazzled] for 1 minute.</p>\n<p><strong>Failure</strong> The target takes full damage and is @UUID[Compendium.sf2e.conditions.Item.Blinded] for 1 minute.</p>\n<p><strong>Critical Failure</strong> As failure, and the target takes double damage.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -222,6 +228,9 @@
         },
         {
             "_id": "XBAj772yjrSSXPnA",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.J3zMwmhIVgI2yzxm"
+            },
             "folder": "DWZvpqhX0tWHYZOh",
             "img": "systems/sf2e/icons/abilities/energy-reaction-2.webp",
             "name": "Call Cosmos",
@@ -341,6 +350,9 @@
         },
         {
             "_id": "ip3uDaHTkBN1uY0U",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.xS4bqHnbodCwjpqI"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/blue-planet-pillar-of-light.webp",
             "name": "Promession  (at will)",
@@ -370,7 +382,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You flash freeze a target then send subsonic waves through it, potentially reducing it into fine powder. Make a spell attack against the target. If you hit a target, the target takes 6d8 cold damage and must attempt a Fortitude save. If you critically hit, the target gets a result one degree of success worse than it rolled on its Fortitude save. A creature reduced to 0 Hit Points is blasted to fine powder; its gear remains.</p><hr /><p><strong>Critical Success</strong> The target is unaffected by further damage.</p>\n<p><strong>Success</strong> The target takes an additional 3d8 sonic damage.</p>\n<p><strong>Failure</strong> The target takes an additional 6d8 sonic damage.</p>\n<p><strong>Critical Failure</strong> The target takes an additional 12d8 sonic damage.</p><hr /><p><strong>Heightened (+1)</strong> The cold and sonic damage each increase by 1d8.</p>"
+                    "value": "<p>You flash freeze a target then send subsonic waves through it, potentially reducing it into fine powder. Make a spell attack against the target. If you hit a target, the target takes 6d8 cold damage and must attempt a Fortitude save. If you critically hit, the target gets a result one degree of success worse than it rolled on its Fortitude save. A creature reduced to 0 Hit Points is blasted to fine powder; its gear remains.</p><hr /><p><strong>Critical Success</strong> The target is unaffected by further damage.</p>\n<p><strong>Success</strong> The target takes an additional @Damage[((@item.level -3)d8)[sonic]] damage.</p>\n<p><strong>Failure</strong> The target takes an additional @Damage[((@item.level)d8)[sonic]] damage.</p>\n<p><strong>Critical Failure</strong> The target takes an additional @Damage[((@item.level +6)d8)[sonic]] damage.</p><hr /><p><strong>Heightened (+1)</strong> The cold and sonic damage each increase by 1d8.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -433,6 +445,9 @@
         },
         {
             "_id": "AMKI2JGgwjzTbREQ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.a02hsymtiVRQvh3i"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/purple-eruption.webp",
             "name": "Slice Reality  (at will)",
@@ -518,6 +533,9 @@
         },
         {
             "_id": "7my0vfkO4aJKvOTp",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uqlxMQQeSGWEVjki"
+            },
             "folder": "zDlxATrLAlbYA2Mv",
             "img": "systems/sf2e/icons/spells/true-seeing.webp",
             "name": "Truesight (constant)",
@@ -547,7 +565,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -580,6 +598,9 @@
         },
         {
             "_id": "CO1yXx0XqzaftZvN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.7WtiWJRYZhT6a9Ey"
+            },
             "folder": "NQpcS2TwtjNNq1Qy",
             "img": "systems/sf2e/icons/abilities/purple-tentacle.webp",
             "name": "Control Machine  (at will)",
@@ -645,6 +666,9 @@
         },
         {
             "_id": "FnTn2qdV7dLwdPhe",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.aqRYNoSvxsVfqglH"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/equipment/feet/boots-leather-laced-brown.webp",
             "name": "Unfettered Movement  (constant)",
@@ -674,7 +698,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -705,6 +729,9 @@
         },
         {
             "_id": "y75ZVtBLrVMtL3od",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Cbj7tDkb2ZTp10Cg"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/blue-twin-lightning-streaks.webp",
             "name": "Electrotether  (at will)",
@@ -787,6 +814,9 @@
         },
         {
             "_id": "yIgeS31f6c5ZaBCl",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.9HpwDN4MYQJnW0LG"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/dispel-magic.webp",
             "name": "Dispel Magic  (at will)",
@@ -816,7 +846,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -848,6 +878,9 @@
         },
         {
             "_id": "193R5fLSpmHHbToM",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.NkvRoN33RbDg3fl9"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/pink-target-sign.webp",
             "name": "Analyze Target",
@@ -861,7 +894,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The circumstance bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The circumstance bonus increases to +3, and you can target any number of creatures.</p>"
+                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The status bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The status bonus increases to +3, and you can target any number of creatures.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -910,6 +943,9 @@
         },
         {
             "_id": "6JufxlNx8cGip9YM",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -926,7 +962,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -941,7 +977,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -975,6 +1011,9 @@
         },
         {
             "_id": "I5l4AYHASffdKzR2",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ZBeKxBcUOsXrfMRo"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/purple-insignia.webp",
             "name": "Implant Data",
@@ -1034,6 +1073,9 @@
         },
         {
             "_id": "oiO44HpJdEf3iRCc",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.OhD2Z6rIGGD5ocZA"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/light/explosion-star-glow-silhouette.webp",
             "name": "Read Aura",
@@ -1077,7 +1119,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1111,6 +1153,9 @@
         },
         {
             "_id": "JcwG120tsraQduHo",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.3VucgRc8FRPGy9NI"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/yellow-star-with-purple-aura.webp",
             "name": "Seek the Stars",

--- a/packs/sf2e/alien-core-bestiary/iridia.json
+++ b/packs/sf2e/alien-core-bestiary/iridia.json
@@ -41,6 +41,9 @@
         },
         {
             "_id": "1ZoyzWJuCNJTinkV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.SwUiVavHKMWG7t5K"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/tongues.webp",
             "name": "Truespeech (constant)",
@@ -69,7 +72,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -100,6 +103,9 @@
         },
         {
             "_id": "ogyjglxXLyTtMt6q",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VlNcjmYyu95vOUe8"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/magic/symbols/ring-circle-smoke-blue.webp",
             "name": "Translocate (at will)",
@@ -139,7 +145,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -170,6 +176,9 @@
         },
         {
             "_id": "awGRPKhxPmiSxf4t",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.eHiWtMiXoI1d48A7"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/purple-alien-brain.webp",
             "name": "Holographic Memory",
@@ -235,6 +244,9 @@
         },
         {
             "_id": "idtT1hrXscnn3ao7",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.GB1RVtoFPwyH1B9G"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/green-acid-sprayer.webp",
             "name": "Caustic Conversion",
@@ -326,6 +338,9 @@
         },
         {
             "_id": "9ODpdjYeoFwIrMs8",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.qOLMHvkAGsVYLhtn"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "icons/magic/perception/third-eye-blue-red.webp",
             "name": "Detect Thoughts",
@@ -340,13 +355,7 @@
                 },
                 "counteraction": false,
                 "damage": {},
-                "defense": {
-                    "passive": null,
-                    "save": {
-                        "basic": false,
-                        "statistic": "will"
-                    }
-                },
+                "defense": null,
                 "description": {
                     "value": "<p>You sense the presence of thinking creatures around you. You detect the presence or absence of thoughts from conscious creatures that have Intelligence modifiers of –3 or higher. You can choose to ignore the thoughts of creatures you're familiar with so they don't interfere with your detection of other thoughts. The spell can penetrate some barriers, but 3 feet of dirt or wood, 1 foot of stone, 1 inch of metal, a thin sheet of lead, or any force barrier blocks it. Creatures who are immune to mental effects are immune to detection by this spell.</p><hr /><p><strong>Heightened (4th)</strong> You detect the number of thinking minds and whether or not the creatures are telepathic. Creatures with telepathy have louder thoughts than creatures who don't have telepathy and might be able to sense your intrusion, at the GM's discretion.</p>"
                 },
@@ -395,6 +404,9 @@
         },
         {
             "_id": "fUfaunOIPPQDiQkP",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ZofLZ5Zs8NN5yDPJ"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/blue-comet.webp",
             "name": "Inject Nanobots",
@@ -474,6 +486,9 @@
         },
         {
             "_id": "jFS4QBQR119XoGeP",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.v2S6tlilNbA4uGdM"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/blue-circuit-board.webp",
             "name": "Skim Data (at will)",
@@ -533,6 +548,9 @@
         },
         {
             "_id": "AQR1NeASXcjrDGHR",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.yXD9uU8w8uFD2OBQ"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/cerulean-circular-sign.webp",
             "name": "Delete",
@@ -592,6 +610,9 @@
         },
         {
             "_id": "f9IdFiw30C8pwaf0",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ZBeKxBcUOsXrfMRo"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/purple-insignia.webp",
             "name": "Implant Data",
@@ -651,6 +672,9 @@
         },
         {
             "_id": "RuocSbdWowWXoF4C",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.dINQzhqGmIsqGMUY"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/mending.webp",
             "name": "Mending",
@@ -695,7 +719,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -727,6 +751,9 @@
         },
         {
             "_id": "VlIaQXr8MCRUkMdO",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.3VucgRc8FRPGy9NI"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/yellow-star-with-purple-aura.webp",
             "name": "Seek the Stars",
@@ -787,6 +814,9 @@
         },
         {
             "_id": "Ei7KXxQmH2KgQQnq",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Sqo1uzSmebVWpqoT"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-comet-swirling.webp",
             "name": "Wisp Ally",

--- a/packs/sf2e/alien-core-bestiary/jinsul-pontiff.json
+++ b/packs/sf2e/alien-core-bestiary/jinsul-pontiff.json
@@ -913,6 +913,9 @@
         },
         {
             "_id": "LsYxpqrt8GQUZ1uM",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.5PS5ESGpnQfJNOdg"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/blue-battery.webp",
             "name": "Battery (Tactical)",
@@ -928,7 +931,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -943,6 +947,7 @@
                     "type": null
                 },
                 "price": {
+                    "per": 1,
                     "value": {
                         "sp": 20
                     }
@@ -961,7 +966,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 20,
                     "value": 20
                 }

--- a/packs/sf2e/alien-core-bestiary/jinsul-pontiff.json
+++ b/packs/sf2e/alien-core-bestiary/jinsul-pontiff.json
@@ -57,6 +57,9 @@
         },
         {
             "_id": "iz1Mlx3uOoqICvjw",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.L6Gww2b2YVM3q0ZQ"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/cerulean-alien-soldier.webp",
             "name": "Selective Invisibility",
@@ -117,6 +120,9 @@
         },
         {
             "_id": "4kqeRMgFQWVAEHSe",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.EhN3GjdjXChMdiFk"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/purple-neurons.webp",
             "name": "Share Pain",
@@ -154,7 +160,7 @@
                 },
                 "heightening": {
                     "levels": {
-                        "4": {
+                        "6": {
                             "damage": {
                                 "dIvEREAgyIVyanqT": {
                                     "applyMod": false,
@@ -200,7 +206,10 @@
                 },
                 "traits": {
                     "rarity": "common",
-                    "traditions": [],
+                    "traditions": [
+                        "divine",
+                        "occult"
+                    ],
                     "value": [
                         "concentrate",
                         "manipulate",
@@ -212,6 +221,9 @@
         },
         {
             "_id": "3tOSW3pmE5vP0OTU",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.qkehzRdn7JeGrR6E"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/alien-skull.webp",
             "name": "Void Whispers",
@@ -280,6 +292,9 @@
         },
         {
             "_id": "vhczMhYfpmcMWxMk",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.3JG1t3T4mWn6vTke"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/blur.webp",
             "name": "Blur",
@@ -309,7 +324,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -341,6 +356,9 @@
         },
         {
             "_id": "iEmuYRLJ0Vbu9gqf",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.XSujb7EsSwKl19Uu"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/bless.webp",
             "name": "Bless",
@@ -373,7 +391,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -405,6 +423,9 @@
         },
         {
             "_id": "1N4lDkBAq0zCY0aN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uBo6g5aW087cLSJR"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/magic/light/explosion-impact-purple.webp",
             "name": "Mind Skewer",
@@ -489,6 +510,9 @@
         },
         {
             "_id": "RJBoaKacpLA3n9fN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.wOjoJjl2ndZKTuFJ"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/orange-timer-fire.webp",
             "name": "Overheat",
@@ -573,6 +597,9 @@
         },
         {
             "_id": "01nJMXRx903xNt7E",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.7P4eBdqWcgQJAFCa"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-laser-beam-rifle.webp",
             "name": "Shifting Surge",
@@ -632,6 +659,9 @@
         },
         {
             "_id": "o17Kl8BGD7cor8Fb",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.szIyEsvihc5e1w8n"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/air/air-burst-spiral-teal-green.webp",
             "name": "Soothe",
@@ -679,7 +709,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -711,6 +741,9 @@
         },
         {
             "_id": "kJl1kfTPzZIpxYot",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.szIyEsvihc5e1w8n"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/air/air-burst-spiral-teal-green.webp",
             "name": "Soothe",
@@ -758,7 +791,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"

--- a/packs/sf2e/alien-core-bestiary/jinsul-trooper.json
+++ b/packs/sf2e/alien-core-bestiary/jinsul-trooper.json
@@ -94,6 +94,9 @@
         },
         {
             "_id": "fTxTK1irZmkmCSdE",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -109,7 +112,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -143,7 +147,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 10,
                     "value": 10
                 }

--- a/packs/sf2e/alien-core-bestiary/jinsul-warblooded.json
+++ b/packs/sf2e/alien-core-bestiary/jinsul-warblooded.json
@@ -95,6 +95,9 @@
         },
         {
             "_id": "WcMBUKcA5emYxbds",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -110,7 +113,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -144,7 +148,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 10,
                     "value": 10
                 }

--- a/packs/sf2e/alien-core-bestiary/jygyk.json
+++ b/packs/sf2e/alien-core-bestiary/jygyk.json
@@ -202,6 +202,9 @@
         },
         {
             "_id": "m7d6r1yIJofrqBi4",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -217,7 +220,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/alien-core-bestiary/liberoba-midwife.json
+++ b/packs/sf2e/alien-core-bestiary/liberoba-midwife.json
@@ -41,6 +41,9 @@
         },
         {
             "_id": "ktjS36jWdNBnzdak",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.kTzbLqmqPcZwOa5F"
+            },
             "folder": "NQpcS2TwtjNNq1Qy",
             "img": "systems/sf2e/icons/abilities/yellow-warning-sign.webp",
             "name": "Wave of Warning",
@@ -127,6 +130,9 @@
         },
         {
             "_id": "KwP8iQp3IdWxSmff",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jyrxfWeeCsrkhNit"
+            },
             "folder": "NuBKgFiv0GJhsx3c",
             "img": "icons/magic/unholy/beam-ringed-impact-purple.webp",
             "name": "Eldritch Wrath",
@@ -214,6 +220,9 @@
         },
         {
             "_id": "uwOUAh5Lx3C1mHXe",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.kR5A0h2a9hY41wav"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/purple-dimension-rift.webp",
             "name": "Entropy Strike",
@@ -334,6 +343,9 @@
         },
         {
             "_id": "rC7G5LvJTIHn8fzH",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.EhN3GjdjXChMdiFk"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/purple-neurons.webp",
             "name": "Share Pain",
@@ -371,7 +383,7 @@
                 },
                 "heightening": {
                     "levels": {
-                        "4": {
+                        "6": {
                             "damage": {
                                 "dIvEREAgyIVyanqT": {
                                     "applyMod": false,
@@ -417,7 +429,10 @@
                 },
                 "traits": {
                     "rarity": "common",
-                    "traditions": [],
+                    "traditions": [
+                        "divine",
+                        "occult"
+                    ],
                     "value": [
                         "concentrate",
                         "manipulate",
@@ -429,6 +444,9 @@
         },
         {
             "_id": "9ZFQcgSuDayZd4dW",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.wzLkNU3AAqOSKFPR"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/magic/fire/orb-vortex.webp",
             "name": "Noise Blast",
@@ -485,7 +503,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -517,6 +535,9 @@
         },
         {
             "_id": "tsun7SD7VpUZrMiX",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.HPHr5aoLMH4eVwaw"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/yellow-hand.webp",
             "name": "Soul Surge",
@@ -598,6 +619,9 @@
         },
         {
             "_id": "ffA5YPlzLrCIRBUT",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.FEaM1B4WuiqFO7Uk"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "icons/magic/unholy/projectile-bolts-salvo-pink.webp",
             "name": "Eldritch Lance",
@@ -678,6 +702,9 @@
         },
         {
             "_id": "Y0XzpeMOHhlND5ut",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uBo6g5aW087cLSJR"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/magic/light/explosion-impact-purple.webp",
             "name": "Mind Skewer",
@@ -762,6 +789,9 @@
         },
         {
             "_id": "MTUKerLL7kll4cDk",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.QpP30fcEl4NGjHwo"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/yellow-sonic-scream.webp",
             "name": "Sonic Scream",

--- a/packs/sf2e/alien-core-bestiary/line-class-soldier-robot.json
+++ b/packs/sf2e/alien-core-bestiary/line-class-soldier-robot.json
@@ -182,6 +182,9 @@
         },
         {
             "_id": "kAPdloqq4dnLFZOY",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -197,7 +200,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -231,7 +235,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 10,
                     "value": 10
                 }

--- a/packs/sf2e/alien-core-bestiary/line-class-soldier-robot.json
+++ b/packs/sf2e/alien-core-bestiary/line-class-soldier-robot.json
@@ -4,6 +4,9 @@
     "items": [
         {
             "_id": "fd9W7WX4DquhT8AA",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.8nvXQmFxd5eCkD9v"
+            },
             "folder": "V89RPpe7fyCFC6NS",
             "img": "icons/weapons/hammers/shorthammer-double-steel-embossed.webp",
             "name": "Integrated Commercial Hammer",
@@ -92,6 +95,9 @@
         },
         {
             "_id": "xSR6bU08NRW2dmxj",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0TSUahGsoVnDZ6kv"
+            },
             "folder": "V89RPpe7fyCFC6NS",
             "img": "systems/sf2e/icons/equipment/weapons/teal-sci-fi-gun.webp",
             "name": "Laser Rifle",

--- a/packs/sf2e/alien-core-bestiary/moon-giant.json
+++ b/packs/sf2e/alien-core-bestiary/moon-giant.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "fJUm3HBbj0HbJWY6",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.a3aQxCpoj1q1NQxC"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "systems/sf2e/icons/spells/sunburst.webp",
             "name": "Sunburst",
@@ -100,7 +103,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -133,6 +136,9 @@
         },
         {
             "_id": "lTxfZjMWJqYHPTW2",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.x21WInzhprQHMyKT"
+            },
             "folder": "MNWDEVo1eeM3A3Ec",
             "img": "systems/sf2e/icons/abilities/purple-gas-cloud.webp",
             "name": "Void Scour",
@@ -221,6 +227,9 @@
         },
         {
             "_id": "m0q3M0c3za1NdREL",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ITzIb93GBvyX8UbJ"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/pink-portal.webp",
             "name": "Pocket Vacuum",
@@ -308,6 +317,9 @@
         },
         {
             "_id": "dorXIzRBiwwT0QRM",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.9BnhadUO8FMLmeZ3"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/mind-probe.webp",
             "name": "Mind Probe",
@@ -342,7 +354,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -374,6 +386,9 @@
         },
         {
             "_id": "xBILbJbZ8nY13lhH",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.kTzbLqmqPcZwOa5F"
+            },
             "folder": "NQpcS2TwtjNNq1Qy",
             "img": "systems/sf2e/icons/abilities/yellow-warning-sign.webp",
             "name": "Wave of Warning",
@@ -461,6 +476,9 @@
         },
         {
             "_id": "ma5aMEQqSgafp5Nf",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.HAaRcHfN4g83eSEC"
+            },
             "folder": "NuBKgFiv0GJhsx3c",
             "img": "icons/magic/earth/construct-stone-long-arms.webp",
             "name": "Cairn Form",
@@ -522,6 +540,9 @@
         },
         {
             "_id": "87GWu84JuFVSgyBJ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ShwUELLERVMtdjwE"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/blue-heart-in-a-circle.webp",
             "name": "Life Seal (at will)",
@@ -580,6 +601,9 @@
         },
         {
             "_id": "dMDOx1go4PYw5vc6",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.t0oFlhMhNOHbb6rG"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/blue-emblem-generic.webp",
             "name": "Reorient",
@@ -640,6 +664,9 @@
         },
         {
             "_id": "dK8Z8Evs48SwE1L9",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.3VucgRc8FRPGy9NI"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/yellow-star-with-purple-aura.webp",
             "name": "Seek the Stars",
@@ -700,6 +727,9 @@
         },
         {
             "_id": "0Hw8Lbx0upzTs6qZ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jgN33YSYXB8iIHTw"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "icons/skills/movement/figure-running-gray.webp",
             "name": "Stumble",

--- a/packs/sf2e/alien-core-bestiary/necrolinked-wight.json
+++ b/packs/sf2e/alien-core-bestiary/necrolinked-wight.json
@@ -4,6 +4,9 @@
     "items": [
         {
             "_id": "C2S204F4g8ZE5Tvo",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.fClhrG92Zi4k14Hq"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/walkie-talkie.webp",
             "name": "Comm Unit",
@@ -19,6 +22,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,

--- a/packs/sf2e/alien-core-bestiary/necrovite.json
+++ b/packs/sf2e/alien-core-bestiary/necrovite.json
@@ -158,6 +158,9 @@
         },
         {
             "_id": "jBtNqOIJI5pqxmCN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.O6VQC1Bs4aSYDa6R"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "icons/commodities/treasure/mask-wood-tan.webp",
             "name": "Mask of Terror",
@@ -191,7 +194,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -227,6 +230,9 @@
         },
         {
             "_id": "rjAy4RsKl9jPxlNy",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.OsOhx3TGIZ7AhD0P"
+            },
             "folder": "zDlxATrLAlbYA2Mv",
             "img": "systems/sf2e/icons/spells/dominate.webp",
             "name": "Dominate",
@@ -260,7 +266,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -293,6 +299,9 @@
         },
         {
             "_id": "YV3ngsWyAlzVzEas",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.a02hsymtiVRQvh3i"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/purple-eruption.webp",
             "name": "Slice Reality",
@@ -377,6 +386,9 @@
         },
         {
             "_id": "skQcBNNeGl4KYmt0",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.OudLZtxmg6gI1UEL"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/alien-mask.webp",
             "name": "Telekinetic Strangulation",
@@ -448,6 +460,9 @@
         },
         {
             "_id": "xslMBiOhUbp8Vw2q",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.IqJ9URobmJ9L9UBG"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "icons/magic/unholy/beam-impact-purple.webp",
             "name": "Shadow Blast",
@@ -514,7 +529,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "varies"
@@ -545,6 +560,9 @@
         },
         {
             "_id": "h4ke7vkbjcryq7y1",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.GP3wewkQXEPrLxYj"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "icons/magic/symbols/runes-carved-stone-yellow.webp",
             "name": "Subconscious Suggestion",
@@ -588,7 +606,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -622,6 +640,9 @@
         },
         {
             "_id": "rSh3yhF7KJs5p7iB",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jyrxfWeeCsrkhNit"
+            },
             "folder": "NuBKgFiv0GJhsx3c",
             "img": "icons/magic/unholy/beam-ringed-impact-purple.webp",
             "name": "Eldritch Wrath",
@@ -708,6 +729,9 @@
         },
         {
             "_id": "frClntAzWnEGsLAd",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.7Ib3qxIC0bFD3ued"
+            },
             "folder": "NuBKgFiv0GJhsx3c",
             "img": "icons/magic/time/clock-stopwatch-white-blue.webp",
             "name": "Weight of Ages",
@@ -801,6 +825,9 @@
         },
         {
             "_id": "3Bkc9t1ISv5LL5QX",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.kR5A0h2a9hY41wav"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/purple-dimension-rift.webp",
             "name": "Entropy Strike",
@@ -920,6 +947,9 @@
         },
         {
             "_id": "QEfzqLJHsT9eRPbr",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.N1Z1oLPdBxaSgrEE"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "systems/sf2e/icons/spells/vampiric-touch.webp",
             "name": "Vampiric Feast",
@@ -971,7 +1001,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -1004,6 +1034,9 @@
         },
         {
             "_id": "w9S3ooJ99V0c0HB7",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4GE2ZdODgIQtg51c"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/darkness.webp",
             "name": "Darkness",
@@ -1035,7 +1068,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -1068,6 +1101,9 @@
         },
         {
             "_id": "jwfMYanYBmCbIB7z",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.9HpwDN4MYQJnW0LG"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/dispel-magic.webp",
             "name": "Dispel Magic",
@@ -1096,7 +1132,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -1128,6 +1164,9 @@
         },
         {
             "_id": "ohq760EnU2ejLYgC",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.XXqE1eY3w3z6xJCB"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/creatures/magical/construct-stone-earth-gray.webp",
             "name": "Invisibility",
@@ -1156,7 +1195,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -1187,6 +1226,9 @@
         },
         {
             "_id": "Zd7A1adYdgUiQsWR",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Fr58LDSrbndgld9n"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/magic/defensive/shield-barrier-deflect-teal.webp",
             "name": "Resist Energy",
@@ -1230,7 +1272,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -1262,6 +1304,9 @@
         },
         {
             "_id": "xlUlYSwnGi3B1t2C",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.NkvRoN33RbDg3fl9"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/pink-target-sign.webp",
             "name": "Analyze Target",
@@ -1275,7 +1320,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The circumstance bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The circumstance bonus increases to +3, and you can target any number of creatures.</p>"
+                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The status bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The status bonus increases to +3, and you can target any number of creatures.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -1324,6 +1369,9 @@
         },
         {
             "_id": "UfvRyZvnw7JYltLE",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -1340,7 +1388,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -1355,7 +1403,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1389,6 +1437,9 @@
         },
         {
             "_id": "7paxNDz7eq84lcLi",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.J7Y7tl0bbdz7TcCc"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/ray-of-enfeeblement.webp",
             "name": "Enfeeble",
@@ -1422,7 +1473,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1453,6 +1504,9 @@
         },
         {
             "_id": "216BS0xbqDjPas13",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gKKqvLohtrSJj3BM"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/magic-missile.webp",
             "name": "Force Barrage",
@@ -1493,7 +1547,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -1524,6 +1578,9 @@
         },
         {
             "_id": "CEqcnNiSZES5k68S",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.vLzFcIaSXs7YTIqJ"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/message.webp",
             "name": "Message",
@@ -1562,7 +1619,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -1598,6 +1655,9 @@
         },
         {
             "_id": "QveYtMdccfWzCVFr",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uBo6g5aW087cLSJR"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/magic/light/explosion-impact-purple.webp",
             "name": "Mind Skewer",
@@ -1681,6 +1741,9 @@
         },
         {
             "_id": "t6Or6Kx03LdOyaOP",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.TVKNbcgTee19PXZR"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/shield.webp",
             "name": "Shield",
@@ -1709,7 +1772,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1741,6 +1804,9 @@
         },
         {
             "_id": "L4QkUJ318fAcIZQr",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.9WGeBwIIbbUuWKq0"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/animate-dead.webp",
             "name": "Summon Undead",
@@ -1769,7 +1835,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1801,6 +1867,9 @@
         },
         {
             "_id": "xAKchzQAAtHkWp7I",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.mAMEt4FFbdqoRnkN"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/chill-touch.webp",
             "name": "Void Warp",
@@ -1852,7 +1921,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"

--- a/packs/sf2e/alien-core-bestiary/necrovite.json
+++ b/packs/sf2e/alien-core-bestiary/necrovite.json
@@ -2036,6 +2036,9 @@
         },
         {
             "_id": "OFlNBGnXmb1AhanS",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.kFfYq4ONuKMgISRi"
+            },
             "folder": "JlUS4L43QWp3cPhu",
             "img": "icons/commodities/gems/gem-faceted-diamond-blue.webp",
             "name": "Aeon Stone (Uplifting)",
@@ -2051,6 +2054,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,

--- a/packs/sf2e/alien-core-bestiary/nihili.json
+++ b/packs/sf2e/alien-core-bestiary/nihili.json
@@ -94,6 +94,9 @@
         },
         {
             "_id": "Ueu6RrR1U41Tzkdq",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.5PS5ESGpnQfJNOdg"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/blue-battery.webp",
             "name": "Battery (Tactical)",
@@ -109,7 +112,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -124,6 +128,7 @@
                     "type": null
                 },
                 "price": {
+                    "per": 1,
                     "value": {
                         "sp": 20
                     }
@@ -142,7 +147,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 20,
                     "value": 20
                 }

--- a/packs/sf2e/alien-core-bestiary/obrhinnshee.json
+++ b/packs/sf2e/alien-core-bestiary/obrhinnshee.json
@@ -49,6 +49,9 @@
         },
         {
             "_id": "qh0XSv8JXHXneNUp",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ahXTkKpQtOTAQOFm"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/equipment/weapons/heavy-gun.webp",
             "name": "Enhance Weapon",
@@ -109,6 +112,9 @@
         },
         {
             "_id": "bGqOWjoTbnaKf9tp",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.V1cojmrEOWkJ1yPF"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-emblem.webp",
             "name": "Glow Up",
@@ -171,6 +177,9 @@
         },
         {
             "_id": "HXeF9VMUJ13Ju02d",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Qw3fnUlaUbnn7ipC"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/symbols/runes-triangle-blue.webp",
             "name": "Prestidigitation",
@@ -199,7 +208,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "10 feet"
@@ -232,6 +241,9 @@
         },
         {
             "_id": "5NUHWddpksJ7XF9v",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.t0oFlhMhNOHbb6rG"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/blue-emblem-generic.webp",
             "name": "Reorient",
@@ -292,6 +304,9 @@
         },
         {
             "_id": "fy3seRXp6aRdXR2e",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.SnjhtQYexDtNDdEg"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/control/debuff-energy-hold-yellow.webp",
             "name": "Stabilize",
@@ -320,7 +335,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -353,6 +368,9 @@
         },
         {
             "_id": "9m6ONmZF6QDzEYyG",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.kcelf6IHl3L9VXXg"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/death/undead-skeleton-fire-green.webp",
             "name": "Vitality Lash",
@@ -404,7 +422,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -436,6 +454,9 @@
         },
         {
             "_id": "XVmphkE5HkEIpfOy",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Sqo1uzSmebVWpqoT"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-comet-swirling.webp",
             "name": "Wisp Ally",

--- a/packs/sf2e/alien-core-bestiary/observer-class-security-robot.json
+++ b/packs/sf2e/alien-core-bestiary/observer-class-security-robot.json
@@ -95,6 +95,9 @@
         },
         {
             "_id": "oxmyD6QhefQtDzX6",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -110,7 +113,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -144,7 +148,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 10,
                     "value": 10
                 }

--- a/packs/sf2e/alien-core-bestiary/oma.json
+++ b/packs/sf2e/alien-core-bestiary/oma.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "gzFe9m1McoQ3n47k",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.TDNlDWbYb58Y55Da"
+            },
             "folder": "zDlxATrLAlbYA2Mv",
             "img": "systems/sf2e/icons/spells/chain-lightning.webp",
             "name": "Chain Lightning",
@@ -96,7 +99,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -127,6 +130,9 @@
         },
         {
             "_id": "Xj21VcafYQ0gE5hW",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5cMDrC3jX1yrxOzh"
+            },
             "folder": "NQpcS2TwtjNNq1Qy",
             "img": "systems/sf2e/icons/abilities/blue-heroic-lightning-symbol.webp",
             "name": "Overload Systems",
@@ -214,6 +220,9 @@
         },
         {
             "_id": "taIth3t19choGbKA",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.rBh2PjtbDGAjbcu6"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/equipment/other/yellow-battery.webp",
             "name": "Discharge",

--- a/packs/sf2e/alien-core-bestiary/omnipath.json
+++ b/packs/sf2e/alien-core-bestiary/omnipath.json
@@ -41,6 +41,9 @@
         },
         {
             "_id": "Al6w7o6MWANMEPuB",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.64DDZxOrmr4ddqs2"
+            },
             "folder": "DWZvpqhX0tWHYZOh",
             "img": "systems/sf2e/icons/abilities/yellow-fist.webp",
             "name": "Telekinetic Tantrum",
@@ -108,6 +111,9 @@
         },
         {
             "_id": "MeiFIg4iqoZeKGgG",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.f98vwzcdxafum8ln"
+            },
             "folder": "uIyg7rfbXLT1OSXC",
             "img": "systems/sf2e/icons/abilities/blue-energy-alien-hand.webp",
             "name": "Akashic Revival",
@@ -158,6 +164,7 @@
                     ],
                     "value": [
                         "concentrate",
+                        "exploration",
                         "manipulate"
                     ]
                 }
@@ -166,6 +173,9 @@
         },
         {
             "_id": "k9AQvoIpdTXzsn06",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.wfleiawxsfhpRRwf"
+            },
             "folder": "IfuYSF4ymX48CZnm",
             "img": "systems/sf2e/icons/spells/disapperance.webp",
             "name": "Disappearance",
@@ -195,7 +205,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -226,6 +236,9 @@
         },
         {
             "_id": "L7xt6sj6Sc6RrrQh",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Y3egStSTzL8k86qc"
+            },
             "folder": "uIyg7rfbXLT1OSXC",
             "img": "systems/sf2e/icons/abilities/spaceship-thruster.webp",
             "name": "Phantasmal Fleet",
@@ -306,6 +319,9 @@
         },
         {
             "_id": "6kpaCDWrwtqBuWcB",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5bTt2CvYHPvaR7QQ"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "icons/magic/lightning/bolt-strike-explosion-purple.webp",
             "name": "Interplanar Teleport",
@@ -335,7 +351,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "5 feet"
@@ -368,6 +384,9 @@
         },
         {
             "_id": "UpyDQrWKJec4tOqG",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.8kJbiBEjMWG4VUjs"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "systems/sf2e/icons/spells/warp-mind.webp",
             "name": "Warp Mind",
@@ -402,7 +421,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -435,6 +454,9 @@
         },
         {
             "_id": "iZIdGg0CthY8wHOM",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.OsOhx3TGIZ7AhD0P"
+            },
             "folder": "zDlxATrLAlbYA2Mv",
             "img": "systems/sf2e/icons/spells/dominate.webp",
             "name": "Dominate",
@@ -473,7 +495,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -506,6 +528,9 @@
         },
         {
             "_id": "9gjdIERe6ZTdyM3Q",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.OudLZtxmg6gI1UEL"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/alien-mask.webp",
             "name": "Telekinetic Strangulation",
@@ -578,6 +603,9 @@
         },
         {
             "_id": "RMxHhPgvOKfdXZo4",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.DPP4TW5FxE85XPKZ"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/blue-piercing-energy.webp",
             "name": "X-Ray Vision",
@@ -638,6 +666,9 @@
         },
         {
             "_id": "NChlkyJGsnEROapb",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.7WtiWJRYZhT6a9Ey"
+            },
             "folder": "NQpcS2TwtjNNq1Qy",
             "img": "systems/sf2e/icons/abilities/purple-tentacle.webp",
             "name": "Control Machine",
@@ -703,6 +734,9 @@
         },
         {
             "_id": "dWWGjrYdzYy4qeww",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5cMDrC3jX1yrxOzh"
+            },
             "folder": "NQpcS2TwtjNNq1Qy",
             "img": "systems/sf2e/icons/abilities/blue-heroic-lightning-symbol.webp",
             "name": "Overload Systems",
@@ -790,6 +824,9 @@
         },
         {
             "_id": "lsBq1zbKbIJYbkP2",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jyrxfWeeCsrkhNit"
+            },
             "folder": "NuBKgFiv0GJhsx3c",
             "img": "icons/magic/unholy/beam-ringed-impact-purple.webp",
             "name": "Eldritch Wrath",
@@ -881,6 +918,9 @@
         },
         {
             "_id": "rL27vx37roq9ZvuP",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.7Ib3qxIC0bFD3ued"
+            },
             "folder": "NuBKgFiv0GJhsx3c",
             "img": "icons/magic/time/clock-stopwatch-white-blue.webp",
             "name": "Weight of Ages",
@@ -975,6 +1015,9 @@
         },
         {
             "_id": "YRJEYTcbZ33Mh39p",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.qkehzRdn7JeGrR6E"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/alien-skull.webp",
             "name": "Void Whispers",
@@ -1047,6 +1090,9 @@
         },
         {
             "_id": "PHkgY3f49AItxWz1",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ijlB3l9IBnpppfK0"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/yellow-warning-sign.webp",
             "name": "Logic Bomb",
@@ -1131,6 +1177,9 @@
         },
         {
             "_id": "WRdTxSVMeOoJgD00",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.v2S6tlilNbA4uGdM"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/blue-circuit-board.webp",
             "name": "Skim Data (at will)",
@@ -1190,6 +1239,9 @@
         },
         {
             "_id": "mrz27EUPPuL5Wh9B",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VynaowCerc7B4yvI"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/sundries/books/book-embossed-jewel-silver-green.webp",
             "name": "Akashic Download",
@@ -1248,6 +1300,9 @@
         },
         {
             "_id": "3Sm9yx0KGPUxSOgj",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.NkvRoN33RbDg3fl9"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/pink-target-sign.webp",
             "name": "Analyze Target",
@@ -1261,7 +1316,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The circumstance bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The circumstance bonus increases to +3, and you can target any number of creatures.</p>"
+                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The status bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The status bonus increases to +3, and you can target any number of creatures.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -1310,6 +1365,9 @@
         },
         {
             "_id": "YHPBTV5Ucc7NLSGD",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.yXD9uU8w8uFD2OBQ"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/cerulean-circular-sign.webp",
             "name": "Delete",
@@ -1369,6 +1427,9 @@
         },
         {
             "_id": "HnxfLZBHm3kyPQS1",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ZBeKxBcUOsXrfMRo"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/purple-insignia.webp",
             "name": "Implant Data",
@@ -1428,6 +1489,9 @@
         },
         {
             "_id": "YIwB3EHWQhVQ3Zg3",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uBo6g5aW087cLSJR"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/magic/light/explosion-impact-purple.webp",
             "name": "Mind Skewer",

--- a/packs/sf2e/alien-core-bestiary/ordinance-class-civil-robot.json
+++ b/packs/sf2e/alien-core-bestiary/ordinance-class-civil-robot.json
@@ -4,6 +4,9 @@
     "items": [
         {
             "_id": "VpbFifzO3fj7e0uS",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.vpjJYIgYZab0UZFa"
+            },
             "folder": "V89RPpe7fyCFC6NS",
             "img": "systems/sf2e/icons/equipment/weapons/metal-sci-fi-gun.webp",
             "name": "Integrated Commercial Pulsecaster Pistol",

--- a/packs/sf2e/alien-core-bestiary/ordinance-class-civil-robot.json
+++ b/packs/sf2e/alien-core-bestiary/ordinance-class-civil-robot.json
@@ -95,6 +95,9 @@
         },
         {
             "_id": "Rq7MMne4lALN8kKK",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.cjOdJfGUs5IDw8Pi"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/flashlight-yellow.webp",
             "name": "Flashlight (Commercial)",
@@ -110,6 +113,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -173,6 +177,9 @@
         },
         {
             "_id": "oImfSd4iHrCDPZEC",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.s1vB3HdXjMigYAnY"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/med-pack.webp",
             "name": "Medkit (Commercial)",
@@ -188,6 +195,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -228,6 +236,9 @@
         },
         {
             "_id": "JxnEVd0RCX0gfWnV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -243,7 +254,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -277,7 +289,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 10,
                     "value": 10
                 }
@@ -286,6 +298,9 @@
         },
         {
             "_id": "TkN0esjJ0uMF9Stm",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -301,7 +316,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -335,7 +351,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 10,
                     "value": 10
                 }

--- a/packs/sf2e/alien-core-bestiary/orocoran.json
+++ b/packs/sf2e/alien-core-bestiary/orocoran.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "fJQBb8RgRHpdI0MJ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.41TZEjhO6D1nWw2X"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/augury.webp",
             "name": "Augury",
@@ -72,7 +75,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -103,6 +106,9 @@
         },
         {
             "_id": "TtkQbXgS3ta0w0Yi",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4gBIw4IDrSfFHik4"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/daze.webp",
             "name": "Daze",
@@ -154,7 +160,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "60 feet"

--- a/packs/sf2e/alien-core-bestiary/oscriss.json
+++ b/packs/sf2e/alien-core-bestiary/oscriss.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "JbmDKuZC15yvzyQh",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.0pl80qKToraH4dvO"
+            },
             "folder": "2cuzA13JVJ0A8JrW",
             "img": "systems/sf2e/icons/abilities/purple-energy-star.webp",
             "name": "Event Horizon",
@@ -131,6 +134,9 @@
         },
         {
             "_id": "BWFka6nWWyN9ULrS",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.a02hsymtiVRQvh3i"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/purple-eruption.webp",
             "name": "Slice Reality",
@@ -216,6 +222,9 @@
         },
         {
             "_id": "vnQOQT3IokWW4rpS",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.a02hsymtiVRQvh3i"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/purple-eruption.webp",
             "name": "Slice Reality (At Will)",
@@ -301,6 +310,9 @@
         },
         {
             "_id": "RSxa7nAiNrUTOSV2",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uqlxMQQeSGWEVjki"
+            },
             "folder": "zDlxATrLAlbYA2Mv",
             "img": "systems/sf2e/icons/spells/true-seeing.webp",
             "name": "Truesight (Constant)",
@@ -330,7 +342,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -363,6 +375,9 @@
         },
         {
             "_id": "HFZqrX6R4oU6jBsf",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VlNcjmYyu95vOUe8"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/magic/symbols/ring-circle-smoke-blue.webp",
             "name": "Translocate (At Will)",
@@ -402,7 +417,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"

--- a/packs/sf2e/alien-core-bestiary/paradox-17.json
+++ b/packs/sf2e/alien-core-bestiary/paradox-17.json
@@ -41,6 +41,9 @@
         },
         {
             "_id": "pQSJPWty1nqQXxiZ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.0pl80qKToraH4dvO"
+            },
             "folder": "2cuzA13JVJ0A8JrW",
             "img": "systems/sf2e/icons/abilities/purple-energy-star.webp",
             "name": "Event Horizon",
@@ -129,6 +132,9 @@
         },
         {
             "_id": "pwGDMxhnPWrX1G6m",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.UG0SmRYSdbrx2rTA"
+            },
             "folder": "x5tjEh1N0FHzbHkv",
             "img": "systems/sf2e/icons/spells/indestructibility.webp",
             "name": "Indestructibility",
@@ -158,7 +164,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -190,6 +196,9 @@
         },
         {
             "_id": "PMvDmmzaBjS8gDwn",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4WS7HrFjwNvTn8T2"
+            },
             "folder": "fi1AYNmuCRvoT15b",
             "img": "systems/sf2e/icons/spells/implosion.webp",
             "name": "Implosion",
@@ -242,7 +251,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -272,6 +281,9 @@
         },
         {
             "_id": "DJzH6cbUJSdJAd4t",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.a02hsymtiVRQvh3i"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/purple-eruption.webp",
             "name": "Slice Reality",
@@ -357,6 +369,9 @@
         },
         {
             "_id": "JKwSIJZU6bgO4IG8",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.SwUiVavHKMWG7t5K"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/tongues.webp",
             "name": "Truespeech (constant)",
@@ -386,7 +401,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -417,6 +432,9 @@
         },
         {
             "_id": "I58e1fSiUS7cPyTZ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.kTzbLqmqPcZwOa5F"
+            },
             "folder": "NQpcS2TwtjNNq1Qy",
             "img": "systems/sf2e/icons/abilities/yellow-warning-sign.webp",
             "name": "Wave of Warning",

--- a/packs/sf2e/alien-core-bestiary/paradoxical-solipsist.json
+++ b/packs/sf2e/alien-core-bestiary/paradoxical-solipsist.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "AM6Vv67yaSiub6l3",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.CptKtBneM7od45nc"
+            },
             "folder": "NQpcS2TwtjNNq1Qy",
             "img": "systems/sf2e/icons/abilities/blue-hex-field-dispersed.webp",
             "name": "Subjective Reality",
@@ -102,6 +105,9 @@
         },
         {
             "_id": "o2lJTMJYqcsGX0sa",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.qwlh6aDgi86U3Q7H"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "systems/sf2e/icons/spells/suggestion.webp",
             "name": "Suggestion",
@@ -146,7 +152,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -180,6 +186,9 @@
         },
         {
             "_id": "kg8knpfVXrEPSGi9",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VlNcjmYyu95vOUe8"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/magic/symbols/ring-circle-smoke-blue.webp",
             "name": "Translocate",
@@ -219,7 +228,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -250,6 +259,9 @@
         },
         {
             "_id": "5NF7hiHsJDBULkKv",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.b515AZlB0sridKSq"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/creatures/abilities/wolf-heads-swirl-purple.webp",
             "name": "Calm",
@@ -287,7 +299,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -320,6 +332,9 @@
         },
         {
             "_id": "SU78pb6xafKpTFjS",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.wRNRWwCEbmSxbHDl"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/yellow-person-silhouette.webp",
             "name": "Vibe Check",
@@ -396,6 +411,9 @@
         },
         {
             "_id": "4QeRC8f2Jq7nMXqV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Sqo1uzSmebVWpqoT"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-comet-swirling.webp",
             "name": "Wisp Ally",

--- a/packs/sf2e/alien-core-bestiary/paradoxical-solipsist.json
+++ b/packs/sf2e/alien-core-bestiary/paradoxical-solipsist.json
@@ -479,12 +479,18 @@
         },
         {
             "_id": "XsZCnfGsWqJQTV8e",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.yJYorlEvJLSxc3VS"
+            },
             "folder": "1zLXGqhSgBIthlcs",
             "img": "systems/sf2e/icons/equipment/weapons/grenade-canister.webp",
             "name": "Flash Grenade (Advanced)",
             "sort": 800000,
             "system": {
-                "ammo": null,
+                "ammo": {
+                    "baseType": null,
+                    "builtIn": false
+                },
                 "baseItem": "grenade",
                 "bonus": {
                     "value": 0
@@ -524,9 +530,6 @@
                 },
                 "price": {
                     "value": {
-                        "cp": 0,
-                        "gp": 0,
-                        "pp": 0,
                         "sp": 120
                     }
                 },
@@ -562,6 +565,7 @@
                     ]
                 },
                 "usage": {
+                    "canBeAmmo": false,
                     "value": "held-in-one-hand"
                 }
             },
@@ -748,6 +752,9 @@
         },
         {
             "_id": "YvTLnw12B3gmDAFn",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.dnv1OFVU6BpyfAWi"
+            },
             "folder": "jjcF0lfrc3ZIoKv1",
             "img": "systems/sf2e/icons/equipment/armor/heavy-helmet.webp",
             "name": "Flight Suit",
@@ -818,6 +825,9 @@
         },
         {
             "_id": "e4NjtVroWiIHSBR0",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.5PS5ESGpnQfJNOdg"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/blue-battery.webp",
             "name": "Battery (Tactical)",
@@ -833,7 +843,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -848,6 +859,7 @@
                     "type": null
                 },
                 "price": {
+                    "per": 1,
                     "value": {
                         "sp": 20
                     }
@@ -866,7 +878,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 20,
                     "value": 20
                 }
@@ -875,6 +887,9 @@
         },
         {
             "_id": "yvKdbQg52mF0mydK",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.5PS5ESGpnQfJNOdg"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/blue-battery.webp",
             "name": "Battery (Tactical)",
@@ -890,7 +905,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -905,6 +921,7 @@
                     "type": null
                 },
                 "price": {
+                    "per": 1,
                     "value": {
                         "sp": 20
                     }
@@ -923,7 +940,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 20,
                     "value": 20
                 }

--- a/packs/sf2e/alien-core-bestiary/presulea-midwife.json
+++ b/packs/sf2e/alien-core-bestiary/presulea-midwife.json
@@ -41,6 +41,9 @@
         },
         {
             "_id": "lgYygHA262qdaNiZ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.HPHr5aoLMH4eVwaw"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/yellow-hand.webp",
             "name": "Soul Surge",
@@ -121,6 +124,9 @@
         },
         {
             "_id": "Z1JRvxFJV5tBerzF",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.hk2mTLH9DIvNqDuS"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "icons/magic/nature/root-vine-thorned-pink.webp",
             "name": "Verdant Code",
@@ -201,6 +207,9 @@
         },
         {
             "_id": "5dn7vK3rEkgjbi1T",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.QiW8VNdBf0SFUq69"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-dna-helix.webp",
             "name": "Cellular Stimulant",
@@ -271,6 +280,9 @@
         },
         {
             "_id": "cVbADdqe1YUb2MOG",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.FEaM1B4WuiqFO7Uk"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "icons/magic/unholy/projectile-bolts-salvo-pink.webp",
             "name": "Eldritch Lance",
@@ -351,6 +363,9 @@
         },
         {
             "_id": "HUiZhlY7wjYSO5E2",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.rfZpqmj0AIIdkVIs"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/life/cross-worn-green.webp",
             "name": "Heal",
@@ -515,7 +530,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "varies"
@@ -546,6 +561,9 @@
         },
         {
             "_id": "zzgrEQGV3L1GGZye",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.t0oFlhMhNOHbb6rG"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/blue-emblem-generic.webp",
             "name": "Reorient",

--- a/packs/sf2e/alien-core-bestiary/protection-class-security-robot.json
+++ b/packs/sf2e/alien-core-bestiary/protection-class-security-robot.json
@@ -94,6 +94,9 @@
         },
         {
             "_id": "geFOxxfxea8KMafY",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.5PS5ESGpnQfJNOdg"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/blue-battery.webp",
             "name": "Battery (Tactical)",
@@ -109,7 +112,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -124,6 +128,7 @@
                     "type": null
                 },
                 "price": {
+                    "per": 1,
                     "value": {
                         "sp": 20
                     }
@@ -142,7 +147,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 20,
                     "value": 20
                 }

--- a/packs/sf2e/alien-core-bestiary/protection-class-security-robot.json
+++ b/packs/sf2e/alien-core-bestiary/protection-class-security-robot.json
@@ -4,6 +4,9 @@
     "items": [
         {
             "_id": "G9r0Ld4jTAcCGZUD",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0TSUahGsoVnDZ6kv"
+            },
             "folder": "V89RPpe7fyCFC6NS",
             "img": "systems/sf2e/icons/equipment/weapons/teal-sci-fi-gun.webp",
             "name": "Integrated Tactical Laser Rifle",

--- a/packs/sf2e/alien-core-bestiary/quyu.json
+++ b/packs/sf2e/alien-core-bestiary/quyu.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "wayQPOVoZ5ZDeUnh",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.vLA0q0WOK2YPuJs6"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/charm.webp",
             "name": "Charm",
@@ -88,7 +91,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"

--- a/packs/sf2e/alien-core-bestiary/sapient-green-orb.json
+++ b/packs/sf2e/alien-core-bestiary/sapient-green-orb.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "bsxTtaZUXkhHt30d",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.kR5A0h2a9hY41wav"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/purple-dimension-rift.webp",
             "name": "Entropy Strike",
@@ -164,6 +167,9 @@
         },
         {
             "_id": "LIdkdTZNAlG7GMwx",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.EhN3GjdjXChMdiFk"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/purple-neurons.webp",
             "name": "Share Pain",
@@ -201,7 +207,7 @@
                 },
                 "heightening": {
                     "levels": {
-                        "4": {
+                        "6": {
                             "damage": {
                                 "dIvEREAgyIVyanqT": {
                                     "applyMod": false,
@@ -251,7 +257,10 @@
                 },
                 "traits": {
                     "rarity": "common",
-                    "traditions": [],
+                    "traditions": [
+                        "divine",
+                        "occult"
+                    ],
                     "value": [
                         "concentrate",
                         "manipulate",
@@ -263,6 +272,9 @@
         },
         {
             "_id": "LMVydZCdr8em9upd",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.mrDi3v933gsmnw25"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/skills/melee/strike-weapon-polearm-ice-blue.webp",
             "name": "Telekinetic Maneuver",
@@ -292,7 +304,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "60 feet"
@@ -324,6 +336,9 @@
         },
         {
             "_id": "mlvDqoFR4LigwmgQ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.vTQvfYu2llKQedmY"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/comprehend-language.webp",
             "name": "Translate",
@@ -367,7 +382,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -398,6 +413,9 @@
         },
         {
             "_id": "zEszalcXu6yLGPb8",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4gBIw4IDrSfFHik4"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/daze.webp",
             "name": "Daze",
@@ -449,7 +467,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "60 feet"
@@ -483,6 +501,9 @@
         },
         {
             "_id": "QibSHibEiDqLP5TJ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.0zU8CPejjQFnhZFI"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/ghost-sound.webp",
             "name": "Figment",
@@ -511,7 +532,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -544,6 +565,9 @@
         },
         {
             "_id": "qgUrAIMIUAqISygu",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uBo6g5aW087cLSJR"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/magic/light/explosion-impact-purple.webp",
             "name": "Mind Skewer",
@@ -628,6 +652,9 @@
         },
         {
             "_id": "kKKnM2ligvY0cuFR",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.3VucgRc8FRPGy9NI"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/yellow-star-with-purple-aura.webp",
             "name": "Seek the Stars",
@@ -688,6 +715,9 @@
         },
         {
             "_id": "HrFLGpjVkc2HLHf8",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.pwzdSlJgYqN7bs2w"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/mage-hand.webp",
             "name": "Telekinetic Hand",
@@ -736,7 +766,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -767,6 +797,9 @@
         },
         {
             "_id": "111aK9ybES7y6A8B",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.60sgbuMWN0268dB7"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/skills/ranged/bullets-triple-ball-yellow.webp",
             "name": "Telekinetic Projectile",
@@ -820,9 +853,13 @@
                             "damage": {
                                 "0": {
                                     "category": null,
+                                    "kinds": [
+                                        "damage"
+                                    ],
                                     "type": "bludgeoning"
                                 }
-                            }
+                            },
+                            "defense": null
                         }
                     },
                     "cUFX7ExSLeoa3vIF": {
@@ -834,9 +871,13 @@
                             "damage": {
                                 "0": {
                                     "category": null,
+                                    "kinds": [
+                                        "damage"
+                                    ],
                                     "type": "piercing"
                                 }
-                            }
+                            },
+                            "defense": null
                         }
                     },
                     "zFWsMjoeCnLxqJaV": {
@@ -848,16 +889,20 @@
                             "damage": {
                                 "0": {
                                     "category": null,
+                                    "kinds": [
+                                        "damage"
+                                    ],
                                     "type": "slashing"
                                 }
-                            }
+                            },
+                            "defense": null
                         }
                     }
                 },
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"

--- a/packs/sf2e/alien-core-bestiary/sapient-purple-orb.json
+++ b/packs/sf2e/alien-core-bestiary/sapient-purple-orb.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "hSMtIQk6750f3gkJ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.mrDi3v933gsmnw25"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/skills/melee/strike-weapon-polearm-ice-blue.webp",
             "name": "Telekinetic Maneuver",
@@ -73,7 +76,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "60 feet"
@@ -105,6 +108,9 @@
         },
         {
             "_id": "t6bDVpXwR6grcxv7",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.vTQvfYu2llKQedmY"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/comprehend-language.webp",
             "name": "Translate",
@@ -148,7 +154,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -179,6 +185,9 @@
         },
         {
             "_id": "hxvejmvmb98b7PEN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4gBIw4IDrSfFHik4"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/daze.webp",
             "name": "Daze",
@@ -230,7 +239,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "60 feet"
@@ -264,6 +273,9 @@
         },
         {
             "_id": "sPhqT6L7l7ubgb6z",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.0zU8CPejjQFnhZFI"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/ghost-sound.webp",
             "name": "Figment",
@@ -292,7 +304,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -325,6 +337,9 @@
         },
         {
             "_id": "VllBUCBoCbd6yTaV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uBo6g5aW087cLSJR"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/magic/light/explosion-impact-purple.webp",
             "name": "Mind Skewer",
@@ -409,6 +424,9 @@
         },
         {
             "_id": "wnylzvYxaWUi8yJ3",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.3VucgRc8FRPGy9NI"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/yellow-star-with-purple-aura.webp",
             "name": "Seek the Stars",
@@ -469,6 +487,9 @@
         },
         {
             "_id": "0vW1zTIAsNHU8fdm",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.szIyEsvihc5e1w8n"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/air/air-burst-spiral-teal-green.webp",
             "name": "Soothe",
@@ -520,7 +541,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -552,6 +573,9 @@
         },
         {
             "_id": "sLxKG5QPzFkfBycv",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.pwzdSlJgYqN7bs2w"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/mage-hand.webp",
             "name": "Telekinetic Hand",
@@ -600,7 +624,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -631,6 +655,9 @@
         },
         {
             "_id": "FpovVZYAGtWva1VZ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.60sgbuMWN0268dB7"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/skills/ranged/bullets-triple-ball-yellow.webp",
             "name": "Telekinetic Projectile",
@@ -684,9 +711,13 @@
                             "damage": {
                                 "0": {
                                     "category": null,
+                                    "kinds": [
+                                        "damage"
+                                    ],
                                     "type": "bludgeoning"
                                 }
-                            }
+                            },
+                            "defense": null
                         }
                     },
                     "cUFX7ExSLeoa3vIF": {
@@ -698,9 +729,13 @@
                             "damage": {
                                 "0": {
                                     "category": null,
+                                    "kinds": [
+                                        "damage"
+                                    ],
                                     "type": "piercing"
                                 }
-                            }
+                            },
+                            "defense": null
                         }
                     },
                     "zFWsMjoeCnLxqJaV": {
@@ -712,16 +747,20 @@
                             "damage": {
                                 "0": {
                                     "category": null,
+                                    "kinds": [
+                                        "damage"
+                                    ],
                                     "type": "slashing"
                                 }
-                            }
+                            },
+                            "defense": null
                         }
                     }
                 },
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"

--- a/packs/sf2e/alien-core-bestiary/scrap-rat.json
+++ b/packs/sf2e/alien-core-bestiary/scrap-rat.json
@@ -4,12 +4,18 @@
     "items": [
         {
             "_id": "IlPI1DbLpJy8dGxw",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.SzGr78zdpnnrorre"
+            },
             "folder": "1zLXGqhSgBIthlcs",
             "img": "systems/sf2e/icons/equipment/weapons/grenade-hand.webp",
             "name": "Frag Grenade (Commercial)",
             "sort": 100000,
             "system": {
-                "ammo": null,
+                "ammo": {
+                    "baseType": null,
+                    "builtIn": false
+                },
                 "baseItem": "grenade",
                 "bonus": {
                     "value": 0

--- a/packs/sf2e/alien-core-bestiary/shipbreaker.json
+++ b/packs/sf2e/alien-core-bestiary/shipbreaker.json
@@ -4,6 +4,9 @@
     "items": [
         {
             "_id": "EHLhQE0VVHKW0ZUv",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.eMNjuin4r6DivIsI"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/yellow-battery.webp",
             "name": "Battery (Advanced)",
@@ -19,7 +22,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -53,7 +57,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 40,
                     "value": 40
                 }

--- a/packs/sf2e/alien-core-bestiary/sihedron-guard-specialist.json
+++ b/packs/sf2e/alien-core-bestiary/sihedron-guard-specialist.json
@@ -1233,12 +1233,18 @@
         },
         {
             "_id": "zJDkvPqldJ2h66My",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.nW1ZJKG81d9I3mAA"
+            },
             "folder": "1zLXGqhSgBIthlcs",
             "img": "systems/sf2e/icons/equipment/weapons/grenade-chemical.webp",
             "name": "Electromag Grenade (Advanced)",
             "sort": 1600000,
             "system": {
-                "ammo": null,
+                "ammo": {
+                    "baseType": null,
+                    "builtIn": false
+                },
                 "baseItem": "grenade",
                 "bonus": {
                     "value": 0
@@ -1387,6 +1393,9 @@
         },
         {
             "_id": "23xVGHEFd406l9yf",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0Hdg9aWMIYVGjvj0"
+            },
             "folder": "7JvVdcPLRxEK9sec",
             "img": "systems/sf2e/icons/abilities/blue-energy-streak.webp",
             "name": "Shock Module (Commercial)",
@@ -1398,10 +1407,11 @@
                 },
                 "containerId": null,
                 "description": {
-                    "value": "<p>This circuit safely courses electricity through your weapon. It deals an extra @Damage[1d6[electricity]] damage. On a critical hit, electricity arcs out to deal an equal amount of electricity damage to up to two other creatures of your choice within 10 feet of the target.</p>"
+                    "value": "<p>This circuit safely courses electricity through your weapon. It deals an extra 1d6 electricity damage. On a critical hit, electricity arcs out to deal an equal amount of electricity damage to up to two other creatures of your choice within 10 feet of the target.</p>"
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -1427,7 +1437,24 @@
                     "title": "Starfinder Player Core"
                 },
                 "quantity": 1,
-                "rules": [],
+                "rules": [
+                    {
+                        "damageType": "electricity",
+                        "diceNumber": 1,
+                        "dieSize": "d6",
+                        "key": "DamageDice",
+                        "selector": "{item|parentItem.id}-damage"
+                    },
+                    {
+                        "key": "Note",
+                        "outcome": [
+                            "criticalSuccess"
+                        ],
+                        "selector": "{item|parentItem.id}-damage",
+                        "text": "SF2E.SpecificRule.Equipment.Upgrades.Weapon.ShockModule.CriticalNote",
+                        "title": "SF2E.SpecificRule.Equipment.Upgrades.Weapon.ShockModule.LabelCommercial"
+                    }
+                ],
                 "size": "med",
                 "slug": "shock-module-commercial",
                 "traits": {
@@ -1439,13 +1466,16 @@
                     ]
                 },
                 "usage": {
-                    "value": "other"
+                    "value": "installed-in-a-weapon"
                 }
             },
             "type": "equipment"
         },
         {
             "_id": "iBLny7sDGnFQImLy",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.kFfYq4ONuKMgISRi"
+            },
             "folder": "JlUS4L43QWp3cPhu",
             "img": "icons/commodities/gems/gem-faceted-diamond-blue.webp",
             "name": "Aeon Stone (Uplifting)",
@@ -1461,6 +1491,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -1511,6 +1542,9 @@
         },
         {
             "_id": "78pIy4cj633wFDRP",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.7psnMwQ95uO5apQz"
+            },
             "folder": "cTmXSS0L1MClVGP3",
             "img": "systems/sf2e/icons/abilities/purple-third-eye.webp",
             "name": "Darkvision Visor",
@@ -1526,6 +1560,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -1566,13 +1601,16 @@
                     ]
                 },
                 "usage": {
-                    "value": "other"
+                    "value": "installed-in-armor"
                 }
             },
             "type": "equipment"
         },
         {
             "_id": "0WehVWuky4urM09p",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.5PS5ESGpnQfJNOdg"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/blue-battery.webp",
             "name": "Battery (Tactical)",
@@ -1588,7 +1626,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -1603,6 +1642,7 @@
                     "type": null
                 },
                 "price": {
+                    "per": 1,
                     "value": {
                         "sp": 20
                     }
@@ -1621,7 +1661,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 20,
                     "value": 20
                 }

--- a/packs/sf2e/alien-core-bestiary/sihedron-guard-specialist.json
+++ b/packs/sf2e/alien-core-bestiary/sihedron-guard-specialist.json
@@ -102,6 +102,9 @@
         },
         {
             "_id": "fWwM3AgnmOo74Xfw",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.a02hsymtiVRQvh3i"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/purple-eruption.webp",
             "name": "Slice Reality",
@@ -186,6 +189,9 @@
         },
         {
             "_id": "KDuX4u61tTHdt3TK",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.PHVHBbdHeQRfjLmE"
+            },
             "folder": "zDlxATrLAlbYA2Mv",
             "img": "systems/sf2e/icons/spells/spiritual-blast.webp",
             "name": "Spirit Blast",
@@ -237,7 +243,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -268,6 +274,9 @@
         },
         {
             "_id": "fvz66jDVLc2ye9OB",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.IqJ9URobmJ9L9UBG"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "icons/magic/unholy/beam-impact-purple.webp",
             "name": "Shadow Blast",
@@ -334,7 +343,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "varies"
@@ -365,6 +374,9 @@
         },
         {
             "_id": "fe5CzEsZBZWuoJTL",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.kTzbLqmqPcZwOa5F"
+            },
             "folder": "NQpcS2TwtjNNq1Qy",
             "img": "systems/sf2e/icons/abilities/yellow-warning-sign.webp",
             "name": "Wave of Warning",
@@ -513,6 +525,9 @@
         },
         {
             "_id": "xsN9MY6OvK2YEfPi",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.hVU9msO9yGkxKZ3J"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/magic/light/projectile-beam-yellow.webp",
             "name": "Divine Wrath",
@@ -569,7 +584,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -600,6 +615,9 @@
         },
         {
             "_id": "v78ElgH0BnzWWP5W",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.7Ib3qxIC0bFD3ued"
+            },
             "folder": "NuBKgFiv0GJhsx3c",
             "img": "icons/magic/time/clock-stopwatch-white-blue.webp",
             "name": "Weight of Ages",
@@ -693,6 +711,9 @@
         },
         {
             "_id": "66kbvpuBDEr0Nl8h",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.NkvRoN33RbDg3fl9"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/pink-target-sign.webp",
             "name": "Analyze Target",
@@ -706,7 +727,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The circumstance bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The circumstance bonus increases to +3, and you can target any number of creatures.</p>"
+                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The status bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The status bonus increases to +3, and you can target any number of creatures.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -755,6 +776,9 @@
         },
         {
             "_id": "AoiKFHWgwVqcpHuQ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -771,7 +795,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -786,7 +810,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -820,6 +844,9 @@
         },
         {
             "_id": "DLqwOOnUFo6tgfig",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.qwZBXN6zBoB9BHXE"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/divine-lance.webp",
             "name": "Divine Lance",
@@ -867,7 +894,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "60 feet"
@@ -900,6 +927,9 @@
         },
         {
             "_id": "LokExv58arhN7skY",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5y70IWhVV6bVjC9N"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-battery-gauge.webp",
             "name": "Recharge Weapon",
@@ -959,6 +989,9 @@
         },
         {
             "_id": "rhFKOroNdkYEfTtv",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.AUctDF2fqPZN2w4W"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/sigil.webp",
             "name": "Sigil",
@@ -987,7 +1020,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"

--- a/packs/sf2e/alien-core-bestiary/sihedron-guard-thunderstriker.json
+++ b/packs/sf2e/alien-core-bestiary/sihedron-guard-thunderstriker.json
@@ -1228,12 +1228,18 @@
         },
         {
             "_id": "xpL6rta45F9xy2PO",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.BmJARyq7RrMXQezF"
+            },
             "folder": "1zLXGqhSgBIthlcs",
             "img": "systems/sf2e/icons/equipment/weapons/grenade-hand.webp",
             "name": "Frag Grenade (Tactical)",
             "sort": 1600000,
             "system": {
-                "ammo": null,
+                "ammo": {
+                    "baseType": null,
+                    "builtIn": false
+                },
                 "baseItem": "grenade",
                 "bonus": {
                     "value": 0
@@ -1273,9 +1279,6 @@
                 },
                 "price": {
                     "value": {
-                        "cp": 0,
-                        "gp": 0,
-                        "pp": 0,
                         "sp": 80
                     }
                 },
@@ -1404,6 +1407,9 @@
         },
         {
             "_id": "GYgXPdNGqcTSFPnT",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.GmdWyq6QB9n1DHxi"
+            },
             "folder": "7JvVdcPLRxEK9sec",
             "img": "systems/sf2e/icons/abilities/red-bullets-in-flight.webp",
             "name": "Undermounted Grenade Launcher (Tactical)",
@@ -1419,6 +1425,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -1454,7 +1461,7 @@
                     ]
                 },
                 "usage": {
-                    "value": "other"
+                    "value": "installed-in-two-handed-weapon"
                 }
             },
             "type": "equipment"
@@ -1626,6 +1633,9 @@
         },
         {
             "_id": "sROxBj5iuBczBlIw",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.5PS5ESGpnQfJNOdg"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/blue-battery.webp",
             "name": "Battery (Tactical)",
@@ -1641,7 +1651,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -1656,6 +1667,7 @@
                     "type": null
                 },
                 "price": {
+                    "per": 1,
                     "value": {
                         "sp": 20
                     }
@@ -1674,7 +1686,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 20,
                     "value": 20
                 }

--- a/packs/sf2e/alien-core-bestiary/sihedron-guard-thunderstriker.json
+++ b/packs/sf2e/alien-core-bestiary/sihedron-guard-thunderstriker.json
@@ -41,6 +41,9 @@
         },
         {
             "_id": "RpAvx2Yj9WtwiWhE",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.rBh2PjtbDGAjbcu6"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/equipment/other/yellow-battery.webp",
             "name": "Discharge",
@@ -106,6 +109,9 @@
         },
         {
             "_id": "8KEpTorRp4SZoz6m",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.kR5A0h2a9hY41wav"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/purple-dimension-rift.webp",
             "name": "Entropy Strike",
@@ -226,6 +232,9 @@
         },
         {
             "_id": "quZ36Jwx8hnSrNvI",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.9h9YCncqah6VNsKf"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/magic/acid/dissolve-arm-flesh.webp",
             "name": "Acid Grip",
@@ -278,7 +287,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -309,6 +318,9 @@
         },
         {
             "_id": "EAxrh6ZDlH9evjzq",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.3JG1t3T4mWn6vTke"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/blur.webp",
             "name": "Blur",
@@ -338,7 +350,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -370,6 +382,9 @@
         },
         {
             "_id": "98IWImrwoU9TMm7r",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.NkvRoN33RbDg3fl9"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/pink-target-sign.webp",
             "name": "Analyze Target",
@@ -383,7 +398,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The circumstance bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The circumstance bonus increases to +3, and you can target any number of creatures.</p>"
+                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The status bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The status bonus increases to +3, and you can target any number of creatures.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -432,6 +447,9 @@
         },
         {
             "_id": "QK6G7RwN5EBYWGjQ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.aIHY2DArKFweIrpf"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/command.webp",
             "name": "Command",
@@ -476,7 +494,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -510,6 +528,9 @@
         },
         {
             "_id": "kCCoSccKEfJYqKmw",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -526,7 +547,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -541,7 +562,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -575,6 +596,9 @@
         },
         {
             "_id": "gIgw11eH1Im7r2Oh",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Wu0xFpewMKRK3HG8"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/grease.webp",
             "name": "Grease",
@@ -609,7 +633,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -639,6 +663,9 @@
         },
         {
             "_id": "kB2oM4wIPl2GX7XN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.wOjoJjl2ndZKTuFJ"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/orange-timer-fire.webp",
             "name": "Overheat",
@@ -723,6 +750,9 @@
         },
         {
             "_id": "5IafHFbal0fKmSZ3",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.sXnWQOcGG2ELcxXb"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-galaxy.webp",
             "name": "Ricochet",
@@ -844,6 +874,9 @@
         },
         {
             "_id": "kQei4lYMGk88HnkX",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.TVKNbcgTee19PXZR"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/shield.webp",
             "name": "Shield",
@@ -872,7 +905,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -904,6 +937,9 @@
         },
         {
             "_id": "H4fRw5xJk9NW3DgF",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Gb7SeieEvd0pL2Eh"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/skills/melee/strike-blade-scimitar-gray-red.webp",
             "name": "Sure Strike",
@@ -933,7 +969,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -963,6 +999,9 @@
         },
         {
             "_id": "w9Y18ef3C8Vx5mRQ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.60sgbuMWN0268dB7"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/skills/ranged/bullets-triple-ball-yellow.webp",
             "name": "Telekinetic Projectile",
@@ -1016,9 +1055,13 @@
                             "damage": {
                                 "0": {
                                     "category": null,
+                                    "kinds": [
+                                        "damage"
+                                    ],
                                     "type": "bludgeoning"
                                 }
-                            }
+                            },
+                            "defense": null
                         }
                     },
                     "cUFX7ExSLeoa3vIF": {
@@ -1030,9 +1073,13 @@
                             "damage": {
                                 "0": {
                                     "category": null,
+                                    "kinds": [
+                                        "damage"
+                                    ],
                                     "type": "piercing"
                                 }
-                            }
+                            },
+                            "defense": null
                         }
                     },
                     "zFWsMjoeCnLxqJaV": {
@@ -1044,16 +1091,20 @@
                             "damage": {
                                 "0": {
                                     "category": null,
+                                    "kinds": [
+                                        "damage"
+                                    ],
                                     "type": "slashing"
                                 }
-                            }
+                            },
+                            "defense": null
                         }
                     }
                 },
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"

--- a/packs/sf2e/alien-core-bestiary/snoop-class-infiltrator-robot.json
+++ b/packs/sf2e/alien-core-bestiary/snoop-class-infiltrator-robot.json
@@ -4,6 +4,9 @@
     "items": [
         {
             "_id": "GalCqJK006J7qkuu",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.gwVhd31nGDXo5HAa"
+            },
             "folder": "V89RPpe7fyCFC6NS",
             "img": "icons/weapons/crossbows/crossbow-heavy-black.webp",
             "name": "Integrated Commercial Crossbolter",
@@ -94,6 +97,9 @@
         },
         {
             "_id": "hZ3JA43iAYqjtQkh",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.qqjDcCW118ySAlAS"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/battery-large.webp",
             "name": "Integrated Hacking Toolkit (Commercial)",
@@ -152,6 +158,9 @@
         },
         {
             "_id": "C5rq5TeKaVAHe1sx",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.coJUVZGcuVg3FoYh"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "icons/tools/hand/lockpicks-steel-grey.webp",
             "name": "Integrated Infiltrator's Toolkit (Commercial)",

--- a/packs/sf2e/alien-core-bestiary/snoop-class-infiltrator-robot.json
+++ b/packs/sf2e/alien-core-bestiary/snoop-class-infiltrator-robot.json
@@ -208,6 +208,9 @@
         },
         {
             "_id": "jbgiQekORJo0f6ra",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -223,7 +226,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/alien-core-bestiary/sterieid-queen.json
+++ b/packs/sf2e/alien-core-bestiary/sterieid-queen.json
@@ -101,6 +101,9 @@
         },
         {
             "_id": "fEED8GsMP4StKnlu",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.YIMampGpij4Y30yE"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "icons/commodities/stone/stone-porous-blue.webp",
             "name": "Speak with Stones",
@@ -130,7 +133,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -162,6 +165,9 @@
         },
         {
             "_id": "zeKxaR9Fs4HhmY3m",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.kOa055FIrO9Smnya"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "icons/commodities/stone/paver-brick-brown.webp",
             "name": "Wall of Stone",
@@ -191,7 +197,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -222,6 +228,9 @@
         },
         {
             "_id": "CiMDUrGPAE0sZMME",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.kTzbLqmqPcZwOa5F"
+            },
             "folder": "NQpcS2TwtjNNq1Qy",
             "img": "systems/sf2e/icons/abilities/yellow-warning-sign.webp",
             "name": "Wave of Warning",
@@ -309,6 +318,9 @@
         },
         {
             "_id": "kVM2lE4sMKJXBtMi",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.HAaRcHfN4g83eSEC"
+            },
             "folder": "NuBKgFiv0GJhsx3c",
             "img": "icons/magic/earth/construct-stone-long-arms.webp",
             "name": "Cairn Form",
@@ -370,6 +382,9 @@
         },
         {
             "_id": "FkM1qmv1CIYWDHj6",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.McnPlLFvKtQVXNcG"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "systems/sf2e/icons/spells/shape-stone.webp",
             "name": "Shape Stone",
@@ -404,7 +419,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -435,6 +450,9 @@
         },
         {
             "_id": "kbPOCHlliAsJvufV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gPvtmKMRpg9I9D7H"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/earth/barrier-stone-explosion-debris.webp",
             "name": "Earthbind",
@@ -469,7 +487,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -500,6 +518,9 @@
         },
         {
             "_id": "GVHZoJ126Xhn9nJa",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Cbj7tDkb2ZTp10Cg"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/blue-twin-lightning-streaks.webp",
             "name": "Electrotether",
@@ -582,6 +603,9 @@
         },
         {
             "_id": "aNyEenC5i28Sz9WN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ShwUELLERVMtdjwE"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/blue-heart-in-a-circle.webp",
             "name": "Life Seal",
@@ -640,6 +664,9 @@
         },
         {
             "_id": "vl1rZ0eQIBfSPZhh",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.vh1RpbWfqdNC4L3P"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/earth/strike-fist-stone-light.webp",
             "name": "One with Stone",
@@ -669,7 +696,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -701,6 +728,9 @@
         },
         {
             "_id": "sdjdEiQe0dcOiH3u",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.GB1RVtoFPwyH1B9G"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/green-acid-sprayer.webp",
             "name": "Caustic Conversion",
@@ -792,6 +822,9 @@
         },
         {
             "_id": "TRpLaQWtVvzSLhu7",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.1xbFBQDRs0hT5xZ9"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/skills/melee/shield-damaged-broken-gold.webp",
             "name": "Shatter",
@@ -839,7 +872,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -870,6 +903,9 @@
         },
         {
             "_id": "SZvgexD7yM0aed6w",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -886,7 +922,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -901,7 +937,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -935,6 +971,9 @@
         },
         {
             "_id": "Bn0qdl1cKUUP6fYc",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.V1cojmrEOWkJ1yPF"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-emblem.webp",
             "name": "Glow Up",
@@ -997,6 +1036,9 @@
         },
         {
             "_id": "GgNITxbm4jPmUth9",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.izcxFQFwf3woCnFs"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/guidance.webp",
             "name": "Guidance",
@@ -1025,7 +1067,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1056,6 +1098,9 @@
         },
         {
             "_id": "p2dYlQTGGk2ZQAJE",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Qw3fnUlaUbnn7ipC"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/symbols/runes-triangle-blue.webp",
             "name": "Prestidigitation",
@@ -1084,7 +1129,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "10 feet"
@@ -1117,6 +1162,9 @@
         },
         {
             "_id": "B4I0LGBJrYhkRhso",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Rn2LkoSq1XhLsODV"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/earth/projectiles-stone-salvo-gray.webp",
             "name": "Pummeling Rubble",
@@ -1173,7 +1221,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1204,6 +1252,9 @@
         },
         {
             "_id": "s6s5O0B9yhh0NDLA",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.nf8q0zvJDnnkzANe"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/blue-broadcast-signal.webp",
             "name": "Scan Environment",
@@ -1255,6 +1306,7 @@
                     "value": [
                         "cantrip",
                         "concentrate",
+                        "exploration",
                         "manipulate"
                     ]
                 }
@@ -1263,6 +1315,9 @@
         },
         {
             "_id": "WzukqRPTXPbzfK5Z",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.3VucgRc8FRPGy9NI"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/yellow-star-with-purple-aura.webp",
             "name": "Seek the Stars",
@@ -1323,6 +1378,9 @@
         },
         {
             "_id": "FJQ9A2sTJsXtjFfW",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jgN33YSYXB8iIHTw"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "icons/skills/movement/figure-running-gray.webp",
             "name": "Stumble",

--- a/packs/sf2e/alien-core-bestiary/sterieid.json
+++ b/packs/sf2e/alien-core-bestiary/sterieid.json
@@ -41,6 +41,9 @@
         },
         {
             "_id": "dutyysAFRTB2d2Q6",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.YIMampGpij4Y30yE"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "icons/commodities/stone/stone-porous-blue.webp",
             "name": "Speak with Stones",
@@ -69,7 +72,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -101,6 +104,9 @@
         },
         {
             "_id": "YKMvZDPdfCTOP5EN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.HAaRcHfN4g83eSEC"
+            },
             "folder": "NuBKgFiv0GJhsx3c",
             "img": "icons/magic/earth/construct-stone-long-arms.webp",
             "name": "Cairn Form",
@@ -162,6 +168,9 @@
         },
         {
             "_id": "LjDdinuTJmL54bqj",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.vh1RpbWfqdNC4L3P"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/earth/strike-fist-stone-light.webp",
             "name": "One with Stone",
@@ -190,7 +199,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -222,6 +231,9 @@
         },
         {
             "_id": "D1M8VPLraOSMkqzZ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Fr58LDSrbndgld9n"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/magic/defensive/shield-barrier-deflect-teal.webp",
             "name": "Resist Energy",
@@ -266,7 +278,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -298,6 +310,9 @@
         },
         {
             "_id": "xunB9Mg77st0m235",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.BCuHKrDeJ4eq53M6"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/etheral-jaunt.webp",
             "name": "Sure Footing",
@@ -327,7 +342,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -359,6 +374,9 @@
         },
         {
             "_id": "B1tmxkVuWJDOtMMq",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.V1cojmrEOWkJ1yPF"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-emblem.webp",
             "name": "Glow Up",
@@ -421,6 +439,9 @@
         },
         {
             "_id": "Pjnnb7RMUd5Cz2Vp",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Rn2LkoSq1XhLsODV"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/earth/projectiles-stone-salvo-gray.webp",
             "name": "Pummeling Rubble",
@@ -477,7 +498,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -508,6 +529,9 @@
         },
         {
             "_id": "SV1k3Nt21Mj4qXJT",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.nf8q0zvJDnnkzANe"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/blue-broadcast-signal.webp",
             "name": "Scan Environment",
@@ -559,6 +583,7 @@
                     "value": [
                         "cantrip",
                         "concentrate",
+                        "exploration",
                         "manipulate"
                     ]
                 }
@@ -567,6 +592,9 @@
         },
         {
             "_id": "HNJhK9KF89Iw1vkq",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.3VucgRc8FRPGy9NI"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/yellow-star-with-purple-aura.webp",
             "name": "Seek the Stars",

--- a/packs/sf2e/alien-core-bestiary/tax-class-civil-robot.json
+++ b/packs/sf2e/alien-core-bestiary/tax-class-civil-robot.json
@@ -264,6 +264,9 @@
         },
         {
             "_id": "ifSUyLTP9DryDDic",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -279,7 +282,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -313,7 +317,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 10,
                     "value": 10
                 }

--- a/packs/sf2e/alien-core-bestiary/tax-class-civil-robot.json
+++ b/packs/sf2e/alien-core-bestiary/tax-class-civil-robot.json
@@ -4,9 +4,12 @@
     "items": [
         {
             "_id": "lnIy0muyOF4GZ2Nm",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.vpjJYIgYZab0UZFa"
+            },
             "folder": "V89RPpe7fyCFC6NS",
             "img": "systems/sf2e/icons/equipment/weapons/metal-sci-fi-gun.webp",
-            "name": "Integrated Pulsecaster Pistol (Commercial)",
+            "name": "Integrated Commercial Pulsecaster Pistol",
             "sort": 100000,
             "system": {
                 "ammo": {
@@ -95,6 +98,9 @@
         },
         {
             "_id": "v1WnD8KXFwmldwuH",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.coJUVZGcuVg3FoYh"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "icons/tools/hand/lockpicks-steel-grey.webp",
             "name": "Integrated Infiltrator's Toolkit (Commercial)",
@@ -110,6 +116,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -150,6 +157,9 @@
         },
         {
             "_id": "1WeE9AEHH8mNj8kY",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.HxaKRfVbL1ZyGcu1"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/blue-tablet.webp",
             "name": "Integrated Datapad (Commercial)",
@@ -165,6 +175,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -207,6 +218,9 @@
         },
         {
             "_id": "th2ObHCOf58ydLsA",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.qqjDcCW118ySAlAS"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/battery-large.webp",
             "name": "Integrated Hacking Toolkit (Commercial)",
@@ -222,6 +236,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,

--- a/packs/sf2e/alien-core-bestiary/temporai.json
+++ b/packs/sf2e/alien-core-bestiary/temporai.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "dA6tSjWHaI6GQziO",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.WG91Z5TiR6oO5FOw"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "icons/magic/unholy/orb-glowing-yellow-purple.webp",
             "name": "Contingency",
@@ -73,7 +76,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -102,6 +105,9 @@
         },
         {
             "_id": "8fze9n2SUBBxo2HQ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.rsZ5c0AUyywe5yoK"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "icons/magic/lightning/projectile-tendrils-red.webp",
             "name": "Retrocognition",
@@ -131,7 +137,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -160,6 +166,9 @@
         },
         {
             "_id": "WD9HeNmy1lIlioL7",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.AlbpWWN87yGegoAF"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "systems/sf2e/icons/spells/true-target.webp",
             "name": "True Target",
@@ -189,7 +198,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "60 feet"
@@ -220,6 +229,9 @@
         },
         {
             "_id": "MUrkNuFPidUtHxWC",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gsYEuWv04XTDxe91"
+            },
             "folder": "6JF73zNhT8zbp1qC",
             "img": "icons/magic/death/undead-ghost-scream-teal.webp",
             "name": "Call Spirit",
@@ -248,7 +260,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -281,6 +293,9 @@
         },
         {
             "_id": "8t1HtaqYjNgplELB",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.SwUiVavHKMWG7t5K"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/tongues.webp",
             "name": "Truespeech (constant)",
@@ -310,7 +325,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -341,6 +356,9 @@
         },
         {
             "_id": "WSuWFbvBeoS4vE6g",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.pkcOby5prOausy1k"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/sundries/gaming/playing-cards-black.webp",
             "name": "Read Omens",
@@ -370,7 +388,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -401,6 +419,9 @@
         },
         {
             "_id": "SGmn7f0vFxtNkZxY",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.FM3SmEW8N1FCRjqt"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "systems/sf2e/icons/spells/talking-corpse.webp",
             "name": "Talking Corpse",
@@ -435,7 +456,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -465,6 +486,9 @@
         },
         {
             "_id": "Zya9fuaY8zhSX9mP",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VlNcjmYyu95vOUe8"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/magic/symbols/ring-circle-smoke-blue.webp",
             "name": "Translocate",
@@ -504,7 +528,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -535,6 +559,9 @@
         },
         {
             "_id": "XP7UpuVthvMRVt1I",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.o6YCGx4lycsYpww4"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "systems/sf2e/icons/spells/haste.webp",
             "name": "Haste",
@@ -574,7 +601,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -605,6 +632,9 @@
         },
         {
             "_id": "as8zbFJzhQMqh7Hl",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.WsUwpfmhKrKwoIe3"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/time/hourglass-tilted-gray.webp",
             "name": "Slow",
@@ -649,7 +679,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -680,6 +710,9 @@
         },
         {
             "_id": "h4ZZDibWb4WIC6Za",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.41TZEjhO6D1nWw2X"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/augury.webp",
             "name": "Augury",
@@ -709,7 +742,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -740,6 +773,9 @@
         },
         {
             "_id": "vPo8aaFczc6MKKBG",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.3JG1t3T4mWn6vTke"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/blur.webp",
             "name": "Blur",
@@ -769,7 +805,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -801,6 +837,9 @@
         },
         {
             "_id": "jWwi3zGISRlXzk3x",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.9HpwDN4MYQJnW0LG"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/dispel-magic.webp",
             "name": "Dispel Magic",
@@ -830,7 +869,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -862,6 +901,9 @@
         },
         {
             "_id": "gi9UERnU0Q04875l",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jwK43yKsHTkJQvQ9"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/see-invisibility.webp",
             "name": "See the Unseen",
@@ -891,7 +933,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -923,6 +965,9 @@
         },
         {
             "_id": "MrSJFlCB9Z6Gp39K",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jwK43yKsHTkJQvQ9"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/see-invisibility.webp",
             "name": "See the Unseen (constant)",
@@ -952,7 +997,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -984,6 +1029,9 @@
         },
         {
             "_id": "e4IgyIiCEBjDVY2c",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -1000,7 +1048,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -1015,7 +1063,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1049,6 +1097,9 @@
         },
         {
             "_id": "TpM2Y5ilFcu9Z9lO",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.qwZBXN6zBoB9BHXE"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/divine-lance.webp",
             "name": "Divine Lance",
@@ -1096,7 +1147,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "60 feet"
@@ -1129,6 +1180,9 @@
         },
         {
             "_id": "mg9T9XCsdFj9SvlI",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.sNUvbMoMeLTnYJm8"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/blue-energy-alien-hand.webp",
             "name": "Injury Echo",
@@ -1182,7 +1236,7 @@
                                 "damage": {
                                     "X6aUcgmF4twJh5gL": "1d8"
                                 },
-                                "interval": 1,
+                                "interval": 2,
                                 "type": "interval"
                             }
                         }
@@ -1209,7 +1263,7 @@
                                 "damage": {
                                     "2kU3mhyAecpOrFci": "1d8"
                                 },
-                                "interval": 1,
+                                "interval": 2,
                                 "type": "interval"
                             }
                         }
@@ -1236,7 +1290,7 @@
                                 "damage": {
                                     "EotUm3XBubhQrtWi": "1d8"
                                 },
-                                "interval": 1,
+                                "interval": 2,
                                 "type": "interval"
                             }
                         }
@@ -1276,6 +1330,9 @@
         },
         {
             "_id": "f6ASqU3aCiXD4xuN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.TVKNbcgTee19PXZR"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/shield.webp",
             "name": "Shield",
@@ -1304,7 +1361,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""

--- a/packs/sf2e/alien-core-bestiary/temporai.json
+++ b/packs/sf2e/alien-core-bestiary/temporai.json
@@ -1730,6 +1730,9 @@
         },
         {
             "_id": "UaVw8THx3Shl0NwI",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.fWrcguxFWeIVsuvl"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/blue-containment-vessel.webp",
             "name": "Battery (Superior)",
@@ -1745,7 +1748,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -1778,7 +1782,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 60,
                     "value": 60
                 }
@@ -1787,6 +1791,9 @@
         },
         {
             "_id": "mDl2iBCJDpg4gNrS",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.fWrcguxFWeIVsuvl"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/blue-containment-vessel.webp",
             "name": "Battery (Superior)",
@@ -1802,7 +1809,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -1835,7 +1843,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 60,
                     "value": 60
                 }

--- a/packs/sf2e/alien-core-bestiary/terror-of-ukulam.json
+++ b/packs/sf2e/alien-core-bestiary/terror-of-ukulam.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "58TUd3eGPqDSzlBO",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.wLIvH0AT1u7oa64N"
+            },
             "folder": "x5tjEh1N0FHzbHkv",
             "img": "icons/magic/earth/lava-explosion-orange.webp",
             "name": "Cataclysm",
@@ -142,7 +145,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "1,000 feet"
@@ -179,6 +182,9 @@
         },
         {
             "_id": "HVwqYzGtk0ITpr60",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.UG0SmRYSdbrx2rTA"
+            },
             "folder": "x5tjEh1N0FHzbHkv",
             "img": "systems/sf2e/icons/spells/indestructibility.webp",
             "name": "Indestructibility",
@@ -208,7 +214,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -240,6 +246,9 @@
         },
         {
             "_id": "UBexbrOUzqzA0Rxr",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.UnWaP06SVi3jRN0M"
+            },
             "folder": "DWZvpqhX0tWHYZOh",
             "img": "systems/sf2e/icons/abilities/orange-mushroom-cloud.webp",
             "name": "Atomic Blast",
@@ -282,7 +291,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You magically split an atom, creating an explosion with radioactive fallout. All targets in the area take 5d12 bludgeoning damage and 5d12 fire damage, and they're exposed to extreme radiation that uses your spellcasting DC as the @Check[fortitude]{Fortitude DC} for radiation sickness incurred by exposure to this radiation. The onset and frequency of this magical radiation is 1 round, and the area remains radioactive for 10 minutes.</p><hr /><p><strong>Critical Success</strong> The target is unaffected by the initial damage.</p>\n<p><strong>Success</strong> The target takes half damage and is @UUID[Compendium.sf2e.conditions.Item.Dazzled] for 1 minute.</p>\n<p><strong>Failure</strong> The target takes full damage and is @UUID[Compendium.sf2e.conditions.Item.Blinded] for 1 minute.</p>\n<p><strong>Critical Failure</strong> As failure, and the target takes double damage.</p>"
+                    "value": "<p>You magically split an atom, creating an explosion with radioactive fallout. All creatures in the area take 5d12 bludgeoning damage and 5d12 fire damage, and they're exposed to extreme radiation that uses your spellcasting DC as the @Check[fortitude]{Fortitude DC} for radiation sickness incurred by exposure to this radiation. The onset and frequency of this magical radiation is 1 round, and the area remains radioactive for 10 minutes.</p><hr /><p><strong>Critical Success</strong> The target is unaffected by the initial damage.</p>\n<p><strong>Success</strong> The target takes half damage and is @UUID[Compendium.sf2e.conditions.Item.Dazzled] for 1 minute.</p>\n<p><strong>Failure</strong> The target takes full damage and is @UUID[Compendium.sf2e.conditions.Item.Blinded] for 1 minute.</p>\n<p><strong>Critical Failure</strong> As failure, and the target takes double damage.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -330,6 +339,9 @@
         },
         {
             "_id": "41UrRJo6RzZKizgT",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.aqRYNoSvxsVfqglH"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/equipment/feet/boots-leather-laced-brown.webp",
             "name": "Unfettered Movement (constant)",
@@ -359,7 +371,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"

--- a/packs/sf2e/alien-core-bestiary/tool-rat.json
+++ b/packs/sf2e/alien-core-bestiary/tool-rat.json
@@ -41,6 +41,9 @@
         },
         {
             "_id": "3nCga39nOpHfRhxx",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ZofLZ5Zs8NN5yDPJ"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/blue-comet.webp",
             "name": "Inject Nanobots",
@@ -120,6 +123,9 @@
         },
         {
             "_id": "VBngL7xt8CpyVScp",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.mnoTqz0gjRmuc4oR"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/purple-tentacle.webp",
             "name": "Instant Virus",
@@ -183,6 +189,9 @@
         },
         {
             "_id": "uwOvgBoBhOc2V9Pl",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.kBhaPuzLUSwS6vVf"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/lightning/bolt-strike-forked-blue.webp",
             "name": "Electric Arc",
@@ -234,7 +243,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -266,6 +275,9 @@
         },
         {
             "_id": "WaI6Mk6qebrvN3H6",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.dINQzhqGmIsqGMUY"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/mending.webp",
             "name": "Mending",
@@ -310,7 +322,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -342,6 +354,9 @@
         },
         {
             "_id": "ia2Oc4Pi2YWIyrGo",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5y70IWhVV6bVjC9N"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-battery-gauge.webp",
             "name": "Recharge Weapon",
@@ -401,6 +416,9 @@
         },
         {
             "_id": "Xz3R3Ciw6v9xju1i",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jgN33YSYXB8iIHTw"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "icons/skills/movement/figure-running-gray.webp",
             "name": "Stumble",
@@ -465,6 +483,9 @@
         },
         {
             "_id": "sx2lQc6EiatbAFeE",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.SbBqa1HStMrV47fb"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-battery.webp",
             "name": "Supercharge Weapon",

--- a/packs/sf2e/alien-core-bestiary/tool-rat.json
+++ b/packs/sf2e/alien-core-bestiary/tool-rat.json
@@ -635,6 +635,9 @@
         },
         {
             "_id": "eLH2GxmU2pxjR7JM",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -650,7 +653,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -684,7 +688,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 10,
                     "value": 10
                 }

--- a/packs/sf2e/alien-core-bestiary/typodaemon.json
+++ b/packs/sf2e/alien-core-bestiary/typodaemon.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "KpEOFUzNzhmLeawO",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Nf6GqoHkNbfWJDQT"
+            },
             "folder": "NuBKgFiv0GJhsx3c",
             "img": "systems/sf2e/icons/abilities/blue-circuit-board-2.webp",
             "name": "Speak with Computers",
@@ -102,6 +105,9 @@
         },
         {
             "_id": "dQQeIT6Q0lEONUS5",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.mnoTqz0gjRmuc4oR"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/purple-tentacle.webp",
             "name": "Instant Virus",
@@ -165,6 +171,9 @@
         },
         {
             "_id": "njhJbB1qvWNCNmGq",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.v2S6tlilNbA4uGdM"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/blue-circuit-board.webp",
             "name": "Skim Data",
@@ -224,6 +233,9 @@
         },
         {
             "_id": "ADdNcraZb8ewJPVU",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.yXD9uU8w8uFD2OBQ"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/cerulean-circular-sign.webp",
             "name": "Delete (At Will)",
@@ -283,6 +295,9 @@
         },
         {
             "_id": "1nBscU3BtpiOuLPq",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ZBeKxBcUOsXrfMRo"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/purple-insignia.webp",
             "name": "Implant Data",
@@ -342,6 +357,9 @@
         },
         {
             "_id": "IsRj32KhWjP84n81",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.bBQ83xDvjQS3W1CG"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/blue-thermometer.webp",
             "name": "Measure",
@@ -405,6 +423,9 @@
         },
         {
             "_id": "VhFljDQGcHy404xn",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.nf8q0zvJDnnkzANe"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/blue-broadcast-signal.webp",
             "name": "Scan Environment",
@@ -456,6 +477,7 @@
                     "value": [
                         "cantrip",
                         "concentrate",
+                        "exploration",
                         "manipulate"
                     ]
                 }

--- a/packs/sf2e/alien-core-bestiary/vanguard-class-soldier-robot.json
+++ b/packs/sf2e/alien-core-bestiary/vanguard-class-soldier-robot.json
@@ -185,6 +185,9 @@
         },
         {
             "_id": "q1pZRD2zNEmCe1uH",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -200,7 +203,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -234,7 +238,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 10,
                     "value": 10
                 }
@@ -243,6 +247,9 @@
         },
         {
             "_id": "I15QMVCvwWLRTP9y",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -258,7 +265,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/alien-core-bestiary/vanguard-class-soldier-robot.json
+++ b/packs/sf2e/alien-core-bestiary/vanguard-class-soldier-robot.json
@@ -4,6 +4,9 @@
     "items": [
         {
             "_id": "i4u2b72cpjGQeZJM",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.eUZcCSon8XlQzOqR"
+            },
             "folder": "V89RPpe7fyCFC6NS",
             "img": "icons/weapons/axes/axe-hammer-blackened.webp",
             "name": "Integrated Advanced Painglaive",
@@ -93,6 +96,9 @@
         },
         {
             "_id": "vkvaqUJKgOZfWo8D",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.2gIo208O7zxPTL5J"
+            },
             "folder": "V89RPpe7fyCFC6NS",
             "img": "systems/sf2e/icons/equipment/weapons/rifle-heavy-stock.webp",
             "name": "Integrated Advanced Seeker Rifle",

--- a/packs/sf2e/alien-core-bestiary/voidsage.json
+++ b/packs/sf2e/alien-core-bestiary/voidsage.json
@@ -41,6 +41,9 @@
         },
         {
             "_id": "qNjqbfVBcyD3CaSa",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jyrxfWeeCsrkhNit"
+            },
             "folder": "NuBKgFiv0GJhsx3c",
             "img": "icons/magic/unholy/beam-ringed-impact-purple.webp",
             "name": "Eldritch Wrath",
@@ -127,6 +130,9 @@
         },
         {
             "_id": "MUBRN9bskvPSckaN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.K2WpC3FFoHrqX9Q5"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "systems/sf2e/icons/spells/hypnotic-pattern.webp",
             "name": "Hypnotize (at will)",
@@ -164,7 +170,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -196,6 +202,9 @@
         },
         {
             "_id": "ekEl4bsmb7hfqmxL",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.KHnhPHL4x1AQHfbC"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "systems/sf2e/icons/spells/mind-reading.webp",
             "name": "Mind Reading (at will)",
@@ -230,7 +239,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -262,6 +271,9 @@
         },
         {
             "_id": "82PbnwwVvoedS68V",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.qkehzRdn7JeGrR6E"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/alien-skull.webp",
             "name": "Void Whispers",
@@ -330,6 +342,9 @@
         },
         {
             "_id": "3aAs0YfCgrwHtbMa",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ijlB3l9IBnpppfK0"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/yellow-warning-sign.webp",
             "name": "Logic Bomb",
@@ -418,6 +433,9 @@
         },
         {
             "_id": "5rLvPp8waV0gEssL",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.v2S6tlilNbA4uGdM"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/blue-circuit-board.webp",
             "name": "Skim Data (at will)",
@@ -477,6 +495,9 @@
         },
         {
             "_id": "kkSTMF2lR62hPzFk",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VynaowCerc7B4yvI"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/sundries/books/book-embossed-jewel-silver-green.webp",
             "name": "Akashic Download",
@@ -535,6 +556,9 @@
         },
         {
             "_id": "FW59e5XgPl57Z0fz",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.NkvRoN33RbDg3fl9"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/pink-target-sign.webp",
             "name": "Analyze Target",
@@ -548,7 +572,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The circumstance bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The circumstance bonus increases to +3, and you can target any number of creatures.</p>"
+                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The status bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The status bonus increases to +3, and you can target any number of creatures.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -597,6 +621,9 @@
         },
         {
             "_id": "9r46DBnDXe0ObjnC",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.yXD9uU8w8uFD2OBQ"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/cerulean-circular-sign.webp",
             "name": "Delete (at will)",
@@ -656,6 +683,9 @@
         },
         {
             "_id": "HSOYrdjx2RUgyvFV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.FEaM1B4WuiqFO7Uk"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "icons/magic/unholy/projectile-bolts-salvo-pink.webp",
             "name": "Eldritch Lance",
@@ -736,6 +766,9 @@
         },
         {
             "_id": "UwShheY2aiX5eBip",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ZBeKxBcUOsXrfMRo"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/purple-insignia.webp",
             "name": "Implant Data",
@@ -795,6 +828,9 @@
         },
         {
             "_id": "yvSZOjAbkrmuxAb2",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uBo6g5aW087cLSJR"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/magic/light/explosion-impact-purple.webp",
             "name": "Mind Skewer",

--- a/packs/sf2e/alien-core-bestiary/wahtunshna.json
+++ b/packs/sf2e/alien-core-bestiary/wahtunshna.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "1nEpQvhZo0JG6SB7",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.qkehzRdn7JeGrR6E"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/alien-skull.webp",
             "name": "Void Whispers",
@@ -112,6 +115,9 @@
         },
         {
             "_id": "UuV3ZSCb8iOoFBn1",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.qOLMHvkAGsVYLhtn"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "icons/magic/perception/third-eye-blue-red.webp",
             "name": "Detect Thoughts",
@@ -126,13 +132,7 @@
                 },
                 "counteraction": false,
                 "damage": {},
-                "defense": {
-                    "passive": null,
-                    "save": {
-                        "basic": false,
-                        "statistic": "will"
-                    }
-                },
+                "defense": null,
                 "description": {
                     "value": "<p>You sense the presence of thinking creatures around you. You detect the presence or absence of thoughts from conscious creatures that have Intelligence modifiers of –3 or higher. You can choose to ignore the thoughts of creatures you're familiar with so they don't interfere with your detection of other thoughts. The spell can penetrate some barriers, but 3 feet of dirt or wood, 1 foot of stone, 1 inch of metal, a thin sheet of lead, or any force barrier blocks it. Creatures who are immune to mental effects are immune to detection by this spell.</p><hr /><p><strong>Heightened (4th)</strong> You detect the number of thinking minds and whether or not the creatures are telepathic. Creatures with telepathy have louder thoughts than creatures who don't have telepathy and might be able to sense your intrusion, at the GM's discretion.</p>"
                 },
@@ -181,6 +181,9 @@
         },
         {
             "_id": "5hfo31s0mFO0QhNi",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VIKDSgBRR3Wd1mQx"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/green-chart.webp",
             "name": "Doom Scroll",
@@ -251,6 +254,9 @@
         },
         {
             "_id": "sQZ0gXHB1NXfcuMY",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.tVTJS07cKDA5rNgc"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/purple-hex-field.webp",
             "name": "Sift the Sphere",
@@ -308,6 +314,9 @@
         },
         {
             "_id": "XODknBB85WTxqjPt",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.7ZinJNzxq0XF0oMx"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/bane.webp",
             "name": "Bane",
@@ -345,7 +354,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -440,6 +449,9 @@
         },
         {
             "_id": "mHgdTsUN2VJTKXOU",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.FEaM1B4WuiqFO7Uk"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "icons/magic/unholy/projectile-bolts-salvo-pink.webp",
             "name": "Eldritch Lance",
@@ -520,6 +532,9 @@
         },
         {
             "_id": "KaeA4d01qmZ2D5bt",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.izcxFQFwf3woCnFs"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/guidance.webp",
             "name": "Guidance",
@@ -548,7 +563,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -579,6 +594,9 @@
         },
         {
             "_id": "9Txi60dRlQzAiJ54",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.vLzFcIaSXs7YTIqJ"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/message.webp",
             "name": "Message",
@@ -617,7 +635,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -653,6 +671,9 @@
         },
         {
             "_id": "IRW14QOW6RaahSLY",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uBo6g5aW087cLSJR"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/magic/light/explosion-impact-purple.webp",
             "name": "Mind Skewer",
@@ -737,6 +758,9 @@
         },
         {
             "_id": "nxLN6dUczkgV4nQr",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uBo6g5aW087cLSJR"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/magic/light/explosion-impact-purple.webp",
             "name": "Mind Skewer",
@@ -821,6 +845,9 @@
         },
         {
             "_id": "GCO830ijS0gCsWqp",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gMODOGamz88rgHuf"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/protection.webp",
             "name": "Protection",
@@ -850,7 +877,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"

--- a/packs/sf2e/alien-core-bestiary/warpstitcher.json
+++ b/packs/sf2e/alien-core-bestiary/warpstitcher.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "TMTA9QLyhICRuspQ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.SwUiVavHKMWG7t5K"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/tongues.webp",
             "name": "Truespeech (constant)",
@@ -72,7 +75,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"

--- a/packs/sf2e/alien-core-bestiary/wayward-warp.json
+++ b/packs/sf2e/alien-core-bestiary/wayward-warp.json
@@ -54,6 +54,9 @@
         },
         {
             "_id": "pFIc85t91OrpuRJX",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.qkehzRdn7JeGrR6E"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/alien-skull.webp",
             "name": "Void Whispers",
@@ -122,6 +125,9 @@
         },
         {
             "_id": "tCmRsQSqvTqQ0Vg7",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.f8SBoXiXQjlCKqly"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/creatures/magical/spirit-undead-winged-ghost.webp",
             "name": "Illusory Creature",
@@ -151,7 +157,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -185,6 +191,9 @@
         },
         {
             "_id": "vvGs7K4e39Ey7PeU",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.f8SBoXiXQjlCKqly"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/creatures/magical/spirit-undead-winged-ghost.webp",
             "name": "Illusory Creature",
@@ -214,7 +223,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -248,6 +257,9 @@
         },
         {
             "_id": "1XEH4CkzLXg664ha",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.CQb8HtQ1BPeZmu9h"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/feeblemind.webp",
             "name": "Stupefy",
@@ -282,7 +294,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -313,6 +325,9 @@
         },
         {
             "_id": "JU76MkM7piV8Hm6C",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.UKsIOWmMx4hSpafl"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/control/buff-luck-fortune-rainbow.webp",
             "name": "Dizzying Colors",
@@ -350,7 +365,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -383,6 +398,9 @@
         },
         {
             "_id": "GKVr0HR3s4rHfhVY",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ZrFj6ktotd0pBnqO"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/environment/settlement/palast.webp",
             "name": "Dream of Home",
@@ -440,7 +458,8 @@
                     "value": [
                         "concentrate",
                         "manipulate",
-                        "mental"
+                        "mental",
+                        "subtle"
                     ]
                 }
             },
@@ -448,6 +467,9 @@
         },
         {
             "_id": "Fwb8tMoCd6HHcGht",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.FEaM1B4WuiqFO7Uk"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "icons/magic/unholy/projectile-bolts-salvo-pink.webp",
             "name": "Eldritch Lance",
@@ -528,6 +550,9 @@
         },
         {
             "_id": "SaxPfDgVK9EymSSv",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.0zU8CPejjQFnhZFI"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/ghost-sound.webp",
             "name": "Figment",
@@ -556,7 +581,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -589,6 +614,9 @@
         },
         {
             "_id": "H2Zm0gX6rq2o36NI",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.2oH5IufzdESuYxat"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/illusory-object.webp",
             "name": "Illusory Object",
@@ -621,7 +649,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "500 feet"
@@ -653,6 +681,9 @@
         },
         {
             "_id": "l7VBLWKoBsGvzinG",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.3VucgRc8FRPGy9NI"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/yellow-star-with-purple-aura.webp",
             "name": "Seek the Stars",
@@ -713,6 +744,9 @@
         },
         {
             "_id": "SQA9QLl1bOuhzK4H",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.pwzdSlJgYqN7bs2w"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/mage-hand.webp",
             "name": "Telekinetic Hand",
@@ -761,7 +795,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -792,6 +826,9 @@
         },
         {
             "_id": "mBEsn5JIz9FzcfGL",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.mAMEt4FFbdqoRnkN"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/chill-touch.webp",
             "name": "Void Warp",
@@ -843,7 +880,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"

--- a/packs/sf2e/alien-core-bestiary/wyspiria.json
+++ b/packs/sf2e/alien-core-bestiary/wyspiria.json
@@ -41,6 +41,9 @@
         },
         {
             "_id": "OYKZ1Xo9bardj20w",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.DPP4TW5FxE85XPKZ"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/blue-piercing-energy.webp",
             "name": "X-Ray Vision",
@@ -101,6 +104,9 @@
         },
         {
             "_id": "SEkdWxlszL37ohoW",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.g58dbrP7FadZhh6j"
+            },
             "folder": "NQpcS2TwtjNNq1Qy",
             "img": "icons/magic/time/hourglass-tilted-gray.webp",
             "name": "Chrono Push",
@@ -185,6 +191,9 @@
         },
         {
             "_id": "n5oi3FisnDSs4tx6",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5cMDrC3jX1yrxOzh"
+            },
             "folder": "NQpcS2TwtjNNq1Qy",
             "img": "systems/sf2e/icons/abilities/blue-heroic-lightning-symbol.webp",
             "name": "Overload Systems",
@@ -272,6 +281,9 @@
         },
         {
             "_id": "R3j4nA2CDCvcq3Qf",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.SwUiVavHKMWG7t5K"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/tongues.webp",
             "name": "Truespeech (constant)",
@@ -301,7 +313,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -332,6 +344,9 @@
         },
         {
             "_id": "1DbL5cZLByz1cOf9",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VlNcjmYyu95vOUe8"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/magic/symbols/ring-circle-smoke-blue.webp",
             "name": "Translocate (at will)",
@@ -371,7 +386,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -402,6 +417,9 @@
         },
         {
             "_id": "CN1i5pFYc3sZlat1",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.rBh2PjtbDGAjbcu6"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/equipment/other/yellow-battery.webp",
             "name": "Discharge",
@@ -467,6 +485,9 @@
         },
         {
             "_id": "OJFFWqks2fQ5KjNT",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.o6YCGx4lycsYpww4"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "systems/sf2e/icons/spells/haste.webp",
             "name": "Haste",
@@ -506,7 +527,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -537,6 +558,9 @@
         },
         {
             "_id": "DMOUEU5uXxKJuZCE",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.eHiWtMiXoI1d48A7"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/purple-alien-brain.webp",
             "name": "Holographic Memory",
@@ -602,6 +626,9 @@
         },
         {
             "_id": "x6VcqwPLe919ljHG",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.WsUwpfmhKrKwoIe3"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/time/hourglass-tilted-gray.webp",
             "name": "Slow",
@@ -646,7 +673,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -677,6 +704,9 @@
         },
         {
             "_id": "3YqM8H6PeJ4LlheA",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.GdlG9a4o0ax0F2HT"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/purple-hourglass.webp",
             "name": "Time's Edge",
@@ -763,6 +793,9 @@
         },
         {
             "_id": "xnNuuhnZijgKRjzc",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.GB1RVtoFPwyH1B9G"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/green-acid-sprayer.webp",
             "name": "Caustic Conversion",
@@ -854,6 +887,9 @@
         },
         {
             "_id": "t92IFUoNxbnoSjwL",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.qOLMHvkAGsVYLhtn"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "icons/magic/perception/third-eye-blue-red.webp",
             "name": "Detect Thoughts",
@@ -868,13 +904,7 @@
                 },
                 "counteraction": false,
                 "damage": {},
-                "defense": {
-                    "passive": null,
-                    "save": {
-                        "basic": false,
-                        "statistic": "will"
-                    }
-                },
+                "defense": null,
                 "description": {
                     "value": "<p>You sense the presence of thinking creatures around you. You detect the presence or absence of thoughts from conscious creatures that have Intelligence modifiers of –3 or higher. You can choose to ignore the thoughts of creatures you're familiar with so they don't interfere with your detection of other thoughts. The spell can penetrate some barriers, but 3 feet of dirt or wood, 1 foot of stone, 1 inch of metal, a thin sheet of lead, or any force barrier blocks it. Creatures who are immune to mental effects are immune to detection by this spell.</p><hr /><p><strong>Heightened (4th)</strong> You detect the number of thinking minds and whether or not the creatures are telepathic. Creatures with telepathy have louder thoughts than creatures who don't have telepathy and might be able to sense your intrusion, at the GM's discretion.</p>"
                 },
@@ -923,6 +953,9 @@
         },
         {
             "_id": "xHgVWj5vIGImf3mT",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ZofLZ5Zs8NN5yDPJ"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/blue-comet.webp",
             "name": "Inject Nanobots",
@@ -1002,6 +1035,9 @@
         },
         {
             "_id": "OyyxtZenyfrbs0gT",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.v2S6tlilNbA4uGdM"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/blue-circuit-board.webp",
             "name": "Skim Data (at will)",
@@ -1061,6 +1097,9 @@
         },
         {
             "_id": "xDuPr1WoZsoMdh5N",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.NkvRoN33RbDg3fl9"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/pink-target-sign.webp",
             "name": "Analyze Target",
@@ -1074,7 +1113,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The circumstance bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The circumstance bonus increases to +3, and you can target any number of creatures.</p>"
+                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The status bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The status bonus increases to +3, and you can target any number of creatures.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -1123,6 +1162,9 @@
         },
         {
             "_id": "U2HZ35yqCCavSGVL",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.yXD9uU8w8uFD2OBQ"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/cerulean-circular-sign.webp",
             "name": "Delete",
@@ -1182,6 +1224,9 @@
         },
         {
             "_id": "sON0VsAhfzkjqmvE",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ZBeKxBcUOsXrfMRo"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/purple-insignia.webp",
             "name": "Implant Data",
@@ -1241,6 +1286,9 @@
         },
         {
             "_id": "Vt4dt6Qj7T3Oshso",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.dINQzhqGmIsqGMUY"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/mending.webp",
             "name": "Mending",
@@ -1285,7 +1333,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -1317,6 +1365,9 @@
         },
         {
             "_id": "K7rxZj4scj5cwVBr",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.3VucgRc8FRPGy9NI"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/yellow-star-with-purple-aura.webp",
             "name": "Seek the Stars",
@@ -1377,6 +1428,9 @@
         },
         {
             "_id": "5TFS4itpzXK3ARau",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Sqo1uzSmebVWpqoT"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-comet-swirling.webp",
             "name": "Wisp Ally",

--- a/packs/sf2e/alien-core-bestiary/xenowarden-biohulk.json
+++ b/packs/sf2e/alien-core-bestiary/xenowarden-biohulk.json
@@ -185,6 +185,9 @@
         },
         {
             "_id": "9EEB0WECLWIK9Ppz",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.Gvd406aqaxjBcnFI"
+            },
             "folder": "1zLXGqhSgBIthlcs",
             "img": "systems/sf2e/icons/equipment/weapons/shotgun-heavy.webp",
             "name": "Grenade Launcher (Tactical)",
@@ -230,9 +233,6 @@
                 },
                 "price": {
                     "value": {
-                        "cp": 0,
-                        "gp": 0,
-                        "pp": 0,
                         "sp": 410
                     }
                 },
@@ -272,12 +272,18 @@
         },
         {
             "_id": "XkQn0rSVwiKKsKxB",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.omxqK2E84pGaMj6x"
+            },
             "folder": "1zLXGqhSgBIthlcs",
             "img": "systems/sf2e/icons/equipment/weapons/grenade-hand.webp",
             "name": "Frag Grenade (Advanced)",
             "sort": 400000,
             "system": {
-                "ammo": null,
+                "ammo": {
+                    "baseType": null,
+                    "builtIn": false
+                },
                 "baseItem": "grenade",
                 "bonus": {
                     "value": 0
@@ -317,9 +323,6 @@
                 },
                 "price": {
                     "value": {
-                        "cp": 0,
-                        "gp": 0,
-                        "pp": 0,
                         "sp": 120
                     }
                 },
@@ -426,6 +429,9 @@
         },
         {
             "_id": "Yk3gfZdZQV5rTZ7F",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.eMNjuin4r6DivIsI"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/yellow-battery.webp",
             "name": "Battery (Advanced)",
@@ -441,7 +447,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -475,7 +482,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 40,
                     "value": 40
                 }

--- a/packs/sf2e/alien-core-bestiary/xenowarden-greenhorn.json
+++ b/packs/sf2e/alien-core-bestiary/xenowarden-greenhorn.json
@@ -44,6 +44,9 @@
         },
         {
             "_id": "ES1Bn1BMKwD3DXHy",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.MPxbKoR54gkYkqLO"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/creatures/claws/claw-hooked-curved.webp",
             "name": "Gouging Claw",
@@ -107,6 +110,9 @@
                             "damage": {
                                 "0": {
                                     "category": null,
+                                    "kinds": [
+                                        "damage"
+                                    ],
                                     "type": "piercing"
                                 }
                             },
@@ -122,16 +128,20 @@
                             "damage": {
                                 "0": {
                                     "category": null,
+                                    "kinds": [
+                                        "damage"
+                                    ],
                                     "type": "slashing"
                                 }
-                            }
+                            },
+                            "defense": null
                         }
                     }
                 },
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -164,6 +174,9 @@
         },
         {
             "_id": "yiGQCxG2Q9OUlAuf",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.nf8q0zvJDnnkzANe"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/blue-broadcast-signal.webp",
             "name": "Scan Environment",
@@ -215,6 +228,7 @@
                     "value": [
                         "cantrip",
                         "concentrate",
+                        "exploration",
                         "manipulate"
                     ]
                 }
@@ -223,6 +237,9 @@
         },
         {
             "_id": "qGchoYTouzcWxAjc",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uZK2BYzPnxUBnDjr"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/nature/root-vine-entangled-hand.webp",
             "name": "Tangle Vine",
@@ -251,7 +268,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"

--- a/packs/sf2e/alien-core-bestiary/xenowarden-greenhorn.json
+++ b/packs/sf2e/alien-core-bestiary/xenowarden-greenhorn.json
@@ -642,6 +642,9 @@
         },
         {
             "_id": "DnjFSJVXDM330gPn",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -657,7 +660,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -691,7 +695,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 10,
                     "value": 10
                 }

--- a/packs/sf2e/alien-core-bestiary/xenowarden-rootsworn.json
+++ b/packs/sf2e/alien-core-bestiary/xenowarden-rootsworn.json
@@ -1399,6 +1399,9 @@
         },
         {
             "_id": "JuWiJENuVYMLLKcG",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -1414,7 +1417,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -1448,7 +1452,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 10,
                     "value": 10
                 }

--- a/packs/sf2e/alien-core-bestiary/xenowarden-rootsworn.json
+++ b/packs/sf2e/alien-core-bestiary/xenowarden-rootsworn.json
@@ -50,6 +50,9 @@
         },
         {
             "_id": "eKgeQ5BQjYfBhF0F",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.J6vNvrUT3b1hx2iA"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/magic/nature/root-vines-grow-brown.webp",
             "name": "Entangling Flora",
@@ -88,7 +91,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -120,6 +123,9 @@
         },
         {
             "_id": "qA1r9fRtabPqU95g",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.hk2mTLH9DIvNqDuS"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "icons/magic/nature/root-vine-thorned-pink.webp",
             "name": "Verdant Code",
@@ -200,6 +206,9 @@
         },
         {
             "_id": "VhDGLhLzKc5FSPyV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -216,7 +225,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -231,7 +240,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -265,6 +274,9 @@
         },
         {
             "_id": "iF0uhu4K4cy42Agn",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.kBhaPuzLUSwS6vVf"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/lightning/bolt-strike-forked-blue.webp",
             "name": "Electric Arc",
@@ -316,7 +328,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -348,6 +360,9 @@
         },
         {
             "_id": "muJg70fCBu5OOiKI",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.MPxbKoR54gkYkqLO"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/creatures/claws/claw-hooked-curved.webp",
             "name": "Gouging Claw",
@@ -411,6 +426,9 @@
                             "damage": {
                                 "0": {
                                     "category": null,
+                                    "kinds": [
+                                        "damage"
+                                    ],
                                     "type": "piercing"
                                 }
                             },
@@ -426,16 +444,20 @@
                             "damage": {
                                 "0": {
                                     "category": null,
+                                    "kinds": [
+                                        "damage"
+                                    ],
                                     "type": "slashing"
                                 }
-                            }
+                            },
+                            "defense": null
                         }
                     }
                 },
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -468,6 +490,9 @@
         },
         {
             "_id": "KGvoxlu3Z92havM8",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.rfZpqmj0AIIdkVIs"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/life/cross-worn-green.webp",
             "name": "Heal",
@@ -632,7 +657,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "varies"
@@ -663,6 +688,9 @@
         },
         {
             "_id": "D17xB6gyWS4fObvK",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jfVCuOpzC6mUrf6f"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/hydraulic-push.webp",
             "name": "Hydraulic Push",
@@ -710,7 +738,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "60 feet"
@@ -742,6 +770,9 @@
         },
         {
             "_id": "tHK5VeNOvmXHKBxa",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.nf8q0zvJDnnkzANe"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/blue-broadcast-signal.webp",
             "name": "Scan Environment",
@@ -793,6 +824,7 @@
                     "value": [
                         "cantrip",
                         "concentrate",
+                        "exploration",
                         "manipulate"
                     ]
                 }
@@ -801,6 +833,9 @@
         },
         {
             "_id": "uCCrt5iiGFtwosb5",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.QpP30fcEl4NGjHwo"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/yellow-sonic-scream.webp",
             "name": "Sonic Scream",
@@ -889,6 +924,9 @@
         },
         {
             "_id": "EqOilawdon6uWumK",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jSRAyd57kd4WZ4yE"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/nature/tree-animated-smile.webp",
             "name": "Summon Plant or Fungus",
@@ -918,7 +956,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -948,6 +986,9 @@
         },
         {
             "_id": "1xX0U9KQ7lzaRwgK",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uZK2BYzPnxUBnDjr"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/nature/root-vine-entangled-hand.webp",
             "name": "Tangle Vine",
@@ -976,7 +1017,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1010,6 +1051,9 @@
         },
         {
             "_id": "ydqQUcYpxBaSuRRd",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.zDJS8E66UI0himqV"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/shocking-grasp.webp",
             "name": "Thunderstrike",
@@ -1073,7 +1117,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"

--- a/packs/sf2e/equipment/medical-items/hypopen-ultimate.json
+++ b/packs/sf2e/equipment/medical-items/hypopen-ultimate.json
@@ -27,6 +27,7 @@
             "type": null
         },
         "price": {
+            "per": 1,
             "value": {
                 "cp": 0,
                 "gp": 0,
@@ -46,7 +47,6 @@
             "rarity": "common",
             "value": [
                 "consumable",
-                "nanite",
                 "tech"
             ]
         },

--- a/packs/sf2e/guilt-of-the-grave-world-bestiary/aeon-guard-trooper.json
+++ b/packs/sf2e/guilt-of-the-grave-world-bestiary/aeon-guard-trooper.json
@@ -379,6 +379,9 @@
         },
         {
             "_id": "q9RvFul8fxOqNEWt",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -394,7 +397,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -437,6 +441,9 @@
         },
         {
             "_id": "F0RDDuJD15XE7NhE",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.5PS5ESGpnQfJNOdg"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/blue-battery.webp",
             "name": "Battery (Tactical)",
@@ -452,7 +459,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/guilt-of-the-grave-world-bestiary/bonecrusher.json
+++ b/packs/sf2e/guilt-of-the-grave-world-bestiary/bonecrusher.json
@@ -249,6 +249,9 @@
         },
         {
             "_id": "K5cMXbfylGrPLFnw",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -264,7 +267,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/guilt-of-the-grave-world-bestiary/boneflayer.json
+++ b/packs/sf2e/guilt-of-the-grave-world-bestiary/boneflayer.json
@@ -4,6 +4,9 @@
     "items": [
         {
             "_id": "X4zMB74suOhOC4SR",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.EnufuFPBa1U2pPDn"
+            },
             "folder": "V89RPpe7fyCFC6NS",
             "img": "systems/sf2e/icons/equipment/weapons/heavy-gun-long.webp",
             "name": "Integrated Advanced Machine Gun",

--- a/packs/sf2e/guilt-of-the-grave-world-bestiary/corpse-fleet-expendable.json
+++ b/packs/sf2e/guilt-of-the-grave-world-bestiary/corpse-fleet-expendable.json
@@ -252,6 +252,9 @@
         },
         {
             "_id": "kHjkjhmZJyyXeMYs",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -267,7 +270,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/guilt-of-the-grave-world-bestiary/corpse-fleet-junior-officer.json
+++ b/packs/sf2e/guilt-of-the-grave-world-bestiary/corpse-fleet-junior-officer.json
@@ -161,6 +161,9 @@
         },
         {
             "_id": "hI0y34zfhI7p9w8c",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.HxaKRfVbL1ZyGcu1"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/blue-tablet.webp",
             "name": "Datapad",
@@ -176,6 +179,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -218,6 +222,9 @@
         },
         {
             "_id": "sHg7pOsKy6CCEn60",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.YhiW4zUtd0WcYeSD"
+            },
             "folder": "aGUZspQIi3yNxIOu",
             "img": "systems/sf2e/icons/equipment/other/green-pouch.webp",
             "name": "Marrow Paste (Commercial)",
@@ -234,7 +241,8 @@
                     "value": "<p>Developed and patented by Eoxian medical conglomerate Nulife, this magenta tincture's metallic odor is reminiscent of fresh blood. When applied to the body of a creature that can benefit from void healing, marrow paste grants fast healing 1 for 1 minute.</p>"
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -251,9 +259,6 @@
                 "price": {
                     "per": 1,
                     "value": {
-                        "cp": 0,
-                        "gp": 0,
-                        "pp": 0,
                         "sp": 60
                     }
                 },
@@ -265,7 +270,7 @@
                 "quantity": 1,
                 "rules": [],
                 "size": "med",
-                "slug": null,
+                "slug": "marrow-paste-commercial",
                 "traits": {
                     "rarity": "common",
                     "value": [
@@ -286,6 +291,9 @@
         },
         {
             "_id": "kjJv6nZYnEdqic64",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -301,7 +309,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/guilt-of-the-grave-world-bestiary/faceless.json
+++ b/packs/sf2e/guilt-of-the-grave-world-bestiary/faceless.json
@@ -41,6 +41,9 @@
         },
         {
             "_id": "UL7kvMqQrgI2TElq",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.J9IWyHhvdtMVBjqg"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "icons/magic/life/heart-broken-red.webp",
             "name": "Deadly Vitality",
@@ -82,7 +85,7 @@
                 },
                 "requirements": "",
                 "rules": [],
-                "slug": null,
+                "slug": "deadly-vitality",
                 "target": {
                     "value": "1 living creature"
                 },
@@ -108,6 +111,9 @@
         },
         {
             "_id": "0GjE24VrtcefA0jU",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.qOLMHvkAGsVYLhtn"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "icons/magic/perception/third-eye-blue-red.webp",
             "name": "Detect Thoughts",
@@ -122,13 +128,7 @@
                 },
                 "counteraction": false,
                 "damage": {},
-                "defense": {
-                    "passive": null,
-                    "save": {
-                        "basic": false,
-                        "statistic": "will"
-                    }
-                },
+                "defense": null,
                 "description": {
                     "value": "<p>You sense the presence of thinking creatures around you. You detect the presence or absence of thoughts from conscious creatures that have Intelligence modifiers of –3 or higher. You can choose to ignore the thoughts of creatures you're familiar with so they don't interfere with your detection of other thoughts. The spell can penetrate some barriers, but 3 feet of dirt or wood, 1 foot of stone, 1 inch of metal, a thin sheet of lead, or any force barrier blocks it. Creatures who are immune to mental effects are immune to detection by this spell.</p><hr /><p><strong>Heightened (4th)</strong> You detect the number of thinking minds and whether or not the creatures are telepathic. Creatures with telepathy have louder thoughts than creatures who don't have telepathy and might be able to sense your intrusion, at the GM's discretion.</p>"
                 },
@@ -176,6 +176,9 @@
         },
         {
             "_id": "TxmQFxZ6uRsJwthg",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.XhypWjpV3NP76ahy"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "icons/magic/control/hypnosis-mesmerism-eye.webp",
             "name": "Twisted Vision",
@@ -217,7 +220,7 @@
                 },
                 "requirements": "",
                 "rules": [],
-                "slug": null,
+                "slug": "twisted-vision",
                 "target": {
                     "value": "1 creature"
                 },
@@ -243,6 +246,9 @@
         },
         {
             "_id": "rED6ynvMcprv8aWF",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.FEaM1B4WuiqFO7Uk"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "icons/magic/unholy/projectile-bolts-salvo-pink.webp",
             "name": "Eldritch Lance",
@@ -323,6 +329,9 @@
         },
         {
             "_id": "QvEAMZzfzhP75UnC",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.sNUvbMoMeLTnYJm8"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/blue-energy-alien-hand.webp",
             "name": "Injury Echo",
@@ -470,6 +479,9 @@
         },
         {
             "_id": "D7u3IvrKdSEgPgYy",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uBo6g5aW087cLSJR"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/magic/light/explosion-impact-purple.webp",
             "name": "Mind Skewer",
@@ -554,6 +566,9 @@
         },
         {
             "_id": "6Yssni0xL3AaBbJo",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.QpP30fcEl4NGjHwo"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/yellow-sonic-scream.webp",
             "name": "Sonic Scream",
@@ -642,6 +657,9 @@
         },
         {
             "_id": "etwtOXlvtXhBkoQj",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.mAMEt4FFbdqoRnkN"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/chill-touch.webp",
             "name": "Void Warp",
@@ -693,7 +711,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"

--- a/packs/sf2e/guilt-of-the-grave-world-bestiary/kitthaine-kitar.json
+++ b/packs/sf2e/guilt-of-the-grave-world-bestiary/kitthaine-kitar.json
@@ -41,6 +41,9 @@
         },
         {
             "_id": "dbynQ5aPTMFZD7oL",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VmtQlZqeraTv0Eer"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "icons/magic/fire/projectile-feathers-embers-gold.webp",
             "name": "Skyfire Wings",
@@ -105,6 +108,9 @@
         },
         {
             "_id": "XRcgvBWR4ub8b26M",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.GB1RVtoFPwyH1B9G"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/green-acid-sprayer.webp",
             "name": "Caustic Conversion",
@@ -195,11 +201,102 @@
             "type": "spell"
         },
         {
+            "_id": "yK6FxRmwpEClWmh9",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.j6KI3dFuaYJmMSZh"
+            },
+            "folder": "KGETkFaB5r8FyUND",
+            "img": "icons/magic/water/projectile-ice-impact-stone.webp",
+            "name": "Liquid Siphon",
+            "sort": 400000,
+            "system": {
+                "area": null,
+                "cost": {
+                    "value": ""
+                },
+                "counteraction": false,
+                "damage": {
+                    "l3hdup9FqPsH2ups": {
+                        "applyMod": false,
+                        "category": null,
+                        "formula": "4d6",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "bludgeoning"
+                    }
+                },
+                "defense": {
+                    "save": {
+                        "basic": false,
+                        "statistic": "fortitude"
+                    }
+                },
+                "description": {
+                    "value": "<p>You drain the moisture out of your target, crumpling them up like an empty beverage can and potentially leaving them a desiccated husk of what they once were. A nonliving target with liquid in its body (such as a vampire, water elemental, or keg of alcohol) can be affected by this spell, but a living creature with no vital liquids is immune. The target creature takes 4d6 bludgeoning damage, depending on the results of its saving throw.</p>\n<p>A target that fails its saving throw creates water that flows into your hands or a held container (1 gallon for Tiny, 2 gallons for Small, 4 for Medium, 6 for Large, 8 for Huge). If the target critically fails its saving throw, double this amount.</p><hr /><p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target takes half damage.</p>\n<p><strong>Failure</strong> The target takes full damage and is @UUID[Compendium.sf2e.conditions.Item.Drained]{Drained 1}.</p>\n<p><strong>Critical Failure</strong> As failure, but double damage and the target is @UUID[Compendium.sf2e.conditions.Item.Drained]{Drained 2}.</p><hr /><p><strong>Heightened (+1)</strong> Increase the damage by 2d6.</p>"
+                },
+                "duration": {
+                    "sustained": false,
+                    "value": ""
+                },
+                "heightening": {
+                    "area": 0,
+                    "damage": {
+                        "l3hdup9FqPsH2ups": "2d6"
+                    },
+                    "interval": 1,
+                    "type": "interval"
+                },
+                "level": {
+                    "value": 2
+                },
+                "location": {
+                    "heightenedLevel": 2,
+                    "value": "LebunvH85R2kh57v"
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Starfinder Guilt of the Grave World"
+                },
+                "range": {
+                    "value": "touch"
+                },
+                "requirements": "",
+                "rules": [],
+                "slug": "liquid-siphon",
+                "target": {
+                    "value": "1 creature or object (see text)"
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traits": {
+                    "rarity": "common",
+                    "traditions": [
+                        "arcane",
+                        "occult",
+                        "primal"
+                    ],
+                    "value": [
+                        "concentrate",
+                        "manipulate",
+                        "water"
+                    ]
+                }
+            },
+            "type": "spell"
+        },
+        {
             "_id": "SC0eqLtx9eEMcadH",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.h7IhypLwItepwhou"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/tentacle-drone.webp",
             "name": "Adhere",
-            "sort": 400000,
+            "sort": 500000,
             "system": {
                 "area": null,
                 "cost": {
@@ -256,10 +353,13 @@
         },
         {
             "_id": "wIxJa34fJq43ImXR",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.QiW8VNdBf0SFUq69"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-dna-helix.webp",
             "name": "Cellular Stimulant",
-            "sort": 500000,
+            "sort": 600000,
             "system": {
                 "area": null,
                 "cost": {
@@ -326,10 +426,13 @@
         },
         {
             "_id": "dqTWxJTxyWekjOlF",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.JIAIyvj4PV84tnFk"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/magic/water/beam-ice-impact.webp",
             "name": "Chill Gaze",
-            "sort": 600000,
+            "sort": 700000,
             "system": {
                 "area": null,
                 "cost": {
@@ -382,7 +485,7 @@
                 },
                 "requirements": "",
                 "rules": [],
-                "slug": null,
+                "slug": "chill-gaze",
                 "target": {
                     "value": "1 creature"
                 },
@@ -407,10 +510,13 @@
         },
         {
             "_id": "8L917LZDjX0cG8Vx",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.kBhaPuzLUSwS6vVf"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/lightning/bolt-strike-forked-blue.webp",
             "name": "Electric Arc",
-            "sort": 700000,
+            "sort": 800000,
             "system": {
                 "area": null,
                 "cost": {
@@ -458,7 +564,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -490,10 +596,13 @@
         },
         {
             "_id": "nCcMP6Q2rBQXi3vO",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.V1cojmrEOWkJ1yPF"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-emblem.webp",
             "name": "Glow Up",
-            "sort": 800000,
+            "sort": 900000,
             "system": {
                 "area": null,
                 "cost": {
@@ -552,10 +661,13 @@
         },
         {
             "_id": "JPZnIO8PyutpbASB",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.6DfLZBl8wKIV03Iq"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/fire/explosion-embers-evade-silhouette.webp",
             "name": "Ignition",
-            "sort": 900000,
+            "sort": 1000000,
             "system": {
                 "area": null,
                 "cost": {
@@ -600,7 +712,9 @@
                         "_id": "eOCNn2ohYAvsYZjn",
                         "overlayType": "override",
                         "sort": 1,
-                        "system": {}
+                        "system": {
+                            "defense": null
+                        }
                     },
                     "xYyA7CV1GaFTRjBQ": {
                         "_id": "xYyA7CV1GaFTRjBQ",
@@ -613,6 +727,7 @@
                                     "formula": "2d6"
                                 }
                             },
+                            "defense": null,
                             "heightening": {
                                 "damage": {
                                     "cQDyW0QpjJ38MlSi": "1d6"
@@ -627,7 +742,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -659,92 +774,10 @@
             "type": "spell"
         },
         {
-            "_id": "yK6FxRmwpEClWmh9",
-            "folder": "KGETkFaB5r8FyUND",
-            "img": "icons/magic/water/projectile-ice-impact-stone.webp",
-            "name": "Liquid Siphon",
-            "sort": 1000000,
-            "system": {
-                "area": null,
-                "cost": {
-                    "value": ""
-                },
-                "counteraction": false,
-                "damage": {
-                    "l3hdup9FqPsH2ups": {
-                        "applyMod": false,
-                        "category": null,
-                        "formula": "4d6",
-                        "kinds": [
-                            "damage"
-                        ],
-                        "materials": [],
-                        "type": "bludgeoning"
-                    }
-                },
-                "defense": {
-                    "save": {
-                        "basic": false,
-                        "statistic": "fortitude"
-                    }
-                },
-                "description": {
-                    "value": "<p>You drain the moisture out of your target, crumpling them up like an empty beverage can and potentially leaving them a desiccated husk of what they once were. A nonliving target with liquid in its body (such as a vampire, water elemental, or keg of alcohol) can be affected by this spell, but a living creature with no vital liquids is immune. The target creature takes 4d6 bludgeoning damage, depending on the results of its saving throw.</p>\n<p>A target that fails its saving throw creates water that flows into your hands or a held container (1 gallon for Tiny, 2 gallons for Small, 4 for Medium, 6 for Large, 8 for Huge). If the target critically fails its saving throw, double this amount.</p><hr /><p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target takes half damage.</p>\n<p><strong>Failure</strong> The target takes full damage and is @UUID[Compendium.sf2e.conditions.Item.Drained]{Drained 1}.</p>\n<p><strong>Critical Failure</strong> As failure, but double damage and the target is @UUID[Compendium.sf2e.conditions.Item.Drained]{Drained 2}.</p><hr /><p><strong>Heightened (+1)</strong> Increase the damage by 2d6.</p>"
-                },
-                "duration": {
-                    "sustained": false,
-                    "value": ""
-                },
-                "heightening": {
-                    "area": 0,
-                    "damage": {
-                        "l3hdup9FqPsH2ups": "2d6"
-                    },
-                    "interval": 1,
-                    "type": "interval"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": {
-                    "heightenedLevel": 2,
-                    "value": "LebunvH85R2kh57v"
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Starfinder Guilt of the Grave World"
-                },
-                "range": {
-                    "value": "touch"
-                },
-                "requirements": "",
-                "rules": [],
-                "slug": null,
-                "target": {
-                    "value": "1 creature or object (see text)"
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traits": {
-                    "rarity": "common",
-                    "traditions": [
-                        "arcane",
-                        "occult",
-                        "primal"
-                    ],
-                    "value": [
-                        "concentrate",
-                        "manipulate",
-                        "water"
-                    ]
-                }
-            },
-            "type": "spell"
-        },
-        {
             "_id": "1ZE1VERjj1eAmKQT",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jgN33YSYXB8iIHTw"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "icons/skills/movement/figure-running-gray.webp",
             "name": "Stumble",

--- a/packs/sf2e/guilt-of-the-grave-world-bestiary/veskarium-paratrooper.json
+++ b/packs/sf2e/guilt-of-the-grave-world-bestiary/veskarium-paratrooper.json
@@ -252,6 +252,9 @@
         },
         {
             "_id": "QM7K2sgbYFoa9Am9",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.49Qja6ALTUaQuVIb"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/gas-canister.webp",
             "name": "Chem Tank (Commercial)",
@@ -267,7 +270,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -282,6 +286,7 @@
                     "type": null
                 },
                 "price": {
+                    "per": 1,
                     "value": {
                         "sp": 5
                     }

--- a/packs/sf2e/guilt-of-the-grave-world-bestiary/wight-scientist.json
+++ b/packs/sf2e/guilt-of-the-grave-world-bestiary/wight-scientist.json
@@ -151,6 +151,9 @@
         },
         {
             "_id": "Ukp7ZSawts2E5vSo",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -166,7 +169,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/guilt-of-the-grave-world-bestiary/zo.json
+++ b/packs/sf2e/guilt-of-the-grave-world-bestiary/zo.json
@@ -41,6 +41,9 @@
         },
         {
             "_id": "ZY0FCu5kK9oww9Ct",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jon2tSGg7fSTqtk9"
+            },
             "folder": "2cuzA13JVJ0A8JrW",
             "img": "systems/sf2e/icons/abilities/blue-emblem-3.webp",
             "name": "New Game",
@@ -100,6 +103,9 @@
         },
         {
             "_id": "TsmSAgkYslthea2C",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.qsNeG9KZpODSACMq"
+            },
             "folder": "fi1AYNmuCRvoT15b",
             "img": "icons/magic/perception/orb-eye-scrying.webp",
             "name": "Foresight",
@@ -129,7 +135,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -162,6 +168,9 @@
         },
         {
             "_id": "hddiYdCTlHeBfwhf",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.64DDZxOrmr4ddqs2"
+            },
             "folder": "DWZvpqhX0tWHYZOh",
             "img": "systems/sf2e/icons/abilities/yellow-fist.webp",
             "name": "Telekinetic Tantrum",
@@ -226,6 +235,9 @@
         },
         {
             "_id": "czG3U1EYtwcCEMfB",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Y3egStSTzL8k86qc"
+            },
             "folder": "uIyg7rfbXLT1OSXC",
             "img": "systems/sf2e/icons/abilities/spaceship-thruster.webp",
             "name": "Phantasmal Fleet",
@@ -306,6 +318,9 @@
         },
         {
             "_id": "vXXeKs1IUDaRz4Xa",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Jvyy6oVIQsD34MHB"
+            },
             "folder": "IfuYSF4ymX48CZnm",
             "img": "systems/sf2e/icons/spells/uncontrollable-dance.webp",
             "name": "Uncontrollable Dance",
@@ -340,7 +355,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -372,6 +387,9 @@
         },
         {
             "_id": "Pxm0PHNvsN4aKInL",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.kGas0LdEAR1WjLGZ"
+            },
             "folder": "MNWDEVo1eeM3A3Ec",
             "img": "systems/sf2e/icons/abilities/purple-event-horizon.webp",
             "name": "Absolute Zero",
@@ -459,6 +477,9 @@
         },
         {
             "_id": "XZBMCCvzYqsj1MHv",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.WG91Z5TiR6oO5FOw"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "icons/magic/unholy/orb-glowing-yellow-purple.webp",
             "name": "Contingency",
@@ -488,7 +509,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -517,6 +538,9 @@
         },
         {
             "_id": "mPVJKHkuG0VRdqC4",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.8kJbiBEjMWG4VUjs"
+            },
             "folder": "xqlqJ6eeiNtWb7bq",
             "img": "systems/sf2e/icons/spells/warp-mind.webp",
             "name": "Warp Mind",
@@ -551,7 +575,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -584,6 +608,9 @@
         },
         {
             "_id": "cUbEFGzq2mOvXUrD",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ITzIb93GBvyX8UbJ"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/pink-portal.webp",
             "name": "Pocket Vacuum",
@@ -671,6 +698,9 @@
         },
         {
             "_id": "rAi6yhMBJfsKcTAb",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.DPP4TW5FxE85XPKZ"
+            },
             "folder": "AZKyKWxyWmrno8ol",
             "img": "systems/sf2e/icons/abilities/blue-piercing-energy.webp",
             "name": "X-Ray Vision",
@@ -731,6 +761,9 @@
         },
         {
             "_id": "L0E7U8GqetqPdau3",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5cMDrC3jX1yrxOzh"
+            },
             "folder": "NQpcS2TwtjNNq1Qy",
             "img": "systems/sf2e/icons/abilities/blue-heroic-lightning-symbol.webp",
             "name": "Overload Systems",
@@ -818,6 +851,9 @@
         },
         {
             "_id": "MX2ysU5VNZGat0fV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.R9xqCBblkS5KE4y7"
+            },
             "folder": "iDjm2cXyRAe4VZ35",
             "img": "systems/sf2e/icons/spells/sending.webp",
             "name": "Sending",
@@ -847,7 +883,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "planetary"
@@ -879,6 +915,9 @@
         },
         {
             "_id": "WS6OKMAjABzhlV2X",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.LiGbewa9pO0yjbsY"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "systems/sf2e/icons/spells/confusion.webp",
             "name": "Confusion",
@@ -923,7 +962,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -955,6 +994,9 @@
         },
         {
             "_id": "E6B2ERxDJUy4Cox3",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.rBh2PjtbDGAjbcu6"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/equipment/other/yellow-battery.webp",
             "name": "Discharge",
@@ -1020,6 +1062,9 @@
         },
         {
             "_id": "XT3BeMuwnpzFNgVO",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ShwUELLERVMtdjwE"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/blue-heart-in-a-circle.webp",
             "name": "Life Seal",
@@ -1078,6 +1123,9 @@
         },
         {
             "_id": "e3ANDCpOauct6Htd",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.0mNmVi9CLXor3McX"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/green-upper-left-arrow.webp",
             "name": "Personal Gravity",
@@ -1138,6 +1186,9 @@
         },
         {
             "_id": "QoTSYd58ynSdpYns",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.L6Gww2b2YVM3q0ZQ"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/cerulean-alien-soldier.webp",
             "name": "Selective Invisibility",
@@ -1197,6 +1248,9 @@
         },
         {
             "_id": "PRVQyBQHcrUjX4WV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VIKDSgBRR3Wd1mQx"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/green-chart.webp",
             "name": "Doom Scroll",
@@ -1266,11 +1320,102 @@
             "type": "spell"
         },
         {
+            "_id": "re3ZmGmp4UUXbntj",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.j6KI3dFuaYJmMSZh"
+            },
+            "folder": "KGETkFaB5r8FyUND",
+            "img": "icons/magic/water/projectile-ice-impact-stone.webp",
+            "name": "Liquid Siphon",
+            "sort": 2000000,
+            "system": {
+                "area": null,
+                "cost": {
+                    "value": ""
+                },
+                "counteraction": false,
+                "damage": {
+                    "l3hdup9FqPsH2ups": {
+                        "applyMod": false,
+                        "category": null,
+                        "formula": "4d6",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "bludgeoning"
+                    }
+                },
+                "defense": {
+                    "save": {
+                        "basic": false,
+                        "statistic": "fortitude"
+                    }
+                },
+                "description": {
+                    "value": "<p>You drain the moisture out of your target, crumpling them up like an empty beverage can and potentially leaving them a desiccated husk of what they once were. A nonliving target with liquid in its body (such as a vampire, water elemental, or keg of alcohol) can be affected by this spell, but a living creature with no vital liquids is immune. The target creature takes 4d6 bludgeoning damage, depending on the results of its saving throw.</p>\n<p>A target that fails its saving throw creates water that flows into your hands or a held container (1 gallon for Tiny, 2 gallons for Small, 4 for Medium, 6 for Large, 8 for Huge). If the target critically fails its saving throw, double this amount.</p><hr /><p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target takes half damage.</p>\n<p><strong>Failure</strong> The target takes full damage and is @UUID[Compendium.sf2e.conditions.Item.Drained]{Drained 1}.</p>\n<p><strong>Critical Failure</strong> As failure, but double damage and the target is @UUID[Compendium.sf2e.conditions.Item.Drained]{Drained 2}.</p><hr /><p><strong>Heightened (+1)</strong> Increase the damage by 2d6.</p>"
+                },
+                "duration": {
+                    "sustained": false,
+                    "value": ""
+                },
+                "heightening": {
+                    "area": 0,
+                    "damage": {
+                        "l3hdup9FqPsH2ups": "2d6"
+                    },
+                    "interval": 1,
+                    "type": "interval"
+                },
+                "level": {
+                    "value": 2
+                },
+                "location": {
+                    "heightenedLevel": 2,
+                    "value": "J95s3W7YlUIv7xh5"
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Starfinder Guilt of the Grave World"
+                },
+                "range": {
+                    "value": "touch"
+                },
+                "requirements": "",
+                "rules": [],
+                "slug": "liquid-siphon",
+                "target": {
+                    "value": "1 creature or object (see text)"
+                },
+                "time": {
+                    "value": "2"
+                },
+                "traits": {
+                    "rarity": "common",
+                    "traditions": [
+                        "arcane",
+                        "occult",
+                        "primal"
+                    ],
+                    "value": [
+                        "concentrate",
+                        "manipulate",
+                        "water"
+                    ]
+                }
+            },
+            "type": "spell"
+        },
+        {
             "_id": "AWoTnKBRNOqPJHjH",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VynaowCerc7B4yvI"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/sundries/books/book-embossed-jewel-silver-green.webp",
             "name": "Akashic Download",
-            "sort": 2000000,
+            "sort": 2100000,
             "system": {
                 "area": null,
                 "cost": {
@@ -1325,10 +1470,13 @@
         },
         {
             "_id": "XclV4E1XnthFwWCO",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.JIAIyvj4PV84tnFk"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/magic/water/beam-ice-impact.webp",
             "name": "Chill Gaze",
-            "sort": 2100000,
+            "sort": 2200000,
             "system": {
                 "area": null,
                 "cost": {
@@ -1381,7 +1529,7 @@
                 },
                 "requirements": "",
                 "rules": [],
-                "slug": null,
+                "slug": "chill-gaze",
                 "target": {
                     "value": "1 creature"
                 },
@@ -1406,10 +1554,13 @@
         },
         {
             "_id": "qlWtfcyFkAhywpNy",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.JIAIyvj4PV84tnFk"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/magic/water/beam-ice-impact.webp",
             "name": "Chill Gaze",
-            "sort": 2200000,
+            "sort": 2300000,
             "system": {
                 "area": null,
                 "cost": {
@@ -1462,7 +1613,7 @@
                 },
                 "requirements": "",
                 "rules": [],
-                "slug": null,
+                "slug": "chill-gaze",
                 "target": {
                     "value": "1 creature"
                 },
@@ -1487,10 +1638,13 @@
         },
         {
             "_id": "G0WdaWLjLlwQTn4R",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4gBIw4IDrSfFHik4"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/daze.webp",
             "name": "Daze",
-            "sort": 2300000,
+            "sort": 2400000,
             "system": {
                 "area": null,
                 "cost": {
@@ -1538,7 +1692,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "60 feet"
@@ -1572,10 +1726,13 @@
         },
         {
             "_id": "4EAHhQvgIWH5BuQD",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.yXD9uU8w8uFD2OBQ"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/cerulean-circular-sign.webp",
             "name": "Delete",
-            "sort": 2400000,
+            "sort": 2500000,
             "system": {
                 "area": null,
                 "cost": {
@@ -1631,10 +1788,13 @@
         },
         {
             "_id": "RE2Ts26cU9AUjres",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.V1cojmrEOWkJ1yPF"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-emblem.webp",
             "name": "Glow Up",
-            "sort": 2500000,
+            "sort": 2600000,
             "system": {
                 "area": null,
                 "cost": {
@@ -1693,10 +1853,13 @@
         },
         {
             "_id": "F5IuCyamrHEppC3S",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ZBeKxBcUOsXrfMRo"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/purple-insignia.webp",
             "name": "Implant Data",
-            "sort": 2600000,
+            "sort": 2700000,
             "system": {
                 "area": null,
                 "cost": {
@@ -1752,10 +1915,13 @@
         },
         {
             "_id": "w3vN0MMmRhABp3h3",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.sNUvbMoMeLTnYJm8"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/blue-energy-alien-hand.webp",
             "name": "Injury Echo",
-            "sort": 2700000,
+            "sort": 2800000,
             "system": {
                 "area": null,
                 "cost": {
@@ -1898,92 +2064,10 @@
             "type": "spell"
         },
         {
-            "_id": "re3ZmGmp4UUXbntj",
-            "folder": "KGETkFaB5r8FyUND",
-            "img": "icons/magic/water/projectile-ice-impact-stone.webp",
-            "name": "Liquid Siphon",
-            "sort": 2800000,
-            "system": {
-                "area": null,
-                "cost": {
-                    "value": ""
-                },
-                "counteraction": false,
-                "damage": {
-                    "l3hdup9FqPsH2ups": {
-                        "applyMod": false,
-                        "category": null,
-                        "formula": "4d6",
-                        "kinds": [
-                            "damage"
-                        ],
-                        "materials": [],
-                        "type": "bludgeoning"
-                    }
-                },
-                "defense": {
-                    "save": {
-                        "basic": false,
-                        "statistic": "fortitude"
-                    }
-                },
-                "description": {
-                    "value": "<p>You drain the moisture out of your target, crumpling them up like an empty beverage can and potentially leaving them a desiccated husk of what they once were. A nonliving target with liquid in its body (such as a vampire, water elemental, or keg of alcohol) can be affected by this spell, but a living creature with no vital liquids is immune. The target creature takes 4d6 bludgeoning damage, depending on the results of its saving throw.</p>\n<p>A target that fails its saving throw creates water that flows into your hands or a held container (1 gallon for Tiny, 2 gallons for Small, 4 for Medium, 6 for Large, 8 for Huge). If the target critically fails its saving throw, double this amount.</p><hr /><p><strong>Critical Success</strong> The target is unaffected.</p>\n<p><strong>Success</strong> The target takes half damage.</p>\n<p><strong>Failure</strong> The target takes full damage and is @UUID[Compendium.sf2e.conditions.Item.Drained]{Drained 1}.</p>\n<p><strong>Critical Failure</strong> As failure, but double damage and the target is @UUID[Compendium.sf2e.conditions.Item.Drained]{Drained 2}.</p><hr /><p><strong>Heightened (+1)</strong> Increase the damage by 2d6.</p>"
-                },
-                "duration": {
-                    "sustained": false,
-                    "value": ""
-                },
-                "heightening": {
-                    "area": 0,
-                    "damage": {
-                        "l3hdup9FqPsH2ups": "2d6"
-                    },
-                    "interval": 1,
-                    "type": "interval"
-                },
-                "level": {
-                    "value": 1
-                },
-                "location": {
-                    "heightenedLevel": 2,
-                    "value": "J95s3W7YlUIv7xh5"
-                },
-                "publication": {
-                    "license": "ORC",
-                    "remaster": true,
-                    "title": "Starfinder Guilt of the Grave World"
-                },
-                "range": {
-                    "value": "touch"
-                },
-                "requirements": "",
-                "rules": [],
-                "slug": null,
-                "target": {
-                    "value": "1 creature or object (see text)"
-                },
-                "time": {
-                    "value": "2"
-                },
-                "traits": {
-                    "rarity": "common",
-                    "traditions": [
-                        "arcane",
-                        "occult",
-                        "primal"
-                    ],
-                    "value": [
-                        "concentrate",
-                        "manipulate",
-                        "water"
-                    ]
-                }
-            },
-            "type": "spell"
-        },
-        {
             "_id": "e5z2BIspqB5N8bbw",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.sXnWQOcGG2ELcxXb"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-galaxy.webp",
             "name": "Ricochet",
@@ -2105,6 +2189,9 @@
         },
         {
             "_id": "8lEXKWcQ4uWObjRc",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.60sgbuMWN0268dB7"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/skills/ranged/bullets-triple-ball-yellow.webp",
             "name": "Telekinetic Projectile",
@@ -2158,9 +2245,13 @@
                             "damage": {
                                 "0": {
                                     "category": null,
+                                    "kinds": [
+                                        "damage"
+                                    ],
                                     "type": "bludgeoning"
                                 }
-                            }
+                            },
+                            "defense": null
                         }
                     },
                     "cUFX7ExSLeoa3vIF": {
@@ -2172,9 +2263,13 @@
                             "damage": {
                                 "0": {
                                     "category": null,
+                                    "kinds": [
+                                        "damage"
+                                    ],
                                     "type": "piercing"
                                 }
-                            }
+                            },
+                            "defense": null
                         }
                     },
                     "zFWsMjoeCnLxqJaV": {
@@ -2186,16 +2281,20 @@
                             "damage": {
                                 "0": {
                                     "category": null,
+                                    "kinds": [
+                                        "damage"
+                                    ],
                                     "type": "slashing"
                                 }
-                            }
+                            },
+                            "defense": null
                         }
                     }
                 },
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"

--- a/packs/sf2e/guilt-of-the-grave-world-bestiary/zo.json
+++ b/packs/sf2e/guilt-of-the-grave-world-bestiary/zo.json
@@ -2793,6 +2793,9 @@
         },
         {
             "_id": "0MfZKQBWKuAS4PH3",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.YhkomhtKBK3i9C7Q"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/white-console.webp",
             "name": "Holoskin (Tactical)",

--- a/packs/sf2e/iconics/chk-chk/chk-chk-level-1.json
+++ b/packs/sf2e/iconics/chk-chk/chk-chk-level-1.json
@@ -670,6 +670,9 @@
         },
         {
             "_id": "ymLfa5HOLUw9iUID",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -685,7 +688,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -886,6 +890,9 @@
         },
         {
             "_id": "9i7fSE0HDbmHOK2j",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.fClhrG92Zi4k14Hq"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/walkie-talkie.webp",
             "name": "Comm Unit",
@@ -901,6 +908,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -976,6 +984,9 @@
         },
         {
             "_id": "zjlJOs4DA8u38SbU",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.vLGDUFrg4yGzpTQX"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/blue-brick.webp",
             "name": "Repair Toolkit (Commercial)",
@@ -991,6 +1002,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,

--- a/packs/sf2e/iconics/chk-chk/chk-chk-level-1.json
+++ b/packs/sf2e/iconics/chk-chk/chk-chk-level-1.json
@@ -1077,6 +1077,9 @@
         },
         {
             "_id": "tyBYcjJxoEEBFaTv",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -1093,7 +1096,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -1108,7 +1111,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1142,6 +1145,9 @@
         },
         {
             "_id": "4fARYjAceunmSNEf",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.FEaM1B4WuiqFO7Uk"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "icons/magic/unholy/projectile-bolts-salvo-pink.webp",
             "name": "Eldritch Lance",
@@ -1222,6 +1228,9 @@
         },
         {
             "_id": "iWMtmJKhceVHoiUr",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.0zU8CPejjQFnhZFI"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/ghost-sound.webp",
             "name": "Figment",
@@ -1250,7 +1259,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1283,6 +1292,9 @@
         },
         {
             "_id": "7m8RPkwKhEPrNBi1",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.izcxFQFwf3woCnFs"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/guidance.webp",
             "name": "Guidance",
@@ -1311,7 +1323,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1342,6 +1354,9 @@
         },
         {
             "_id": "l4b0p5yz1vodPuQH",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.mAMEt4FFbdqoRnkN"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/chill-touch.webp",
             "name": "Void Warp",
@@ -1393,7 +1408,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1426,6 +1441,9 @@
         },
         {
             "_id": "fywSUrGFqkVLk1Gy",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.k34hDOfIIMAxNL4a"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/grim-tendrils.webp",
             "name": "Grim Tendrils",
@@ -1481,7 +1499,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1512,6 +1530,9 @@
         },
         {
             "_id": "gOyUssxh0NwblkEJ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.rfZpqmj0AIIdkVIs"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/life/cross-worn-green.webp",
             "name": "Heal",
@@ -1676,7 +1697,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "varies"
@@ -1707,6 +1728,9 @@
         },
         {
             "_id": "AGgzad0El0E6Dwjp",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5ZZca1GGJs44OxC8"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/battery-pack.webp",
             "name": "Motivating Ringtone",
@@ -1830,6 +1854,9 @@
         },
         {
             "_id": "PIrH3LF8zdTMcBTo",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uh9Br4yrKvJA6zq0"
+            },
             "folder": "w6FyVHHsHMOXbY2w",
             "img": "systems/sf2e/icons/abilities/purple-flowing-energy.webp",
             "name": "Shadow Snap",
@@ -1859,7 +1886,7 @@
                     "save": null
                 },
                 "description": {
-                    "value": "<p>With a snap of your fingers, you command the target's shadow to either attack or stalk its body. If you command it to attack, attempt a spell attack roll against the target's AC, dealing 1d10 cold damage on a hit (or double damage on a critical hit). This attack uses and contributes to your multiple attack penalty.</p>\n<p>If you command the shadow to stalk, attempt a spell attack roll against the target's AC the first time the target uses a manipulate action or a move action, makes a ranged attack, or leaves a square during a move action it's using; dealing 1d10 cold damage on a hit. If the attack is a critical hit, the shadow disrupts that action.</p>\n<p>Each time you Sustain the spell, you can choose to either attack the target or command the shadow to stalk the target until the end of your next turn.</p><hr /><p><strong>Heightened (+1)</strong> The cold damage increases by 1d10.</p>"
+                    "value": "<p>With a snap of your fingers, you beckon the target's shadow to obey you. When you Cast this Spell and the first time you Sustain it each turn on subsequent rounds, you can choose to either attack or stalk the target with its shadow. If you choose to attack, attempt a spell attack roll against the target's AC, dealing 1d10 cold damage on a hit (or double damage on a critical hit). This attack uses and contributes to your multiple attack penalty.</p>\n<p>If you stalk, attempt a spell attack roll against the target's AC the first time the target uses a manipulate action or a move action, makes a ranged attack, or leaves a square during a move action it's using until the end of your next turn; dealing 1d10 cold damage on a hit. If the attack is a critical hit, the shadow disrupts that action.</p>\n<p>Each time you Sustain the spell, you can choose to either attack the target or command the shadow to stalk the target until the end of your next turn.</p><hr /><p><strong>Heightened (+1)</strong> The cold damage increases by 1d10.</p>"
                 },
                 "duration": {
                     "sustained": true,
@@ -1900,6 +1927,7 @@
                     "rarity": "uncommon",
                     "traditions": [],
                     "value": [
+                        "attack",
                         "concentrate",
                         "focus",
                         "manipulate",

--- a/packs/sf2e/iconics/chk-chk/chk-chk-level-3.json
+++ b/packs/sf2e/iconics/chk-chk/chk-chk-level-3.json
@@ -670,6 +670,9 @@
         },
         {
             "_id": "ymLfa5HOLUw9iUID",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -685,7 +688,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -700,6 +704,7 @@
                     "type": null
                 },
                 "price": {
+                    "per": 1,
                     "value": {
                         "sp": 10
                     }
@@ -718,7 +723,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 10,
                     "value": 10
                 }
@@ -885,6 +890,9 @@
         },
         {
             "_id": "9i7fSE0HDbmHOK2j",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.fClhrG92Zi4k14Hq"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/walkie-talkie.webp",
             "name": "Comm Unit",
@@ -900,6 +908,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -975,6 +984,9 @@
         },
         {
             "_id": "zjlJOs4DA8u38SbU",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.vLGDUFrg4yGzpTQX"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/blue-brick.webp",
             "name": "Repair Toolkit (Commercial)",
@@ -990,6 +1002,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -2073,6 +2086,9 @@
         },
         {
             "_id": "y1JvJiVPXIhqJvHv",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.s1vB3HdXjMigYAnY"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/med-pack.webp",
             "name": "Medkit (Commercial)",
@@ -2088,6 +2104,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,

--- a/packs/sf2e/iconics/chk-chk/chk-chk-level-3.json
+++ b/packs/sf2e/iconics/chk-chk/chk-chk-level-3.json
@@ -1080,6 +1080,9 @@
         },
         {
             "_id": "tyBYcjJxoEEBFaTv",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -1096,7 +1099,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -1111,7 +1114,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1145,6 +1148,9 @@
         },
         {
             "_id": "4fARYjAceunmSNEf",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.FEaM1B4WuiqFO7Uk"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "icons/magic/unholy/projectile-bolts-salvo-pink.webp",
             "name": "Eldritch Lance",
@@ -1225,6 +1231,9 @@
         },
         {
             "_id": "iWMtmJKhceVHoiUr",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.0zU8CPejjQFnhZFI"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/ghost-sound.webp",
             "name": "Figment",
@@ -1253,7 +1262,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1286,6 +1295,9 @@
         },
         {
             "_id": "7m8RPkwKhEPrNBi1",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.izcxFQFwf3woCnFs"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/guidance.webp",
             "name": "Guidance",
@@ -1314,7 +1326,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1345,6 +1357,9 @@
         },
         {
             "_id": "l4b0p5yz1vodPuQH",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.mAMEt4FFbdqoRnkN"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/chill-touch.webp",
             "name": "Void Warp",
@@ -1396,7 +1411,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1429,6 +1444,9 @@
         },
         {
             "_id": "fywSUrGFqkVLk1Gy",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.k34hDOfIIMAxNL4a"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/grim-tendrils.webp",
             "name": "Grim Tendrils",
@@ -1485,7 +1503,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1516,6 +1534,9 @@
         },
         {
             "_id": "gOyUssxh0NwblkEJ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.rfZpqmj0AIIdkVIs"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/life/cross-worn-green.webp",
             "name": "Heal",
@@ -1680,7 +1701,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "varies"
@@ -1711,6 +1732,9 @@
         },
         {
             "_id": "AGgzad0El0E6Dwjp",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5ZZca1GGJs44OxC8"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/battery-pack.webp",
             "name": "Motivating Ringtone",
@@ -1834,6 +1858,9 @@
         },
         {
             "_id": "PIrH3LF8zdTMcBTo",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uh9Br4yrKvJA6zq0"
+            },
             "folder": "w6FyVHHsHMOXbY2w",
             "img": "systems/sf2e/icons/abilities/purple-flowing-energy.webp",
             "name": "Shadow Snap",
@@ -1863,7 +1890,7 @@
                     "save": null
                 },
                 "description": {
-                    "value": "<p>With a snap of your fingers, you command the target's shadow to either attack or stalk its body. If you command it to attack, attempt a spell attack roll against the target's AC, dealing 1d10 cold damage on a hit (or double damage on a critical hit). This attack uses and contributes to your multiple attack penalty.</p>\n<p>If you command the shadow to stalk, attempt a spell attack roll against the target's AC the first time the target uses a manipulate action or a move action, makes a ranged attack, or leaves a square during a move action it's using; dealing 1d10 cold damage on a hit. If the attack is a critical hit, the shadow disrupts that action.</p>\n<p>Each time you Sustain the spell, you can choose to either attack the target or command the shadow to stalk the target until the end of your next turn.</p><hr /><p><strong>Heightened (+1)</strong> The cold damage increases by 1d10.</p>"
+                    "value": "<p>With a snap of your fingers, you beckon the target's shadow to obey you. When you Cast this Spell and the first time you Sustain it each turn on subsequent rounds, you can choose to either attack or stalk the target with its shadow. If you choose to attack, attempt a spell attack roll against the target's AC, dealing 1d10 cold damage on a hit (or double damage on a critical hit). This attack uses and contributes to your multiple attack penalty.</p>\n<p>If you stalk, attempt a spell attack roll against the target's AC the first time the target uses a manipulate action or a move action, makes a ranged attack, or leaves a square during a move action it's using until the end of your next turn; dealing 1d10 cold damage on a hit. If the attack is a critical hit, the shadow disrupts that action.</p>\n<p>Each time you Sustain the spell, you can choose to either attack the target or command the shadow to stalk the target until the end of your next turn.</p><hr /><p><strong>Heightened (+1)</strong> The cold damage increases by 1d10.</p>"
                 },
                 "duration": {
                     "sustained": true,
@@ -1904,6 +1931,7 @@
                     "rarity": "uncommon",
                     "traditions": [],
                     "value": [
+                        "attack",
                         "concentrate",
                         "focus",
                         "manipulate",
@@ -2158,6 +2186,9 @@
         },
         {
             "_id": "I7kT9cuLQcYAeER1",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4koZzrnMXhhosn0D"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/fear.webp",
             "name": "Fear",
@@ -2202,7 +2233,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -2237,6 +2268,9 @@
         },
         {
             "_id": "PWpXtNEpcaeTtlUK",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.HPHr5aoLMH4eVwaw"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/yellow-hand.webp",
             "name": "Soul Surge",
@@ -2416,6 +2450,9 @@
         },
         {
             "_id": "eLAalc91mIWbNauR",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.XXqE1eY3w3z6xJCB"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/creatures/magical/construct-stone-earth-gray.webp",
             "name": "Invisibility",
@@ -2445,7 +2482,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -2476,6 +2513,9 @@
         },
         {
             "_id": "6mETyyGRovrWtoJP",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.rfZpqmj0AIIdkVIs"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/life/cross-worn-green.webp",
             "name": "Heal",
@@ -2640,7 +2680,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "varies"

--- a/packs/sf2e/iconics/chk-chk/chk-chk-level-5.json
+++ b/packs/sf2e/iconics/chk-chk/chk-chk-level-5.json
@@ -1151,6 +1151,9 @@
         },
         {
             "_id": "tyBYcjJxoEEBFaTv",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -1167,7 +1170,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -1182,7 +1185,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1216,6 +1219,9 @@
         },
         {
             "_id": "4fARYjAceunmSNEf",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.FEaM1B4WuiqFO7Uk"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "icons/magic/unholy/projectile-bolts-salvo-pink.webp",
             "name": "Eldritch Lance",
@@ -1296,6 +1302,9 @@
         },
         {
             "_id": "iWMtmJKhceVHoiUr",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.0zU8CPejjQFnhZFI"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/ghost-sound.webp",
             "name": "Figment",
@@ -1324,7 +1333,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1357,6 +1366,9 @@
         },
         {
             "_id": "7m8RPkwKhEPrNBi1",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.izcxFQFwf3woCnFs"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/guidance.webp",
             "name": "Guidance",
@@ -1385,7 +1397,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1416,6 +1428,9 @@
         },
         {
             "_id": "l4b0p5yz1vodPuQH",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.mAMEt4FFbdqoRnkN"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/chill-touch.webp",
             "name": "Void Warp",
@@ -1467,7 +1482,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1500,6 +1515,9 @@
         },
         {
             "_id": "fywSUrGFqkVLk1Gy",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.k34hDOfIIMAxNL4a"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/grim-tendrils.webp",
             "name": "Grim Tendrils",
@@ -1556,7 +1574,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1587,6 +1605,9 @@
         },
         {
             "_id": "gOyUssxh0NwblkEJ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.rfZpqmj0AIIdkVIs"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/life/cross-worn-green.webp",
             "name": "Heal",
@@ -1751,7 +1772,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "varies"
@@ -1782,6 +1803,9 @@
         },
         {
             "_id": "AGgzad0El0E6Dwjp",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5ZZca1GGJs44OxC8"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/battery-pack.webp",
             "name": "Motivating Ringtone",
@@ -1905,6 +1929,9 @@
         },
         {
             "_id": "PIrH3LF8zdTMcBTo",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uh9Br4yrKvJA6zq0"
+            },
             "folder": "w6FyVHHsHMOXbY2w",
             "img": "systems/sf2e/icons/abilities/purple-flowing-energy.webp",
             "name": "Shadow Snap",
@@ -1934,7 +1961,7 @@
                     "save": null
                 },
                 "description": {
-                    "value": "<p>With a snap of your fingers, you command the target's shadow to either attack or stalk its body. If you command it to attack, attempt a spell attack roll against the target's AC, dealing 1d10 cold damage on a hit (or double damage on a critical hit). This attack uses and contributes to your multiple attack penalty.</p>\n<p>If you command the shadow to stalk, attempt a spell attack roll against the target's AC the first time the target uses a manipulate action or a move action, makes a ranged attack, or leaves a square during a move action it's using; dealing 1d10 cold damage on a hit. If the attack is a critical hit, the shadow disrupts that action.</p>\n<p>Each time you Sustain the spell, you can choose to either attack the target or command the shadow to stalk the target until the end of your next turn.</p><hr /><p><strong>Heightened (+1)</strong> The cold damage increases by 1d10.</p>"
+                    "value": "<p>With a snap of your fingers, you beckon the target's shadow to obey you. When you Cast this Spell and the first time you Sustain it each turn on subsequent rounds, you can choose to either attack or stalk the target with its shadow. If you choose to attack, attempt a spell attack roll against the target's AC, dealing 1d10 cold damage on a hit (or double damage on a critical hit). This attack uses and contributes to your multiple attack penalty.</p>\n<p>If you stalk, attempt a spell attack roll against the target's AC the first time the target uses a manipulate action or a move action, makes a ranged attack, or leaves a square during a move action it's using until the end of your next turn; dealing 1d10 cold damage on a hit. If the attack is a critical hit, the shadow disrupts that action.</p>\n<p>Each time you Sustain the spell, you can choose to either attack the target or command the shadow to stalk the target until the end of your next turn.</p><hr /><p><strong>Heightened (+1)</strong> The cold damage increases by 1d10.</p>"
                 },
                 "duration": {
                     "sustained": true,
@@ -1975,6 +2002,7 @@
                     "rarity": "uncommon",
                     "traditions": [],
                     "value": [
+                        "attack",
                         "concentrate",
                         "focus",
                         "manipulate",
@@ -2229,6 +2257,9 @@
         },
         {
             "_id": "I7kT9cuLQcYAeER1",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4koZzrnMXhhosn0D"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/fear.webp",
             "name": "Fear",
@@ -2273,7 +2304,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -2308,6 +2339,9 @@
         },
         {
             "_id": "PWpXtNEpcaeTtlUK",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.HPHr5aoLMH4eVwaw"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/yellow-hand.webp",
             "name": "Soul Surge",
@@ -2487,6 +2521,9 @@
         },
         {
             "_id": "htM9mF50aHGd5owz",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.XXqE1eY3w3z6xJCB"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/creatures/magical/construct-stone-earth-gray.webp",
             "name": "Invisibility",
@@ -2516,7 +2553,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -2547,6 +2584,9 @@
         },
         {
             "_id": "2LyQV22Ch4J1ZyYz",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.rfZpqmj0AIIdkVIs"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/life/cross-worn-green.webp",
             "name": "Heal",
@@ -2711,7 +2751,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "varies"
@@ -2742,6 +2782,9 @@
         },
         {
             "_id": "47IzJJ8w0TKXiqcU",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.EfFMLVbmkBWmzoLF"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/detect-alignment.webp",
             "name": "Clear Mind",
@@ -2771,7 +2814,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -2804,6 +2847,9 @@
         },
         {
             "_id": "XH43SPAvC8KMm4dC",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.rfZpqmj0AIIdkVIs"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/life/cross-worn-green.webp",
             "name": "Heal",
@@ -2968,7 +3014,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "varies"
@@ -2999,6 +3045,9 @@
         },
         {
             "_id": "wvrAaTrqS1p0M5fe",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.EhN3GjdjXChMdiFk"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/purple-neurons.webp",
             "name": "Share Pain",
@@ -3036,7 +3085,7 @@
                 },
                 "heightening": {
                     "levels": {
-                        "4": {
+                        "6": {
                             "damage": {
                                 "dIvEREAgyIVyanqT": {
                                     "applyMod": false,
@@ -3082,7 +3131,10 @@
                 },
                 "traits": {
                     "rarity": "common",
-                    "traditions": [],
+                    "traditions": [
+                        "divine",
+                        "occult"
+                    ],
                     "value": [
                         "concentrate",
                         "manipulate",
@@ -3094,6 +3146,9 @@
         },
         {
             "_id": "tdKipgjER8VH1dRV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.WsUwpfmhKrKwoIe3"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/time/hourglass-tilted-gray.webp",
             "name": "Slow",
@@ -3139,7 +3194,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"

--- a/packs/sf2e/iconics/chk-chk/chk-chk-level-5.json
+++ b/packs/sf2e/iconics/chk-chk/chk-chk-level-5.json
@@ -670,6 +670,9 @@
         },
         {
             "_id": "ymLfa5HOLUw9iUID",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -685,7 +688,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -700,6 +704,7 @@
                     "type": null
                 },
                 "price": {
+                    "per": 1,
                     "value": {
                         "sp": 10
                     }
@@ -718,7 +723,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 10,
                     "value": 10
                 }
@@ -952,6 +957,9 @@
         },
         {
             "_id": "9i7fSE0HDbmHOK2j",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.fClhrG92Zi4k14Hq"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/walkie-talkie.webp",
             "name": "Comm Unit",
@@ -967,6 +975,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -1042,6 +1051,9 @@
         },
         {
             "_id": "zjlJOs4DA8u38SbU",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.vLGDUFrg4yGzpTQX"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/blue-brick.webp",
             "name": "Repair Toolkit (Commercial)",
@@ -1057,6 +1069,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -2144,6 +2157,9 @@
         },
         {
             "_id": "y1JvJiVPXIhqJvHv",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.s1vB3HdXjMigYAnY"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/med-pack.webp",
             "name": "Medkit (Commercial)",
@@ -2159,6 +2175,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -3404,6 +3421,9 @@
         },
         {
             "_id": "MVHnQtBLN9oitOFA",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.5Zgnk1EEYEaddjSY"
+            },
             "folder": "VGsfnIyGP1k7iP2r",
             "img": "icons/commodities/biological/wing-insect-green.webp",
             "name": "Ultralight Wings (Commercial)",
@@ -3449,6 +3469,7 @@
                     {
                         "key": "BaseSpeed",
                         "predicate": [
+                            "wings-deployed",
                             {
                                 "nor": [
                                     "armor:category:heavy",
@@ -3462,9 +3483,12 @@
                     {
                         "key": "FlatModifier",
                         "predicate": [
-                            "action:maneuver-in-flight"
+                            "action:maneuver-in-flight",
+                            "wings-deployed"
                         ],
-                        "selector": "acrobatics",
+                        "selector": [
+                            "acrobatics"
+                        ],
                         "type": "item",
                         "value": 1
                     }

--- a/packs/sf2e/iconics/chk-chk/chk-chk-level-7.json
+++ b/packs/sf2e/iconics/chk-chk/chk-chk-level-7.json
@@ -670,6 +670,9 @@
         },
         {
             "_id": "ymLfa5HOLUw9iUID",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -685,7 +688,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -700,6 +704,7 @@
                     "type": null
                 },
                 "price": {
+                    "per": 1,
                     "value": {
                         "sp": 10
                     }
@@ -718,7 +723,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 10,
                     "value": 10
                 }
@@ -952,6 +957,9 @@
         },
         {
             "_id": "9i7fSE0HDbmHOK2j",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.fClhrG92Zi4k14Hq"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/walkie-talkie.webp",
             "name": "Comm Unit",
@@ -967,6 +975,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -1042,6 +1051,9 @@
         },
         {
             "_id": "zjlJOs4DA8u38SbU",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.vLGDUFrg4yGzpTQX"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/blue-brick.webp",
             "name": "Repair Toolkit (Commercial)",
@@ -1057,6 +1069,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -3353,6 +3366,9 @@
         },
         {
             "_id": "MVHnQtBLN9oitOFA",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.5Zgnk1EEYEaddjSY"
+            },
             "folder": "VGsfnIyGP1k7iP2r",
             "img": "icons/commodities/biological/wing-insect-green.webp",
             "name": "Ultralight Wings (Commercial)",
@@ -3398,6 +3414,7 @@
                     {
                         "key": "BaseSpeed",
                         "predicate": [
+                            "wings-deployed",
                             {
                                 "nor": [
                                     "armor:category:heavy",
@@ -3411,9 +3428,12 @@
                     {
                         "key": "FlatModifier",
                         "predicate": [
-                            "action:maneuver-in-flight"
+                            "action:maneuver-in-flight",
+                            "wings-deployed"
                         ],
-                        "selector": "acrobatics",
+                        "selector": [
+                            "acrobatics"
+                        ],
                         "type": "item",
                         "value": 1
                     }
@@ -3434,6 +3454,9 @@
         },
         {
             "_id": "Ichx7fvSQbTAuMrn",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.SGkOHFyBbzWdBk8D"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/med-pack.webp",
             "name": "Medkit (Tactical)",
@@ -3449,6 +3472,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,

--- a/packs/sf2e/iconics/chk-chk/chk-chk-level-7.json
+++ b/packs/sf2e/iconics/chk-chk/chk-chk-level-7.json
@@ -1155,6 +1155,9 @@
         },
         {
             "_id": "tyBYcjJxoEEBFaTv",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -1171,7 +1174,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -1186,7 +1189,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1220,6 +1223,9 @@
         },
         {
             "_id": "4fARYjAceunmSNEf",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.FEaM1B4WuiqFO7Uk"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "icons/magic/unholy/projectile-bolts-salvo-pink.webp",
             "name": "Eldritch Lance",
@@ -1300,6 +1306,9 @@
         },
         {
             "_id": "iWMtmJKhceVHoiUr",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.0zU8CPejjQFnhZFI"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/ghost-sound.webp",
             "name": "Figment",
@@ -1328,7 +1337,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1361,6 +1370,9 @@
         },
         {
             "_id": "7m8RPkwKhEPrNBi1",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.izcxFQFwf3woCnFs"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/guidance.webp",
             "name": "Guidance",
@@ -1389,7 +1401,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1420,6 +1432,9 @@
         },
         {
             "_id": "l4b0p5yz1vodPuQH",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.mAMEt4FFbdqoRnkN"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/chill-touch.webp",
             "name": "Void Warp",
@@ -1471,7 +1486,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1504,6 +1519,9 @@
         },
         {
             "_id": "fywSUrGFqkVLk1Gy",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.k34hDOfIIMAxNL4a"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/grim-tendrils.webp",
             "name": "Grim Tendrils",
@@ -1560,7 +1578,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1591,6 +1609,9 @@
         },
         {
             "_id": "gOyUssxh0NwblkEJ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.rfZpqmj0AIIdkVIs"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/life/cross-worn-green.webp",
             "name": "Heal",
@@ -1755,7 +1776,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "varies"
@@ -1786,6 +1807,9 @@
         },
         {
             "_id": "AGgzad0El0E6Dwjp",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5ZZca1GGJs44OxC8"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/battery-pack.webp",
             "name": "Motivating Ringtone",
@@ -1909,6 +1933,9 @@
         },
         {
             "_id": "PIrH3LF8zdTMcBTo",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uh9Br4yrKvJA6zq0"
+            },
             "folder": "w6FyVHHsHMOXbY2w",
             "img": "systems/sf2e/icons/abilities/purple-flowing-energy.webp",
             "name": "Shadow Snap",
@@ -1938,7 +1965,7 @@
                     "save": null
                 },
                 "description": {
-                    "value": "<p>With a snap of your fingers, you command the target's shadow to either attack or stalk its body. If you command it to attack, attempt a spell attack roll against the target's AC, dealing 1d10 cold damage on a hit (or double damage on a critical hit). This attack uses and contributes to your multiple attack penalty.</p>\n<p>If you command the shadow to stalk, attempt a spell attack roll against the target's AC the first time the target uses a manipulate action or a move action, makes a ranged attack, or leaves a square during a move action it's using; dealing 1d10 cold damage on a hit. If the attack is a critical hit, the shadow disrupts that action.</p>\n<p>Each time you Sustain the spell, you can choose to either attack the target or command the shadow to stalk the target until the end of your next turn.</p><hr /><p><strong>Heightened (+1)</strong> The cold damage increases by 1d10.</p>"
+                    "value": "<p>With a snap of your fingers, you beckon the target's shadow to obey you. When you Cast this Spell and the first time you Sustain it each turn on subsequent rounds, you can choose to either attack or stalk the target with its shadow. If you choose to attack, attempt a spell attack roll against the target's AC, dealing 1d10 cold damage on a hit (or double damage on a critical hit). This attack uses and contributes to your multiple attack penalty.</p>\n<p>If you stalk, attempt a spell attack roll against the target's AC the first time the target uses a manipulate action or a move action, makes a ranged attack, or leaves a square during a move action it's using until the end of your next turn; dealing 1d10 cold damage on a hit. If the attack is a critical hit, the shadow disrupts that action.</p>\n<p>Each time you Sustain the spell, you can choose to either attack the target or command the shadow to stalk the target until the end of your next turn.</p><hr /><p><strong>Heightened (+1)</strong> The cold damage increases by 1d10.</p>"
                 },
                 "duration": {
                     "sustained": true,
@@ -1979,6 +2006,7 @@
                     "rarity": "uncommon",
                     "traditions": [],
                     "value": [
+                        "attack",
                         "concentrate",
                         "focus",
                         "manipulate",
@@ -2178,6 +2206,9 @@
         },
         {
             "_id": "I7kT9cuLQcYAeER1",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4koZzrnMXhhosn0D"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/fear.webp",
             "name": "Fear",
@@ -2222,7 +2253,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -2257,6 +2288,9 @@
         },
         {
             "_id": "PWpXtNEpcaeTtlUK",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.HPHr5aoLMH4eVwaw"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/yellow-hand.webp",
             "name": "Soul Surge",
@@ -2436,6 +2470,9 @@
         },
         {
             "_id": "htM9mF50aHGd5owz",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.XXqE1eY3w3z6xJCB"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/creatures/magical/construct-stone-earth-gray.webp",
             "name": "Invisibility",
@@ -2465,7 +2502,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -2496,6 +2533,9 @@
         },
         {
             "_id": "2LyQV22Ch4J1ZyYz",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.rfZpqmj0AIIdkVIs"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/life/cross-worn-green.webp",
             "name": "Heal",
@@ -2660,7 +2700,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "varies"
@@ -2691,6 +2731,9 @@
         },
         {
             "_id": "47IzJJ8w0TKXiqcU",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.EfFMLVbmkBWmzoLF"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/detect-alignment.webp",
             "name": "Clear Mind",
@@ -2720,7 +2763,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -2753,6 +2796,9 @@
         },
         {
             "_id": "XH43SPAvC8KMm4dC",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.rfZpqmj0AIIdkVIs"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/life/cross-worn-green.webp",
             "name": "Heal",
@@ -2917,7 +2963,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "varies"
@@ -2948,6 +2994,9 @@
         },
         {
             "_id": "wvrAaTrqS1p0M5fe",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.EhN3GjdjXChMdiFk"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/purple-neurons.webp",
             "name": "Share Pain",
@@ -2985,7 +3034,7 @@
                 },
                 "heightening": {
                     "levels": {
-                        "4": {
+                        "6": {
                             "damage": {
                                 "dIvEREAgyIVyanqT": {
                                     "applyMod": false,
@@ -3031,7 +3080,10 @@
                 },
                 "traits": {
                     "rarity": "common",
-                    "traditions": [],
+                    "traditions": [
+                        "divine",
+                        "occult"
+                    ],
                     "value": [
                         "concentrate",
                         "manipulate",
@@ -3043,6 +3095,9 @@
         },
         {
             "_id": "tdKipgjER8VH1dRV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.WsUwpfmhKrKwoIe3"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/time/hourglass-tilted-gray.webp",
             "name": "Slow",
@@ -3088,7 +3143,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -3709,6 +3764,9 @@
         },
         {
             "_id": "IuWzpEAxtdDauLIR",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ShwUELLERVMtdjwE"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/blue-heart-in-a-circle.webp",
             "name": "Life Seal",
@@ -3767,6 +3825,9 @@
         },
         {
             "_id": "OaG7WydTASAfforE",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.zR67Rt3UMHKC5evy"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "systems/sf2e/icons/spells/blink.webp",
             "name": "Flicker",
@@ -3797,7 +3858,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -3828,6 +3889,9 @@
         },
         {
             "_id": "m93v6t0YQDgM1O6q",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.s6J1Q0e28Gb42epQ"
+            },
             "folder": "NuBKgFiv0GJhsx3c",
             "img": "systems/sf2e/icons/abilities/green-dna-helix.webp",
             "name": "Genetic Regeneration",
@@ -3889,6 +3953,9 @@
         },
         {
             "_id": "vJHK8MnPzbUaf4AM",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.rfZpqmj0AIIdkVIs"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/life/cross-worn-green.webp",
             "name": "Heal",
@@ -4053,7 +4120,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "varies"

--- a/packs/sf2e/iconics/dae/dae-level-1.json
+++ b/packs/sf2e/iconics/dae/dae-level-1.json
@@ -575,6 +575,9 @@
         },
         {
             "_id": "6sBXVzOzypjGFk7a",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.fClhrG92Zi4k14Hq"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/walkie-talkie.webp",
             "name": "Comm Unit",
@@ -590,6 +593,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -736,6 +740,9 @@
         },
         {
             "_id": "1ncGURdGnC8unHY5",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.B0FiYMxy7iDiHh48"
+            },
             "folder": "aGUZspQIi3yNxIOu",
             "img": "systems/sf2e/icons/equipment/other/med-kit.webp",
             "name": "Medpatch (Commercial)",
@@ -756,7 +763,8 @@
                     "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> (manipulate)</p><hr /><p>Medpatches accelerate the body's natural healing. You regain @Damage[(1d6)[healing]] Hit Points and gain a +1 item bonus to saving throws against diseases and poisons for 10 minutes.</p>\n<p>@UUID[Compendium.sf2e.equipment-effects.Item.Effect: Medpatch]</p>"
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -772,9 +780,6 @@
                 },
                 "price": {
                     "value": {
-                        "cp": 0,
-                        "gp": 0,
-                        "pp": 0,
                         "sp": 30
                     }
                 },
@@ -899,6 +904,9 @@
         },
         {
             "_id": "olkzznMbbFFtRfk0",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -914,7 +922,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/iconics/dae/dae-level-3.json
+++ b/packs/sf2e/iconics/dae/dae-level-3.json
@@ -578,6 +578,9 @@
         },
         {
             "_id": "6sBXVzOzypjGFk7a",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.fClhrG92Zi4k14Hq"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/walkie-talkie.webp",
             "name": "Comm Unit",
@@ -593,6 +596,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -739,6 +743,9 @@
         },
         {
             "_id": "1ncGURdGnC8unHY5",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.B0FiYMxy7iDiHh48"
+            },
             "folder": "aGUZspQIi3yNxIOu",
             "img": "systems/sf2e/icons/equipment/other/med-kit.webp",
             "name": "Medpatch (Commercial)",
@@ -759,7 +766,8 @@
                     "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> (manipulate)</p><hr /><p>Medpatches accelerate the body's natural healing. You regain @Damage[(1d6)[healing]] Hit Points and gain a +1 item bonus to saving throws against diseases and poisons for 10 minutes.</p>\n<p>@UUID[Compendium.sf2e.equipment-effects.Item.Effect: Medpatch]</p>"
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -775,9 +783,6 @@
                 },
                 "price": {
                     "value": {
-                        "cp": 0,
-                        "gp": 0,
-                        "pp": 0,
                         "sp": 30
                     }
                 },
@@ -902,6 +907,9 @@
         },
         {
             "_id": "olkzznMbbFFtRfk0",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -917,7 +925,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -962,6 +971,9 @@
         },
         {
             "_id": "jWTFpwzqV8zrKgBV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.HxaKRfVbL1ZyGcu1"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/blue-tablet.webp",
             "name": "Datapad",
@@ -977,6 +989,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -1019,6 +1032,9 @@
         },
         {
             "_id": "SLNb6AssT1UU2OAb",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.9huJDWkgN0zK5jNw"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/control-panel-large.webp",
             "name": "Portable Amp",
@@ -1034,6 +1050,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,

--- a/packs/sf2e/iconics/dae/dae-level-5.json
+++ b/packs/sf2e/iconics/dae/dae-level-5.json
@@ -578,6 +578,9 @@
         },
         {
             "_id": "6sBXVzOzypjGFk7a",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.fClhrG92Zi4k14Hq"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/walkie-talkie.webp",
             "name": "Comm Unit",
@@ -593,6 +596,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -739,6 +743,9 @@
         },
         {
             "_id": "1ncGURdGnC8unHY5",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.B0FiYMxy7iDiHh48"
+            },
             "folder": "aGUZspQIi3yNxIOu",
             "img": "systems/sf2e/icons/equipment/other/med-kit.webp",
             "name": "Medpatch (Commercial)",
@@ -759,7 +766,8 @@
                     "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> (manipulate)</p><hr /><p>Medpatches accelerate the body's natural healing. You regain @Damage[(1d6)[healing]] Hit Points and gain a +1 item bonus to saving throws against diseases and poisons for 10 minutes.</p>\n<p>@UUID[Compendium.sf2e.equipment-effects.Item.Effect: Medpatch]</p>"
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -775,9 +783,6 @@
                 },
                 "price": {
                     "value": {
-                        "cp": 0,
-                        "gp": 0,
-                        "pp": 0,
                         "sp": 30
                     }
                 },
@@ -902,6 +907,9 @@
         },
         {
             "_id": "olkzznMbbFFtRfk0",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -917,7 +925,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -962,6 +971,9 @@
         },
         {
             "_id": "jWTFpwzqV8zrKgBV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.HxaKRfVbL1ZyGcu1"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/blue-tablet.webp",
             "name": "Datapad",
@@ -977,6 +989,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -1019,6 +1032,9 @@
         },
         {
             "_id": "SLNb6AssT1UU2OAb",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.9huJDWkgN0zK5jNw"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/control-panel-large.webp",
             "name": "Portable Amp",
@@ -1034,6 +1050,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -1278,6 +1295,9 @@
         },
         {
             "_id": "jyzy8YkwRs1dTTyU",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.CJwfbmQO91Q9v3kg"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/visor.webp",
             "name": "Sunshades (Tactical)",
@@ -1293,6 +1313,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -1392,6 +1413,9 @@
         },
         {
             "_id": "QO81tiEX7d09kOej",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.7CMMrOsOmHPKffsB"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "icons/equipment/feet/boots-plate-pointed.webp",
             "name": "Magboots",

--- a/packs/sf2e/iconics/dae/dae-level-7.json
+++ b/packs/sf2e/iconics/dae/dae-level-7.json
@@ -578,6 +578,9 @@
         },
         {
             "_id": "6sBXVzOzypjGFk7a",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.fClhrG92Zi4k14Hq"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/walkie-talkie.webp",
             "name": "Comm Unit",
@@ -593,6 +596,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -668,6 +672,9 @@
         },
         {
             "_id": "1ncGURdGnC8unHY5",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.B0FiYMxy7iDiHh48"
+            },
             "folder": "aGUZspQIi3yNxIOu",
             "img": "systems/sf2e/icons/equipment/other/med-kit.webp",
             "name": "Medpatch (Commercial)",
@@ -688,7 +695,8 @@
                     "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> (manipulate)</p><hr /><p>Medpatches accelerate the body's natural healing. You regain @Damage[(1d6)[healing]] Hit Points and gain a +1 item bonus to saving throws against diseases and poisons for 10 minutes.</p>\n<p>@UUID[Compendium.sf2e.equipment-effects.Item.Effect: Medpatch]</p>"
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -704,9 +712,6 @@
                 },
                 "price": {
                     "value": {
-                        "cp": 0,
-                        "gp": 0,
-                        "pp": 0,
                         "sp": 30
                     }
                 },
@@ -831,6 +836,9 @@
         },
         {
             "_id": "olkzznMbbFFtRfk0",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -846,7 +854,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -891,6 +900,9 @@
         },
         {
             "_id": "jWTFpwzqV8zrKgBV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.HxaKRfVbL1ZyGcu1"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/blue-tablet.webp",
             "name": "Datapad",
@@ -906,6 +918,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -948,6 +961,9 @@
         },
         {
             "_id": "SLNb6AssT1UU2OAb",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.9huJDWkgN0zK5jNw"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/control-panel-large.webp",
             "name": "Portable Amp",
@@ -963,6 +979,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -1207,6 +1224,9 @@
         },
         {
             "_id": "jyzy8YkwRs1dTTyU",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.CJwfbmQO91Q9v3kg"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/visor.webp",
             "name": "Sunshades (Tactical)",
@@ -1222,6 +1242,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -1321,6 +1342,9 @@
         },
         {
             "_id": "QO81tiEX7d09kOej",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.7CMMrOsOmHPKffsB"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "icons/equipment/feet/boots-plate-pointed.webp",
             "name": "Magboots",

--- a/packs/sf2e/iconics/iseph/iseph-level-1.json
+++ b/packs/sf2e/iconics/iseph/iseph-level-1.json
@@ -706,6 +706,9 @@
         },
         {
             "_id": "Knx7O7vtrb6WqE3k",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.fClhrG92Zi4k14Hq"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/walkie-talkie.webp",
             "name": "Comm Unit",
@@ -721,6 +724,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -796,6 +800,9 @@
         },
         {
             "_id": "N96s12QzwN1Rhmt5",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.ZdItrVii0l2yuSMJ"
+            },
             "folder": "cTmXSS0L1MClVGP3",
             "img": "systems/sf2e/icons/abilities/blue-alien-insignia.webp",
             "name": "Force Field (Commercial)",
@@ -811,6 +818,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -846,19 +854,25 @@
                     ]
                 },
                 "usage": {
-                    "value": "other"
+                    "value": "installed-in-armor"
                 }
             },
             "type": "equipment"
         },
         {
             "_id": "5riohyR807teLb66",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.EgAVqAYCrSJzxF1j"
+            },
             "folder": "1zLXGqhSgBIthlcs",
             "img": "systems/sf2e/icons/equipment/weapons/grenade.webp",
             "name": "Incendiary Grenade (Commercial)",
             "sort": 0,
             "system": {
-                "ammo": null,
+                "ammo": {
+                    "baseType": null,
+                    "builtIn": false
+                },
                 "baseItem": "grenade",
                 "bonus": {
                     "value": 0
@@ -939,6 +953,9 @@
         },
         {
             "_id": "mMHNlmp0r3h1Gvwu",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.B0FiYMxy7iDiHh48"
+            },
             "folder": "aGUZspQIi3yNxIOu",
             "img": "systems/sf2e/icons/equipment/other/med-kit.webp",
             "name": "Medpatch (Commercial)",
@@ -959,7 +976,8 @@
                     "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> (manipulate)</p><hr /><p>Medpatches accelerate the body's natural healing. You regain @Damage[(1d6)[healing]] Hit Points and gain a +1 item bonus to saving throws against diseases and poisons for 10 minutes.</p>\n<p>@UUID[Compendium.sf2e.equipment-effects.Item.Effect: Medpatch]</p>"
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -975,9 +993,6 @@
                 },
                 "price": {
                     "value": {
-                        "cp": 0,
-                        "gp": 0,
-                        "pp": 0,
                         "sp": 30
                     }
                 },
@@ -1173,6 +1188,9 @@
         },
         {
             "_id": "vyy1xnqos4H76SPz",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -1188,7 +1206,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -1323,6 +1342,9 @@
         },
         {
             "_id": "vvb3MeWkjPBKY6Mi",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.coJUVZGcuVg3FoYh"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "icons/tools/hand/lockpicks-steel-grey.webp",
             "name": "Infiltrator's Toolkit (Commercial)",
@@ -1338,6 +1360,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,

--- a/packs/sf2e/iconics/iseph/iseph-level-3.json
+++ b/packs/sf2e/iconics/iseph/iseph-level-3.json
@@ -706,6 +706,9 @@
         },
         {
             "_id": "Knx7O7vtrb6WqE3k",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.fClhrG92Zi4k14Hq"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/walkie-talkie.webp",
             "name": "Comm Unit",
@@ -721,6 +724,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -796,6 +800,9 @@
         },
         {
             "_id": "N96s12QzwN1Rhmt5",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.ZdItrVii0l2yuSMJ"
+            },
             "folder": "cTmXSS0L1MClVGP3",
             "img": "systems/sf2e/icons/abilities/blue-alien-insignia.webp",
             "name": "Force Field (Commercial)",
@@ -811,6 +818,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -846,19 +854,25 @@
                     ]
                 },
                 "usage": {
-                    "value": "other"
+                    "value": "installed-in-armor"
                 }
             },
             "type": "equipment"
         },
         {
             "_id": "5riohyR807teLb66",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.EgAVqAYCrSJzxF1j"
+            },
             "folder": "1zLXGqhSgBIthlcs",
             "img": "systems/sf2e/icons/equipment/weapons/grenade.webp",
             "name": "Incendiary Grenade (Commercial)",
             "sort": 0,
             "system": {
-                "ammo": null,
+                "ammo": {
+                    "baseType": null,
+                    "builtIn": false
+                },
                 "baseItem": "grenade",
                 "bonus": {
                     "value": 0
@@ -939,6 +953,9 @@
         },
         {
             "_id": "mMHNlmp0r3h1Gvwu",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.B0FiYMxy7iDiHh48"
+            },
             "folder": "aGUZspQIi3yNxIOu",
             "img": "systems/sf2e/icons/equipment/other/med-kit.webp",
             "name": "Medpatch (Commercial)",
@@ -959,7 +976,8 @@
                     "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> (manipulate)</p><hr /><p>Medpatches accelerate the body's natural healing. You regain @Damage[(1d6)[healing]] Hit Points and gain a +1 item bonus to saving throws against diseases and poisons for 10 minutes.</p>\n<p>@UUID[Compendium.sf2e.equipment-effects.Item.Effect: Medpatch]</p>"
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -975,9 +993,6 @@
                 },
                 "price": {
                     "value": {
-                        "cp": 0,
-                        "gp": 0,
-                        "pp": 0,
                         "sp": 30
                     }
                 },
@@ -1173,6 +1188,9 @@
         },
         {
             "_id": "vyy1xnqos4H76SPz",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -1188,7 +1206,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -1323,6 +1342,9 @@
         },
         {
             "_id": "vvb3MeWkjPBKY6Mi",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.coJUVZGcuVg3FoYh"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "icons/tools/hand/lockpicks-steel-grey.webp",
             "name": "Infiltrator's Toolkit (Commercial)",
@@ -1338,6 +1360,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,

--- a/packs/sf2e/iconics/iseph/iseph-level-5.json
+++ b/packs/sf2e/iconics/iseph/iseph-level-5.json
@@ -706,6 +706,9 @@
         },
         {
             "_id": "Knx7O7vtrb6WqE3k",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.fClhrG92Zi4k14Hq"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/walkie-talkie.webp",
             "name": "Comm Unit",
@@ -721,6 +724,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -796,6 +800,9 @@
         },
         {
             "_id": "N96s12QzwN1Rhmt5",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.ZdItrVii0l2yuSMJ"
+            },
             "folder": "cTmXSS0L1MClVGP3",
             "img": "systems/sf2e/icons/abilities/blue-alien-insignia.webp",
             "name": "Force Field (Commercial)",
@@ -811,6 +818,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -846,19 +854,25 @@
                     ]
                 },
                 "usage": {
-                    "value": "other"
+                    "value": "installed-in-armor"
                 }
             },
             "type": "equipment"
         },
         {
             "_id": "5riohyR807teLb66",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.EgAVqAYCrSJzxF1j"
+            },
             "folder": "1zLXGqhSgBIthlcs",
             "img": "systems/sf2e/icons/equipment/weapons/grenade.webp",
             "name": "Incendiary Grenade (Commercial)",
             "sort": 0,
             "system": {
-                "ammo": null,
+                "ammo": {
+                    "baseType": null,
+                    "builtIn": false
+                },
                 "baseItem": "grenade",
                 "bonus": {
                     "value": 0
@@ -932,7 +946,6 @@
                     ]
                 },
                 "usage": {
-                    "canBeAmmo": false,
                     "value": "held-in-one-hand"
                 }
             },
@@ -1102,6 +1115,9 @@
         },
         {
             "_id": "vyy1xnqos4H76SPz",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -1117,7 +1133,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -1252,6 +1269,9 @@
         },
         {
             "_id": "vvb3MeWkjPBKY6Mi",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.coJUVZGcuVg3FoYh"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "icons/tools/hand/lockpicks-steel-grey.webp",
             "name": "Infiltrator's Toolkit (Commercial)",
@@ -1267,6 +1287,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -1628,6 +1649,9 @@
         },
         {
             "_id": "VQZili8ZcCZH5SPf",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.HWHdAQArhRauTpm6"
+            },
             "folder": "aGUZspQIi3yNxIOu",
             "img": "systems/sf2e/icons/equipment/other/med-kit.webp",
             "name": "Medpatch (Tactical)",
@@ -1648,7 +1672,8 @@
                     "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> (manipulate)</p><hr /><p>Medpatches accelerate the body's natural healing. You regain @Damage[(3d6+6)[healing]] Hit Points and gain a +1 item bonus to saving throws against diseases and poisons for 10 minutes.</p>\n<p>@UUID[Compendium.sf2e.equipment-effects.Item.Effect: Medpatch]</p>"
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/iconics/iseph/iseph-level-5.json
+++ b/packs/sf2e/iconics/iseph/iseph-level-5.json
@@ -1905,6 +1905,9 @@
         },
         {
             "_id": "5gJ3CCeG0FEeu6DX",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Gb7SeieEvd0pL2Eh"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/skills/melee/strike-blade-scimitar-gray-red.webp",
             "name": "Sure Strike",
@@ -1934,7 +1937,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""

--- a/packs/sf2e/iconics/iseph/iseph-level-7.json
+++ b/packs/sf2e/iconics/iseph/iseph-level-7.json
@@ -706,6 +706,9 @@
         },
         {
             "_id": "Knx7O7vtrb6WqE3k",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.fClhrG92Zi4k14Hq"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/walkie-talkie.webp",
             "name": "Comm Unit",
@@ -721,6 +724,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -796,12 +800,18 @@
         },
         {
             "_id": "5riohyR807teLb66",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.EgAVqAYCrSJzxF1j"
+            },
             "folder": "1zLXGqhSgBIthlcs",
             "img": "systems/sf2e/icons/equipment/weapons/grenade.webp",
             "name": "Incendiary Grenade (Commercial)",
             "sort": 0,
             "system": {
-                "ammo": null,
+                "ammo": {
+                    "baseType": null,
+                    "builtIn": false
+                },
                 "baseItem": "grenade",
                 "bonus": {
                     "value": 0
@@ -875,7 +885,6 @@
                     ]
                 },
                 "usage": {
-                    "canBeAmmo": false,
                     "value": "held-in-one-hand"
                 }
             },
@@ -1045,6 +1054,9 @@
         },
         {
             "_id": "vyy1xnqos4H76SPz",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -1060,7 +1072,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -1195,6 +1208,9 @@
         },
         {
             "_id": "vvb3MeWkjPBKY6Mi",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.coJUVZGcuVg3FoYh"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "icons/tools/hand/lockpicks-steel-grey.webp",
             "name": "Infiltrator's Toolkit (Commercial)",
@@ -1210,6 +1226,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -1571,6 +1588,9 @@
         },
         {
             "_id": "VQZili8ZcCZH5SPf",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.HWHdAQArhRauTpm6"
+            },
             "folder": "aGUZspQIi3yNxIOu",
             "img": "systems/sf2e/icons/equipment/other/med-kit.webp",
             "name": "Medpatch (Tactical)",
@@ -1591,7 +1611,8 @@
                     "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> (manipulate)</p><hr /><p>Medpatches accelerate the body's natural healing. You regain @Damage[(3d6+6)[healing]] Hit Points and gain a +1 item bonus to saving throws against diseases and poisons for 10 minutes.</p>\n<p>@UUID[Compendium.sf2e.equipment-effects.Item.Effect: Medpatch]</p>"
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -1910,6 +1931,9 @@
         },
         {
             "_id": "DjKoUUtKdCOEKrgR",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.6ZW9IcSwd4WCFuf6"
+            },
             "folder": "cTmXSS0L1MClVGP3",
             "img": "systems/sf2e/icons/abilities/blue-alien-insignia.webp",
             "name": "Force Field (Tactical)",
@@ -1925,6 +1949,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -1960,7 +1985,7 @@
                     ]
                 },
                 "usage": {
-                    "value": "other"
+                    "value": "installed-in-armor"
                 }
             },
             "type": "equipment"

--- a/packs/sf2e/iconics/iseph/iseph-level-7.json
+++ b/packs/sf2e/iconics/iseph/iseph-level-7.json
@@ -1848,6 +1848,9 @@
         },
         {
             "_id": "5gJ3CCeG0FEeu6DX",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Gb7SeieEvd0pL2Eh"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/skills/melee/strike-blade-scimitar-gray-red.webp",
             "name": "Sure Strike",
@@ -1877,7 +1880,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""

--- a/packs/sf2e/iconics/navasi/navasi-level-1.json
+++ b/packs/sf2e/iconics/navasi/navasi-level-1.json
@@ -620,6 +620,9 @@
         },
         {
             "_id": "ZJ2OuTFtni06RNWA",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.fClhrG92Zi4k14Hq"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/walkie-talkie.webp",
             "name": "Comm Unit",
@@ -635,6 +638,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -801,6 +805,9 @@
         },
         {
             "_id": "2JauvXniZy780USV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.s1vB3HdXjMigYAnY"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/med-pack.webp",
             "name": "Medkit (Commercial)",
@@ -816,6 +823,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -947,6 +955,9 @@
         },
         {
             "_id": "xGMY83VushiybEK2",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -962,7 +973,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -1007,6 +1019,9 @@
         },
         {
             "_id": "QVRkL74yOfzhAhb4",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.qqjDcCW118ySAlAS"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/battery-large.webp",
             "name": "Hacking Toolkit (Commercial)",
@@ -1022,6 +1037,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -1064,6 +1080,9 @@
         },
         {
             "_id": "YK21dMnHSjmXXeXZ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.coJUVZGcuVg3FoYh"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "icons/tools/hand/lockpicks-steel-grey.webp",
             "name": "Infiltrator's Toolkit (Commercial)",
@@ -1079,6 +1098,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -1119,6 +1139,9 @@
         },
         {
             "_id": "7PFUkkBIFFSTi52j",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.XRk3UWHAQ5WVkZGu"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/ammo-pouch.webp",
             "name": "Container (Ordinary)",

--- a/packs/sf2e/iconics/navasi/navasi-level-3.json
+++ b/packs/sf2e/iconics/navasi/navasi-level-3.json
@@ -549,6 +549,9 @@
         },
         {
             "_id": "ZJ2OuTFtni06RNWA",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.fClhrG92Zi4k14Hq"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/walkie-talkie.webp",
             "name": "Comm Unit",
@@ -564,6 +567,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -730,6 +734,9 @@
         },
         {
             "_id": "2JauvXniZy780USV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.s1vB3HdXjMigYAnY"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/med-pack.webp",
             "name": "Medkit (Commercial)",
@@ -745,6 +752,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -876,6 +884,9 @@
         },
         {
             "_id": "xGMY83VushiybEK2",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -891,7 +902,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -936,6 +948,9 @@
         },
         {
             "_id": "QVRkL74yOfzhAhb4",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.qqjDcCW118ySAlAS"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/battery-large.webp",
             "name": "Hacking Toolkit (Commercial)",
@@ -951,6 +966,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -993,6 +1009,9 @@
         },
         {
             "_id": "YK21dMnHSjmXXeXZ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.coJUVZGcuVg3FoYh"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "icons/tools/hand/lockpicks-steel-grey.webp",
             "name": "Infiltrator's Toolkit (Commercial)",
@@ -1008,6 +1027,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -1048,6 +1068,9 @@
         },
         {
             "_id": "7PFUkkBIFFSTi52j",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.XRk3UWHAQ5WVkZGu"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/ammo-pouch.webp",
             "name": "Container (Ordinary)",
@@ -1500,6 +1523,9 @@
         },
         {
             "_id": "4aFLgVmKjrd2idFT",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -1515,7 +1541,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -1530,6 +1557,7 @@
                     "type": null
                 },
                 "price": {
+                    "per": 1,
                     "value": {
                         "sp": 10
                     }
@@ -1548,7 +1576,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 10,
                     "value": 10
                 }

--- a/packs/sf2e/iconics/navasi/navasi-level-5.json
+++ b/packs/sf2e/iconics/navasi/navasi-level-5.json
@@ -549,6 +549,9 @@
         },
         {
             "_id": "ZJ2OuTFtni06RNWA",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.fClhrG92Zi4k14Hq"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/walkie-talkie.webp",
             "name": "Comm Unit",
@@ -564,6 +567,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -730,6 +734,9 @@
         },
         {
             "_id": "2JauvXniZy780USV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.s1vB3HdXjMigYAnY"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/med-pack.webp",
             "name": "Medkit (Commercial)",
@@ -745,6 +752,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -876,6 +884,9 @@
         },
         {
             "_id": "xGMY83VushiybEK2",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -891,7 +902,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -936,6 +948,9 @@
         },
         {
             "_id": "QVRkL74yOfzhAhb4",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.qqjDcCW118ySAlAS"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/battery-large.webp",
             "name": "Hacking Toolkit (Commercial)",
@@ -951,6 +966,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -993,6 +1009,9 @@
         },
         {
             "_id": "YK21dMnHSjmXXeXZ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.coJUVZGcuVg3FoYh"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "icons/tools/hand/lockpicks-steel-grey.webp",
             "name": "Infiltrator's Toolkit (Commercial)",
@@ -1008,6 +1027,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -1048,6 +1068,9 @@
         },
         {
             "_id": "7PFUkkBIFFSTi52j",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.XRk3UWHAQ5WVkZGu"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/ammo-pouch.webp",
             "name": "Container (Ordinary)",
@@ -1742,6 +1765,9 @@
         },
         {
             "_id": "mKQU0WmjJDmNP5PN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.5PS5ESGpnQfJNOdg"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/blue-battery.webp",
             "name": "Battery (Tactical)",
@@ -1757,7 +1783,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -1772,6 +1799,7 @@
                     "type": null
                 },
                 "price": {
+                    "per": 1,
                     "value": {
                         "sp": 20
                     }
@@ -1790,7 +1818,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 20,
                     "value": 20
                 }
@@ -1799,6 +1827,9 @@
         },
         {
             "_id": "leUogNMGljeT8E7h",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.HWHdAQArhRauTpm6"
+            },
             "folder": "aGUZspQIi3yNxIOu",
             "img": "systems/sf2e/icons/equipment/other/med-kit.webp",
             "name": "Medpatch (Tactical)",

--- a/packs/sf2e/iconics/navasi/navasi-level-7.json
+++ b/packs/sf2e/iconics/navasi/navasi-level-7.json
@@ -549,6 +549,9 @@
         },
         {
             "_id": "ZJ2OuTFtni06RNWA",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.fClhrG92Zi4k14Hq"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/walkie-talkie.webp",
             "name": "Comm Unit",
@@ -564,6 +567,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -730,6 +734,9 @@
         },
         {
             "_id": "2JauvXniZy780USV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.s1vB3HdXjMigYAnY"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/med-pack.webp",
             "name": "Medkit (Commercial)",
@@ -745,6 +752,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -876,6 +884,9 @@
         },
         {
             "_id": "xGMY83VushiybEK2",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -891,7 +902,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -936,6 +948,9 @@
         },
         {
             "_id": "YK21dMnHSjmXXeXZ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.coJUVZGcuVg3FoYh"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "icons/tools/hand/lockpicks-steel-grey.webp",
             "name": "Infiltrator's Toolkit (Commercial)",
@@ -951,6 +966,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -1624,6 +1640,9 @@
         },
         {
             "_id": "mKQU0WmjJDmNP5PN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.5PS5ESGpnQfJNOdg"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/blue-battery.webp",
             "name": "Battery (Tactical)",
@@ -1639,7 +1658,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -1654,6 +1674,7 @@
                     "type": null
                 },
                 "price": {
+                    "per": 1,
                     "value": {
                         "sp": 20
                     }
@@ -1672,7 +1693,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 20,
                     "value": 20
                 }
@@ -1681,6 +1702,9 @@
         },
         {
             "_id": "leUogNMGljeT8E7h",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.HWHdAQArhRauTpm6"
+            },
             "folder": "aGUZspQIi3yNxIOu",
             "img": "systems/sf2e/icons/equipment/other/med-kit.webp",
             "name": "Medpatch (Tactical)",
@@ -1899,6 +1923,9 @@
         },
         {
             "_id": "yGJTrxymrUMK3O7X",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.Jvp0x2Sc82WVpExT"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/white-console.webp",
             "name": "Holoskin (Commercial)",
@@ -1914,6 +1941,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -1956,6 +1984,9 @@
         },
         {
             "_id": "y6wfNqbjLQWhujPE",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.2lTv6zUJBAtgcxs2"
+            },
             "folder": "HRcg3kaDspIJNQ2Z",
             "img": "systems/sf2e/icons/abilities/green-syringe-2.webp",
             "name": "Invisibility Spell Amp",
@@ -1972,7 +2003,8 @@
                     "value": "<p>Known on most worlds as \"spell amps,\" spell ampoules are ready-to-use magic injections that confer the benefits of a spell of the specified rank.</p>\n<p><strong>Activate—Inject</strong> <span class=\"action-glyph\">1</span> (manipulate)</p><hr /><p><strong>Effect</strong> 2nd-rank @UUID[Compendium.sf2e.spells.Item.Invisibility] spell</p>"
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -1987,17 +2019,15 @@
                     "type": null
                 },
                 "price": {
+                    "per": 1,
                     "value": {
-                        "cp": 0,
-                        "gp": 0,
-                        "pp": 0,
                         "sp": 200
                     }
                 },
                 "publication": {
-                    "license": "OGL",
-                    "remaster": false,
-                    "title": ""
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Starfinder Player Core"
                 },
                 "quantity": 1,
                 "rules": [],
@@ -2023,6 +2053,9 @@
         },
         {
             "_id": "edCOxUd8SYX1iTrj",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.EAMHdtJLqWUO0ZU0"
+            },
             "folder": "JlUS4L43QWp3cPhu",
             "img": "systems/sf2e/icons/abilities/blue-power-stone.webp",
             "name": "Null Space Chamber (Commercial)",
@@ -2042,6 +2075,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -2087,6 +2121,9 @@
         },
         {
             "_id": "EqA7R2WBAiZMUQ3K",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.5o7wOnkxEsyBwBNj"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/battery-large.webp",
             "name": "Hacking Toolkit (Tactical)",
@@ -2102,6 +2139,7 @@
                 },
                 "equipped": {
                     "carryType": "stowed",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,

--- a/packs/sf2e/iconics/obozaya/obozaya-level-1.json
+++ b/packs/sf2e/iconics/obozaya/obozaya-level-1.json
@@ -566,6 +566,9 @@
         },
         {
             "_id": "2GaC8L7AmaTACoZQ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.fClhrG92Zi4k14Hq"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/walkie-talkie.webp",
             "name": "Comm Unit",
@@ -581,6 +584,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -905,6 +909,9 @@
         },
         {
             "_id": "ojKpAbUiTTSMG3wk",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -920,7 +927,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/iconics/obozaya/obozaya-level-3.json
+++ b/packs/sf2e/iconics/obozaya/obozaya-level-3.json
@@ -566,6 +566,9 @@
         },
         {
             "_id": "2GaC8L7AmaTACoZQ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.fClhrG92Zi4k14Hq"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/walkie-talkie.webp",
             "name": "Comm Unit",
@@ -581,6 +584,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -836,6 +840,9 @@
         },
         {
             "_id": "ojKpAbUiTTSMG3wk",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -851,7 +858,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/iconics/obozaya/obozaya-level-5.json
+++ b/packs/sf2e/iconics/obozaya/obozaya-level-5.json
@@ -566,6 +566,9 @@
         },
         {
             "_id": "2GaC8L7AmaTACoZQ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.fClhrG92Zi4k14Hq"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/walkie-talkie.webp",
             "name": "Comm Unit",
@@ -581,6 +584,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -836,6 +840,9 @@
         },
         {
             "_id": "ojKpAbUiTTSMG3wk",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -851,7 +858,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -1246,12 +1254,18 @@
         },
         {
             "_id": "iU7j34nz2dUKFN4r",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.SzGr78zdpnnrorre"
+            },
             "folder": "1zLXGqhSgBIthlcs",
             "img": "systems/sf2e/icons/equipment/weapons/grenade-hand.webp",
             "name": "Frag Grenade (Commercial)",
             "sort": 0,
             "system": {
-                "ammo": null,
+                "ammo": {
+                    "baseType": null,
+                    "builtIn": false
+                },
                 "baseItem": "grenade",
                 "bonus": {
                     "value": 0
@@ -1331,6 +1345,9 @@
         },
         {
             "_id": "38XjxHHh2sq9dhAK",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.rgprAOXrCIFtwfpr"
+            },
             "folder": "1zLXGqhSgBIthlcs",
             "img": "systems/sf2e/icons/equipment/weapons/shotgun-heavy.webp",
             "name": "Grenade Launcher (Commercial)",
@@ -1414,12 +1431,18 @@
         },
         {
             "_id": "jMuJaMOvs5pCPzaR",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.EgAVqAYCrSJzxF1j"
+            },
             "folder": "1zLXGqhSgBIthlcs",
             "img": "systems/sf2e/icons/equipment/weapons/grenade.webp",
             "name": "Incendiary Grenade (Commercial)",
             "sort": 0,
             "system": {
-                "ammo": null,
+                "ammo": {
+                    "baseType": null,
+                    "builtIn": false
+                },
                 "baseItem": "grenade",
                 "bonus": {
                     "value": 0

--- a/packs/sf2e/iconics/obozaya/obozaya-level-7.json
+++ b/packs/sf2e/iconics/obozaya/obozaya-level-7.json
@@ -566,6 +566,9 @@
         },
         {
             "_id": "2GaC8L7AmaTACoZQ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.fClhrG92Zi4k14Hq"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/walkie-talkie.webp",
             "name": "Comm Unit",
@@ -581,6 +584,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -836,6 +840,9 @@
         },
         {
             "_id": "ojKpAbUiTTSMG3wk",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -851,7 +858,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -1359,12 +1367,18 @@
         },
         {
             "_id": "iU7j34nz2dUKFN4r",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.SzGr78zdpnnrorre"
+            },
             "folder": "1zLXGqhSgBIthlcs",
             "img": "systems/sf2e/icons/equipment/weapons/grenade-hand.webp",
             "name": "Frag Grenade (Commercial)",
             "sort": 0,
             "system": {
-                "ammo": null,
+                "ammo": {
+                    "baseType": null,
+                    "builtIn": false
+                },
                 "baseItem": "grenade",
                 "bonus": {
                     "value": 0
@@ -1444,6 +1458,9 @@
         },
         {
             "_id": "38XjxHHh2sq9dhAK",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.rgprAOXrCIFtwfpr"
+            },
             "folder": "1zLXGqhSgBIthlcs",
             "img": "systems/sf2e/icons/equipment/weapons/shotgun-heavy.webp",
             "name": "Grenade Launcher (Commercial)",
@@ -1527,12 +1544,18 @@
         },
         {
             "_id": "jMuJaMOvs5pCPzaR",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.EgAVqAYCrSJzxF1j"
+            },
             "folder": "1zLXGqhSgBIthlcs",
             "img": "systems/sf2e/icons/equipment/weapons/grenade.webp",
             "name": "Incendiary Grenade (Commercial)",
             "sort": 0,
             "system": {
-                "ammo": null,
+                "ammo": {
+                    "baseType": null,
+                    "builtIn": false
+                },
                 "baseItem": "grenade",
                 "bonus": {
                     "value": 0

--- a/packs/sf2e/iconics/zemir/zemir-level-1.json
+++ b/packs/sf2e/iconics/zemir/zemir-level-1.json
@@ -712,6 +712,9 @@
         },
         {
             "_id": "tqHgsGLbwoA4wnFN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.fClhrG92Zi4k14Hq"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/walkie-talkie.webp",
             "name": "Comm Unit",
@@ -727,6 +730,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -802,6 +806,9 @@
         },
         {
             "_id": "dF047wlhXubOTS4c",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.ckRc9E6AmJRalfV4"
+            },
             "folder": "aGUZspQIi3yNxIOu",
             "img": "systems/sf2e/icons/equipment/other/blue-containment-vessel.webp",
             "name": "Hypopen (Commercial)",
@@ -818,7 +825,8 @@
                     "value": "<p>This tiny cylinder contains specialized nanites that either</p><ul><li>Remove the @UUID[Compendium.sf2e.conditions.Item.Fatigued] condition</li><li>Decrease the value of the @UUID[Compendium.sf2e.conditions.Item.Clumsy] or @UUID[Compendium.sf2e.conditions.Item.Sickened] condition by 1.</li></ul>"
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -851,7 +859,6 @@
                     "rarity": "common",
                     "value": [
                         "consumable",
-                        "nanite",
                         "tech"
                     ]
                 },
@@ -868,6 +875,9 @@
         },
         {
             "_id": "4dLfkAlhzk7uVhIo",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.B0FiYMxy7iDiHh48"
+            },
             "folder": "aGUZspQIi3yNxIOu",
             "img": "systems/sf2e/icons/equipment/other/med-kit.webp",
             "name": "Medpatch (Commercial)",
@@ -888,7 +898,8 @@
                     "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> (manipulate)</p><hr /><p>Medpatches accelerate the body's natural healing. You regain @Damage[(1d6)[healing]] Hit Points and gain a +1 item bonus to saving throws against diseases and poisons for 10 minutes.</p>\n<p>@UUID[Compendium.sf2e.equipment-effects.Item.Effect: Medpatch]</p>"
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -904,9 +915,6 @@
                 },
                 "price": {
                     "value": {
-                        "cp": 0,
-                        "gp": 0,
-                        "pp": 0,
                         "sp": 30
                     }
                 },
@@ -940,6 +948,9 @@
         },
         {
             "_id": "QYXGLkPL4LSVm2Tk",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.XRk3UWHAQ5WVkZGu"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/ammo-pouch.webp",
             "name": "Container (Ordinary)",
@@ -959,6 +970,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -1162,6 +1174,9 @@
         },
         {
             "_id": "K1vV4h9pQycXIF29",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -1177,7 +1192,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/iconics/zemir/zemir-level-1.json
+++ b/packs/sf2e/iconics/zemir/zemir-level-1.json
@@ -1268,6 +1268,9 @@
         },
         {
             "_id": "KutKMVQ73bFCi4y2",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -1284,7 +1287,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -1299,7 +1302,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1333,6 +1336,9 @@
         },
         {
             "_id": "00eIMxQiQXpcoQfN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jgN33YSYXB8iIHTw"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "icons/skills/movement/figure-running-gray.webp",
             "name": "Stumble",
@@ -1397,6 +1403,9 @@
         },
         {
             "_id": "nhG0nHqD6uwgcFxE",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.7P4eBdqWcgQJAFCa"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-laser-beam-rifle.webp",
             "name": "Shifting Surge",
@@ -1497,6 +1506,9 @@
         },
         {
             "_id": "Rqa9AjKOtRm0Z65u",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.TN2pHF9l3k4ZJ7di"
+            },
             "folder": "AF5tLnq9AryanMqw",
             "img": "systems/sf2e/icons/abilities/blue-eruption.webp",
             "name": "Warp Terrain",
@@ -1537,7 +1549,7 @@
                     "value": ""
                 },
                 "time": {
-                    "value": "2"
+                    "value": "1"
                 },
                 "traits": {
                     "rarity": "uncommon",
@@ -1554,6 +1566,9 @@
         },
         {
             "_id": "H4Eokdhml3G0VRVN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gKKqvLohtrSJj3BM"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/magic-missile.webp",
             "name": "Force Barrage",
@@ -1595,7 +1610,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -1626,6 +1641,9 @@
         },
         {
             "_id": "GaakkBAHltKyowC7",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.zDJS8E66UI0himqV"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/shocking-grasp.webp",
             "name": "Thunderstrike",
@@ -1689,7 +1707,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -1721,6 +1739,9 @@
         },
         {
             "_id": "RRrOnmWCHH8ZN6YJ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.0zU8CPejjQFnhZFI"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/ghost-sound.webp",
             "name": "Figment",
@@ -1749,7 +1770,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1782,6 +1803,9 @@
         },
         {
             "_id": "aGlEKg85U84EYgNU",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.sNUvbMoMeLTnYJm8"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/blue-energy-alien-hand.webp",
             "name": "Injury Echo",
@@ -1835,7 +1859,7 @@
                                 "damage": {
                                     "X6aUcgmF4twJh5gL": "1d8"
                                 },
-                                "interval": 1,
+                                "interval": 2,
                                 "type": "interval"
                             }
                         }
@@ -1862,7 +1886,7 @@
                                 "damage": {
                                     "2kU3mhyAecpOrFci": "1d8"
                                 },
-                                "interval": 1,
+                                "interval": 2,
                                 "type": "interval"
                             }
                         }
@@ -1889,7 +1913,7 @@
                                 "damage": {
                                     "EotUm3XBubhQrtWi": "1d8"
                                 },
-                                "interval": 1,
+                                "interval": 2,
                                 "type": "interval"
                             }
                         }
@@ -1929,6 +1953,9 @@
         },
         {
             "_id": "JJLkER08c0tZPled",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.WBmvzNDfpwka3qT4"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/light.webp",
             "name": "Light",
@@ -1957,7 +1984,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"

--- a/packs/sf2e/iconics/zemir/zemir-level-3.json
+++ b/packs/sf2e/iconics/zemir/zemir-level-3.json
@@ -1201,6 +1201,9 @@
         },
         {
             "_id": "KutKMVQ73bFCi4y2",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -1217,7 +1220,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -1232,7 +1235,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1266,6 +1269,9 @@
         },
         {
             "_id": "00eIMxQiQXpcoQfN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jgN33YSYXB8iIHTw"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "icons/skills/movement/figure-running-gray.webp",
             "name": "Stumble",
@@ -1330,6 +1336,9 @@
         },
         {
             "_id": "nhG0nHqD6uwgcFxE",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.7P4eBdqWcgQJAFCa"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-laser-beam-rifle.webp",
             "name": "Shifting Surge",
@@ -1430,6 +1439,9 @@
         },
         {
             "_id": "Rqa9AjKOtRm0Z65u",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.TN2pHF9l3k4ZJ7di"
+            },
             "folder": "AF5tLnq9AryanMqw",
             "img": "systems/sf2e/icons/abilities/blue-eruption.webp",
             "name": "Warp Terrain",
@@ -1470,7 +1482,7 @@
                     "value": ""
                 },
                 "time": {
-                    "value": "2"
+                    "value": "1"
                 },
                 "traits": {
                     "rarity": "uncommon",
@@ -1487,6 +1499,9 @@
         },
         {
             "_id": "H4Eokdhml3G0VRVN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gKKqvLohtrSJj3BM"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/magic-missile.webp",
             "name": "Force Barrage",
@@ -1528,7 +1543,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -1559,6 +1574,9 @@
         },
         {
             "_id": "GaakkBAHltKyowC7",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.zDJS8E66UI0himqV"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/shocking-grasp.webp",
             "name": "Thunderstrike",
@@ -1623,7 +1641,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -1655,6 +1673,9 @@
         },
         {
             "_id": "RRrOnmWCHH8ZN6YJ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.0zU8CPejjQFnhZFI"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/ghost-sound.webp",
             "name": "Figment",
@@ -1683,7 +1704,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1716,6 +1737,9 @@
         },
         {
             "_id": "aGlEKg85U84EYgNU",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.sNUvbMoMeLTnYJm8"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/blue-energy-alien-hand.webp",
             "name": "Injury Echo",
@@ -1769,7 +1793,7 @@
                                 "damage": {
                                     "X6aUcgmF4twJh5gL": "1d8"
                                 },
-                                "interval": 1,
+                                "interval": 2,
                                 "type": "interval"
                             }
                         }
@@ -1796,7 +1820,7 @@
                                 "damage": {
                                     "2kU3mhyAecpOrFci": "1d8"
                                 },
-                                "interval": 1,
+                                "interval": 2,
                                 "type": "interval"
                             }
                         }
@@ -1823,7 +1847,7 @@
                                 "damage": {
                                     "EotUm3XBubhQrtWi": "1d8"
                                 },
-                                "interval": 1,
+                                "interval": 2,
                                 "type": "interval"
                             }
                         }
@@ -1863,6 +1887,9 @@
         },
         {
             "_id": "JJLkER08c0tZPled",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.WBmvzNDfpwka3qT4"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/light.webp",
             "name": "Light",
@@ -1891,7 +1918,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -2263,6 +2290,9 @@
         },
         {
             "_id": "TVbQBKp7r4itSEZs",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Q7QQ91vQtyi1Ux36"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/jump.webp",
             "name": "Jump",
@@ -2305,7 +2335,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -2335,6 +2365,9 @@
         },
         {
             "_id": "Y6aAUwMDtLl6nbeM",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.GB1RVtoFPwyH1B9G"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/green-acid-sprayer.webp",
             "name": "Caustic Conversion",
@@ -2427,6 +2460,9 @@
         },
         {
             "_id": "JFq1ypPEpbzDu6LT",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.9HpwDN4MYQJnW0LG"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/dispel-magic.webp",
             "name": "Dispel Magic",
@@ -2456,7 +2492,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -2488,6 +2524,9 @@
         },
         {
             "_id": "uDBnOE9TQRWkWLIp",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Fr58LDSrbndgld9n"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/magic/defensive/shield-barrier-deflect-teal.webp",
             "name": "Resist Energy",
@@ -2532,7 +2571,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"

--- a/packs/sf2e/iconics/zemir/zemir-level-3.json
+++ b/packs/sf2e/iconics/zemir/zemir-level-3.json
@@ -712,6 +712,9 @@
         },
         {
             "_id": "tqHgsGLbwoA4wnFN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.fClhrG92Zi4k14Hq"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/walkie-talkie.webp",
             "name": "Comm Unit",
@@ -727,6 +730,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -802,6 +806,9 @@
         },
         {
             "_id": "dF047wlhXubOTS4c",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.ckRc9E6AmJRalfV4"
+            },
             "folder": "aGUZspQIi3yNxIOu",
             "img": "systems/sf2e/icons/equipment/other/blue-containment-vessel.webp",
             "name": "Hypopen (Commercial)",
@@ -818,7 +825,8 @@
                     "value": "<p>This tiny cylinder contains specialized nanites that either</p><ul><li>Remove the @UUID[Compendium.sf2e.conditions.Item.Fatigued] condition</li><li>Decrease the value of the @UUID[Compendium.sf2e.conditions.Item.Clumsy] or @UUID[Compendium.sf2e.conditions.Item.Sickened] condition by 1.</li></ul>"
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -851,7 +859,6 @@
                     "rarity": "common",
                     "value": [
                         "consumable",
-                        "nanite",
                         "tech"
                     ]
                 },
@@ -868,6 +875,9 @@
         },
         {
             "_id": "4dLfkAlhzk7uVhIo",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.B0FiYMxy7iDiHh48"
+            },
             "folder": "aGUZspQIi3yNxIOu",
             "img": "systems/sf2e/icons/equipment/other/med-kit.webp",
             "name": "Medpatch (Commercial)",
@@ -888,7 +898,8 @@
                     "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> (manipulate)</p><hr /><p>Medpatches accelerate the body's natural healing. You regain @Damage[(1d6)[healing]] Hit Points and gain a +1 item bonus to saving throws against diseases and poisons for 10 minutes.</p>\n<p>@UUID[Compendium.sf2e.equipment-effects.Item.Effect: Medpatch]</p>"
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -904,9 +915,6 @@
                 },
                 "price": {
                     "value": {
-                        "cp": 0,
-                        "gp": 0,
-                        "pp": 0,
                         "sp": 30
                     }
                 },
@@ -940,6 +948,9 @@
         },
         {
             "_id": "QYXGLkPL4LSVm2Tk",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.XRk3UWHAQ5WVkZGu"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/ammo-pouch.webp",
             "name": "Container (Ordinary)",
@@ -959,6 +970,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -1091,6 +1103,9 @@
         },
         {
             "_id": "K1vV4h9pQycXIF29",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -1106,7 +1121,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/iconics/zemir/zemir-level-5.json
+++ b/packs/sf2e/iconics/zemir/zemir-level-5.json
@@ -712,6 +712,9 @@
         },
         {
             "_id": "tqHgsGLbwoA4wnFN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.fClhrG92Zi4k14Hq"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/walkie-talkie.webp",
             "name": "Comm Unit",
@@ -727,6 +730,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -802,6 +806,9 @@
         },
         {
             "_id": "QYXGLkPL4LSVm2Tk",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.XRk3UWHAQ5WVkZGu"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/ammo-pouch.webp",
             "name": "Container (Ordinary)",
@@ -821,6 +828,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -953,6 +961,9 @@
         },
         {
             "_id": "K1vV4h9pQycXIF29",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -968,7 +979,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -2672,6 +2684,9 @@
         },
         {
             "_id": "bWsdwS9MXW1IU3qJ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.LD6JfxuvszVgQWVd"
+            },
             "folder": "aGUZspQIi3yNxIOu",
             "img": "systems/sf2e/icons/equipment/other/blue-containment-vessel.webp",
             "name": "Hypopen (Tactical)",
@@ -2688,7 +2703,8 @@
                     "value": "<p>This tiny cylinder contains specialized nanites that either</p><ul><li>Remove the @UUID[Compendium.sf2e.conditions.Item.Fatigued] or @UUID[Compendium.sf2e.conditions.Item.Paralyzed] condition</li><li>Decrease the value of the @UUID[Compendium.sf2e.conditions.Item.Clumsy] or @UUID[Compendium.sf2e.conditions.Item.Sickened] condition by 1.</li></ul>"
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -2704,9 +2720,6 @@
                 },
                 "price": {
                     "value": {
-                        "cp": 0,
-                        "gp": 0,
-                        "pp": 0,
                         "sp": 120
                     }
                 },
@@ -2723,7 +2736,6 @@
                     "rarity": "common",
                     "value": [
                         "consumable",
-                        "nanite",
                         "tech"
                     ]
                 },
@@ -2740,6 +2752,9 @@
         },
         {
             "_id": "ZtIM7hFxnlPp2174",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.HWHdAQArhRauTpm6"
+            },
             "folder": "aGUZspQIi3yNxIOu",
             "img": "systems/sf2e/icons/equipment/other/med-kit.webp",
             "name": "Medpatch (Tactical)",
@@ -2760,7 +2775,8 @@
                     "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> (manipulate)</p><hr /><p>Medpatches accelerate the body's natural healing. You regain @Damage[(3d6+6)[healing]] Hit Points and gain a +1 item bonus to saving throws against diseases and poisons for 10 minutes.</p>\n<p>@UUID[Compendium.sf2e.equipment-effects.Item.Effect: Medpatch]</p>"
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -2809,6 +2825,9 @@
         },
         {
             "_id": "8dzjz65ML91gkwTz",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.qqjDcCW118ySAlAS"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/battery-large.webp",
             "name": "Hacking Toolkit (Commercial)",
@@ -2824,6 +2843,7 @@
                 },
                 "equipped": {
                     "carryType": "stowed",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -2866,6 +2886,9 @@
         },
         {
             "_id": "pxa0xBaVILV084CY",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.coJUVZGcuVg3FoYh"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "icons/tools/hand/lockpicks-steel-grey.webp",
             "name": "Infiltrator's Toolkit (Commercial)",
@@ -2881,6 +2904,7 @@
                 },
                 "equipped": {
                     "carryType": "stowed",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,

--- a/packs/sf2e/iconics/zemir/zemir-level-5.json
+++ b/packs/sf2e/iconics/zemir/zemir-level-5.json
@@ -1067,6 +1067,9 @@
         },
         {
             "_id": "KutKMVQ73bFCi4y2",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -1083,7 +1086,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -1098,7 +1101,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1132,6 +1135,9 @@
         },
         {
             "_id": "00eIMxQiQXpcoQfN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jgN33YSYXB8iIHTw"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "icons/skills/movement/figure-running-gray.webp",
             "name": "Stumble",
@@ -1196,6 +1202,9 @@
         },
         {
             "_id": "nhG0nHqD6uwgcFxE",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.7P4eBdqWcgQJAFCa"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-laser-beam-rifle.webp",
             "name": "Shifting Surge",
@@ -1296,6 +1305,9 @@
         },
         {
             "_id": "Rqa9AjKOtRm0Z65u",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.TN2pHF9l3k4ZJ7di"
+            },
             "folder": "AF5tLnq9AryanMqw",
             "img": "systems/sf2e/icons/abilities/blue-eruption.webp",
             "name": "Warp Terrain",
@@ -1336,7 +1348,7 @@
                     "value": ""
                 },
                 "time": {
-                    "value": "2"
+                    "value": "1"
                 },
                 "traits": {
                     "rarity": "uncommon",
@@ -1353,6 +1365,9 @@
         },
         {
             "_id": "H4Eokdhml3G0VRVN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gKKqvLohtrSJj3BM"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/magic-missile.webp",
             "name": "Force Barrage",
@@ -1394,7 +1409,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -1425,6 +1440,9 @@
         },
         {
             "_id": "GaakkBAHltKyowC7",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.zDJS8E66UI0himqV"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/shocking-grasp.webp",
             "name": "Thunderstrike",
@@ -1489,7 +1507,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -1521,6 +1539,9 @@
         },
         {
             "_id": "RRrOnmWCHH8ZN6YJ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.0zU8CPejjQFnhZFI"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/ghost-sound.webp",
             "name": "Figment",
@@ -1549,7 +1570,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1582,6 +1603,9 @@
         },
         {
             "_id": "aGlEKg85U84EYgNU",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.sNUvbMoMeLTnYJm8"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/blue-energy-alien-hand.webp",
             "name": "Injury Echo",
@@ -1635,7 +1659,7 @@
                                 "damage": {
                                     "X6aUcgmF4twJh5gL": "1d8"
                                 },
-                                "interval": 1,
+                                "interval": 2,
                                 "type": "interval"
                             }
                         }
@@ -1662,7 +1686,7 @@
                                 "damage": {
                                     "2kU3mhyAecpOrFci": "1d8"
                                 },
-                                "interval": 1,
+                                "interval": 2,
                                 "type": "interval"
                             }
                         }
@@ -1689,7 +1713,7 @@
                                 "damage": {
                                     "EotUm3XBubhQrtWi": "1d8"
                                 },
-                                "interval": 1,
+                                "interval": 2,
                                 "type": "interval"
                             }
                         }
@@ -1729,6 +1753,9 @@
         },
         {
             "_id": "JJLkER08c0tZPled",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.WBmvzNDfpwka3qT4"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/light.webp",
             "name": "Light",
@@ -1757,7 +1784,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -2129,6 +2156,9 @@
         },
         {
             "_id": "TVbQBKp7r4itSEZs",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Q7QQ91vQtyi1Ux36"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/jump.webp",
             "name": "Jump",
@@ -2171,7 +2201,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -2201,6 +2231,9 @@
         },
         {
             "_id": "Y6aAUwMDtLl6nbeM",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.GB1RVtoFPwyH1B9G"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/green-acid-sprayer.webp",
             "name": "Caustic Conversion",
@@ -2293,6 +2326,9 @@
         },
         {
             "_id": "JFq1ypPEpbzDu6LT",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.9HpwDN4MYQJnW0LG"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/dispel-magic.webp",
             "name": "Dispel Magic",
@@ -2322,7 +2358,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -2354,6 +2390,9 @@
         },
         {
             "_id": "uDBnOE9TQRWkWLIp",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Fr58LDSrbndgld9n"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/magic/defensive/shield-barrier-deflect-teal.webp",
             "name": "Resist Energy",
@@ -2398,7 +2437,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -3274,6 +3313,9 @@
         },
         {
             "_id": "J6e0RVwjLxB0fPLc",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.hk2mTLH9DIvNqDuS"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "icons/magic/nature/root-vine-thorned-pink.webp",
             "name": "Verdant Code",
@@ -3354,6 +3396,9 @@
         },
         {
             "_id": "Dxf3ekajTii7re20",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ASOR3qVrjqStL4Ph"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "icons/environment/settlement/hut.webp",
             "name": "Cozy Crashpad",
@@ -3405,6 +3450,7 @@
                     ],
                     "value": [
                         "concentrate",
+                        "exploration",
                         "manipulate",
                         "metal"
                     ]
@@ -3414,6 +3460,9 @@
         },
         {
             "_id": "FxnacbxEjxv8TYNw",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.o6YCGx4lycsYpww4"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "systems/sf2e/icons/spells/haste.webp",
             "name": "Haste",
@@ -3453,7 +3502,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -3484,6 +3533,9 @@
         },
         {
             "_id": "jbpg39Z2qiC2RGby",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.9AAkVUCwF6WVNNY2"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/lightning/bolt-strike-sparks-blue.webp",
             "name": "Lightning Bolt",
@@ -3540,7 +3592,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""

--- a/packs/sf2e/iconics/zemir/zemir-level-7.json
+++ b/packs/sf2e/iconics/zemir/zemir-level-7.json
@@ -1071,6 +1071,9 @@
         },
         {
             "_id": "KutKMVQ73bFCi4y2",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -1087,7 +1090,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -1102,7 +1105,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1136,6 +1139,9 @@
         },
         {
             "_id": "00eIMxQiQXpcoQfN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.jgN33YSYXB8iIHTw"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "icons/skills/movement/figure-running-gray.webp",
             "name": "Stumble",
@@ -1200,6 +1206,9 @@
         },
         {
             "_id": "nhG0nHqD6uwgcFxE",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.7P4eBdqWcgQJAFCa"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-laser-beam-rifle.webp",
             "name": "Shifting Surge",
@@ -1300,6 +1309,9 @@
         },
         {
             "_id": "Rqa9AjKOtRm0Z65u",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.TN2pHF9l3k4ZJ7di"
+            },
             "folder": "AF5tLnq9AryanMqw",
             "img": "systems/sf2e/icons/abilities/blue-eruption.webp",
             "name": "Warp Terrain",
@@ -1340,7 +1352,7 @@
                     "value": ""
                 },
                 "time": {
-                    "value": "2"
+                    "value": "1"
                 },
                 "traits": {
                     "rarity": "uncommon",
@@ -1357,6 +1369,9 @@
         },
         {
             "_id": "H4Eokdhml3G0VRVN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gKKqvLohtrSJj3BM"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/magic-missile.webp",
             "name": "Force Barrage",
@@ -1398,7 +1413,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -1429,6 +1444,9 @@
         },
         {
             "_id": "GaakkBAHltKyowC7",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.zDJS8E66UI0himqV"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/shocking-grasp.webp",
             "name": "Thunderstrike",
@@ -1493,7 +1511,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -1525,6 +1543,9 @@
         },
         {
             "_id": "RRrOnmWCHH8ZN6YJ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.0zU8CPejjQFnhZFI"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/ghost-sound.webp",
             "name": "Figment",
@@ -1553,7 +1574,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -1586,6 +1607,9 @@
         },
         {
             "_id": "aGlEKg85U84EYgNU",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.sNUvbMoMeLTnYJm8"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/blue-energy-alien-hand.webp",
             "name": "Injury Echo",
@@ -1639,7 +1663,7 @@
                                 "damage": {
                                     "X6aUcgmF4twJh5gL": "1d8"
                                 },
-                                "interval": 1,
+                                "interval": 2,
                                 "type": "interval"
                             }
                         }
@@ -1666,7 +1690,7 @@
                                 "damage": {
                                     "2kU3mhyAecpOrFci": "1d8"
                                 },
-                                "interval": 1,
+                                "interval": 2,
                                 "type": "interval"
                             }
                         }
@@ -1693,7 +1717,7 @@
                                 "damage": {
                                     "EotUm3XBubhQrtWi": "1d8"
                                 },
-                                "interval": 1,
+                                "interval": 2,
                                 "type": "interval"
                             }
                         }
@@ -1733,6 +1757,9 @@
         },
         {
             "_id": "JJLkER08c0tZPled",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.WBmvzNDfpwka3qT4"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/light.webp",
             "name": "Light",
@@ -1761,7 +1788,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -2193,6 +2220,9 @@
         },
         {
             "_id": "TVbQBKp7r4itSEZs",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Q7QQ91vQtyi1Ux36"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/jump.webp",
             "name": "Jump",
@@ -2235,7 +2265,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -2265,6 +2295,9 @@
         },
         {
             "_id": "Y6aAUwMDtLl6nbeM",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.GB1RVtoFPwyH1B9G"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/green-acid-sprayer.webp",
             "name": "Caustic Conversion",
@@ -2357,6 +2390,9 @@
         },
         {
             "_id": "JFq1ypPEpbzDu6LT",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.9HpwDN4MYQJnW0LG"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/dispel-magic.webp",
             "name": "Dispel Magic",
@@ -2386,7 +2422,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -2418,6 +2454,9 @@
         },
         {
             "_id": "uDBnOE9TQRWkWLIp",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Fr58LDSrbndgld9n"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "icons/magic/defensive/shield-barrier-deflect-teal.webp",
             "name": "Resist Energy",
@@ -2462,7 +2501,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -3342,6 +3381,9 @@
         },
         {
             "_id": "J6e0RVwjLxB0fPLc",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.hk2mTLH9DIvNqDuS"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "icons/magic/nature/root-vine-thorned-pink.webp",
             "name": "Verdant Code",
@@ -3422,6 +3464,9 @@
         },
         {
             "_id": "Dxf3ekajTii7re20",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ASOR3qVrjqStL4Ph"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "icons/environment/settlement/hut.webp",
             "name": "Cozy Crashpad",
@@ -3473,6 +3518,7 @@
                     ],
                     "value": [
                         "concentrate",
+                        "exploration",
                         "manipulate",
                         "metal"
                     ]
@@ -3482,6 +3528,9 @@
         },
         {
             "_id": "FxnacbxEjxv8TYNw",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.o6YCGx4lycsYpww4"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "systems/sf2e/icons/spells/haste.webp",
             "name": "Haste",
@@ -3521,7 +3570,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -3552,6 +3601,9 @@
         },
         {
             "_id": "jbpg39Z2qiC2RGby",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.9AAkVUCwF6WVNNY2"
+            },
             "folder": "4fJHnYFqH0VjZXPv",
             "img": "icons/magic/lightning/bolt-strike-sparks-blue.webp",
             "name": "Lightning Bolt",
@@ -3608,7 +3660,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -3877,6 +3929,9 @@
         },
         {
             "_id": "eo1AxdR78Pdc8Lg1",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.qkehzRdn7JeGrR6E"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/alien-skull.webp",
             "name": "Void Whispers",
@@ -3945,6 +4000,9 @@
         },
         {
             "_id": "7yBRTejHFDKxCslx",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.A2JfEKe6BZcTG1S8"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/creatures/mammals/bats-movement-flying-black.webp",
             "name": "Fly",
@@ -3974,7 +4032,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -4006,6 +4064,9 @@
         },
         {
             "_id": "R2nes1Yu50BTzJPm",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VlNcjmYyu95vOUe8"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/magic/symbols/ring-circle-smoke-blue.webp",
             "name": "Translocate",
@@ -4046,7 +4107,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -4077,6 +4138,9 @@
         },
         {
             "_id": "TxLgGp9cqohJp90G",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.aqRYNoSvxsVfqglH"
+            },
             "folder": "7cyoYPoPYA01mErU",
             "img": "icons/equipment/feet/boots-leather-laced-brown.webp",
             "name": "Unfettered Movement",
@@ -4106,7 +4170,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"

--- a/packs/sf2e/iconics/zemir/zemir-level-7.json
+++ b/packs/sf2e/iconics/zemir/zemir-level-7.json
@@ -712,6 +712,9 @@
         },
         {
             "_id": "tqHgsGLbwoA4wnFN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.fClhrG92Zi4k14Hq"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/walkie-talkie.webp",
             "name": "Comm Unit",
@@ -727,6 +730,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -802,6 +806,9 @@
         },
         {
             "_id": "QYXGLkPL4LSVm2Tk",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.XRk3UWHAQ5WVkZGu"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/ammo-pouch.webp",
             "name": "Container (Ordinary)",
@@ -821,6 +828,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -953,6 +961,9 @@
         },
         {
             "_id": "K1vV4h9pQycXIF29",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -968,7 +979,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -2736,6 +2748,9 @@
         },
         {
             "_id": "bWsdwS9MXW1IU3qJ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.LD6JfxuvszVgQWVd"
+            },
             "folder": "aGUZspQIi3yNxIOu",
             "img": "systems/sf2e/icons/equipment/other/blue-containment-vessel.webp",
             "name": "Hypopen (Tactical)",
@@ -2752,7 +2767,8 @@
                     "value": "<p>This tiny cylinder contains specialized nanites that either</p><ul><li>Remove the @UUID[Compendium.sf2e.conditions.Item.Fatigued] or @UUID[Compendium.sf2e.conditions.Item.Paralyzed] condition</li><li>Decrease the value of the @UUID[Compendium.sf2e.conditions.Item.Clumsy] or @UUID[Compendium.sf2e.conditions.Item.Sickened] condition by 1.</li></ul>"
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -2768,9 +2784,6 @@
                 },
                 "price": {
                     "value": {
-                        "cp": 0,
-                        "gp": 0,
-                        "pp": 0,
                         "sp": 120
                     }
                 },
@@ -2787,7 +2800,6 @@
                     "rarity": "common",
                     "value": [
                         "consumable",
-                        "nanite",
                         "tech"
                     ]
                 },
@@ -2804,6 +2816,9 @@
         },
         {
             "_id": "ZtIM7hFxnlPp2174",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.HWHdAQArhRauTpm6"
+            },
             "folder": "aGUZspQIi3yNxIOu",
             "img": "systems/sf2e/icons/equipment/other/med-kit.webp",
             "name": "Medpatch (Tactical)",
@@ -2824,7 +2839,8 @@
                     "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> (manipulate)</p><hr /><p>Medpatches accelerate the body's natural healing. You regain @Damage[(3d6+6)[healing]] Hit Points and gain a +1 item bonus to saving throws against diseases and poisons for 10 minutes.</p>\n<p>@UUID[Compendium.sf2e.equipment-effects.Item.Effect: Medpatch]</p>"
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -2873,6 +2889,9 @@
         },
         {
             "_id": "8dzjz65ML91gkwTz",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.qqjDcCW118ySAlAS"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/battery-large.webp",
             "name": "Hacking Toolkit (Commercial)",
@@ -2888,6 +2907,7 @@
                 },
                 "equipped": {
                     "carryType": "stowed",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -2930,6 +2950,9 @@
         },
         {
             "_id": "pxa0xBaVILV084CY",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.coJUVZGcuVg3FoYh"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "icons/tools/hand/lockpicks-steel-grey.webp",
             "name": "Infiltrator's Toolkit (Commercial)",
@@ -2945,6 +2968,7 @@
                 },
                 "equipped": {
                     "carryType": "stowed",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,

--- a/packs/sf2e/paizo-pregens/murder-in-metal-city/jaedana.json
+++ b/packs/sf2e/paizo-pregens/murder-in-metal-city/jaedana.json
@@ -1193,7 +1193,8 @@
                     "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> (manipulate)</p><hr /><p>Medpatches accelerate the body's natural healing. You regain @Damage[(1d6)[healing]] Hit Points and gain a +1 item bonus to saving throws against diseases and poisons for 10 minutes.</p>\n<p>@UUID[Compendium.sf2e.equipment-effects.Item.Effect: Medpatch]</p>"
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -1209,9 +1210,6 @@
                 },
                 "price": {
                     "value": {
-                        "cp": 0,
-                        "gp": 0,
-                        "pp": 0,
                         "sp": 30
                     }
                 },
@@ -1522,7 +1520,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -1583,7 +1582,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/paizo-pregens/murder-in-metal-city/lunar-17.json
+++ b/packs/sf2e/paizo-pregens/murder-in-metal-city/lunar-17.json
@@ -1011,6 +1011,9 @@
         },
         {
             "_id": "moSiQ4SCnzbiaJQj",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VynaowCerc7B4yvI"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/sundries/books/book-embossed-jewel-silver-green.webp",
             "name": "Akashic Download",
@@ -1047,7 +1050,7 @@
                 },
                 "requirements": "You have a comm unit or computer, used as a locus.",
                 "rules": [],
-                "slug": null,
+                "slug": "akashic-download",
                 "target": {
                     "value": ""
                 },
@@ -1069,6 +1072,9 @@
         },
         {
             "_id": "QaSv52vQjda3N833",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.rfZpqmj0AIIdkVIs"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/life/cross-worn-green.webp",
             "name": "Heal",
@@ -1157,14 +1163,10 @@
                         }
                     },
                     "7qdtetowq348s9oc": {
+                        "_id": "7qdtetowq348s9oc",
                         "overlayType": "override",
                         "sort": 1,
                         "system": {
-                            "damage": {
-                                "0": {
-                                    "category": null
-                                }
-                            },
                             "range": {
                                 "value": "touch"
                             },
@@ -1174,20 +1176,13 @@
                         }
                     },
                     "7vbvdrv2cl87sqta": {
+                        "_id": "7vbvdrv2cl87sqta",
                         "overlayType": "override",
                         "sort": 4,
                         "system": {
                             "area": {
                                 "type": "emanation",
                                 "value": 30
-                            },
-                            "damage": {
-                                "0": {
-                                    "category": null
-                                }
-                            },
-                            "heightening": {
-                                "area": 0
                             },
                             "range": {
                                 "value": ""
@@ -1244,7 +1239,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "varies"
@@ -1275,6 +1270,9 @@
         },
         {
             "_id": "nwg4H2QsjSgwCOBI",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.D442XMADp01qJ7Cs"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/mindlink.webp",
             "name": "Mindlink",
@@ -1304,7 +1302,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -1335,6 +1333,9 @@
         },
         {
             "_id": "6ZzehNJeglY6Qrb0",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -1351,7 +1352,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -1366,7 +1367,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1400,6 +1401,9 @@
         },
         {
             "_id": "8e0XUHl6gxE4iJJN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.FEaM1B4WuiqFO7Uk"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "icons/magic/unholy/projectile-bolts-salvo-pink.webp",
             "name": "Eldritch Lance",
@@ -1410,7 +1414,18 @@
                     "value": ""
                 },
                 "counteraction": false,
-                "damage": {},
+                "damage": {
+                    "HSVx7dCjnK53Ic2d": {
+                        "applyMod": false,
+                        "category": null,
+                        "formula": "2d6",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "mental"
+                    }
+                },
                 "defense": null,
                 "description": {
                     "value": "<p>You condense a beam of mind-assaulting eldritch energy from the dark spaces between the stars and fire it at a target. Make a ranged spell attack roll against the target's AC. If you hit, you deal 2d6 mental damage. On a critical success, you deal double damage.</p><hr /><p><strong>Heightened (+1)</strong> The damage increases by 1d6.</p>"
@@ -1418,6 +1433,14 @@
                 "duration": {
                     "sustained": false,
                     "value": ""
+                },
+                "heightening": {
+                    "area": 0,
+                    "damage": {
+                        "HSVx7dCjnK53Ic2d": "1d6"
+                    },
+                    "interval": 1,
+                    "type": "interval"
                 },
                 "level": {
                     "value": 1
@@ -1435,7 +1458,7 @@
                 },
                 "requirements": "",
                 "rules": [],
-                "slug": null,
+                "slug": "eldritch-lance",
                 "target": {
                     "value": "1 creature"
                 },
@@ -1461,6 +1484,9 @@
         },
         {
             "_id": "5ycw1mWDTR8bWAm1",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.ZBeKxBcUOsXrfMRo"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/purple-insignia.webp",
             "name": "Implant Data",
@@ -1496,7 +1522,7 @@
                 },
                 "requirements": "",
                 "rules": [],
-                "slug": null,
+                "slug": "implant-data",
                 "target": {
                     "value": "1 computer"
                 },
@@ -1520,6 +1546,9 @@
         },
         {
             "_id": "Fg6rA6f0Ktfg7ZYV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.bBQ83xDvjQS3W1CG"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/blue-thermometer.webp",
             "name": "Measure",
@@ -1558,7 +1587,7 @@
                 },
                 "requirements": "",
                 "rules": [],
-                "slug": null,
+                "slug": "measure",
                 "target": {
                     "value": ""
                 },
@@ -1583,6 +1612,9 @@
         },
         {
             "_id": "PmJolFHCJZbrPjAT",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.nf8q0zvJDnnkzANe"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/blue-broadcast-signal.webp",
             "name": "Scan Environment",
@@ -1618,7 +1650,7 @@
                 },
                 "requirements": "",
                 "rules": [],
-                "slug": null,
+                "slug": "scan-environment",
                 "target": {
                     "value": ""
                 },
@@ -1634,6 +1666,7 @@
                     "value": [
                         "cantrip",
                         "concentrate",
+                        "exploration",
                         "manipulate"
                     ]
                 }

--- a/packs/sf2e/paizo-pregens/murder-in-metal-city/lunar-17.json
+++ b/packs/sf2e/paizo-pregens/murder-in-metal-city/lunar-17.json
@@ -2266,7 +2266,8 @@
                     "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> (manipulate)</p><hr /><p>Medpatches accelerate the body's natural healing. You regain @Damage[(1d6)[healing]] Hit Points and gain a +1 item bonus to saving throws against diseases and poisons for 10 minutes.</p>\n<p>@UUID[Compendium.sf2e.equipment-effects.Item.Effect: Medpatch]</p>"
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -2282,9 +2283,6 @@
                 },
                 "price": {
                     "value": {
-                        "cp": 0,
-                        "gp": 0,
-                        "pp": 0,
                         "sp": 30
                     }
                 },
@@ -2410,7 +2408,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -2471,7 +2470,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -2585,7 +2585,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/paizo-pregens/murder-in-metal-city/nitpick-bennit.json
+++ b/packs/sf2e/paizo-pregens/murder-in-metal-city/nitpick-bennit.json
@@ -2164,6 +2164,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -2501,7 +2502,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -2562,7 +2564,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/paizo-pregens/murder-in-metal-city/nitpick-bennit.json
+++ b/packs/sf2e/paizo-pregens/murder-in-metal-city/nitpick-bennit.json
@@ -1071,6 +1071,9 @@
         },
         {
             "_id": "IQ0tNiEe7G0fqihM",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.7P4eBdqWcgQJAFCa"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-laser-beam-rifle.webp",
             "name": "Shifting Surge",
@@ -1107,7 +1110,7 @@
                 },
                 "requirements": "",
                 "rules": [],
-                "slug": null,
+                "slug": "shifting-surge",
                 "target": {
                     "value": "one weapon held by you or a willing ally that deals acid, cold, electricity, fire, or sonic damage"
                 },
@@ -1130,6 +1133,9 @@
         },
         {
             "_id": "ZZm7CSXCn98TwqVw",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Gb7SeieEvd0pL2Eh"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/skills/melee/strike-blade-scimitar-gray-red.webp",
             "name": "Sure Strike",
@@ -1159,7 +1165,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -1189,6 +1195,9 @@
         },
         {
             "_id": "UwYFIn9DJaesGXzq",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.zDJS8E66UI0himqV"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/shocking-grasp.webp",
             "name": "Thunderstrike",
@@ -1252,7 +1261,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -1284,6 +1293,9 @@
         },
         {
             "_id": "kkV4ZEeTJ7uPv7Tz",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.NkvRoN33RbDg3fl9"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/pink-target-sign.webp",
             "name": "Analyze Target",
@@ -1297,7 +1309,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to Impersonate the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The circumstance bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The circumstance bonus increases to +3, and you can target any number of creatures.</p>"
+                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The status bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The status bonus increases to +3, and you can target any number of creatures.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -1319,7 +1331,7 @@
                 },
                 "requirements": "",
                 "rules": [],
-                "slug": null,
+                "slug": "analyze-target",
                 "target": {
                     "value": "1 creature"
                 },
@@ -1346,6 +1358,9 @@
         },
         {
             "_id": "QMjKy4fpTt325yd8",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.MPxbKoR54gkYkqLO"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/creatures/claws/claw-hooked-curved.webp",
             "name": "Gouging Claw",
@@ -1409,6 +1424,9 @@
                             "damage": {
                                 "0": {
                                     "category": null,
+                                    "kinds": [
+                                        "damage"
+                                    ],
                                     "type": "piercing"
                                 }
                             },
@@ -1424,16 +1442,20 @@
                             "damage": {
                                 "0": {
                                     "category": null,
+                                    "kinds": [
+                                        "damage"
+                                    ],
                                     "type": "slashing"
                                 }
-                            }
+                            },
+                            "defense": null
                         }
                     }
                 },
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "touch"
@@ -1466,6 +1488,9 @@
         },
         {
             "_id": "32odwOs3r6Pr6F33",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.Qw3fnUlaUbnn7ipC"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/symbols/runes-triangle-blue.webp",
             "name": "Prestidigitation",
@@ -1494,7 +1519,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "10 feet"
@@ -1527,6 +1552,9 @@
         },
         {
             "_id": "TTkLnFceMQk6zDbR",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.sXnWQOcGG2ELcxXb"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-galaxy.webp",
             "name": "Ricochet",
@@ -1537,18 +1565,7 @@
                     "value": ""
                 },
                 "counteraction": false,
-                "damage": {
-                    "IxEclWQHfqdivMNQ": {
-                        "applyMod": false,
-                        "category": null,
-                        "formula": "2d4",
-                        "kinds": [
-                            "damage"
-                        ],
-                        "materials": [],
-                        "type": "bludgeoning"
-                    }
-                },
+                "damage": {},
                 "defense": {
                     "save": {
                         "basic": true,
@@ -1562,14 +1579,6 @@
                     "sustained": false,
                     "value": ""
                 },
-                "heightening": {
-                    "area": 0,
-                    "damage": {
-                        "IxEclWQHfqdivMNQ": "1d4"
-                    },
-                    "interval": 1,
-                    "type": "interval"
-                },
                 "level": {
                     "value": 1
                 },
@@ -1577,31 +1586,57 @@
                     "value": "kEg204j5ScOrDOlz"
                 },
                 "overlays": {
-                    "br1AYCTToco9CFbh": {
+                    "9SFquoV10l0vCBx3": {
                         "name": "Ricochet (Bludgeoning)",
                         "overlayType": "override",
                         "sort": 1,
                         "system": {
                             "damage": {
-                                "IxEclWQHfqdivMNQ": {
-                                    "category": null
+                                "jDyOaf3hVw8NnEOE": {
+                                    "applyMod": false,
+                                    "category": null,
+                                    "formula": "2d4",
+                                    "kinds": [
+                                        "damage"
+                                    ],
+                                    "materials": [],
+                                    "type": "bludgeoning"
                                 }
+                            },
+                            "heightening": {
+                                "area": 0,
+                                "damage": {
+                                    "jDyOaf3hVw8NnEOE": "1d4"
+                                },
+                                "interval": 1,
+                                "type": "interval"
                             }
                         }
                     },
-                    "nZLY4xPlbMXARgd3": {
+                    "FlQr3ix5EROJM6jK": {
                         "name": "Ricochet (Slashing)",
                         "overlayType": "override",
                         "sort": 2,
                         "system": {
                             "damage": {
-                                "IxEclWQHfqdivMNQ": {
+                                "fqgYj9q7LZWoPKGz": {
+                                    "applyMod": false,
                                     "category": null,
+                                    "formula": "2d4",
                                     "kinds": [
                                         "damage"
                                     ],
+                                    "materials": [],
                                     "type": "slashing"
                                 }
+                            },
+                            "heightening": {
+                                "area": 0,
+                                "damage": {
+                                    "fqgYj9q7LZWoPKGz": "1d4"
+                                },
+                                "interval": 1,
+                                "type": "interval"
                             }
                         }
                     }
@@ -1616,7 +1651,7 @@
                 },
                 "requirements": "",
                 "rules": [],
-                "slug": null,
+                "slug": "ricochet",
                 "target": {
                     "value": "1 or 2 creatures"
                 },
@@ -1641,6 +1676,9 @@
         },
         {
             "_id": "4TvOUSW7XkRXgaRd",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.pwzdSlJgYqN7bs2w"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/mage-hand.webp",
             "name": "Telekinetic Hand",
@@ -1689,7 +1727,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"

--- a/packs/sf2e/paizo-pregens/murder-in-metal-city/old-growth-wildfire.json
+++ b/packs/sf2e/paizo-pregens/murder-in-metal-city/old-growth-wildfire.json
@@ -1301,7 +1301,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/paizo-pregens/murder-in-metal-city/tapkey.json
+++ b/packs/sf2e/paizo-pregens/murder-in-metal-city/tapkey.json
@@ -1325,7 +1325,8 @@
                     "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> (manipulate)</p><hr /><p>Medpatches accelerate the body's natural healing. You regain @Damage[(1d6)[healing]] Hit Points and gain a +1 item bonus to saving throws against diseases and poisons for 10 minutes.</p>\n<p>@UUID[Compendium.sf2e.equipment-effects.Item.Effect: Medpatch]</p>"
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -1341,9 +1342,6 @@
                 },
                 "price": {
                     "value": {
-                        "cp": 0,
-                        "gp": 0,
-                        "pp": 0,
                         "sp": 30
                     }
                 },
@@ -1564,7 +1562,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/paizo-pregens/murder-in-metal-city/vorza-moonshot.json
+++ b/packs/sf2e/paizo-pregens/murder-in-metal-city/vorza-moonshot.json
@@ -1099,7 +1099,8 @@
                     "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> (manipulate)</p><hr /><p>Medpatches accelerate the body's natural healing. You regain @Damage[(1d6)[healing]] Hit Points and gain a +1 item bonus to saving throws against diseases and poisons for 10 minutes.</p>\n<p>@UUID[Compendium.sf2e.equipment-effects.Item.Effect: Medpatch]</p>"
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -1115,9 +1116,6 @@
                 },
                 "price": {
                     "value": {
-                        "cp": 0,
-                        "gp": 0,
-                        "pp": 0,
                         "sp": 30
                     }
                 },
@@ -1334,7 +1332,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/standalone-adventure-bestiary/battle-for-nova-rush/captain-phaedra-firestorm.json
+++ b/packs/sf2e/standalone-adventure-bestiary/battle-for-nova-rush/captain-phaedra-firestorm.json
@@ -321,6 +321,9 @@
         },
         {
             "_id": "OLJWWD9Rj7SR9gi3",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -336,7 +339,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -381,6 +385,9 @@
         },
         {
             "_id": "Xmk49OvoUjzHgGhH",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -396,7 +403,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/standalone-adventure-bestiary/battle-for-nova-rush/nova-pirate.json
+++ b/packs/sf2e/standalone-adventure-bestiary/battle-for-nova-rush/nova-pirate.json
@@ -184,6 +184,9 @@
         },
         {
             "_id": "JZUC2l9jxF1ChGcA",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.SzGr78zdpnnrorre"
+            },
             "folder": "1zLXGqhSgBIthlcs",
             "img": "systems/sf2e/icons/equipment/weapons/grenade-hand.webp",
             "name": "Frag Grenade (Commercial)",
@@ -343,6 +346,9 @@
         },
         {
             "_id": "9ZDlbMSqvzpaZu47",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -358,7 +364,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -401,6 +408,9 @@
         },
         {
             "_id": "WlOQhpL9iNtTBJTc",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -416,7 +426,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/standalone-adventure-bestiary/murder-in-metal-city/agent-z.json
+++ b/packs/sf2e/standalone-adventure-bestiary/murder-in-metal-city/agent-z.json
@@ -55,6 +55,9 @@
         },
         {
             "_id": "hOwbWyheK71mYRtO",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.kR5A0h2a9hY41wav"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/purple-dimension-rift.webp",
             "name": "Entropy Strike",
@@ -65,18 +68,7 @@
                     "value": ""
                 },
                 "counteraction": false,
-                "damage": {
-                    "3tefev8txDHc5c92": {
-                        "applyMod": false,
-                        "category": null,
-                        "formula": "5d8",
-                        "kinds": [
-                            "damage"
-                        ],
-                        "materials": [],
-                        "type": "void"
-                    }
-                },
+                "damage": {},
                 "defense": null,
                 "description": {
                     "value": "<p>You unleash a ray of entropy that rapidly and indiscriminately decays matter. Make a ranged spell attack against the target's AC. On a hit, the target takes 5d8 void damage, or it takes 2d6 persistent acid damage and is glitching 1 if it has the tech trait. On a critical hit, double the damage, and if the creature has the tech trait, it's glitching 2 and @UUID[Compendium.sf2e.conditions.Item.Stunned]{Stunned 1}.</p><hr /><p><strong>Heightened (+1)</strong> The damage increases by 1 die.</p>"
@@ -87,9 +79,7 @@
                 },
                 "heightening": {
                     "area": 0,
-                    "damage": {
-                        "3tefev8txDHc5c92": "1d8"
-                    },
+                    "damage": {},
                     "interval": 1,
                     "type": "interval"
                 },
@@ -108,10 +98,22 @@
                         "system": {
                             "damage": {
                                 "3tefev8txDHc5c92": {
-                                    "category": null
+                                    "applyMod": false,
+                                    "category": null,
+                                    "formula": "5d8",
+                                    "kinds": [
+                                        "damage"
+                                    ],
+                                    "materials": [],
+                                    "type": "void"
                                 }
                             },
-                            "defense": null
+                            "defense": null,
+                            "heightening": {
+                                "damage": {
+                                    "3tefev8txDHc5c92": "1d8"
+                                }
+                            }
                         }
                     },
                     "z3AdZivCvPIwQBMP": {
@@ -121,6 +123,7 @@
                         "system": {
                             "damage": {
                                 "3tefev8txDHc5c92": {
+                                    "applyMod": false,
                                     "category": "persistent",
                                     "formula": "2d6",
                                     "kinds": [
@@ -148,7 +151,7 @@
                 },
                 "requirements": "",
                 "rules": [],
-                "slug": null,
+                "slug": "entropy-strike",
                 "target": {
                     "value": "1 creature or unattended object"
                 },
@@ -175,6 +178,9 @@
         },
         {
             "_id": "NkKhJ7ZXf69MoqZu",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.GdlG9a4o0ax0F2HT"
+            },
             "folder": "o04idOr2cgTUSO5w",
             "img": "systems/sf2e/icons/abilities/purple-hourglass.webp",
             "name": "Time's Edge",
@@ -238,7 +244,7 @@
                 },
                 "requirements": "",
                 "rules": [],
-                "slug": null,
+                "slug": "times-edge",
                 "target": {
                     "value": ""
                 },
@@ -261,6 +267,9 @@
         },
         {
             "_id": "10tZONmHG9iClklS",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VIKDSgBRR3Wd1mQx"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/green-chart.webp",
             "name": "Doom Scroll",
@@ -305,7 +314,7 @@
                 },
                 "requirements": "",
                 "rules": [],
-                "slug": null,
+                "slug": "doom-scroll",
                 "target": {
                     "value": ""
                 },
@@ -331,6 +340,9 @@
         },
         {
             "_id": "yuVFaDYoUQMpkdxx",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.H0WECXb2wvTHT9yk"
+            },
             "folder": "KGETkFaB5r8FyUND",
             "img": "systems/sf2e/icons/abilities/blue-ammunition.webp",
             "name": "Temporal Bullets",
@@ -344,7 +356,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p><strong>Trigger</strong> You fail (but not critically fail) an attack roll with a weapon.</p>\n<p>You rewind time and adjust probability to ensure an attack that just missed still does damage to its intended target. Roll damage as though you hit the target with the Strike, but the target only takes half the damage. You are then immune to temporal bullets for 10 minutes.</p>"
+                    "value": "<p><strong>Trigger</strong> You fail (but not critically fail) an attack roll with a weapon.</p><hr /><p>You rewind time and adjust probability to ensure an attack that just missed still does damage to its intended target. Roll damage as though you hit the target with the Strike, but the target only takes half the damage. You are then immune to temporal bullets for 10 minutes.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -367,7 +379,7 @@
                 },
                 "requirements": "",
                 "rules": [],
-                "slug": null,
+                "slug": "temporal-bullets",
                 "target": {
                     "value": ""
                 },
@@ -390,6 +402,9 @@
         },
         {
             "_id": "NyR9x14mdNk8o31Y",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VynaowCerc7B4yvI"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/sundries/books/book-embossed-jewel-silver-green.webp",
             "name": "Akashic Download",
@@ -403,7 +418,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You execute a psychic search of the Akashic Record for information about a specific topic and magically transfer this data to your comm unit or computer. When you Cast this Spell, choose any skill in which you're trained that has the @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] action.</p>\n<p>Any time during the duration, you can consult your comm unit while attempting a Recall Knowledge check using your chosen skill. This check gains a +1 status bonus. Checking your comm unit is part of the action to Recall Knowledge. You must be holding the comm unit to do so. The comm unit instantly compiles and displays snippets and selections from various media relevant to the topic, which grants you the bonus. If you roll a critical failure on this check, you get a failure instead. If the check is successful and the subject is a creature, you gain additional information or context about the creature. Once you reference the comm unit, the spell ends. When the spell ends, your access to the Akashic Record ends, and all the information you downloaded returns to the Akashic Record.</p><hr /><p><strong>Heightened (3rd)</strong> You can reference your comm unit three times before the spell ends.</p>"
+                    "value": "<p>You execute a psychic search of the Akashic Record for information about a specific topic and magically transfer this data to your comm unit or computer. When you Cast this Spell, choose any skill in which you're trained that has the @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] action.</p>\n<p>Any time during the duration, you can consult your comm unit while attempting a Recall Knowledge check using your chosen skill. This check gains a +1 status bonus. Checking your comm unit is part of the action to Recall Knowledge. You must be holding the comm unit to do so. The comm unit instantly compiles and displays snippets and selections from various media relevant to the topic, which grants you the bonus. If you roll a critical failure on this check, you get a failure instead. If the check is successful and the subject is a creature, you gain additional information or context about the creature. Once you reference the comm unit, the spell ends. When the spell ends, your access to the Akashic Record ends, and all the information you downloaded returns to the Akashic Record.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Akashic Download]</p><hr /><p><strong>Heightened (3rd)</strong> You can reference your comm unit three times before the spell ends.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -426,7 +441,7 @@
                 },
                 "requirements": "You have a comm unit or computer, used as a locus.",
                 "rules": [],
-                "slug": null,
+                "slug": "akashic-download",
                 "target": {
                     "value": ""
                 },
@@ -448,6 +463,9 @@
         },
         {
             "_id": "n3cX0bfsrkPP9VXF",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.NkvRoN33RbDg3fl9"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/pink-target-sign.webp",
             "name": "Analyze Target",
@@ -461,7 +479,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to Impersonate the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p><hr /><p><strong>Heightened (3rd)</strong> The circumstance bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The circumstance bonus increases to +3, and you can target any number of creatures.</p>"
+                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The status bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The status bonus increases to +3, and you can target any number of creatures.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -483,7 +501,7 @@
                 },
                 "requirements": "",
                 "rules": [],
-                "slug": null,
+                "slug": "analyze-target",
                 "target": {
                     "value": "1 creature"
                 },
@@ -510,6 +528,9 @@
         },
         {
             "_id": "G55xB4DQnVUspe4Z",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -526,7 +547,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -541,7 +562,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -575,6 +596,9 @@
         },
         {
             "_id": "GKIUFx1Q7RVju9qT",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.FEaM1B4WuiqFO7Uk"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/magic/unholy/projectile-bolts-salvo-pink.webp",
             "name": "Eldritch Lance",
@@ -585,7 +609,18 @@
                     "value": ""
                 },
                 "counteraction": false,
-                "damage": {},
+                "damage": {
+                    "HSVx7dCjnK53Ic2d": {
+                        "applyMod": false,
+                        "category": null,
+                        "formula": "2d6",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "mental"
+                    }
+                },
                 "defense": null,
                 "description": {
                     "value": "<p>You condense a beam of mind-assaulting eldritch energy from the dark spaces between the stars and fire it at a target. Make a ranged spell attack roll against the target's AC. If you hit, you deal 2d6 mental damage. On a critical success, you deal double damage.</p><hr /><p><strong>Heightened (+1)</strong> The damage increases by 1d6.</p>"
@@ -593,6 +628,14 @@
                 "duration": {
                     "sustained": false,
                     "value": ""
+                },
+                "heightening": {
+                    "area": 0,
+                    "damage": {
+                        "HSVx7dCjnK53Ic2d": "1d6"
+                    },
+                    "interval": 1,
+                    "type": "interval"
                 },
                 "level": {
                     "value": 1
@@ -610,7 +653,7 @@
                 },
                 "requirements": "",
                 "rules": [],
-                "slug": null,
+                "slug": "eldritch-lance",
                 "target": {
                     "value": "1 creature"
                 },
@@ -636,6 +679,9 @@
         },
         {
             "_id": "RND0f5k4Sc9EJifz",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.sNUvbMoMeLTnYJm8"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-energy-alien-hand.webp",
             "name": "Injury Echo",
@@ -646,18 +692,7 @@
                     "value": ""
                 },
                 "counteraction": false,
-                "damage": {
-                    "MKcVf1RIGVpzDPer": {
-                        "applyMod": false,
-                        "category": null,
-                        "formula": "1d8",
-                        "kinds": [
-                            "damage"
-                        ],
-                        "materials": [],
-                        "type": "bludgeoning"
-                    }
-                },
+                "damage": {},
                 "defense": {
                     "save": {
                         "basic": true,
@@ -665,19 +700,11 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You manifest an injury from the future or past to harm a creature in the present. Choose bludgeoning, piercing, or slashing damage. The target takes 1d8 of the selected damage type with a basic Will save. If the target fails its save and then takes the same type of damage before the end of your next turn, it takes an additional 1d4 persistent bleed damage.</p><hr /><p><strong>Heightened (+2)</strong> The initial damage increases by 1d8, and the persistent damage on a failure increases by 1d4.</p>"
+                    "value": "<p>You manifest an injury from the future or past to harm a creature in the present. Choose bludgeoning, piercing, or slashing damage. The target takes 1d8 of the selected damage type with a basic Will save. If the target fails its save and then takes the same type of damage before the end of your next turn, it takes an additional @Damage[ceil((@item.level)/2)d4[persistent,bleed]] damage.</p><hr /><p><strong>Heightened (+2)</strong> The initial damage increases by 1d8, and the persistent damage on a failure increases by 1d4.</p>"
                 },
                 "duration": {
                     "sustained": false,
                     "value": ""
-                },
-                "heightening": {
-                    "area": 0,
-                    "damage": {
-                        "MKcVf1RIGVpzDPer": "1d8"
-                    },
-                    "interval": 2,
-                    "type": "interval"
                 },
                 "level": {
                     "value": 1
@@ -686,47 +713,84 @@
                     "value": "Q7C75iSUKaRpcmEY"
                 },
                 "overlays": {
-                    "4jPDYGN5K2VeNKqW": {
-                        "name": "Injury Echo (Bludgeoning)",
-                        "overlayType": "override",
-                        "sort": 1,
-                        "system": {
-                            "damage": {
-                                "MKcVf1RIGVpzDPer": {
-                                    "category": null
-                                }
-                            }
-                        }
-                    },
-                    "MU30RFbsCMge6HgC": {
-                        "name": "Injury Echo (Slashing)",
-                        "overlayType": "override",
-                        "sort": 3,
-                        "system": {
-                            "damage": {
-                                "MKcVf1RIGVpzDPer": {
-                                    "category": null,
-                                    "kinds": [
-                                        "damage"
-                                    ],
-                                    "type": "slashing"
-                                }
-                            }
-                        }
-                    },
-                    "fWvfeWjJGmEUyoIi": {
+                    "Nz2Dt9pkBviU7YNx": {
                         "name": "Injury Echo (Piercing)",
                         "overlayType": "override",
                         "sort": 2,
                         "system": {
                             "damage": {
-                                "MKcVf1RIGVpzDPer": {
+                                "X6aUcgmF4twJh5gL": {
+                                    "applyMod": false,
                                     "category": null,
+                                    "formula": "1d8",
                                     "kinds": [
                                         "damage"
                                     ],
+                                    "materials": [],
                                     "type": "piercing"
                                 }
+                            },
+                            "heightening": {
+                                "area": 0,
+                                "damage": {
+                                    "X6aUcgmF4twJh5gL": "1d8"
+                                },
+                                "interval": 2,
+                                "type": "interval"
+                            }
+                        }
+                    },
+                    "bTPhCN8qHDYgs8Bd": {
+                        "name": "Injury Echo (Bludgeoning)",
+                        "overlayType": "override",
+                        "sort": 1,
+                        "system": {
+                            "damage": {
+                                "2kU3mhyAecpOrFci": {
+                                    "applyMod": false,
+                                    "category": null,
+                                    "formula": "1d8",
+                                    "kinds": [
+                                        "damage"
+                                    ],
+                                    "materials": [],
+                                    "type": "bludgeoning"
+                                }
+                            },
+                            "heightening": {
+                                "area": 0,
+                                "damage": {
+                                    "2kU3mhyAecpOrFci": "1d8"
+                                },
+                                "interval": 2,
+                                "type": "interval"
+                            }
+                        }
+                    },
+                    "ljkuQpKCf9OtjqEM": {
+                        "name": "Injury Echo (Slashing)",
+                        "overlayType": "override",
+                        "sort": 3,
+                        "system": {
+                            "damage": {
+                                "EotUm3XBubhQrtWi": {
+                                    "applyMod": false,
+                                    "category": null,
+                                    "formula": "1d8",
+                                    "kinds": [
+                                        "damage"
+                                    ],
+                                    "materials": [],
+                                    "type": "slashing"
+                                }
+                            },
+                            "heightening": {
+                                "area": 0,
+                                "damage": {
+                                    "EotUm3XBubhQrtWi": "1d8"
+                                },
+                                "interval": 2,
+                                "type": "interval"
                             }
                         }
                     }
@@ -741,7 +805,7 @@
                 },
                 "requirements": "",
                 "rules": [],
-                "slug": null,
+                "slug": "injury-echo",
                 "target": {
                     "value": "1 creature"
                 },
@@ -765,8 +829,11 @@
         },
         {
             "_id": "tK8B30CkLWaW9RKZ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uBo6g5aW087cLSJR"
+            },
             "folder": "PUfxgisPd7TTDluV",
-            "img": "systems/sf2e/icons/abilities/blue-arrow-up.webp",
+            "img": "icons/magic/light/explosion-impact-purple.webp",
             "name": "Mind Skewer",
             "sort": 1100000,
             "system": {
@@ -775,7 +842,18 @@
                     "value": ""
                 },
                 "counteraction": false,
-                "damage": {},
+                "damage": {
+                    "7Kfw2D6v6EKf50rP": {
+                        "applyMod": false,
+                        "category": null,
+                        "formula": "2d6",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "mental"
+                    }
+                },
                 "defense": {
                     "save": {
                         "basic": true,
@@ -788,6 +866,14 @@
                 "duration": {
                     "sustained": false,
                     "value": ""
+                },
+                "heightening": {
+                    "area": 0,
+                    "damage": {
+                        "7Kfw2D6v6EKf50rP": "2d6"
+                    },
+                    "interval": 1,
+                    "type": "interval"
                 },
                 "level": {
                     "value": 1
@@ -806,7 +892,7 @@
                 },
                 "requirements": "",
                 "rules": [],
-                "slug": null,
+                "slug": "mind-skewer",
                 "target": {
                     "value": "1 creature"
                 },
@@ -830,6 +916,9 @@
         },
         {
             "_id": "DAtLi81aIZdhOXcg",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.TVKNbcgTee19PXZR"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/shield.webp",
             "name": "Shield",
@@ -858,7 +947,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -890,6 +979,9 @@
         },
         {
             "_id": "Np8AIWdEwpV6I6SY",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.7P4eBdqWcgQJAFCa"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-laser-beam-rifle.webp",
             "name": "Shifting Surge",
@@ -903,7 +995,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You release a surge of magical energy that temporarily changes the type of damage dealt by a weapon. The next Strike the weapon makes deals your choice of acid, cold, electricity, fire, or sonic damage and deals an additional 1d6 extra damage of the same type as the weapon's normal damage.</p><hr /><p><strong>Heightened (+2)</strong> The extra damage increases by 1d6.</p>"
+                    "value": "<p>You release a surge of magical energy that temporarily changes the type of damage dealt by a weapon. The next Strike the weapon makes deals your choice of acid, cold, electricity, fire, or sonic damage and deals an additional 1d6 extra damage of the same type as the weapon's normal damage.</p><hr /><p><strong>Heightened (+2)</strong> The extra damage increases by 1d6.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Shifting Surge]</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -926,7 +1018,7 @@
                 },
                 "requirements": "",
                 "rules": [],
-                "slug": null,
+                "slug": "shifting-surge",
                 "target": {
                     "value": "one weapon held by you or a willing ally that deals acid, cold, electricity, fire, or sonic damage"
                 },

--- a/packs/sf2e/standalone-adventure-bestiary/murder-in-metal-city/hardlight-dragonet.json
+++ b/packs/sf2e/standalone-adventure-bestiary/murder-in-metal-city/hardlight-dragonet.json
@@ -42,6 +42,9 @@
         },
         {
             "_id": "CQs8rMQBAQgCoRIS",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.h7IhypLwItepwhou"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/tentacle-drone.webp",
             "name": "Adhere",
@@ -55,7 +58,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You create a molecular bond between an unattended object you touch (or an object you're holding) and another object or surface that object is touching. Pulling the object free of that surface requires a successful Athletics check against your spell DC to @UUID[Compendium.sf2e.actions.Item.Force Open].</p>\n<p>If you instead touch one unoccupied 5-foot square, that surface becomes charged with adhering magic. That space becomes greater difficult terrain.</p>"
+                    "value": "<p>You create a molecular bond between an unattended object you touch (or an object you're holding) and another object or surface that object is touching. Pulling the object free of that surface requires a successful [[/act force-open]]{Athletics} check against your spell DC to @UUID[Compendium.sf2e.actions.Item.Force Open].</p>\n<p>If you instead touch one unoccupied 5-foot square, that surface becomes charged with adhering magic. That space becomes greater difficult terrain.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -77,7 +80,7 @@
                 },
                 "requirements": "",
                 "rules": [],
-                "slug": null,
+                "slug": "adhere",
                 "target": {
                     "value": "1 held or unattended object or a 5-foot- square surface"
                 },
@@ -102,6 +105,9 @@
         },
         {
             "_id": "VFVqGfzloVxq7JNi",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.VynaowCerc7B4yvI"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/sundries/books/book-embossed-jewel-silver-green.webp",
             "name": "Akashic Download",
@@ -115,7 +121,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You execute a psychic search of the Akashic Record for information about a specific topic and magically transfer this data to your comm unit or computer. When you Cast this Spell, choose any skill in which you're trained that has the @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] action.</p>\n<p>Any time during the duration, you can consult your comm unit while attempting a Recall Knowledge check using your chosen skill. This check gains a +1 status bonus. Checking your comm unit is part of the action to Recall Knowledge. You must be holding the comm unit to do so. The comm unit instantly compiles and displays snippets and selections from various media relevant to the topic, which grants you the bonus. If you roll a critical failure on this check, you get a failure instead. If the check is successful and the subject is a creature, you gain additional information or context about the creature. Once you reference the comm unit, the spell ends. When the spell ends, your access to the Akashic Record ends, and all the information you downloaded returns to the Akashic Record.</p><hr /><p><strong>Heightened (3rd)</strong> You can reference your comm unit three times before the spell ends.</p>"
+                    "value": "<p>You execute a psychic search of the Akashic Record for information about a specific topic and magically transfer this data to your comm unit or computer. When you Cast this Spell, choose any skill in which you're trained that has the @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] action.</p>\n<p>Any time during the duration, you can consult your comm unit while attempting a Recall Knowledge check using your chosen skill. This check gains a +1 status bonus. Checking your comm unit is part of the action to Recall Knowledge. You must be holding the comm unit to do so. The comm unit instantly compiles and displays snippets and selections from various media relevant to the topic, which grants you the bonus. If you roll a critical failure on this check, you get a failure instead. If the check is successful and the subject is a creature, you gain additional information or context about the creature. Once you reference the comm unit, the spell ends. When the spell ends, your access to the Akashic Record ends, and all the information you downloaded returns to the Akashic Record.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Akashic Download]</p><hr /><p><strong>Heightened (3rd)</strong> You can reference your comm unit three times before the spell ends.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -137,7 +143,7 @@
                 },
                 "requirements": "You have a comm unit or computer, used as a locus.",
                 "rules": [],
-                "slug": null,
+                "slug": "akashic-download",
                 "target": {
                     "value": ""
                 },
@@ -159,6 +165,9 @@
         },
         {
             "_id": "OQyyZWdHLiSj5e7l",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.NkvRoN33RbDg3fl9"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/pink-target-sign.webp",
             "name": "Analyze Target",
@@ -172,7 +181,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to Impersonate the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p><hr /><p><strong>Heightened (3rd)</strong> The circumstance bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The circumstance bonus increases to +3, and you can target any number of creatures.</p>"
+                    "value": "<p>You focus on the target, gathering data as magical holograms display information. When the casting is complete, you learn biometric information about the target, including its fingerprints, medical conditions, and other basic physiological information. You or anyone you advise about the analysis gains a +1 status bonus to checks to @UUID[Compendium.sf2e.actions.Item.Impersonate] the creature, to @UUID[Compendium.sf2e.actions.Item.Treat Wounds] on the creature, and to @UUID[Compendium.sf2e.actions.Item.Recall Knowledge] about it. If the target is illusory or under the effects of illusion magic, you detect this only if the effect's rank is lower than the rank of your analyze target spell.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Analyze Target]</p><hr /><p><strong>Heightened (3rd)</strong> The status bonus increases to +2, and you can target up to 10 creatures.</p>\n<p><strong>Heightened (6th)</strong> The status bonus increases to +3, and you can target any number of creatures.</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -194,7 +203,7 @@
                 },
                 "requirements": "",
                 "rules": [],
-                "slug": null,
+                "slug": "analyze-target",
                 "target": {
                     "value": "1 creature"
                 },
@@ -221,6 +230,9 @@
         },
         {
             "_id": "N2yYKIQmdifvWBor",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.yXD9uU8w8uFD2OBQ"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/cerulean-circular-sign.webp",
             "name": "Delete",
@@ -257,7 +269,7 @@
                 },
                 "requirements": "",
                 "rules": [],
-                "slug": null,
+                "slug": "delete",
                 "target": {
                     "value": "1 dataset or tech item with the tracking trait"
                 },
@@ -280,6 +292,9 @@
         },
         {
             "_id": "9eZYIETe6KZmDXkk",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -296,7 +311,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -311,7 +326,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -345,6 +360,9 @@
         },
         {
             "_id": "wR1B0YXEHHKU79Kc",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.bBQ83xDvjQS3W1CG"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-thermometer.webp",
             "name": "Measure",
@@ -383,7 +401,7 @@
                 },
                 "requirements": "",
                 "rules": [],
-                "slug": null,
+                "slug": "measure",
                 "target": {
                     "value": ""
                 },
@@ -408,6 +426,9 @@
         },
         {
             "_id": "cGyV7dam9ImFfvrd",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.KlJEDmAOk1ztdNFf"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/purpule-mechanical-arm.webp",
             "name": "Summon Robot",
@@ -421,7 +442,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You summon a creature that has the tech trait and whose level is –1 to fight for you.</p><hr /><p><strong>Heightened</strong> As listed in the summon trait.</p>"
+                    "value": "<p>You summon a creature that has the tech trait and whose level is –1 to fight for you.</p><hr /><p><strong>Heightened</strong> As listed in the @UUID[Compendium.sf2e.journals.JournalEntry.S55aqwWIzpQRFhcq.JournalEntryPage.8gcp880pEWZ9VPnF]{summon} trait.</p>"
                 },
                 "duration": {
                     "sustained": true,
@@ -444,7 +465,7 @@
                 },
                 "requirements": "",
                 "rules": [],
-                "slug": null,
+                "slug": "summon-robot",
                 "target": {
                     "value": ""
                 },

--- a/packs/sf2e/standalone-adventure-bestiary/murder-in-metal-city/sworn-blade-of-sigils.json
+++ b/packs/sf2e/standalone-adventure-bestiary/murder-in-metal-city/sworn-blade-of-sigils.json
@@ -47,6 +47,9 @@
         },
         {
             "_id": "lEvPcgS0UkyHf2JE",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -63,7 +66,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -78,7 +81,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -112,6 +115,9 @@
         },
         {
             "_id": "2A1WORNHHBnYCuWV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.FEaM1B4WuiqFO7Uk"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/magic/unholy/projectile-bolts-salvo-pink.webp",
             "name": "Eldritch Lance",
@@ -122,7 +128,18 @@
                     "value": ""
                 },
                 "counteraction": false,
-                "damage": {},
+                "damage": {
+                    "HSVx7dCjnK53Ic2d": {
+                        "applyMod": false,
+                        "category": null,
+                        "formula": "2d6",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "mental"
+                    }
+                },
                 "defense": null,
                 "description": {
                     "value": "<p>You condense a beam of mind-assaulting eldritch energy from the dark spaces between the stars and fire it at a target. Make a ranged spell attack roll against the target's AC. If you hit, you deal 2d6 mental damage. On a critical success, you deal double damage.</p><hr /><p><strong>Heightened (+1)</strong> The damage increases by 1d6.</p>"
@@ -130,6 +147,14 @@
                 "duration": {
                     "sustained": false,
                     "value": ""
+                },
+                "heightening": {
+                    "area": 0,
+                    "damage": {
+                        "HSVx7dCjnK53Ic2d": "1d6"
+                    },
+                    "interval": 1,
+                    "type": "interval"
                 },
                 "level": {
                     "value": 1
@@ -147,7 +172,7 @@
                 },
                 "requirements": "",
                 "rules": [],
-                "slug": null,
+                "slug": "eldritch-lance",
                 "target": {
                     "value": "1 creature"
                 },
@@ -173,6 +198,9 @@
         },
         {
             "_id": "Kfg1eErbg0dJ7PuP",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.sNUvbMoMeLTnYJm8"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-energy-alien-hand.webp",
             "name": "Injury Echo",
@@ -183,18 +211,7 @@
                     "value": ""
                 },
                 "counteraction": false,
-                "damage": {
-                    "MKcVf1RIGVpzDPer": {
-                        "applyMod": false,
-                        "category": null,
-                        "formula": "1d8",
-                        "kinds": [
-                            "damage"
-                        ],
-                        "materials": [],
-                        "type": "bludgeoning"
-                    }
-                },
+                "damage": {},
                 "defense": {
                     "save": {
                         "basic": true,
@@ -202,19 +219,11 @@
                     }
                 },
                 "description": {
-                    "value": "<p>You manifest an injury from the future or past to harm a creature in the present. Choose bludgeoning, piercing, or slashing damage. The target takes 1d8 of the selected damage type with a basic Will save. If the target fails its save and then takes the same type of damage before the end of your next turn, it takes an additional 1d4 persistent bleed damage.</p><hr /><p><strong>Heightened (+2)</strong> The initial damage increases by 1d8, and the persistent damage on a failure increases by 1d4.</p>"
+                    "value": "<p>You manifest an injury from the future or past to harm a creature in the present. Choose bludgeoning, piercing, or slashing damage. The target takes 1d8 of the selected damage type with a basic Will save. If the target fails its save and then takes the same type of damage before the end of your next turn, it takes an additional @Damage[ceil((@item.level)/2)d4[persistent,bleed]] damage.</p><hr /><p><strong>Heightened (+2)</strong> The initial damage increases by 1d8, and the persistent damage on a failure increases by 1d4.</p>"
                 },
                 "duration": {
                     "sustained": false,
                     "value": ""
-                },
-                "heightening": {
-                    "area": 0,
-                    "damage": {
-                        "MKcVf1RIGVpzDPer": "1d8"
-                    },
-                    "interval": 2,
-                    "type": "interval"
                 },
                 "level": {
                     "value": 1
@@ -223,47 +232,84 @@
                     "value": "IdCTOq0ety9fKHxH"
                 },
                 "overlays": {
-                    "4jPDYGN5K2VeNKqW": {
-                        "name": "Injury Echo (Bludgeoning)",
-                        "overlayType": "override",
-                        "sort": 1,
-                        "system": {
-                            "damage": {
-                                "MKcVf1RIGVpzDPer": {
-                                    "category": null
-                                }
-                            }
-                        }
-                    },
-                    "MU30RFbsCMge6HgC": {
-                        "name": "Injury Echo (Slashing)",
-                        "overlayType": "override",
-                        "sort": 3,
-                        "system": {
-                            "damage": {
-                                "MKcVf1RIGVpzDPer": {
-                                    "category": null,
-                                    "kinds": [
-                                        "damage"
-                                    ],
-                                    "type": "slashing"
-                                }
-                            }
-                        }
-                    },
-                    "fWvfeWjJGmEUyoIi": {
+                    "Nz2Dt9pkBviU7YNx": {
                         "name": "Injury Echo (Piercing)",
                         "overlayType": "override",
                         "sort": 2,
                         "system": {
                             "damage": {
-                                "MKcVf1RIGVpzDPer": {
+                                "X6aUcgmF4twJh5gL": {
+                                    "applyMod": false,
                                     "category": null,
+                                    "formula": "1d8",
                                     "kinds": [
                                         "damage"
                                     ],
+                                    "materials": [],
                                     "type": "piercing"
                                 }
+                            },
+                            "heightening": {
+                                "area": 0,
+                                "damage": {
+                                    "X6aUcgmF4twJh5gL": "1d8"
+                                },
+                                "interval": 2,
+                                "type": "interval"
+                            }
+                        }
+                    },
+                    "bTPhCN8qHDYgs8Bd": {
+                        "name": "Injury Echo (Bludgeoning)",
+                        "overlayType": "override",
+                        "sort": 1,
+                        "system": {
+                            "damage": {
+                                "2kU3mhyAecpOrFci": {
+                                    "applyMod": false,
+                                    "category": null,
+                                    "formula": "1d8",
+                                    "kinds": [
+                                        "damage"
+                                    ],
+                                    "materials": [],
+                                    "type": "bludgeoning"
+                                }
+                            },
+                            "heightening": {
+                                "area": 0,
+                                "damage": {
+                                    "2kU3mhyAecpOrFci": "1d8"
+                                },
+                                "interval": 2,
+                                "type": "interval"
+                            }
+                        }
+                    },
+                    "ljkuQpKCf9OtjqEM": {
+                        "name": "Injury Echo (Slashing)",
+                        "overlayType": "override",
+                        "sort": 3,
+                        "system": {
+                            "damage": {
+                                "EotUm3XBubhQrtWi": {
+                                    "applyMod": false,
+                                    "category": null,
+                                    "formula": "1d8",
+                                    "kinds": [
+                                        "damage"
+                                    ],
+                                    "materials": [],
+                                    "type": "slashing"
+                                }
+                            },
+                            "heightening": {
+                                "area": 0,
+                                "damage": {
+                                    "EotUm3XBubhQrtWi": "1d8"
+                                },
+                                "interval": 2,
+                                "type": "interval"
                             }
                         }
                     }
@@ -278,7 +324,7 @@
                 },
                 "requirements": "",
                 "rules": [],
-                "slug": null,
+                "slug": "injury-echo",
                 "target": {
                     "value": "1 creature"
                 },
@@ -302,8 +348,11 @@
         },
         {
             "_id": "sdSOVoN8TO5jHnuP",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uBo6g5aW087cLSJR"
+            },
             "folder": "PUfxgisPd7TTDluV",
-            "img": "systems/sf2e/icons/abilities/blue-arrow-up.webp",
+            "img": "icons/magic/light/explosion-impact-purple.webp",
             "name": "Mind Skewer",
             "sort": 500000,
             "system": {
@@ -312,7 +361,18 @@
                     "value": ""
                 },
                 "counteraction": false,
-                "damage": {},
+                "damage": {
+                    "7Kfw2D6v6EKf50rP": {
+                        "applyMod": false,
+                        "category": null,
+                        "formula": "2d6",
+                        "kinds": [
+                            "damage"
+                        ],
+                        "materials": [],
+                        "type": "mental"
+                    }
+                },
                 "defense": {
                     "save": {
                         "basic": true,
@@ -325,6 +385,14 @@
                 "duration": {
                     "sustained": false,
                     "value": ""
+                },
+                "heightening": {
+                    "area": 0,
+                    "damage": {
+                        "7Kfw2D6v6EKf50rP": "2d6"
+                    },
+                    "interval": 1,
+                    "type": "interval"
                 },
                 "level": {
                     "value": 1
@@ -342,7 +410,7 @@
                 },
                 "requirements": "",
                 "rules": [],
-                "slug": null,
+                "slug": "mind-skewer",
                 "target": {
                     "value": "1 creature"
                 },
@@ -366,6 +434,9 @@
         },
         {
             "_id": "kaob5KImotpjiHpc",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.TVKNbcgTee19PXZR"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/shield.webp",
             "name": "Shield",
@@ -394,7 +465,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -426,6 +497,9 @@
         },
         {
             "_id": "99e6ri5Tcn6xpaoO",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.QpP30fcEl4NGjHwo"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/yellow-sonic-scream.webp",
             "name": "Sonic Scream",
@@ -488,7 +562,7 @@
                 },
                 "requirements": "",
                 "rules": [],
-                "slug": null,
+                "slug": "sonic-scream",
                 "target": {
                     "value": ""
                 },

--- a/packs/sf2e/starfinder-society-bestiary/season-1/1-00/nodocite-gunner.json
+++ b/packs/sf2e/starfinder-society-bestiary/season-1/1-00/nodocite-gunner.json
@@ -99,6 +99,9 @@
         },
         {
             "_id": "oMH1Ljgaso4TSlyS",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -114,7 +117,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -129,6 +133,7 @@
                     "type": null
                 },
                 "price": {
+                    "per": 1,
                     "value": {
                         "sp": 10
                     }
@@ -147,7 +152,7 @@
                     "value": []
                 },
                 "uses": {
-                    "autoDestroy": true,
+                    "autoDestroy": false,
                     "max": 10,
                     "value": 10
                 }

--- a/packs/sf2e/starfinder-society-bestiary/season-1/1-00/nodocite-gunner.json
+++ b/packs/sf2e/starfinder-society-bestiary/season-1/1-00/nodocite-gunner.json
@@ -5,13 +5,16 @@
     "items": [
         {
             "_id": "EXeNJFXgek9PnOSN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.KnGzQ30kkhYPxABY"
+            },
             "folder": "V89RPpe7fyCFC6NS",
             "img": "systems/sf2e/icons/equipment/weapons/blue-sci-fi-gun.webp",
             "name": "Integrated Tactical Reality Ripper",
             "sort": 100000,
             "system": {
                 "ammo": {
-                    "baseType": null,
+                    "baseType": "battery",
                     "builtIn": false,
                     "capacity": 1
                 },
@@ -54,9 +57,6 @@
                 },
                 "price": {
                     "value": {
-                        "cp": 0,
-                        "gp": 0,
-                        "pp": 0,
                         "sp": 410
                     }
                 },
@@ -77,16 +77,32 @@
                     "striking": 0
                 },
                 "size": "med",
-                "slug": null,
+                "slug": "reality-ripper",
                 "splashDamage": {
                     "value": 0
                 },
                 "traits": {
+                    "config": {
+                        "modular": [
+                            {
+                                "damageType": "acid",
+                                "traits": [
+                                    "razing"
+                                ]
+                            },
+                            {
+                                "damageType": "void",
+                                "traits": [
+                                    "deadly-d10"
+                                ]
+                            }
+                        ]
+                    },
                     "rarity": "uncommon",
                     "value": [
                         "caster",
-                        "deadly-d10",
                         "magical",
+                        "modular",
                         "tech",
                         "unwieldy"
                     ]

--- a/packs/sf2e/starfinder-society-bestiary/season-1/1-00/nodocite-sentry.json
+++ b/packs/sf2e/starfinder-society-bestiary/season-1/1-00/nodocite-sentry.json
@@ -5,12 +5,18 @@
     "items": [
         {
             "_id": "rRDwVRmrvjNoOb4V",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.EgAVqAYCrSJzxF1j"
+            },
             "folder": "1zLXGqhSgBIthlcs",
             "img": "systems/sf2e/icons/equipment/weapons/grenade.webp",
             "name": "Incendiary Grenade (Commercial)",
             "sort": 100000,
             "system": {
-                "ammo": null,
+                "ammo": {
+                    "baseType": null,
+                    "builtIn": false
+                },
                 "baseItem": "grenade",
                 "bonus": {
                     "value": 0

--- a/packs/sf2e/starfinder-society-bestiary/season-1/1-02/beyond-terror.json
+++ b/packs/sf2e/starfinder-society-bestiary/season-1/1-02/beyond-terror.json
@@ -45,6 +45,9 @@
         },
         {
             "_id": "SD3RGeWJWpAVI97x",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.mAMEt4FFbdqoRnkN"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/chill-touch.webp",
             "name": "Void Warp",
@@ -96,7 +99,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"

--- a/packs/sf2e/starfinder-society-bestiary/season-1/1-03/ichorwell-handler.json
+++ b/packs/sf2e/starfinder-society-bestiary/season-1/1-03/ichorwell-handler.json
@@ -45,6 +45,9 @@
         },
         {
             "_id": "JrkUXqYEoOqJxY0R",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.41TZEjhO6D1nWw2X"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/augury.webp",
             "name": "Augury",
@@ -73,7 +76,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -104,6 +107,9 @@
         },
         {
             "_id": "Z1fT1RpeOWwjvUCR",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4gBIw4IDrSfFHik4"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/daze.webp",
             "name": "Daze",
@@ -155,7 +161,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "60 feet"

--- a/packs/sf2e/starfinder-society-bestiary/season-1/1-03/ichorwell-raider.json
+++ b/packs/sf2e/starfinder-society-bestiary/season-1/1-03/ichorwell-raider.json
@@ -45,6 +45,9 @@
         },
         {
             "_id": "2fjLj0WQ4jeUJsOz",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.41TZEjhO6D1nWw2X"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/augury.webp",
             "name": "Augury",
@@ -73,7 +76,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -104,6 +107,9 @@
         },
         {
             "_id": "7FnOEg1z2SuO6zE9",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4gBIw4IDrSfFHik4"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/daze.webp",
             "name": "Daze",
@@ -155,7 +161,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "60 feet"

--- a/packs/sf2e/starfinder-society-bestiary/season-1/1-03/shosodax.json
+++ b/packs/sf2e/starfinder-society-bestiary/season-1/1-03/shosodax.json
@@ -45,6 +45,9 @@
         },
         {
             "_id": "9sByLUEeVftEaubX",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.41TZEjhO6D1nWw2X"
+            },
             "folder": "lPzcDrjGDFbzuF2r",
             "img": "systems/sf2e/icons/spells/augury.webp",
             "name": "Augury",
@@ -73,7 +76,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -104,6 +107,9 @@
         },
         {
             "_id": "WGEWrkDSiIfEpAeP",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4gBIw4IDrSfFHik4"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/daze.webp",
             "name": "Daze",
@@ -155,7 +161,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "60 feet"

--- a/packs/sf2e/starfinder-society-bestiary/season-1/1-03/shosodax.json
+++ b/packs/sf2e/starfinder-society-bestiary/season-1/1-03/shosodax.json
@@ -356,6 +356,9 @@
         },
         {
             "_id": "bGHFKqVZCx7PRxHh",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -371,7 +374,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/starfinder-society-bestiary/season-1/1-07/eclipse-armiger.json
+++ b/packs/sf2e/starfinder-society-bestiary/season-1/1-07/eclipse-armiger.json
@@ -254,6 +254,9 @@
         },
         {
             "_id": "EwtvBrTjlEPNTcaK",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -269,7 +272,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/starfinder-society-bestiary/season-1/1-07/officer-kanren.json
+++ b/packs/sf2e/starfinder-society-bestiary/season-1/1-07/officer-kanren.json
@@ -183,12 +183,18 @@
         },
         {
             "_id": "06eYcwetp9ywdZYB",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.EgAVqAYCrSJzxF1j"
+            },
             "folder": "1zLXGqhSgBIthlcs",
             "img": "systems/sf2e/icons/equipment/weapons/grenade.webp",
             "name": "Incendiary Grenade (Commercial)",
             "sort": 300000,
             "system": {
-                "ammo": null,
+                "ammo": {
+                    "baseType": null,
+                    "builtIn": false
+                },
                 "baseItem": "grenade",
                 "bonus": {
                     "value": 0
@@ -262,7 +268,6 @@
                     ]
                 },
                 "usage": {
-                    "canBeAmmo": false,
                     "value": "held-in-one-hand"
                 }
             },
@@ -270,6 +275,9 @@
         },
         {
             "_id": "WlKv8eSrK6T1QJZV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.7fIZAOxTqKohRhVv"
+            },
             "folder": "L1vkq5i6BuC4zDci",
             "img": "icons/equipment/shield/heater-steel-grey.webp",
             "name": "Carbon Shield",
@@ -285,7 +293,8 @@
                     "value": "<p>This durable yet lightweight defensive plate comes in a variety of shapes and sizes, and it's often customized with LED displays that broadcast personal insignia or an organization's colors and symbols.</p>"
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "grade": "commercial",
                 "hardness": 5,
@@ -397,6 +406,9 @@
         },
         {
             "_id": "ruA8WT5UNjiDIxq5",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -412,7 +424,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -457,6 +470,9 @@
         },
         {
             "_id": "DujialDUhpgxqVnp",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -472,7 +488,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/starfinder-society-bestiary/season-1/1-08/whisper-in-the-code.json
+++ b/packs/sf2e/starfinder-society-bestiary/season-1/1-08/whisper-in-the-code.json
@@ -909,6 +909,9 @@
         },
         {
             "_id": "Cwex4MQ4eiJ1pVV3",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.qqjDcCW118ySAlAS"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/battery-large.webp",
             "name": "Hacking Toolkit (Commercial)",
@@ -924,6 +927,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -966,6 +970,9 @@
         },
         {
             "_id": "X4m7uAVuPE1NwpuL",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.coJUVZGcuVg3FoYh"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "icons/tools/hand/lockpicks-steel-grey.webp",
             "name": "Infiltrator's Toolkit (Commercial)",
@@ -981,6 +988,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -1021,6 +1029,9 @@
         },
         {
             "_id": "G8TuxEyQhUd8x7KL",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.vLGDUFrg4yGzpTQX"
+            },
             "folder": "cJoNKs2FMCJkyEDK",
             "img": "systems/sf2e/icons/equipment/other/blue-brick.webp",
             "name": "Repair Toolkit (Commercial)",
@@ -1036,6 +1047,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -1076,6 +1088,9 @@
         },
         {
             "_id": "jJ9RlUSWBXCGhugo",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.SPGtFVOnoOSFNk89"
+            },
             "folder": "aGUZspQIi3yNxIOu",
             "img": "systems/sf2e/icons/equipment/other/syringe.webp",
             "name": "Machine Mind Serum (Commercial)",
@@ -1092,7 +1107,8 @@
                     "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> (manipulate)</p><hr /><p>When you inject this serum, magitech nanites infuse your body with machine-like circuitry that pulses and glows beneath your skin. For 1 minute, you gain a +1 item bonus to saving throws against mental effects. You also gain resistance 5 to mental damage. Due to your more machine-like nature, you gain weakness 5 to electricity.</p>"
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -1119,7 +1135,7 @@
                 "quantity": 3,
                 "rules": [],
                 "size": "med",
-                "slug": null,
+                "slug": "machine-mind-serum-commercial",
                 "traits": {
                     "rarity": "uncommon",
                     "value": [
@@ -1141,6 +1157,9 @@
         },
         {
             "_id": "mIIkXFCrJ9cvJQgp",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -1156,7 +1175,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -1201,6 +1221,9 @@
         },
         {
             "_id": "9Pbt0LWV1NhDmYgA",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -1216,7 +1239,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/starfinder-society-bestiary/season-1/1-08/whisper-in-the-code.json
+++ b/packs/sf2e/starfinder-society-bestiary/season-1/1-08/whisper-in-the-code.json
@@ -47,6 +47,9 @@
         },
         {
             "_id": "AUVeykQYZSOjAKlE",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.aIHY2DArKFweIrpf"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/command.webp",
             "name": "Command",
@@ -91,7 +94,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"
@@ -125,6 +128,9 @@
         },
         {
             "_id": "LbtNl0Se1x0zGMlx",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.4gBIw4IDrSfFHik4"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/daze.webp",
             "name": "Daze",
@@ -176,7 +182,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "60 feet"
@@ -210,6 +216,9 @@
         },
         {
             "_id": "ZLJ9GzBw89ieEVAZ",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -226,7 +235,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -241,7 +250,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -275,6 +284,9 @@
         },
         {
             "_id": "y10jyKm5q5bBFZrV",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gKKqvLohtrSJj3BM"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/magic-missile.webp",
             "name": "Force Barrage",
@@ -316,7 +328,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -347,6 +359,9 @@
         },
         {
             "_id": "xhvSknA9MR3c5Edb",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.WBmvzNDfpwka3qT4"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/light.webp",
             "name": "Light",
@@ -375,7 +390,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -409,6 +424,9 @@
         },
         {
             "_id": "qVwdS3bEdDoCsugx",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.uBo6g5aW087cLSJR"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "icons/magic/light/explosion-impact-purple.webp",
             "name": "Mind Skewer",
@@ -493,6 +511,9 @@
         },
         {
             "_id": "WrO3R8uemMyCrVW8",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.TVKNbcgTee19PXZR"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/shield.webp",
             "name": "Shield",
@@ -521,7 +542,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -553,6 +574,9 @@
         },
         {
             "_id": "M50btrq2Q5iOG80Z",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.mAMEt4FFbdqoRnkN"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/chill-touch.webp",
             "name": "Void Warp",
@@ -604,7 +628,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"

--- a/packs/sf2e/starfinder-society-bestiary/season-1/1-09/aruk.json
+++ b/packs/sf2e/starfinder-society-bestiary/season-1/1-09/aruk.json
@@ -84,6 +84,9 @@
         },
         {
             "_id": "fQQrOC4urCFM7ocA",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.WzLKjSw6hsBhuklC"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/create-water.webp",
             "name": "Create Water",
@@ -113,7 +116,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "0 feet"
@@ -145,6 +148,9 @@
         },
         {
             "_id": "yFn98NwmwnXQlqZv",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.gpzpAAAJ1Lza2JVl"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/detect-magic.webp",
             "name": "Detect Magic",
@@ -161,7 +167,7 @@
                 "damage": {},
                 "defense": null,
                 "description": {
-                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an @UUID[Compendium.sf2e.equipment.Item.Invisibility Potion]) typically are detected normally.</p>\n<hr />\n<p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
+                    "value": "<p>You send out a pulse that registers the presence of magic. You receive no information beyond the presence or absence of magic. You can choose to ignore magic you're fully aware of, such as the magic items and ongoing spells of you and your allies. You detect illusion magic only if that magic's effect has a lower rank than the rank of your <em>detect magic</em> spell. However, items that have an illusion aura but aren't deceptive in appearance (such as an <em>invisibility potion</em>) typically are detected normally.</p><hr /><p><strong>Heightened (3rd)</strong> You learn the rank or level of the most powerful magical effect the spell detects, as determined by the GM.</p>\n<p><strong>Heightened (4th)</strong> As 3rd rank, but you also pinpoint the source of the highest-rank magic. Like for an imprecise sense, you don't learn the exact location, but can narrow down the source to within a 5-foot cube (or the nearest if larger than that).</p>"
                 },
                 "duration": {
                     "sustained": false,
@@ -176,7 +182,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -210,6 +216,9 @@
         },
         {
             "_id": "RzRkHWEGTiTh7acR",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.d5dmu4HZ3YyrwcaF"
+            },
             "folder": "w6FyVHHsHMOXbY2w",
             "img": "systems/sf2e/icons/abilities/cerulean-plasma-rifle.webp",
             "name": "Elemental Weapon",
@@ -267,6 +276,9 @@
         },
         {
             "_id": "XumK1TK55d7vNXo0",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.g8QqHpv2CWDwmIm1"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "systems/sf2e/icons/spells/gust-of-wind.webp",
             "name": "Gust of Wind",
@@ -315,7 +327,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": ""
@@ -346,6 +358,9 @@
         },
         {
             "_id": "x7PrJtTn7BY3pow2",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.rfZpqmj0AIIdkVIs"
+            },
             "folder": "T8AzYUgNIAgTJ9Iz",
             "img": "icons/magic/life/cross-worn-green.webp",
             "name": "Heal",
@@ -510,7 +525,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "varies"
@@ -541,6 +556,9 @@
         },
         {
             "_id": "FvA8PicPj343BD56",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.WBmvzNDfpwka3qT4"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "systems/sf2e/icons/spells/light.webp",
             "name": "Light",
@@ -569,7 +587,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "120 feet"
@@ -603,6 +621,9 @@
         },
         {
             "_id": "T8Z66toPenvTA5XN",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.5y70IWhVV6bVjC9N"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-battery-gauge.webp",
             "name": "Recharge Weapon",
@@ -662,6 +683,9 @@
         },
         {
             "_id": "gST78rTic7RT7RFd",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.nf8q0zvJDnnkzANe"
+            },
             "folder": "9xujKNVgcczpuL4g",
             "img": "systems/sf2e/icons/abilities/blue-broadcast-signal.webp",
             "name": "Scan Environment",
@@ -713,6 +737,7 @@
                     "value": [
                         "cantrip",
                         "concentrate",
+                        "exploration",
                         "manipulate"
                     ]
                 }
@@ -721,6 +746,9 @@
         },
         {
             "_id": "lott5AJpc4q8urIz",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.7P4eBdqWcgQJAFCa"
+            },
             "folder": "PUfxgisPd7TTDluV",
             "img": "systems/sf2e/icons/abilities/blue-laser-beam-rifle.webp",
             "name": "Shifting Surge",
@@ -780,6 +808,9 @@
         },
         {
             "_id": "h2TlKpREB0Tvf4mW",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.spells.Item.SnjhtQYexDtNDdEg"
+            },
             "folder": "D7UVaOiB40wTR6kv",
             "img": "icons/magic/control/debuff-energy-hold-yellow.webp",
             "name": "Stabilize",
@@ -808,7 +839,7 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder Player Core"
+                    "title": "Starfinder Player Core"
                 },
                 "range": {
                     "value": "30 feet"

--- a/packs/sf2e/starfinder-society-bestiary/season-1/1-09/aruk.json
+++ b/packs/sf2e/starfinder-society-bestiary/season-1/1-09/aruk.json
@@ -1032,6 +1032,9 @@
         },
         {
             "_id": "cmHfIqt8i46FbucK",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.nPmeqjZ8b0mjqSfs"
+            },
             "folder": "7JvVdcPLRxEK9sec",
             "img": "systems/sf2e/icons/equipment/consumables/other-consumables/silencer.webp",
             "name": "Silencer (Commercial)",
@@ -1047,6 +1050,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -1089,6 +1093,9 @@
         },
         {
             "_id": "7BnfaxPinBhdUE6j",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.10lYyQDoJXUojKm2"
+            },
             "folder": "7JvVdcPLRxEK9sec",
             "img": "systems/sf2e/icons/equipment/other/attached-items/scope.webp",
             "name": "Sniper's Scope (Commercial)",
@@ -1104,6 +1111,7 @@
                 },
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
                     "invested": null
                 },
                 "hardness": 0,
@@ -1188,6 +1196,9 @@
         },
         {
             "_id": "Gy3YjGhrEUEzDG4y",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.JSS89QXZggfF3OHJ"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/weapons/red-rounds.webp",
             "name": "Projectile Ammo",
@@ -1203,7 +1214,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/starfinder-society-bestiary/season-1/1-09/functionary-agent.json
+++ b/packs/sf2e/starfinder-society-bestiary/season-1/1-09/functionary-agent.json
@@ -5,6 +5,9 @@
     "items": [
         {
             "_id": "ycccToFYC1ySByq2",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.EgAVqAYCrSJzxF1j"
+            },
             "folder": "1zLXGqhSgBIthlcs",
             "img": "systems/sf2e/icons/equipment/weapons/grenade.webp",
             "name": "Incendiary Grenade (Commercial)",
@@ -345,6 +348,9 @@
         },
         {
             "_id": "2dchOb4ofFmgeGPU",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -360,7 +366,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/starfinder-society-bestiary/season-1/1-10/burnt-circle-conspirator.json
+++ b/packs/sf2e/starfinder-society-bestiary/season-1/1-10/burnt-circle-conspirator.json
@@ -254,6 +254,9 @@
         },
         {
             "_id": "SzwTgDdBvNoK9LLu",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.0jSc8zqUPnAByMf9"
+            },
             "folder": "F6h7fO0Z7cgQBVRD",
             "img": "systems/sf2e/icons/equipment/other/green-battery.webp",
             "name": "Battery (Commercial)",
@@ -269,7 +272,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/starfinder-society-bestiary/season-1/1-11/frozen-trove-field-scientist.json
+++ b/packs/sf2e/starfinder-society-bestiary/season-1/1-11/frozen-trove-field-scientist.json
@@ -851,6 +851,8 @@
                 "dexCap": 2,
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
+                    "inSlot": false,
                     "invested": null
                 },
                 "grade": "commercial",
@@ -924,7 +926,8 @@
                     "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> (manipulate)</p><hr /><p>Medpatches accelerate the body's natural healing. You regain @Damage[(1d6)[healing]] Hit Points and gain a +1 item bonus to saving throws against diseases and poisons for 10 minutes.</p>\n<p>@UUID[Compendium.sf2e.equipment-effects.Item.Effect: Medpatch]</p>"
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -940,9 +943,6 @@
                 },
                 "price": {
                     "value": {
-                        "cp": 0,
-                        "gp": 0,
-                        "pp": 0,
                         "sp": 30
                     }
                 },
@@ -1164,7 +1164,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -1179,6 +1180,7 @@
                     "type": null
                 },
                 "price": {
+                    "per": 1,
                     "value": {
                         "sp": 5
                     }

--- a/packs/sf2e/starfinder-society-bestiary/season-1/1-11/frozen-trove-security-specialist.json
+++ b/packs/sf2e/starfinder-society-bestiary/season-1/1-11/frozen-trove-security-specialist.json
@@ -120,6 +120,8 @@
                 "dexCap": 2,
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
+                    "inSlot": false,
                     "invested": null
                 },
                 "grade": "commercial",
@@ -191,7 +193,8 @@
                     "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> (manipulate)</p><hr /><p>Medpatches accelerate the body's natural healing. You regain @Damage[(1d6)[healing]] Hit Points and gain a +1 item bonus to saving throws against diseases and poisons for 10 minutes.</p>\n<p>@UUID[Compendium.sf2e.equipment-effects.Item.Effect: Medpatch]</p>"
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -207,9 +210,6 @@
                 },
                 "price": {
                     "value": {
-                        "cp": 0,
-                        "gp": 0,
-                        "pp": 0,
                         "sp": 30
                     }
                 },
@@ -261,7 +261,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/starfinder-society-bestiary/season-1/1-12/beasts-of-bo-bandit.json
+++ b/packs/sf2e/starfinder-society-bestiary/season-1/1-12/beasts-of-bo-bandit.json
@@ -76,7 +76,7 @@
                     "striking": 0
                 },
                 "size": "med",
-                "slug": null,
+                "slug": "degradation-grenade-commercial",
                 "splashDamage": {
                     "value": 0
                 },
@@ -305,6 +305,8 @@
                 "dexCap": 2,
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
+                    "inSlot": false,
                     "invested": null
                 },
                 "grade": "commercial",
@@ -378,7 +380,8 @@
                     "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> (manipulate)</p><hr /><p>Medpatches accelerate the body's natural healing. You regain @Damage[(1d6)[healing]] Hit Points and gain a +1 item bonus to saving throws against diseases and poisons for 10 minutes.</p>\n<p>@UUID[Compendium.sf2e.equipment-effects.Item.Effect: Medpatch]</p>"
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -394,9 +397,6 @@
                 },
                 "price": {
                     "value": {
-                        "cp": 0,
-                        "gp": 0,
-                        "pp": 0,
                         "sp": 30
                     }
                 },
@@ -448,7 +448,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/starfinder-society-bestiary/season-1/1-12/rip.json
+++ b/packs/sf2e/starfinder-society-bestiary/season-1/1-12/rip.json
@@ -121,6 +121,8 @@
                 "dexCap": 1,
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
+                    "inSlot": false,
                     "invested": null
                 },
                 "grade": "commercial",
@@ -187,7 +189,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/starfinder-society-bestiary/season-1/1-12/tear.json
+++ b/packs/sf2e/starfinder-society-bestiary/season-1/1-12/tear.json
@@ -212,6 +212,8 @@
                 "dexCap": 1,
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
+                    "inSlot": false,
                     "invested": null
                 },
                 "grade": "commercial",
@@ -278,7 +280,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -339,7 +342,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/starfinder-society-bestiary/season-1/1-13/newborn-disciple.json
+++ b/packs/sf2e/starfinder-society-bestiary/season-1/1-13/newborn-disciple.json
@@ -460,7 +460,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/starfinder-society-bestiary/season-1/1-14/beasts-of-bo-bandit.json
+++ b/packs/sf2e/starfinder-society-bestiary/season-1/1-14/beasts-of-bo-bandit.json
@@ -305,6 +305,8 @@
                 "dexCap": 2,
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
+                    "inSlot": false,
                     "invested": null
                 },
                 "grade": "commercial",
@@ -378,7 +380,8 @@
                     "value": "<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> (manipulate)</p><hr /><p>Medpatches accelerate the body's natural healing. You regain @Damage[(1d6)[healing]] Hit Points and gain a +1 item bonus to saving throws against diseases and poisons for 10 minutes.</p>\n<p>@UUID[Compendium.sf2e.equipment-effects.Item.Effect: Medpatch]</p>"
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {
@@ -394,9 +397,6 @@
                 },
                 "price": {
                     "value": {
-                        "cp": 0,
-                        "gp": 0,
-                        "pp": 0,
                         "sp": 30
                     }
                 },
@@ -448,7 +448,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/starfinder-society-bestiary/season-1/1-14/bo-shek.json
+++ b/packs/sf2e/starfinder-society-bestiary/season-1/1-14/bo-shek.json
@@ -34,6 +34,7 @@
                 "equipped": {
                     "carryType": "worn",
                     "handsHeld": 0,
+                    "inSlot": false,
                     "invested": null
                 },
                 "expend": null,
@@ -53,9 +54,6 @@
                 },
                 "price": {
                     "value": {
-                        "cp": 0,
-                        "gp": 0,
-                        "pp": 0,
                         "sp": 1005
                     }
                 },
@@ -240,9 +238,6 @@
                 },
                 "price": {
                     "value": {
-                        "cp": 0,
-                        "gp": 0,
-                        "pp": 0,
                         "sp": 410
                     }
                 },
@@ -333,9 +328,6 @@
                 },
                 "price": {
                     "value": {
-                        "cp": 0,
-                        "gp": 0,
-                        "pp": 0,
                         "sp": 120
                     }
                 },
@@ -369,7 +361,6 @@
                     ]
                 },
                 "usage": {
-                    "canBeAmmo": false,
                     "value": "held-in-one-hand"
                 }
             },
@@ -458,8 +449,9 @@
                                 "value": "<p>A layer of treated lead lines your armor with integrated radiation sensors networked into your comm unit. While you're wearing armor with this upgrade, you gain resistance 2 to poison damage from radiation effects and a +1 status bonus to Fortitude saves against radiation.</p>"
                             },
                             "equipped": {
-                                "carryType": "installed",
-                                "handsHeld": 0
+                                "carryType": "worn",
+                                "handsHeld": 0,
+                                "invested": null
                             },
                             "hardness": 0,
                             "hp": {
@@ -551,7 +543,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/packs/sf2e/starfinder-society-bestiary/season-1/1-14/chendre.json
+++ b/packs/sf2e/starfinder-society-bestiary/season-1/1-14/chendre.json
@@ -622,6 +622,8 @@
                 "dexCap": 3,
                 "equipped": {
                     "carryType": "worn",
+                    "handsHeld": 0,
+                    "inSlot": false,
                     "invested": null
                 },
                 "grade": "commercial",
@@ -688,7 +690,8 @@
                     "value": ""
                 },
                 "equipped": {
-                    "carryType": "worn"
+                    "carryType": "worn",
+                    "handsHeld": 0
                 },
                 "hardness": 0,
                 "hp": {

--- a/src/scripts/config/traits.ts
+++ b/src/scripts/config/traits.ts
@@ -869,6 +869,7 @@ const consumableTraits = {
     structure: "PF2E.TraitStructure",
     talisman: "PF2E.TraitTalisman",
     tea: "PF2E.TraitTea",
+    tech: "PF2E.TraitTech",
     teleportation: "PF2E.TraitTeleportation",
     trap: "PF2E.TraitTrap",
     virulent: "PF2E.TraitVirulent",


### PR DESCRIPTION
Tech trait was necessary for medpatch and hypopen. They lost the traits on export otherwise.

I've added source ids for all the spells and physical items that I could match with compendia, then refreshed them but kept the _source name.

- Closes #21314