### PR TITLE
Fix player looting in SF2e

### DIFF
--- a/src/module/actor/item-transfer.ts
+++ b/src/module/actor/item-transfer.ts
@@ -61,7 +61,7 @@ export class ItemTransfer implements ItemTransferData {
         }
 
         console.debug(`PF2e System | Requesting item transfer from GM ${gamemaster.name}`);
-        game.socket.emit("system.pf2e", { request: "itemTransfer", data: this } satisfies SocketMessage);
+        game.socket.emit(`system.${SYSTEM_ID}`, { request: "itemTransfer", data: this } satisfies SocketMessage);
     }
 
     // Only a GM can call this method, or else Foundry will block it (or would if we didn't first)

--- a/src/scripts/socket.ts
+++ b/src/scripts/socket.ts
@@ -4,7 +4,7 @@ import type { AppV1RenderOptions } from "@client/appv1/api/application-v1.d.mts"
 import { ErrorPF2e } from "@util";
 
 function activateSocketListener(): void {
-    game.socket.on("system.pf2e", async (...[message, userId]: PF2eSocketEventParams) => {
+    game.socket.on(`system.${SYSTEM_ID}`, async (...[message, userId]: PF2eSocketEventParams) => {
         const sender = game.users.get(userId, { strict: true });
         switch (message.request) {
             case "itemTransfer":


### PR DESCRIPTION
- Closes #21361

I searched and these are the last hardcoded references to `x.pf2e.y` apart from `game.pf2e.y`, which all work fine