### PR TITLE
Map SF2e GM Screen's id to match PF2e's GM Screen

### DIFF
--- a/packs/sf2e/journals/gm-screen.json
+++ b/packs/sf2e/journals/gm-screen.json
@@ -1,5 +1,5 @@
 {
-    "_id": "vG2QyOE5hFYTens0",
+    "_id": "S55aqwWIzpQRFhcq",
     "categories": [],
     "name": "GM Screen",
     "ownership": {

--- a/packs/sf2e/spells/spells/rank-5/summon-celestial.json
+++ b/packs/sf2e/spells/spells/rank-5/summon-celestial.json
@@ -12,7 +12,7 @@
         "damage": {},
         "defense": null,
         "description": {
-            "value": "<p>You summon a creature that has the celestial trait and whose level is 5 or lower to fight for you. The GM might determine your deity restricts the specific types of celestials you can summon in certain cases.</p>\n<hr />\n<p><strong>Heightened</strong> As listed in the @UUID[Compendium.pf2e.journals.JournalEntry.S55aqwWIzpQRFhcq.JournalEntryPage.8gcp880pEWZ9VPnF]{summon} trait.</p>"
+            "value": "<p>You summon a creature that has the celestial trait and whose level is 5 or lower to fight for you. The GM might determine your deity restricts the specific types of celestials you can summon in certain cases.</p><hr /><p><strong>Heightened</strong> As listed in the @UUID[Compendium.sf2e.journals.JournalEntry.S55aqwWIzpQRFhcq.JournalEntryPage.8gcp880pEWZ9VPnF]{summon} trait.</p>"
         },
         "duration": {
             "sustained": true,


### PR DESCRIPTION
Turns out that change didn't stick.

Hoping this fix the broken summon trait links in SF2e.