### PR TITLE
Add an option to report excluded duplicates when building anachronism

### DIFF
--- a/build/anachronism.ts
+++ b/build/anachronism.ts
@@ -186,13 +186,13 @@ for (const contentSystem of contentSystems) {
                 const idOverlap = packPair.idOverlaps.has(d._id);
                 if (idOverlap) {
                     if (reportDuplicates.includes("id"))
-                        reportSkipped.push({ name: d.name, id: d._id ?? "", pack: pack?.id, reason: "same id" });
+                        reportSkipped.push({ name: d.name, id: d._id ?? "", pack: pack?.id, reason: "id" });
                     return false;
                 }
                 const nameOverlap = packPair.nameOverlaps.has(d.name);
                 if (nameOverlap) {
                     if (reportDuplicates.includes("name"))
-                        reportSkipped.push({ name: d.name, id: d._id ?? "", pack: pack?.id, reason: "same name" });
+                        reportSkipped.push({ name: d.name, id: d._id ?? "", pack: pack?.id, reason: "name" });
                     return false;
                 }
                 return !nameOverlap;

--- a/build/anachronism.ts
+++ b/build/anachronism.ts
@@ -354,7 +354,7 @@ for (const contentSystem of contentSystems) {
 
     // Produce report of skipped duplicates
     if (reportSkipped.length > 0) {
-        console.log("Excluded duplicates:");
+        console.log("Excluded entries:");
         for (const pack of R.unique(reportSkipped.map((r) => r.pack))) {
             console.log(` Pack "${pack}":`);
             for (const entry of R.sortBy(

--- a/build/anachronism.ts
+++ b/build/anachronism.ts
@@ -25,6 +25,12 @@ const args = argv
             choices: ["pf2e", "sf2e", "both"],
             default: "both",
         });
+        argv.option("reportDuplicates", {
+            describe: "Report duplicate entries and the reason they were excluded",
+            type: "string",
+            choices: ["off", "id", "name", "all"],
+            default: "off",
+        });
     })
     .help(false)
     .version(false)
@@ -33,6 +39,8 @@ const args = argv
 const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
 const distDir = path.resolve(__dirname, "..", "dist");
 const contentSystems = args.system === "both" ? (["pf2e", "sf2e"] as const) : [args.system];
+const reportDuplicates =
+    args.reportDuplicates === "off" ? [] : args.reportDuplicates === "all" ? ["id", "name"] : [args.reportDuplicates];
 
 /** Root module file contents of anachronism. This should be moved to a file somewhere. */
 const moduleSourceContents = String.raw`
@@ -79,7 +87,11 @@ const packPairs = allPackDirs.map((dir) => {
 
     // Get all overlaps between the two systems, which we need to redirect and not export
     // JournalEntries do not redirect, as they may be linked to by content in each system
-    const overlaps =
+    const idOverlaps =
+        manifestData.type === "JournalEntry"
+            ? new Set()
+            : new Set(pf2e?.data.map((d) => d._id)).intersection(new Set(sf2e?.data.map((d) => d._id)));
+    const nameOverlaps =
         manifestData.type === "JournalEntry"
             ? new Set()
             : new Set(pf2e?.data.map((d) => d.name)).intersection(new Set(sf2e?.data.map((d) => d.name)));
@@ -90,7 +102,8 @@ const packPairs = allPackDirs.map((dir) => {
         pf2e,
         sf2e,
         duplicated: new Set(duplicated),
-        overlaps,
+        idOverlaps,
+        nameOverlaps,
         get: (system: SystemId, idOrName: string): PackEntry | null => {
             const mapping = system === "pf2e" ? pf2eMap : sf2eMap;
             return mapping[idOrName] ?? null;
@@ -123,6 +136,7 @@ for (const contentSystem of contentSystems) {
     const targetSystem = contentSystem === "pf2e" ? "sf2e" : "pf2e";
     const contentPacks: CompendiumPack[] = [];
     console.log(`Starting ${contentSystem}-anachronism build`);
+    const reportSkipped: { name: string; id: string; pack: string; reason: string }[] = [];
 
     /**
      * Creates a resolver to convert pack/doctype/doc name data for the build
@@ -141,7 +155,8 @@ for (const contentSystem of contentSystems) {
 
         const duplicated = targetSystem === "sf2e" && pair.duplicated.has(name);
         const useTargetSystem =
-            !!entryInTargetSystem && (!entryInContentSystem || pair.overlaps.has(name) || duplicated);
+            !!entryInTargetSystem &&
+            (!entryInContentSystem || pair.idOverlaps.has(name) || pair.nameOverlaps.has(name) || duplicated);
         const packageId = useTargetSystem ? targetSystem : `${contentSystem}-anachronism`;
         const packId = useTargetSystem ? pair[targetSystem]!.id : pair[contentSystem]!.dirName;
         const resolvedEntry = useTargetSystem ? entryInTargetSystem : entryInContentSystem;
@@ -167,7 +182,21 @@ for (const contentSystem of contentSystems) {
         if (!pack) continue;
 
         const data = pack.data
-            .filter((d) => !packPair.overlaps.has(d.name))
+            .filter((d) => {
+                const idOverlap = packPair.idOverlaps.has(d._id);
+                if (idOverlap) {
+                    if (reportDuplicates.includes("id"))
+                        reportSkipped.push({ name: d.name, id: d._id ?? "", pack: pack?.id, reason: "same id" });
+                    return false;
+                }
+                const nameOverlap = packPair.nameOverlaps.has(d.name);
+                if (nameOverlap) {
+                    if (reportDuplicates.includes("name"))
+                        reportSkipped.push({ name: d.name, id: d._id ?? "", pack: pack?.id, reason: "same name" });
+                    return false;
+                }
+                return !nameOverlap;
+            })
             .map((entry) => {
                 entry = recursiveReplaceString(entry, (s) => {
                     s = s.replaceAll(`systems/${contentSystem}`, `systems/${targetSystem}`);
@@ -236,15 +265,19 @@ for (const contentSystem of contentSystems) {
                 const contentPack = pair[contentSystem];
                 const targetPack = pair[targetSystem];
                 if (!contentPack || !targetPack) return result;
-                for (const overlap of pair.overlaps) {
+                for (const id of pair.idOverlaps) {
+                    const docType = pair.docType;
+                    const originUUID = `Compendium.${contentSystem}.${contentPack.id}.${docType}.${id}`;
+                    const targetUUID = `Compendium.${targetSystem}.${targetPack.id}.${docType}.${id}`;
+                    result[originUUID] = targetUUID;
+                }
+                for (const name of pair.nameOverlaps) {
                     const docType = pair.docType;
                     const originId = (
-                        contentPack.data.find((d) => d.name === overlap) ??
-                        targetPack.data.find((d) => d.name === overlap)
+                        contentPack.data.find((d) => d.name === name) ?? targetPack.data.find((d) => d.name === name)
                     )?._id;
                     const targetId = (
-                        targetPack.data.find((d) => d.name === overlap) ??
-                        contentPack.data.find((d) => d.name === overlap)
+                        targetPack.data.find((d) => d.name === name) ?? contentPack.data.find((d) => d.name === name)
                     )?._id;
                     const originUUID = `Compendium.${contentSystem}.${contentPack.id}.${docType}.${originId}`;
                     const targetUUID = `Compendium.${targetSystem}.${targetPack.id}.${docType}.${targetId}`;
@@ -318,6 +351,20 @@ for (const contentSystem of contentSystems) {
         await db.close();
     }
     console.log(`Finished building ${contentSystem}-anachronism`);
+
+    // Produce report of skipped duplicates
+    if (reportSkipped.length > 0) {
+        console.log("Excluded duplicates:");
+        for (const pack of R.unique(reportSkipped.map((r) => r.pack))) {
+            console.log(` Pack "${pack}":`);
+            for (const entry of R.sortBy(
+                reportSkipped.filter((r) => r.pack === pack),
+                R.prop("name"),
+            )) {
+                console.log("   " + ` [${entry.id ?? " ".repeat(16)}] ` + entry.name + ` (${entry.reason})`);
+            }
+        }
+    }
 }
 
 /** A simple uuid remapper function */

--- a/build/anachronism.ts
+++ b/build/anachronism.ts
@@ -136,7 +136,7 @@ for (const contentSystem of contentSystems) {
     const targetSystem = contentSystem === "pf2e" ? "sf2e" : "pf2e";
     const contentPacks: CompendiumPack[] = [];
     console.log(`Starting ${contentSystem}-anachronism build`);
-    const reportSkipped: { name: string; id: string; pack: string; reason: string }[] = [];
+    const skippedEntries: { name: string; id: string; pack: string; reason: string }[] = [];
 
     /**
      * Creates a resolver to convert pack/doctype/doc name data for the build
@@ -186,13 +186,13 @@ for (const contentSystem of contentSystems) {
                 const idOverlap = packPair.idOverlaps.has(d._id);
                 if (idOverlap) {
                     if (reportDuplicates.includes("id"))
-                        reportSkipped.push({ name: d.name, id: d._id ?? "", pack: pack?.id, reason: "id" });
+                        skippedEntries.push({ name: d.name, id: d._id ?? "", pack: pack?.id, reason: "id" });
                     return false;
                 }
                 const nameOverlap = packPair.nameOverlaps.has(d.name);
                 if (nameOverlap) {
                     if (reportDuplicates.includes("name"))
-                        reportSkipped.push({ name: d.name, id: d._id ?? "", pack: pack?.id, reason: "name" });
+                        skippedEntries.push({ name: d.name, id: d._id ?? "", pack: pack?.id, reason: "name" });
                     return false;
                 }
                 return !nameOverlap;
@@ -353,12 +353,12 @@ for (const contentSystem of contentSystems) {
     console.log(`Finished building ${contentSystem}-anachronism`);
 
     // Produce report of skipped duplicates
-    if (reportSkipped.length > 0) {
+    if (skippedEntries.length > 0) {
         console.log("Excluded entries:");
-        for (const pack of R.unique(reportSkipped.map((r) => r.pack))) {
+        for (const pack of R.unique(skippedEntries.map((r) => r.pack))) {
             console.log(` Pack "${pack}":`);
             for (const entry of R.sortBy(
-                reportSkipped.filter((r) => r.pack === pack),
+                skippedEntries.filter((r) => r.pack === pack),
                 R.prop("name"),
             )) {
                 console.log("   " + ` [${entry.id ?? " ".repeat(16)}] ` + entry.name + ` (${entry.reason})`);


### PR DESCRIPTION
Primarily for ironing out which duplicates should stay.

Produces a report on duplicates including the reason they were skipped - id or name. It prioritizes ids (so if the entry was skipped due to id match, it won't report is as a name match)
<img width="354" height="299" alt="image" src="https://github.com/user-attachments/assets/b5f4fbf3-3e05-409f-a495-cee455ae26ae" />
<img width="380" height="293" alt="image" src="https://github.com/user-attachments/assets/d64baa67-a95e-44d4-b662-1f5529bbfc65" />
<img width="406" height="395" alt="image" src="https://github.com/user-attachments/assets/991f74d2-6612-4b4c-8149-83a50f656601" />

It does have a side effect of excluding entries by id (I could have just ignored the id duplicates, but it didn't seem right to me).