### PR TITLE
Fix a bug preventing players from trading in sf2e

### DIFF
--- a/src/module/apps/trade-dialog/app.svelte
+++ b/src/module/apps/trade-dialog/app.svelte
@@ -36,7 +36,7 @@
     const pendingQueries: Set<Promise<unknown>> = new Set();
     async function sendQuery(data: TradeQueryData): Promise<void> {
         await Promise.allSettled(pendingQueries);
-        const promise = traderUser.query("pf2e.trade", data, { timeout: 15_000 });
+        const promise = traderUser.query(`${SYSTEM_ID}.trade`, data, { timeout: 15_000 });
         pendingQueries.add(promise);
         promise
             .then((data) => {

--- a/src/scripts/hooks/load.ts
+++ b/src/scripts/hooks/load.ts
@@ -160,7 +160,7 @@ export class Load {
         Math.match = (...args) => args.find((a) => a !== null) ?? 0;
         Math.when = (condition, then) => (condition ? then : null);
 
-        CONFIG.queries["pf2e.trade"] = TradeDialog.handleQuery;
+        CONFIG.queries[`${SYSTEM_ID}.trade`] = TradeDialog.handleQuery;
 
         // Mystery Man but with a drop shadow
         Actor.DEFAULT_ICON = `systems/${SYSTEM_ID}/icons/default-icons/mystery-man.svg`;


### PR DESCRIPTION
In sf2e, the following line was erroring since there was no query for `sf2e.trade` registered.
https://github.com/foundryvtt/pf2e/blob/78482d1550b40b67d7ce75ff8fdedd72290ac5c3/src/module/apps/trade-dialog/app.ts#L136