### PR TITLE
Fix basic save in the robe of the erinys description

### DIFF
--- a/packs/pf2e/equipment/robe-of-the-erinys.json
+++ b/packs/pf2e/equipment/robe-of-the-erinys.json
@@ -9,7 +9,7 @@
         },
         "containerId": null,
         "description": {
-            "value": "<p>This exquisite scarlet robe embroidered with golden depictions of fiends and their weapons is fashioned after the garb of the cloistered Sisters of the Golden Erinys. The robe's belt is embroidered to look like a snake, complete with metal fangs.</p>\n<p><strong>Activate—Biting Belt</strong> <span class=\"action-glyph\">2</span> (concentrate, manipulate)</p>\n<p><strong>Frequency</strong> once per day</p><hr /><p><strong>Effect</strong> You remove the robe's belt and snap it at an enemy within your reach. As you do, it briefly animates to bite that foe, dealing @Damage[2d8[poison]] damage with a basic @Check[fortitude|dc:18] save. On a critical failure, the target is also @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 1}.</p>"
+            "value": "<p>This exquisite scarlet robe embroidered with golden depictions of fiends and their weapons is fashioned after the garb of the cloistered Sisters of the Golden Erinys. The robe's belt is embroidered to look like a snake, complete with metal fangs.</p>\n<p><strong>Activate—Biting Belt</strong> <span class=\"action-glyph\">2</span> (concentrate, manipulate)</p>\n<p><strong>Frequency</strong> once per day</p><hr /><p><strong>Effect</strong> You remove the robe's belt and snap it at an enemy within your reach. As you do, it briefly animates to bite that foe, dealing @Damage[2d8[poison]] damage with a @Check[fortitude|dc:18|basic] save. On a critical failure, the target is also @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 1}.</p>"
         },
         "hardness": 0,
         "hp": {

--- a/packs/pf2e/equipment/robe-of-the-erinys.json
+++ b/packs/pf2e/equipment/robe-of-the-erinys.json
@@ -9,7 +9,7 @@
         },
         "containerId": null,
         "description": {
-            "value": "<p>This exquisite scarlet robe embroidered with golden depictions of fiends and their weapons is fashioned after the garb of the cloistered Sisters of the Golden Erinys. The robe's belt is embroidered to look like a snake, complete with metal fangs.</p>\n<p><strong>Activate—Biting Belt</strong> <span class=\"action-glyph\">2</span> (concentrate, manipulate)</p>\n<p><strong>Frequency</strong> once per day</p><hr /><p><strong>Effect</strong> You remove the robe's belt and snap it at an enemy within your reach. As you do, it briefly animates to bite that foe, dealing @Damage[2d8[poison]] damage with a @Check[fortitude|dc:18|basic] save. On a critical failure, the target is also @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 1}.</p>"
+            "value": "<p>This exquisite scarlet robe embroidered with golden depictions of fiends and their weapons is fashioned after the garb of the cloistered Sisters of the Golden Erinys. The robe's belt is embroidered to look like a snake, complete with metal fangs.</p>\n<p><strong>Activate—Biting Belt</strong> <span class=\"action-glyph\">2</span> (concentrate, manipulate)</p>\n<p><strong>Frequency</strong> once per day</p><hr /><p><strong>Effect</strong> You remove the robe's belt and snap it at an enemy within your reach. As you do, it briefly animates to bite that foe, dealing @Damage[2d8[poison]] damage with a @Check[fortitude|dc:18|basic|options:inflicts:sickened|traits:concentrate,manipulate] save. On a critical failure, the target is also @UUID[Compendium.pf2e.conditionitems.Item.Sickened]{Sickened 1}.</p>"
         },
         "hardness": 0,
         "hp": {


### PR DESCRIPTION
Updated the description of the robe to include a basic save in the effect.