### PR TITLE
Change SF2e Summon Celestial spell to a unique entry

### DIFF
--- a/build/duplicates.json
+++ b/build/duplicates.json
@@ -549,7 +549,6 @@
                 "Subconscious Suggestion",
                 "Suggestion",
                 "Summon Animal",
-                "Summon Celestial",
                 "Summon Construct",
                 "Summon Dragon",
                 "Summon Elemental",

--- a/packs/sf2e/feats/skill/level-1/stitch-flesh.json
+++ b/packs/sf2e/feats/skill/level-1/stitch-flesh.json
@@ -12,7 +12,7 @@
         },
         "category": "skill",
         "description": {
-            "value": "<p>You can use @UUID[Compendium.pf2e.actionspf2e.Item.Treat Wounds] to restore Hit Points to undead creatures, not just living ones. The techniques you use to do so vary, but all require sutures, bandages, and other tools included in a medkit. Some conditions that might raise the DC of treating undead's wounds differ from that of living creatures. For instance, the GM might increase the DC if the undead is being treated in a Pharasmin medbay or the wounds were caused by powerful vital energy.</p>"
+            "value": "<p>You can use @UUID[Compendium.sf2e.actions.Item.Treat Wounds] to restore Hit Points to undead creatures, not just living ones. The techniques you use to do so vary, but all require sutures, bandages, and other tools included in a medkit. Some conditions that might raise the DC of treating undead's wounds differ from that of living creatures. For instance, the GM might increase the DC if the undead is being treated in a Pharasmin medbay or the wounds were caused by powerful vital energy.</p>"
         },
         "level": {
             "value": 1

--- a/packs/sf2e/feats/skill/level-1/stitch-flesh.json
+++ b/packs/sf2e/feats/skill/level-1/stitch-flesh.json
@@ -27,7 +27,7 @@
         "publication": {
             "license": "ORC",
             "remaster": true,
-            "title": " Starfinder Guilt of the Grave World Player's Guide"
+            "title": "Starfinder Guilt of the Grave World Player's Guide"
         },
         "rules": [],
         "traits": {

--- a/packs/sf2e/feats/skill/level-1/stitch-flesh.json
+++ b/packs/sf2e/feats/skill/level-1/stitch-flesh.json
@@ -1,0 +1,42 @@
+{
+    "_id": "QShgLWlfKYJO750P",
+    "folder": "admZiPs6ML6NgwMt",
+    "img": "systems/sf2e/icons/default-icons/feats-sf2e.webp",
+    "name": "Stitch Flesh",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "skill",
+        "description": {
+            "value": "<p>You can use @UUID[Compendium.pf2e.actionspf2e.Item.Treat Wounds] to restore Hit Points to undead creatures, not just living ones. The techniques you use to do so vary, but all require sutures, bandages, and other tools included in a medkit. Some conditions that might raise the DC of treating undead's wounds differ from that of living creatures. For instance, the GM might increase the DC if the undead is being treated in a Pharasmin medbay or the wounds were caused by powerful vital energy.</p>"
+        },
+        "level": {
+            "value": 1
+        },
+        "prerequisites": {
+            "value": [
+                {
+                    "value": "trained in Medicine"
+                }
+            ]
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": " Starfinder Guilt of the Grave World Player's Guide"
+        },
+        "rules": [],
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "general",
+                "skill"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/packs/sf2e/spells/spells/rank-5/summon-celestial.json
+++ b/packs/sf2e/spells/spells/rank-5/summon-celestial.json
@@ -1,0 +1,53 @@
+{
+    "_id": "lTDixrrNKaCvLKwX",
+    "folder": "NQpcS2TwtjNNq1Qy",
+    "img": "icons/creatures/abilities/wings-birdlike-blue.webp",
+    "name": "Summon Celestial",
+    "system": {
+        "area": null,
+        "cost": {
+            "value": ""
+        },
+        "counteraction": false,
+        "damage": {},
+        "defense": null,
+        "description": {
+            "value": "<p>You summon a creature that has the celestial trait and whose level is 5 or lower to fight for you. The GM might determine your deity restricts the specific types of celestials you can summon in certain cases.</p>\n<hr />\n<p><strong>Heightened</strong> As listed in the @UUID[Compendium.pf2e.journals.JournalEntry.S55aqwWIzpQRFhcq.JournalEntryPage.8gcp880pEWZ9VPnF]{summon} trait.</p>"
+        },
+        "duration": {
+            "sustained": true,
+            "value": "1 minute"
+        },
+        "level": {
+            "value": 5
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Starfinder Player Core"
+        },
+        "range": {
+            "value": "30 feet"
+        },
+        "requirements": "",
+        "rules": [],
+        "target": {
+            "value": ""
+        },
+        "time": {
+            "value": "3"
+        },
+        "traits": {
+            "rarity": "common",
+            "traditions": [
+                "divine"
+            ],
+            "value": [
+                "concentrate",
+                "manipulate",
+                "summon"
+            ]
+        }
+    },
+    "type": "spell"
+}


### PR DESCRIPTION
Technically not a full duplicate, but the change is really minor and doesn't contradict the SF lore. Decided to make it a separate entry just in case.

Also added the Stitch Flesh feat from GotGW Player's Guide.