### PR TITLE
Fix loading of Blockthrower and Reality Ripper

### DIFF
--- a/packs/sf2e/equipment/weapons/blockthrower.json
+++ b/packs/sf2e/equipment/weapons/blockthrower.json
@@ -6,7 +6,8 @@
     "system": {
         "ammo": {
             "baseType": "battery",
-            "builtIn": false
+            "builtIn": false,
+            "capacity": 1
         },
         "baseItem": "blockthrower",
         "bonus": {

--- a/packs/sf2e/equipment/weapons/reality-ripper.json
+++ b/packs/sf2e/equipment/weapons/reality-ripper.json
@@ -6,7 +6,8 @@
     "system": {
         "ammo": {
             "baseType": "battery",
-            "builtIn": false
+            "builtIn": false,
+            "capacity": 1
         },
         "baseItem": "reality-ripper",
         "bonus": {


### PR DESCRIPTION
Turns out if capacity isn't set they won't load