### PR TITLE
Add effects for Enhance Weapon and Enhance Body

### DIFF
--- a/packs/sf2e/spell-effects/spell-effect-enhance-body.json
+++ b/packs/sf2e/spell-effects/spell-effect-enhance-body.json
@@ -4,7 +4,7 @@
     "name": "Spell Effect: Enhance Body",
     "system": {
         "description": {
-            "value": ""
+            "value": "<p>Granted by @UUID[Compendium.sf2e.spells.Item.Enhance Body]</p>\n<p>Your unarmed attacks gain the tracking +1 trait, and increase the number of damage dice to two.</p><hr /><p><strong>Heightened (6th)</strong> The unarmed attacks gain the tracking +2 trait, and increase the number of weapon damage dice to three.</p>\n<p><strong>Heightened (9th)</strong> The unarmed attacks gain the tracking +3 trait, and increase the number of weapon damage dice to four.</p>"
         },
         "duration": {
             "expiry": "turn-start",

--- a/packs/sf2e/spell-effects/spell-effect-enhance-body.json
+++ b/packs/sf2e/spell-effects/spell-effect-enhance-body.json
@@ -1,0 +1,94 @@
+{
+    "_id": "oGUuRPGJHouppf8V",
+    "img": "icons/magic/unholy/strike-body-life-soul-green.webp",
+    "name": "Spell Effect: Enhance Body",
+    "system": {
+        "description": {
+            "value": ""
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "minutes",
+            "value": 1
+        },
+        "fromSpell": false,
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Starfinder Player Core"
+        },
+        "rules": [
+            {
+                "fromEquipment": false,
+                "itemType": "weapon",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:category:unarmed"
+                ],
+                "property": "traits",
+                "value": "tracking-1"
+            },
+            {
+                "fromEquipment": false,
+                "itemType": "weapon",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:category:unarmed",
+                    {
+                        "gte": [
+                            "{item|level}",
+                            6
+                        ]
+                    }
+                ],
+                "property": "traits",
+                "value": "tracking-2"
+            },
+            {
+                "fromEquipment": false,
+                "itemType": "weapon",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "item:category:unarmed",
+                    {
+                        "gte": [
+                            "{item|level}",
+                            9
+                        ]
+                    }
+                ],
+                "property": "traits",
+                "value": "tracking-3"
+            },
+            {
+                "fromEquipment": false,
+                "itemType": "weapon",
+                "key": "ItemAlteration",
+                "mode": "upgrade",
+                "predicate": [
+                    "item:category:unarmed"
+                ],
+                "property": "damage-dice-number",
+                "value": "ternary(gte(@item.level,9),4,ternary(gte(@item.level,6),3,2))"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/sf2e/spell-effects/spell-effect-enhance-weapon.json
+++ b/packs/sf2e/spell-effects/spell-effect-enhance-weapon.json
@@ -1,0 +1,86 @@
+{
+    "_id": "yopd0S7smKU5eB07",
+    "img": "systems/sf2e/icons/equipment/weapons/heavy-gun.webp",
+    "name": "Spell Effect: Enhance Weapon",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.sf2e.spells.Item.Enhance Weapon]</p>\n<p>The target weapon becomes an advanced weapon, gaining a +1 item bonus to attack rolls and increasing the number of weapon damage dice to two.</p><hr /><p><strong>Heightened (6th)</strong> If the target is a commercial, tactical, advanced, or superior weapon, it becomes an elite weapon, gaining a +2 item bonus to attack rolls and increasing the number of weapon damage dice to three.</p>\n<p><strong>Heightened (9th)</strong> The target becomes a paragon weapon, gaining a +3 to item bonus to attack rolls and increasing the number of weapon damage dice to four.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "minutes",
+            "value": 1
+        },
+        "fromSpell": false,
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Starfinder Player Core"
+        },
+        "rules": [
+            {
+                "choices": {
+                    "ownedItems": true,
+                    "types": [
+                        "weapon"
+                    ]
+                },
+                "flag": "weapon",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.Weapon"
+            },
+            {
+                "itemId": "{item|flags.sf2e.rulesSelections.weapon}",
+                "key": "ItemAlteration",
+                "mode": "upgrade",
+                "property": "grade",
+                "value": "advanced"
+            },
+            {
+                "itemId": "{item|flags.sf2e.rulesSelections.weapon}",
+                "key": "ItemAlteration",
+                "mode": "upgrade",
+                "predicate": [
+                    {
+                        "gte": [
+                            "{item|level}",
+                            6
+                        ]
+                    }
+                ],
+                "property": "grade",
+                "value": "elite"
+            },
+            {
+                "itemId": "{item|flags.sf2e.rulesSelections.weapon}",
+                "key": "ItemAlteration",
+                "mode": "upgrade",
+                "predicate": [
+                    {
+                        "gte": [
+                            "{item|level}",
+                            9
+                        ]
+                    }
+                ],
+                "property": "grade",
+                "value": "paragon"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/sf2e/spells/spells/rank-1/enhance-body.json
+++ b/packs/sf2e/spells/spells/rank-1/enhance-body.json
@@ -12,7 +12,7 @@
         "damage": {},
         "defense": null,
         "description": {
-            "value": "<p>You infuse the target's body with magic power. All its unarmed attacks gain the tracking +1 trait, and increase the number of weapon damage dice to two.</p><hr /><p><strong>Heightened (6th)</strong> The unarmed attacks gain the tracking +2 trait, and increase the number of weapon damage dice to three.</p>\n<p><strong>Heightened (9th)</strong> The unarmed attacks gain the tracking +3 trait, and increase the number of weapon damage dice to four.</p>"
+            "value": "<p>You infuse the target's body with magic power. All its unarmed attacks gain the tracking +1 trait, and increase the number of weapon damage dice to two.</p><hr /><p><strong>Heightened (6th)</strong> The unarmed attacks gain the tracking +2 trait, and increase the number of weapon damage dice to three.</p>\n<p><strong>Heightened (9th)</strong> The unarmed attacks gain the tracking +3 trait, and increase the number of weapon damage dice to four.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Enhance Body]</p>"
         },
         "duration": {
             "sustained": false,

--- a/packs/sf2e/spells/spells/rank-1/enhance-weapon.json
+++ b/packs/sf2e/spells/spells/rank-1/enhance-weapon.json
@@ -12,7 +12,7 @@
         "damage": {},
         "defense": null,
         "description": {
-            "value": "<p>You infuse the weapon with magic allowing it to safely operate beyond its normal parameters. If the target is a commercial or tactical weapon, it becomes an advanced weapon, gaining a +1 item bonus to attack rolls and increasing the number of weapon damage dice to two.</p><hr /><p><strong>Heightened (6th)</strong> If the target is a commercial, tactical, advanced, or superior weapon, it becomes an elite weapon, gaining a +2 item bonus to attack rolls and increasing the number of weapon damage dice to three.</p>\n<p><strong>Heightened (9th)</strong> The target becomes a paragon weapon, gaining a +3 to item bonus to attack rolls and increasing the number of weapon damage dice to four.</p>"
+            "value": "<p>You infuse the weapon with magic allowing it to safely operate beyond its normal parameters. If the target is a commercial or tactical weapon, it becomes an advanced weapon, gaining a +1 item bonus to attack rolls and increasing the number of weapon damage dice to two.</p><hr /><p><strong>Heightened (6th)</strong> If the target is a commercial, tactical, advanced, or superior weapon, it becomes an elite weapon, gaining a +2 item bonus to attack rolls and increasing the number of weapon damage dice to three.</p>\n<p><strong>Heightened (9th)</strong> The target becomes a paragon weapon, gaining a +3 to item bonus to attack rolls and increasing the number of weapon damage dice to four.</p>\n<p>@UUID[Compendium.sf2e.spell-effects.Item.Spell Effect: Enhance Weapon]</p>"
         },
         "duration": {
             "sustained": false,


### PR DESCRIPTION
Automates Enhance Weapon spell effect with new `grade` ItemAlteration. Also automated Enhance Body but by adding Tracking +1 trait and upgrading damage dice.