### PR TITLE
Add suspended respiration ancestry feature to Sarcecian ancestry

### DIFF
--- a/packs/sf2e/ancestries/sarcesian.json
+++ b/packs/sf2e/ancestries/sarcesian.json
@@ -48,6 +48,12 @@
                 "level": 1,
                 "name": "Energy Wings",
                 "uuid": "Compendium.sf2e.ancestry-features.Item.Energy Wings"
+            },
+            "nMNH8": {
+                "img": "systems/sf2e/icons/spells/vacuum.webp",
+                "level": 1,
+                "name": "Suspended Respiration",
+                "uuid": "Compendium.sf2e.ancestry-features.Item.Suspended Respiration"
             }
         },
         "languages": {

--- a/packs/sf2e/ancestry-features/sarcesian/suspended-respiration.json
+++ b/packs/sf2e/ancestry-features/sarcesian/suspended-respiration.json
@@ -1,0 +1,42 @@
+{
+    "_id": "QurWzrxrUpo2ywih",
+    "folder": "q0V6WBmimSXmqjx3",
+    "img": "systems/sf2e/icons/spells/vacuum.webp",
+    "name": "Suspended Respiration",
+    "system": {
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "ancestryfeature",
+        "description": {
+            "value": "<p> You're capable of surviving for a limited time in the void of space, suspending your respiration and shielding your body from its dangerous environmental effects. Whenever you enter a vacuum, you temporarily gain the cosmic trait. You have this trait for as long as you remain in a vacuum, up to a maximum of 1 hour. Creatures with the cosmic trait don't need to breathe while in space or a vacuum and are immune to the harmful environmental effects of being in space.</p>"
+        },
+        "level": {
+            "value": 1
+        },
+        "prerequisites": {
+            "value": []
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Starfinder Galaxy Guide"
+        },
+        "rules": [],
+        "subfeatures": {
+            "proficiencies": {},
+            "senses": {},
+            "suppressedFeatures": []
+        },
+        "traits": {
+            "rarity": "common",
+            "value": [
+                "sarcesian"
+            ]
+        }
+    },
+    "type": "feat"
+}

--- a/packs/sf2e/ancestry-features/sarcesian/suspended-respiration.json
+++ b/packs/sf2e/ancestry-features/sarcesian/suspended-respiration.json
@@ -12,7 +12,7 @@
         },
         "category": "ancestryfeature",
         "description": {
-            "value": "<p> You're capable of surviving for a limited time in the void of space, suspending your respiration and shielding your body from its dangerous environmental effects. Whenever you enter a vacuum, you temporarily gain the cosmic trait. You have this trait for as long as you remain in a vacuum, up to a maximum of 1 hour. Creatures with the cosmic trait don't need to breathe while in space or a vacuum and are immune to the harmful environmental effects of being in space.</p>"
+            "value": "<p>You're capable of surviving for a limited time in the void of space, suspending your respiration and shielding your body from its dangerous environmental effects. Whenever you enter a vacuum, you temporarily gain the cosmic trait. You have this trait for as long as you remain in a vacuum, up to a maximum of 1 hour. Creatures with the cosmic trait don't need to breathe while in space or a vacuum and are immune to the harmful environmental effects of being in space.</p>"
         },
         "level": {
             "value": 1


### PR DESCRIPTION
Fixes https://github.com/foundryvtt/pf2e/issues/21271

Adds a new ancestry feature and includes it in the Sarcesian ancestry by including it in the items list.