### PR TITLE
Update Ysoki starting languages list

### DIFF
--- a/packs/sf2e/ancestries/ysoki.json
+++ b/packs/sf2e/ancestries/ysoki.json
@@ -53,7 +53,9 @@
         "languages": {
             "custom": "",
             "value": [
-                "common"
+                "akitonian",
+                "common",
+                "ysoki"
             ]
         },
         "publication": {


### PR DESCRIPTION
Fixes https://github.com/foundryvtt/pf2e/issues/21551

Simple data change to include the expected starting languages for Ysoki. Not sure if the order of the languages is important for Foundry, but I put them in the same order as the Ysoki ancestry page in the rulebook.