### PR TITLE
Fix wisdom modifier for Inkdrop

### DIFF
--- a/packs/pf2e/lost-omens-bestiary/tian-xia-world-guide/inkdrop.json
+++ b/packs/pf2e/lost-omens-bestiary/tian-xia-world-guide/inkdrop.json
@@ -214,7 +214,7 @@
                 "mod": 0
             },
             "wis": {
-                "mod": null
+                "mod": 0
             }
         },
         "attributes": {


### PR DESCRIPTION
Wisdom stat in Inkdrop was "null" in the json. Fixes this to 0. I confirmed it should be 0 by official PDF. 