### PR TITLE
Add missing monster strike traits from Alien Core

### DIFF
--- a/packs/sf2e/alien-core-bestiary/aeon-guard-commander.json
+++ b/packs/sf2e/alien-core-bestiary/aeon-guard-commander.json
@@ -510,7 +510,10 @@
                 "slug": "boom-pistol",
                 "traits": {
                     "value": [
+                        "boost-1d6",
+                        "expend-2",
                         "razing",
+                        "reload-1",
                         "tech",
                         "tracking-1"
                     ]

--- a/packs/sf2e/alien-core-bestiary/aeon-guard-trooper.json
+++ b/packs/sf2e/alien-core-bestiary/aeon-guard-trooper.json
@@ -515,6 +515,10 @@
                 "slug": "aeon-rifle",
                 "traits": {
                     "value": [
+                        "aeon",
+                        "caster",
+                        "expend-1",
+                        "reload-1",
                         "tech"
                     ]
                 }
@@ -561,6 +565,7 @@
                     "value": [
                         "agile",
                         "free-hand",
+                        "powered",
                         "trip"
                     ]
                 }

--- a/packs/sf2e/alien-core-bestiary/corpse-fleet-infantry.json
+++ b/packs/sf2e/alien-core-bestiary/corpse-fleet-infantry.json
@@ -508,7 +508,10 @@
                 "slug": "arc-pistol",
                 "traits": {
                     "value": [
-                        "reload-1"
+                        "arc",
+                        "expend-2",
+                        "reload-1",
+                        "tech"
                     ]
                 }
             },
@@ -556,7 +559,9 @@
                 "traits": {
                     "value": [
                         "analog",
-                        "automatic"
+                        "automatic",
+                        "expend-1",
+                        "reload-2"
                     ]
                 }
             },

--- a/packs/sf2e/alien-core-bestiary/corpse-fleet-officer.json
+++ b/packs/sf2e/alien-core-bestiary/corpse-fleet-officer.json
@@ -415,6 +415,8 @@
                 "slug": "laser-pistol",
                 "traits": {
                     "value": [
+                        "expend-2",
+                        "reload-1",
                         "tech"
                     ]
                 }
@@ -460,8 +462,7 @@
                 "traits": {
                     "value": [
                         "analog",
-                        "deadly-d6",
-                        "sweep"
+                        "powered"
                     ]
                 }
             },

--- a/packs/sf2e/alien-core-bestiary/corpse-fleet-recruiter.json
+++ b/packs/sf2e/alien-core-bestiary/corpse-fleet-recruiter.json
@@ -1780,6 +1780,7 @@
                     "value": [
                         "agile",
                         "free-hand",
+                        "powered",
                         "reach-0",
                         "tech",
                         "tracking-1"
@@ -1829,6 +1830,8 @@
                 "slug": "zero-pistol",
                 "traits": {
                     "value": [
+                        "expend-2",
+                        "reload-1",
                         "tech",
                         "tracking-1"
                     ]

--- a/packs/sf2e/alien-core-bestiary/cybernetic-zombie.json
+++ b/packs/sf2e/alien-core-bestiary/cybernetic-zombie.json
@@ -198,6 +198,8 @@
                 "slug": "laser-pistol",
                 "traits": {
                     "value": [
+                        "expend-2",
+                        "reload-1",
                         "tech"
                     ]
                 }

--- a/packs/sf2e/alien-core-bestiary/demolition-class-assassin-robot.json
+++ b/packs/sf2e/alien-core-bestiary/demolition-class-assassin-robot.json
@@ -259,8 +259,11 @@
                     "value": [
                         "analog",
                         "concussive",
+                        "expend-1",
                         "kickback",
-                        "razing"
+                        "ranged-shove",
+                        "razing",
+                        "reload-1"
                     ]
                 }
             },

