### PR TITLE
Correct usage on Name Pendant

### DIFF
--- a/packs/pf2e/equipment/name-pendant.json
+++ b/packs/pf2e/equipment/name-pendant.json
@@ -55,7 +55,7 @@
             ]
         },
         "usage": {
-            "value": "held-in-one-hand"
+            "value": "worn"
         }
     },
     "type": "equipment"


### PR DESCRIPTION
- Closes #21388

Predicates look correct.
<img width="328" height="218" alt="image" src="https://github.com/user-attachments/assets/c0dc2293-0cbd-4540-bcde-5aed445af2c7" />