### PR TITLE
Update predicate for commanders banner effect

### DIFF
--- a/packs/pf2e/feat-effects/effect-commanders-banner.json
+++ b/packs/pf2e/feat-effects/effect-commanders-banner.json
@@ -26,7 +26,7 @@
                 "hideIfDisabled": true,
                 "key": "FlatModifier",
                 "predicate": [
-                    "item:trait:fear"
+                    "fear"
                 ],
                 "selector": [
                     "ac",


### PR DESCRIPTION
Makes it consistent with Courageous Anthem, making it work for effects such as Demoralize that are not `items` and thus do not have `item:trait:` prefixes.