### PR TITLE
Use weapon potency for Fox Arson bonus damage calculation

### DIFF
--- a/packs/pf2e/feats/ancestry/kitsune/level-9/fox-arson.json
+++ b/packs/pf2e/feats/ancestry/kitsune/level-9/fox-arson.json
@@ -43,7 +43,7 @@
                 "damageCategory": "persistent",
                 "key": "FlatModifier",
                 "selector": "foxfire-damage",
-                "value": "@weapon.system.runes.potency"
+                "value": "@weapon.flags.system.attackItemBonus"
             }
         ],
         "traits": {

--- a/packs/pf2e/feats/ancestry/kitsune/level-9/fox-arson.json
+++ b/packs/pf2e/feats/ancestry/kitsune/level-9/fox-arson.json
@@ -43,7 +43,7 @@
                 "damageCategory": "persistent",
                 "key": "FlatModifier",
                 "selector": "foxfire-damage",
-                "value": "@item.flags.system.attackItemBonus"
+                "value": "@weapon.system.runes.potency"
             }
         ],
         "traits": {


### PR DESCRIPTION
Fixes https://github.com/foundryvtt/pf2e/issues/21133
Quote from the feat: 'You gain an item bonus to this persistent damage equal to the foxfire’s item bonus to attack rolls.'
Unfortunately this is not a clean fix, as it doesn't correctly work with other item bonuses to attack (Quicksilver Mutagen for example), but it works most of the time. 
If there's a better reference for this, would appreciate the advice