### PR TITLE
Fix Walking Armory penalties

### DIFF
--- a/packs/sf2e/class-features/soldier/walking-armory.json
+++ b/packs/sf2e/class-features/soldier/walking-armory.json
@@ -35,6 +35,12 @@
                             "attribute:con:mod",
                             "armor:strength"
                         ]
+                    },
+                    {
+                        "lt": [
+                            "attribute:str:mod",
+                            "armor:strength"
+                        ]
                     }
                 ],
                 "selector": "skill-check",
@@ -46,10 +52,20 @@
                 "predicate": [
                     "penalty:slug:armor-speed-penalty",
                     {
-                        "gte": [
-                            "attribute:con:mod",
-                            "armor:strength"
-                        ]
+                        "and": [
+                            {
+                                "gte": [
+                                    "attribute:con:mod",
+                                    "armor:strength"
+                                ]
+                            },
+                            {
+                                "lt": [
+                                    "attribute:str:mod",
+                                    "armor:strength"
+                                ]
+                            }
+                        ]   
                     }
                 ],
                 "selector": "speed",


### PR DESCRIPTION
Fixes https://github.com/foundryvtt/pf2e/issues/21531

Initially tried putting `lt` predicate in the same object as the 'gte' clause.

```
{
    "gte": [
    "attribute:con:mod",
    "armor:strength"
    ],
    "lt": [
    "attribute:str:mod",
    "armor:strength"
    ]
}
```

This didn't work, giving an error message saying "predicate.1: must be a recognized predication statement". Next thing tried was using an `and` predicate to combine the two clauses together.

```
{
    "and": [
        {
            "gte": [
                "attribute:con:mod",
                "armor:strength"
            ]
        },
        {
            "lt": [
                "attribute:str:mod",
                "armor:strength"
            ]
        }
    ]
}
```

That did work! Confirmed all of this on a test actor with a strength of 3 and a constitution of 4 with Commercial Aegis Series armor. Where before there would be no speed reduction, this change makes sure that there is a speed penalty of -5 (reduced from -10).

The issue didn't mention this, but the same problem existed for the check penalty on armor. I applied the same fix to that as for the the speed penalty.

## Testing

Recording which shows the fix to speed and check penalty against this change.


https://github.com/user-attachments/assets/1276a6e0-f0b8-4161-835d-6cb45d1226d5

