### PR TITLE
Add missing localization strings to SF2e

### DIFF
--- a/packs/sf2e/alien-core-bestiary/emvermod.json
+++ b/packs/sf2e/alien-core-bestiary/emvermod.json
@@ -625,7 +625,7 @@
                     },
                     {
                         "key": "RollOption",
-                        "label": "Comm Unit - Flashlight",
+                        "label": "SF2E.SpecificRule.Equipment.CommUnit.Flashlight",
                         "option": "flashlight",
                         "toggleable": true
                     },

--- a/packs/sf2e/alien-core-bestiary/ignurso.json
+++ b/packs/sf2e/alien-core-bestiary/ignurso.json
@@ -101,7 +101,7 @@
                             "lavaproof"
                         ],
                         "key": "Immunity",
-                        "label": "lavaproof",
+                        "label": "SF2E.NPCAbility.Ignurso.Lavaproof.ImmunityLabel",
                         "type": "custom"
                     }
                 ],

--- a/packs/sf2e/alien-core-bestiary/illumantula.json
+++ b/packs/sf2e/alien-core-bestiary/illumantula.json
@@ -1433,7 +1433,7 @@
                             "fortune"
                         ],
                         "key": "Weakness",
-                        "label": "fortune",
+                        "label": "SF2E.NPCAbility.Illumantula.RelativityField.WeaknessLabel",
                         "type": "custom",
                         "value": 10
                     }

--- a/packs/sf2e/alien-core-bestiary/necrolinked-wight.json
+++ b/packs/sf2e/alien-core-bestiary/necrolinked-wight.json
@@ -70,7 +70,7 @@
                     },
                     {
                         "key": "RollOption",
-                        "label": "Comm Unit - Flashlight",
+                        "label": "SF2E.SpecificRule.Equipment.CommUnit.Flashlight",
                         "option": "flashlight",
                         "toggleable": true
                     },

--- a/packs/sf2e/alien-core-bestiary/paradox-17.json
+++ b/packs/sf2e/alien-core-bestiary/paradox-17.json
@@ -820,7 +820,7 @@
                                 "definition": [
                                     "natural-invisibility"
                                 ],
-                                "label": "from creatures observing it"
+                                "label": "SF2E.NPCAbility.Paradox17.NaturalInvisibility.ResistanceException"
                             }
                         ],
                         "key": "Resistance",

--- a/packs/sf2e/alien-core-bestiary/paradoxical-solipsist.json
+++ b/packs/sf2e/alien-core-bestiary/paradoxical-solipsist.json
@@ -1144,7 +1144,7 @@
                                 "definition": [
                                     "origin:condition:hidden"
                                 ],
-                                "label": "unless the source of the damage is hidden to them"
+                                "label": "SF2E.NPCAbility.ParadoxicalSolipsist.PerceiveUnreality.ResistanceException"
                             }
                         ],
                         "key": "Resistance",

--- a/packs/sf2e/alien-core-bestiary/sihedron-guard-thunderstriker.json
+++ b/packs/sf2e/alien-core-bestiary/sihedron-guard-thunderstriker.json
@@ -1860,7 +1860,7 @@
                         "property": "description",
                         "value": [
                             {
-                                "text": "If the next action the aeon guard uses is to Cast a Spell that has a range, increase that spell's range by 30 feet."
+                                "text": "SF2E.NPCAbility.SihedronGuardThunderstriker.NavigationalSpellshape.Alteration"
                             }
                         ]
                     }

--- a/packs/sf2e/ancestry-features/vlaka/sensory-diversity.json
+++ b/packs/sf2e/ancestry-features/vlaka/sensory-diversity.json
@@ -36,25 +36,25 @@
                 "adjustName": false,
                 "choices": [
                     {
-                        "label": "Blind",
+                        "label": "SF2E.SpecificRule.Vlaka.SensoryDiversity.Blind",
                         "value": "blind"
                     },
                     {
-                        "label": "Deaf",
+                        "label": "SF2E.SpecificRule.Vlaka.SensoryDiversity.Deaf",
                         "value": "deaf"
                     },
                     {
-                        "label": "Deafblind",
+                        "label": "SF2E.SpecificRule.Vlaka.SensoryDiversity.Deafblind",
                         "value": "deafblind"
                     },
                     {
-                        "label": "Hearing/Sighted",
+                        "label": "SF2E.SpecificRule.Vlaka.SensoryDiversity.HearingSighted",
                         "value": "hearing-sighted"
                     }
                 ],
                 "flag": "sensoryDiversity",
                 "key": "ChoiceSet",
