### PR TITLE
Fix missing DC value in some check context flags

### DIFF
--- a/src/module/system/check/check.ts
+++ b/src/module/system/check/check.ts
@@ -304,7 +304,12 @@ class Check {
             title: context.title ?? "PF2E.Check.Label",
             traits: context.traits ?? [],
             substitutions,
-            dc: context.dc ? R.omit(context.dc, ["statistic"]) : null,
+            dc: context.dc
+                ? {
+                      ...R.omit(context.dc, ["statistic"]),
+                      value: context.dc.value,
+                  }
+                : null,
             skipDialog: context.skipDialog,
             isReroll: context.isReroll ?? false,
             outcome: context.outcome ?? null,

--- a/src/module/system/check/check.ts
+++ b/src/module/system/check/check.ts
@@ -304,12 +304,7 @@ class Check {
             title: context.title ?? "PF2E.Check.Label",
             traits: context.traits ?? [],
             substitutions,
-            dc: context.dc
-                ? {
-                      ...R.omit(context.dc, ["statistic"]),
-                      value: context.dc.value,
-                  }
-                : null,
+            dc: context.dc ? R.pick(context.dc, ["label", "scope", "slug", "value", "visible"]) : null,
             skipDialog: context.skipDialog,
             isReroll: context.isReroll ?? false,
             outcome: context.outcome ?? null,


### PR DESCRIPTION
When  `context.dc` is a `StatisticDifficultyClass`, the DC value is a getter and is therefore non-enumerable, causing it to be dropped by the `omit` helper.

Closes #21205 