### PR TITLE
Update some Choice Sets to use spell rank config list

### DIFF
--- a/packs/pf2e/feat-effects/effect-energy-ablation.json
+++ b/packs/pf2e/feat-effects/effect-energy-ablation.json
@@ -31,51 +31,12 @@
             },
             {
                 "adjustName": false,
-                "choices": [
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.First",
-                        "value": 1
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Second",
-                        "value": 2
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Third",
-                        "value": 3
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Fourth",
-                        "value": 4
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Fifth",
-                        "value": 5
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Sixth",
-                        "value": 6
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Seventh",
-                        "value": 7
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Eighth",
-                        "value": 8
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Ninth",
-                        "value": 9
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Tenth",
-                        "value": 10
-                    }
-                ],
+                "choices": {
+                    "config": "rank"
+                },
                 "flag": "energyAblationRank",
                 "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.SpellRank.Prompt"
+                "prompt": "PF2E.SpecificRule.Prompt.Rank"
             },
             {
                 "key": "Resistance",

--- a/packs/pf2e/feat-effects/effect-kindling.json
+++ b/packs/pf2e/feat-effects/effect-kindling.json
@@ -22,51 +22,12 @@
         },
         "rules": [
             {
-                "choices": [
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.First",
-                        "value": 1
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Second",
-                        "value": 2
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Third",
-                        "value": 3
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Fourth",
-                        "value": 4
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Fifth",
-                        "value": 5
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Sixth",
-                        "value": 6
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Seventh",
-                        "value": 7
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Eighth",
-                        "value": 8
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Ninth",
-                        "value": 9
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Tenth",
-                        "value": 10
-                    }
-                ],
+                "choices": {
+                    "config": "rank"
+                },
                 "flag": "rank",
                 "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.SpellRank.Prompt"
+                "prompt": "PF2E.SpecificRule.Prompt.Rank"
             },
             {
                 "key": "FlatModifier",

--- a/packs/sf2e/feat-effects/effect-spellsurge-ammo.json
+++ b/packs/sf2e/feat-effects/effect-spellsurge-ammo.json
@@ -24,51 +24,12 @@
         "rules": [
             {
                 "adjustName": false,
-                "choices": [
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.First",
-                        "value": 1
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Second",
-                        "value": 2
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Third",
-                        "value": 3
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Fourth",
-                        "value": 4
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Fifth",
-                        "value": 5
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Sixth",
-                        "value": 6
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Seventh",
-                        "value": 7
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Eighth",
-                        "value": 8
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Ninth",
-                        "value": 9
-                    },
-                    {
-                        "label": "PF2E.SpecificRule.SpellRank.Tenth",
-                        "value": 10
-                    }
-                ],
+                "choices": {
+                    "config": "rank"
+                },
                 "flag": "rank",
                 "key": "ChoiceSet",
-                "prompt": "PF2E.SpecificRule.SpellRank.Prompt"
+                "prompt": "PF2E.SpecificRule.Prompt.Rank"
             },
             {
                 "adjustName": false,


### PR DESCRIPTION
There's others, but those have predicates in their choices that would end up worse as config.