--- a/packs/sf2e/alien-core-bestiary/draiclipsed.json
+++ b/packs/sf2e/alien-core-bestiary/draiclipsed.json
@@ -108,7 +108,7 @@
                 },
                 "damageRolls": {
                     "Olks0VmHmS26LZRO": {
-                        "damage": "11",
+                        "damage": "1d6+11",
                         "damageType": "cold"
                     },
                     "mS9m9C9CgANNsYa3": {

--- a/packs/sf2e/alien-core-bestiary/elimination-class-assassin-robot.json
+++ b/packs/sf2e/alien-core-bestiary/elimination-class-assassin-robot.json
@@ -502,6 +502,8 @@
                 "traits": {
                     "value": [
                         "analog",
+                        "expend-1",
+                        "reload-1",
                         "tracking-1"
                     ]
                 }
@@ -551,9 +553,13 @@
                     "value": [
                         "analog",
                         "deadly-d12",
+                        "expend-1",
                         "fatal-d12",
                         "kickback",
-                        "tracking-1"
+                        "reload-1",
+                        "tracking-1",
+                        "unwieldy",
+                        "volley-30"
                     ]
                 }
             },

--- a/packs/sf2e/alien-core-bestiary/elindrian-celebrant.json
+++ b/packs/sf2e/alien-core-bestiary/elindrian-celebrant.json
@@ -176,6 +176,9 @@
                 "slug": null,
                 "traits": {
                     "value": [
+                        "boost-1d4",
+                        "powered",
+                        "reach-10",
                         "tech"
                     ]
                 }

--- a/packs/sf2e/alien-core-bestiary/emissary-class-infiltrator-robot.json
+++ b/packs/sf2e/alien-core-bestiary/emissary-class-infiltrator-robot.json
@@ -473,7 +473,9 @@
                 "slug": "semi-auto-pistol",
                 "traits": {
                     "value": [
-                        "analog"
+                        "analog",
+                        "expend-1",
+                        "reload-1"
                     ]
                 }
             },

