### PR TITLE
Add slug to Urthagul's jaws strike to fix Fulcrum Lens effect not working properly when the Strike name is translated

### DIFF
--- a/packs/pf2e/abomination-vaults-bestiary/abomination-vaults-hardcover-compilation/urthagul.json
+++ b/packs/pf2e/abomination-vaults-bestiary/abomination-vaults-hardcover-compilation/urthagul.json
@@ -207,7 +207,7 @@
                 },
                 "range": null,
                 "rules": [],
-                "slug": null,
+                "slug": "jaws",
                 "traits": {
                     "rarity": "common",
                     "value": [


### PR DESCRIPTION
Fixes the immediate issue, but automatic slugging of NPC Strikes on build should be considered.