### PR TITLE
Update flags.pf2e to flags.sf2e in sf2e packs

### DIFF
--- a/packs/sf2e/bestiary-effects/effect-resonance.json
+++ b/packs/sf2e/bestiary-effects/effect-resonance.json
@@ -73,7 +73,7 @@
             {
                 "key": "FlatModifier",
                 "predicate": [
-                    "{item|flags.pf2e.rulesSelections.element}"
+                    "{item|flags.sf2e.rulesSelections.element}"
                 ],
                 "selector": [
                     "attack",
@@ -86,10 +86,10 @@
             {
                 "key": "FlatModifier",
                 "predicate": [
-                    "self:trait:{item|flags.pf2e.rulesSelections.element}",
+                    "self:trait:{item|flags.sf2e.rulesSelections.element}",
                     "self:trait:elemental",
                     {
-                        "not": "{item|flags.pf2e.rulesSelections.element}"
+                        "not": "{item|flags.sf2e.rulesSelections.element}"
                     }
                 ],
                 "selector": [

--- a/packs/sf2e/feats/skill/level-1/terrain-expertise.json
+++ b/packs/sf2e/feats/skill/level-1/terrain-expertise.json
@@ -77,7 +77,7 @@
             {
                 "key": "FlatModifier",
                 "predicate": [
-                    "terrain:{item|flags.pf2e.rulesSelections.terrain}"
+                    "terrain:{item|flags.sf2e.rulesSelections.terrain}"
                 ],
                 "selector": "survival",
                 "type": "circumstance",

--- a/packs/sf2e/feats/skill/level-1/virtuosic-performer.json
+++ b/packs/sf2e/feats/skill/level-1/virtuosic-performer.json
@@ -80,7 +80,7 @@
             {
                 "key": "FlatModifier",
                 "predicate": [
-                    "action:perform:{item|flags.pf2e.rulesSelections.performanceType}"
+                    "action:perform:{item|flags.sf2e.rulesSelections.performanceType}"
                 ],
                 "selector": "performance",
                 "type": "circumstance",

--- a/packs/sf2e/heritages/human/skilled-human.json
+++ b/packs/sf2e/heritages/human/skilled-human.json
@@ -29,7 +29,7 @@
             {
                 "key": "ActiveEffectLike",
                 "mode": "upgrade",
-                "path": "system.skills.{item|flags.pf2e.rulesSelections.skill}.rank",
+                "path": "system.skills.{item|flags.sf2e.rulesSelections.skill}.rank",
                 "value": "ternary(gte(@actor.level,5),2,1)"
             }
         ],

--- a/packs/sf2e/iconics/navasi/navasi-level-1.json
+++ b/packs/sf2e/iconics/navasi/navasi-level-1.json
@@ -112,7 +112,7 @@
                     {
                         "key": "ActiveEffectLike",
                         "mode": "upgrade",
-                        "path": "system.skills.{item|flags.pf2e.rulesSelections.skill}.rank",
+                        "path": "system.skills.{item|flags.sf2e.rulesSelections.skill}.rank",
                         "value": "ternary(gte(@actor.level,5),2,1)"
                     }
                 ],

--- a/packs/sf2e/iconics/navasi/navasi-level-3.json
+++ b/packs/sf2e/iconics/navasi/navasi-level-3.json
@@ -112,7 +112,7 @@
                     {
                         "key": "ActiveEffectLike",
                         "mode": "upgrade",
-                        "path": "system.skills.{item|flags.pf2e.rulesSelections.skill}.rank",
+                        "path": "system.skills.{item|flags.sf2e.rulesSelections.skill}.rank",
                         "value": "ternary(gte(@actor.level,5),2,1)"
                     }
                 ],

--- a/packs/sf2e/iconics/navasi/navasi-level-5.json
+++ b/packs/sf2e/iconics/navasi/navasi-level-5.json
@@ -112,7 +112,7 @@
                     {
                         "key": "ActiveEffectLike",
                         "mode": "upgrade",
-                        "path": "system.skills.{item|flags.pf2e.rulesSelections.skill}.rank",
+                        "path": "system.skills.{item|flags.sf2e.rulesSelections.skill}.rank",
                         "value": "ternary(gte(@actor.level,5),2,1)"
                     }
                 ],

--- a/packs/sf2e/iconics/navasi/navasi-level-7.json
+++ b/packs/sf2e/iconics/navasi/navasi-level-7.json
@@ -112,7 +112,7 @@
                     {
                         "key": "ActiveEffectLike",
                         "mode": "upgrade",
-                        "path": "system.skills.{item|flags.pf2e.rulesSelections.skill}.rank",
+                        "path": "system.skills.{item|flags.sf2e.rulesSelections.skill}.rank",
                         "value": "ternary(gte(@actor.level,5),2,1)"
                     }
                 ],

--- a/packs/sf2e/spell-effects/spell-effect-dragon-form.json
+++ b/packs/sf2e/spell-effects/spell-effect-dragon-form.json
@@ -283,13 +283,13 @@
                 "uuid": "Compendium.sf2e.actions.Item.Dragon Breath (Dragon Form)"
             },
             {
-                "itemId": "{item|flags.pf2e.itemGrants.dragonBreath.id}",
+                "itemId": "{item|flags.sf2e.itemGrants.dragonBreath.id}",
                 "key": "ItemAlteration",
                 "mode": "override",
                 "property": "description",
                 "value": [
                     {
-                        "text": "PF2E.SpecificRule.DragonForm.DragonBreath.{item|flags.pf2e.rulesSelections.dragonForm.breathShape}.{item|flags.pf2e.rulesSelections.dragonForm.saveType}"
+                        "text": "PF2E.SpecificRule.DragonForm.DragonBreath.{item|flags.sf2e.rulesSelections.dragonForm.breathShape}.{item|flags.sf2e.rulesSelections.dragonForm.saveType}"
                     }
                 ]
             },


### PR DESCRIPTION
Fixes "Failed to resolve injected property" errors for sf2e-native pack items referencing flags.pf2e.rulesSelections.