### PR TITLE
Update SF2e PFS tab for SFS2

### DIFF
--- a/static/lang/sf2e-overrides-en.json
+++ b/static/lang/sf2e-overrides-en.json
@@ -31,6 +31,7 @@
             }
         },
         "SystemNameShort": "Starfinder",
+        "TabPathfinderSociety": "Starfinder Society",
         "TraitDescriptionDeadly": "On a critical hit, the weapon adds a weapon damage die of the listed size. Roll this after doubling the weapon's damage. This increases to two dice for elite and ultimate grade weapons and 3 dice for paragon grade weapons. For instance, an elite nano-edge rapier deals an additional 2d8 piercing damage on a critical hit. An ability that changes the size of the weapon's normal damage dice doesn't change the size of its deadly die.",
         "TraitDescriptionRatfolk": "A creature with this trait is a member of the ysoki ancestry. Ysoki are also known as ratfolk and are known for their ingenuity and comradery. An ability with this trait can be used or selected only by ratfolk or ysoki.",
         "TraitRatfolk": "Ysoki"

--- a/static/templates/actors/character/tabs/pfs.hbs
+++ b/static/templates/actors/character/tabs/pfs.hbs
@@ -7,6 +7,7 @@
             <span class="dash">&ndash;</span>
             <input type="number" class="character-number details-input" id="{{options.id}}-pfs-character-number" name="system.pfs.characterNumber" value="{{data.pfs.characterNumber}}" min="2001" max="9999" placeholder="2001" />
     </section>
+    {{#unless (eq systemId "sf2e")}}
     <section class="level-bump">
         <label class="details-label" for="{{options.id}}-pfs-level-bump">{{localize "PF2E.PFS.LevelBump"}}</label>
         <div class="toggle{{#if data.pfs.levelBump}} enabled{{/if}}">
@@ -30,6 +31,7 @@
         {{/each}}
         </div>
     </section>
+    {{/unless}}
 
     <header data-group-id="pfs">
         {{localize "PF2E.FeatPFSBoonHeader"}}


### PR DESCRIPTION
Factions, reputation, and level bump aren't used in SFS2 play.