### PR TITLE
Use token assets for all SF2e iconic prototype tokens

### DIFF
--- a/packs/sf2e/iconics/chk-chk/chk-chk-level-1.json
+++ b/packs/sf2e/iconics/chk-chk/chk-chk-level-1.json
@@ -2730,7 +2730,7 @@
         "texture": {
             "scaleX": 1.2,
             "scaleY": 1.2,
-            "src": "systems/sf2e/icons/iconics/portraits/chk-chk.webp"
+            "src": "systems/sf2e/icons/iconics/tokens/chk-chk.webp"
         }
     },
     "system": {

--- a/packs/sf2e/iconics/chk-chk/chk-chk-level-3.json
+++ b/packs/sf2e/iconics/chk-chk/chk-chk-level-3.json
@@ -3504,7 +3504,7 @@
         "texture": {
             "scaleX": 1.2,
             "scaleY": 1.2,
-            "src": "systems/sf2e/icons/iconics/portraits/chk-chk.webp"
+            "src": "systems/sf2e/icons/iconics/tokens/chk-chk.webp"
         }
     },
     "system": {

--- a/packs/sf2e/iconics/chk-chk/chk-chk-level-5.json
+++ b/packs/sf2e/iconics/chk-chk/chk-chk-level-5.json
@@ -4253,7 +4253,7 @@
         "texture": {
             "scaleX": 1.2,
             "scaleY": 1.2,
-            "src": "systems/sf2e/icons/iconics/portraits/chk-chk.webp"
+            "src": "systems/sf2e/icons/iconics/tokens/chk-chk.webp"
         }
     },
     "system": {

--- a/packs/sf2e/iconics/chk-chk/chk-chk-level-7.json
+++ b/packs/sf2e/iconics/chk-chk/chk-chk-level-7.json
@@ -4859,7 +4859,7 @@
         "texture": {
             "scaleX": 1.2,
             "scaleY": 1.2,
-            "src": "systems/sf2e/icons/iconics/portraits/chk-chk.webp"
+            "src": "systems/sf2e/icons/iconics/tokens/chk-chk.webp"
         }
     },
     "system": {

--- a/packs/sf2e/iconics/dae/dae-level-1.json
+++ b/packs/sf2e/iconics/dae/dae-level-1.json
@@ -1559,7 +1559,7 @@
         "texture": {
             "scaleX": 1.2,
             "scaleY": 1.2,
-            "src": "systems/sf2e/icons/iconics/portraits/dae.webp"
+            "src": "systems/sf2e/icons/iconics/tokens/dae.webp"
         }
     },
     "system": {

--- a/packs/sf2e/iconics/dae/dae-level-3.json
+++ b/packs/sf2e/iconics/dae/dae-level-3.json
@@ -1893,7 +1893,7 @@
         "texture": {
             "scaleX": 1.2,
             "scaleY": 1.2,
-            "src": "systems/sf2e/icons/iconics/portraits/dae.webp"
+            "src": "systems/sf2e/icons/iconics/tokens/dae.webp"
         }
     },
     "system": {

--- a/packs/sf2e/iconics/dae/dae-level-5.json
+++ b/packs/sf2e/iconics/dae/dae-level-5.json
@@ -2556,7 +2556,7 @@
         "texture": {
             "scaleX": 1.2,
             "scaleY": 1.2,
-            "src": "systems/sf2e/icons/iconics/portraits/dae.webp"
+            "src": "systems/sf2e/icons/iconics/tokens/dae.webp"
         }
     },
     "system": {

--- a/packs/sf2e/iconics/dae/dae-level-7.json
+++ b/packs/sf2e/iconics/dae/dae-level-7.json
@@ -3108,7 +3108,7 @@
         "texture": {
             "scaleX": 1.2,
             "scaleY": 1.2,
-            "src": "systems/sf2e/icons/iconics/portraits/dae.webp"
+            "src": "systems/sf2e/icons/iconics/tokens/dae.webp"
         }
     },
     "system": {

--- a/packs/sf2e/iconics/iseph/iseph-level-1.json
+++ b/packs/sf2e/iconics/iseph/iseph-level-1.json
@@ -1915,7 +1915,7 @@
         "texture": {
             "scaleX": 1.2,
             "scaleY": 1.2,
-            "src": "systems/sf2e/icons/iconics/portraits/iseph.webp"
+            "src": "systems/sf2e/icons/iconics/tokens/iseph.webp"
         }
     },
     "system": {

--- a/packs/sf2e/iconics/iseph/iseph-level-3.json
+++ b/packs/sf2e/iconics/iseph/iseph-level-3.json
@@ -2316,7 +2316,7 @@
         "texture": {
             "scaleX": 1.2,
             "scaleY": 1.2,
-            "src": "systems/sf2e/icons/iconics/portraits/iseph.webp"
+            "src": "systems/sf2e/icons/iconics/tokens/iseph.webp"
         }
     },
     "system": {

--- a/packs/sf2e/iconics/iseph/iseph-level-5.json
+++ b/packs/sf2e/iconics/iseph/iseph-level-5.json
@@ -2597,7 +2597,7 @@
         "texture": {
             "scaleX": 1.2,
             "scaleY": 1.2,
-            "src": "systems/sf2e/icons/iconics/portraits/iseph.webp"
+            "src": "systems/sf2e/icons/iconics/tokens/iseph.webp"
         }
     },
     "system": {

--- a/packs/sf2e/iconics/iseph/iseph-level-7.json
+++ b/packs/sf2e/iconics/iseph/iseph-level-7.json
@@ -2965,7 +2965,7 @@
         "texture": {
             "scaleX": 1.2,
             "scaleY": 1.2,
-            "src": "systems/sf2e/icons/iconics/portraits/iseph.webp"
+            "src": "systems/sf2e/icons/iconics/tokens/iseph.webp"
         }
     },
     "system": {

--- a/packs/sf2e/iconics/navasi/navasi-level-1.json
+++ b/packs/sf2e/iconics/navasi/navasi-level-1.json
@@ -1872,7 +1872,7 @@
         "texture": {
             "scaleX": 1.2,
             "scaleY": 1.2,
-            "src": "systems/sf2e/icons/iconics/portraits/navasi.webp"
+            "src": "systems/sf2e/icons/iconics/tokens/navasi.webp"
         }
     },
     "system": {

--- a/packs/sf2e/iconics/navasi/navasi-level-3.json
+++ b/packs/sf2e/iconics/navasi/navasi-level-3.json
@@ -2347,7 +2347,7 @@
         "texture": {
             "scaleX": 1.2,
             "scaleY": 1.2,
-            "src": "systems/sf2e/icons/iconics/portraits/navasi.webp"
+            "src": "systems/sf2e/icons/iconics/tokens/navasi.webp"
         }
     },
     "system": {

--- a/packs/sf2e/iconics/navasi/navasi-level-5.json
+++ b/packs/sf2e/iconics/navasi/navasi-level-5.json
@@ -2726,7 +2726,7 @@
         "texture": {
             "scaleX": 1.2,
             "scaleY": 1.2,
-            "src": "systems/sf2e/icons/iconics/portraits/navasi.webp"
+            "src": "systems/sf2e/icons/iconics/tokens/navasi.webp"
         }
     },
     "system": {

--- a/packs/sf2e/iconics/navasi/navasi-level-7.json
+++ b/packs/sf2e/iconics/navasi/navasi-level-7.json
@@ -3502,7 +3502,7 @@
         "texture": {
             "scaleX": 1.2,
             "scaleY": 1.2,
-            "src": "systems/sf2e/icons/iconics/portraits/navasi.webp"
+            "src": "systems/sf2e/icons/iconics/tokens/navasi.webp"
         }
     },
     "system": {

--- a/packs/sf2e/iconics/obozaya/obozaya-level-1.json
+++ b/packs/sf2e/iconics/obozaya/obozaya-level-1.json
@@ -1443,7 +1443,7 @@
         "texture": {
             "scaleX": 1.2,
             "scaleY": 1.2,
-            "src": "systems/sf2e/icons/iconics/portraits/oobozaya.webp"
+            "src": "systems/sf2e/icons/iconics/tokens/oobozaya.webp"
         }
     },
     "system": {

--- a/packs/sf2e/iconics/obozaya/obozaya-level-3.json
+++ b/packs/sf2e/iconics/obozaya/obozaya-level-3.json
@@ -1721,7 +1721,7 @@
         "texture": {
             "scaleX": 1.2,
             "scaleY": 1.2,
-            "src": "systems/sf2e/icons/iconics/portraits/oobozaya.webp"
+            "src": "systems/sf2e/icons/iconics/tokens/oobozaya.webp"
         }
     },
     "system": {

--- a/packs/sf2e/iconics/obozaya/obozaya-level-5.json
+++ b/packs/sf2e/iconics/obozaya/obozaya-level-5.json
@@ -2247,7 +2247,7 @@
         "texture": {
             "scaleX": 1.2,
             "scaleY": 1.2,
-            "src": "systems/sf2e/icons/iconics/portraits/oobozaya.webp"
+            "src": "systems/sf2e/icons/iconics/tokens/oobozaya.webp"
         }
     },
     "system": {

--- a/packs/sf2e/iconics/obozaya/obozaya-level-7.json
+++ b/packs/sf2e/iconics/obozaya/obozaya-level-7.json
@@ -2920,7 +2920,7 @@
         "texture": {
             "scaleX": 1.2,
             "scaleY": 1.2,
-            "src": "systems/sf2e/icons/iconics/portraits/oobozaya.webp"
+            "src": "systems/sf2e/icons/iconics/tokens/oobozaya.webp"
         }
     },
     "system": {

--- a/packs/sf2e/iconics/zemir/zemir-level-1.json
+++ b/packs/sf2e/iconics/zemir/zemir-level-1.json
@@ -2788,7 +2788,7 @@
         "texture": {
             "scaleX": 1.2,
             "scaleY": 1.2,
-            "src": "systems/sf2e/icons/iconics/portraits/zemir.webp"
+            "src": "systems/sf2e/icons/iconics/tokens/zemir.webp"
         }
     },
     "system": {

--- a/packs/sf2e/iconics/zemir/zemir-level-3.json
+++ b/packs/sf2e/iconics/zemir/zemir-level-3.json
@@ -3541,7 +3541,7 @@
         "texture": {
             "scaleX": 1.2,
             "scaleY": 1.2,
-            "src": "systems/sf2e/icons/iconics/portraits/zemir.webp"
+            "src": "systems/sf2e/icons/iconics/tokens/zemir.webp"
         }
     },
     "system": {

--- a/packs/sf2e/iconics/zemir/zemir-level-5.json
+++ b/packs/sf2e/iconics/zemir/zemir-level-5.json
@@ -4459,7 +4459,7 @@
         "texture": {
             "scaleX": 1.2,
             "scaleY": 1.2,
-            "src": "systems/sf2e/icons/iconics/portraits/zemir.webp"
+            "src": "systems/sf2e/icons/iconics/tokens/zemir.webp"
         }
     },
     "system": {

--- a/packs/sf2e/iconics/zemir/zemir-level-7.json
+++ b/packs/sf2e/iconics/zemir/zemir-level-7.json
@@ -5075,7 +5075,7 @@
         "texture": {
             "scaleX": 1.2,
             "scaleY": 1.2,
-            "src": "systems/sf2e/icons/iconics/portraits/zemir.webp"
+            "src": "systems/sf2e/icons/iconics/tokens/zemir.webp"
         }
     },
     "system": {


### PR DESCRIPTION
SF2e iconic prototype tokens currently point at the portrait assets.
Update them to use the token assets.