-                "prompt": "Select one sensory array"
+                "prompt": "SF2E.SpecificRule.Vlaka.SensoryDiversity.Prompt"
             },
             {
                 "key": "RollOption",

--- a/packs/sf2e/bestiary-ability-glossary-srd/magical-adjustments/magical-magical-resilience.json
+++ b/packs/sf2e/bestiary-ability-glossary-srd/magical-adjustments/magical-magical-resilience.json
@@ -22,7 +22,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Magical Resilience",
                 "predicate": [
                     "magical-resilience"
                 ],

--- a/packs/sf2e/bestiary-ability-glossary-srd/security-robot/security-robot-exigency.json
+++ b/packs/sf2e/bestiary-ability-glossary-srd/security-robot/security-robot-exigency.json
@@ -26,7 +26,6 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Exigency",
                 "predicate": [
                     "exigency"
                 ],

--- a/packs/sf2e/equipment/adventuring-gear/comm-unit.json
+++ b/packs/sf2e/equipment/adventuring-gear/comm-unit.json
@@ -57,7 +57,7 @@
             },
             {
                 "key": "RollOption",
-                "label": "Comm Unit - Flashlight",
+                "label": "SF2E.SpecificRule.Equipment.CommUnit.Flashlight",
                 "option": "flashlight",
                 "toggleable": true
             },

