### PR TITLE
Fix Status Effect Duplication

### DIFF
--- a/src/module/canvas/status-effects.ts
+++ b/src/module/canvas/status-effects.ts
@@ -181,7 +181,7 @@ export class StatusEffects {
 
     /** Called by `EncounterPF2e#_onUpdate` */
     static onUpdateEncounter(encounter: EncounterPF2e): void {
-        if (!(game.user.isGM && game.settings.get(SYSTEM_ID, "statusEffectShowCombatMessage"))) return;
+        if (!(game.user.isActiveGM && game.settings.get(SYSTEM_ID, "statusEffectShowCombatMessage"))) return;
 
         if (!encounter.started) {
             this.#lastCombatantToken = null;


### PR DESCRIPTION
This changes the `isGM()` check in status-effects.ts to `isActiveGM()`, preventing it from running multiple times.

This should resolve #21391