### PR TITLE
Brush up Crystal Dragons

### DIFF
--- a/packs/pf2e/actions/class/exemplar/brandish-the-gorgons-gaze.json
+++ b/packs/pf2e/actions/class/exemplar/brandish-the-gorgons-gaze.json
@@ -12,7 +12,7 @@
         },
         "category": "offensive",
         "description": {
-            "value": "<p>You Raise your @UUID[Compendium.pf2e.classfeatures.Item.Mirrored Aegis], though it seems to lose some of its usual luster in favor of the dull sheen of stone. If you @UUID[Compendium.pf2e.feats-srd.Item.Shield Block] a melee attack with the mirrored aegis before the beginning of your next turn, the gorgon's eyes upon it flash at the triggering creature, who must attempt a @Check[fortitude|against:exemplar|inflicts:slowed] save against your class DC. On a failure, they are @UUID[Compendium.pf2e.conditionitems.Item.Slowed]{Slowed 1} for 1 minute as their body partially petrifies. Regardless of the outcome, that creature is temporarily immune to this effect for 24 hours.</p>"
+            "value": "<p>You Raise your @UUID[Compendium.pf2e.classfeatures.Item.Mirrored Aegis], though it seems to lose some of its usual luster in favor of the dull sheen of stone. If you @UUID[Compendium.pf2e.feats-srd.Item.Shield Block] a melee attack with the mirrored aegis before the beginning of your next turn, the gorgon's eyes upon it flash at the triggering creature, who must attempt a @Check[fortitude|against:exemplar|options:inflicts:slowed] save against your class DC. On a failure, they are @UUID[Compendium.pf2e.conditionitems.Item.Slowed]{Slowed 1} for 1 minute as their body partially petrifies. Regardless of the outcome, that creature is temporarily immune to this effect for 24 hours.</p>"
         },
         "publication": {
             "license": "ORC",

--- a/packs/pf2e/age-of-ashes-bestiary/book-4-fires-of-the-haunted-city/carnivorous-crystal.json
+++ b/packs/pf2e/age-of-ashes-bestiary/book-4-fires-of-the-haunted-city/carnivorous-crystal.json
@@ -163,7 +163,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p><strong>Requirements</strong> The crystal has a creature engulfed.</p>\n<hr />\n<p><strong>Effect</strong> The engulfed creature must succeed at a @Check[fortitude|dc:28|name:Crystalize] save or become @UUID[Compendium.pf2e.conditionitems.Item.Slowed]{Slowed 1} until it is no longer engulfed. If the creature is already slowed, it becomes petrified as it is turned into crystal and expelled by the carnivorous crystal onto the ground.</p>\n<p>In [[/gmr 1d4 #hours]]{1d4 hours}, the petrified victim shatters and a new carnivorous crystal emerges from the remains.</p>"
+                    "value": "<p><strong>Requirements</strong> The crystal has a creature engulfed.</p>\n<hr />\n<p><strong>Effect</strong> The engulfed creature must succeed at a @Check[fortitude|dc:28|options:inflicts:petrified,inflicts:slowed] save or become @UUID[Compendium.pf2e.conditionitems.Item.Slowed]{Slowed 1} until it is no longer engulfed. If the creature is already slowed, it becomes @UUID[Compendium.pf2e.conditionitems.Item.Petrified] as it is turned into crystal and expelled by the carnivorous crystal onto the ground.</p>\n<p>In [[/gmr 1d4 #hours]]{1d4 hours}, the petrified victim shatters and a new carnivorous crystal emerges from the remains.</p>"
                 },
                 "publication": {
                     "license": "OGL",

--- a/packs/pf2e/equipment/crystallized-dragon-heart.json
+++ b/packs/pf2e/equipment/crystallized-dragon-heart.json
@@ -1,6 +1,6 @@
 {
     "_id": "svhZ61CaSgatn5by",
-    "img": "systems/pf2e/icons/equipment/treasure/art-objects/major-art-object/crystallized-dragon-heart.webp",
+    "img": "icons/commodities/gems/gem-shattered-violet.webp",
     "name": "Crystallized dragon heart",
     "system": {
         "baseItem": null,

--- a/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-archdragon-spellcaster.json
+++ b/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-archdragon-spellcaster.json
@@ -2737,7 +2737,7 @@
                 "value": 19
             },
             "privateNotes": "",
-            "publicNotes": "",
+            "publicNotes": "<p>Crystal dragons consider themselves among the more beautiful dragon species and expect others to recognize this. They see little need to accessorize their crystalline hides but might spend hours each day tending to their appearance. They clean themselves frequently, and each scale must be properly faceted and free of imperfections. A crystal dragon may retreat into its lair if its hide gets damaged, manually removing the damaged scales (a painful process!) and then waiting for the replacements to grow in.</p>\n<p>Crystal dragons are also proud of their lairs, which typically contain hoards of gems and crystals. An individual dragon's creative nature shows through in their decor. So do their organizational skills—they can't tolerate a mess. Their habit of constantly updating and rearranging their spaces means visitors might see a fair bit of disarray, however, depending on their timing.</p>",
             "publication": {
                 "license": "ORC",
                 "remaster": true,

--- a/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-archdragon-spellcaster.json
+++ b/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-archdragon-spellcaster.json
@@ -2454,7 +2454,7 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> A creature at least 10 feet away from the dragon targets them with an attack</p>\n<p><strong>Requirements</strong> The dragon is on the ground and there is at least one unoccupied square between themself and the attacker</p><hr /><p><strong>Effect</strong> The dragon conjures a thin slab of stone in an unoccupied square between themself and the attacker. The dragon gains standard cover against the triggering attack. The stone falls on the first person other than the dragon who enters that square, dealing @Damage[9d6[bludgeoning]] damage with a @Check[reflex|dc:38|basic] save. Otherwise, it crumbles harmlessly after 1 round.</p>"
+                    "value": "<p><strong>Trigger</strong> A creature at least 10 feet away from the dragon targets them with an attack</p>\n<p><strong>Requirements</strong> The dragon is on the ground and there is at least one unoccupied square between themself and the attacker</p><hr /><p><strong>Effect</strong> The dragon conjures a thin slab of stone in an unoccupied square between themself and the attacker. The dragon gains standard @UUID[Compendium.pf2e.other-effects.Item.Effect: Cover]{Cover} against the triggering attack. The stone falls on the first person other than the dragon who enters that square, dealing @Damage[9d6[bludgeoning]] damage with a @Check[reflex|dc:38|basic] save. Otherwise, it crumbles harmlessly after 1 round.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -2490,7 +2490,21 @@
                     "remaster": false,
                     "title": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "key": "Note",
+                        "outcome": [
+                            "criticalSuccess"
+                        ],
+                        "predicate": [
+                            "item:damage:category:physical"
+                        ],
+                        "selector": "damage-received",
+                        "text": "{item|description}",
+                        "title": "{item|name}",
+                        "visibility": "owner"
+                    }
+                ],
                 "slug": null,
                 "traits": {
                     "value": []
@@ -2515,7 +2529,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The claws and tail of a crystal archdragon embed shards that slowly turns the flesh of those they Strike to crystal. The target must succeed at a @Check[fortitude|dc:38|options:inflicts:petrified,inflicts:slowed] save or become @UUID[Compendium.pf2e.conditionitems.Item.Slowed]{Slowed 1} (@UUID[Compendium.pf2e.conditionitems.Item.Slowed]{Slowed 2} on a critical failure) for 1 minute. Further failed saves against crystallize increase the slowed condition. Once a creature's actions are reduced to 0 by crystallize, that creature becomes petrified, turned into crystal instead of stone.</p>"
+                    "value": "<p>The claws and tail of a crystal archdragon embed shards that slowly turns the flesh of those they Strike to crystal. The target must succeed at a @Check[fortitude|dc:38|options:inflicts:petrified,inflicts:slowed] save or become @UUID[Compendium.pf2e.conditionitems.Item.Slowed]{Slowed 1} (@UUID[Compendium.pf2e.conditionitems.Item.Slowed]{Slowed 2} on a critical failure) for 1 minute. Further failed saves against crystallize increase the slowed condition. Once a creature's actions are reduced to 0 by crystallize, that creature becomes @UUID[Compendium.pf2e.conditionitems.Item.Petrified], turned into crystal instead of stone.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -2550,7 +2564,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The dragon strikes a pose that makes its hide sparkle in the light. Each creature within 20 feet must succeed at a @Check[fortitude|dc:38|inflicts:dazzled] save or become @UUID[Compendium.pf2e.conditionitems.Item.Dazzled] for 1 round.</p>"
+                    "value": "<p>The dragon strikes a pose that makes its hide sparkle in the light. Each creature within @Template[emanation|distance:20]{20 feet} must succeed at a @Check[fortitude|dc:38|options:area-effect,inflicts:dazzled] save or become @UUID[Compendium.pf2e.conditionitems.Item.Dazzled] for 1 round.</p>"
                 },
                 "publication": {
                     "license": "OGL",

--- a/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-archdragon.json
+++ b/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-archdragon.json
@@ -577,7 +577,7 @@
                 "value": 19
             },
             "privateNotes": "",
-            "publicNotes": "",
+            "publicNotes": "<p>Crystal dragons consider themselves among the more beautiful dragon species and expect others to recognize this. They see little need to accessorize their crystalline hides but might spend hours each day tending to their appearance. They clean themselves frequently, and each scale must be properly faceted and free of imperfections. A crystal dragon may retreat into its lair if its hide gets damaged, manually removing the damaged scales (a painful process!) and then waiting for the replacements to grow in.</p>\n<p>Crystal dragons are also proud of their lairs, which typically contain hoards of gems and crystals. An individual dragon's creative nature shows through in their decor. So do their organizational skills—they can't tolerate a mess. Their habit of constantly updating and rearranging their spaces means visitors might see a fair bit of disarray, however, depending on their timing.</p>",
             "publication": {
                 "license": "ORC",
                 "remaster": true,

--- a/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-archdragon.json
+++ b/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-archdragon.json
@@ -225,7 +225,7 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> A creature at least 10 feet away from the dragon targets them with an attack</p>\n<p><strong>Requirements</strong> The dragon is on the ground and there is at least one unoccupied square between themself and the attacker</p><hr /><p><strong>Effect</strong> The dragon conjures a thin slab of stone in an unoccupied square between themself and the attacker. The dragon gains standard cover against the triggering attack. The stone falls on the first person other than the dragon who enters that square, dealing @Damage[9d6[bludgeoning]] damage with a @Check[reflex|dc:38|basic] save. Otherwise, it crumbles harmlessly after 1 round.</p>"
+                    "value": "<p><strong>Trigger</strong> A creature at least 10 feet away from the dragon targets them with an attack</p>\n<p><strong>Requirements</strong> The dragon is on the ground and there is at least one unoccupied square between themself and the attacker</p><hr /><p><strong>Effect</strong> The dragon conjures a thin slab of stone in an unoccupied square between themself and the attacker. The dragon gains standard @UUID[Compendium.pf2e.other-effects.Item.Effect: Cover]{Cover} against the triggering attack. The stone falls on the first person other than the dragon who enters that square, dealing @Damage[9d6[bludgeoning]] damage with a @Check[reflex|dc:38|basic] save. Otherwise, it crumbles harmlessly after 1 round.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -261,7 +261,21 @@
                     "remaster": false,
                     "title": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "key": "Note",
+                        "outcome": [
+                            "criticalSuccess"
+                        ],
+                        "predicate": [
+                            "item:damage:category:physical"
+                        ],
+                        "selector": "damage-received",
+                        "text": "{item|description}",
+                        "title": "{item|name}",
+                        "visibility": "owner"
+                    }
+                ],
                 "slug": null,
                 "traits": {
                     "value": []
@@ -286,7 +300,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The claws and tail of a crystal archdragon embed shards that slowly turns the flesh of those they Strike to crystal. The target must succeed at a @Check[fortitude|dc:38|options:inflicts:petrified,inflicts:slowed] save or become @UUID[Compendium.pf2e.conditionitems.Item.Slowed]{Slowed 1} (@UUID[Compendium.pf2e.conditionitems.Item.Slowed]{Slowed 2} on a critical failure) for 1 minute. Further failed saves against crystallize increase the slowed condition. Once a creature's actions are reduced to 0 by crystallize, that creature becomes petrified, turned into crystal instead of stone.</p>"
+                    "value": "<p>The claws and tail of a crystal archdragon embed shards that slowly turns the flesh of those they Strike to crystal. The target must succeed at a @Check[fortitude|dc:38|options:inflicts:petrified,inflicts:slowed] save or become @UUID[Compendium.pf2e.conditionitems.Item.Slowed]{Slowed 1} (@UUID[Compendium.pf2e.conditionitems.Item.Slowed]{Slowed 2} on a critical failure) for 1 minute. Further failed saves against crystallize increase the slowed condition. Once a creature's actions are reduced to 0 by crystallize, that creature becomes @UUID[Compendium.pf2e.conditionitems.Item.Petrified], turned into crystal instead of stone.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -393,7 +407,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The dragon strikes a pose that makes its hide sparkle in the light. Each creature within 20 feet must succeed at a @Check[fortitude|dc:38|inflicts:dazzled] save or become @UUID[Compendium.pf2e.conditionitems.Item.Dazzled] for 1 round.</p>"
+                    "value": "<p>The dragon strikes a pose that makes its hide sparkle in the light. Each creature within @Template[emanation|distance:20]{20 feet} must succeed at a @Check[fortitude|dc:38|options:area-effect,inflicts:dazzled] save or become @UUID[Compendium.pf2e.conditionitems.Item.Dazzled] for 1 round.</p>"
                 },
                 "publication": {
                     "license": "OGL",

--- a/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-dragon-adult-spellcaster.json
+++ b/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-dragon-adult-spellcaster.json
@@ -2161,7 +2161,7 @@
                 "value": 11
             },
             "privateNotes": "",
-            "publicNotes": "",
+            "publicNotes": "<p>Crystal dragons consider themselves among the more beautiful dragon species and expect others to recognize this. They see little need to accessorize their crystalline hides but might spend hours each day tending to their appearance. They clean themselves frequently, and each scale must be properly faceted and free of imperfections. A crystal dragon may retreat into its lair if its hide gets damaged, manually removing the damaged scales (a painful process!) and then waiting for the replacements to grow in.</p>\n<p>Crystal dragons are also proud of their lairs, which typically contain hoards of gems and crystals. An individual dragon's creative nature shows through in their decor. So do their organizational skills—they can't tolerate a mess. Their habit of constantly updating and rearranging their spaces means visitors might see a fair bit of disarray, however, depending on their timing.</p>",
             "publication": {
                 "license": "ORC",
                 "remaster": true,

--- a/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-dragon-adult-spellcaster.json
+++ b/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-dragon-adult-spellcaster.json
@@ -1827,7 +1827,7 @@
                 "traits": {
                     "value": [
                         "magical",
-                        "reach-10"
+                        "reach-15"
                     ]
                 }
             },
@@ -1908,7 +1908,7 @@
                 "traits": {
                     "value": [
                         "magical",
-                        "reach-15"
+                        "reach-20"
                     ]
                 }
             },
@@ -2005,7 +2005,7 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> A creature at least 10 feet away from the dragon targets them with an attack</p>\n<p><strong>Requirements</strong> The dragon is on the ground and there is at least one unoccupied square between themself and the attacker</p><hr /><p><strong>Effect</strong> The dragon conjures a thin slab of stone in an unoccupied square between themself and the attacker. The dragon gains standard cover against the triggering attack. The stone falls on the first person other than the dragon who enters that square, dealing @Damage[6d6[bludgeoning]] damage with a @Check[reflex|dc:27|basic] save. Otherwise, it crumbles harmlessly after 1 round.</p>"
+                    "value": "<p><strong>Trigger</strong> A creature at least 10 feet away from the dragon targets them with an attack</p>\n<p><strong>Requirements</strong> The dragon is on the ground and there is at least one unoccupied square between themself and the attacker</p><hr /><p><strong>Effect</strong> The dragon conjures a thin slab of stone in an unoccupied square between themself and the attacker. The dragon gains standard @UUID[Compendium.pf2e.other-effects.Item.Effect: Cover]{Cover} against the triggering attack. The stone falls on the first person other than the dragon who enters that square, dealing @Damage[6d6[bludgeoning]] damage with a @Check[reflex|dc:27|basic] save. Otherwise, it crumbles harmlessly after 1 round.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -2034,7 +2034,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The dragon strikes a pose that makes its hide sparkle in the light. Each creature within 20 feet must succeed at a @Check[fortitude|dc:27|inflicts:dazzled] save or become @UUID[Compendium.pf2e.conditionitems.Item.Dazzled] for 1 round.</p>"
+                    "value": "<p>The dragon strikes a pose that makes its hide sparkle in the light. Each creature within @Template[emanation|distance:20]{20 feet} must succeed at a @Check[fortitude|dc:27|options:area-effect,inflicts:dazzled] save or become @UUID[Compendium.pf2e.conditionitems.Item.Dazzled] for 1 round.</p>"
                 },
                 "publication": {
                     "license": "OGL",

--- a/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-dragon-adult.json
+++ b/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-dragon-adult.json
@@ -437,7 +437,7 @@
                 "value": 11
             },
             "privateNotes": "",