--- a/packs/sf2e/equipment/adventuring-gear/magboots.json
+++ b/packs/sf2e/equipment/adventuring-gear/magboots.json
@@ -43,7 +43,7 @@
             },
             {
                 "key": "FlatModifier",
-                "label": "Magboots - climb metal surfaces",
+                "label": "SF2E.SpecificRule.Equipment.Magboots.ClimbMetalSurfaces",
                 "predicate": [
                     "action:climb",
                     "magboots"

--- a/packs/sf2e/feat-effects/effect-face-in-the-crowd.json
+++ b/packs/sf2e/feat-effects/effect-face-in-the-crowd.json
@@ -25,7 +25,7 @@
             {
                 "choices": [
                     {
-                        "label": "At least 10 creatures",
+                        "label": "SF2E.SpecificRule.SkillFeat.FaceInTheCrowd.CrowdSize.Ten",
                         "predicate": [
                             {
                                 "lte": [
@@ -37,7 +37,7 @@
                         "value": 2
                     },
                     {
-                        "label": "At least 5 creatures",
+                        "label": "SF2E.SpecificRule.SkillFeat.FaceInTheCrowd.CrowdSize.Five",
                         "predicate": [
                             {
                                 "gte": [
@@ -49,13 +49,13 @@
                         "value": 2
                     },
                     {
-                        "label": "At least 100 creatures",
+                        "label": "SF2E.SpecificRule.SkillFeat.FaceInTheCrowd.CrowdSize.Hundred",
                         "value": 4
                     }
                 ],
                 "flag": "crowdSizeBonus",
                 "key": "ChoiceSet",
-                "prompt": "Select a crowd size"
+                "prompt": "SF2E.SpecificRule.SkillFeat.FaceInTheCrowd.Prompt"
             },
             {
                 "key": "FlatModifier",

--- a/packs/sf2e/feat-effects/effect-rally-the-troops.json
+++ b/packs/sf2e/feat-effects/effect-rally-the-troops.json
@@ -25,11 +25,11 @@
             {
                 "choices": [
                     {
-                        "label": "Next to Ally",
+                        "label": "SF2E.NPCAbility.RallyTheTroops.Ally",
                         "value": "ally"
                     },
                     {
-                        "label": "Next to Commander",
+                        "label": "SF2E.NPCAbility.RallyTheTroops.Commander",
                         "value": "commander"
                     }
                 ],

--- a/packs/sf2e/feats/ancestry/contemplative/level-1/telepredict.json
+++ b/packs/sf2e/feats/ancestry/contemplative/level-1/telepredict.json
@@ -61,7 +61,7 @@
             {
                 "domain": "all",
                 "key": "RollOption",
-                "label": "Dealt Mental Damage to target of Telepredict",
+                "label": "SF2E.SpecificRule.Contemplative.Telepredict.Toggle",
                 "option": "mental-damage",
                 "toggleable": true,
                 "value": true

--- a/packs/sf2e/feats/ancestry/contemplative/level-13/psychic-constellation.json
+++ b/packs/sf2e/feats/ancestry/contemplative/level-13/psychic-constellation.json
@@ -33,7 +33,7 @@
             {
                 "domain": "all",
                 "key": "RollOption",
-                "label": "You have an empty Telekinetic Hand",
+                "label": "SF2E.SpecificRule.Contemplative.OverwhelmingEgo.Label",
                 "option": "empty-telekinetic-hand",
                 "toggleable": true
             },

--- a/packs/sf2e/feats/ancestry/contemplative/level-5/overwhelming-ego.json
+++ b/packs/sf2e/feats/ancestry/contemplative/level-5/overwhelming-ego.json
@@ -39,7 +39,7 @@
             {
                 "domain": "all",
                 "key": "RollOption",
-                "label": "First Psychic Shock strike this round",
+                "label": "SF2E.SpecificRule.Contemplative.OverwhelmingEgo.Label",
                 "option": "overwhelming-ego-strike",
                 "toggleable": true
             },

--- a/packs/sf2e/feats/ancestry/dragonkin/level-1/dragonkin-breath.json
+++ b/packs/sf2e/feats/ancestry/dragonkin/level-1/dragonkin-breath.json
@@ -38,56 +38,56 @@
                 "adjustName": true,
                 "choices": [
                     {
-                        "label": "Acid (Corrosive)",
+                        "label": "SF2E.SpecificRule.Dragonkin.DragonkinBreath.Acid",
                         "value": {
                             "damageType": "acid",
                             "group": "corrosive"
                         }
                     },
                     {
-                        "label": "Bludgeoning (Hammer)",
+                        "label": "SF2E.SpecificRule.Dragonkin.DragonkinBreath.Bludgeoning",
                         "value": {
                             "damageType": "bludgeoning",
                             "group": "hammer"
                         }
                     },
                     {
-                        "label": "Cold (Cryo)",
+                        "label": "SF2E.SpecificRule.Dragonkin.DragonkinBreath.Cold",
                         "value": {
                             "damageType": "cold",
                             "group": "cryo"
                         }
                     },
                     {
-                        "label": "Electricity (Shock)",
+                        "label": "SF2E.SpecificRule.Dragonkin.DragonkinBreath.Electricity",
                         "value": {
                             "damageType": "electricity",
                             "group": "shock"
                         }
                     },
                     {
-                        "label": "Fire (Flame)",
+                        "label": "SF2E.SpecificRule.Dragonkin.DragonkinBreath.Fire",
                         "value": {
                             "damageType": "fire",
                             "group": "flame"
                         }
                     },
                     {
-                        "label": "Piercing (Spear)",
+                        "label": "SF2E.SpecificRule.Dragonkin.DragonkinBreath.Piercing",
                         "value": {
                             "damageType": "piercing",
                             "group": "spear"
                         }
                     },
                     {
-                        "label": "Slashing (Knife)",
+                        "label": "SF2E.SpecificRule.Dragonkin.DragonkinBreath.Slashing",
                         "value": {
                             "damageType": "slashing",
                             "group": "knife"
                         }
                     },
                     {
-                        "label": "Sonic (Sonic)",
+                        "label": "SF2E.SpecificRule.Dragonkin.DragonkinBreath.Sonic",
                         "value": {
                             "damageType": "sonic",
                             "group": "sonic"

--- a/packs/sf2e/feats/ancestry/dragonkin/level-1/moodscales.json
+++ b/packs/sf2e/feats/ancestry/dragonkin/level-1/moodscales.json
@@ -28,7 +28,7 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Against emotion effects",
+                "label": "SF2E.SpecificRule.Dragonkin.Moodscales.Modifier",
                 "predicate": [
                     "emotion"
                 ],
@@ -56,7 +56,7 @@
                     "emotion"
                 ],
                 "selector": "saving-throw",
-                "text": "If you roll a success on a saving throw against an emotion effect, you get a critical success instead.",
+                "text": "SF2E.SpecificRule.Dragonkin.Moodscales.Note",
                 "title": "{item|name}"
             }
         ],

--- a/packs/sf2e/feats/ancestry/dragonkin/level-5/dragons-tenacity.json
+++ b/packs/sf2e/feats/ancestry/dragonkin/level-5/dragons-tenacity.json
@@ -28,9 +28,9 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Against effects that would make you Paralyzed",
+                "label": "SF2E.SpecificRule.Dragonkin.DragonsTenacity.InflictsParalyzed",
                 "predicate": [
-                    "effect:paralyzed"
+                    "inflicts:paralyzed"
                 ],
                 "selector": "saving-throw",
                 "type": "circumstance",
@@ -38,9 +38,9 @@
             },
             {
                 "key": "FlatModifier",
-                "label": "Against magic effects that would make you Paralyzed",
+                "label": "SF2E.SpecificRule.Dragonkin.DragonsTenacity.MagicEffect",
                 "predicate": [
-                    "effect:paralyzed",
+                    "inflicts:paralyzed",
                     {
                         "or": [
                             "item:magical",

--- a/packs/sf2e/feats/ancestry/kalo/level-1/silent-tide.json
+++ b/packs/sf2e/feats/ancestry/kalo/level-1/silent-tide.json
@@ -28,7 +28,7 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "label": "Improved Sneak While Swimming",
+                "label": "SF2E.SpecificRule.Kalo.SilentTide.ImprovedSneak",
                 "predicate": [
                     "swimming",
                     "have-ability-to-move-full-speed-while-sneaking",

--- a/packs/sf2e/feats/ancestry/kalo/level-9/enhanced-echolocation.json
+++ b/packs/sf2e/feats/ancestry/kalo/level-9/enhanced-echolocation.json
@@ -47,7 +47,7 @@
             },
             {
                 "key": "RollOption",
-                "label": "Focus Senses",
+                "label": "SF2E.SpecificRule.Kalo.EnhancedEcholocation.FocusSenses",
                 "option": "focus-senses",
                 "toggleable": true
             },

--- a/packs/sf2e/feats/ancestry/sarcesian/level-5/undead-slayer.json
+++ b/packs/sf2e/feats/ancestry/sarcesian/level-5/undead-slayer.json
@@ -49,7 +49,7 @@
                     "action:recall-knowledge"
                 ],
                 "selector": "skill-check",
-                "text": "When you succeed or critically succeed at a check to Recall Knowledge against an undead creature that you can see, you identify a weak spot in their defenses—for 1 minute, you gain access to the critical specialization effects of all weapons and unarmed attacks for attacks you make against that specific creature.",
+                "text": "SF2E.SpecificRule.Sarcesian.UndeadSlayer.Note",
                 "title": "{item|name}"
             }
         ],

--- a/packs/sf2e/feats/ancestry/vlaka/level-1/talented-tracker.json
+++ b/packs/sf2e/feats/ancestry/vlaka/level-1/talented-tracker.json
@@ -29,7 +29,7 @@
             {
                 "domain": "all",
                 "key": "RollOption",
-                "label": "Track by scent",
+                "label": "SF2E.SpecificRule.Vlaka.TalentedTracker.TrackByScent",
                 "option": "talented-tracker-scent",
                 "toggleable": true
             },
@@ -47,7 +47,7 @@
             },
             {
                 "key": "FlatModifier",
-                "label": "Track by scent",
+                "label": "SF2E.SpecificRule.Vlaka.TalentedTracker.TrackByScent",
                 "predicate": [
                     "action:track",
                     "talented-tracker-scent"

--- a/packs/sf2e/feats/ancestry/vlaka/level-5/ruin-delver.json
+++ b/packs/sf2e/feats/ancestry/vlaka/level-5/ruin-delver.json
@@ -29,7 +29,7 @@
             {
                 "domain": "all",
                 "key": "RollOption",
-                "label": "Against hazards",
+                "label": "SF2E.SpecificRule.Vlaka.RuinDelver.AgainstHazards",
                 "option": "ruin-delver",
                 "toggleable": true
             },

--- a/packs/sf2e/feats/archetype/multiclass-archetypes/solarian-archetype/solar-manifestation-expert.json
+++ b/packs/sf2e/feats/archetype/multiclass-archetypes/solarian-archetype/solar-manifestation-expert.json
@@ -44,7 +44,7 @@
                     "item:slug:solar-flare"
                 ],
                 "key": "MartialProficiency",
-                "label": "Solar Flare",
+                "label": "SF2E.SpecificRule.Solarian.SolarFlare.Label",
                 "slug": "solar-flare",
                 "value": 2
             },
@@ -53,7 +53,7 @@
                     "item:slug:solar-weapon"
                 ],
                 "key": "MartialProficiency",
-                "label": "Solar Weapon",
+                "label": "SF2E.SpecificRule.Solarian.SolarWeapon.Label",
                 "slug": "solar-weapon",
                 "value": 2
             }

--- a/packs/sf2e/heritages/vlaka/star-marked-vlaka.json
+++ b/packs/sf2e/heritages/vlaka/star-marked-vlaka.json
@@ -20,7 +20,7 @@
         "rules": [
             {
                 "key": "RollOption",
-                "label": "Shedding Light",
+                "label": "SF2E.SpecificRule.Vlaka.StarMarked.SheddingLight",
                 "option": "shed-light",
                 "toggleable": true
             },

--- a/packs/sf2e/iconics/chk-chk/chk-chk-level-1.json
+++ b/packs/sf2e/iconics/chk-chk/chk-chk-level-1.json
@@ -1605,7 +1605,7 @@
                     },
                     {
                         "key": "RollOption",
-                        "label": "Comm Unit - Flashlight",
+                        "label": "SF2E.SpecificRule.Equipment.CommUnit.Flashlight",
                         "option": "flashlight",
                         "toggleable": true
                     },

--- a/packs/sf2e/iconics/chk-chk/chk-chk-level-3.json
+++ b/packs/sf2e/iconics/chk-chk/chk-chk-level-3.json
@@ -1543,7 +1543,7 @@
                     },
                     {
                         "key": "RollOption",
-                        "label": "Comm Unit - Flashlight",
+                        "label": "SF2E.SpecificRule.Equipment.CommUnit.Flashlight",
                         "option": "flashlight",
                         "toggleable": true
                     },

--- a/packs/sf2e/iconics/chk-chk/chk-chk-level-5.json
+++ b/packs/sf2e/iconics/chk-chk/chk-chk-level-5.json
@@ -1610,7 +1610,7 @@
                     },
                     {
                         "key": "RollOption",
-                        "label": "Comm Unit - Flashlight",
+                        "label": "SF2E.SpecificRule.Equipment.CommUnit.Flashlight",
                         "option": "flashlight",
                         "toggleable": true
                     },

--- a/packs/sf2e/iconics/chk-chk/chk-chk-level-7.json
+++ b/packs/sf2e/iconics/chk-chk/chk-chk-level-7.json
@@ -1610,7 +1610,7 @@
                     },
                     {
                         "key": "RollOption",
-                        "label": "Comm Unit - Flashlight",
+                        "label": "SF2E.SpecificRule.Equipment.CommUnit.Flashlight",
                         "option": "flashlight",
                         "toggleable": true
                     },

--- a/packs/sf2e/iconics/dae/dae-level-1.json
+++ b/packs/sf2e/iconics/dae/dae-level-1.json
@@ -1175,7 +1175,7 @@
                     },
                     {
                         "key": "RollOption",
-                        "label": "Comm Unit - Flashlight",
+                        "label": "SF2E.SpecificRule.Equipment.CommUnit.Flashlight",
                         "option": "flashlight",
                         "toggleable": true
                     },

--- a/packs/sf2e/iconics/dae/dae-level-3.json
+++ b/packs/sf2e/iconics/dae/dae-level-3.json
@@ -1177,7 +1177,7 @@
                     },
                     {
                         "key": "RollOption",
-                        "label": "Comm Unit - Flashlight",
+                        "label": "SF2E.SpecificRule.Equipment.CommUnit.Flashlight",
                         "option": "flashlight",
                         "toggleable": true
                     },

--- a/packs/sf2e/iconics/dae/dae-level-5.json
+++ b/packs/sf2e/iconics/dae/dae-level-5.json
@@ -1177,7 +1177,7 @@
                     },
                     {
                         "key": "RollOption",
-                        "label": "Comm Unit - Flashlight",
+                        "label": "SF2E.SpecificRule.Equipment.CommUnit.Flashlight",
                         "option": "flashlight",
                         "toggleable": true
                     },
@@ -1913,7 +1913,7 @@
                     },
                     {
                         "key": "FlatModifier",
-                        "label": "Magboots - climb metal surfaces",
+                        "label": "SF2E.SpecificRule.Equipment.Magboots.ClimbMetalSurfaces",
                         "predicate": [
                             "action:climb",
                             "magboots"

--- a/packs/sf2e/iconics/dae/dae-level-7.json
+++ b/packs/sf2e/iconics/dae/dae-level-7.json
@@ -1176,7 +1176,7 @@
                     },
                     {
                         "key": "RollOption",
-                        "label": "Comm Unit - Flashlight",
+                        "label": "SF2E.SpecificRule.Equipment.CommUnit.Flashlight",
                         "option": "flashlight",
                         "toggleable": true
                     },
@@ -1912,7 +1912,7 @@
                     },
                     {
                         "key": "FlatModifier",
-                        "label": "Magboots - climb metal surfaces",
+                        "label": "SF2E.SpecificRule.Equipment.Magboots.ClimbMetalSurfaces",
                         "predicate": [
                             "action:climb",
                             "magboots"

--- a/packs/sf2e/iconics/iseph/iseph-level-1.json
+++ b/packs/sf2e/iconics/iseph/iseph-level-1.json
@@ -1179,7 +1179,7 @@
                     },
                     {
                         "key": "RollOption",
-                        "label": "Comm Unit - Flashlight",
+                        "label": "SF2E.SpecificRule.Equipment.CommUnit.Flashlight",
                         "option": "flashlight",
                         "toggleable": true
                     },

--- a/packs/sf2e/iconics/iseph/iseph-level-3.json
+++ b/packs/sf2e/iconics/iseph/iseph-level-3.json
@@ -1179,7 +1179,7 @@
                     },
                     {
                         "key": "RollOption",
-                        "label": "Comm Unit - Flashlight",
+                        "label": "SF2E.SpecificRule.Equipment.CommUnit.Flashlight",
                         "option": "flashlight",
                         "toggleable": true
                     },

--- a/packs/sf2e/iconics/iseph/iseph-level-5.json
+++ b/packs/sf2e/iconics/iseph/iseph-level-5.json
@@ -1179,7 +1179,7 @@
                     },
                     {
                         "key": "RollOption",
-                        "label": "Comm Unit - Flashlight",
+                        "label": "SF2E.SpecificRule.Equipment.CommUnit.Flashlight",
                         "option": "flashlight",
                         "toggleable": true
                     },

