### PR TITLE
Add missing backgrounds of Gambler, Detective, Emissary, Prisoner, and Raised by Belief

### DIFF
--- a/packs/sf2e/backgrounds/galaxy-guide/gambler.json
+++ b/packs/sf2e/backgrounds/galaxy-guide/gambler.json
@@ -1,0 +1,56 @@
+{
+    "_id": "8uRRbZjG1wVtJXTz",
+    "folder": "3SFWKhzBesp37sy9",
+    "img": "systems/sf2e/icons/default-icons/background.svg",
+    "name": "Gambler",
+    "system": {
+        "boosts": {
+            "0": {
+                "value": [
+                    "cha",
+                    "dex"
+                ]
+            },
+            "1": {
+                "value": [
+                    "cha",
+                    "con",
+                    "dex",
+                    "int",
+                    "str",
+                    "wis"
+                ]
+            }
+        },
+        "description": {
+            "value": "<p>You play the hand you're dealt. You might be a high-rolling card shark, high-stakes risker, lucky winner, or cheater.</p>\n<p>Choose two attribute boosts. One must be to <strong>Dexterity</strong> or <strong>Charisma</strong>, and one is a free attribute boost.</p>\n<p>You're trained in the Deception skill, and the Gambling Lore skill. You gain the @UUID[Compendium.sf2e.feats.Item.Lie to Me] skill feat.</p>"
+        },
+        "items": {
+            "cIy4p": {
+                "img": "systems/sf2e/icons/default-icons/feats-sf2e.webp",
+                "level": 1,
+                "name": "Lie to Me",
+                "uuid": "Compendium.sf2e.feats.Item.Lie to Me"
+            }
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Starfinder Galaxy Guide"
+        },
+        "rules": [],
+        "trainedSkills": {
+            "lore": [
+                "Gambling Lore"
+            ],
+            "value": [
+                "deception"
+            ]
+        },
+        "traits": {
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "type": "background"
+}

--- a/packs/sf2e/backgrounds/player-core/detective.json
+++ b/packs/sf2e/backgrounds/player-core/detective.json
@@ -1,0 +1,56 @@
+{
+    "_id": "5jzxJvcRvPlI5Ug3",
+    "folder": "9DzgrrI9HDXpQ0Ws",
+    "img": "systems/sf2e/icons/default-icons/background.svg",
+    "name": "Detective",
+    "system": {
+        "boosts": {
+            "0": {
+                "value": [
+                    "int",
+                    "wis"
+                ]
+            },
+            "1": {
+                "value": [
+                    "cha",
+                    "con",
+                    "dex",
+                    "int",
+                    "str",
+                    "wis"
+                ]
+            }
+        },
+        "description": {
+            "value": "<p>You solved crimes as a police inspector or took clandestine jobs for various clients as a private investigator. You might have become an adventurer as part of your next big mystery, but it's equally likely it was due to the consequences or aftermath of a prior case.</p>\n<p>Choose two attribute boosts. One must be to <strong>Intelligence</strong> or <strong>Wisdom</strong>, and one is a free attribute boost.</p>\n<p>You're trained in the Society skill, and the Underworld Lore skill. You gain the @UUID[Compendium.sf2e.feats.Item.Streetwise] Streetwise skill feat.</p>"
+        },
+        "items": {
+            "3YNjG": {
+                "img": "systems/sf2e/icons/default-icons/feats-sf2e.webp",
+                "level": 1,
+                "name": "Streetwise",
+                "uuid": "Compendium.sf2e.feats.Item.Streetwise"
+            }
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Starfinder Player Core"
+        },
+        "rules": [],
+        "trainedSkills": {
+            "lore": [
+                "Underworld Lore"
+            ],
+            "value": [
+                "society"
+            ]
+        },
+        "traits": {
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "type": "background"
+}

--- a/packs/sf2e/backgrounds/player-core/detective.json
+++ b/packs/sf2e/backgrounds/player-core/detective.json
@@ -1,5 +1,5 @@
 {
-    "_id": "5jzxJvcRvPlI5Ug3",
+    "_id": "dVRDDjT4FOu6uLDR",
     "folder": "9DzgrrI9HDXpQ0Ws",
     "img": "systems/sf2e/icons/default-icons/background.svg",
     "name": "Detective",

--- a/packs/sf2e/backgrounds/player-core/emisary.json
+++ b/packs/sf2e/backgrounds/player-core/emisary.json
@@ -1,0 +1,54 @@
+{
+    "_id": "2Lkk5DxHBLqX7Zf6",
+    "folder": "9DzgrrI9HDXpQ0Ws",
+    "img": "systems/sf2e/icons/default-icons/background.svg",
+    "name": "Emisary",
+    "system": {
+        "boosts": {
+            "0": {
+                "value": [
+                    "cha",
+                    "int"
+                ]
+            },
+            "1": {
+                "value": [
+                    "cha",
+                    "con",
+                    "dex",
+                    "int",
+                    "str",
+                    "wis"
+                ]
+            }
+        },
+        "description": {
+            "value": "<p>As a diplomat or messenger, you traveled extensively, communicating with new people and brokering alliances wherever you went.</p>\n<p>Choose two attribute boosts. One must be to <strong>Intelligence</strong> or <strong>Charisma</strong>, and one is a free attribute boost.</p>\n<p>You're trained in the Society skill and a Lore Skill related to one city or region you've visited often. You gain the @UUID[Compendium.sf2e.feats.Item.Multilingual] skill feat.</p>"
+        },
+        "items": {
+            "xC0ab": {
+                "img": "systems/sf2e/icons/default-icons/feats-sf2e.webp",
+                "level": 1,
+                "name": "Multilingual",
+                "uuid": "Compendium.sf2e.feats.Item.Multilingual"
+            }
+        },
+        "publication": {
+            "license": "OGL",
+            "remaster": false,
+            "title": ""
+        },
+        "rules": [],
+        "trainedSkills": {
+            "lore": [],
+            "value": [
+                "society"
+            ]
+        },
+        "traits": {
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "type": "background"
+}

--- a/packs/sf2e/backgrounds/player-core/emissary.json
+++ b/packs/sf2e/backgrounds/player-core/emissary.json
@@ -2,7 +2,7 @@
     "_id": "2Lkk5DxHBLqX7Zf6",
     "folder": "9DzgrrI9HDXpQ0Ws",
     "img": "systems/sf2e/icons/default-icons/background.svg",
-    "name": "Emisary",
+    "name": "Emissary",
     "system": {
         "boosts": {
             "0": {

--- a/packs/sf2e/backgrounds/player-core/emissary.json
+++ b/packs/sf2e/backgrounds/player-core/emissary.json
@@ -1,5 +1,5 @@
 {
-    "_id": "2Lkk5DxHBLqX7Zf6",
+    "_id": "3WPo7m6rJQh9L7MN",
     "folder": "9DzgrrI9HDXpQ0Ws",
     "img": "systems/sf2e/icons/default-icons/background.svg",
     "name": "Emissary",

--- a/packs/sf2e/backgrounds/player-core/gambler.json
+++ b/packs/sf2e/backgrounds/player-core/gambler.json
@@ -1,0 +1,56 @@
+{
+    "_id": "8IDVJ0MJWv04Wffs",
+    "folder": "9DzgrrI9HDXpQ0Ws",
+    "img": "systems/sf2e/icons/default-icons/background.svg",
+    "name": "Gambler",
+    "system": {
+        "boosts": {
+            "0": {
+                "value": [
+                    "cha",
+                    "dex"
+                ]
+            },
+            "1": {
+                "value": [
+                    "cha",
+                    "con",
+                    "dex",
+                    "int",
+                    "str",
+                    "wis"
+                ]
+            }
+        },
+        "description": {
+            "value": "<p>The thrill of the win drew you into games of chance. This might have been a lucrative pastime that paled in comparison to the real risks of adventuring, or you might have fallen on hard times due to your gambling and pursued adventuring as a way out of a spiral.</p>\n<p>Choose two attribute boosts. One must be to <strong>Dexterity</strong> or <strong>Charisma</strong>, and one is a free attribute boost.</p>\n<p>You're trained in the Deception skill, and the Games Lore skill. You gain the @UUID[Compendium.sf2e.feats.Item.Lie to Me] skill feat.</p>"
+        },
+        "items": {
+            "MYiqR": {
+                "img": "systems/sf2e/icons/default-icons/feats-sf2e.webp",
+                "level": 1,
+                "name": "Lie to Me",
+                "uuid": "Compendium.sf2e.feats.Item.Lie to Me"
+            }
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Starfinder Player Core"
+        },
+        "rules": [],
+        "trainedSkills": {
+            "lore": [
+                "Games Lore"
+            ],
+            "value": [
+                "deception"
+            ]
+        },
+        "traits": {
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "type": "background"
+}

--- a/packs/sf2e/backgrounds/player-core/gambler.json
+++ b/packs/sf2e/backgrounds/player-core/gambler.json
@@ -1,5 +1,5 @@
 {
-    "_id": "8IDVJ0MJWv04Wffs",
+    "_id": "89LEOv97ZwsjnhNx",
     "folder": "9DzgrrI9HDXpQ0Ws",
     "img": "systems/sf2e/icons/default-icons/background.svg",
     "name": "Gambler",

--- a/packs/sf2e/backgrounds/player-core/prisoner.json
+++ b/packs/sf2e/backgrounds/player-core/prisoner.json
@@ -1,5 +1,5 @@
 {
-    "_id": "5anLD519vDWVNSWv",
+    "_id": "apXTV7jJx6yJpj8D",
     "folder": "9DzgrrI9HDXpQ0Ws",
     "img": "systems/sf2e/icons/default-icons/background.svg",
     "name": "Prisoner",

--- a/packs/sf2e/backgrounds/player-core/prisoner.json
+++ b/packs/sf2e/backgrounds/player-core/prisoner.json
@@ -1,0 +1,56 @@
+{
+    "_id": "5anLD519vDWVNSWv",
+    "folder": "9DzgrrI9HDXpQ0Ws",
+    "img": "systems/sf2e/icons/default-icons/background.svg",
+    "name": "Prisoner",
+    "system": {
+        "boosts": {
+            "0": {
+                "value": [
+                    "con",
+                    "str"
+                ]
+            },
+            "1": {
+                "value": [
+                    "cha",
+                    "con",
+                    "dex",
+                    "int",
+                    "str",
+                    "wis"
+                ]
+            }
+        },
+        "description": {
+            "value": "<p>You’ve been imprisoned or punished for a crime, whether you were guilty or not. Now that your sentence has ended or you’ve escaped, you take full advantage of the newfound freedom of your adventuring life.</p>\n<p>Choose two attribute boosts. One must be to <strong>Strength</strong> or <strong>Constitution</strong>, and one is a free attribute boost.</p>\n<p>You're trained in the Stealth skill, and the Underworld Lore skill. You gain the @UUID[Compendium.sf2e.feats.Item.Experienced Smuggler]{Experienced Smuggler }skill feat.</p>"
+        },
+        "items": {
+            "FaaZ8": {
+                "img": "systems/sf2e/icons/default-icons/feats-sf2e.webp",
+                "level": 1,
+                "name": "Experienced Smuggler",
+                "uuid": "Compendium.sf2e.feats.Item.Experienced Smuggler"
+            }
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Starfinder Player Core"
+        },
+        "rules": [],
+        "trainedSkills": {
+            "lore": [
+                "Underworld Lore"
+            ],
+            "value": [
+                "stealth"
+            ]
+        },
+        "traits": {
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "type": "background"
+}

--- a/packs/sf2e/backgrounds/player-core/raised-by-belief.json
+++ b/packs/sf2e/backgrounds/player-core/raised-by-belief.json
@@ -1,0 +1,56 @@
+{
+    "_id": "llx9BeTYqAkOuXIc",
+    "folder": "9DzgrrI9HDXpQ0Ws",
+    "img": "systems/sf2e/icons/default-icons/background.svg",
+    "name": "Raised by Belief",
+    "system": {
+        "boosts": {
+            "0": {
+                "value": [
+                    "cha",
+                    "con",
+                    "dex",
+                    "int",
+                    "str",
+                    "wis"
+                ]
+            },
+            "1": {
+                "value": [
+                    "cha",
+                    "con",
+                    "dex",
+                    "int",
+                    "str",
+                    "wis"
+                ]
+            }
+        },
+        "description": {
+            "value": "<p>Whether in a monastery, a religious household, or just as part of your everyday life, your upbringing was steeped in the traditions of a particular deity. You might remain committed, or you might have turned from your childhood creed, but your skills are still founded in your devotion.</p>\n<p>Choose two attribute boosts. One must be an attribute specified in your deity's <strong>divine attribute</strong> entry, and the other is a free attribute boost.</p>\n<p>You're trained in the deity's listed divine skill and gain the @UUID[Compendium.sf2e.feats.Item.Assurance] feat with that skill. You are also trained in a Lore skill related to your deity (Abadar Lore, for example).</p>"
+        },
+        "items": {
+            "humzE": {
+                "img": "systems/sf2e/icons/default-icons/feats-sf2e.webp",
+                "level": 1,
+                "name": "Assurance",
+                "uuid": "Compendium.sf2e.feats.Item.Assurance"
+            }
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Starfinder Player Core"
+        },
+        "rules": [],
+        "trainedSkills": {
+            "lore": [],
+            "value": []
+        },
+        "traits": {
+            "rarity": "common",
+            "value": []
+        }
+    },
+    "type": "background"
+}

--- a/packs/sf2e/backgrounds/player-core/raised-by-belief.json
+++ b/packs/sf2e/backgrounds/player-core/raised-by-belief.json
@@ -1,5 +1,5 @@
 {
-    "_id": "llx9BeTYqAkOuXIc",
+    "_id": "RC4l6WsxPn89a1f8",
     "folder": "9DzgrrI9HDXpQ0Ws",
     "img": "systems/sf2e/icons/default-icons/background.svg",
     "name": "Raised by Belief",


### PR DESCRIPTION
[SF2E]
These were PF2E backgrounds that have slight verbiage differences. Also, Gambler was defined in both Player Core and Galaxy Guide, with flavor text differences and they grant different Lore skills, so I added each under the appropriate sub folder.