### PR TITLE
Fix Armor Expertise resistances on SF2e

### DIFF
--- a/src/module/item/base/data/model.ts
+++ b/src/module/item/base/data/model.ts
@@ -105,6 +105,7 @@ class TraitConfigField extends PrunedSchemaField<TraitConfigSchema> {
                 }),
                 { required: false, nullable: false },
             ),
+            resilient: new fields.NumberField({ required: false, nullable: false, initial: 0, min: 0 }),
         });
     }
 }
@@ -117,6 +118,7 @@ type TraitConfigSchema = {
         false,
         false
     >;
+    resilient: fields.NumberField<number, number, false, false, true>;
 };
 
 type ModularConfigSchema = {

--- a/src/module/item/base/data/system.ts
+++ b/src/module/item/base/data/system.ts
@@ -28,7 +28,7 @@ interface TraitConfig {
     deadly?: string;
     fatal?: string;
     modular: ModularConfig[] | undefined;
-    resilient?: number;
+    resilient: number;
     thrown?: number;
     tracking?: number;
     versatile?: DamageType[];

--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -53,7 +53,8 @@ import type {
     RawItemChatData,
     TraitChatData,
 } from "./data/index.ts";
-import type { ItemDescriptionData, ItemTrait, TraitConfig } from "./data/system.ts";
+import { TraitConfigField } from "./data/model.ts";
+import type { ItemDescriptionData, ItemTrait } from "./data/system.ts";
 import type { ItemSheetPF2e } from "./sheet/sheet.ts";
 
 /** The basic `Item` subclass for the system */
@@ -274,7 +275,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
             const validTraits = this.constructor.validTraits;
             const original = this.system.traits.value;
             this.system.traits.value = [];
-            this.system.traits.config ??= {} as TraitConfig;
+            this.system.traits.config = new TraitConfigField().clean(this.system.traits.config ?? {});
             for (const trait of original) {
                 if (!(trait in validTraits)) continue;
                 addOrUpgradeTrait(this.system.traits, trait);

--- a/src/module/item/helpers.ts
+++ b/src/module/item/helpers.ts
@@ -99,7 +99,7 @@ function addOrUpgradeTrait<TTrait extends ItemTrait>(
     // Get traits and annotations object to potentially upgrade
     const isArray = Array.isArray(traits);
     const value = isArray ? traits : traits.value;
-    const config = isArray ? null : (traits.config ??= { modular: undefined });
+    const config = isArray ? null : (traits.config ??= { resilient: 0, modular: undefined });
 
     // Any special non-numerical annotated trait like area or versatile. These need special handling.
     const specialTraitRegex = /^(area|versatile)-(.*)$/;


### PR DESCRIPTION
SF2e's Armor Expertise rule element references
@armor.system.traits.config.resilient in its formula, but this property is only set when armor has a resilient-X trait. This caused formula resolution failures on SF2e actors with Armor Expertise when wearing armor without the resilient trait.

Initialize traits.config.resilient to 0 during prepareBaseData to ensure the property is always defined, matching the pattern used by PF2e's system.runes.potency field (which defaults to 0 via schema).