--- a/packs/sf2e/iconics/iseph/iseph-level-7.json
+++ b/packs/sf2e/iconics/iseph/iseph-level-7.json
@@ -1179,7 +1179,7 @@
                     },
                     {
                         "key": "RollOption",
-                        "label": "Comm Unit - Flashlight",
+                        "label": "SF2E.SpecificRule.Equipment.CommUnit.Flashlight",
                         "option": "flashlight",
                         "toggleable": true
                     },

--- a/packs/sf2e/iconics/navasi/navasi-level-1.json
+++ b/packs/sf2e/iconics/navasi/navasi-level-1.json
@@ -1032,7 +1032,7 @@
                     },
                     {
                         "key": "RollOption",
-                        "label": "Comm Unit - Flashlight",
+                        "label": "SF2E.SpecificRule.Equipment.CommUnit.Flashlight",
                         "option": "flashlight",
                         "toggleable": true
                     },

--- a/packs/sf2e/iconics/navasi/navasi-level-3.json
+++ b/packs/sf2e/iconics/navasi/navasi-level-3.json
@@ -1033,7 +1033,7 @@
                     },
                     {
                         "key": "RollOption",
-                        "label": "Comm Unit - Flashlight",
+                        "label": "SF2E.SpecificRule.Equipment.CommUnit.Flashlight",
                         "option": "flashlight",
                         "toggleable": true
                     },

