### PR TITLE
Fix logic in DamageAlteration dice face upgrades/downgrades

### DIFF
--- a/src/module/rules/rule-element/damage-alteration/alteration.ts
+++ b/src/module/rules/rule-element/damage-alteration/alteration.ts
@@ -54,13 +54,17 @@ class DamageAlteration {
                 }
                 const currentFaces = damageDieSizeToFaces(damage.dieSize);
                 if (rule.mode === "downgrade") {
-                    return tupleHasValue(DAMAGE_DICE_FACES, change) && change <= currentFaces
-                        ? change
+                    return tupleHasValue(DAMAGE_DICE_FACES, change)
+                        ? change <= currentFaces
+                            ? change
+                            : currentFaces
                         : Number(nextDamageDieSize({ downgrade: damage.dieSize }).replace("d", ""));
                 }
                 if (rule.mode === "upgrade") {
-                    return tupleHasValue(DAMAGE_DICE_FACES, change) && change >= currentFaces
-                        ? change
+                    return tupleHasValue(DAMAGE_DICE_FACES, change)
+                        ? change >= currentFaces
+                            ? change
+                            : currentFaces
                         : Number(nextDamageDieSize({ upgrade: damage.dieSize }).replace("d", ""));
                 }
                 if (rule.mode === "override" && tupleHasValue(DAMAGE_DICE_FACES, change)) {

--- a/src/module/rules/rule-element/damage-alteration/alteration.ts
+++ b/src/module/rules/rule-element/damage-alteration/alteration.ts
@@ -55,16 +55,12 @@ class DamageAlteration {
                 const currentFaces = damageDieSizeToFaces(damage.dieSize);
                 if (rule.mode === "downgrade") {
                     return tupleHasValue(DAMAGE_DICE_FACES, change)
-                        ? change <= currentFaces
-                            ? change
-                            : currentFaces
+                        ? Math.min(change, currentFaces)
                         : Number(nextDamageDieSize({ downgrade: damage.dieSize }).replace("d", ""));
                 }
                 if (rule.mode === "upgrade") {
                     return tupleHasValue(DAMAGE_DICE_FACES, change)
-                        ? change >= currentFaces
-                            ? change
-                            : currentFaces
+                        ? Math.max(change, currentFaces)
                         : Number(nextDamageDieSize({ upgrade: damage.dieSize }).replace("d", ""));
                 }
                 if (rule.mode === "override" && tupleHasValue(DAMAGE_DICE_FACES, change)) {


### PR DESCRIPTION
Noticed that the way it currently is wouldn't work quite as expected from other uses of upgrade/downgrade. If you set an upgrade to 6 then it would turn a d4 to a d6, but also upgrade any dice d6 or above to the next step up.