### PR TITLE
Add missing Murder in Metal City Item

### DIFF
--- a/packs/sf2e/equipment/magic-items/consecrated-keycaps.json
+++ b/packs/sf2e/equipment/magic-items/consecrated-keycaps.json
@@ -1,0 +1,51 @@
+{
+    "_id": "27MAeDRqYR9OASPd",
+    "folder": "JlUS4L43QWp3cPhu",
+    "img": "systems/sf2e/icons/equipment/worn-items/other-worn-items/hag-eye.webp",
+    "name": "Consecrated Keycaps",
+    "system": {
+        "baseItem": null,
+        "bulk": {
+            "value": 0
+        },
+        "containerId": null,
+        "description": {
+            "value": "<p>These strange keycaps were left as a gift at the memorial of the deceased anacite, Tier-99-Professor.</p>\n<p><strong>Activate—Idle Typing</strong> <span class=\"action-glyph\">2</span> (concentrate)</p>\n<p><strong>Frequency</strong> once per day</p><hr /><p><strong>Effect</strong> You cast a 1st-rank @UUID[Compendium.sf2e.spells.Item.Implant Data] spell.</p>"
+        },
+        "hardness": 0,
+        "hp": {
+            "max": 0,
+            "value": 0
+        },
+        "level": {
+            "value": 1
+        },
+        "material": {
+            "grade": null,
+            "type": null
+        },
+        "price": {
+            "value": {
+                "sp": 50
+            }
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Starfinder Murder in Metal City Deluxe Adventure"
+        },
+        "quantity": 1,
+        "rules": [],
+        "size": "med",
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "tech"
+            ]
+        },
+        "usage": {
+            "value": "installed-in-a-datapad"
+        }
+    },
+    "type": "equipment"
+}

--- a/src/scripts/config/usage.ts
+++ b/src/scripts/config/usage.ts
@@ -109,6 +109,7 @@ const USAGES = {
     "held-in-one-or-two-hands": "PF2E.TraitHeldOneTwoHands",
     "held-in-two-hands": "PF2E.TraitHeldTwoHands",
     implanted: "PF2E.TraitImplanted",
+    "installed-in-a-datapad": "PF2E.TraitInstalledInADatapad",
     "mounted-on-a-tripod-or-bracket": "PF2E.TraitMountedOnATripodOrBracket",
     other: "PF2E.TraitOther",
     "sewn-into-clothing": "PF2E.TraitSewnIntoClothing",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -5305,6 +5305,7 @@
         "TraitInstalledInArmorWithTheEnergyShieldingUpgrade": "Installed in Armor with the Energy Shielding upgrade",
         "TraitInstalledInArmorWithTheExposedTrait": "Installed in Armor with the Exposed trait",
         "TraitInstalledInAGrenadeLauncherOrTwoHandedWeaponWithAnUndermoundedGrenadeLauncher": "Installed in a Grenade Launcher or Two-Handed Weapon with an Undermounded Grenade Launcher",
+        "TraitInstalledInADatapad": "Installed in a Datapad",
         "TraitInstalledInAWeaponSight": "Installed in a Weapon Sight",
         "TraitInstalledInAWeaponWithTheKickbackTrait": "Installed in a Weapon with the Kickback trait",
         "TraitInstalledInAWeapon": "Installed in a Weapon",


### PR DESCRIPTION
An item that was missed in data entry which was printed only on a card handout in Murder in Metal City, was also missed by AoN, but it's on Demiplane https://app.demiplane.com/nexus/starfinder2e/items/consecrated-keycaps

It has a usage "Installed in a Datapad"