--- a/packs/sf2e/iconics/navasi/navasi-level-5.json
+++ b/packs/sf2e/iconics/navasi/navasi-level-5.json
@@ -1032,7 +1032,7 @@
                     },
                     {
                         "key": "RollOption",
-                        "label": "Comm Unit - Flashlight",
+                        "label": "SF2E.SpecificRule.Equipment.CommUnit.Flashlight",
                         "option": "flashlight",
                         "toggleable": true
                     },

--- a/packs/sf2e/iconics/navasi/navasi-level-7.json
+++ b/packs/sf2e/iconics/navasi/navasi-level-7.json
@@ -1032,7 +1032,7 @@
                     },
                     {
                         "key": "RollOption",
-                        "label": "Comm Unit - Flashlight",
+                        "label": "SF2E.SpecificRule.Equipment.CommUnit.Flashlight",
                         "option": "flashlight",
                         "toggleable": true
                     },

--- a/packs/sf2e/iconics/obozaya/obozaya-level-1.json
+++ b/packs/sf2e/iconics/obozaya/obozaya-level-1.json
@@ -983,7 +983,7 @@
                     },
                     {
                         "key": "RollOption",
-                        "label": "Comm Unit - Flashlight",
+                        "label": "SF2E.SpecificRule.Equipment.CommUnit.Flashlight",
                         "option": "flashlight",
                         "toggleable": true
                     },