-            "publicNotes": "",
+            "publicNotes": "<p>Crystal dragons consider themselves among the more beautiful dragon species and expect others to recognize this. They see little need to accessorize their crystalline hides but might spend hours each day tending to their appearance. They clean themselves frequently, and each scale must be properly faceted and free of imperfections. A crystal dragon may retreat into its lair if its hide gets damaged, manually removing the damaged scales (a painful process!) and then waiting for the replacements to grow in.</p>\n<p>Crystal dragons are also proud of their lairs, which typically contain hoards of gems and crystals. An individual dragon's creative nature shows through in their decor. So do their organizational skills—they can't tolerate a mess. Their habit of constantly updating and rearranging their spaces means visitors might see a fair bit of disarray, however, depending on their timing.</p>",
             "publication": {
                 "license": "ORC",
                 "remaster": true,

--- a/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-dragon-adult.json
+++ b/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-dragon-adult.json
@@ -37,7 +37,7 @@
                 "traits": {
                     "value": [
                         "magical",
-                        "reach-10"
+                        "reach-15"
                     ]
                 }
             },
@@ -118,7 +118,7 @@
                 "traits": {
                     "value": [
                         "magical",
-                        "reach-15"
+                        "reach-20"
                     ]
                 }
             },
@@ -215,7 +215,7 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> A creature at least 10 feet away from the dragon targets them with an attack</p>\n<p><strong>Requirements</strong> The dragon is on the ground and there is at least one unoccupied square between themself and the attacker</p><hr /><p><strong>Effect</strong> The dragon conjures a thin slab of stone in an unoccupied square between themself and the attacker. The dragon gains standard cover against the triggering attack. The stone falls on the first person other than the dragon who enters that square, dealing @Damage[6d6[bludgeoning]] damage with a @Check[reflex|dc:27|basic] save. Otherwise, it crumbles harmlessly after 1 round.</p>"
+                    "value": "<p><strong>Trigger</strong> A creature at least 10 feet away from the dragon targets them with an attack</p>\n<p><strong>Requirements</strong> The dragon is on the ground and there is at least one unoccupied square between themself and the attacker</p><hr /><p><strong>Effect</strong> The dragon conjures a thin slab of stone in an unoccupied square between themself and the attacker. The dragon gains standard @UUID[Compendium.pf2e.other-effects.Item.Effect: Cover]{Cover} against the triggering attack. The stone falls on the first person other than the dragon who enters that square, dealing @Damage[6d6[bludgeoning]] damage with a @Check[reflex|dc:27|basic] save. Otherwise, it crumbles harmlessly after 1 round.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -313,7 +313,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The dragon strikes a pose that makes its hide sparkle in the light. Each creature within 20 feet must succeed at a @Check[fortitude|dc:27|inflicts:dazzled] save or become @UUID[Compendium.pf2e.conditionitems.Item.Dazzled] for 1 round.</p>"
+                    "value": "<p>The dragon strikes a pose that makes its hide sparkle in the light. Each creature within @Template[emanation|distance:20]{20 feet} must succeed at a @Check[fortitude|dc:27|options:area-effect,inflicts:dazzled] save or become @UUID[Compendium.pf2e.conditionitems.Item.Dazzled] for 1 round.</p>"
                 },
                 "publication": {
                     "license": "OGL",

--- a/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-dragon-ancient-spellcaster.json
+++ b/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-dragon-ancient-spellcaster.json
@@ -2274,7 +2274,7 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> A creature at least 10 feet away from the dragon targets them with an attack</p>\n<p><strong>Requirements</strong> The dragon is on the ground and there is at least one unoccupied square between themself and the attacker</p><hr /><p><strong>Effect</strong> The dragon conjures a thin slab of stone in an unoccupied square between themself and the attacker. The dragon gains standard cover against the triggering attack. The stone falls on the first person other than the dragon who enters that square, dealing @Damage[8d6[bludgeoning]] damage with a @Check[reflex|dc:34|basic] save. Otherwise, it crumbles harmlessly after 1 round.</p>"
+                    "value": "<p><strong>Trigger</strong> A creature at least 10 feet away from the dragon targets them with an attack</p>\n<p><strong>Requirements</strong> The dragon is on the ground and there is at least one unoccupied square between themself and the attacker</p><hr /><p><strong>Effect</strong> The dragon conjures a thin slab of stone in an unoccupied square between themself and the attacker. The dragon gains standard @UUID[Compendium.pf2e.other-effects.Item.Effect: Cover]{Cover} against the triggering attack. The stone falls on the first person other than the dragon who enters that square, dealing @Damage[8d6[bludgeoning]] damage with a @Check[reflex|dc:34|basic] save. Otherwise, it crumbles harmlessly after 1 round.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -2310,7 +2310,21 @@
                     "remaster": false,
                     "title": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "key": "Note",
+                        "outcome": [
+                            "criticalSuccess"
+                        ],
+                        "predicate": [
+                            "item:damage:category:physical"
+                        ],
+                        "selector": "damage-received",
+                        "text": "{item|description}",
+                        "title": "{item|name}",
+                        "visibility": "owner"
+                    }
+                ],
                 "slug": null,
                 "traits": {
                     "value": []
@@ -2332,7 +2346,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The claws of an ancient crystal dragon embed shards that slowly turns the flesh of those they Strike to crystal. The target must succeed at a @Check[fortitude|dc:34|options:inflicts:petrified,inflicts:slowed] save or become @UUID[Compendium.pf2e.conditionitems.Item.Slowed]{Slowed 1} (@UUID[Compendium.pf2e.conditionitems.Item.Slowed]{Slowed 2} on a critical failure) for 1 minute. Further failed saves against crystallize increase the slowed condition. Once a creature's actions are reduced to 0 by crystallize, that creature becomes petrified, turned into crystal instead of stone.</p>"
+                    "value": "<p>The claws of an ancient crystal dragon embed shards that slowly turns the flesh of those they Strike to crystal. The target must succeed at a @Check[fortitude|dc:34|options:inflicts:petrified,inflicts:slowed] save or become @UUID[Compendium.pf2e.conditionitems.Item.Slowed]{Slowed 1} (@UUID[Compendium.pf2e.conditionitems.Item.Slowed]{Slowed 2} on a critical failure) for 1 minute. Further failed saves against crystallize increase the slowed condition. Once a creature's actions are reduced to 0 by crystallize, that creature becomes @UUID[Compendium.pf2e.conditionitems.Item.Petrified], turned into crystal instead of stone.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -2364,7 +2378,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The dragon strikes a pose that makes its hide sparkle in the light. Each creature within 20 feet must succeed at a @Check[fortitude|dc:34|inflicts:dazzled] save or become @UUID[Compendium.pf2e.conditionitems.Item.Dazzled] for 1 round.</p>"
+                    "value": "<p>The dragon strikes a pose that makes its hide sparkle in the light. Each creature within @Template[emanation|distance:20]{20 feet} must succeed at a @Check[fortitude|dc:34|options:area-effect,inflicts:dazzled] save or become @UUID[Compendium.pf2e.conditionitems.Item.Dazzled] for 1 round.</p>"
                 },
                 "publication": {
                     "license": "OGL",

--- a/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-dragon-ancient-spellcaster.json
+++ b/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-dragon-ancient-spellcaster.json
@@ -2515,7 +2515,7 @@
                 "value": 16
             },
             "privateNotes": "",
