### PR TITLE
Fix Light Mortar Innovation benefit calculation due to misspelling of level

### DIFF
--- a/packs/pf2e/class-features/light-mortar-innovation.json
+++ b/packs/pf2e/class-features/light-mortar-innovation.json
@@ -29,7 +29,7 @@
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
                 "path": "system.proficiencies.classDCs.inventor.rank",
-                "value": "ternary(gte(@actor.leve,15),3,ternary(gte(@actor.level,7),2,1))"
+                "value": "ternary(gte(@actor.level,15),3,ternary(gte(@actor.level,7),2,1))"
             },
             {
                 "key": "GrantItem",


### PR DESCRIPTION
Fix mortar benefit calculation due to misspelling of level. Noticed the misspelling while doing a search.