--- a/packs/sf2e/iconics/obozaya/obozaya-level-3.json
+++ b/packs/sf2e/iconics/obozaya/obozaya-level-3.json
@@ -983,7 +983,7 @@
                     },
                     {
                         "key": "RollOption",
-                        "label": "Comm Unit - Flashlight",
+                        "label": "SF2E.SpecificRule.Equipment.CommUnit.Flashlight",
                         "option": "flashlight",
                         "toggleable": true
                     },

--- a/packs/sf2e/iconics/obozaya/obozaya-level-5.json
+++ b/packs/sf2e/iconics/obozaya/obozaya-level-5.json
@@ -983,7 +983,7 @@
                     },
                     {
                         "key": "RollOption",
-                        "label": "Comm Unit - Flashlight",
+                        "label": "SF2E.SpecificRule.Equipment.CommUnit.Flashlight",
                         "option": "flashlight",
                         "toggleable": true
                     },

--- a/packs/sf2e/iconics/obozaya/obozaya-level-7.json
+++ b/packs/sf2e/iconics/obozaya/obozaya-level-7.json
@@ -983,7 +983,7 @@
                     },
                     {
                         "key": "RollOption",
-                        "label": "Comm Unit - Flashlight",
+                        "label": "SF2E.SpecificRule.Equipment.CommUnit.Flashlight",
                         "option": "flashlight",
                         "toggleable": true
                     },

