### PR TITLE
Add Troop thresholds to NPC sheet and snap HP during damage

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -1225,6 +1225,15 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
             delta: finalDamage - damageAbsorbedByShield - damageAbsorbedByActor,
         });
 
+        // Test troop thresholds. If reached, snap the hp to that threshold and print a message later
+        const thresholds = this.isOfType("npc") ? this.system.attributes.hp.thresholds : null;
+        const threatenedThreshold = thresholds?.find((t) => hitPoints.max > t.hp);
+        const reachedThreshold =
+            threatenedThreshold && threatenedThreshold.hp >= damageResult.updates["system.attributes.hp.value"];
+        if (reachedThreshold) {
+            damageResult.updates["system.attributes.hp.value"] = threatenedThreshold.hp;
+        }
+
         // Save the pre-update state to calculate undo values
         const preUpdateSource = this.toObject();
 
@@ -1304,10 +1313,12 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
                       : localize("ShieldDamagedForN")
                 : null;
 
+        const thresholdStatement = reachedThreshold ? localize("TroopThresholdReached") : null;
+
         const statements = ((): string => {
             const deathMessage =
                 instantDeath && localize(`InstantDeath.${sluggify(instantDeath, { camel: "bactrian" })}`);
-            const concatenated = [hpStatement, shieldStatement, deathMessage]
+            const concatenated = [hpStatement, shieldStatement, thresholdStatement, deathMessage]
                 .filter(R.isTruthy)
                 .map((s) =>
                     game.i18n.format(s, {
@@ -1315,6 +1326,7 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
                         hpDamage: Math.abs(damageResult.totalApplied),
                         absorbedDamage: damageAbsorbedByShield,
                         shieldDamage,
+                        segments: threatenedThreshold?.segments,
                     }),
                 )
                 .join(" ");

--- a/src/module/actor/npc/data.ts
+++ b/src/module/actor/npc/data.ts
@@ -242,6 +242,7 @@ interface NPCSaves {
 
 interface NPCHitPoints extends HitPointsStatistic {
     base?: number;
+    thresholds: { hp: number; segments: number }[] | null;
 }
 
 /** System Data for skill special modifiers (such as +9 to climb) */

--- a/src/module/actor/npc/document.ts
+++ b/src/module/actor/npc/document.ts
@@ -204,6 +204,17 @@ class NPCPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | nul
             ].join(", ");
             system.attributes.hp = stat;
             setHitPointsRollOptions(this);
+
+            // Troop Thresholds
+            const hpMax = stat.max;
+            system.attributes.hp.thresholds = null;
+            if (this.system.traits.value.includes("troop") && hpMax >= 3) {
+                system.attributes.hp.thresholds = [
+                    { hp: hpMax, segments: 4 },
+                    { hp: Math.floor((hpMax * 2) / 3), segments: 3 },
+                    { hp: Math.floor(hpMax / 3), segments: 2 },
+                ];
+            }
         }
 
         this.prepareMovementData();

--- a/src/module/actor/npc/sheet.ts
+++ b/src/module/actor/npc/sheet.ts
@@ -243,15 +243,29 @@ class NPCSheetPF2e extends AbstractNPCSheet {
         level.adjustedHigher = level.value > Number(level.base);
         level.adjustedLower = level.value < Number(level.base);
 
-        const { ac, hp, hardness } = sheetData.data.attributes;
+        const { ac, hardness } = sheetData.data.attributes;
         const perception = sheetData.data.perception;
         const sourceAttributes = actorSource.system.attributes;
         ac.adjustedHigher = ac.value > sourceAttributes.ac.value;
         ac.adjustedLower = ac.value < sourceAttributes.ac.value;
-        hp.adjustedHigher = hp.max > sourceAttributes.hp.max;
-        hp.adjustedLower = hp.max < sourceAttributes.hp.max;
         perception.adjustedHigher = perception.totalModifier > actorSource.system.perception.mod;
         perception.adjustedLower = perception.totalModifier < actorSource.system.perception.mod;
+
+        // Health and Thresholds
+        const hp = actorSource.system.attributes.hp;
+        sheetData.hp = {
+            ...sheetData.data.attributes.hp,
+            adjustedHigher: hp.max > sourceAttributes.hp.max,
+            adjustedLower: hp.max < sourceAttributes.hp.max,
+            thresholds: null,
+        };
+        if (actor.system.attributes.hp.thresholds) {
+            sheetData.hp.thresholds = actor.system.attributes.hp.thresholds.map((t) => ({ ...t, selected: false }));
+            const selected = sheetData.hp.thresholds.findLast((t) => t.hp >= hp.value);
+            if (selected) selected.selected = true;
+        }
+
+        // Speed
         const speeds = sheetData.data.movement.speeds;
         const noLandTravel = R.omit(speeds, ["land", "travel"]);
         sheetData.speeds = {

--- a/src/module/actor/npc/types.ts
+++ b/src/module/actor/npc/types.ts
@@ -1,11 +1,10 @@
 import type { CreatureSheetData } from "@actor/creature/sheet.ts";
-import type { HitPointsStatistic } from "@actor/data/base.ts";
 import type { AbilityViewData } from "@actor/sheet/data-types.ts";
 import type { MovementType, SaveType, SkillSlug } from "@actor/types.ts";
 import type { ImageFilePath, VideoFilePath } from "@common/constants.d.mts";
 import type { ItemPF2e } from "@item";
 import type { SpellcastingSheetData } from "@item/spellcasting-entry/index.ts";
-import type { ZeroToFour } from "@module/data.ts";
+import type { ValueAndMax, ZeroToFour } from "@module/data.ts";
 import type { NPCAttackTraitOrTag, TagifyEntry } from "@module/sheet/helpers.ts";
 import type { ArmorClassTraceData } from "@system/statistic/index.ts";
 import type { NPCAttributes, NPCPerceptionData, NPCSaveData, NPCSkillData, NPCSystemData } from "./data.ts";
@@ -45,7 +44,6 @@ interface NPCSystemSheetData extends NPCSystemData {
     perception: NPCPerceptionData & WithAdjustments & WithRank;
     attributes: NPCAttributes & {
         ac: ArmorClassTraceData & WithAdjustments;
-        hp: HitPointsStatistic & WithAdjustments;
     };
     details: NPCSystemData["details"] & {
         level: NPCSystemData["details"]["level"] & WithAdjustments;
@@ -75,6 +73,10 @@ interface NPCSpellcastingSheetData extends SpellcastingSheetData {
 
 /** Additional fields added in sheet data preparation */
 interface NPCSheetData extends CreatureSheetData<NPCPF2e> {
+    hp: ValueAndMax & {
+        details: string;
+        thresholds: { hp: number; segments: number; selected: boolean }[] | null;
+    } & WithAdjustments;
     attacks: NPCStrikeSheetData[];
     actions: NPCActionSheetData;
     data: NPCSystemSheetData;

--- a/src/styles/actor/npc/_sidebar.scss
+++ b/src/styles/actor/npc/_sidebar.scss
@@ -262,4 +262,13 @@
     justify-content: start;
     padding-top: 0.125rem;
     width: 100%;
+
+    .threshold {
+        display: flex;
+        justify-content: space-between;
+        width: 100%;
+        &.selected {
+            font-weight: 600;
+        }
+    }
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -134,7 +134,8 @@
                 "ShieldDamagedForNDestroyed": "Their shield also takes {shieldDamage} damage, destroying it.",
                 "ShieldNotRaised": "{actor} has not raised their shield.",
                 "TakesNoDamage": "<actor>{actor}</actor> takes no damage.",
-                "TheTarget": "The target"
+                "TheTarget": "The target",
+                "TroopThresholdReached": "The troop has reached their next threshold ({segments} segments remaining)."
             },
             "AttackEffects": {
                 "PlusList": "(plus {list})"
@@ -659,6 +660,7 @@
                     }
                 },
                 "LevelN": "Creature {level}",
+                "SegmentsN": "{n} Segments",
                 "SimpleSheet": "Simple NPC Sheet",
                 "SpecialSkill": "+{mod} {label}",
                 "SkillsEditor": {
@@ -671,7 +673,8 @@
                     "Predicate": "Predicate",
                     "Special": "Special",
                     "Title": "Skills Editor ({actor})"
-                }
+                },
+                "Thresholds": "Thresholds"
             },
             "Party": {
                 "BlankSlate": "This party doesn't have any members. Drag a creature from the actor sidebar to get started.",

--- a/static/templates/actors/npc/partials/sidebar.hbs
+++ b/static/templates/actors/npc/partials/sidebar.hbs
@@ -128,6 +128,26 @@
     </div>
 </div>
 
+{{#if hp.thresholds}}
+    {{!-- Troop Thresholds --}}
+    <div class="subsection">
+        <header>
+            <label>
+                <i class="fa-solid fa-fw fa-people-group"></i>
+                <span>{{localize "PF2E.Actor.NPC.Thresholds"}}</span>
+            </label>
+        </header>
+        <div class="side-bar-section-content">
+            {{#each hp.thresholds as |t|}}
+                <div class="threshold {{#if t.selected}}selected{{/if}}">
+                    <span>{{localize "PF2E.Actor.NPC.SegmentsN" n=t.segments}}</span>
+                    <span>{{t.hp}}{{localize "PF2E.HitPointsShortLabel"}}</span>
+                </div>
+            {{/each}}
+        </div>
+    </div>
+{{/if}}
+
 {{!-- INITIATIVE --}}
 <div class="subsection initiative">
     <header>


### PR DESCRIPTION
This adds troop thresholds to the npc sheet sidebar and snaps HP to the next threshold when damage is applied. The current threshold region is also bolded. This does not implement any of the token sided things yet, which are going to be significantly more involved.

<img width="680" height="694" alt="image" src="https://github.com/user-attachments/assets/6a4f6233-65a2-4cf9-a141-b83b8fcf523d" />

<img width="298" height="130" alt="image" src="https://github.com/user-attachments/assets/7971fb25-b083-4f4c-a5ea-aa1cd96660ae" />

### Alternative

During development I played around with this look, I like the look of it more, but its not really dummy proof (this was before the selected threshold boldening feature, so imagine in your brain that the 4 segments line is bolded).

<img width="831" height="867" alt="image" src="https://github.com/user-attachments/assets/413fcc4e-9886-4f5a-9edd-6e7b2073db05" />

