### PR TITLE
Fix getTokenDocument options

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -978,7 +978,7 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
     /** Ensure newly-created tokens have dimensions matching this actor's size category */
     override async getTokenDocument(
         data: DeepPartial<foundry.documents.TokenSource> = {},
-        options?: DocumentConstructionContext<this>,
+        options?: DocumentConstructionContext<ScenePF2e>,
     ): Promise<NonNullable<TParent>> {
         if (this.prototypeToken.flags[SYSTEM_ID].linkToActorSize) {
             Object.assign(data, this.system.traits?.size?.tokenDimensions);

--- a/types/foundry/client/documents/actor.d.mts
+++ b/types/foundry/client/documents/actor.d.mts
@@ -127,7 +127,7 @@ declare class Actor<TParent extends TokenDocument | null = TokenDocument | null>
      */
     getTokenDocument(
         data?: DeepPartial<foundry.documents.TokenSource>,
-        options?: Partial<DocumentConstructionContext<this>>,
+        options?: Partial<DocumentConstructionContext<Scene>>,
     ): Promise<NonNullable<TParent>>;
 
     /** Get an Array of Token images which could represent this Actor */


### PR DESCRIPTION
Fixes the options parameter of `Actor.getTokenDocument`, it should be the `DocumentConstructionContext` of the parent of the document it's returning. In this case it's returning a `TokenDocument` which as `Scene` as it's parent.