### PR TITLE
Add support for hardlight handwraps

### DIFF
--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -48,7 +48,8 @@ import { getPropertyRuneDegreeAdjustments, getPropertyRuneStrikeAdjustments } fr
 import type { EffectAreaShape, ItemType } from "@item/types.ts";
 import type { WeaponSource } from "@item/weapon/data.ts";
 import { processTwoHandTrait } from "@item/weapon/helpers.ts";
-import { PROFICIENCY_RANKS, ZeroToFour, ZeroToTwo } from "@module/data.ts";
+import { WeaponTrait } from "@item/weapon/types.ts";
+import { OneToThree, PROFICIENCY_RANKS, ZeroToFour, ZeroToTwo } from "@module/data.ts";
 import {
     extractDegreeOfSuccessAdjustments,
     extractModifierAdjustments,
@@ -1026,46 +1027,58 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
         const unarmedRunes = fu.deepClone(handwraps?._source.system.runes) ?? { potency: 0, striking: 0, property: [] };
 
         // Add a basic unarmed strike
-        const basicUnarmed = includeBasicUnarmed
-            ? ((): WeaponPF2e<this> => {
-                  const source: PreCreate<WeaponSource> = {
-                      _id: "xxPF2ExUNARMEDxx",
-                      name: game.i18n.localize("PF2E.WeaponTypeUnarmed"),
-                      type: "weapon",
-                      img: "icons/skills/melee/unarmed-punch-fist.webp",
-                      system: {
-                          slug: "basic-unarmed",
-                          category: "unarmed",
-                          baseItem: null,
-                          bonus: { value: 0 },
-                          damage: { dice: 1, die: "d4", damageType: "bludgeoning" } as const,
-                          equipped: {
-                              carryType: "worn",
-                              inSlot: true,
-                              handsHeld: 0,
-                          },
-                          group: "brawling",
-                          traits: { value: ["agile", "finesse", "nonlethal", "unarmed"] },
-                          usage: { value: "worngloves" },
-                          runes: unarmedRunes,
-                      },
-                  };
+        const basicUnarmed = (() => {
+            if (!includeBasicUnarmed) return null;
 
-                  // No handwraps, so generate straight from source
-                  const attack = new WeaponPF2e(source, { parent: this });
-                  for (const rule of this.synthetics.itemAlterations) {
-                      rule.applyAlteration({ singleItem: attack });
-                  }
-                  return attack;
-              })()
-            : null;
+            // Get traits, and include tracking from handwraps (Hardlight Handwraps)
+            const traits: WeaponTrait[] = ["agile", "finesse", "nonlethal", "unarmed"];
+            const handwrapsTracking = handwraps?.system.traits.config.tracking;
+            if (handwrapsTracking) {
+                traits.push(`tracking-${handwrapsTracking as OneToThree}`);
+            }
+
+            const source: PreCreate<WeaponSource> = {
+                _id: "xxPF2ExUNARMEDxx",
+                name: game.i18n.localize("PF2E.WeaponTypeUnarmed"),
+                type: "weapon",
+                img: "icons/skills/melee/unarmed-punch-fist.webp",
+                system: {
+                    slug: "basic-unarmed",
+                    category: "unarmed",
+                    baseItem: null,
+                    bonus: { value: 0 },
+                    damage: { dice: 1, die: "d4", damageType: "bludgeoning" } as const,
+                    equipped: {
+                        carryType: "worn",
+                        inSlot: true,
+                        handsHeld: 0,
+                    },
+                    group: "brawling",
+                    traits: { value: traits },
+                    usage: { value: "worngloves" },
+                    runes: unarmedRunes,
+                },
+                flags: {
+                    [SYSTEM_ID]: {
+                        handwraps: handwraps?.uuid,
+                    },
+                },
+            };
+
+            // No handwraps, so generate straight from source
+            const attack = new WeaponPF2e(source, { parent: this });
+            for (const rule of this.synthetics.itemAlterations) {
+                rule.applyAlteration({ singleItem: attack });
+            }
+            return attack;
+        })();
 
         const ammos = [
             ...itemTypes.ammo.filter((i) => !i.isStowed),
             ...itemTypes.weapon.filter((w) => w.system.usage.canBeAmmo),
         ];
         const syntheticWeapons = Object.values(synthetics.strikes)
-            .map((s) => s(unarmedRunes))
+            .map((s) => s({ unarmedRunes, handwraps }))
             .filter(R.isNonNull);
         // Exclude handwraps as a strike
         const weapons = [

--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -336,6 +336,15 @@ function getStrikeAttackDomains(
         "all",
     ].flat();
 
+    // Inherit some domains from any treatAs weapons to handle Hardlight Handwraps
+    const handwraps =
+        weapon.isOfType("weapon") && weapon.flags[SYSTEM_ID].handwraps
+            ? fromUuidSync(weapon.flags[SYSTEM_ID].handwraps)
+            : null;
+    if (handwraps) {
+        domains.push(`${handwraps.id}-attack`);
+    }
+
     if (typeof proficiencyRank === "number") {
         const proficiencies = ["untrained", "trained", "expert", "master", "legendary"] as const;
         domains.push(`${proficiencies[proficiencyRank]}-attack`);
@@ -398,6 +407,15 @@ function getAttackDamageDomains(
         `${action}-damage`,
         "damage",
     ].filter(R.isTruthy);
+
+    // Inherit some domains from any treatAs weapons to handle Hardlight Handwraps
+    const handwraps =
+        weapon.isOfType("weapon") && weapon.flags[SYSTEM_ID].handwraps
+            ? fromUuidSync(weapon.flags[SYSTEM_ID].handwraps)
+            : null;
+    if (handwraps) {
+        domains.push(`${handwraps.id}-damage`);
+    }
 
     if (weapon.baseType) {
         domains.push(`${weapon.baseType}-base-type-damage`);

--- a/src/module/item/weapon/data.ts
+++ b/src/module/item/weapon/data.ts
@@ -1,4 +1,5 @@
 import { AttributeString } from "@actor/types.ts";
+import { ItemUUID } from "@common/documents/_module.mjs";
 import type { AmmoType } from "@item/ammo/types.ts";
 import type { PhysicalItemSource } from "@item/base/data/index.ts";
 import type { ItemFlagsPF2e, TraitConfig } from "@item/base/data/system.ts";
@@ -48,6 +49,8 @@ type WeaponFlags = ItemFlagsPF2e & {
         attackItemBonus: number;
         /** A tracking property of whether the damage die size has been upgraded */
         damageFacesUpgraded: boolean;
+        /** The handwraps modifying this weapon */
+        handwraps?: ItemUUID | null;
     };
 };
 

--- a/src/module/rules/rule-element/strike.ts
+++ b/src/module/rules/rule-element/strike.ts
@@ -12,6 +12,7 @@ import type {
     WeaponRangeIncrement,
     WeaponTrait,
 } from "@item/weapon/types.ts";
+import { OneToThree } from "@module/data.ts";
 import type { DamageDieSize, DamageType } from "@system/damage/index.ts";
 import { objectHasKey, sluggify } from "@util";
 import { RuleElement, RuleElementOptions } from "./base.ts";
@@ -176,7 +177,7 @@ class StrikeRuleElement extends RuleElement<StrikeSchema> {
     override beforePrepareData(): void {
         if (!this.test()) return;
         const slug = this.slug ?? sluggify(this.label);
-        this.actor.synthetics.strikes[slug] = (unarmedRunes) => this.#constructWeapon({ slug, unarmedRunes });
+        this.actor.synthetics.strikes[slug] = (options = {}) => this.#constructWeapon({ ...options, slug });
     }
 
     /** Exclude other strikes if this rule element specifies that its strike replaces all others */
@@ -206,7 +207,7 @@ class StrikeRuleElement extends RuleElement<StrikeSchema> {
      * Construct a `WeaponPF2e` instance for use as the synthetic strike
      * @param damageType The resolved damage type for the strike
      */
-    #constructWeapon({ slug, unarmedRunes }: ConstructWeaponParams): WeaponPF2e<ActorPF2e> | null {
+    #constructWeapon({ slug, unarmedRunes, handwraps }: ConstructWeaponParams): WeaponPF2e<ActorPF2e> | null {
         const actor = this.actor;
 
         const attribute = this.resolveInjectedProperties(this.ability) || null;
@@ -233,6 +234,12 @@ class StrikeRuleElement extends RuleElement<StrikeSchema> {
             return null;
         }
 
+        const traits = this.traits.filter((t): t is WeaponTrait => objectHasKey(CONFIG.PF2E.weaponTraits, t));
+        const handwrapsTracking = handwraps?.system.traits.config.tracking;
+        if (handwrapsTracking) {
+            traits.push(`tracking-${handwrapsTracking as OneToThree}`);
+        }
+
         const actorIsNPC = actor.isOfType("npc");
         const source: PreCreate<WeaponSource> = fu.deepClone({
             _id: this.fist ? "xxxxxxFISTxxxxxx" : this.item.id,
@@ -243,6 +250,7 @@ class StrikeRuleElement extends RuleElement<StrikeSchema> {
                 [SYSTEM_ID]: {
                     battleForm: this.battleForm,
                     fixedAttack: actorIsNPC ? (this.attackModifier ?? null) : null,
+                    handwraps: this.category === "unarmed" ? handwraps?.uuid : null,
                 },
             },
             system: {
@@ -263,7 +271,7 @@ class StrikeRuleElement extends RuleElement<StrikeSchema> {
                 range: (this.range?.increment ?? null) as WeaponRangeIncrement | null,
                 maxRange: this.range?.max ?? null,
                 traits: {
-                    value: this.traits as WeaponTrait[],
+                    value: traits,
                     otherTags: this.otherTags,
                     rarity: "common",
                     toggles: {
@@ -387,7 +395,9 @@ type StrikeSchema = RuleElementSchema & {
 interface ConstructWeaponParams {
     slug: string;
     /** Weapon runes from handwraps of mighty blows */
-    unarmedRunes: Maybe<WeaponRuneSource>;
+    unarmedRunes?: Maybe<WeaponRuneSource>;
+    /** The handwraps currently active on this character */
+    handwraps?: Maybe<WeaponPF2e>;
 }
 
 interface StrikeSource extends RuleElementSource {

--- a/src/module/rules/synthetics.ts
+++ b/src/module/rules/synthetics.ts
@@ -89,7 +89,10 @@ type DeferredModifier = DeferredValue<Modifier>;
 type DeferredDamageDice = (args: DeferredDamageDiceOptions) => DamageDicePF2e | null;
 type DeferredMovementType = DeferredValue<BaseSpeedSynthetic | null>;
 type DeferredEphemeralEffect = DeferredPromise<EffectSource | ConditionSource | null>;
-type DeferredStrike = (runes?: WeaponRuneSource) => WeaponPF2e<ActorPF2e> | null;
+type DeferredStrike = (options?: {
+    unarmedRunes?: WeaponRuneSource;
+    handwraps?: WeaponPF2e;
+}) => WeaponPF2e<ActorPF2e> | null;
 
 interface BaseSpeedSynthetic extends Omit<LabeledSpeed, "label" | "type"> {
     type: MovementType;


### PR DESCRIPTION
This uses the suggestion of including `{handwraps?.id}-attack` in the domains so that the nested upgrade subitems also apply those unarmed strikes, without having to clone the upgrades themselves. If this doesn't work out we can change to cloning them, but so far this seems to work pretty well.