### PR TITLE
Make Channel Divine Spark increase Nimbus's aura and prevent it's deactivation

### DIFF
--- a/packs/pf2e/feat-effects/effect-channel-divine-spark.json
+++ b/packs/pf2e/feat-effects/effect-channel-divine-spark.json
@@ -40,6 +40,15 @@
                 "selector": "melee-strike-damage",
                 "text": "PF2E.SpecificRule.AscendedCelestial.ChannelDivineSpark.Note",
                 "title": "{item|name}"
+            },
+            {
+                "key":"ActiveEffectLike",
+                "mode":"override",
+                "predicate": [
+                    "ascended-celestial-nimbus"
+                ],
+                "path":"flags.system.ascendedCelestial.aura",
+                "value":60
             }
         ],
         "start": {

--- a/packs/pf2e/feat-effects/effect-channel-divine-spark.json
+++ b/packs/pf2e/feat-effects/effect-channel-divine-spark.json
@@ -42,13 +42,13 @@
                 "title": "{item|name}"
             },
             {
-                "key":"ActiveEffectLike",
-                "mode":"override",
+                "key": "ActiveEffectLike",
+                "mode": "override",
                 "predicate": [
                     "ascended-celestial-nimbus"
                 ],
-                "path":"flags.system.ascendedCelestial.aura",
-                "value":60
+                "path": "flags.system.ascendedCelestial.aura",
+                "value": 60
             }
         ],
         "start": {

--- a/packs/pf2e/feats/archetype/ascended-celestial/ascended-celestial-dedication.json
+++ b/packs/pf2e/feats/archetype/ascended-celestial/ascended-celestial-dedication.json
@@ -34,7 +34,12 @@
                 "key": "RollOption",
                 "label": "PF2E.SpecificRule.AscendedCelestial.Dedication.NimbusToggle",
                 "option": "ascended-celestial-nimbus",
-                "toggleable": true
+                "toggleable": true,
+                "value": false,
+                "disabledIf": [
+                    "self:effect:channel-divine-spark"
+                    ],
+                "disabledValue": true
             },
             {
                 "key": "RollOption",

--- a/packs/pf2e/feats/archetype/ascended-celestial/ascended-celestial-dedication.json
+++ b/packs/pf2e/feats/archetype/ascended-celestial/ascended-celestial-dedication.json
@@ -35,7 +35,6 @@
                 "label": "PF2E.SpecificRule.AscendedCelestial.Dedication.NimbusToggle",
                 "option": "ascended-celestial-nimbus",
                 "toggleable": true,
-                "value": false,
                 "disabledIf": [
                     "self:effect:channel-divine-spark"
                     ],

--- a/packs/pf2e/feats/archetype/ascended-celestial/ascended-celestial-dedication.json
+++ b/packs/pf2e/feats/archetype/ascended-celestial/ascended-celestial-dedication.json
@@ -37,7 +37,7 @@
                 "toggleable": true,
                 "disabledIf": [
                     "self:effect:channel-divine-spark"
-                    ],
+                ],
                 "disabledValue": true
             },
             {


### PR DESCRIPTION
Fixes https://github.com/foundryvtt/pf2e/issues/21253
Also prevents Nimbus from being turned off while under Channel Divine Spark effect as per feat [description](https://2e.aonprd.com/Feats.aspx?ID=7335#:~:text=You%20can%E2%80%99t%20suppress%20your%20nimbus%20while%20Channeling%20your%20Divine%20Spark.)