### PR TITLE
add missing Ysoki ancestry feats 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ The project uses webpack to package the SASS files needed for a build and can cr
 
 - Run `npm run watch` to have any coding changes you make in your dev environment trigger an automatic rebuild.
 
-- To update compendium datafiles, run `npm run extractPacks ${compendium db filename} --system=pf2e` after editing the item directly in the built world's compendium, rather than editing the json files directly.
+- To update compendium datafiles, run `pnpm run extractPacks ${compendium db filename} --system=pf2e` after editing the item directly in the built world's compendium, rather than editing the json files directly.
 
 ## How to Help
 

--- a/packs/sf2e/feats/ancestry/ysoki/level-1/tinkering-fingers.json
+++ b/packs/sf2e/feats/ancestry/ysoki/level-1/tinkering-fingers.json
@@ -1,5 +1,5 @@
 {
-    "_id": "pSIQMN8AOMNlfevw",
+    "_id": "wTT8ieLvfWsZZaWT",
     "folder": "lSy9DEaCT6ETIExr",
     "img": "systems/sf2e/icons/default-icons/feats-sf2e.webp",
     "name": "Tinkering Fingers",

--- a/packs/sf2e/feats/ancestry/ysoki/level-1/tinkering-fingers.json
+++ b/packs/sf2e/feats/ancestry/ysoki/level-1/tinkering-fingers.json
@@ -1,0 +1,49 @@
+{
+    "_id": "pSIQMN8AOMNlfevw",
+    "folder": "lSy9DEaCT6ETIExr",
+    "img": "systems/sf2e/icons/default-icons/feats-sf2e.webp",
+    "name": "Tinkering Fingers",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "ancestry",
+        "description": {
+            "value": "<p>You grew up learning to tinker with devices, repair objects, and take things apart. You're trained in Crafting. If you're trained in Crafting from another source (from your background or class, for example), you instead become trained in a skill of your choice. You can @UUID[Compendium.sf2e.actions.Item.Repair] an item without using a repair toolkit without taking the –2 circumstance penalty, improvising tools from whatever you have at hand. You gain a +1 circumstance bonus to Crafting checks to Repair an item when you have a repair toolkit.</p>"
+        },
+        "level": {
+            "value": 1
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Starfinder Player Core"
+        },
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "system.skills.crafting.rank",
+                "value": 1
+            }
+        ],
+        "subfeatures": {
+            "proficiencies": {},
+            "senses": {},
+            "suppressedFeatures": []
+        },
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "ratfolk"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/packs/sf2e/feats/ancestry/ysoki/level-5/cornered-fury.json
+++ b/packs/sf2e/feats/ancestry/ysoki/level-5/cornered-fury.json
@@ -1,5 +1,5 @@
 {
-    "_id": "VC1YL0dDOGacYqN2",
+    "_id": "ulrGnvF0KAgEaifX",
     "folder": "GIgYFdpFEabcVZwR",
     "img": "systems/sf2e/icons/default-icons/feats-sf2e.webp",
     "name": "Cornered Fury",

--- a/packs/sf2e/feats/ancestry/ysoki/level-5/cornered-fury.json
+++ b/packs/sf2e/feats/ancestry/ysoki/level-5/cornered-fury.json
@@ -1,0 +1,63 @@
+{
+    "_id": "VC1YL0dDOGacYqN2",
+    "folder": "GIgYFdpFEabcVZwR",
+    "img": "systems/sf2e/icons/default-icons/feats-sf2e.webp",
+    "name": "Cornered Fury",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "bonus",
+        "description": {
+            "value": "<p>When you're physically outmatched, you fight with unexpected ferocity. If a foe of a larger size than you critically hits and damages you, that foe is @UUID[Compendium.sf2e.conditions.Item.Off-Guard] to you for 1 round.</p>"
+        },
+        "level": {
+            "value": 5
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Starfinder Player Core"
+        },
+        "rules": [
+            {
+                "key": "Note",
+                "outcome": [
+                    "criticalSuccess"
+                ],
+                "predicate": [
+                    "origin:enemy",
+                    {
+                        "gt": [
+                            "origin:size",
+                            "self:size"
+                        ]
+                    }
+                ],
+                "selector": [
+                    "damage-received"
+                ],
+                "text": "{item|description}",
+                "title": "{item|name}"
+            }
+        ],
+        "subfeatures": {
+            "proficiencies": {},
+            "senses": {},
+            "suppressedFeatures": []
+        },
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "ratfolk"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/packs/sf2e/feats/ancestry/ysoki/level-9/overcrowd.json
+++ b/packs/sf2e/feats/ancestry/ysoki/level-9/overcrowd.json
@@ -1,5 +1,5 @@
 {
-    "_id": "Vte2FWJNSEUIoxTm",
+    "_id": "LK6niBb38mEraYRS",
     "folder": "tizoMsGDD033loXD",
     "img": "systems/sf2e/icons/default-icons/feats-sf2e.webp",
     "name": "Overcrowd",

--- a/packs/sf2e/feats/ancestry/ysoki/level-9/overcrowd.json
+++ b/packs/sf2e/feats/ancestry/ysoki/level-9/overcrowd.json
@@ -1,0 +1,42 @@
+{
+    "_id": "Vte2FWJNSEUIoxTm",
+    "folder": "tizoMsGDD033loXD",
+    "img": "systems/sf2e/icons/default-icons/feats-sf2e.webp",
+    "name": "Overcrowd",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "bonus",
+        "description": {
+            "value": "<p>You can pack into tight spaces with other small creatures. As long as you’re Small, you can end your movement in the same square as a Small ally. Only two creatures total can share the same space when using this ability or a similar one.</p>"
+        },
+        "level": {
+            "value": 9
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Starfinder Player Core"
+        },
+        "rules": [],
+        "subfeatures": {
+            "proficiencies": {},
+            "senses": {},
+            "suppressedFeatures": []
+        },
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "ratfolk"
+            ]
+        }
+    },
+    "type": "feat"
+}


### PR DESCRIPTION
This adds the Tinkering Fingers level 1 Ysoki ancestry feat, the Cornered Fury level 5 Ysoki ancestry feat, and the Overcrowd level 9 Ysoki ancestry feat. Also updates the command to extract packs in the Contributing.md file.

Closes https://github.com/foundryvtt/pf2e/issues/21345