### PR TITLE
Fix updates to nested ammo wiping the ammo type

### DIFF
--- a/src/module/item/ammo/sheet.ts
+++ b/src/module/item/ammo/sheet.ts
@@ -63,11 +63,6 @@ class AmmoSheetPF2e extends PhysicalItemSheetPF2e<AmmoPF2e> {
             tagify(getInput("system.craftableAs"), { whitelist: validAmmoTypes });
         }
     }
-
-    protected override async _updateObject(event: Event, formData: Record<string, unknown>): Promise<void> {
-        formData["system.baseItem"] ||= null;
-        return super._updateObject(event, formData);
-    }
 }
 
 interface AmmoSheetData extends PhysicalItemSheetData<AmmoPF2e> {

--- a/static/templates/items/ammo-details.hbs
+++ b/static/templates/items/ammo-details.hbs
@@ -4,7 +4,7 @@
         <i class="fa-solid fa-circle-info" data-tooltip="PF2E.Item.Ammo.IsSpecialAmmo.hint"></i>
     </label>
     <div class="form-fields">
-        <input id="{{fieldIdPrefix}}special-ammo" type="checkbox" data-action="set-special-ammo" {{checked isSpecialAmmo}} />
+        <input id="{{fieldIdPrefix}}special-ammo" type="checkbox" data-action="set-special-ammo" {{checked isSpecialAmmo}} {{disabled item.parentItem}} />
     </div>
 </div>
 


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/21341

Handling empty string base items is already handled by a parent sheet.