### PR TITLE
Fix Calculate XP Macro to use the correct XP budget and Award methods

### DIFF
--- a/src/scripts/macros/xp/index.ts
+++ b/src/scripts/macros/xp/index.ts
@@ -50,6 +50,14 @@ const xpSimpleHazardDifferences = new Map([
     [4, 32],
 ]);
 
+const xpCharacterAdjustment = new Map([
+    ['trivial', 10],
+    ['low', 20],
+    ['moderate', 20],
+    ['severe', 30],
+    ['extreme', 40],
+])
+
 function getXPFromMap(partyLevel: number, entityLevel: number, values: Map<number, number>): number {
     // add +1 to all levels to account for -1 levels
     const difference = entityLevel + 1 - (partyLevel + 1);
@@ -83,14 +91,19 @@ export interface EncounterBudgets {
 }
 
 function generateEncounterBudgets(partySize: number): EncounterBudgets {
-    const budget = partySize * 20;
+    const baseBudget = 80;
     return {
-        trivial: Math.floor(budget * 0.5),
-        low: Math.floor(budget * 0.75),
-        moderate: budget,
-        severe: Math.floor(budget * 1.5),
-        extreme: Math.floor(budget * 2),
+        trivial: Math.floor(baseBudget * 0.5) + getXPCharacterAdjustment(partySize, 'trivial'),
+        low: Math.floor(baseBudget * 0.75) + getXPCharacterAdjustment(partySize, 'low'),
+        moderate: baseBudget + getXPCharacterAdjustment(partySize, 'moderate'),
+        severe: Math.floor(baseBudget * 1.5) + getXPCharacterAdjustment(partySize, 'severe'),
+        extreme: Math.floor(baseBudget * 2) + getXPCharacterAdjustment(partySize, 'extreme'),
     };
+}
+
+function getXPCharacterAdjustment(partySize: number, rating: string): number {
+    const partySizeAdjustment = 4 - partySize;
+    return partySizeAdjustment * xpCharacterAdjustment.get(rating)
 }
 
 const rewardEncounterBudgets = generateEncounterBudgets(4);
@@ -143,6 +156,7 @@ function calculateXP(
     const encounterBudgets = generateEncounterBudgets(partySize);
     const rating = calculateEncounterRating(totalXP, encounterBudgets);
     const ratingXP = rewardEncounterBudgets[rating];
+    const xpAwardCharacterAdjustment = getXPCharacterAdjustment(partySize, rating)
     return {
         partyLevel,
         partySize,
@@ -150,7 +164,7 @@ function calculateXP(
         encounterBudgets,
         rating,
         ratingXP,
-        xpPerPlayer: Math.floor((totalXP / partySize) * 4),
+        xpPerPlayer: totalXP - xpAwardCharacterAdjustment,
     };
 }
 

--- a/src/scripts/macros/xp/index.ts
+++ b/src/scripts/macros/xp/index.ts
@@ -103,7 +103,7 @@ function generateEncounterBudgets(partySize: number): EncounterBudgets {
 
 function getXPCharacterAdjustment(partySize: number, rating: string): number {
     const partySizeAdjustment = 4 - partySize;
-    return partySizeAdjustment * xpCharacterAdjustment.get(rating)
+    return partySizeAdjustment * (xpCharacterAdjustment.get(rating) ?? 0)
 }
 
 const rewardEncounterBudgets = generateEncounterBudgets(4);


### PR DESCRIPTION
**Issue**
Currently the system uses the following method to calculate XP Award and Budget `baseXP * 4 / partyCount`, however this isn't RAW.

**Intended Results**

RAW XP award is as follows [1](https://2e.aonprd.com/Rules.aspx?ID=2651&Redirected=1)
> Encounters with adversaries and hazards grant a set amount of XP. When the group overcomes an encounter with creatures or hazards, each character gains XP equal to the total XP of the creatures and hazards in the encounter (**this excludes XP adjustments for different party sizes**; see Party Size for details)

And then the party size page gives a table of encounter budget and adjustments [2](https://2e.aonprd.com/Rules.aspx?ID=2717)


Thus i believe it should probably instead of using the above formula do the following (which I've attempted to do in this PR)

**Encounter Budget** = `BASE XP + (adjustment * extra characters)`