--- a/packs/sf2e/iconics/zemir/zemir-level-1.json
+++ b/packs/sf2e/iconics/zemir/zemir-level-1.json
@@ -1246,7 +1246,7 @@
                     },
                     {
                         "key": "RollOption",
-                        "label": "Comm Unit - Flashlight",
+                        "label": "SF2E.SpecificRule.Equipment.CommUnit.Flashlight",
                         "option": "flashlight",
                         "toggleable": true
                     },

--- a/packs/sf2e/iconics/zemir/zemir-level-3.json
+++ b/packs/sf2e/iconics/zemir/zemir-level-3.json
@@ -1246,7 +1246,7 @@
                     },
                     {
                         "key": "RollOption",
-                        "label": "Comm Unit - Flashlight",
+                        "label": "SF2E.SpecificRule.Equipment.CommUnit.Flashlight",
                         "option": "flashlight",
                         "toggleable": true
                     },

--- a/packs/sf2e/iconics/zemir/zemir-level-5.json
+++ b/packs/sf2e/iconics/zemir/zemir-level-5.json
@@ -1246,7 +1246,7 @@
                     },
                     {
                         "key": "RollOption",
-                        "label": "Comm Unit - Flashlight",
+                        "label": "SF2E.SpecificRule.Equipment.CommUnit.Flashlight",
                         "option": "flashlight",
                         "toggleable": true
                     },

