### PR TITLE
Convert all boons and curses to feats

### DIFF
--- a/packs/pf2e/boons-and-curses/achaekek-major-boon.json
+++ b/packs/pf2e/boons-and-curses/achaekek-major-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>You gain the @UUID[Compendium.pf2e.classfeatures.Item.Sneak Attack] rogue class feature, dealing 3d6 precision damage. If you already have that class feature, you increase your sneak attack damage by 3d6.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -46,17 +40,20 @@
                 "selector": "strike-damage"
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/achaekek-major-curse.json
+++ b/packs/pf2e/boons-and-curses/achaekek-major-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>The Mantis God doesn't waste his time toying with or tormenting those who truly anger him or those who dare to consider themselves divine. He rips open a portal to your location, kills you, drags your soul to judgment in a way that prevents resurrection magic, and then leaves.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Adventure: Prey for Death"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/achaekek-minor-boon.json
+++ b/packs/pf2e/boons-and-curses/achaekek-minor-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Once, when you would fail a Stealth check, you critically succeed instead.</p>\n<p>Achaekek typically grants this boon for an extremely consequential Stealth check that could lead to an assassination, such as one that could get you into position to kill an important target, but rarely on a Stealth check to help you escape.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -32,17 +26,20 @@
                 "visibility": "gm"
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/achaekek-minor-curse.json
+++ b/packs/pf2e/boons-and-curses/achaekek-minor-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Non-sapient insects (especially mantises) become hostile against you.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Adventure: Prey for Death"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/achaekek-moderate-boon.json
+++ b/packs/pf2e/boons-and-curses/achaekek-moderate-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>You can cast @UUID[Compendium.pf2e.spells-srd.Item.Blood Vendetta] once per day as an innate divine spell; this spell automatically heightens to a rank equal to your half your level.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Adventure: Prey for Death"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/achaekek-moderate-curse.json
+++ b/packs/pf2e/boons-and-curses/achaekek-moderate-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Hubris brings death. Your name and location are projected into the mind of a Red Mantis assassin, who is tasked with eliminating you.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Adventure: Prey for Death"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/alseta-major-boon.json
+++ b/packs/pf2e/boons-and-curses/alseta-major-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>You transition unimpeded through the world.</p>\n<p>You can open any door or portal simply by placing your palm upon it with a single Interact action, even if it's locked or magically sealed, and you can enter any open door or threshold, even if it's magically warded to prevent entry. This doesn't overcome the locks and magic of artifacts, deities, and similarly powerful effects.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/alseta-major-curse.json
+++ b/packs/pf2e/boons-and-curses/alseta-major-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Transportation magic no longer works for you. You cannot be transported by any magical means, nor can you transport, conjure, or summon others. Even extradimensional spaces like @UUID[Compendium.pf2e.equipment-srd.Item.Spacious Pouch (Type I)]{bags of holding} are inaccessible and unusable to you, as using them requires magical transportation to the extradimensional space.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/alseta-minor-boon.json
+++ b/packs/pf2e/boons-and-curses/alseta-minor-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Alseta's guiding hand aids your journeys.</p>\n<p>Once, when employing teleportation magic, you appear exactly on target, even if you used a notoriously imprecise spell like @UUID[Compendium.pf2e.spells-srd.Item.Interplanar Teleport].</p>\n<p>Alseta typically grants this boon for extremely consequential magical travel, especially when time is of the essence.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/alseta-minor-curse.json
+++ b/packs/pf2e/boons-and-curses/alseta-minor-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Doors jam and locks stick when you try to open them. It takes 3 @UUID[Compendium.pf2e.actionspf2e.Item.Interact] actions for you to open even an unlocked door, and each attempt to @UUID[Compendium.pf2e.actionspf2e.Item.Pick a Lock] takes you 2 rounds instead of 2 actions.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/alseta-moderate-boon.json
+++ b/packs/pf2e/boons-and-curses/alseta-moderate-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>New doors open themselves for you. You can cast @UUID[Compendium.pf2e.spells-srd.Item.Knock] once per day as a divine innate spell.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/alseta-moderate-curse.json
+++ b/packs/pf2e/boons-and-curses/alseta-moderate-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Crossing thresholds becomes daunting. Whenever you move through a portal, gateway, or door, you gain the @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 2} condition. Magical travel is even more exhausting; after traveling via teleportation, @UUID[Compendium.pf2e.spells-srd.Item.Interplanar Teleport], or the like, you also gain the @UUID[Compendium.pf2e.conditionitems.Item.Fatigued] condition until you get a full night's rest.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/arazni-major-boon.json
+++ b/packs/pf2e/boons-and-curses/arazni-major-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Upon death, you return to life with the effects of a critical success on a @UUID[Compendium.pf2e.spells-srd.Item.Resurrect] ritual to enact vengeance against your killers. When you successfully achieve vengeance, abandon your vengeance for other pursuits, or fail outright, you crumble to scarlet dust.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/arazni-major-curse.json
+++ b/packs/pf2e/boons-and-curses/arazni-major-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>When you would regain Hit Points due to either a vitality or void effect, you lose that many Hit Points instead.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/arazni-minor-boon.json
+++ b/packs/pf2e/boons-and-curses/arazni-minor-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Once, when you fail a saving throw against an effect that would compel you to take some action against your will, you critically succeed instead.</p>\n<p>Arazni typically grants this boon for consequential actions or particularly egregious violations of free will.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/arazni-minor-curse.json
+++ b/packs/pf2e/boons-and-curses/arazni-minor-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Someone you've wronged gains information they desire about you, with the effects of a critical success at the @UUID[Compendium.pf2e.spells-srd.Item.Commune] ritual.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/arazni-moderate-boon.json
+++ b/packs/pf2e/boons-and-curses/arazni-moderate-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Blood from your wounds forms into armor or a piece of equipment you need. If what you need most is information, the blood forms letters spelling out that information.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/arazni-moderate-curse.json
+++ b/packs/pf2e/boons-and-curses/arazni-moderate-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Creatures weaker than you gain a status bonus on all attack rolls against you equal to your difference in levels, to a maximum of +4. Whenever you are damaged by a such a creature, you take persistent bleed damage equal to twice the difference between your levels (no maximum).</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/besmara-major-boon.json
+++ b/packs/pf2e/boons-and-curses/besmara-major-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>You seem to be unaffected by storms.</p>\n<p>You ignore all effects and penalties caused by precipitation and winds, and you can see normally through fog, rain, and other weather conditions.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/besmara-major-curse.json
+++ b/packs/pf2e/boons-and-curses/besmara-major-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>You meet extreme financial ruin for daring to gravely offend the Pirate Queen. Besmara's agents steal all your booty and bring the spoils to Besmara's ship, <em>Seawraith</em>. If you want a chance to recover your lost wealth, you must parlay with the goddess and accept whatever dangerous terms she offers, usually requiring a heist she will find sufficiently amusing to watch whether you succeed or fail, and requiring you to trade your spoils from that quest for your previous belongings.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/besmara-minor-boon.json
+++ b/packs/pf2e/boons-and-curses/besmara-minor-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Besmara wants you to amuse her, placing both plunder and peril in your path.</p>\n<p>This intercession often takes the form of an unexpected treasure map, a message in a bottle, or some other sign leading you to a great reward, assuming you can handle the challenges along the way.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/besmara-minor-curse.json
+++ b/packs/pf2e/boons-and-curses/besmara-minor-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>You feel some of the effects of scurvy, making your wounds flow more easily. The DC of the flat check for you to remove persistent bleed damage is 20 instead of 15 (or 15 instead of 10 if using extremely efficient methods to assist your recovery), and you don't recover from persistent bleed damage automatically when you reach full Hit Points.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -32,17 +26,20 @@
                 "value": 20
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/besmara-moderate-boon.json
+++ b/packs/pf2e/boons-and-curses/besmara-moderate-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>You are at home on the seas and always ready to plunder an enemy vessel or defend your own. When aboard a boat, you gain a +2 status bonus to all initiative rolls, Acrobatics checks to @UUID[Compendium.pf2e.actionspf2e.Item.Balance], and Athletics checks to @UUID[Compendium.pf2e.actionspf2e.Item.Climb]. In addition, you never get seasick.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -51,17 +45,20 @@
                 "value": 2
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/besmara-moderate-curse.json
+++ b/packs/pf2e/boons-and-curses/besmara-moderate-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>You get seasick, becoming @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 2} whenever you can see the sea or are on a boat at sea. You can't reduce this condition until you can no longer see the sea or are off the boat, though you can manage to stomach enough food and water to survive on a voyage, with extreme discomfort.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/brigh-major-boon.json
+++ b/packs/pf2e/boons-and-curses/brigh-major-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>You gain the companionship of a loyal construct ally of Brigh's choice at least 1 level lower than you. If the construct is destroyed, it rebuilds itself over the course of a week, and as you gain levels, the construct upgrades and improves itself, becoming more powerful.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/brigh-major-curse.json
+++ b/packs/pf2e/boons-and-curses/brigh-major-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Constructs—even mindless constructs you thought you could control—seek your demise. All constructs are hostile to you and attack you when they notice your presence. Occasionally, inanimate statues and other objects animate as constructs to pursue Brigh's vengeance.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/brigh-minor-boon.json
+++ b/packs/pf2e/boons-and-curses/brigh-minor-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Knowledge floods your mind.</p>\n<p>Once, you can reroll a failed skill check to @UUID[Compendium.pf2e.actionspf2e.Item.Recall Knowledge]; you must use the second result, even if it's worse.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/brigh-minor-curse.json
+++ b/packs/pf2e/boons-and-curses/brigh-minor-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Your hands shake when attempting delicate work. All your failures to @UUID[Compendium.pf2e.actionspf2e.Item.Craft] or @UUID[Compendium.pf2e.actionspf2e.Item.Repair] items are instead critical failures.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -37,17 +31,20 @@
                 "selector": "skill-check"
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/brigh-moderate-boon.json
+++ b/packs/pf2e/boons-and-curses/brigh-moderate-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>You become a wellspring of invention. You gain the @UUID[Compendium.pf2e.feats-srd.Item.Inventor] feat, even if you don't meet its prerequisites, and when you roll a Crafting check for the Inventor feat, you use the result one degree of success better than the result you rolled.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -26,17 +20,20 @@
                 "uuid": "Compendium.pf2e.feats-srd.Item.Inventor"
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/brigh-moderate-curse.json
+++ b/packs/pf2e/boons-and-curses/brigh-moderate-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Whenever you try to perform engineering or science tasks, everything just seems to explode. Whenever you attempt to create or use an alchemical item or a construct, @UUID[Compendium.pf2e.actionspf2e.Item.Disable a Device], and so on, you must attempt a @Check[flat|dc:15]. On a failure, something explodes and you take @Damage[1d6[fire]] damage (or a different type of damage, if appropriate) per level of the item, construct, or device (@Check[reflex|dc:40|basic] save).</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/casandalee-major-boon.json
+++ b/packs/pf2e/boons-and-curses/casandalee-major-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Casandalee backs up your memory and soul within her divine data flow.</p>\n<p>After you die, she casts your consciousness into a new artificial body. While Casandalee constructed your new body artificially, it is otherwise similar to the old, with the same effects as a critical success on a @UUID[Compendium.pf2e.spells-srd.Item.Resurrect] ritual. Casandalee is instead willing to provide different bodies to those who request them.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/casandalee-major-curse.json
+++ b/packs/pf2e/boons-and-curses/casandalee-major-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>The code of your soul is constantly being rewritten, and not for the better. You are never temporarily immune against a harmful effect.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/casandalee-minor-boon.json
+++ b/packs/pf2e/boons-and-curses/casandalee-minor-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Casandalee frees your thinking from dangerous control.</p>\n<p>Once, when you fail a Will save against an effect that would control your actions, you critically succeed instead.</p>\n<p>Casandalee typically grants this boon for particularly consequential violations of autonomy and agency.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/casandalee-minor-curse.json
+++ b/packs/pf2e/boons-and-curses/casandalee-minor-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Your joints stiffen, and your mind becomes clouded. You take a -2 status penalty to all rolls for initiative.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -28,17 +22,20 @@
                 "value": -2
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/casandalee-moderate-boon.json
+++ b/packs/pf2e/boons-and-curses/casandalee-moderate-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Your organs are partially transformed into mechanical counterparts. You gain resistance 10 to void damage, and the DC of your flat check to remove persistent bleed damage is only 5.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -37,17 +31,20 @@
                 "value": 5
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/casandalee-moderate-curse.json
+++ b/packs/pf2e/boons-and-curses/casandalee-moderate-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Casandalee attempts to bring you unwanted intellectual advancement to help you become something better. Each day, at some point during the day, Casandalee bestows a strange insight upon you that you find uncomfortable. If you embrace it, you aren't otherwise affected, but if you don't, you become @UUID[Compendium.pf2e.conditionitems.Item.Confused] for 10 minutes.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/chaldira-major-boon.json
+++ b/packs/pf2e/boons-and-curses/chaldira-major-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Chaldira's major boon grants truly improbable luck in combat.</p>\n<p>Your movement doesn't trigger reactions. You always succeed at flat checks you make to hit opponents with attack actions; this is a fortune effect.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/chaldira-major-curse.json
+++ b/packs/pf2e/boons-and-curses/chaldira-major-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Ill luck causes even once-certain aid to fail with frustrating regularity. You cannot benefit from circumstance or status bonuses, or from fortune effects.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -38,17 +32,20 @@
                 "suppress": true
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/chaldira-minor-boon.json
+++ b/packs/pf2e/boons-and-curses/chaldira-minor-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Once, you can choose the result of the next ordinary coin you flip or ordinary die you roll. If this ability is used for personal gain at the expense of someone innocent or less fortunate, Chaldira levies her moderate curse on you as punishment.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/chaldira-minor-curse.json
+++ b/packs/pf2e/boons-and-curses/chaldira-minor-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Any time you refuse a request made in good faith, you vomit up a frog, mouse, or other small animal. This deals no damage and causes no conditions, but is obvious to all bystanders.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/chaldira-moderate-boon.json
+++ b/packs/pf2e/boons-and-curses/chaldira-moderate-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>You gain a lucky impetuousness, allowing you to roll for initiative twice and use the higher result once per day. This is a fortune effect.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/chaldira-moderate-curse.json
+++ b/packs/pf2e/boons-and-curses/chaldira-moderate-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>You are plagued with ill luck just when fortune is most needed. You must always roll flat checks twice and use the worse result. This is a misfortune effect.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -27,17 +21,20 @@
                 "selector": "all"
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/ghlaunder-major-boon.json
+++ b/packs/pf2e/boons-and-curses/ghlaunder-major-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Ghlaunder rewards his followers with the ability to safely spread illness—or on occasion, offers respite to desperate petitioners who please him.</p>\n<p>You do not take negative effects from any disease you are infected with unless or until Ghlaunder rescinds this benefit.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/ghlaunder-major-curse.json
+++ b/packs/pf2e/boons-and-curses/ghlaunder-major-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>You are struck with a contagious disease of the GM's choice. You and anyone else you infect can't be cured of the disease or improve its condition to an earlier stage in any way until you infect two other sapient beings with the disease.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/ghlaunder-minor-boon.json
+++ b/packs/pf2e/boons-and-curses/ghlaunder-minor-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Your commitment to filth draws a small cloud of disease-laden insects.</p>\n<p>Once, you can summon a cloud of midges, mosquitos, and flies to surround you for 1 minute. Creatures adjacent to you at any point during that time become @UUID[Compendium.pf2e.conditionitems.Item.Drained]{Drained 1}, @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 1}, and exposed to a blood-borne illness.</p>\n<p>Ghlaunder typically grants this boon when you can infect a significant number of creatures.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/ghlaunder-minor-curse.json
+++ b/packs/pf2e/boons-and-curses/ghlaunder-minor-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Ghlaunder drains away your life force for himself. You become @UUID[Compendium.pf2e.conditionitems.Item.Drained]{Drained 1} and can't reduce your drained condition below 1.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -27,17 +21,20 @@
                 "uuid": "Compendium.pf2e.conditionitems.Item.Drained"
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/ghlaunder-moderate-boon.json
+++ b/packs/pf2e/boons-and-curses/ghlaunder-moderate-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Ghlaunder teaches you to bide your time, corrupting and infecting until the time is right. When you expose a creature to a disease and it succeeds at its Fortitude save, it is still infected unless it critically succeeds. However, such a creature experiences no effects and the disease does not progress for the first 24 hours, even if the disease is normally fast-acting or someone uses another ability to progress the disease. It's very difficult to detect the infection in the first day; the DC for Medicine checks to do so is 5 higher.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/ghlaunder-moderate-curse.json
+++ b/packs/pf2e/boons-and-curses/ghlaunder-moderate-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Ghlaunder leeches your energy from you as easily as blood. Any time you fail a Fortitude save, you become @UUID[Compendium.pf2e.conditionitems.Item.Fatigued] in addition to all other effects.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -32,17 +26,20 @@
                 "title": "{item|name}"
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/grandmother-spider-major-boon.json
+++ b/packs/pf2e/boons-and-curses/grandmother-spider-major-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Grandmother Spider rejoices in freedom and tricks those who would limit it.</p>\n<p>Any time you would become @UUID[Compendium.pf2e.conditionitems.Item.Grabbed], @UUID[Compendium.pf2e.conditionitems.Item.Immobilized], or @UUID[Compendium.pf2e.conditionitems.Item.Restrained], attempt a @Check[flat|dc:10]. On a success, you ignore the effect, and the originator of the effect becomes grabbed, immobilized, or restrained instead. If this simply causes a creature to grab itself, it can usually @UUID[Compendium.pf2e.actionspf2e.Item.Escape] as a free action, but it might be stuck if it tried to immobilize you in other ways.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/grandmother-spider-major-curse.json
+++ b/packs/pf2e/boons-and-curses/grandmother-spider-major-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Grandmother Spider throws all of her might behind the underdog. Any time a creature with a level lower than yours rolls a success on a check against you, it critically succeeds instead; any time you roll a failure on a check against a creature with a level lower than yours, you critically fail instead.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -53,17 +47,20 @@
                 "selector": "check"
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/grandmother-spider-minor-boon.json
+++ b/packs/pf2e/boons-and-curses/grandmother-spider-minor-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Grandmother Spider rescues your prank from the jaws of failure.</p>\n<p>Once, when you would fail a Deception check, you critically succeed instead.</p>\n<p>Grandmother Spider typically grants this boon for deceptions that are necessary for an interesting or consequential prank.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/grandmother-spider-minor-curse.json
+++ b/packs/pf2e/boons-and-curses/grandmother-spider-minor-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>When your pranks start going wrong, they dissolve into a string of catastrophic failures. When you roll a failure on a Deception or Stealth check, you get a critical failure instead.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -36,17 +30,20 @@
                 "selector": "stealth"
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/grandmother-spider-moderate-boon.json
+++ b/packs/pf2e/boons-and-curses/grandmother-spider-moderate-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>You can feel tugs on the strands of fate. You gain a +2 status bonus to initiative rolls.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -28,17 +22,20 @@
                 "value": 2
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/grandmother-spider-moderate-curse.json
+++ b/packs/pf2e/boons-and-curses/grandmother-spider-moderate-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Grandmother Spider weaves a web to ensnare you, and you trail webs behind you wherever you go. You become permanently @UUID[Compendium.pf2e.conditionitems.Item.Slowed]{Slowed 1} and take a –10-foot circumstance penalty to your Speeds.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -33,17 +27,20 @@
                 "value": -10
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/groetus-major-boon.json
+++ b/packs/pf2e/boons-and-curses/groetus-major-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Your touch unravels things that have survived past their appointed time, according to Groetus's reckoning.</p>\n<p>Such a creature or object takes @Damage[10d6[void]] damage each round you continue touching it; the damage ignores all Hardness and is capable of destroying nonliving objects, creatures immune to void effects, and even undead or other creatures with void healing. This boon might even be able to destroy some artifacts that have survived past their time.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/groetus-major-curse.json
+++ b/packs/pf2e/boons-and-curses/groetus-major-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>You bring about the end to everything around you. Every item you carry or wear gains the @UUID[Compendium.pf2e.conditionitems.Item.Broken] condition after 10 minutes of exposure to you, and is destroyed after a further hour. This effect can't destroy artifacts or items of similar power.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/groetus-minor-boon.json
+++ b/packs/pf2e/boons-and-curses/groetus-minor-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>You wield power over disorder.</p>\n<p>Once, when you are @UUID[Compendium.pf2e.conditionitems.Item.Confused], you act normally enough to control your own actions in combat without penalty for the duration, though you still babble incoherently and otherwise behave strangely.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/groetus-minor-curse.json
+++ b/packs/pf2e/boons-and-curses/groetus-minor-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Whenever you are illuminated by a light source other than natural sunlight, your head appears to be a bare skull. The DC for your recovery checks is 12 + your dying value, rather than 10 + your dying value, and you don't benefit from effects that reduce the DC, such as from the @UUID[Compendium.pf2e.feats-srd.Item.Toughness] feat.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -28,17 +22,20 @@
                 "value": 12
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/groetus-moderate-boon.json
+++ b/packs/pf2e/boons-and-curses/groetus-moderate-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Groetus grants you knowledge to further the end times. Each week, he sends you a cryptic, incoherent message about something important to the end times that will happen in the coming week.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/groetus-moderate-curse.json
+++ b/packs/pf2e/boons-and-curses/groetus-moderate-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>The horrors at the end of reality become overwhelming and constantly race through your mind. You are permanently @UUID[Compendium.pf2e.conditionitems.Item.Stupefied]{Stupefied 2}.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -34,17 +28,20 @@
                 "uuid": "Compendium.pf2e.conditionitems.Item.Stupefied"
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/gruhastha-major-boon.json
+++ b/packs/pf2e/boons-and-curses/gruhastha-major-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>You are a divine inspiration to others around you.</p>\n<p>When attempting any checks to @UUID[Compendium.pf2e.actionspf2e.Item.Recall Knowledge], you can roll twice and use the better result; this is a fortune effect. Additionally, allies within 60 feet gain a +2 status bonus to Will saves.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -42,17 +36,20 @@
                 "slug": "gruhastha-major-boon"
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/gruhastha-major-curse.json
+++ b/packs/pf2e/boons-and-curses/gruhastha-major-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>The written word turns against you, blurring into illegibility. You are incapable of reading anything or making out symbols of any sort, including the words on scrolls, spellbooks, or magic items.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/gruhastha-minor-boon.json
+++ b/packs/pf2e/boons-and-curses/gruhastha-minor-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Books fall open to insightful passages, and memories spring to mind when they are most needed.</p>\n<p>Once, when you fail a check to @UUID[Compendium.pf2e.actionspf2e.Item.Recall Knowledge], you critically succeed instead.</p>\n<p>Gruhastha typically grants this boon for an extremely consequential attempt to Recall Knowledge, particularly when misinformation would have dire consequences.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/gruhastha-minor-curse.json
+++ b/packs/pf2e/boons-and-curses/gruhastha-minor-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>As you stray from the truth, dissonant notes seem to interrupt you whenever you speak. You take a -2 status penalty to all Deception checks.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -28,17 +22,20 @@
                 "value": -2
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/gruhastha-moderate-boon.json
+++ b/packs/pf2e/boons-and-curses/gruhastha-moderate-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>The Keeper speeds your path toward learning new talents. You become permanently trained in two additional skills of your choice. Additionally, you can select a skill you are already trained in and permanently increase your proficiency rank in that skill, following the usual rules for skill increases.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -95,17 +89,20 @@
                 "value": 1
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/gruhastha-moderate-curse.json
+++ b/packs/pf2e/boons-and-curses/gruhastha-moderate-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Enlightenment begins to elude you, leaving you at a loss for knowledge. Whenever you attempt a check to @UUID[Compendium.pf2e.actionspf2e.Item.Recall Knowledge], you use a result one degree of success worse than the result you rolled.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -32,17 +26,20 @@
                 "selector": "skill-check"
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/hei-feng-major-boon.json
+++ b/packs/pf2e/boons-and-curses/hei-feng-major-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>The instruments of the storm spare you from their fury.</p>\n<p>You ignore all effects and penalties caused by precipitation and winds, and you can see normally through fog, rain, and other weather conditions.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/hei-feng-major-curse.json
+++ b/packs/pf2e/boons-and-curses/hei-feng-major-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>The Duke of Thunder's ire follows you wherever you go. The weather in a 500-foot radius around you is always stormy. Roughly twice each minute you are outside, you are struck by a bolt of lightning that deals @Damage[10d6[electricity]] damage (@Check[reflex|dc:40|basic] save).</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/hei-feng-minor-boon.json
+++ b/packs/pf2e/boons-and-curses/hei-feng-minor-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>The Heavenly Court's most boastful deity ensures your boasts hit home.</p>\n<p>Once, when you fail an Intimidation check, you critically succeed instead.</p>\n<p>Hei Feng grants this boon capriciously based on his mood, sometimes even for trivial or inconsequential boasts, and he sometimes grants it for other skill checks related to boasts.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/hei-feng-minor-curse.json
+++ b/packs/pf2e/boons-and-curses/hei-feng-minor-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Hei Feng's belligerence hangs over you like a thunderhead. You take a -1 status penalty to checks with Charisma-based skills. If you consume even a drop of alcohol, this penalty becomes -3 until the next sunrise.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -45,17 +39,20 @@
                 "value": -3
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/hei-feng-moderate-boon.json
+++ b/packs/pf2e/boons-and-curses/hei-feng-moderate-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Fair winds and currents speed your passage. Any vessel you use to travel over the sea gains a +10-foot status bonus to its Speeds.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/hei-feng-moderate-curse.json
+++ b/packs/pf2e/boons-and-curses/hei-feng-moderate-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Your heart is as quick to change as Hei Feng's. If you roll a failure on a saving throw against an emotion effect, you get a critical failure instead.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -32,17 +26,20 @@
                 "selector": "saving-throw"
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/kazutal-major-boon.json
+++ b/packs/pf2e/boons-and-curses/kazutal-major-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Kazutal smiles upon those who seek to offer aid, no matter how meek or helpless they may be.</p>\n<p>Any time creatures attempt a check to @UUID[Compendium.pf2e.actionspf2e.Item.Aid] you, they can choose to automatically succeed. If a creature chooses to roll for the attempt and rolls a success, it gets a critical success instead, granting a +4 circumstance bonus even if it doesn't have legendary proficiency in that skill. You gain the same benefits when you attempt to Aid others.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/kazutal-major-curse.json
+++ b/packs/pf2e/boons-and-curses/kazutal-major-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>You are cursed to depend upon others for your survival. You can't eat anything, drink anything, or use any gear or magic items unless they were willingly given to you by someone who rightfully owns them. Work-arounds like having an ally strip the gear from someone's corpse and then give it to you willingly automatically fail.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/kazutal-minor-boon.json
+++ b/packs/pf2e/boons-and-curses/kazutal-minor-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>With Kazutal's blessing, food tastes richer. Any meal that you eat tastes delicious and has improved nutritional value. This doesn't protect you from anything dangerous in your food, but it also doesn't prevent you from tasting those dangerous elements of the food.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/kazutal-minor-curse.json
+++ b/packs/pf2e/boons-and-curses/kazutal-minor-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Community opinion turns against you. Humanoids in your community who would normally start as indifferent toward you start as unfriendly instead.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/kazutal-moderate-boon.json
+++ b/packs/pf2e/boons-and-curses/kazutal-moderate-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>You always seem to find safe shelter when you most need it. Once per day, you can cast @UUID[Compendium.pf2e.spells-srd.Item.Rope Trick] as a divine innate spell.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/kazutal-moderate-curse.json
+++ b/packs/pf2e/boons-and-curses/kazutal-moderate-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Your strength betrays you, preventing you from taking more than your fair share. You are @UUID[Compendium.pf2e.conditionitems.Item.Enfeebled]{Enfeebled 2} and can't carry anything beyond the gear you are actively wearing or using.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -34,17 +28,20 @@
                 "uuid": "Compendium.pf2e.conditionitems.Item.Enfeebled"
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/kurgess-major-boon.json
+++ b/packs/pf2e/boons-and-curses/kurgess-major-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>You possess a true champion's might.</p>\n<p>When you roll a critical failure on an Athletics check, you get a failure instead, and when you roll a success, you instead get a critical success.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -30,17 +24,20 @@
                 "selector": "athletics"
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/kurgess-major-curse.json
+++ b/packs/pf2e/boons-and-curses/kurgess-major-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>The wrath of Kurgess withers you almost to nothing. You are permanently @UUID[Compendium.pf2e.conditionitems.Item.Drained]{Drained 2} and @UUID[Compendium.pf2e.conditionitems.Item.Enfeebled]{Enfeebled 4}.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -46,17 +40,20 @@
                 "uuid": "Compendium.pf2e.conditionitems.Item.Enfeebled"
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/kurgess-minor-boon.json
+++ b/packs/pf2e/boons-and-curses/kurgess-minor-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>The Strong Man blesses you with a measure of his strength. Increase your maximum and encumbered Bulk limits by 2.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -34,17 +28,20 @@
                 "value": 2
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/kurgess-minor-curse.json
+++ b/packs/pf2e/boons-and-curses/kurgess-minor-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Difficulty lifting burdens is a sign of divine disapproval. Your maximum and encumbered Bulk limits decrease by 2.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -34,17 +28,20 @@
                 "value": -2
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/kurgess-moderate-boon.json
+++ b/packs/pf2e/boons-and-curses/kurgess-moderate-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>You fear no exertion. You can employ exploration tactics normally while @UUID[Compendium.pf2e.conditionitems.Item.Fatigued].</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/kurgess-moderate-curse.json
+++ b/packs/pf2e/boons-and-curses/kurgess-moderate-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Kurgess's displeasure breaks your competitive edge, causing you to fail at the cusp of success. If your check result exactly equals the DC, you fail instead of succeeding.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/milani-major-boon.json
+++ b/packs/pf2e/boons-and-curses/milani-major-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>You gain +4 status bonus to checks to @UUID[Compendium.pf2e.actionspf2e.Item.Request] during attempts to satisfy one of Milani's edicts. Once per day, you can sound a battle cry that grants creatures within a @Template[emanation|distance:30] the effects of @UUID[Compendium.pf2e.spells-srd.Item.Unfettered Movement] and affects all doors, locks, containers, and other bindings used to restrain or imprison others with the effects of the @UUID[Compendium.pf2e.spells-srd.Item.Knock] spell.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -32,17 +26,20 @@
                 "value": 4
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/milani-major-curse.json
+++ b/packs/pf2e/boons-and-curses/milani-major-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Small wounds bleed more than seems physically possible. Whenever you take slashing or piercing damage, you also take persistent bleed damage equal to the level of the creature or effect that inflicted the damage.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/milani-minor-boon.json
+++ b/packs/pf2e/boons-and-curses/milani-minor-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Once, when you roll a failure on a Deception or Stealth check to protect an uprising from discovery, you critically succeed instead.</p>\n<p>Milani typically grants this boon for extremely significant checks on which the uprising's survival hinges.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/milani-minor-curse.json
+++ b/packs/pf2e/boons-and-curses/milani-minor-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>A magical wreath of thorny, bloodred roses endlessly grows from your scalp, no matter how much you try to remove it. You gain weakness 5 to piercing damage.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -27,17 +21,20 @@
                 "value": 5
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/milani-moderate-boon.json
+++ b/packs/pf2e/boons-and-curses/milani-moderate-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>When you use it to protect others, your shield blooms with roses brimming with razor-sharp thorns. You gain the @UUID[Compendium.pf2e.feats-srd.Item.Shield Warden]{Shield Warden (Fighter)} feat, even if you don't meet its prerequisites. If you already had that feat, if your shield takes damage from a melee Strike in defense of your ally, the attacker takes piercing damage equal to half the shield's Hardness.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -26,17 +20,20 @@
                 "uuid": "Compendium.pf2e.feats-srd.Item.Shield Warden"
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/milani-moderate-curse.json
+++ b/packs/pf2e/boons-and-curses/milani-moderate-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Ropes, chains, manacles, and other equipment used to bind or constrain become blazing hot in your hands, bursting into flame or melting as if engulfed in a forge. When you attempt to hold such an item, you take @Damage[2d6[fire]] damage and the item is destroyed.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/nivi-rhombodazzle-major-boon.json
+++ b/packs/pf2e/boons-and-curses/nivi-rhombodazzle-major-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Those who have done much to please Nivi find themselves slipping from sight when needed.</p>\n<p>Any time you attempt a Stealth check to @UUID[Compendium.pf2e.actionspf2e.Item.Hide] or @UUID[Compendium.pf2e.actionspf2e.Item.Sneak], you also gain the effects of 2nd-rank @UUID[Compendium.pf2e.spells-srd.Item.Invisibility] and @UUID[Compendium.pf2e.spells-srd.Item.Fleet Step] spells to help you elude your enemies. These effects last until the end of your next turn or until you stop Hiding or Sneaking, whichever comes first (you can continue to Hide or Sneak, turn after turn, to extend these effects).</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/nivi-rhombodazzle-major-curse.json
+++ b/packs/pf2e/boons-and-curses/nivi-rhombodazzle-major-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Nivi curses unworthy adherents with recklessness. Any time you are presented with a wager, you are compelled to accept, no matter the odds. If you succeed at a @Check[will|dc:40] save, you can at least attempt to alter the stakes of that wager in your favor, but you must still accept.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/nivi-rhombodazzle-minor-boon.json
+++ b/packs/pf2e/boons-and-curses/nivi-rhombodazzle-minor-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Those who have earned Nivi's trust are blessed with wild turns of luck in the worst of circumstances.</p>\n<p>Once, instead of attempting the check you would normally roll, you attempt a @Check[flat|dc:11] with the same results.</p>\n<p>Nivi always grants this boon when the odds are stacked against you (though this same effect is an alternate to her minor curse if she uses it for a check when you would have been very likely to succeed).</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/nivi-rhombodazzle-minor-curse.json
+++ b/packs/pf2e/boons-and-curses/nivi-rhombodazzle-minor-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Those who betray Nivi's trust find defeat where there was sure to be victory. Once, when you roll a natural 20 on a die, the result becomes a natural 1 instead. Nivi typically uses this curse for maximum poetic justice.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/nivi-rhombodazzle-moderate-boon.json
+++ b/packs/pf2e/boons-and-curses/nivi-rhombodazzle-moderate-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Nivi bestows a fraction of her skill at pushing consequences down the road. Once per day, after attempting a check, you can roll a second time. You must use the result of the second roll, even if it is worse. This is a fortune effect. At any point after you use this boon, the GM can replace one of your check results with the first result of the check you attempted when using this boon; this delayed result can't be further delayed, prevented, or affected in any way, even by other divine intercessions.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/nivi-rhombodazzle-moderate-curse.json
+++ b/packs/pf2e/boons-and-curses/nivi-rhombodazzle-moderate-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Those who arouse Nivi's wrath find themselves bound to the earth with no place to hide. You are wreathed in constant @UUID[Compendium.pf2e.spells-srd.Item.Faerie Fire] and constantly affected by @UUID[Compendium.pf2e.spells-srd.Item.Earthbind], and any effect that grants @UUID[Compendium.pf2e.conditionitems.Item.Invisible]{Invisibility} doesn't work on you.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/nocticula-major-boon.json
+++ b/packs/pf2e/boons-and-curses/nocticula-major-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>You become an idealized version of yourself, as if created by a divine artist.</p>\n<p>You permanently gain a set of 4 ability boosts that follow the same rules as the ability boosts you gain at every 5th level.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/nocticula-major-curse.json
+++ b/packs/pf2e/boons-and-curses/nocticula-major-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>You are exiled from companionship. You can't communicate with any other creature, nor can you feel other creatures' touch.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/nocticula-minor-boon.json
+++ b/packs/pf2e/boons-and-curses/nocticula-minor-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>The night sky inspires you in a specific way.</p>\n<p>Once, when you roll a failure on a Crafting or Performance check under the night sky, you critically succeed instead.</p>\n<p>Nocticula typically grants this boon for a consequential piece of artwork or performance.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/nocticula-minor-curse.json
+++ b/packs/pf2e/boons-and-curses/nocticula-minor-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Midnight looms and obscures your fate. You are only able to see up to 60 feet away from you, regardless of the lighting or what senses you have.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/nocticula-moderate-boon.json
+++ b/packs/pf2e/boons-and-curses/nocticula-moderate-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>You draw on the power of midnight to guide you on your journeys. You gain darkvision. If you already had darkvision, you can cast @UUID[Compendium.pf2e.spells-srd.Item.Darkness] once per day as a divine innate spell.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -26,17 +20,20 @@
                 "selector": "darkvision"
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/nocticula-moderate-curse.json
+++ b/packs/pf2e/boons-and-curses/nocticula-moderate-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>You are plagued with doubt in your own skills. You are always untrained with Crafting, Performance, and one other skill (determined by the GM, but themed to the event that brought on your curse), regardless of any effect that would improve your proficiency. You can't retrain those skills.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -103,17 +97,20 @@
                 "value": 0
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/shizuru-major-boon.json
+++ b/packs/pf2e/boons-and-curses/shizuru-major-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Shizuru bestows upon you a golden suit of armor made from sunlight, or transforms your favorite armor to gain that aspect.</p>\n<p>Once per hour while you are wearing the armor, if an attack would reduce your Hit Points to 0, the attack is instead completely negated.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/shizuru-major-curse.json
+++ b/packs/pf2e/boons-and-curses/shizuru-major-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Those who incite Shizuru's personal wrath earn the hatred of all of her subjects. All imperial dragons and animals you encounter are automatically hostile to you, and you gain weakness 15 to draconic breath weapons.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -32,17 +26,20 @@
                 "value": 15
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/shizuru-minor-boon.json
+++ b/packs/pf2e/boons-and-curses/shizuru-minor-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Your attacks help eradicate darkness.</p>\n<p>When you successfully Strike a foe, your weapon glows with bright light out to 60 feet for 1 minute. This is a light effect with a counteract rank equal to half your level rounded up.</p>\n<p>@UUID[Compendium.pf2e.boons-and-curses.Item.Effect: Shizuru's Light]</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -32,17 +26,20 @@
                 "title": "{item|name}"
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/shizuru-minor-curse.json
+++ b/packs/pf2e/boons-and-curses/shizuru-minor-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Your equipment turns on you for a disgraceful act. The next time you make an attack, your weapon or armor gains the @UUID[Compendium.pf2e.conditionitems.Item.Broken] condition.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -28,17 +22,20 @@
                 "title": "{item|name}"
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/shizuru-moderate-boon.json
+++ b/packs/pf2e/boons-and-curses/shizuru-moderate-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Shizuru's light flows through your blade. Your weapons and unarmed attacks deal an additional 1d6 fire damage or 1d6 spirit damage; you choose each time you make an attack.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -46,17 +40,20 @@
                 "selector": "strike-damage"
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/shizuru-moderate-curse.json
+++ b/packs/pf2e/boons-and-curses/shizuru-moderate-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Shizuru decrees that her light is no longer your ally. You gain @UUID[Compendium.pf2e.bestiary-ability-glossary-srd.Item.Light Blindness].</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -26,17 +20,20 @@
                 "uuid": "Compendium.pf2e.bestiary-ability-glossary-srd.Item.Light Blindness"
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/sivanah-major-boon.json
+++ b/packs/pf2e/boons-and-curses/sivanah-major-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>You spread your illusions over a larger area.</p>\n<p>You can designate an area to permanently gain the effects of @UUID[Compendium.pf2e.spells-srd.Item.Mirage]. All creatures within this area gain the effects of @UUID[Compendium.pf2e.spells-srd.Item.Illusory Disguise], changing their forms as you wish. You can designate a new area as a 1-minute activity, but doing so dismisses any previously designated areas.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/sivanah-major-curse.json
+++ b/packs/pf2e/boons-and-curses/sivanah-major-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Mirrors break whenever you cross their paths. You cannot be concealed by illusion magic of any kind (the spell automatically fails), and all creatures that see you know your true identity.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/sivanah-minor-boon.json
+++ b/packs/pf2e/boons-and-curses/sivanah-minor-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Sivanah prevents your enemies from pulling off your veil.</p>\n<p>Once, when a foe rolls a success on a Perception check to disbelieve your illusion, it gets a critical failure instead.</p>\n<p>Sivanah typically grants this benefit to protect an elaborate or consequential illusory deception, and she never uses it to improve the effect of a harmful illusion.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/sivanah-minor-curse.json
+++ b/packs/pf2e/boons-and-curses/sivanah-minor-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Your hair becomes a wild variety of colors, which cannot be altered with mundane or magical means, and it somehow grows out from under any cap, scarf, or other headwear intended to disguise it. You gain a -2 status penalty to Deception skill checks to @UUID[Compendium.pf2e.actionspf2e.Item.Impersonate] anyone else.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -31,17 +25,20 @@
                 "value": -2
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/sivanah-moderate-boon.json
+++ b/packs/pf2e/boons-and-curses/sivanah-moderate-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>You wear a veil of illusion wherever you go. You can cast @UUID[Compendium.pf2e.spells-srd.Item.Illusory Disguise] at will as an innate divine spell.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/sivanah-moderate-curse.json
+++ b/packs/pf2e/boons-and-curses/sivanah-moderate-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Those who betray the secrets of others find their own secrets laid bare. Each person from whom you are keeping a secret immediately learns one of your secrets involving that person. This curse doesn't give away other people's secrets you are keeping, only your own.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/tsukiyo-major-boon.json
+++ b/packs/pf2e/boons-and-curses/tsukiyo-major-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Tsukiyo shares some of his own nature and can lead a favored soul back along the same path he has walked.</p>\n<p>The next time you would die, you are instead instantly restored to full health and lose any negative conditions you have.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/tsukiyo-major-curse.json
+++ b/packs/pf2e/boons-and-curses/tsukiyo-major-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>When Tsukiyo truly loses patience with someone, he forces them to experience the hardships of others firsthand. Whenever you touch another creature or another creature touches you, you immediately gain any negative curses, diseases, and conditions they are suffering. These effects spread to you even when you Strike another creature or a creature Strikes you.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/tsukiyo-minor-boon.json
+++ b/packs/pf2e/boons-and-curses/tsukiyo-minor-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Tsukiyo's simplest show of gratitude is a gift of clarity.</p>\n<p>Once, when you roll a failure on a saving throw against a mental effect, you get a critical success instead.</p>\n<p>Tsukiyo typically grants this boon against a particularly consequential mental effect.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/tsukiyo-minor-curse.json
+++ b/packs/pf2e/boons-and-curses/tsukiyo-minor-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Those who offend Tsukiyo find that light actively shuns them. You lose any low-light vision or darkvision you have, and you treat all light levels as one step lower.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/tsukiyo-moderate-boon.json
+++ b/packs/pf2e/boons-and-curses/tsukiyo-moderate-boon.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>Tsukiyo watches over you and guards your sleep. You are guaranteed a peaceful night's rest no matter what conditions you are sleeping in. Even nightmare and similar abilities can't disrupt your sleep unless they come from a deity, artifact, or similarly powerful source.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -21,17 +15,20 @@
             "title": "Pathfinder Lost Omens Gods & Magic"
         },
         "rules": [],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "deityboon",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }

