### PR TITLE
Add support for troop segment tokens

### DIFF
--- a/src/module/actor/npc/document.ts
+++ b/src/module/actor/npc/document.ts
@@ -205,7 +205,7 @@ class NPCPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | nul
             system.attributes.hp = stat;
             setHitPointsRollOptions(this);
 
-            // Troop Thresholds
+            // Troop Thresholds and special segment token size
             const hpMax = stat.max;
             system.attributes.hp.thresholds = null;
             if (this.system.traits.value.includes("troop") && hpMax >= 3) {
@@ -214,6 +214,11 @@ class NPCPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | nul
                     { hp: Math.floor((hpMax * 2) / 3), segments: 3 },
                     { hp: Math.floor(hpMax / 3), segments: 2 },
                 ];
+                this.system.traits.size = new ActorSizePF2e({
+                    value: this.system.traits.size.value,
+                    wide: 10,
+                    long: 10,
+                });
             }
         }
 

--- a/src/module/canvas/token/object.ts
+++ b/src/module/canvas/token/object.ts
@@ -281,11 +281,17 @@ class TokenPF2e<TDocument extends TokenDocumentPF2e = TokenDocumentPF2e> extends
         );
     }
 
-    /** Reposition aura textures after this token has moved. */
-    protected override _applyRenderFlags(flags: Record<string, boolean>): void {
+    /**
+     * Reposition aura textures after this token has moved.
+     * Also propagate refreshes to child tokens such as troops.
+     */
+    override _applyRenderFlags(flags: Record<string, boolean>): void {
         super._applyRenderFlags(flags);
         if (flags.refreshPosition) this.auras.refreshPositions();
         if (flags.refreshDistanceLabel) this.#refreshDistanceLabel();
+        for (const child of this.document.childTokens) {
+            child.object?._applyRenderFlags(flags);
+        }
     }
 
     /** Draw auras and flanking highlight lines if certain conditions are met */

--- a/src/module/scene/token-document/data.ts
+++ b/src/module/scene/token-document/data.ts
@@ -4,6 +4,10 @@ import type { TokenSchema } from "@common/documents/token.d.mts";
 
 type TokenFlagsPF2e = DocumentFlags & {
     [SYSTEM_ID]: {
+        /** If true, this token is the primary token of a troop */
+        hasChildTokens?: boolean;
+        /** The parent token of a troop segment which certain operations should defer to */
+        parentTokenId?: string;
         linkToActorSize: boolean;
         autoscale: boolean;
     };

--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -8,6 +8,7 @@ import type { Point } from "@common/_types.d.mts";
 import type {
     DatabaseCreateCallbackOptions,
     DatabaseDeleteCallbackOptions,
+    DatabaseDeleteOperation,
     DatabaseOperation,
 } from "@common/abstract/_types.d.mts";
 import type Document from "@common/abstract/document.d.mts";
@@ -36,6 +37,31 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
         return this.actor?.isOfType("party")
             ? this.actor.members.every((a) => game.combat?.getCombatantsByActor(a).length)
             : super.inCombat;
+    }
+
+    override get actor(): ActorPF2e<this | null> | null {
+        return (this.parentToken?.actor ?? super.actor) as ActorPF2e<this | null> | null;
+    }
+
+    override get baseActor(): ActorPF2e<null> | null {
+        return (this.parentToken?.baseActor ?? super.baseActor) as ActorPF2e<null> | null;
+    }
+
+    override get combatant(): CombatantPF2e<EncounterPF2e, this> | null {
+        return (super.combatant ?? this.parentToken?.combatant ?? null) as CombatantPF2e<EncounterPF2e, this> | null;
+    }
+
+    /** Returns the parent token if this is a troop segment */
+    get parentToken(): TokenDocumentPF2e | null {
+        const parentTokenId = this.flags[SYSTEM_ID].parentTokenId;
+        return parentTokenId ? (this.scene?.tokens.get(parentTokenId) ?? null) : null;
+    }
+
+    /** Returns tokens that are additional views of this one. used for troops */
+    get childTokens(): TokenDocumentPF2e[] {
+        return this.flags[SYSTEM_ID].hasChildTokens
+            ? (this.scene?.tokens.filter((t) => t.flags[SYSTEM_ID].parentTokenId === this.id) ?? [])
+            : [];
     }
 
     /** This should be in Foundry core, but ... */
@@ -483,6 +509,47 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
         }
     }
 
