### PR TITLE
Add Starfinder Pact Standard (AG) to world clock options

### DIFF
--- a/src/module/apps/world-clock/app.ts
+++ b/src/module/apps/world-clock/app.ts
@@ -88,7 +88,7 @@ export class WorldClock extends fa.api.HandlebarsApplicationMixin(fa.api.Applica
     };
 
     /** Setting: the date theme (Imperial Calendar not yet supported) */
-    get dateTheme(): "AR" | "IC" | "AD" | "CE" {
+    get dateTheme(): "AR" | "IC" | "AG" | "AD" | "CE" {
         return game.pf2e.settings.worldClock.dateTheme;
     }
 
@@ -127,6 +127,7 @@ export class WorldClock extends fa.api.HandlebarsApplicationMixin(fa.api.Applica
         switch (this.dateTheme) {
             case "AR": // Absalom Reckoning
             case "IC": // Imperial Calendar
+            case "AG": // After Gap
                 return game.i18n.localize(CONFIG.PF2E.worldClock[this.dateTheme].Era);
             case "AD": // Earth on the Material Plane
                 return this.worldTime.toFormat("G");
@@ -145,7 +146,8 @@ export class WorldClock extends fa.api.HandlebarsApplicationMixin(fa.api.Applica
     get month(): string {
         switch (this.dateTheme) {
             case "AR":
-            case "IC": {
+            case "IC":
+            case "AG": {
                 const months = CONFIG.PF2E.worldClock.AR.Months;
                 const month = this.worldTime.setLocale("en-US").monthLong as keyof typeof months;
                 return game.i18n.localize(months[month]);
@@ -161,6 +163,11 @@ export class WorldClock extends fa.api.HandlebarsApplicationMixin(fa.api.Applica
             case "AR":
             case "IC": {
                 const weekdays = CONFIG.PF2E.worldClock.AR.Weekdays;
+                const weekday = this.worldTime.setLocale("en-US").weekdayLong as keyof typeof weekdays;
+                return game.i18n.localize(weekdays[weekday]);
+            }
+            case "AG": {
+                const weekdays = CONFIG.PF2E.worldClock.AG.Weekdays;
                 const weekday = this.worldTime.setLocale("en-US").weekdayLong as keyof typeof weekdays;
                 return game.i18n.localize(weekdays[weekday]);
             }

--- a/src/module/system/settings/world-clock.ts
+++ b/src/module/system/settings/world-clock.ts
@@ -58,7 +58,11 @@ export class WorldClockSettings extends fa.api.HandlebarsApplicationMixin(fa.api
     };
 
     static #SCHEMA: fields.SchemaField<WorldClockSettingSchema> = new fields.SchemaField({
-        dateTheme: new fields.StringField({ required: true, choices: ["AR", "IC", "AG", "AD", "CE"], initial: "AR" }),
+        dateTheme: new fields.StringField({
+            required: true,
+            choices: ["AR", "IC", "AG", "AD", "CE"],
+            initial: SYSTEM_ID === "sf2e" ? "AG" : "AR",
+        }),
         playersCanView: new fields.BooleanField(),
         showClockButton: new fields.BooleanField({ initial: true }),
         syncDarkness: new fields.BooleanField(),

--- a/src/module/system/settings/world-clock.ts
+++ b/src/module/system/settings/world-clock.ts
@@ -13,7 +13,7 @@ interface SettingsContext extends fa.ApplicationRenderContext {
 }
 
 type WorldClockSettingSchema = {
-    dateTheme: fields.StringField<"AR" | "IC" | "AD" | "CE", "AR" | "IC" | "AD" | "CE", true, false, true>;
+    dateTheme: fields.StringField<"AR" | "IC" | "AG" | "AD" | "CE", "AR" | "IC" | "AG" | "AD" | "CE", true, false, true>;
     playersCanView: fields.BooleanField;
     showClockButton: fields.BooleanField;
     syncDarkness: fields.BooleanField;
@@ -52,7 +52,7 @@ export class WorldClockSettings extends fa.api.HandlebarsApplicationMixin(fa.api
     };
 
     static #SCHEMA: fields.SchemaField<WorldClockSettingSchema> = new fields.SchemaField({
-        dateTheme: new fields.StringField({ required: true, choices: ["AR", "IC", "AD", "CE"], initial: "AR" }),
+        dateTheme: new fields.StringField({ required: true, choices: ["AR", "IC", "AG", "AD", "CE"], initial: "AR" }),
         playersCanView: new fields.BooleanField(),
         showClockButton: new fields.BooleanField({ initial: true }),
         syncDarkness: new fields.BooleanField(),
@@ -102,7 +102,7 @@ export class WorldClockSettings extends fa.api.HandlebarsApplicationMixin(fa.api
             rootId: this.id,
             fields: WorldClockSettings.#SCHEMA.fields,
             settings: game.pf2e.settings.worldClock,
-            dateThemes: R.mapToObj(["AR", "IC", "AD", "CE"], (k) => [
+            dateThemes: R.mapToObj(["AR", "IC", "AG", "AD", "CE"], (k) => [
                 k,
                 game.i18n.localize(`PF2E.SETTINGS.WorldClock.DateThemes.${k}`),
             ]),

--- a/src/module/system/settings/world-clock.ts
+++ b/src/module/system/settings/world-clock.ts
@@ -13,7 +13,13 @@ interface SettingsContext extends fa.ApplicationRenderContext {
 }
 
 type WorldClockSettingSchema = {
-    dateTheme: fields.StringField<"AR" | "IC" | "AG" | "AD" | "CE", "AR" | "IC" | "AG" | "AD" | "CE", true, false, true>;
+    dateTheme: fields.StringField<
+        "AR" | "IC" | "AG" | "AD" | "CE",
+        "AR" | "IC" | "AG" | "AD" | "CE",
+        true,
+        false,
+        true
+    >;
     playersCanView: fields.BooleanField;
     showClockButton: fields.BooleanField;
     syncDarkness: fields.BooleanField;

--- a/src/scripts/config/index.ts
+++ b/src/scripts/config/index.ts
@@ -997,6 +997,7 @@ export const PF2ECONFIG = {
     worldClock: fu.mergeObject(configFromLocalization(EN_JSON.PF2E.WorldClock, "PF2E.WorldClock"), {
         AR: { yearOffset: 2700 },
         IC: { yearOffset: 5200 },
+        AG: { yearOffset: -1700 },
         AD: { yearOffset: -95 },
         CE: { yearOffset: 0 },
     }),

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -4037,6 +4037,7 @@
                 "DateThemes": {
                     "AD": "Earth (Gregorian Calendar)",
                     "AR": "Golarion (Absalom Reckoning)",
+                    "AG": "Pact Standard (After Gap)",
                     "CE": "Unthemed (Gregorian Calendar)",
                     "IC": "Golarion (Imperial Calendar)"
                 },
@@ -6740,6 +6741,18 @@
             "Date": "{weekday}, {day} of {month}, {year} {era}",
             "IC": {
                 "Era": "IC"
+            },
+            "AG": {
+                "Era": "AG",
+                "Weekdays": {
+                    "Friday": "Fifthday",
+                    "Monday": "Firstday",
+                    "Saturday": "Sixthday",
+                    "Sunday": "Seventhday",
+                    "Thursday": "Fourthday",
+                    "Tuesday": "Seconday",
+                    "Wednesday": "Thirday"
+                }
             },
             "Placeholder": "Number",
             "Title": "World Clock"


### PR DESCRIPTION
Adds Pact Standard time measured in After Gap (AG), with an offset of -1700 years as the current year should be 326 AG. Includes localization for the Starfinder days of the week which are just Firstday, Seconday, etc.