### PR TITLE
Fix hunter NPC's On the Hunt precision damage

### DIFF
--- a/packs/pf2e/pathfinder-npc-core/explorer/hunter.json
+++ b/packs/pf2e/pathfinder-npc-core/explorer/hunter.json
@@ -675,7 +675,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The hunter designates one creature they're observing or tracking as their prey.</p>\n<p>The hunter gains a +2 circumstance bonus to Perception checks to [[/act seek]] the prey and to Survival checks to [[/act track]] the prey.</p>\n<p>The first time the hunter hits the designated prey in a round, they deal an additional 1d4 precision damage. These effects last until the poacher uses On the Hunt again.</p>"
+                    "value": "<p>The hunter designates one creature they're observing or tracking as their prey.</p>\n<p>The hunter gains a +2 circumstance bonus to Perception checks to [[/act seek]] the prey and to Survival checks to [[/act track]] the prey.</p>\n<p>The first time the hunter hits the designated prey in a round, they deal an additional 1d8 precision damage. These effects last until the poacher uses On the Hunt again.</p>"
                 },
                 "publication": {
                     "license": "ORC",
@@ -728,7 +728,7 @@
                     {
                         "category": "precision",
                         "diceNumber": 1,
-                        "dieSize": "d4",
+                        "dieSize": "d8",
                         "key": "DamageDice",
                         "predicate": [
                             "first-attack"

--- a/packs/pf2e/pathfinder-npc-core/explorer/hunter.json
+++ b/packs/pf2e/pathfinder-npc-core/explorer/hunter.json
@@ -675,7 +675,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The hunter designates one creature they're observing or tracking as their prey.</p>\n<p>The hunter gains a +2 circumstance bonus to Perception checks to [[/act seek]] the prey and to Survival checks to [[/act track]] the prey.</p>\n<p>The first time the hunter hits the designated prey in a round, they deal an additional 1d8 precision damage. These effects last until the poacher uses On the Hunt again.</p>"
+                    "value": "<p>The hunter designates one creature they're observing or tracking as their prey.</p>\n<p>The hunter gains a +2 circumstance bonus to Perception checks to [[/act seek]] the prey and to Survival checks to [[/act track]] the prey.</p>\n<p>The first time the hunter hits the designated prey in a round, they deal an additional 1d8 precision damage. These effects last until the hunter uses On the Hunt again.</p>"
                 },
                 "publication": {
                     "license": "ORC",

--- a/packs/pf2e/pathfinder-npc-core/explorer/tracker.json
+++ b/packs/pf2e/pathfinder-npc-core/explorer/tracker.json
@@ -587,7 +587,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The tracker designates one creature they're observing or tracking as their prey.</p>\n<p>The tracker gains a +2 circumstance bonus to Perception checks to [[/act seek]] the prey and to Survival checks to [[/act track]] the prey.</p>\n<p>The first time the tracker hits the designated prey in a round, they deal an additional 1d4 precision damage. These effects last until the poacher uses On the Hunt again.</p>"
+                    "value": "<p>The tracker designates one creature they're observing or tracking as their prey.</p>\n<p>The tracker gains a +2 circumstance bonus to Perception checks to [[/act seek]] the prey and to Survival checks to [[/act track]] the prey.</p>\n<p>The first time the tracker hits the designated prey in a round, they deal an additional 1d4 precision damage. These effects last until the tracker uses On the Hunt again.</p>"
                 },
                 "publication": {
                     "license": "ORC",


### PR DESCRIPTION
PDF reads "As a poacher, but 1d8 precision damage".
AoN is correct on this one, Demiplane is wrong.