+    static override async deleteDocuments<TDocument extends Document>(
+        this: ConstructorOf<TDocument>,
+        ids?: string[],
+        operation?: Partial<DatabaseDeleteOperation<TDocument["parent"]>>,
+    ): Promise<TDocument[]>;
+    static override async deleteDocuments(
+        ids: string[] = [],
+        operation: Partial<DatabaseDeleteOperation<ScenePF2e>> = {},
+    ): Promise<TokenDocumentPF2e[]> {
+        // If this is a troop with child tokens, we might have to perform a swap if the real one is getting deleting
+        // This keeps the real one alive for the other children to refer to
+        const scene = operation.parent;
+        const tokens = ids.map((i) => scene?.tokens.get(i)).filter((t) => !!t) ?? [];
+        const withChildren = tokens.filter((t) => t.flags[SYSTEM_ID].hasChildTokens);
+        const updates: EmbeddedDocumentUpdateData[] = [];
+        for (const token of withChildren) {
+            const sacrifice = token.childTokens.find((t) => !ids.includes(t.id));
+            if (!sacrifice) continue;
+            ids.splice(ids.indexOf(token.id), 1, sacrifice.id);
+            updates.push({ _id: token.id, x: sacrifice.x, y: sacrifice.y });
+        }
+
+        const result = (await super.deleteDocuments(ids, operation)) as TokenDocumentPF2e[];
+        if (updates.length && result) {
+            scene?.updateEmbeddedDocuments("Token", updates, { animate: false });
+        }
+        return result;
+    }
+
+    static override createCombatants(tokens: TokenDocumentPF2e[], options?: { combat?: Combat }): Promise<Combatant[]> {
+        // Overriden to redirect to parent tokens in the case of troops
+        tokens = R.unique(tokens.map((t) => t.parentToken ?? t));
+        return super.createCombatants(tokens, options);
+    }
+
+    static override deleteCombatants(tokens: TokenDocumentPF2e[], options?: { combat?: Combat }): Promise<Combatant[]> {
+        // Overriden to redirect to parent tokens in the case of troops
+        tokens = R.unique(tokens.map((t) => t.parentToken ?? t));
+        return super.deleteCombatants(tokens, options);
+    }
+
     /* -------------------------------------------- */
     /*  Event Handlers                              */
     /* -------------------------------------------- */
@@ -516,6 +583,32 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
         super._onCreate(data, options, userId);
         if (game.user.id === userId && this.actor?.isOfType("loot")) {
             this.actor.toggleTokenHiding();
+        }
+
+        // Create other child tokens for troop actors. Infinite recursion is prevented by checking the parentTokenId
+        // todo: consider sqrt to determine offset count and don't hardcode thresholds if people want more customizability here
+        const { actor, object, scene } = this;
+        const isNPC = actor?.isOfType("npc");
+        const thresholds = isNPC ? actor.system.attributes.hp.thresholds : null;
+        if (scene && object && isNPC && thresholds && !this.flags[SYSTEM_ID].parentTokenId) {
+            const widthPixels = this.mechanicalBounds.width;
+            const offsets = [
+                [1, 0],
+                [0, 1],
+                [1, 1],
+            ];
+            const segments = thresholds.findLast((t) => t.hp >= actor.system.attributes.hp.value)?.segments ?? 1;
+            const newTokens = R.range(0, Math.clamp(segments, 1, 4) - 1).map((idx) => {
+                const [xOffset, yOffset] = offsets[idx];
+                return {
+                    ...R.omit(this.toObject(), ["delta"]),
+                    x: this.x + xOffset * widthPixels,
+                    y: this.y + yOffset * widthPixels,
+                    flags: { pf2e: { parentTokenId: this.id } },
+                };
+            });
+            scene.createEmbeddedDocuments("Token", newTokens);
+            this.update({ flags: { [SYSTEM_ID]: { hasChildTokens: true } } });
         }
     }
 
@@ -580,8 +673,6 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
 interface TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> extends TokenDocument<TParent> {
     flags: TokenFlagsPF2e;
     regions: Set<RegionDocumentPF2e<NonNullable<TParent>>>;
-    get actor(): ActorPF2e<this | null> | null;
-    get combatant(): CombatantPF2e<EncounterPF2e, this> | null;
     get object(): TokenPF2e<this> | null;
     get sheet(): TokenConfigPF2e;
 }

--- a/src/module/scene/token-document/sheets/mixin.ts
+++ b/src/module/scene/token-document/sheets/mixin.ts
@@ -37,6 +37,9 @@ function TokenConfigMixinPF2e<TBase extends ReturnType<typeof TokenApplicationMi
         /** Get this token's dimensions were they linked to its actor's size */
         get dimensionsFromActorSize(): number {
             const actorSize = this.actor?.size ?? "med";
+            if (this.actor?.isOfType("npc") && this.actor?.system.attributes.hp?.thresholds) {
+                return 2;
+            }
             return {
                 tiny: 0.5,
                 sm: 1,

--- a/types/foundry/client/documents/scene.d.mts
+++ b/types/foundry/client/documents/scene.d.mts
@@ -284,6 +284,7 @@ export interface EmbeddedTokenUpdateOperation<TParent extends Scene> extends Dat
     /** Is the operation undoing a previous operation, only used by embedded Documents within a Scene */
     isUndo?: boolean;
     animation?: TokenAnimationOptions;
+    animate?: boolean;
 }
 
 export type SceneTokenOperation<TParent extends Scene> = SceneEmbeddedOperation<TParent> & {


### PR DESCRIPTION
https://github.com/user-attachments/assets/bf31fd35-6ff6-488a-8764-61f7a12b2014

https://github.com/user-attachments/assets/19dd438b-8dc7-4bdb-904d-43c3dabae43a

The following features are missing, but should be fine to split off since they may require new discussions:
* Manually adding segments in the case of accidental deletes
* Some way for users to know which tokens are interlinked
* Flanking using the targeted token (mirror thaumaturge needs the same handling, so we can maybe do it in a separate PR)
* Handling for actor linked troops (or non-handling?)

I don't know if we should try to also propagate floaty text. 

As for the code itself, I'm uncertain about the parent/child naming. Its more of a real/illusion sort of illusion, but I don't know what to call that. `hasChildTokens` is a performance consideration so we're not checking every single token on non-troops for everything. It is also unclear if troops should be one actor or four (conditions affecting only one is odd, since you can always attack with the best one, and I have no idea how I'd handle draining a single segment). If troops should be an actor per segment with linked HP, it will need a different implementation.