### PR TITLE
Refresh Sihedron Guard Thunderstriker's spell gem

### DIFF
--- a/packs/sf2e/alien-core-bestiary/sihedron-guard-thunderstriker.json
+++ b/packs/sf2e/alien-core-bestiary/sihedron-guard-thunderstriker.json
@@ -1468,6 +1468,10 @@
         },
         {
             "_id": "nvJrPV9p9BUel91h",
+            "_stats": {
+                "compendiumSource": "Compendium.sf2e.equipment.Item.Nwl7YydQ0r8cAhw7"
+            },
+            "folder": "xufbk3JaZawfTzj8",
             "img": "systems/sf2e/icons/abilities/purple-glowing-cannister.webp",
             "name": "Spell Gem of Thunderstrike (Rank 3)",
             "sort": 1900000,
@@ -1476,7 +1480,7 @@
                 "bulk": {
                     "value": 0.1
                 },
-                "category": "scroll",
+                "category": "spell-gem",
                 "containerId": null,
                 "damage": null,
                 "description": {
@@ -1498,6 +1502,7 @@
                     "type": null
                 },
                 "price": {
+                    "per": 1,
                     "value": {
                         "sp": 300
                     }
@@ -1505,12 +1510,12 @@
                 "publication": {
                     "license": "ORC",
                     "remaster": true,
-                    "title": "Pathfinder GM Core"
+                    "title": "Starfinder Player Core"
                 },
                 "quantity": 1,
                 "rules": [],
                 "size": "med",
-                "slug": "spell-gem-of-thunderstrike-rank-3",
+                "slug": "spell-gem-3rd-rank-spell",
                 "spell": {
                     "_id": "jUVupcujUAwXKAzg",
                     "_stats": {
@@ -1579,7 +1584,7 @@
                         "publication": {
                             "license": "ORC",
                             "remaster": true,
-                            "title": "Pathfinder Player Core"
+                            "title": "Starfinder Player Core"
                         },
                         "range": {
                             "value": "120 feet"


### PR DESCRIPTION
Actually, this is the only spell gem that needed updating.
All the others seem up to date.