--- a/packs/pf2e/boons-and-curses/tsukiyo-moderate-curse.json
+++ b/packs/pf2e/boons-and-curses/tsukiyo-moderate-curse.json
@@ -6,12 +6,6 @@
         "description": {
             "value": "<p>If Tsukiyo is particularly offended by someone, they may find themselves lost in delusions of moonlight. When attempting to navigate or find something at night, if you roll a success or critical success on your Perception check, Survival check, or other check to do so, you get a failure instead.</p>"
         },
-        "duration": {
-            "expiry": null,
-            "sustained": false,
-            "unit": "unlimited",
-            "value": -1
-        },
         "level": {
             "value": 0
         },
@@ -58,17 +52,20 @@
                 "selector": "skill-check"
             }
         ],
-        "start": {
-            "initiative": null,
-            "value": 0
-        },
-        "tokenIcon": {
-            "show": false
-        },
         "traits": {
             "rarity": "common",
             "value": []
+        },
+        "actionType": {
+            "value": "passive"
+        },
+        "actions": {
+            "value": null
+        },
+        "category": "curse",
+        "prerequisites": {
+            "value": []
         }
     },
-    "type": "effect"
+    "type": "feat"
 }


### PR DESCRIPTION
Based on https://github.com/foundryvtt/pf2e/issues/21465

Some of the boons and curses used 'effect' type, some - 'feat'. This brings everything to a uniform format, and adds corresponding categories (deityboon/curse)