### PR TITLE
Fix Rule Element contention on Sextant of the Night

### DIFF
--- a/packs/pf2e/equipment/sextant-of-the-night.json
+++ b/packs/pf2e/equipment/sextant-of-the-night.json
@@ -38,6 +38,7 @@
             {
                 "key": "FlatModifier",
                 "selector": "survival",
+                "slug": "sextant-base-bonus",
                 "type": "item",
                 "value": 1
             },

--- a/packs/pf2e/equipment/sextant-of-the-night.json
+++ b/packs/pf2e/equipment/sextant-of-the-night.json
@@ -47,7 +47,7 @@
                     "action:sense-direction"
                 ],
                 "selector": "survival",
-                "slug": "sextant-of-the-night-action",
+                "slug": "sextant-sense-direction-bonus",
                 "type": "item",
                 "value": 2
             }

--- a/packs/pf2e/equipment/sextant-of-the-night.json
+++ b/packs/pf2e/equipment/sextant-of-the-night.json
@@ -47,6 +47,7 @@
                     "action:sense-direction"
                 ],
                 "selector": "survival",
+                "slug": "sextant-of-the-night-action",
                 "type": "item",
                 "value": 2
             }


### PR DESCRIPTION
added a slug to one of colliding rule elements on sextant of the night so both FlatModifiers on the item function as intended