### PR TITLE
Distinguish null from 0 saves in hazards

### DIFF
--- a/src/module/actor/hazard/data.ts
+++ b/src/module/actor/hazard/data.ts
@@ -37,7 +37,7 @@ class HazardSystemData extends ActorSystemModel<HazardPF2e, HazardSystemSchema> 
 
         const createSaveDataSchema = () =>
             new fields.SchemaField<HazardSaveDataSchema>({
-                value: new fields.NumberField({ required: true, nullable: false, integer: true, initial: 0 }),
+                value: new fields.NumberField({ required: true, nullable: true, integer: true, initial: null }),
             });
 
         return {
@@ -212,7 +212,7 @@ interface HazardTraits extends fields.ModelPropsFromSchema<HazardTraitsSchema> {
 }
 
 type HazardSaveDataSchema = {
-    value: fields.NumberField<number, number, true, false, true>;
+    value: fields.NumberField<number, number, true, true, true>;
 };
 
 type HazardAttributesSchema = {

--- a/src/module/actor/hazard/document.ts
+++ b/src/module/actor/hazard/document.ts
@@ -182,10 +182,7 @@ class HazardPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | 
             const save = system.saves[saveType];
             const label = game.i18n.localize(CONFIG.PF2E.saves[saveType]);
             const base = save.value;
-
-            // Saving Throws with a value of 0 are not usable by the hazard
-            // Later on we'll need to explicitly check for null, since 0 is supposed to be valid
-            if (!base) return saves;
+            if (base === null) return saves;
 
             const statistic = new Statistic(this, {
                 slug: saveType,

--- a/src/module/migration/migrations/955-hazard-null-saves.ts
+++ b/src/module/migration/migrations/955-hazard-null-saves.ts
@@ -1,0 +1,23 @@
+import { ActorSourcePF2e } from "@actor/data/index.ts";
+import { MigrationBase } from "../base.ts";
+
+/**
+ * Converts 0 value saves to null on hazards.
+ * Until this migration, a 0 save meant it didn't exist, but now that's what null means.
+ * This migration is not safe to run multiple times, as 0 is a valid value.
+ */
+export class Migration955HazardNullSaves extends MigrationBase {
+    static override version = 0.955;
+
+    override async updateActor(source: ActorSourcePF2e): Promise<void> {
+        if (source.type !== "hazard") return;
+
+        // This migration is not idempotent and cannot be run multiple times
+        const version = source.system._migration?.version;
+        if (version && version >= this.version) return;
+
+        for (const save of Object.values(source.system.saves)) {
+            save.value ||= null;
+        }
+    }
+}

--- a/src/module/migration/migrations/index.ts
+++ b/src/module/migration/migrations/index.ts
@@ -253,3 +253,4 @@ export { Migration951TreasureCategories } from "./951-treasure-categories.ts";
 export { Migration952AmmoTraitsAndOptions } from "./952-ammo-traits-options.ts";
 export { Migration953NotStrikeDamage } from "./953-not-strike-damage.ts";
 export { Migration954ExplicitBleedImmunity } from "./954-explicit-bleed-immunity.ts";
+export { Migration955HazardNullSaves } from "./955-hazard-null-saves.ts";

--- a/src/module/migration/runner/base.ts
+++ b/src/module/migration/runner/base.ts
@@ -14,7 +14,7 @@ interface CollectionDiff<T extends foundry.documents.ActiveEffectSource | ItemSo
 export class MigrationRunnerBase {
     migrations: MigrationBase[];
 
-    static LATEST_SCHEMA_VERSION = 0.954;
+    static LATEST_SCHEMA_VERSION = 0.955;
 
     static MINIMUM_SAFE_VERSION = 0.7;
 


### PR DESCRIPTION
Migration will be run as a followup.