### PR TITLE
Correct Weapon Expertise Critical Specialization for Swashbuckler to exclude Unarmed Weapons

### DIFF
--- a/packs/pf2e/class-features/weapon-expertise.json
+++ b/packs/pf2e/class-features/weapon-expertise.json
@@ -52,7 +52,10 @@
                             2
                         ]
                     },
-                    "class:swashbuckler"
+                    "class:swashbuckler",
+                    {
+                        "not": "item:category:unarmed"
+                    }
                 ]
             },
             {


### PR DESCRIPTION
- Closes #21323