-            "publicNotes": "",
+            "publicNotes": "<p>Crystal dragons consider themselves among the more beautiful dragon species and expect others to recognize this. They see little need to accessorize their crystalline hides but might spend hours each day tending to their appearance. They clean themselves frequently, and each scale must be properly faceted and free of imperfections. A crystal dragon may retreat into its lair if its hide gets damaged, manually removing the damaged scales (a painful process!) and then waiting for the replacements to grow in.</p>\n<p>Crystal dragons are also proud of their lairs, which typically contain hoards of gems and crystals. An individual dragon's creative nature shows through in their decor. So do their organizational skills—they can't tolerate a mess. Their habit of constantly updating and rearranging their spaces means visitors might see a fair bit of disarray, however, depending on their timing.</p>",
             "publication": {
                 "license": "ORC",
                 "remaster": true,

--- a/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-dragon-ancient.json
+++ b/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-dragon-ancient.json
@@ -217,7 +217,7 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> A creature at least 10 feet away from the dragon targets them with an attack</p>\n<p><strong>Requirements</strong> The dragon is on the ground and there is at least one unoccupied square between themself and the attacker</p><hr /><p><strong>Effect</strong> The dragon conjures a thin slab of stone in an unoccupied square between themself and the attacker. The dragon gains standard cover against the triggering attack. The stone falls on the first person other than the dragon who enters that square, dealing @Damage[8d6[bludgeoning]] damage with a @Check[reflex|dc:34|basic] save. Otherwise, it crumbles harmlessly after 1 round.</p>"
+                    "value": "<p><strong>Trigger</strong> A creature at least 10 feet away from the dragon targets them with an attack</p>\n<p><strong>Requirements</strong> The dragon is on the ground and there is at least one unoccupied square between themself and the attacker</p><hr /><p><strong>Effect</strong> The dragon conjures a thin slab of stone in an unoccupied square between themself and the attacker. The dragon gains standard @UUID[Compendium.pf2e.other-effects.Item.Effect: Cover]{Cover} against the triggering attack. The stone falls on the first person other than the dragon who enters that square, dealing @Damage[8d6[bludgeoning]] damage with a @Check[reflex|dc:34|basic] save. Otherwise, it crumbles harmlessly after 1 round.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -253,7 +253,21 @@
                     "remaster": false,
                     "title": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "key": "Note",
+                        "outcome": [
+                            "criticalSuccess"
+                        ],
+                        "predicate": [
+                            "item:damage:category:physical"
+                        ],
+                        "selector": "damage-received",
+                        "text": "{item|description}",
+                        "title": "{item|name}",
+                        "visibility": "owner"
+                    }
+                ],
                 "slug": null,
                 "traits": {
                     "value": []
@@ -275,7 +289,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The claws of an ancient crystal dragon embed shards that slowly turns the flesh of those they Strike to crystal. The target must succeed at a @Check[fortitude|dc:34|options:inflicts:petrified,inflicts:slowed] save or become @UUID[Compendium.pf2e.conditionitems.Item.Slowed]{Slowed 1} (@UUID[Compendium.pf2e.conditionitems.Item.Slowed]{Slowed 2} on a critical failure) for 1 minute. Further failed saves against crystallize increase the slowed condition. Once a creature's actions are reduced to 0 by crystallize, that creature becomes petrified, turned into crystal instead of stone.</p>"
+                    "value": "<p>The claws of an ancient crystal dragon embed shards that slowly turns the flesh of those they Strike to crystal. The target must succeed at a @Check[fortitude|dc:34|options:inflicts:petrified,inflicts:slowed] save or become @UUID[Compendium.pf2e.conditionitems.Item.Slowed]{Slowed 1} (@UUID[Compendium.pf2e.conditionitems.Item.Slowed]{Slowed 2} on a critical failure) for 1 minute. Further failed saves against crystallize increase the slowed condition. Once a creature's actions are reduced to 0 by crystallize, that creature becomes @UUID[Compendium.pf2e.conditionitems.Item.Petrified], turned into crystal instead of stone.</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -376,7 +390,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>The dragon strikes a pose that makes its hide sparkle in the light. Each creature within 20 feet must succeed at a @Check[fortitude|dc:34|inflicts:dazzled] save or become @UUID[Compendium.pf2e.conditionitems.Item.Dazzled] for 1 round.</p>"
+                    "value": "<p>The dragon strikes a pose that makes its hide sparkle in the light. Each creature within @Template[emanation|distance:20]{20 feet} must succeed at a @Check[fortitude|dc:34|options:area-effect,inflicts:dazzled] save or become @UUID[Compendium.pf2e.conditionitems.Item.Dazzled] for 1 round.</p>"
                 },
                 "publication": {
                     "license": "OGL",

--- a/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-dragon-ancient.json
+++ b/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-dragon-ancient.json
@@ -524,7 +524,7 @@
                 "value": 16
             },
             "privateNotes": "",
