### PR TITLE
Fix roll options passed to escape act macros

### DIFF
--- a/src/module/system/action-macros/basic/escape.ts
+++ b/src/module/system/action-macros/basic/escape.ts
@@ -21,10 +21,9 @@ function unarmedStrikeWithHighestModifier<ItemType extends ItemPF2e<ActorPF2e>>(
     opts: CheckContextOptions<ItemType>,
     data: CheckContextData<ItemType>,
 ) {
-    const actionRollOptions = ["action:escape", "action:escape:unarmed"];
     const { rollOptions } = opts.buildContext({
         actor: opts.actor,
-        rollOptions: actionRollOptions,
+        rollOptions: ["action:escape:unarmed", ...data.rollOptions],
         target: opts.target,
     });
     const actor = opts.actor;
@@ -63,10 +62,9 @@ function escapeCheckContext<ItemType extends ItemPF2e<ActorPF2e>>(
         .map((slug) => opts.actor.getStatistic(slug))
         .filter((statistic): statistic is Statistic => !!statistic)
         .map((statistic) => {
-            const actionRollOptions = ["action:escape", `action:escape:${statistic.slug}`];
             const rollOptions = opts.buildContext({
                 actor: opts.actor,
-                rollOptions: actionRollOptions,
+                rollOptions: [`action:escape:${statistic.slug}`, ...data.rollOptions],
                 target: opts.target,
             }).rollOptions;
             const newStatistic = new StatisticModifier(


### PR DESCRIPTION
action:escape is already passed into data.rollOptions. Closes https://github.com/foundryvtt/pf2e/issues/21277.

This not only applies to macros but also using the options param in an inline act link.