--- a/packs/sf2e/alien-core-bestiary/emvermod.json
+++ b/packs/sf2e/alien-core-bestiary/emvermod.json
@@ -754,6 +754,7 @@
                 "slug": "pulsecaster-pistol",
                 "traits": {
                     "value": [
+                        "expend-1",
                         "nonlethal",
                         "reload-1",
                         "tech"

--- a/packs/sf2e/alien-core-bestiary/erabryth.json
+++ b/packs/sf2e/alien-core-bestiary/erabryth.json
@@ -514,10 +514,53 @@
             "type": "melee"
         },
         {
+            "_id": "qZOtA8e6Hkpm6gre",
+            "img": "systems/sf2e/icons/default-icons/melee.svg",
+            "name": "Light Ray",
+            "sort": 1000000,
+            "system": {
+                "action": "strike",
+                "area": null,
+                "attackEffects": {
+                    "value": [
+                        "shepherds-touch"
+                    ]
+                },
+                "bonus": {
+                    "value": 9
+                },
+                "damageRolls": {
+                    "OzokWrv0aBmNBc43": {
+                        "damage": "1d6",
+                        "damageType": "fire"
+                    }
+                },
+                "description": {
+                    "value": ""
+                },
+                "publication": {
+                    "license": "ORC",
+                    "remaster": true,
+                    "title": "Starfinder Alien Core"
+                },
+                "range": null,
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "config": {},
+                    "value": [
+                        "boost-1d4",
+                        "magical"
+                    ]
+                }
+            },
+            "type": "melee"
+        },
+        {
             "_id": "k1hxrHhmAgRb0zbw",
             "img": "systems/sf2e/icons/actions/Passive.webp",
             "name": "Buffering Zone",
-            "sort": 1000000,
+            "sort": 1100000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -562,7 +605,7 @@
             "_id": "HIxj8NAGalDHg7Mv",
             "img": "systems/sf2e/icons/actions/Reaction.webp",
             "name": "Reflect Aggression",
-            "sort": 1100000,
+            "sort": 1200000,
             "system": {
                 "actionType": {
                     "value": "reaction"
@@ -593,7 +636,7 @@
             "_id": "7SXoFgzCKSyWLlQJ",
             "img": "systems/sf2e/icons/actions/OneAction.webp",
             "name": "Forced Reflection",
-            "sort": 1200000,
+            "sort": 1300000,
             "system": {
                 "actionType": {
                     "value": "action"
@@ -628,7 +671,7 @@
             "_id": "i1OoK1fCXrmApXm4",
             "img": "systems/sf2e/icons/actions/Passive.webp",
             "name": "Shepherd's Touch",
-            "sort": 1300000,
+            "sort": 1400000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -684,7 +727,7 @@
             "_id": "wTdhnUkvXjoTwGyP",
             "img": "systems/sf2e/icons/default-icons/lore.svg",
             "name": "Android Lore",
-            "sort": 1400000,
+            "sort": 1500000,
             "system": {
                 "description": {
                     "value": ""
@@ -710,7 +753,7 @@
             "_id": "OxPmWECnkvxhaVpY",
             "img": "systems/sf2e/icons/default-icons/lore.svg",
             "name": "Boneyard Lore",
-            "sort": 1500000,
+            "sort": 1600000,
             "system": {
                 "description": {
                     "value": ""

--- a/packs/sf2e/alien-core-bestiary/free-captain-gunner.json
+++ b/packs/sf2e/alien-core-bestiary/free-captain-gunner.json
@@ -472,8 +472,11 @@
                     "value": [
                         "analog",
                         "concussive",
+                        "expend-1",
                         "kickback",
-                        "razing"
+                        "ranged-shove",
+                        "razing",
+                        "reload-1"
                     ]
                 }
             },

--- a/packs/sf2e/alien-core-bestiary/free-captain-knave.json
+++ b/packs/sf2e/alien-core-bestiary/free-captain-knave.json
@@ -402,6 +402,8 @@
                 "slug": "laser-pistol",
                 "traits": {
                     "value": [
+                        "expend-2",
+                        "reload-1",
                         "tech"
                     ]
                 }

--- a/packs/sf2e/alien-core-bestiary/free-captain.json
+++ b/packs/sf2e/alien-core-bestiary/free-captain.json
@@ -476,6 +476,7 @@
                     "value": [
                         "analog",
                         "deadly-d6",
+                        "powered",
                         "sweep",
                         "tech",
                         "tracking-1"
@@ -520,8 +521,11 @@
                 "slug": null,
                 "traits": {
                     "value": [
+                        "expend-5",
                         "reload-1",
-                        "tracking-1"
+                        "tech",
+                        "tracking-1",
+                        "unwieldy"
                     ]
                 }
             },

--- a/packs/sf2e/alien-core-bestiary/hellknight-armiger.json
+++ b/packs/sf2e/alien-core-bestiary/hellknight-armiger.json
@@ -536,6 +536,8 @@
                 "slug": "laser-rifle",
                 "traits": {
                     "value": [
+                        "expend-2",
+                        "reload-1",
                         "tech"
                     ]
                 }

--- a/packs/sf2e/alien-core-bestiary/hellknight-signifer.json
+++ b/packs/sf2e/alien-core-bestiary/hellknight-signifer.json
@@ -2094,6 +2094,9 @@
                 "slug": "laser-pistol",
                 "traits": {
                     "value": [
+                        "expend-2",
+                        "reload-1",
+                        "tech",
                         "tracking-1"
                     ]
                 }

--- a/packs/sf2e/alien-core-bestiary/jinsul-pontiff.json
+++ b/packs/sf2e/alien-core-bestiary/jinsul-pontiff.json
@@ -1014,6 +1014,8 @@
                 "slug": "laser-pistol",
                 "traits": {
                     "value": [
+                        "expend-2",
+                        "reload-1",
                         "tech",
                         "tracking-1"
                     ]

--- a/packs/sf2e/alien-core-bestiary/jinsul-trooper.json
+++ b/packs/sf2e/alien-core-bestiary/jinsul-trooper.json
@@ -195,6 +195,8 @@
                 "slug": "laser-rifle",
                 "traits": {
                     "value": [
+                        "expend-2",
+                        "reload-1",
                         "tech"
                     ]
                 }

--- a/packs/sf2e/alien-core-bestiary/jinsul-warblooded.json
+++ b/packs/sf2e/alien-core-bestiary/jinsul-warblooded.json
@@ -196,7 +196,10 @@
                 "slug": "arc-rifle",
                 "traits": {
                     "value": [
-                        "reload-1"
+                        "arc",
+                        "expend-2",
+                        "reload-1",
+                        "tech"
                     ]
                 }
             },

--- a/packs/sf2e/alien-core-bestiary/jygyk.json
+++ b/packs/sf2e/alien-core-bestiary/jygyk.json
@@ -349,9 +349,14 @@
                     "value": [
                         "analog",
                         "backstabber",
+                        "breakdown",
+                        "expend-1",
                         "fatal-d12",
+                        "reload-1",
                         "tracking-1",
-                        "unholy"
+                        "unholy",
+                        "unwieldy",
+                        "volley-30"
                     ]
                 }
             },

--- a/packs/sf2e/alien-core-bestiary/line-class-soldier-robot.json
+++ b/packs/sf2e/alien-core-bestiary/line-class-soldier-robot.json
@@ -334,6 +334,8 @@
                 "slug": "laser-rifle",
                 "traits": {
                     "value": [
+                        "expend-2",
+                        "reload-1",
                         "tech"
                     ]
                 }

--- a/packs/sf2e/alien-core-bestiary/nihili.json
+++ b/packs/sf2e/alien-core-bestiary/nihili.json
@@ -199,6 +199,7 @@
                 "slug": "laser-rifle",
                 "traits": {
                     "value": [
+                        "expend-2",
                         "reload-1",
                         "tech",
                         "tracking-1"

--- a/packs/sf2e/alien-core-bestiary/observer-class-security-robot.json
+++ b/packs/sf2e/alien-core-bestiary/observer-class-security-robot.json
@@ -233,6 +233,8 @@
                 "slug": "pulsecaster-pistol",
                 "traits": {
                     "value": [
+                        "expend-2",
+                        "nonlethal",
                         "reload-1",
                         "tech"
                     ]

--- a/packs/sf2e/alien-core-bestiary/ordinance-class-civil-robot.json
+++ b/packs/sf2e/alien-core-bestiary/ordinance-class-civil-robot.json
@@ -402,6 +402,8 @@
                 "slug": "pulsecaster-pistol",
                 "traits": {
                     "value": [
+                        "expend-2",
+                        "nonlethal",
                         "reload-1",
                         "tech"
                     ]

--- a/packs/sf2e/alien-core-bestiary/paradoxical-solipsist.json
+++ b/packs/sf2e/alien-core-bestiary/paradoxical-solipsist.json
@@ -988,6 +988,8 @@
                 "slug": "laser-pistol",
                 "traits": {
                     "value": [
+                        "expend-2",
+                        "reload-1",
                         "tech",
                         "tracking-1"
                     ]
@@ -1033,6 +1035,9 @@
                 "slug": "polyglove",
                 "traits": {
                     "value": [
+                        "arc",
+                        "powered",
+                        "tech",
                         "tracking-1"
                     ]
                 }

--- a/packs/sf2e/alien-core-bestiary/protection-class-security-robot.json
+++ b/packs/sf2e/alien-core-bestiary/protection-class-security-robot.json
@@ -198,6 +198,8 @@
                 "slug": "laser-rifle",
                 "traits": {
                     "value": [
+                        "expend-2",
+                        "reload-1",
                         "tech",
                         "tracking-1"
                     ]

--- a/packs/sf2e/alien-core-bestiary/ranonek.json
+++ b/packs/sf2e/alien-core-bestiary/ranonek.json
@@ -125,7 +125,8 @@
                 "traits": {
                     "value": [
                         "brutal",
-                        "ranged-trip"
+                        "ranged-trip",
+                        "unwieldy"
                     ]
                 }
             },

--- a/packs/sf2e/alien-core-bestiary/scavenger-slime.json
+++ b/packs/sf2e/alien-core-bestiary/scavenger-slime.json
@@ -260,6 +260,9 @@
                 "slug": null,
                 "traits": {
                     "value": [
+                        "arc",
+                        "expend-2",
+                        "reload-1",
                         "tech",
                         "tracking-1"
                     ]

--- a/packs/sf2e/alien-core-bestiary/snoop-class-infiltrator-robot.json
+++ b/packs/sf2e/alien-core-bestiary/snoop-class-infiltrator-robot.json
@@ -320,7 +320,9 @@
                 "slug": "crossbolter",
                 "traits": {
                     "value": [
-                        "analog"
+                        "analog",
+                        "expend-1",
+                        "reload-1"
                     ]
                 }
             },

--- a/packs/sf2e/alien-core-bestiary/tax-class-civil-robot.json
+++ b/packs/sf2e/alien-core-bestiary/tax-class-civil-robot.json
@@ -380,6 +380,8 @@
                 "slug": "pulsecaster-pistol",
                 "traits": {
                     "value": [
+                        "expend-2",
+                        "nonlethal",
                         "reload-1",
                         "tech"
                     ]

--- a/packs/sf2e/alien-core-bestiary/temporai.json
+++ b/packs/sf2e/alien-core-bestiary/temporai.json
@@ -1891,6 +1891,7 @@
                 "traits": {
                     "value": [
                         "tech",
+                        "reach-10",
                         "tracking-2"
                     ]
                 }
@@ -1940,6 +1941,8 @@
                 "slug": "laser-rifle",
                 "traits": {
                     "value": [
+                        "expend-2",
+                        "reload-1",
                         "tech",
                         "tracking-2"
                     ]

--- a/packs/sf2e/alien-core-bestiary/tool-rat.json
+++ b/packs/sf2e/alien-core-bestiary/tool-rat.json
@@ -736,6 +736,8 @@
                 "slug": "arc-rifle",
                 "traits": {
                     "value": [
+                        "arc",
+                        "expend-2",
                         "reload-1",
                         "tech",
                         "tracking-1"

--- a/packs/sf2e/alien-core-bestiary/vanguard-class-soldier-robot.json
+++ b/packs/sf2e/alien-core-bestiary/vanguard-class-soldier-robot.json
@@ -353,6 +353,10 @@
                 "slug": "painglaive",
                 "traits": {
                     "value": [
+                        "boost-1d4",
+                        "powered",
+                        "reach",
+                        "tech",
                         "tracking-1"
                     ]
                 }
@@ -401,7 +405,9 @@
                 "traits": {
                     "value": [
                         "analog",
+                        "expend-1",
                         "kickback",
+                        "reload-1",
                         "tracking-1",
                         "volley-30"
                     ]

--- a/packs/sf2e/alien-core-bestiary/xenowarden-greenhorn.json
+++ b/packs/sf2e/alien-core-bestiary/xenowarden-greenhorn.json
@@ -743,7 +743,10 @@
                 "slug": "arc-pistol",
                 "traits": {
                     "value": [
-                        "reload-1"
+                        "arc",
+                        "expend-2",
+                        "reload-1",
+                        "tech"
                     ]
                 }
             },

--- a/packs/sf2e/alien-core-bestiary/xenowarden-rootsworn.json
+++ b/packs/sf2e/alien-core-bestiary/xenowarden-rootsworn.json
@@ -1500,6 +1500,7 @@
                 "slug": "laser-pistol",
                 "traits": {
                     "value": [
+                        "expend-2",
                         "reload-1",
                         "tech"
                     ]


### PR DESCRIPTION
Many of the monsters in Alien Core are missing traits from SF2e like boost, expend, powered, and others. Even if some of these aren't automated on NPCs yet, I figured it would be good to get this data on the creatures now so it's at least listed. ~~(Many of these creatures also had Mag traits but the system doesn't accept the mag trait yet)~~