### PR TITLE
Include party tokens in door reach checks

### DIFF
--- a/src/module/canvas/door-control.ts
+++ b/src/module/canvas/door-control.ts
@@ -18,8 +18,13 @@ export class DoorControlPF2e extends fc.containers.DoorControl {
             { x: wallDoc.c[2], y: wallDoc.c[3] },
             this.center,
         ];
+        const character = game.user.character;
+        const partyTokens =
+            character?.isOfType("creature") && character.parties.size > 0
+                ? [...character.parties].flatMap((p) => p.getActiveTokens(true, false))
+                : [];
         const isInReach = R.unique(
-            [canvas.tokens.controlled, game.user.character?.getActiveTokens(true, false) ?? []].flat(),
+            [canvas.tokens.controlled, character?.getActiveTokens(true, false) ?? [], partyTokens].flat(),
         ).some((token) => {
             const actor = token.actor;
             if (!actor?.isOwner || !actor.isOfType("creature", "party")) return false;


### PR DESCRIPTION
When party members are collected into a party token, check if the party token is in reach of doors so players can operate them.