### PR TITLE
Add build-time check for name duplicates

### DIFF
--- a/build/lib/compendium-pack.ts
+++ b/build/lib/compendium-pack.ts
@@ -112,6 +112,10 @@ class CompendiumPack {
         };
 
         for (const docSource of this.data) {
+            // Assert there are no entries with the same name
+            if (packMap.has(docSource.name))
+                throw PackError(`Compendium ${this.id} (${dirName}) has multiple entries named ${docSource.name}.`);
+
             // Populate CompendiumPack.namesToIds for later conversion of compendium links
             packMap.set(docSource.name, docSource._id ?? "");
 

--- a/build/lib/compendium-pack.ts
+++ b/build/lib/compendium-pack.ts
@@ -113,8 +113,9 @@ class CompendiumPack {
 
         for (const docSource of this.data) {
             // Assert there are no entries with the same name
-            if (packMap.has(docSource.name))
+            if (packMap.has(docSource.name)) {
                 throw PackError(`Compendium ${this.id} (${dirName}) has multiple entries named ${docSource.name}.`);
+            }
 
             // Populate CompendiumPack.namesToIds for later conversion of compendium links
             packMap.set(docSource.name, docSource._id ?? "");


### PR DESCRIPTION
Will prevent build from finishing as duplicate entries make source uuid links ambiguous.

Will currently fail SF build due to gambler duplicate, but will work correctly after it's resolved.

Will allow extracting the pack normally, but won't let packing it back.