### PR TITLE
Remove the mention of aiuvarin heritage in SF2e Multitalented feat

### DIFF
--- a/build/duplicates.json
+++ b/build/duplicates.json
@@ -263,7 +263,6 @@
                 "Magical Crafting",
                 "Monster Crafting",
                 "Multilingual",
-                "Multitalented",
                 "Nanite Surge",
                 "Natural Ambition",
                 "Natural Skill",

--- a/packs/sf2e/feats/ancestry/human/level-9/multitalented.json
+++ b/packs/sf2e/feats/ancestry/human/level-9/multitalented.json
@@ -1,0 +1,57 @@
+{
+    "_id": "C80vQCKQBGRaqcmq",
+    "folder": "9CAWI709PwWJexze",
+    "img": "systems/sf2e/icons/default-icons/feats-sf2e.webp",
+    "name": "Multitalented",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "ancestry",
+        "description": {
+            "value": "<p>You've learned to split your focus between multiple classes with ease. You gain a 2nd-level multiclass dedication feat, even if you normally couldn't take another dedication feat until you take more feats from your current archetype.</p>"
+        },
+        "level": {
+            "value": 9
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Starfinder Player Core"
+        },
+        "rules": [
+            {
+                "adjustName": false,
+                "choices": {
+                    "filter": [
+                        "item:level:2",
+                        "item:category:class",
+                        "item:trait:dedication",
+                        "item:trait:multiclass"
+                    ],
+                    "itemType": "feat"
+                },
+                "flag": "multitalented",
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Multitalented.Prompt"
+            },
+            {
+                "key": "GrantItem",
+                "uuid": "{item|flags.sf2e.rulesSelections.multitalented}"
+            }
+        ],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "human"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/packs/sf2e/feats/ancestry/shared/level-5/double-draw.json
+++ b/packs/sf2e/feats/ancestry/shared/level-5/double-draw.json
@@ -1,6 +1,6 @@
 {
     "_id": "61txGmMLr22B93cU",
-    "folder": "T2ffDGjgKB5GO1oN",
+    "folder": "2DASKkTnIwteMuWt",
     "img": "systems/sf2e/icons/default-icons/feats-sf2e.webp",
     "name": "Double Draw",
     "system": {


### PR DESCRIPTION
Also, correct the Double Draw folder so that it doesn't get moved on extractPacks