### PR TITLE
Also resolve persistent damage for troop segments and familiars

### DIFF
--- a/src/module/encounter/combatant.ts
+++ b/src/module/encounter/combatant.ts
@@ -161,27 +161,35 @@ class CombatantPF2e<
         Hooks.callAll("pf2e.startTurn", this, encounter, game.user.id);
     }
 
+    /** Runs end turn events. These run per represented actor, so for troops it'll run per segment. */
     async endTurn(options: { round: number }): Promise<void> {
         const round = options.round;
-        const { actor, encounter } = this;
-        if (!encounter || !actor) return;
+        const { encounter } = this;
+        const thisActor = this.actor;
+        if (!encounter || !thisActor) return;
 
-        // Run condition end of turn effects, unless the actor is dead
-        if (!actor.isDead) {
-            const activeConditions = actor.conditions.active;
-            for (const condition of activeConditions) {
-                await condition.onEndTurn({ token: this.token });
+        const tokens = this.tokens;
+        const scene = tokens.at(0)?.scene;
+        const familiar = thisActor.isOfType("character") ? thisActor.familiar : null;
+        if (familiar && scene) {
+            const famToken = familiar.getDependentTokens({ scenes: [scene] })?.[0];
+            if (famToken) tokens.push(famToken);
+        }
+        for (const token of tokens) {
+            const actor = token.actor;
+            if (!actor) continue;
+
+            // Run condition end of turn effects, unless the actor is dead
+            if (!actor.isDead) {
+                const activeConditions = actor.conditions.active;
+                for (const condition of activeConditions) {
+                    await condition.onEndTurn({ token });
+                }
             }
-        }
 
-        // Effect changes on turn start/end
-        const eventType = "turn-end";
-        for (const effect of actor.itemTypes.effect) {
-            await effect.onEncounterEvent(eventType);
-        }
-        if (actor.isOfType("character") && actor.familiar) {
-            for (const effect of actor.familiar.itemTypes.effect) {
-                await effect.onEncounterEvent(eventType);
+            // Effect changes on turn end
+            for (const effect of actor.itemTypes.effect) {
+                await effect.onEncounterEvent("turn-end");
             }
         }
 


### PR DESCRIPTION
Should we include familiars in `combatant.tokens`. This would also include them in combatant pings and probably lead to better overall handling in the future of shared turn combatants. But I wasn't sure yet.