-            "publicNotes": "",
+            "publicNotes": "<p>Crystal dragons consider themselves among the more beautiful dragon species and expect others to recognize this. They see little need to accessorize their crystalline hides but might spend hours each day tending to their appearance. They clean themselves frequently, and each scale must be properly faceted and free of imperfections. A crystal dragon may retreat into its lair if its hide gets damaged, manually removing the damaged scales (a painful process!) and then waiting for the replacements to grow in.</p>\n<p>Crystal dragons are also proud of their lairs, which typically contain hoards of gems and crystals. An individual dragon's creative nature shows through in their decor. So do their organizational skills—they can't tolerate a mess. Their habit of constantly updating and rearranging their spaces means visitors might see a fair bit of disarray, however, depending on their timing.</p>",
             "publication": {
                 "license": "ORC",
                 "remaster": true,

--- a/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-dragon-young-spellcaster.json
+++ b/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-dragon-young-spellcaster.json
@@ -1657,7 +1657,7 @@
                 "value": 7
             },
             "privateNotes": "",
-            "publicNotes": "",
+            "publicNotes": "<p>Crystal dragons consider themselves among the more beautiful dragon species and expect others to recognize this. They see little need to accessorize their crystalline hides but might spend hours each day tending to their appearance. They clean themselves frequently, and each scale must be properly faceted and free of imperfections. A crystal dragon may retreat into its lair if its hide gets damaged, manually removing the damaged scales (a painful process!) and then waiting for the replacements to grow in.</p>\n<p>Crystal dragons are also proud of their lairs, which typically contain hoards of gems and crystals. An individual dragon's creative nature shows through in their decor. So do their organizational skills—they can't tolerate a mess. Their habit of constantly updating and rearranging their spaces means visitors might see a fair bit of disarray, however, depending on their timing.</p>",
             "publication": {
                 "license": "ORC",
                 "remaster": true,

--- a/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-dragon-young-spellcaster.json
+++ b/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-dragon-young-spellcaster.json
@@ -1532,7 +1532,7 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> A creature at least 10 feet away from the dragon targets them with an attack</p>\n<p><strong>Requirements</strong> The dragon is on the ground and there is at least one unoccupied square between themself and the attacker</p><hr /><p><strong>Effect</strong> The dragon conjures a thin slab of stone in an unoccupied square between themself and the attacker. The dragon gains standard cover against the triggering attack. The stone falls on the first person other than the dragon who enters that square, dealing @Damage[4d6[bludgeoning]] damage with a @Check[reflex|dc:22|basic] save. Otherwise, it crumbles harmlessly after 1 round.</p>"
+                    "value": "<p><strong>Trigger</strong> A creature at least 10 feet away from the dragon targets them with an attack</p>\n<p><strong>Requirements</strong> The dragon is on the ground and there is at least one unoccupied square between themself and the attacker</p><hr /><p><strong>Effect</strong> The dragon conjures a thin slab of stone in an unoccupied square between themself and the attacker. The dragon gains standard @UUID[Compendium.pf2e.other-effects.Item.Effect: Cover]{Cover} against the triggering attack. The stone falls on the first person other than the dragon who enters that square, dealing @Damage[4d6[bludgeoning]] damage with a @Check[reflex|dc:22|basic] save. Otherwise, it crumbles harmlessly after 1 round.</p>"
                 },
                 "publication": {
                     "license": "OGL",

--- a/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-dragon-young.json
+++ b/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-dragon-young.json
@@ -367,7 +367,7 @@
                 "value": 7
             },
             "privateNotes": "",