--- a/packs/sf2e/iconics/zemir/zemir-level-7.json
+++ b/packs/sf2e/iconics/zemir/zemir-level-7.json
@@ -1246,7 +1246,7 @@
                     },
                     {
                         "key": "RollOption",
-                        "label": "Comm Unit - Flashlight",
+                        "label": "SF2E.SpecificRule.Equipment.CommUnit.Flashlight",
                         "option": "flashlight",
                         "toggleable": true
                     },

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -7590,7 +7590,7 @@
             },
             "SihedronGuardThunderstriker": {
                 "NavigationalSpellshape": {
-                    "Alteration": "If the next action the aeon guard uses is to Cast a Spell that has a range, increase that spell's range by 30 feet."
+                    "Alteration": "If the next action the aeon guard uses is to Cast a Spell that has a range, increase that spell's range by 30 feet. In addition, if the spell requires an attack roll or a Reflex save, any targets of the spell that have lesser cover reduce the bonuses they gain from cover by 1 against the spell."
                 }
             },
             "Vorthuul": {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -1636,8 +1636,7 @@
                 "Dragontongue": {
                     "ImmunityLabel": "dragontongue"
                 },
-                "PowerfulUtterance": 
-                {
+                "PowerfulUtterance": {
                     "ImmunityLabel": "powerful utterance"
                 }
             },
@@ -7565,6 +7564,35 @@
             "Hardlight": {
                 "TouchingProjectorLabel": "Touching Projector"
             },
+            "Ignurso": {
+                "Lavaproof": {
+                    "ImmunityLabel": "lavaproof"
+                }
+            },
+            "Illumantula": {
+                "RelativityField": {
+                    "WeaknessLabel": "fortune"
+                }
+            },
+            "Paradox17": {
+                "NaturalInvisibility": {
+                    "ResistanceException": "from creatures observing it"
+                }
+            },
+            "ParadoxicalSolipsist": {
+                "PerceiveUnreality": {
+                    "ResistanceException": "source of damage is hidden to them"
+                }
+            },
+            "RallyTheTroops": {
+                "Ally": "Next to Ally",
+                "Commander": "Next to Commander"
+            },
+            "SihedronGuardThunderstriker": {
+                "NavigationalSpellshape": {
+                    "Alteration": "If the next action the aeon guard uses is to Cast a Spell that has a range, increase that spell's range by 30 feet."
+                }
+            },
             "Vorthuul": {
                 "QuantumDuality": {
                     "AbsoluteTranquility": "Absolute Tranquility",
@@ -7622,8 +7650,11 @@
                 "Mindrender": {
                     "Label": "Psychic Shock"
                 },
+                "OverwhelmingEgo": {
+                    "Label": "First Psychic Shock strike this round"
+                },
                 "Telepredict": {
-                    "Toggle": "Telepredict: Dealt mental damage"
+                    "Toggle": "Telepredict — Dealt mental damage"
                 }
             },
             "Corpsefolk": {
@@ -7632,6 +7663,24 @@
                 }
             },
             "Dragonkin": {
+                "DragonkinBreath": {
+                    "Acid": "Acid (Corrosive)",
+                    "Bludgeoning": "Bludgeoning (Hammer)",
+                    "Cold": "Cold (Cryo)",
+                    "Electricity": "Electricity (Shock)",
+                    "Fire": "Fire (Flame)",
+                    "Piercing": "Piercing (Spear)",
+                    "Slashing": "Slashing (Knife)",
+                    "Sonic": "Sonic (Sonic)"
+                },
+                "DragonsTenacity": {
+                    "InflictsParalyzed": "Dragon's Tenacity — Effect makes you Paralyzed",
+                    "MagicEffect": "Dragon's Tenacity — Magic effect makes you Paralyzed"
+                },
+                "Moodscales": {
+                    "Modifier": "Moodscales — Against emotion effects",
+                    "Note": "If you roll a success on a saving throw against an emotion effect, you get a critical success instead."
+                },
                 "WeaponFamiliarity": {
                     "AdvancedWeapons": "Advanced Dragonkin Weapons",
                     "MartialWeapons": "Martial Dragonkin Weapons"
@@ -7687,7 +7736,7 @@
                     }
                 },
                 "CommUnit": {
-                    "Lit": "Comm Unit Lit"
+                    "Flashlight": "Comm Unit — Flashlight"
                 },
                 "Flashlight": {
                     "Lit": "Flashlight Lit"
@@ -7699,6 +7748,9 @@
                     "Superior": "Attempt a @Check[flat|dc:18] check. On a success, the critical hit becomes a normal hit.",
                     "Tactical": "Attempt a @Check[flat|dc:20] check. On a success, the critical hit becomes a normal hit.",
                     "Ultimate": "Attempt a @Check[flat|dc:16] check. On a success, the critical hit becomes a normal hit."
+                },
+                "Magboots": {
+                    "ClimbMetalSurfaces": "Magboots — Climb metal surfaces"
                 },
                 "SolarianCrystals": {
                     "Gluon": {
@@ -7795,8 +7847,14 @@
                 "ElectricKalo": {
                     "Alteration": "If you cast this spell with only 1 target, you gain electricity resistance equal to half your level (minimum 1) until the end of your next turn."
                 },
+                "EnhancedEcholocation": {
+                    "FocusSenses": "Focus Senses"
+                },
                 "GelidBite": {
                     "Note": "On a critical hit, the target is also @UUID[Compendium.sf2e.conditions.Item.enA7BxAjBb7ns1iF]{Suppressed} until the end of your next turn, unless it succeeds at a @Check[fortitude|against:class-spell] save against your class DC or spell DC, whichever is higher."
+                },
+                "SilentTide": {
+                    "ImprovedSneak": "Silent Tide — Improved Sneak While Swimming"
                 }
             },
             "Kasatha": {
@@ -7954,6 +8012,9 @@
                 "CoronalFlare": {
                     "Note": "Coronal Flare"
                 },
+                "UndeadSlayer": {
+                    "Note": "When you succeed or critically succeed at a check to Recall Knowledge against an undead creature that you can see, you identify a weak spot in their defenses—for 1 minute, you gain access to the critical specialization effects of all weapons and unarmed attacks for attacks you make against that specific creature."
+                },
                 "WeaponFamiliarity": {
                     "AdvancedWeapons": "Advanced Sarcesian Weapons",
                     "MartialWeapons": "Martial Sarcesian Weapons"
@@ -7979,6 +8040,16 @@
                 "WeaponFamiliarity": {
                     "AdvancedWeapons": "Advanced Shobhad Weapons",
                     "MartialWeapons": "Martial Shobhad Weapons"
+                }
+            },
+            "SkillFeat": {
+                "FaceInTheCrowd": {
+                    "CrowdSize": {
+                        "Five": "At least 5 creatures",
+                        "Ten": "At least 10 creatures",
+                        "Hundred": "At least 100 creatures"
+                    },
+                    "Prompt": "Select a crowd size."
                 }
             },
             "Skittermander": {
@@ -8129,6 +8200,22 @@
             "Vlaka": {
                 "MenacingSnarl": {
                     "Label": "Target frightened by Menacing Snarl"
+                },
+                "RuinDelver": {
+                    "AgainstHazards": "Ruin Delver — Against hazards"
+                },
+                "SensoryDiversity": {
+                    "Blind": "Blind",
+                    "Deaf": "Deaf",
+                    "Deafblind": "Deafblind",
+                    "HearingSighted": "Hearing/Sighted",
+                    "Prompt": "Select one sensory array."
+                },
+                "StarMarked": {
+                    "SheddingLight": "Shedding Light"
+                },
+                "TalentedTracker": {
+                    "TrackByScent": "Talented Tracker — Track by Scent"
                 }
             },
             "Witchwarper": {


### PR DESCRIPTION
Will probably need some review and adjustment.

Only SF here. I'll do PF piecemeal later as I've found 767 entries (most of them in bestiaries).