### PR TITLE
Fixed Roaring Applause's Heightening Value

### DIFF
--- a/packs/pf2e/spells/spells/rank-3/roaring-applause.json
+++ b/packs/pf2e/spells/spells/rank-3/roaring-applause.json
@@ -1,5 +1,5 @@
 {
-    "_id": "sFWkLAYgwfj6VeRm",
+    "_id": "czO0wbT1i320gcu9",
     "folder": "4fJHnYFqH0VjZXPv",
     "img": "systems/pf2e/icons/spells/roaring-applause.webp",
     "name": "Roaring Applause",

--- a/packs/pf2e/spells/spells/rank-3/roaring-applause.json
+++ b/packs/pf2e/spells/spells/rank-3/roaring-applause.json
@@ -1,5 +1,5 @@
 {
-    "_id": "czO0wbT1i320gcu9",
+    "_id": "sFWkLAYgwfj6VeRm",
     "folder": "4fJHnYFqH0VjZXPv",
     "img": "systems/pf2e/icons/spells/roaring-applause.webp",
     "name": "Roaring Applause",
@@ -25,7 +25,7 @@
         },
         "heightening": {
             "levels": {
-                "4": {
+                "6": {
                     "target": {
                         "value": "10 creatures"
                     }


### PR DESCRIPTION
I noticed during play yesterday that Roaring Applause's heighten value didn't line up with the text. Quick PR to address that.