### PR TITLE
Add late preparation for generated shield attacks in CharacterPF2e

### DIFF
--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -44,6 +44,7 @@ import { WeaponPF2e } from "@item";
 import type { AbilityTrait } from "@item/ability/types.ts";
 import { ARMOR_CATEGORIES } from "@item/armor/values.ts";
 import { ActionCost } from "@item/base/data/index.ts";
+import { performLatePreparation } from "@item/helpers.ts";
 import { getPropertyRuneDegreeAdjustments, getPropertyRuneStrikeAdjustments } from "@item/physical/runes.ts";
 import type { EffectAreaShape, ItemType } from "@item/types.ts";
 import type { WeaponSource } from "@item/weapon/data.ts";
@@ -1075,7 +1076,11 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
             // Generate a shield attacks from the character's shields
             this.itemTypes.shield
                 .filter((s) => !s.isStowed && !s.isBroken && !s.isDestroyed)
-                .map((s) => s.generateWeapon()),
+                .map((s) => {
+                    const w = s.generateWeapon();
+                    if (w) performLatePreparation(w);
+                    return w;
+                }),
             this.inventory.flatMap((i) =>
                 i.isEquipped
                     ? i.subitems.filter(

--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -44,7 +44,6 @@ import { WeaponPF2e } from "@item";
 import type { AbilityTrait } from "@item/ability/types.ts";
 import { ARMOR_CATEGORIES } from "@item/armor/values.ts";
 import { ActionCost } from "@item/base/data/index.ts";
-import { performLatePreparation } from "@item/helpers.ts";
 import { getPropertyRuneDegreeAdjustments, getPropertyRuneStrikeAdjustments } from "@item/physical/runes.ts";
 import type { EffectAreaShape, ItemType } from "@item/types.ts";
 import type { WeaponSource } from "@item/weapon/data.ts";
@@ -1076,11 +1075,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
             // Generate a shield attacks from the character's shields
             this.itemTypes.shield
                 .filter((s) => !s.isStowed && !s.isBroken && !s.isDestroyed)
-                .map((s) => {
-                    const w = s.generateWeapon();
-                    if (w) performLatePreparation(w);
-                    return w;
-                }),
+                .map((s) => s.generateWeapon()),
             this.inventory.flatMap((i) =>
                 i.isEquipped
                     ? i.subitems.filter(

--- a/src/module/item/shield/document.ts
+++ b/src/module/item/shield/document.ts
@@ -258,8 +258,8 @@ class ShieldPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
             },
         });
 
-        let weaponData: BaseWeaponData | undefined;
-        if (this.system.traits.integrated) {
+        const weaponData: BaseWeaponData = (() => {
+            if (!this.system.traits.integrated) return baseData;
             const damageType = this.system.traits.integrated.damageType;
             const versatileTrait = this.system.traits.value.find((t) => t.includes("versatile"));
             const versatileWeaponTrait = versatileTrait?.slice(versatileTrait.indexOf("versatile")) ?? null;
@@ -281,13 +281,10 @@ class ShieldPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
             if (integratedWeaponRunes?.potency || integratedWeaponRunes?.striking) {
                 additionalData.name = this._source.name;
             }
-            weaponData = fu.mergeObject(baseData, additionalData);
-        }
+            return fu.mergeObject(baseData, additionalData);
+        })();
 
-        const weapon = new ItemProxyPF2e(weaponData ?? baseData, {
-            parent: this.parent,
-            shield: this,
-        }) as WeaponPF2e<TParent>;
+        const weapon = new ItemProxyPF2e(weaponData, { parent: this.parent, shield: this }) as WeaponPF2e<TParent>;
         performLatePreparation(weapon);
         return weapon;
     }

--- a/src/module/item/shield/document.ts
+++ b/src/module/item/shield/document.ts
@@ -18,6 +18,7 @@ import * as R from "remeda";
 import type { IntegratedWeaponData, ShieldSource, ShieldSystemData } from "./data.ts";
 import { setActorShieldData } from "./helpers.ts";
 import type { BaseShieldType, ShieldTrait } from "./types.ts";
