### PR TITLE
Fix aura-blind areas appearing when aura touches a wall

### DIFF
--- a/src/module/canvas/token/aura/util.ts
+++ b/src/module/canvas/token/aura/util.ts
@@ -48,7 +48,7 @@ export function getAreaSquares(data: GetAreaSquaresParams): EffectAreaSquare[] {
         }),
     );
 
-    const squareGrid = Array.from({ length: rowCount * rowCount }, (_, i) => {
+    const squares = Array.from({ length: rowCount * rowCount }, (_, i) => {
         const dx = Math.floor(i / rowCount);
         const dy = i % rowCount;
         return new EffectAreaSquare(
@@ -59,7 +59,7 @@ export function getAreaSquares(data: GetAreaSquaresParams): EffectAreaSquare[] {
         );
     });
 
-    return squareGrid
+    return squares
         .filter((s) => measureDistanceCuboid(tokenBounds, s) <= data.radius)
         .map((square) => {
             square.active = tokenCenterPolygons.some((c) => c.contains(square.center.x, square.center.y));

--- a/src/module/canvas/token/aura/util.ts
+++ b/src/module/canvas/token/aura/util.ts
@@ -8,24 +8,6 @@ export function getAreaSquares(data: GetAreaSquaresParams): EffectAreaSquare[] {
     if (!canvas.ready) return [];
     const squareWidth = canvas.dimensions.size;
     const rowCount = Math.ceil(data.bounds.width / squareWidth);
-    const emptyVector = Array<null>(rowCount - 1).fill(null);
-    const genColumn = (square: EffectAreaSquare): EffectAreaSquare[] => {
-        return emptyVector.reduce(
-            (colSquares) => {
-                const squareAbove = colSquares.at(-1)!;
-                const squareBelow = new EffectAreaSquare(
-                    square.x,
-                    squareAbove.y + squareWidth,
-                    squareWidth,
-                    squareWidth,
-                );
-                colSquares.push(squareBelow);
-                return colSquares;
-            },
-            [square],
-        );
-    };
-    const topLeftSquare = new EffectAreaSquare(data.bounds.x, data.bounds.y, squareWidth, squareWidth);
     const collisionType =
         data.traits?.includes("visual") && !data.traits.includes("auditory")
             ? "sight"
@@ -66,19 +48,18 @@ export function getAreaSquares(data: GetAreaSquaresParams): EffectAreaSquare[] {
         }),
     );
 
-    return emptyVector
-        .reduce(
-            (squares: EffectAreaSquare[][]) => {
-                const lastSquare = squares.at(-1)?.at(-1) ?? { x: NaN, y: NaN };
-                const column = genColumn(
-                    new EffectAreaSquare(lastSquare.x + squareWidth, topLeftSquare.y, squareWidth, squareWidth),
-                );
-                squares.push(column);
-                return squares;
-            },
-            [genColumn(topLeftSquare)],
-        )
-        .flat()
+    const squareGrid = Array.from({ length: rowCount * rowCount }, (_, i) => {
+        const dx = Math.floor(i / rowCount);
+        const dy = i % rowCount;
+        return new EffectAreaSquare(
+            data.bounds.x + squareWidth * dx,
+            data.bounds.y + squareWidth * dy,
+            squareWidth,
+            squareWidth,
+        );
+    });
+
+    return squareGrid
         .filter((s) => measureDistanceCuboid(tokenBounds, s) <= data.radius)
         .map((square) => {
             square.active = tokenCenterPolygons.some((c) => c.contains(square.center.x, square.center.y));

--- a/src/module/canvas/token/aura/util.ts
+++ b/src/module/canvas/token/aura/util.ts
@@ -62,7 +62,7 @@ export function getAreaSquares(data: GetAreaSquaresParams): EffectAreaSquare[] {
         CONFIG.Canvas.polygonBackends[collisionType].create(c, {
             type: collisionType,
             source: pointSource,
-            boundaryShapes: [data.bounds],
+            radius: data.radiusPixels,
         }),
     );
 
@@ -89,6 +89,7 @@ export function getAreaSquares(data: GetAreaSquaresParams): EffectAreaSquare[] {
 interface GetAreaSquaresParams {
     bounds: PIXI.Rectangle;
     radius: number;
+    radiusPixels: number;
     token: TokenPF2e | TokenDocumentPF2e;
     traits?: string[];
 }

--- a/src/module/scene/token-document/clown-car.ts
+++ b/src/module/scene/token-document/clown-car.ts
@@ -84,7 +84,9 @@ class PartyClownCar {
         const distance = canvas.dimensions?.distance ?? 5;
         const radius = radiusPixels / distance;
         const areaBounds = new PIXI.Rectangle(center.x - radiusPixels, center.y - radiusPixels, diameter, diameter);
-        const squares = getAreaSquares({ bounds: areaBounds, radius, token: placeable }).filter((s) => s.active);
+        const squares = getAreaSquares({ bounds: areaBounds, radius, radiusPixels, token: placeable }).filter(
+            (s) => s.active,
+        );
         return R.sortBy(
             squares
                 .filter(


### PR DESCRIPTION
Make `getAreaSquares` use radius in pixels instead of bounding box for polygons.
I still think it treats a symptom, and not a cause, but that would require delving deep into how core Foundry handles polygon intersection beyond what I already did, and I don't want to.

Handles https://github.com/foundryvtt/pf2e/issues/20478 and https://github.com/foundryvtt/pf2e/issues/20599

Before:

https://github.com/user-attachments/assets/8507cdb5-e44f-48de-a5fd-6fd7bf31bd78

After:

https://github.com/user-attachments/assets/346a2bcd-b035-49d8-b2b8-6a844badc859

