### PR TITLE
Add SF2e locale overrides for Home World and Port of Call

### DIFF
--- a/static/lang/sf2e-overrides-en.json
+++ b/static/lang/sf2e-overrides-en.json
@@ -23,6 +23,8 @@
                 }
             }
         },
+        "Ethnicity": "Home World",
+        "Nationality": "Port of Call",
         "Scene": {
             "HearingRange": {
                 "Hint": "Limit the range* creatures can hear in this scene as a representation of \"an environment that distorts the sense, such as a noisy room\" (Starfinder Player Core pg. 424). Requires rules-based vision to be enabled."


### PR DESCRIPTION
Fixes #21290