### PR TITLE
Add a parameter to hide /act skill label

### DIFF
--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -464,7 +464,13 @@ class TextEditorPF2e extends foundry.applications.ux.TextEditor {
         // statistic
         const statistic = (params["statistic"] || params["stat"] || params["skill"])?.trim();
 
-        if ((dc && showDC) || statistic) {
+        // "false" or "never" to never show
+        const showStatisticOverride = (params["show-statistic"] || params["show-stat"] || params["show-skill"])
+            ?.trim()
+            .toLowerCase();
+        const showStatistic = statistic && !(showStatisticOverride === "false" || showStatisticOverride === "never");
+
+        if ((dc && showDC) || showStatistic) {
             element.appendChild(document.createTextNode(" "));
 
             const details = document.createElement("span");
@@ -472,7 +478,7 @@ class TextEditorPF2e extends foundry.applications.ux.TextEditor {
                 if (!Number.isNumeric(dc)) {
                     // (Statistic vs Defense DC)
                     const defense = _loc(`PF2E.Check.DC.Specific.${dc}`);
-                    const text = statistic
+                    const text = showStatistic
                         ? _loc("PF2E.InlineAction.Check.StatisticVsDefense", {
                               defense,
                               statistic: ActionMacroHelpers.getSimpleCheckLabel(statistic) || statistic,
@@ -485,7 +491,9 @@ class TextEditorPF2e extends foundry.applications.ux.TextEditor {
                         dataset: { visibility },
                         children: [_loc("PF2E.InlineAction.Check.DC", { dc })],
                     });
-                    const end = statistic ? ` ${ActionMacroHelpers.getSimpleCheckLabel(statistic) || statistic})` : ")";
+                    const end = showStatistic
+                        ? ` ${ActionMacroHelpers.getSimpleCheckLabel(statistic) || statistic})`
+                        : ")";
                     details.append("(", span, end);
                 } else {
                     // <span data-visibility="...">(DC #)</span>
@@ -493,7 +501,7 @@ class TextEditorPF2e extends foundry.applications.ux.TextEditor {
                     details.innerText = `(${_loc("PF2E.InlineAction.Check.DC", { dc })})`;
                 }
             } else {
-                // (Statistic)
+                // (showStatistic)
                 const text = ActionMacroHelpers.getSimpleCheckLabel(statistic) || statistic;
                 details.innerText = `(${text})`;
             }

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -439,6 +439,7 @@ class TextEditorPF2e extends foundry.applications.ux.TextEditor {
         };
         for (const [alias, value] of Object.entries(params)) {
             const key = aliases[alias] ?? alias;
+            if (["show-statistic", "show-stat", "show-skill"].includes(key)) continue;
             const attribute = sluggify(`pf2-${key}`, { camel: "dromedary" });
             element.dataset[attribute] = value;
         }


### PR DESCRIPTION
<img width="330" height="81" alt="image" src="https://github.com/user-attachments/assets/31cae5eb-fe02-464c-914a-4b8431f52eb7" />

<img width="438" height="118" alt="image" src="https://github.com/user-attachments/assets/c8062828-2711-490b-bde2-92802a250e76" />

The goal is to use those in descriptions and hazard disables when the button label is the same as the used skill (to avoid `Athletics (Athletics)`).
I wanted to have an option to display the default statistic too, but the current type of actions collection doesn't allow getting the default statistic of the action, so I skipped it for now. The parameter name was chosen similar to "show-dc", but as I don't think there is a need to hide it from non-GM, the choice would be simpler.
I'm not sure what would be the better name for the parameter value. Currently it's "false" or "never" to not show the skill label (potentially expanding to "true" or "always" in case there is ever a need to show the default skill label). Those are just my suggestions.