### PR TITLE
Add `item:trait` roll options to action macros

### DIFF
--- a/src/module/system/action-macros/helpers.ts
+++ b/src/module/system/action-macros/helpers.ts
@@ -166,6 +166,7 @@ class ActionMacroHelpers {
                 const actionTraits = (options.traits ?? []).filter(
                     (t): t is AbilityTrait => t in CONFIG.PF2E.actionTraits,
                 );
+                combinedOptions.push(...actionTraits.map(t => `item:trait:` + t) ?? [])
                 const notes = options.extraNotes?.(statistic.slug) ?? [];
                 const label = (await options.content?.(header)) ?? header;
 

--- a/src/module/system/action-macros/helpers.ts
+++ b/src/module/system/action-macros/helpers.ts
@@ -166,7 +166,7 @@ class ActionMacroHelpers {
                 const actionTraits = (options.traits ?? []).filter(
                     (t): t is AbilityTrait => t in CONFIG.PF2E.actionTraits,
                 );
-                combinedOptions.push(...actionTraits.map(t => `item:trait:` + t) ?? [])
+                combinedOptions.push(...(actionTraits.map((t) => `item:trait:` + t) ?? []));
                 const notes = options.extraNotes?.(statistic.slug) ?? [];
                 const label = (await options.content?.(header)) ?? header;
 


### PR DESCRIPTION
Action macros not including them is a pain, and we have had a standard in data entry for years of using `item:trait:x` for added specificity. The action macros are stand ins for the action items themselves, and should pass the proper roll options for the item they are standing in for.