+import { performLatePreparation } from "@item/helpers.ts";
 
 class ShieldPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends PhysicalItemPF2e<TParent> {
     static override get validTraits(): Record<ShieldTrait, string> {
@@ -238,7 +239,7 @@ class ShieldPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
         const shieldThrowTrait = this.system.traits.value.find((t) => t.startsWith("shield-throw-"));
         if (shieldThrowTrait) weaponTraits.push(`thrown-${shieldThrowTrait.slice(-2)}` as WeaponTrait);
 
-        const baseData: BaseWeaponData = fu.deepClone({
+        let weaponData: BaseWeaponData = fu.deepClone({
             ...R.pick(this, ["_id", "name", "img"]),
             type: "weapon",
             system: {
@@ -262,8 +263,8 @@ class ShieldPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
             const versatileTrait = this.system.traits.value.find((t) => t.includes("versatile"));
             const versatileWeaponTrait = versatileTrait?.slice(versatileTrait.indexOf("versatile")) ?? null;
             if (objectHasKey(CONFIG.PF2E.weaponTraits, versatileWeaponTrait)) {
-                baseData.system.traits.value.push(versatileWeaponTrait);
-                baseData.system.traits.toggles = {
+                weaponData.system.traits.value.push(versatileWeaponTrait);
+                weaponData.system.traits.toggles = {
                     versatile: { selected: this.system.traits.integrated.versatile?.selected ?? damageType },
                 };
             }
@@ -279,12 +280,12 @@ class ShieldPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
             if (integratedWeaponRunes?.potency || integratedWeaponRunes?.striking) {
                 additionalData.name = this._source.name;
             }
-            const combinedData = fu.mergeObject(baseData, additionalData);
-
-            return new ItemProxyPF2e(combinedData, { parent: this.parent, shield: this }) as WeaponPF2e<TParent>;
+            weaponData = fu.mergeObject(weaponData, additionalData);
         }
 
-        return new ItemProxyPF2e(baseData, { parent: this.parent, shield: this }) as WeaponPF2e<TParent>;
+        const weapon = new ItemProxyPF2e(weaponData, { parent: this.parent, shield: this }) as WeaponPF2e<TParent>;
+        performLatePreparation(weapon);
+        return weapon;
     }
 
     protected override async _preUpdate(

--- a/src/module/item/shield/document.ts
+++ b/src/module/item/shield/document.ts
@@ -20,6 +20,10 @@ import { setActorShieldData } from "./helpers.ts";
 import type { BaseShieldType, ShieldTrait } from "./types.ts";
 import { performLatePreparation } from "@item/helpers.ts";
 
+type BaseWeaponData = Pick<WeaponSource, "_id" | "type" | "name" | "img"> & {
+    system: Partial<WeaponSystemSource> & { traits: WeaponTraitsSource };
+};
+
 class ShieldPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends PhysicalItemPF2e<TParent> {
     static override get validTraits(): Record<ShieldTrait, string> {
         return CONFIG.PF2E.shieldTraits;
@@ -226,13 +230,36 @@ class ShieldPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
         return typeOnly ? itemType : game.i18n.format("PF2E.identification.UnidentifiedItem", { item: itemType });
     }
 
+    /** Build the data for an integrated weapon from this shield */
+    #buildIntegratedWeaponData(baseData: BaseWeaponData): BaseWeaponData {
+        if (!this.system.traits.integrated) return baseData;
+        const damageType = this.system.traits.integrated.damageType;
+        const versatileTrait = this.system.traits.value.find((t) => t.includes("versatile"));
+        const versatileWeaponTrait = versatileTrait?.slice(versatileTrait.indexOf("versatile")) ?? null;
+        if (objectHasKey(CONFIG.PF2E.weaponTraits, versatileWeaponTrait)) {
+            baseData.system.traits.value.push(versatileWeaponTrait);
+            baseData.system.traits.toggles = {
+                versatile: { selected: this.system.traits.integrated.versatile?.selected ?? damageType },
+            };
+        }
+
+        const integratedWeaponRunes = this.system.traits.integrated?.runes;
+        const additionalData: { name?: string; system: Partial<WeaponSystemSource> } = {
+            system: {
+                damage: { dice: 1, die: "d6", damageType, modifier: 0, persistent: null },
+                runes: integratedWeaponRunes,
+            },
+        };
+        // Allow the weapon to be renamed
+        if (integratedWeaponRunes?.potency || integratedWeaponRunes?.striking) {
+            additionalData.name = this._source.name;
+        }
+        return fu.mergeObject(baseData, additionalData);
+    }
+
     /** Generate a shield bash or other weapon(-like) item from this shield */
     generateWeapon(): WeaponPF2e<TParent> | null {
         if (this.isStowed) return null;
-
-        type BaseWeaponData = Pick<WeaponSource, "_id" | "type" | "name" | "img"> & {
-            system: Partial<WeaponSystemSource> & { traits: WeaponTraitsSource };
-        };
 
         const shieldTraits: string[] = this.system.traits.value;
         const weaponTraits: WeaponTrait[] = shieldTraits.filter((t): t is WeaponTrait => t in CONFIG.PF2E.weaponTraits);
@@ -258,33 +285,10 @@ class ShieldPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
             },
         });
 
-        const weaponData: BaseWeaponData = (() => {
-            if (!this.system.traits.integrated) return baseData;
-            const damageType = this.system.traits.integrated.damageType;
-            const versatileTrait = this.system.traits.value.find((t) => t.includes("versatile"));
-            const versatileWeaponTrait = versatileTrait?.slice(versatileTrait.indexOf("versatile")) ?? null;
-            if (objectHasKey(CONFIG.PF2E.weaponTraits, versatileWeaponTrait)) {
-                baseData.system.traits.value.push(versatileWeaponTrait);
-                baseData.system.traits.toggles = {
-                    versatile: { selected: this.system.traits.integrated.versatile?.selected ?? damageType },
-                };
-            }
-
-            const integratedWeaponRunes = this.system.traits.integrated?.runes;
-            const additionalData: { name?: string; system: Partial<WeaponSystemSource> } = {
-                system: {
-                    damage: { dice: 1, die: "d6", damageType, modifier: 0, persistent: null },
-                    runes: integratedWeaponRunes,
-                },
-            };
-            // Allow the weapon to be renamed
-            if (integratedWeaponRunes?.potency || integratedWeaponRunes?.striking) {
-                additionalData.name = this._source.name;
-            }
-            return fu.mergeObject(baseData, additionalData);
-        })();
-
-        const weapon = new ItemProxyPF2e(weaponData, { parent: this.parent, shield: this }) as WeaponPF2e<TParent>;
+        const weapon = new ItemProxyPF2e(this.#buildIntegratedWeaponData(baseData), {
+            parent: this.parent,
+            shield: this,
+        }) as WeaponPF2e<TParent>;
         performLatePreparation(weapon);
         return weapon;
     }

--- a/src/module/item/shield/document.ts
+++ b/src/module/item/shield/document.ts
@@ -239,7 +239,7 @@ class ShieldPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
         const shieldThrowTrait = this.system.traits.value.find((t) => t.startsWith("shield-throw-"));
         if (shieldThrowTrait) weaponTraits.push(`thrown-${shieldThrowTrait.slice(-2)}` as WeaponTrait);
 
-        let weaponData: BaseWeaponData = fu.deepClone({
+        const baseData: BaseWeaponData = fu.deepClone({
             ...R.pick(this, ["_id", "name", "img"]),
             type: "weapon",
             system: {
@@ -258,13 +258,14 @@ class ShieldPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
             },
         });
 
+        let weaponData: BaseWeaponData | undefined;
         if (this.system.traits.integrated) {
             const damageType = this.system.traits.integrated.damageType;
             const versatileTrait = this.system.traits.value.find((t) => t.includes("versatile"));
             const versatileWeaponTrait = versatileTrait?.slice(versatileTrait.indexOf("versatile")) ?? null;
             if (objectHasKey(CONFIG.PF2E.weaponTraits, versatileWeaponTrait)) {
-                weaponData.system.traits.value.push(versatileWeaponTrait);
-                weaponData.system.traits.toggles = {
+                baseData.system.traits.value.push(versatileWeaponTrait);
+                baseData.system.traits.toggles = {
                     versatile: { selected: this.system.traits.integrated.versatile?.selected ?? damageType },
                 };
             }
@@ -280,10 +281,11 @@ class ShieldPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
             if (integratedWeaponRunes?.potency || integratedWeaponRunes?.striking) {
                 additionalData.name = this._source.name;
             }
-            weaponData = fu.mergeObject(weaponData, additionalData);
+            weaponData = fu.mergeObject(baseData, additionalData);
         }
 
-        const weapon = new ItemProxyPF2e(weaponData, { parent: this.parent, shield: this }) as WeaponPF2e<TParent>;
+        const weapon = new ItemProxyPF2e(weaponData ?? baseData, 
+            { parent: this.parent, shield: this }) as WeaponPF2e<TParent>;
         performLatePreparation(weapon);
         return weapon;
     }

--- a/src/module/item/shield/document.ts
+++ b/src/module/item/shield/document.ts
@@ -284,8 +284,10 @@ class ShieldPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
             weaponData = fu.mergeObject(baseData, additionalData);
         }
 
-        const weapon = new ItemProxyPF2e(weaponData ?? baseData, 
-            { parent: this.parent, shield: this }) as WeaponPF2e<TParent>;
+        const weapon = new ItemProxyPF2e(weaponData ?? baseData, {
+            parent: this.parent,
+            shield: this,
+        }) as WeaponPF2e<TParent>;
         performLatePreparation(weapon);
         return weapon;
     }


### PR DESCRIPTION
Fixes https://github.com/foundryvtt/pf2e/issues/19680

Item alterations for weapons run over the set of items returned by #getItemsOfType() (i.e. only embedded weapons). Shield Bash is created on the fly, so ItemAlteration didn't work on it.
I found performLatePreparation used in StrikeRuleElement and applied it to strikes generated from shields. 

Testing this using a rule below, it appears to work now. But since this is my first real change to the code, would appreciate advice and comments

```{"key":"ItemAlteration","itemType":"weapon","mode":"upgrade","property":"damage-dice-faces","predicate":["item:equipped","item:group:shield","item:melee"]}```