-            "publicNotes": "",
+            "publicNotes": "<p>Crystal dragons consider themselves among the more beautiful dragon species and expect others to recognize this. They see little need to accessorize their crystalline hides but might spend hours each day tending to their appearance. They clean themselves frequently, and each scale must be properly faceted and free of imperfections. A crystal dragon may retreat into its lair if its hide gets damaged, manually removing the damaged scales (a painful process!) and then waiting for the replacements to grow in.</p>\n<p>Crystal dragons are also proud of their lairs, which typically contain hoards of gems and crystals. An individual dragon's creative nature shows through in their decor. So do their organizational skills—they can't tolerate a mess. Their habit of constantly updating and rearranging their spaces means visitors might see a fair bit of disarray, however, depending on their timing.</p>",
             "publication": {
                 "license": "ORC",
                 "remaster": true,

--- a/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-dragon-young.json
+++ b/packs/pf2e/lost-omens-bestiary/draconic-codex/crystal/crystal-dragon-young.json
@@ -176,7 +176,7 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> A creature at least 10 feet away from the dragon targets them with an attack</p>\n<p><strong>Requirements</strong> The dragon is on the ground and there is at least one unoccupied square between themself and the attacker</p><hr /><p><strong>Effect</strong> The dragon conjures a thin slab of stone in an unoccupied square between themself and the attacker. The dragon gains standard cover against the triggering attack. The stone falls on the first person other than the dragon who enters that square, dealing @Damage[4d6[bludgeoning]] damage with a @Check[reflex|dc:22|basic] save. Otherwise, it crumbles harmlessly after 1 round.</p>"
+                    "value": "<p><strong>Trigger</strong> A creature at least 10 feet away from the dragon targets them with an attack</p>\n<p><strong>Requirements</strong> The dragon is on the ground and there is at least one unoccupied square between themself and the attacker</p><hr /><p><strong>Effect</strong> The dragon conjures a thin slab of stone in an unoccupied square between themself and the attacker. The dragon gains standard @UUID[Compendium.pf2e.other-effects.Item.Effect: Cover]{Cover} against the triggering attack. The stone falls on the first person other than the dragon who enters that square, dealing @Damage[4d6[bludgeoning]] damage with a @Check[reflex|dc:22|basic] save. Otherwise, it crumbles harmlessly after 1 round.</p>"
                 },
                 "publication": {
                     "license": "OGL",

--- a/packs/pf2e/rollable-tables/major-art-object.json
+++ b/packs/pf2e/rollable-tables/major-art-object.json
@@ -155,7 +155,7 @@
             "description": "",
             "documentUuid": "Compendium.pf2e.equipment-srd.Item.svhZ61CaSgatn5by",
             "drawn": false,
-            "img": "systems/pf2e/icons/equipment/treasure/art-objects/major-art-object/crystallized-dragon-heart.webp",
+            "img": "icons/commodities/gems/gem-shattered-violet.webp",
             "name": "Crystallized dragon heart",
             "range": [
                 51,


### PR DESCRIPTION
Fix inline roll options for Brandish the Gorgon's Gaze
Add roll options and petrified link to Carnivorous Crystal's Crystallize
Replace lower-resolution system icon with identical core icon for Crystallized dragon heart