### PR TITLE
Add export log for anachronism builds

### DIFF
--- a/build/anachronism.ts
+++ b/build/anachronism.ts
@@ -1,4 +1,6 @@
-import { recursiveReplaceString } from "@util/misc.ts";
+import { ItemSourcePF2e } from "@item/base/data/index.ts";
+import { itemIsOfType } from "@item/helpers.ts";
+import { objectHasKey, recursiveReplaceString, sluggify } from "@util/misc.ts";
 import fs from "fs";
 import path from "path";
 import * as R from "remeda";
@@ -6,6 +8,7 @@ import url from "url";
 import yargs, { Argv } from "yargs";
 import pf2eAnachronismManifest from "../module.pf2e-anachronism.json" with { type: "json" };
 import sf2eAnachronismManifest from "../module.sf2e-anachronism.json" with { type: "json" };
+import langEn from "../static/lang/en.json" with { type: "json" };
 import pf2eManifest from "../system.pf2e.json" with { type: "json" };
 import sf2eManifest from "../system.sf2e.json" with { type: "json" };
 import duplicates from "./duplicates.json" with { type: "json" };
@@ -54,6 +57,7 @@ const sf2ePacks = fs
     .map((p) => CompendiumPack.loadJSON(path.join(sf2eInDir, p), { systemId: "sf2e" }));
 console.log("SF2e Packs Loaded");
 
+// Assemble pack pairs, which are used to detect duplicates and overlaps
 const allPackDirs = R.unique([...pf2eManifest.packs, ...sf2eManifest.packs].map((p) => path.basename(p.path)));
 const packPairs = allPackDirs.map((dir) => {
     const pf2e = pf2ePacks.find((p) => p.dirName === dir);
@@ -317,6 +321,34 @@ for (const contentSystem of contentSystems) {
         await db.createPack(pack.finalizeAll({ remap: false }), pack.folders);
         await db.close();
     }
+
+    // Create export log.
+    // These help check for content removed between releases, such as when an ancestry from pf2e is added to sf2e.
+    const getObjectProp = <T extends object, K extends string | null>(obj: T, key: K) => {
+        return objectHasKey(obj, key) ? obj[key] : undefined;
+    };
+    const exportLog = R.pipe(
+        contentPacks.filter((p) => p.documentName === "Item"),
+        R.flatMap((p) => p.data as ItemSourcePF2e[]), // filtered by documentName
+        R.groupBy((i) => (itemIsOfType(i, "feat") ? `feat-${i.system.category}` : i.type)),
+        R.entries(),
+        R.map(([key, value]) => {
+            const featCategorySlug = key.startsWith("feat-")
+                ? sluggify(key.replace("feat-", ""), { camel: "bactrian" }).replace("feature", "Feature")
+                : null;
+            const featCategoryLabel =
+                getObjectProp(langEn.PF2E.Item.Feat.Category, featCategorySlug) ?? featCategorySlug;
+            const itemType = featCategorySlug ? "Feat/Feature" : (getObjectProp(langEn.TYPES.Item, key) ?? key);
+            return [
+                featCategoryLabel ? `${itemType} (${featCategoryLabel})` : itemType,
+                ...R.sortBy(value, (v) => v.name).map((v) => `  [${v._id}] ${v.name}`),
+            ];
+        }),
+        R.sortBy((values) => values[0]),
+        R.flat(),
+    ).join("\n");
+    await fs.promises.writeFile(path.join(__dirname, `exports/${contentSystem}-anachronism.txt`), exportLog, "utf8");
+
     console.log(`Finished building ${contentSystem}-anachronism`);
 }
 

--- a/build/exports/pf2e-anachronism.txt
+++ b/build/exports/pf2e-anachronism.txt
@@ -1,0 +1,20063 @@
+Ability
+  [rraWyBNnO9PepelJ] (Adamantine Dragon) Cratering Smash
+  [9rwssyPzNfxuqX5d] (Adamantine Dragon) Magnetic Roar
+  [hNwFT7H3Zd2eHsi4] (Adamantine Dragon) Petrifying Blow
+  [atbn1J9kkvGuH9U7] (Adamantine Dragon) Repelling Blast
+  [8UbjOjhhGGrTAWMq] (Adamantine Dragon) Scything Wings
+  [GpT5RXUwhINODqkJ] (Affinity Ablaze) Arms of Balance: Walking the Cardinal Paths
+  [8CZwqRQ1w8OaAtO7] (Affinity Ablaze) Biting Roses: Glimpses to Beyond
+  [46pkhUrd57gTd4th] (Affinity Ablaze) Speakers to the Winds: All is One, One is All
+  [PZGE4lLJ8DHbGIUI] (Affinity Ablaze) Steps of the Sun: Grand Harmony
+  [Pw8VOyhZP1RW7LNM] (Affinity Ablaze) Winter's Roar: Rampaging Glacier Charge
+  [KOnVQPlRY1CqcJXy] (Beheaded) Bleeding
+  [HEmOAVbJ3T9pon6T] (Beheaded) Entangling
+  [1gsgecz7rhvHeiCX] (Beheaded) Fiendish
+  [1p2UcxwgYDQzVqov] (Beheaded) Furious Headbutt
+  [rlNiZiUb9pRKFKQo] (Beheaded) Giant
+  [4pBHIGtTK9yQmZ7h] (Beheaded) Lifesense 60 feet
+  [X0KoXRDEJYYtwGgK] (Beheaded) Whispering
+  [kLQ0eq18SvKEvggc] (Blackfrost Dead) Blackfrost
+  [ydrDZ7lqioLPWRlB] (Blackfrost Dead) Blackfrost Breath
+  [yR9VLXIjJ2iOX77z] (Blackfrost Dead) Ice Climb
+  [hEeHuM3OVzJADsSa] (Blackfrost Dead) Mindburning Gaze
+  [v14HanKkdPGQd7Km] (Blackfrost Dead) Shattering Death
+  [LZsABXwRruB99A0k] (Blight) Blight Domination
+  [h6rf7Z7Vy1OD1YFw] (Blight) Cursed Domain
+  [Sx3uEPB6AD1iGbDp] (Blight) Oversee Domain
+  [xGwpAMVb1UGFJqf9] (Blight) Rejuvenation
+  [qrdDLvBJMrLYtFQ8] (Bulwark) Serpentstone Breath
+  [h2C99bXIwPGRdZQ0] (Castrovelian) Extra Large
+  [7V3M78uYKXxJTW37] (Castrovelian) Gaseous Adaptation
+  [D54bMK3tv4232W0X] (Cinder Dragon) Cloud of Ashes
+  [qI1dHuib2vuitFMJ] (Cinder Dragon) Inextinguishable Aura
+  [SBnCmBgRgdh0nBRM] (Cinder Dragon) Inflame Emotions
+  [pyBxJKGeheGA8et4] (Clockwork Creature) Malfunction - Backfire
+  [kUApLn0cOsXQNSrL] (Clockwork Creature) Malfunction - Damaged Propulsion
+  [xuXloICuGtfA42AN] (Clockwork Creature) Malfunction - Loose Screws
+  [xS8ybzuqPSi3Jb8k] (Clockwork Creature) Wind-Up
+  [OrWZVlCohFRGzWsB] (Conspirator Dragon) Apex Paranoids
+  [Y9tkwsBQKbXTFxjT] (Conspirator Dragon) Mental Feedback
+  [k9R1zUe2GCWci5Gd] (Conspirator Dragon) Obscure Revelations
+  [WG1csSWO85nU7mce] (Conspirator Dragon) Occult Whisperers
+  [rviye8dQX9vCsVm8] (Coral Dragon) Grasping Waves
+  [VmiXrvmqg7JdKopn] (Coral Dragon) Palytoxin
+  [VpXDP2fGKgYSU9uJ] (Coral Dragon) Primal Tide
+  [zkjsfsweJmsB66CS] (Coven) Contribute Spell
+  [Y7cRjlRkdo3siz5y] (Coven) Locate Coven
+  [jsZZJDd4ZuYMlEVV] (Coven) Share Senses
+  [UsWJ13sDyOgOGWvm] (Cryptid, Experimental) Augmented
+  [uDjn2b2ZrZycQQyv] (Cryptid, Experimental) Clobber
+  [qYVKpytVx46oBVox] (Cryptid, Experimental) Energy Wave
+  [xxI7QpVWLiGjdu4B] (Cryptid, Experimental) Operational Flaw
+  [uQ7cI0oerU7lDLhT] (Cryptid, Experimental) Power Surge
+  [cfqRc4clMniqQNsl] (Cryptid, Mutant) Explosive End
+  [WLmFKSzR6Xz9RqAu] (Cryptid, Mutant) Marrowlance
+  [ZUxt6s54TMgydXoW] (Cryptid, Mutant) Shifting Iridescence
+  [SEU4K3QRAUHEMRl2] (Cryptid, Mutant) Unusual Bane
+  [z9yqLBExOMk1y9cg] (Cryptid, Primeval) Broken Arsenal
+  [R0tsWv6QHd2jbQON] (Cryptid, Primeval) Grasp for Life
+  [l5FyTQQ0OfICCS1c] (Cryptid, Primeval) Shockwave
+  [7llQJrvVuCh7KjZO] (Cryptid, Primeval) Stench
+  [Bqnh5wiXVymfDgTw] (Cryptid, Rumored) Burning Eyes
+  [qfDwBrCXeIYp0W8T] (Cryptid, Rumored) Creature Obscura
+  [KLMdplDgOfXSLh6g] (Cryptid, Rumored) Howl
+  [a7SNHoP22SBoOAmA] (Cryptid, Rumored) Hybrid Form
+  [l2ov5uPpfOAoyXAL] (Cryptid, Rumored) Obscura Vulnerability
+  [K0scCV18j5FzM2ei] (Cryptid, Rumored) Shifting Form
+  [XpGCN9KJN0CCIlzU] (Cryptid, Rumored) Stalk
+  [N9OUII3LfRr6hNP8] (Cryptid, Rumored) Vanishing Escape
+  [DvBztBzWQQco4nWs] (Despair Dragon) Cursed Memories
+  [SctZqyzjpNLVas9Z] (Despair Dragon) Lights Out
+  [zup3V3RgZJ1sy9Vy] (Despair Dragon) Manifest Fear
+  [VL0wMhHgm7NJKDHZ] (Diabolic Dragon) Diabolic Disguise
+  [6F56Okhz5aRzUmZV] (Diabolic Dragon) Infernal Rift
+  [RLqgyWn86ZyB9CBL] (Diabolic Dragon) Intercept Summons
+  [jD0M3yV6gjkXafsJ] (Divine Warden) Divine Destruction
+  [0B9eEetIbeSPhulD] (Divine Warden) Divine Domain Spells
+  [DlHTe9jLssEELY6a] (Divine Warden) Divine Innate Spells
+  [OPGu0WsUHpHSmu80] (Divine Warden) Faith Bound
+  [UlKGxPaKtRGWuq3V] (Divine Warden) Faithful Weapon
+  [L80gn6WOWi9roJW3] (Divine Warden) Instrument of Faith
+  [0VT6gz9Tm8d5tCYx] (Divine Warden) Sanctification
+  [mEbrInCpag7YThH2] (Dragon) Change Shape
+  [ZdlH2u3E1EAHchVP] (Empyreal Dragon) Restorative Halo
+  [9Gt3bYla9VqLrOPB] (Empyreal Dragon) Sacrificial Shield
+  [MUQT8abHdjAP1OeQ] (Empyreal Dragon) Wreath of Holy Light
+  [7RxVsRFGtZX9eIxq] (Failed Prophet) Broken Mindscape
+  [YXaiRbK6LFSHP5fV] (Failed Prophet) Greedy Grab
+  [33PtgISC92HeTzRr] (Failed Prophet) Taboos
+  [QKzMfQLBrD48eTLq] (Failed Prophet) This Is My Reality!
+  [8uOu4L083uOru5yi] (Failed Prophet) Wealthsense
+  [529SPxfajGnUO5Aw] (Floodslain) Drowning Touch
+  [Er6lawGn6pPbhYuk] (Floodslain) Floodslain Spawn
+  [njqGmYb9I0QakRWD] (Floodslain) Hard to Burn
+  [oFLIc3Rnm68rEm72] (Floodslain) Sodden Ground
+  [zXpmQxDNYYvxhgye] (Floodslain) Vomit Flotsam
+  [3olcA5ZNYWKBYkRA] (Fortune Dragon) Chimeric Nature
+  [bAYATJsZVkQw636K] (Fortune Dragon) Hidden Wealth
+  [9LwWHRazIImJYvD3] (Fortune Dragon) Shield of Fortune
+  [m6teF5ADh7vuM8Zr] (Ghast) Consume Flesh
+  [hA6HsM4i4yPfEsDH] (Ghast) Ghast Fever
+  [bVZ6KizWVTLJUBXi] (Ghast) Paralysis
+  [SEzkqVJxr2eJDsuJ] (Ghast) Stench
+  [4Aj4FWKObfMYoSvh] (Ghost) Beatific Appearance
+  [AydIHjDNbOZizj5U] (Ghost) Cold Spot
+  [WQjFPBQPDu6vyJny] (Ghost) Corporeal Manifestation
+  [ga0Oj7mmjSwWQgmR] (Ghost) Corrupting Gaze
+  [fVyoHEO3fSR737M1] (Ghost) Draining Touch
+  [uV4jf2pkMRGLdhJX] (Ghost) Dreamwalker
+  [lAnJ25DSs44Ya8jg] (Ghost) Fade
+  [tDfv2oEPal19NtSM] (Ghost) Fetch
+  [aiwlPSmNY9b6Psvd] (Ghost) Frightful Moan
+  [i7m74TphAiFYvzPL] (Ghost) Ghost Storm
+  [jTuK430yY8VgIByB] (Ghost) Haunted House
+  [JSBmboE6bYVxDT9d] (Ghost) Inhabit Object
+  [4p06ewIsPnWZwuwc] (Ghost) Lynchpin
+  [iwLj14liESK5OBN8] (Ghost) Malevolent Possession
+  [nF7RKPONY5H9kEIo] (Ghost) Memento Mori
+  [cYkEpJzpMu3mCrFc] (Ghost) Phantasmagoria
+  [5lv9r2ubDCov4dFn] (Ghost) Pyre's Memory
+  [unR8VVR4yyRnsmnB] (Ghost) Rejuvenation
+  [wzezkgOufQev7BLK] (Ghost) Revenant
+  [BcSlVpaN72LoQ5BV] (Ghost) Site Bound
+  [0K3vhX14UEPftqu8] (Ghost) Telekinetic Assault
+  [ixPqVlqLaYTB1b23] (Ghoul) Consume Flesh
+  [N7UV5CZXtcoxDxCF] (Ghoul) Ghoul Fever
+  [pOW2IvfVusdmD5v5] (Ghoul) Ghoul Whispers
+  [227zB1x6U0TyU1nd] (Ghoul) Grave Knowledge
+  [FW4KAUHb7r8WkxUc] (Ghoul) Paralysis
+  [UU1Fp3PRuTFONjC9] (Ghoul) Swift Leap
+  [r34QDwKiWZoVymJa] (Golem) Golem Antimagic
+  [qt2exWwQTzoObKfW] (Golem) Inexorable March
+  [pxiSbjfWaKCG1xLD] (Graveknight) Betrayed Revivification
+  [OMSsLUcnRj6ycEUa] (Graveknight) Channel Magic
+  [fmUBaLklyVmNt3VD] (Graveknight) Clutching Armor
+  [W5fD1ebH6Ri8HNzh] (Graveknight) Create Grave Squire
+  [QMWvYf8Qowj2Fzmx] (Graveknight) Dark Deliverance
+  [IxJbFJ8dG5RbZWBD] (Graveknight) Devastating Blast
+  [AkkmaixGqzw75h7W] (Graveknight) Eager for Battle
+  [03knx0BWuYBNciXI] (Graveknight) Empty Save for Dust
+  [5dbzWZbiTyPKgwKS] (Graveknight) Graveknight's Curse
+  [mZpX54PgTxPta5y4] (Graveknight) Graveknight's Shield
+  [BgbSHRdkGH7raOgA] (Graveknight) Phantom Mount
+  [0MBZJdTv863X2jwz] (Graveknight) Portentous Glare
+  [ZIFaA4jDQjM0vq8q] (Graveknight) Rejuvenation
+  [7jWANvnDmNcQvFve] (Graveknight) Ruinous Weapons
+  [bTJnxBQjr7G8yr30] (Graveknight) Sacrilegious Aura
+  [6isn9nqnvfRrC1wW] (Graveknight) Weapon Master
+  [wlhvSroB6r5cSd8Y] (Greater Barghest) Mutation - Poison Fangs
+  [KcUHCVhHnkMD8j3k] (Greater Barghest) Mutation - Toxic Breath
+  [mwEig0MYM7EIibSU] (Greater Barghest) Mutation - Vestigial Arm Strike
+  [OD3VPUalSKDTYFmF] (Greater Barghest) Mutation - Wings
+  [mrFrAaCFB4ZhnkCT] (Halfling) Keen Eyes
+  [6GApXnJDAMAchNl7] (Harrowkin) Defensive Suit
+  [Zt1p0dh8ZUXIMxEt] (Harrowkin) Harrowkin Suit
+  [nJBaRtGMGVcQNg6Z] (Harrowkin) Read the Cards
+  [bpoyTnJ7zn3kG6Y9] (Harrowkin) Shuffle the Deck
+  [STynsk9Ro0kAQTxr] (Horned Dragon) Apex Dominance
+  [FRIgZwQtHqp1rEo3] (Horned Dragon) Horn Projectile
+  [KINhG5lnnok03UKZ] (Horned Dragon) Invigorating Spores
+  [jjWisLWwcdxsqv8o] (Kallas Devil) Blameless
+  [LOd8QwaKP3hnyGkc] (Kallas Devil) Cold Currents
+  [NSO2l1jXK32oTnVP] (Kallas Devil) Freezing Touch
+  [na1WJDEaoqpcQuOR] (Kallas Devil) Infectious Water
+  [KJrQdJQ0ZEmKYH4Y] (Kallas Devil) Suffer the Children
+  [PjYwPIUUrirQFiee] (Kallas Devil) Underwater Views
+  [qlNOqsfJH2gj7DCs] (Kallas Devil) Waterfall Torrent
+  [pEJkjqjjBXj4YjYZ] (Kuworsys) Careless Block
+  [WtRxZEPH963RkUCj] (Kuworsys) Rain Blows
+  [49aAeGbH5p2IJ5Fz] (Kuworsys) Rapid Bombardment
+  [RvzFTym3r22VhMrm] (Kuworsys) Smash and Grab
+  [mMfvpqD6hqrjqKEz] (Leshy) Verdant Burst
+  [EyFVoDiReJsBx1rf] (Lich) Animate Cage
+  [px2XMvw2s5RLV0X1] (Lich) Aura of Rot
+  [871jo3ZGnybF6dC8] (Lich) Blasphemous Utterances
+  [wh2T2L5SMsa32RyE] (Lich) Cold Beyond Cold
+  [fTk5nmm7HHtXOdSo] (Lich) Dark Deliverance
+  [fqZhojt2M5LfSKSH] (Lich) Drain Soul Cage
+  [nxF03w5vKrw1jmxQ] (Lich) Familiar Soul
+  [7TYLgIMDGgUfbgGY] (Lich) Mask Death
+  [3VN2BLNE5zakeDCM] (Lich) Metamagic Alteration
+  [XvPm866TKSfclErJ] (Lich) Paralyzing Touch
+  [tdqw4QXzA2x7fDLT] (Lich) Pillage Mind
+  [a7A4xY3NeWI2Ya4Z] (Lich) Rejuvenation
+  [b3p8x6sgTa0BOvAb] (Lich) Siphon Life
+  [hfT7YDwx0UX4expm] (Lich) Steal Soul
+  [OeLdzrhIrDOvsm3E] (Lich) Unholy Touch
+  [yWNcEsEJIoeXKBnk] (Lich) Void Shroud
+  [YQmf1Otd4xoxsSGU] (Mana Wastes Mutant) Caustic Pustules
+  [mmotrGIfshEHi8Rr] (Mana Wastes Mutant) Chameleon Skin
+  [SFDNK6AauPO6io5B] (Mana Wastes Mutant) Eldritch Attraction
+  [Hy7bO4TSNoQNMzA6] (Mana Wastes Mutant) Energy Blast
+  [kew9yPbf83smsCyL] (Mana Wastes Mutant) Energy Resistance
+  [3vcDqURRKk0mtdav] (Mana Wastes Mutant) Grasping Tentacle
+  [trYchslD8fLokkT9] (Mana Wastes Mutant) Hulking Form
+  [Bqiumr3LEo05d8x1] (Mana Wastes Mutant) Hungry Maw
+  [wJDfLmOJ2eJTmSwQ] (Mana Wastes Mutant) Increased Speed
+  [fOpw4k05kayaL13a] (Mana Wastes Mutant) Magic Hunger
+  [FdUuCIkQxVoTGM78] (Mana Wastes Mutant) Mirror Thing
+  [lD9Onw05RxdcmM2e] (Mana Wastes Mutant) Revolting Appearance
+  [lv1T0kAmG2JS7PWs] (Mana Wastes Mutant) Sprouted Limb
+  [Yv0mQAeVuQ2Id9vk] (Mana Wastes Mutant) Too Many Eyes
+  [mqai5e7YAuK2tbB9] (Mana Wastes Mutant) Vengeful Bite
+  [oPD06BSNbKA34Zoy] (Martial Artist) Blazing Gate
+  [03L72Xz3efBz7fSJ] (Martial Artist) Competitive Taunt
+  [qkwZCQBAldlO29Nx] (Martial Artist) Constant Feint Stance
+  [Jn4PgQJwnn5p6hK7] (Martial Artist) Defensive Side Kick
+  [YZ9CI5ejw6jqnJoU] (Martial Artist) Kiai!
+  [wtyCnF83CCxeeCIw] (Martial Artist, Dirty Fighting) Concealed Spikes
+  [1fg4aDbE5LCJVkqL] (Martial Artist, Dirty Fighting) Contraband Substance
+  [8dC2Zg0l0aUNzyTe] (Martial Artist, Dirty Fighting) Illegal Bite
+  [yTtnzqVA1yYnJiQB] (Martial Artist, Dirty Fighting) Sand in Your Eye
+  [AhSTA79huGDDe8x1] (Martial Artist, Grandmaster) Life Burn Aura
+  [lgwcXtBfqLtv6xVZ] (Martial Artist, Grandmaster) Solar Surge
+  [WGpv23G4FFSGDMC5] (Martial Artist, Grandmaster) Super Qi Blast
+  [G4yIjHMzD0KVpaCm] (Melfesh Monster) Burrowing Grasp
+  [qs21GajPmFYel3pc] (Melfesh Monster) Corpse Bomb
+  [wdO3EvDCGoDYW44S] (Melfesh Monster) Death Throes
+  [i4WBOAb7CmY53doM] (Melfesh Monster) False Synapses
+  [UOqq8lkBPcPtKoCN] (Melfesh Monster) Flame Lash
+  [VXKiqiW7gXfFCz1U] (Melfesh Monster) Mycelial Tomb
+  [iiIhLkjuPYJ93Upw] (Melfesh Monster) Smolderstench
+  [d6eWuFd6pw6ffvPC] (Melfesh Monster) Swell
+  [tQY2xmcIhzCM7oCC] (Melfesh Monster) Torrential Advance
+  [oD1cA9uXYQ8evT8f] (Melfesh Monster) Vent Flames
+  [8FJ0GmjLaxAT3H25] (Mirage Dragon) Afterimage
+  [edpWHUorHAO5Z7SF] (Mirage Dragon) Phantasmal Terror
+  [4JD49GKrvl2aR6j7] (Mirage Dragon) Reshape Terrain
+  [gBVe0BJNScPePlMj] (Mythic) Ambush Excellence
+  [7CREET2Z24B7pulA] (Mythic) Brutish Athleticism
+  [ByHEY3s7piqH1rJD] (Mythic) Deadly Striker
+  [xhOSLp4nJXUDX4q3] (Mythic) Devastating Magic
+  [YwglzjZ7wQCyOYrw] (Mythic) Hazard Immunity
+  [exNN1xhUYQXMRN7x] (Mythic) Mythic Defenses
+  [MDxvZazutX6i95mF] (Mythic) Mythic Ferocity
+  [CvKc38D8oaZEq0Xu] (Mythic) Mythic Immunity
+  [0NncsizpKo4wrEGa] (Mythic) Mythic Knowledge
+  [ZKrCKzH0ievnVBmw] (Mythic) Mythic Mobility
+  [jNW79frpM2miwJvD] (Mythic) Mythic Power
+  [0zvUNv8hRTdwXmhF] (Mythic) Mythic Resilience
+  [neS9sqernQewAuPZ] (Mythic) Mythic Resilience (Mythic Ambusher)
+  [anjtXUW6krim20UM] (Mythic) Mythic Resistance
+  [gNxphcYARRn2bZ1i] (Mythic) Mythic Skill
+  [bWO8ScQpiFtoGi93] (Mythic) Mythic Weakness (Extreme Frailty)
+  [AQLgA4LnpmcWEkP6] (Mythic) Mythic Weakness (Frailty)
+  [mg5fmA9Dnu0Z88nJ] (Mythic) Mythic Weakness (Weak-Willed)
+  [Amur69xCgfyCsY34] (Mythic) Recharge
+  [HhD6EWTdYOyH6Rbr] (Mythic) Recharge Spell
+  [ta5reS33mtwBHWzX] (Mythic) Remove a Condition
+  [MFADnbvNMY9AQNzG] (Mythic) Reroll
+  [kDe93M70RBcImRlG] (Mythic) Titanic Might
+  [fnwTADEGOKtTxDPu] (Mythic) Undying Myth
+  [pC1w0DC8tcgfhiRv] (Mythic) Unimpeded
+  [2kgvmo7z0nRQVNGy] (Nemesis) Additional Damage
+  [hrX8wChrtscSGkkN] (Nemesis) Enhanced Sense
+  [v8DDA7RFIt7ayv3z] (Nemesis) Explosive Blast
+  [95GtEVW0qI1h9oPq] (Nemesis) Fast Healing
+  [glb03wxLyMzzeH13] (Nemesis) Ghostly Flicker
+  [dYDrrBn5sNgoo4Au] (Nemesis) Immunity
+  [N6OADmxP3Y1qUZKv] (Nemesis) Ravage Mind
+  [nq282ijl9aKm2JST] (Nemesis) Resilient
+  [eXleBXdAemiEoHA8] (Nymph Queen) Change Shape
+  [SEmSk1INZDmeoB5R] (Nymph Queen) Focus Beauty
+  [IFQd4GiHlV33p7oK] (Nymph Queen) Inspiration
+  [kG4fDd16fYEFvmgy] (Nymph Queen) Nymph's Beauty
+  [UHuA1hue5xrRM6KK] (Nymph Queen) Tied to the Land
+  [Z7BKGKMsvkZBg9XN] (Omen Dragon) Forewarned and Forearmed
+  [ACtEZDv5sogaOgcG] (Omen Dragon) Link Fates
+  [SPNfbhNa46L3V2NQ] (Path Maiden) Apostate's Shroud
+  [3H0xMglx23V5PP2N] (Path Maiden) Blasphemous Aura
+  [VupsXjJEpavg5ByS] (Path Maiden) Corrupting Doubt
+  [igFRStfWiTekB9cU] (Path Maiden) Imprisoning Grave
+  [gTORJ6OyH2GvfJLC] (Path Maiden) Limited Flight
+  [UQ2ZvIag5gPL2QiU] (Path Maiden) Scorn Fate
+  [rB3msRRnN5M9z5Vm] (Path Maiden) Sour Victory
+  [w5wDTUUeGHAAoZH1] (Path Maiden) Vengeful Frenzy
+  [OgtpOXZuyzuSyZ1j] (Phase Dragon) Afterimage Jumps
+  [hjToSb8qs12q0K3M] (Phase Dragon) Dematerialize
+  [HqT1fM4S5kmCLrBU] (Phase Dragon) Second Glance
+  [IOk0MRs3f9FrarKL] (Protean) Protean Anatomy
+  [HKFoOZZV4WdjkeeJ] (Protean) Warpwave
+  [VLCECgjkL5bNOxpx] (Ravener) Consume Soul
+  [6Alm4mLj3ORxCXC2] (Ravener) Cowering Fear
+  [HLPLYJ9bOazb2ZPX] (Ravener) Discorporate
+  [FsqVhavMWAoFro1L] (Ravener) Soul Ward
+  [fYDrunTldWmFvfjl] (Ravener) Soulsense
+  [XbHMVjHtbPaPr9P5] (Ravener) Vicious Criticals
+  [695gtfH7p2H0G6Ch] (Requiem Dragon) Die Together
+  [6vq8c3BM9Haf5dcH] (Requiem Dragon) Soul Roar
+  [9dCKA0ld81TuubR5] (Resurrection Dragon) Deathless Servant
+  [F1MbFmS07oKnJdIw] (Resurrection Dragon) Harmful Claw
+  [V3xivGSkm73pdnu1] (Resurrection Dragon) Shred Souls
+  [NmiklEFz8kLCvF6L] (Retired) Rusty
+  [eM0wkvhSx2xXpz04] (Retired) Still Got It!
+  [d5gy2aWgkM95fTN4] (Risen Nemesis) Euphoric Cackle
+  [sLhidNrdrlnBpIcH] (Risen Nemesis) Fixated Obsession
+  [JrDcRygSLTr6IekW] (Risen Nemesis) Indignant Curse
+  [w4RUMCiHixgqJiy7] (Risen Nemesis) Pained Retribution
+  [NoWUUKD9HK7Tu945] (Rune Dragon) Catalyzing Rune
+  [MKeRtn8lAPs098qk] (Rune Dragon) Runic Jail
+  [9w9hhvqGhrxdAzMH] (Secret Society) Connected
+  [3oajfAIPSf77dSBL] (Secret Society) Get out of Jail
+  [gSXxJ2FYEGrX1Psy] (Secret Society) Not Today!
+  [vX0CRZWok5ghasb3] (Secret Society) Prepared Diversion
+  [L6EypYQTdK4XPldM] (Secret Society) Prepared Trap
+  [YELSFD2oTNMFkPJ2] (Secret Society) Shibboleth
+  [XWtIvqCWmg8Tfr1N] (Secret Society) Skill Savvy
+  [ndN9zEIheRZGOEUW] (Secret Society) Tag Team
+  [jciRdEHgGNGFXLsg] (Siabrae) Blight Mastery
+  [DIYZNvVP28U2UnDb] (Siabrae) Earth Glide
+  [Es8g7kZrLAuNdiD1] (Siabrae) Miasma
+  [gbKpCw21tEmehq6e] (Siabrae) Rejuvenation
+  [TIJ7r9lXvNYSIMLI] (Siabrae) Stone Antlers
+  [WUXY9F8SLVQSC2b8] (Siabrae) Stony Shards
+  [AvoSAlqB8mZfjwr9] (Skeleton) Aquatic Bones
+  [9oy2zWxy7Klk9FxR] (Skeleton) Blaze
+  [P5YTG6I8ci4lwhZ1] (Skeleton) Bloody
+  [RgYpzTk3XapgVeXZ] (Skeleton) Bone Missile
+  [sajLbVE6VpCsR0Kl] (Skeleton) Bone Powder
+  [yLdiZ2AnjZ8KuT7v] (Skeleton) Bone Storm
+  [K5bNE90vmeFzktnM] (Skeleton) Collapse
+  [YVw626nVHlWwm4ej] (Skeleton) Crumbling Bones
+  [W77QhVNE46WDyMXi] (Skeleton) Explosive Death
+  [buyzzomLTrIdVvTU] (Skeleton) Frozen
+  [97Eo5oA1WeMJA7nR] (Skeleton) Grave Eruption
+  [ZRHUnhaHK2w1el8f] (Skeleton) Lacquered
+  [rdQzd5ClgGPP4Qmt] (Skeleton) Nimble
+  [2GhEuIlgLj02gV9r] (Skeleton) Rotten
+  [MAC97gjFcdiqLyhp] (Skeleton) Screaming Skull
+  [HdSaMUb4uEsbtQTn] (Skeleton) Skeleton of Roses
+  [zSblw5RF9sc0pnGB] (Spawn of Rovagug) Absolute Regeneration
+  [Q360DlhKmOp8ieHp] (Spawn of Rovagug) Slumbering Armageddon
+  [o5jz2Gv9WGYsecYY] (Spawning Soulrider) Celestial Flare
+  [J6L3PChyDWicAi8B] (Spawning Soulrider) Fiendish Lunge
+  [IvTJfaZqfGupUMvd] (Spawning Soulrider) Monitor Escape
+  [dHoR22T6amQxcS36] (Sporeborn) Consume Biomatter
+  [Acal6RaZleMsVwCw] (Sporeborn) Contagious Spores
+  [C4Gzvv335YYUm1zl] (Sporeborn) Fungal Armor
+  [m3flWBRtelwHv9oP] (Sporeborn) Potent Poison
+  [NekhS5WlNuVVLBXe] (Sporeborn) Rancid Spore Pods
+  [HENTrR5W8AZvsIyv] (Sporeborn) Spore Explosion
+  [EosAqVmnYlxMEGdT] (Sporeborn) Sporeborn Infestation
+  [hEWAzlIoJg3NzA7Q] (Spring-Heeled Jack) Change Shape
+  [yaDe9hO9fm2N4SqH] (Spring-Heeled Jack) Resonant Terror
+  [KwmYKsaXHKfZgB2c] (Spring-Heeled Jack) Vanishing Leap
+  [lFRU108HnGlnMwqS] (Stargut Hydra) Skymetal Metamorphosis (Abysium)
+  [Bds5RP9grJxhZALW] (Stargut Hydra) Skymetal Metamorphosis (Adamantine)
+  [N4l6y6v9pKy8Nj5i] (Stargut Hydra) Skymetal Metamorphosis (Djezet)
+  [5bRdhgghjtWF1Vuu] (Stargut Hydra) Skymetal Metamorphosis (Inubrix)
+  [sTlptNnUX2eA0DIH] (Stargut Hydra) Skymetal Metamorphosis (Noqual)
+  [6Z0v9Tsthm9hyzb3] (Stargut Hydra) Skymetal Metamorphosis (Orichalcum)
+  [SXJRjw4R8m7NPDGc] (Stargut Hydra) Skymetal Metamorphosis (Siccatite)
+  [zsYcDy8Svo8t9BHj] (Swarm Strider) Clinging Remnants
+  [PUMypO3XfoRmuNsf] (Swarm Strider) Discorporate
+  [JSNZab0XFa4KMXki] (Swarm Strider) Draw Bugs
+  [YCfdIkp4AQ81ry5M] (Swarm Strider) Squirming Embrace
+  [sSOqei4h1Ms0jlTn] (Swarm Strider) Swarm Shape
+  [awFTdoQfYva84HkU] (Ulgrem-Axaan) Befouling Odor
+  [Y46uZK6X7J7iMsgq] (Ulgrem-Axaan) Crocodile Tears
+  [yfcqbMRmCkfPWV9O] (Ulgrem-Axaan) Crushing Weight
+  [RQ9NaIerG95wkhjl] (Ulgrem-Axaan) Fallen Victim
+  [9wX6EFimVFYFZjD7] (Ulgrem-Axaan) Ichor Coating
+  [xk59gaht1NBNxvgi] (Ulgrem-Axaan) Ichor Trail
+  [EDjWNsh3EbT7nAIB] (Union Organizer) Solidarity
+  [RJkRiqoxU1xMdZ81] (Valkyrie Tempest) Mounted Troop
+  [FXHjmH1oce7Z3tZb] (Vampire, Basic) Coffin Restoration
+  [c04ICnrzygyFG3PK] (Vampire, Basic) Drink Blood
+  [5DuBTf37u88IrphJ] (Vampire, Basic) Vampire Vulnerabilities
+  [OSnNiMdqgARyEVuv] (Vampire, Jiang-Shi, Basic) Breathsense 60 feet
+  [QMlQ5AvcunCvjlfM] (Vampire, Jiang-Shi, Basic) Drain Qi
+  [R1vYhCJ2KvT8uAy1] (Vampire, Jiang-Shi, Basic) Jiang-Shi Vulnerabilities
+  [BBqjQN5Gbe4PWP56] (Vampire, Jiang-Shi, Basic) One More Breath
+  [O6AXB9aZB0K14sS5] (Vampire, Jiang-Shi, Basic) Rigor Mortis
+  [hwrZQSADT36TjDdv] (Vampire, Jiang-Shi, Basic) Warped Fulu
+  [xwbiTvx3qyVEOqh6] (Vampire, Jiang-Shi, Minister) Dark Enlightenment
+  [1AnBJbwfdlvzA7SK] (Vampire, Jiang-Shi, Minister) Distant Steps
+  [L7kL2ps5k80XLtwV] (Vampire, Jiang-Shi, Minister) Tumult of the Blood
+  [yDE3ZEoxRUqQmAsX] (Vampire, Nosferatu Overlord) Air of Sickness
+  [uMedzgKYui5X3Qtn] (Vampire, Nosferatu Overlord) Divine Innate Spells
+  [EsbdyB9DwvPvhCCC] (Vampire, Nosferatu Overlord) Paralytic Fear
+  [2BjqIO36k0Y6tgZf] (Vampire, Nosferatu Thrall) Fast Healing
+  [LKxsPOf0hAS32Sp8] (Vampire, Nosferatu Thrall) Mindbound
+  [OQt7nHInDBAmHaG6] (Vampire, Nosferatu Thrall) Mortal Shield
+  [IL8wtCi23ch62zXG] (Vampire, Nosferatu Thrall) Rally
+  [8MACWp05F4SacE7E] (Vampire, Nosferatu Thrall) Weakness
+  [DWku0nZzkqmYjrQ5] (Vampire, Nosferatu) Change Shape
+  [8UQWXpYfn9oE1ZHu] (Vampire, Nosferatu) Command Thrall
+  [EwhjPJGLSW9v1Fbb] (Vampire, Nosferatu) Divine Innate Spells
+  [4B8O9QBJuDhJkVcz] (Vampire, Nosferatu) Dominate
+  [GpKQH8hnSYWiyuQU] (Vampire, Nosferatu) Drink Blood
+  [Sj1IGDjUmlwFpC35] (Vampire, Nosferatu) Nosferatu Vulnerabilities
+  [NgiwaeUqMPfkYvQq] (Vampire, Nosferatu) Plague of Ancients
+  [hOOXkWcTw9EFKJev] (Vampire, Nosferatu) Plagued Coffin Restoration
+  [8IQqWkLqzvWA1JRJ] (Vampire, Strigoi Progenitor) Create Spawn
+  [fh7ar6QrFT8YWgQ9] (Vampire, Strigoi Progenitor) Drink Essence
+  [R5VgwNbwc3QbqVXC] (Vampire, Strigoi Progenitor) Shadow Escape
+  [AzvCvgx9SUAB2blo] (Vampire, Strigoi) Domain of Dusk
+  [rBc9fJlMXhzvn05L] (Vampire, Strigoi) Drink Essence
+  [zehifmU1fTeGs2ev] (Vampire, Strigoi) Levitation
+  [eQLGYrJhu787pEwc] (Vampire, Strigoi) Shadow Form
+  [qjgrMhwz78T31kLU] (Vampire, Strigoi) Strigoi Weaknesses
+  [ZMTnwyXjyfy7Ryi6] (Vampire, True) Change Shape
+  [noOXyIXmwYN2rRd1] (Vampire, True) Children of the Night
+  [wqptDG0IW6ExnISC] (Vampire, True) Create Servitor
+  [AjTkksppymqzCivT] (Vampire, True) Dominate
+  [XHut4MN0JBgm7WaN] (Vampire, True) Drink Blood
+  [sAyR4uJbsWukZFZf] (Vampire, True) Mist Escape
+  [Nnl5wg6smOzieTop] (Vampire, True) Turn to Mist
+  [EpDyZ0mG9beLkBna] (Vampire, Vetalarana, Basic) Drain Thoughts
+  [268Q7HdtylwpznvG] (Vampire, Vetalarana, Basic) Mental Rebirth
+  [GgmLWLBLGaFvunTS] (Vampire, Vetalarana, Basic) Thoughtsense 100 feet
+  [rwEFqSLw4yIscGrO] (Vampire, Vetalarana, Basic) Vetalarana Vulnerabilities
+  [sWDlb5vJRK092MMt] (Vampire, Vetalarana, Manipulator) Control Comatose
+  [wEL7ZDMaSWSSYQG9] (Vampire, Vetalarana, Manipulator) Drain Thoughts
+  [yfNDFjz7VBvvLwee] (Vampire, Vetalarana, Manipulator) Paralyzing Claws
+  [haMVGGDY3mLuKy9s] (Vampire, Vrykolakas Master) Bubonic Plague
+  [sECjzfaYaW68vbLV] (Vampire, Vrykolakas Master) Change Shape
+  [tKixfds07IRH2nnh] (Vampire, Vrykolakas Master) Children of the Night
+  [QuHeuVNDnmOCS9M1] (Vampire, Vrykolakas Master) Create Spawn
+  [zwgUxJBNFqWOuaBX] (Vampire, Vrykolakas Master) Dominate Animal
+  [s6JRMjgA7hSGUAYX] (Vampire, Vrykolakas Master) Pestilential Aura
+  [98twzz56mMGN5Ftw] (Vampire, Vrykolakas) Drink Blood
+  [oXRnrQQ04oi8OkDG] (Vampire, Vrykolakas) Feral Possession
+  [br5Oup4USIUXQani] (Vampire, Vrykolakas) Swift Tracker
+  [5arYoSY5kcRo8TeM] (Vampire, Vrykolakas) Vrykolakas Vulnerabilities
+  [VzKVJlX2ocv1ezzp] (Visitant) Noxious Breath
+  [vOocS1EiRCXPtbgB] (Visitant) Roar
+  [eSp48kG7v1GNuGgh] (Visitant) Vengeful Presence
+  [kQZ6pzdSn6FaxWF2] (Visitant) Visitant Spells
+  [4UEZY3G3CiCP78Kx] (Visitant) Wrestle
+  [QOwFuM3LwNzOSb6B] (Warden of the Wild) Voice of Nature
+  [b0MH9TC5Cdnc9c0i] (Warden of the Wild) Warden's Crown
+  [iAXHLkxuuCUOwqkN] (Werecreature) Animal Empathy
+  [08egiRxOvMX97XTc] (Werecreature) Change Shape
+  [ICnpftxZEilrYjn0] (Werecreature) Curse of the Werecreature
+  [FA0ri2fAcMa1HgZe] (Werecreature) Moon Frenzy
+  [N2RrmpcKHBpqZ3ud] (Whisper Dragon) Change Shape
+  [Tro2ZR9B7SgFbZps] (Whisper Dragon) Draft Contract
+  [2LRP9Pm34qOvlo0V] (Whisper Dragon) Share Sight
+  [edpED1d9NbvR2NmB] (Woodblessed) Explosive End
+  [WIVta5JyoDl9b2UO] (Woodblessed) Luminant Aura
+  [p7VpIVDh5geLj7Ze] (Woodblessed) Primal Innate Spells
+  [tEP4ajRcD7cr644Z] (Woodblessed) Reactive Flare
+  [sQ2nzNDLMdGqECm6] (Woodblessed) Tap Planar Gate
+  [QlrbnkeZu6M4kvOy] (Worm That Walks) Discorporate
+  [Zu6feO9NUZJlsKuc] (Worm That Walks) Squirming Embrace
+  [X2mdpb1Dhl890YbA] (Worm That Walks) Swarm Shape
+  [CdjqkgAexKk8khbB] (Zombie) Ankle Biter
+  [v6he7HLxYGzaMnvL] (Zombie) Disgusting Pustules
+  [ipGBYIXk4u47Mp1D] (Zombie) Feast
+  [apVBHJT95t9Fhxpb] (Zombie) Infested Zombie
+  [qZnZriRRtjK7FtP8] (Zombie) Persistent Limbs
+  [MhymIeTQoxbacG1o] (Zombie) Plague-Ridden
+  [Ez8sVqv1EBcJuorK] (Zombie) Putrid Stench
+  [CxiEpXt7Gw3tSIOh] (Zombie) Rotting Aura
+  [7W6v0oULg9TCz9ym] (Zombie) Spitting Zombie
+  [Qf94y985g0o6lEoN] (Zombie) Tearing Grapple
+  [2k0X7JdI9MMt4pp0] (Zombie) Unholy Speed
+  [BSLqIYqxcCVBb2Vp] (Zombie) Unkillable
+  [GD1ZD4Rl2hTPhvjL] (Zombie, Shock) Arcing Strikes
+  [4AN6IgzsbhjCPYIZ] (Zombie, Shock) Breath Weapon
+  [vOvzh8XCMmvtW0Ws] (Zombie, Shock) Electromechanical Phasing
+  [ii98NEWkpvIJXgFZ] (Zombie, Shock) Lightning Rod
+  [kquBnQ0kObZztnBc] +1 Status to All Saves vs. Magic
+  [c40APnn4a7bWhtcZ] A Challenge for Heroes
+  [kAwE9YqU6GH1cD7W] A Moment Unending
+  [BRR0HS8yRhgBfipz] A Quick Glimpse Beyond
+  [iBZzOaRNodGtfMVJ] Absorb Familiar
+  [S9PZFOVe7zhORkUc] Absorb into the Aegis
+  [VAcxOCFQLb3Bap7K] Accept Echo
+  [FzZAYGib08aEq5P2] Accidental Shot
+  [92lgSEPFIDLvKOCF] Accompanist
+  [NRjBkjYx10MAXp3T] Acrid Barrage
+  [2KV87ponbWXgGIhZ] Act Together
+  [PpfkUdNMckFE22WI] Activate Resonant Reflection
+  [Qkm7jcKPA3elk9Nx] Administer
+  [PWNi3h0F9EsttE2p] Administer Ambient Magic
+  [OHzBFzMQp7MLlk5W] Aegis of Envy
+  [9Nmz5114UB87n7Aj] Affix a Fulu
+  [UAaQk93a30nx0nYY] Affix a Talisman
+  [HCl3pzVefiv9ZKQW] Aid
+  [Rv1KTRioaZOWyQI6] Alchemical Gut
+  [9qV49KjZujZnSp6w] All-Around Vision
+  [Z0HyZyvCe3Y1Chaa] Alley-Oop
+  [ZJ8KJp5mZYgzPJYN] Amassed Assault
+  [7ZxPS0UU7pf7wjp0] Ambassador
+  [A0C86V3MUECpX5jd] Amphibious
+  [Or6RLXeoZkN8CLdi] Amulet's Abeyance
+  [8aIe57gXJ94mPpW4] Anadi Venom
+  [pqTq0yi330rXewMb] Ancestors' Call
+  [xpsD4DsYHKXCB4ac] Anchor
+  [wcFeaZ0TmoaLtpIQ] Animated
+  [Bw2L4guiRFphTpF1] Appeal to Shadowy Intruders
+  [3P0rSASN69wXV6Fw] Approach Duneshadow
+  [HBrBrUzjfvj2gDXB] Aquatic Ambush
+  [HbejhIywqIufrmVM] Arcane Cascade
+  [8b63qGzqSUENQgOT] Armor Up!
+  [qm7xptMSozAinnPS] Arrest a Fall
+  [cCCOjU9ihfrn0spp] Arrow Splits Arrow
+  [hvvzc86tW5MgElMB] Assessing Tatzlford's Defenses
+  [lAvEK4yNL3Y7pVmr] Assume a Role
+  [2YRDYVnC1eljaXKK] At-Will Spells
+  [hFtNbo1LKYCoDy2O] Attack of Opportunity
+  [mKmBgQmPmiLOlEvw] Augury
+  [v61oEQaDdcRpaZ9X] Aura
+  [9sXQf1SyppS5B6O1] Automaton Aim
+  [ePfdZYZRmycMpSWU] Avoid Dire Fate
+  [IE2nThCmoyhQA0Jn] Avoid Notice
+  [p4CE62CG9S9RpU5F] Azata's Grace
+  [b3h3QqvwS5fnaiu1] Banshee Cry
+  [oAWNluJaMlaGysXA] Barbed Quills
+  [nTBrvt2b9wngyr0i] Base Kinesis
+  [dCuvfq3r2K9wXY9g] Basic Finisher
+  [ukt9Dr4qmj9pUQII] Bear Allies' Burdens
+  [cx0juTYewwBmrYWv] Beast's Charge
+  [JDotze7IlwSWlOzg] Beginner's Luck
+  [3cuTA58ObXhuFX2r] Bend Time
+  [CCMemaB1RoVa0aOu] Bestial Clarity
+  [9X80J5RN21Uoaeiw] Binding Vow
+  [k6ML9SPMxaGJyjqO] Bite and Sting
+  [XotRIv6tKRtuAGAF] Blazing Conflagration
+  [x5hIMfjmsDlpQWyt] Blend In
+  [scCEnY6IhU59uekX] Bless Ally
+  [Y6ee2ZvIE2fzzvAY] Blinding of the Needle
+  [a47Npi5XHXo47y49] Blizzard Evasion
+  [zt5fgBBOQpr84CGE] Bloody Guillotine
+  [bG91dbtbgOnw7Ofx] Board
+  [vZltxwRNvF5khf9a] Boarding Assault
+  [4d6QSFBP4lMUYrVK] Bond with Spirit
+  [OizxuPb44g3eHPFh] Borrow an Arcane Spell
+  [OpiIzr7h1EKY8wKh] Bounce Away
+  [5VbPhxZYfagIqE1z] Brandish the Gorgon's Gaze
+  [ZL5o9c4jV5fRwTGR] Break Free
+  [NYR2IdfUiHevdt1V] Break Them Down
+  [Y9XUwC8ihxZCfndG] Break the Sun's Legs
+  [OV77buFW6zHl4Smo] Breaking and Entering
+  [WKFZlmmuZGnucRen] Breaking the Chains
+  [Vr3w3t028ZKDg0mO] Breath Weapon
+  [IGPbMkKjnlFW1w1a] Bribe Contact
+  [nZMQh4AaBr291TUf] Buck
+  [3sNSr6NEVkUZ0dIr] Buckle-Cut Blitz
+  [hQ5BAIjAKpp2dYhR] Build Connections
+  [OxRT8qhujKG9Rhb2] Build Infirmary
+  [IuD5u9tSTabZ0KD1] Build Library
+  [AvpKHblov4xjANaH] Build Training Facility
+  [rI9qKyONeMPtajZ8] Build Workshop (Crafting)
+  [SMF1hTWPHtmlS8Cd] Bullet Dancer Stance
+  [TXqTIwNGULs3j6CH] Bullying Press
+  [ZhVJ7EUTJngrIO2Z] Burn out of Time
+  [H6v1VgowHaKHnVlG] Burrow
+  [uy15sDBuYNK48N3v] Burrower
+  [Fha8jFmfkOPxAsrZ] Calculate Threats
+  [8kGpUUUSX1sB2OqQ] Call Companion
+  [qyqlwr1hYf227fxD] Call Follower
+  [ESMIHOOahLQoqxW1] Call Gun
+  [mk6rzaAzsBBRGJnh] Call Upon the Brightness
+  [a8d5iIf1up9W0gVg] Call Warshard Weapon
+  [8w6esW689NNbbq3i] Call on Ancient Blood
+  [k5TASjIxghvGCy7g] Call to Axis
+  [Ghx29M00zTSXDxnU] Call to Hand
+  [rs4Awf4k1e0Mj797] Cantrip Connection
+  [jTfJzj1yfmPLsxmj] Captivating Charm
+  [aBQ8ajvEBByv45yz] Cast a Spell
+  [uG0Z8PsyZtsYuvGR] Catch Rock
+  [2424g94rpoiN1IPh] Catharsis
+  [71ypBixnbV4bE5Hv] Chained Charge
+  [USyDPcSdzcm024zT] Change Formation
+  [34E7k2YRcsOU5uyl] Change Shape
+  [eQM5hQ1W3d1uen97] Change Shape
+  [s4s40hJr5uRLOqix] Change Tradition Focus
+  [Ce9vzE3XWn0u5NcL] Channel Draconic Essence
+  [g8QrV39TmZfkbXgE] Channel Elements
+  [YjrM5G8Up0wv6x0u] Chaotic Destiny
+  [uOlyklPCUWLtCaYI] Chassis Deflection
+  [HcASfeYcE8QXayfk] Check the Walls
+  [zs4ZMcH9oFSCgkBx] Claw Stance
+  [lySoX0VbIaEEEnDZ] Clean
+  [ZhKXvnw7ND2hQ2pp] Cleanse Soul Path
+  [iQfHTjg9dNLbuzr8] Clear Courtyard
+  [tw1KDRPdBAkg5DlS] Clear a Path
+  [pprgrYQ1QnIDGZiy] Climb
+  [dWTfO5WbLkD5mw2H] Climber
+  [25WDi1cVUrW92sUj] Clue In
+  [PE1jm9lBveujj2md] Cobble Together
+  [tHCqgwjtQtzNqVvd] Coerce
+  [mbOa48mQCqj86lVw] Coiling Serpents
+  [LWrR6UiGm3eCAALJ] Collect Spirit Remnant
+  [WJmc30zb7GmKaETx] Command a Construct
+  [q9nbyIF0PEBqMtYe] Command an Animal
+  [799p70dXF3UYkTih] Communicate From Beyond
+  [yM20ZnvmNxu9qMDV] Compose Missive
+  [qVNVSmsgpKFGk9hV] Conceal an Object
+  [BKnN9la3WNrRgZ6n] Conduct Energy
+  [K878asDgf1EF0B9S] Confident Finisher
+  [KC6o1cvbr45xnMei] Conjure Bullet
+  [kakyXBG5WA8c6Zfd] Constant Spells
+  [g26YiEIfSHCpLocV] Constrict
+  [5eqcXtPsYunphMOZ] Construct
+  [1If9lLVoZdO8woVg] Consume Flesh
+  [FyT7VwMCJjjHDSgO] Contact Steel Falcons
+  [mluc8JLd20HjGrqu] Convince Mengkare
+  [6uHxON55vtaperC2] Convocation of Greed
+  [Kp325Qf0qpF6RCDE] Coordinating Maneuvers
+  [56ajIlNy3SEvP9Ud] Costar
+  [mech0dhb4eKbCAu0] Coughing Dragon
+  [52CdldlWMiVTZk1F] Coven
+  [SB7cMECVtE06kByk] Cover Tracks
+  [gBhWEy3ToxQeCLQm] Covered Reload
+  [iBf9uGn5LOHkWpZ6] Craft Disharmonic Instrument
+  [I75R9NSfsVrit6cU] Cram
+  [XyfC1zPgSTP01ZUr] Cram
+  [Cu7P7NB3XH67mi1N] Crash Against Me
+  [Tj055UcNm6UEgtCg] Crawl
+  [NT1rtY5DFJGsR5QR] Create Familiar Fulu
+  [ftG89SjTSa9DYDOD] Create Forgery
+  [GkmbTGfg8KcgynOA] Create a Diversion
+  [bweyCSaXUjmcSTAO] Creative Spark
+  [2XQowhfM4SfAhJaf] Crescent Spray
+  [k50ynPhpPSPZ4Akg] Cry Havoc!
+  [zF3q1nTANa5NYYJu] Cunning Disguise
+  [Oh6H1fuXC6jK4Hcp] Cycle Elemental Stance
+  [mK3mAUWiRLZZYNdz] Damage Avoidance
+  [cczvLO5r7QuHaXwx] Dampening Harmonics
+  [1ejGup6ouh9t9S96] Dancing Dodge
+  [y6qvt8ac3fF4snwU] Dancing Shadow
+  [dpjf1CyMEILpJWyp] Darkeater
+  [0Xrkk46IM43iI1Fv] Darkvision
+  [qCCLZhnp2HhP3Ex6] Darkvision
+  [5LW1k5DUkzbbYuYL] Daydream Trance
+  [0LwQufKtXfRda0BR] Dazzle Seeker
+  [m8wjlYnTAAfddWyA] Dazzling Show
+  [rKWfjflS15KEB3Yt] De-Animating Gestures (False)
+  [rR8UYHHpo2Rffi1p] De-Animating Gestures (True)
+  [vkNAmvpzqWrIw43j] Deadly Spark
+  [nLLgAxo4IHebsyg1] Deadly Traps
+  [6iGoVnEJuBHJqgpi] Death Drone
+  [bp0Up04x3dzGK5bB] Debilitating Strike
+  [1LDOfV8jEka09eXr] Deceptive Sidestep
+  [Qj36ramjkoKE8kzJ] Decompose
+  [ZUAaBIAntZhFQixm] Deconstruct
+  [WlXmO2kwyWGgAuOv] Deduce Traditions
+  [cYtYKa1gDEl7y2N0] Defend
+  [5V49l0K460CcvBOO] Defend Life
+  [UJi0VYnhVSdnl9II] Defensive Retreat
+  [A72nHGUtNXgY5Ey9] Delay
+  [2u915NdUyQan6uKF] Demoralize
+  [q1dvlKJI2Kfegc4Y] Demoralizing Charge
+  [JmCuw6Rhwfwo90ed] Designate Ally
+  [r5Uth6yvCoE4tr9z] Destructive Vengeance
+  [Yb0C1uLzeHrVLl7a] Detect Magic
+  [m0f2B7G9eaaTmhFL] Devise a Stratagem
+  [3sgY9afTTBhZXE8V] Devour Ambient Magic
+  [H72AAzknXiojqXdY] Direct Follower
+  [Dt6B1slsBy8ipJu9] Disarm
+  [jl1euufxNpAhVt26] Disarming Interception
+  [JLPY5hl4qiJ1zLi1] Discover
+  [Z025dWgZtawbuRLI] Disease
+  [AjLSHZSWQ90exdLo] Dismiss
+  [hq5KwJRPbTVcoD3k] Dispel a Disguise
+  [Fe487XZBdqEI2InL] Dispelling Bullet
+  [nVdoKUIWaJ47xMuB] Distract Guards
+  [s2RrhZx1f1X4YnYV] Divert Lightning
+  [k2YHPUydoyEKdhmP] Divine Retribution
+  [G8xZPhzoLF1SGyV9] Diviner on Duty
+  [c5jVVnNYlP5HB6Ob] Double Team
+  [uMFB3uw8WTWL0LZD] Draconic Frenzy
+  [hSTE1wvCsYYvCsHC] Draconic Salvation
+  [embGS7NjgydDw8KO] Dragon
+  [oanRfXGLnBm6mMVg] Dragon Breath
+  [Zt9bo3FYLQihmpAz] Dragon's Protection
+  [v82XtjAVN4ffgVVR] Drain Bonded Item
+  [rmnhzmJqfzEVnz1h] Drain Familiar
+  [JPHWzD2soqjffeSU] Drain Life
+  [JxuXTJIKRwmYn08D] Drain Realm
+  [GKIKJNInDev72qai] Drape Ambient Magic
+  [rJTg9cKnBF0jsGbr] Draw From the Pages
+  [6hrDW8tF6CDIaZl7] Dream Research
+  [YMhmebfXAoOFXeSB] Drifter's Wake
+  [49F65W6VwuXhmv8K] Drink Blood
+  [D91jQs0wleU5ml4K] Drink from the Chalice
+  [vZwa0PZLQvm3X5ME] Drink of my Foes
+  [uS3qDAgOkZ7b8ERL] Drive
+  [HYNhdaPtF1QmQbR3] Drop Prone
+  [xGqOIheAOV12RGU4] Dueling Counter
+  [KyKXp599tK9BgodC] Dutiful Retaliation
+  [Oko8SYegarqBkxhM] Ease Burden
+  [jfCmKk6pXcINVROk] Echolocation
+  [DS9sDOWkXrz2xmHi] Eldritch Shot
+  [ch6nFcRJO1fm8B4D] Elemental
+  [6U04OKtvRURExkli] Elemental Attack
+  [6lbr0Jnv0zMB5uGb] Elemental Blast
+  [Cb9XbKqHBHPAbQKk] Elemental Burst
+  [RIx6b1GvTEBh4ExW] Elemental Familiar (Air)
+  [ZV4J5YTZGrqh6cvY] Elemental Familiar (Earth)
+  [5019hvUZcNe9dLEO] Elemental Familiar (Fire)
+  [ZJdMyCjRvUTtg90u] Elemental Familiar (Metal)
+  [mIl4YjbssQ5AERWS] Elemental Familiar (Water)
+  [XYb2udoNGaE0M11Y] Elemental Familiar (Wood)
+  [H8EXYfvFOSuq6vo8] Elemental Maelstrom
+  [URZRO1ROM9VOS1nN] Elements of Creation
+  [V4HToYPQlkw8AW50] Embrace of Destiny
+  [fL7FhTBcKxMzLBAs] Empty Vessel
+  [e2ePMDa7ixbLRryj] Encouraging Words
+  [lI4JCQcqvrZE2U5n] End It!
+  [7qjfYsLNTr17Aftf] Energy Emanation
+  [TSDbyYRQwhIyY2Oq] Energy Shot
+  [qYdreGwopQ1ODgC6] Engineer's Efficiency
+  [zU3Ovaet4xQ5Gmvy] Engulf
+  [PaQL7cyry64nx9CG] Enlightenment in Adversity
+  [8PuITkuyl9swzWWq] Enter Runewell
+  [QWAWf8NDKpo1mzLE] Enter Seat Of Power
+  [djULKW76BbSoN3zb] Enter Spirit Trance
+  [5bCZGpp9yFHXDz1j] Entity's Resurgence
+  [BrCbXsCUIFYfu26E] Entreat Pact
+  [s4V7JWSMF9JPJAeX] Envenom
+  [KsYvgnBNvdC23gnC] Erect Barricades
+  [cy7bdQqVANipyljS] Erudite
+  [wfUIsKBxCBfXi1TF] Erupting Spurs
+  [SkZAQRkLLkmBQNB9] Escape
+  [GkcfzMAJVX159ua7] Executioner's Volley
+  [aCFKA59YgGDNnSJ8] Exhale Poison
+  [jftNJjBNxp2cleoi] Expeditious Inspection
+  [IV8sgoLO6ShD3DCJ] Expel Maelstrom
+  [naKVqd8POxcnGclz] Explode
+  [fodJ3zuwQsYnBbtk] Exploit Vulnerability
+  [MFyKaQVMMphwpHut] Explore the Electric Castle
+  [CRiItJtc8N9Hc0X0] Explore the Vault of Boundless Wonder
+  [ModT5b0jvnaitzJH] Extra Alchemy
+  [ZtKb89o1PPhwJ3Lx] Extra Vial
+  [low5ORd87QeA9Oug] Extract Element
+  [AJeLwbQBt1YH3S6v] Fade Into Daydreams
+  [jdlefpPcSCIe27vO] Familiar Focus
+  [6ZmgkMHUGGb1mDhr] Familiar of Balanced Luck
+  [HNoR0D2sKQaDNh5Z] Familiar of Bolstering Aid
+  [xXMPZXcwQgKRAu38] Familiar of Enticing Negotiation
+  [9ypX5ZMor6RMiFKv] Familiar of Flowing Script
+  [9xTjRt8LkZPB42Vi] Familiar of Freezing Rime
+  [YptMhsztTS9dYGAY] Familiar of Insightful Observation
+  [onye3PN84lmca11D] Familiar of Keen Senses
+  [uFsWy6Ii1WxA0u0w] Familiar of Nimble Flight
+  [Fouq5RMNS8P1CDzx] Familiar of Obscuring Snowfall
+  [mu9OL8v4rmr9311e] Familiar of Ongoing Misery
+  [xH7lvZkYYAAuxR62] Familiar of Overwhelming Tides
+  [bhpa7DVdMsaNfodz] Familiar of Paired Perplexity
+  [J5Wyh1EPmk848ivR] Familiar of Parasitic Might
+  [ZCze1FY3Rmnvd6Dx] Familiar of Restored Spirit
+  [FeEts6s2ABVEi0H6] Familiar of Stalking Night
+  [t6nzeTpsTJDwAUFZ] Familiar of Swarm's Heart
+  [fJSNOw4zHGbIm4bZ] Fast Healing
+  [BXssJhTJjKrfojwG] Fast Movement
+  [gU93T2UqxLsX9gyF] Fated Not to Die
+  [PdEJEiPUP0FDaBki] Feed the Masses
+  [QNAVeNKtHA0EUw4X] Feint
+  [tN8ChaJweDy1lT0s] Feral Claws
+  [K3hd3w20M707t6Iq] Feral Swing
+  [N1kstYbHScxgUQtN] Ferocity
+  [FomdyTNeKcV1dQMx] Fey Jump
+  [7WczIXwjOs9raMja] Fey Luck
+  [TMBXArwICQRJdwT6] Fey's Fortune
+  [tNrBIYct9l1lrW1I] Field of Roots
+  [0nyMrziUqqRcSxXD] Fight Fires
+  [L8UbCtOYzgEutput] Fight the Fire
+  [hi56uHG1aAb84Zzu] Fight with Fear
+  [EHa0owz6mccnmSBf] Final Surge
+  [e5JscXqvBUC867oo] Find Fault
+  [EUU6zUeCzYm9jIhT] Find the Cells
+  [4IxCKbGaEM9nUhld] Finish The Job
+  [UEkGL7uAGYDPFNfK] Fire in the Hole
+  [aw2JzLBAsmO8dD3r] Fire the Cannons! (3-4)
+  [0z53rJzCIGysXGTy] Fire the Cannons! (5-6)
+  [M1DXVrZlCTfm8PQs] Flare Bolt
+  [ITWUi1r8Z7EtChkB] Flash of Grandeur
+  [ZI4jRoVdz9YLtKlv] Flash of Memory
+  [6cwswBPHm1GWdx5j] Flatten
+  [ObFY26oKlreyVIUm] Fleeting Arc through Heaven and Earth
+  [ZHSzNt3NxkXbj1mI] Flier
+  [04VQuQih77pxX06q] Fling Magic
+  [6xWX8Ey5ShAyj1HO] Flowing Spirit Strike
+  [nbfNETdpee8CVM17] Flurry of Blows
+  [cS9nfDRGD83bNU1p] Fly
+  [dypCcXb9mwVbg6xD] Flyby Attack
+  [O5TIjqXAuta8iVSz] Focused Rejuvenation
+  [tfa4Sh7wcxCEqL29] Follow the Expert
+  [SjmKHgI7a5Z9JzBx] Force Open
+  [r0qPSxLoa1xRSWYL] Forced Pact
+  [VOEWhPQfN3lvHivK] Foresight
+  [7dq6bpYvLArJ5odx] Forge Documents
+  [3Pr6Jk6AobttQRqN] Forge Documents
+  [764EVGVADrDSbdqu] Forgive Foe
+  [OvqohW9YuahnFaiX] Form Up
+  [cNJ83EsE9OeCCpaE] Form of Fury
+  [KvVdGkUi0iJwapvD] Fortify Camp
+  [SRdiCXHSLxqu3C67] Fortify Focus
+  [Ei4T4aQx0a5EdBhm] Fracture Mountains
+  [etMnv73EIdEZrYYu] Frightful Presence
+  [jew52aXGdNyR4N5B] Fungus
+  [06frwOOuo4HJtivl] Furious Strike
+  [MLchOIG6uLvzK3r0] Gain Contact
+  [plBGdZhqq5JBl1D8] Gather Information
+  [URxnrN8ji84AoVup] Gather to Me!
+  [O1iircZOOCo42r9Y] Ghost Shot
+  [tzuYnmYCvA3zrj6w] Giant-Felling Comet
+  [lpyJAl5B4j2DC7mc] Gills
+  [Yfl6q6Pi42FttDRE] Glimpse Vulnerability
+  [tuZnRWHixLArvaIf] Glimpse of Redemption
+  [JjSNVfQO7qc4bgz1] Gluttonous Feast
+  [izvfZ561JTdeyh6i] Goblin Jubilee
+  [BCp3tn2HATUOUEdQ] Gossip
+  [Tkd8sH4pwFIPzqTr] Grab
+  [3yoajuKjwHZ9ApUY] Grab an Edge
+  [PMbdMWc2QroouFGD] Grapple
+  [LUBS9csNNgRTui4p] Grasping Tendrils
+  [OmV6E3aELvq9CkK1] Greater Constrict
+  [4Ho2xMPEC05aSxzr] Greater Darkvision
+  [zKTL9y9et0oTHEYS] Greater Resistance
+  [rI2MSXR1MQzgQUO7] Grim Swagger
+  [5tOovJGK2TQIBHUZ] Grow
+  [VE8P7wCsKo5eSwAz] Guerrilla Assault
+  [RX62MAyEUtuHMNBm] Guild Investigation
+  [EuoCFSHTzi0VOfuf] Harrow the Fiend
+  [GrzbczH9S3SHPiIQ] Harvest Blood
+  [h4Tzdhqfryp5m2fO] Harvest Heartsliver
+  [BnKNrkcM6F3v0p7s] Haul Supplies
+  [4oHjLO6qMfxIchRB] Haunting Visage
+  [TspxQ2di6yfPrRnP] Heat Haze
+  [JtEzSceixS0WA8wn] Heaven Rains an Ending
+  [CJnA1wEg2kA5BXfe] Heavy is the Crown
+  [ASt94swgHlproIcd] Hellbreaker Strike
+  [XMcnh4cSI32tljXa] Hide
+  [2HJ4yuEFY1Cast4h] High Jump
+  [ReTbL6UDEkkdkHAY] Holy Light
+  [o6hu1my40jfcLHqD] Host Event
+  [a1FVA0l58GOEq6xP] Host of Wrath
+  [JYi4MnsdFu618hPm] Hunt Prey
+  [I6gG9rqTTLkzrhKF] Hunt Runelord
+  [FLz8SEF0Y4UEavvD] Hunt the Animals
+  [Yrc21SgKRWOMNo7C] Hunt the Razer's Pawn
+  [JuqmIAnkL9hVGai8] Hustle
+  [wKPtG0pzARZLGHZT] I Defy You!
+  [Q4kdWVOf2ztIBFg1] Identify Alchemy
+  [eReSHVEPCsdkSL4G] Identify Magic
+  [dnaPJfA0CDLNrWcW] Implement's Interruption
+  [WKEFnxUH0CkM8bWq] Impromptu Investment
+  [i18TlebMzwONyPhI] Improved Grab
+  [LbnsT8yXchHMQT3t] Improved Knockdown
+  [6l7e7CHQLESlI57U] Improved Push
+  [2fiQzoEKu6YUnrU9] Independent
+  [Xc5MLIbT5OPhnFIJ] Indomitable Act
+  [PACnDVj2YLLSpr8Y] Infiltrator's Draw
+  [6Oe9dg3Lu10slyeC] Influence
+  [fUNCyoyLgpIYFLe1] Influence Guild
+  [yy5PeDyV7kIWlPOU] Influence Regent
+  [HFv62jIK98S2xw4x] Influence Rumor
+  [D0ltNUJnN7UjJpA1] Innate Surge
+  [lgpJoFrkzfkjAzeV] Inscribe Shadow Pamor
+  [ZXvJGxMJc0HRpcQh] Inspired Stratagem
+  [ut0jFv67YpvHBzD9] Insta-Ballista
+  [8UJaVPsT5FA8XH87] Instant Recovery
+  [HAmGozJwLAal5v82] Intensify Vulnerability
+  [pvQ5rY2zrtPI614F] Interact
+  [vhO1f7oTD2s3Ncg9] Intercept Attack
+  [0MZ5tFUYKGMq21NV] Intercession Spell
+  [Uq2qy9aGNQ5JcPI1] Into the Fray
+  [travkW5KLTnIUt9Y] Inured to Death
+  [lvqPQDdWT2DDO0k2] Invest an Item
+  [EwgTZBWsc8qKaViP] Investigate
+  [43vVOSRi8Lnk1Ril] Investigate Chamber
+  [Ul4I0ER6pj3U5eAk] Invigorating Fear
+  [Aq2mXT2hLlstFL5C] Invoke Celestial Privilege
+  [9NWMchSkF940L0SW] Invoke Eiseth
+  [Su0ZQXpm2D60kWa0] Invoke Shrine Blessing
+  [M8RCbthRhB4bxO9t] Iron Command
+  [zIwbbth7qyKraiWV] Issue Challenge
+  [Ms8EVO2mNbr4Zp1i] Item Delivery
+  [fhyQ6uTSvfErTzyE] Jet
+  [hFRHPBj6wjAayNtW] Jinx
+  [wt6jdjjje16Nx34f] Jumping Jenny
+  [HmanpP99Uk47e4OB] Kick Dust
+  [PFH7Y57hbdBvebvp] Kick Up Dust
+  [gVPtUSEPZYGRIRyQ] Kindling
+  [qTxH8mSOvc4PMzrP] Kinspeech
+  [BCLvAx4Pz4MLa2pu] Knockdown
+  [7QosmRHlyLLhU1hX] Lab Assistant
+  [ako5zZwC6o26cfCQ] Lantern Beam
+  [aVGNaNgG6cYNRp5A] Lantern Strobe
+  [yUjuLbBMflVum8Yn] Launch Fireworks
+  [x1qSEkzHAviQ5jry] Lay Down Arms
+  [d5I6018Mci2SWokk] Leap
+  [yOtu5X3qWfjuX8Vy] Learn Name
+  [q9IXWngAOCpsXxsO] Levitator
+  [egXlMyYLBthoQSgh] Liar's Hidden Blade
+  [IX1VlVCL5sFTptEE] Liberating Step
+  [ewwCglB7XOPLUz72] Lie
+  [Iuq8CeNqv3a0oWfQ] Life Block
+  [deC1yIM2S5szGdzT] Lifelink
+  [sebk9XseMCRkDqRg] Lifesense
+  [I0HYG0ctCLP5JRsW] Light Blindness
+  [zwWgHjcU0iZ6gUDY] Lightning Armillary
+  [0R18Nd0CotPo9KD7] Lightning Needles
+  [ddxnMTdRXNUvYH7B] Linguistic Nexus
+  [FwI9BgkmMQ25ltVI] Liralarue's Glimpse
+  [31uM8IkenDZdeid6] Little Ripple's Blessing
+  [9MJcQEMVVrmMyGyq] Living Fortification
+  [sT8EpCnySUSiBqBp] Locked Doors
+  [JUvAvruz7yRQXfz2] Long Jump
+  [DXIZ4DHGxhZiWNWb] Long-Term Rest
+  [R90HXdiRwl0Fa4wb] Loot the Vaults
+  [fFu2sZz4KB01fVRc] Low-Light Vision
+  [RxIPBjodIRm7Pd6W] Lucky Break
+  [ou91pzf9TlOnIjYn] Luminous
+  [hMrxiUPHXKpKu1Ha] Major Resistance
+  [5DVnTrN2xt3NINGZ] Make General Repairs
+  [OX4fy22hQgUHDr0q] Make an Impression
+  [k3Dbgb8iS73atDqB] Makes Me Stronger
+  [Qf1ylAbdVi1rkc8M] Maneuver in Flight
+  [n5vwBnLSlIXL9ptp] Manifest Eidolon
+  [IfWF56KiSFQbNmHj] Manifest Realm
+  [KMKuJ0onVS72t9Fv] Manifest Soulforged Armament
+  [cT5octWchU4gjrhP] Manual Dexterity
+  [Ba9EuLV1I2b1ue9P] Map the Area
+  [AZt0m0EHRmtDCd5s] Marathon Dash
+  [orjJjLdm4XNAcFi8] Mark for Death
+  [jD8RW5PdLI6snlsO] Mark the Center
+  [C16JgmeJJG249WXz] Mask Freeze
+  [1fRkeUkPJFiBJ5u6] Mass-Produced
+  [Rlp7ND33yYfxiEWi] Master Strike
+  [1obHWaFiFI1pnC3R] Master's Eye
+  [JRP2bdkdCdj2JDrq] Master's Form
+  [ReIgBsaM95BTvHpN] Medic
+  [MgSwLes5lp3TE1ZV] Mental Ward
+  [jwo5CvftA5puYp7i] Mesmerizing Performance
+  [74iat04PtfG8gn2Q] Mighty Rage
+  [Mh4Vdg6gu8g8RAjh] Mirror's Reflection
+  [CPTolKAF55p7D7Sn] Mirror-Trickery
+  [EKEZGfOBKTNWTFDe] Mirrored Wall
+  [I9k9qe4gOT8UVK4e] Mist Blending
+  [yWTdfPklh8jL94GZ] Mobbing Assault
+  [PM5jvValFkbFH3TV] Mount
+  [bAXkEXAlnBx78S7t] Mountaineering Training
+  [00LNVSCbwJ8pszwE] Mutagenic Flashback
+  [T8ZnkumXGAbqsOqt] My Legend Must Be Told
+  [ur4AfegC9RqRgy3e] Mystic Aegis
+  [wdLdqMu0S90Kc7gj] Mythic Echo
+  [fsR3X4c3p19W8RB2] Name Drop
+  [zuTNF3UEr0ZNleqR] Naval Training
+  [m9Si1ygkv9ISjKVN] Navigate Steamgrotto
+  [wCnsRCHvtZkZTmO0] Nimble Dodge
+  [JdpUaQeNwoVr2VHL] No Scar but This
+  [rlGVQku78DGoOl9V] Nudging Whisper
+  [BKMxC0ZvdYfdhx7C] Objection
+  [hi80qyUsXbaq2Wf4] Obscure
+  [7wQe43fSCG9DSWdj] Offer Story
+  [2r4BY90F9PLFai3c] Once Bitten
+  [IEBBHnI7wWRt44KG] One Moment till Glory
+  [Tlrde2xh7AhesXNB] One Shot, One Kill
+  [8r9ePG6BnrnO6YE1] Only You and I
+  [EfjoIuDmtUn4yiow] Opportune Riposte
+  [bUgSKcdHyEKbtXhl] Opportunistic Accusation
+  [Dir7OyCss7H1XQGX] Organize Labor
+  [QGeA2sPtDdryTpWw] Overawe Crowd
+  [3D9kGfwg4LUZBR9A] Overdrive
+  [ZJcc7KGOEsYvN6SE] Overload Vision
+  [zUWj4zmBNWOTzeFJ] Overwhelming Combination
+  [oAGawsNqr6FfMrSG] Pacifying Infusion
+  [ijZ0DDFpMkWqaShd] Palm an Object
+  [awJY2ylrsVEJNTFi] Pander to the Crowd
+  [v7zE3tKQb9G6PaYU] Partner in Crime
+  [BfC5pWAns8PNewW3] Passage of Lines
+  [O0XJIvMGK36yg9TJ] Path of the Tempest
+  [ZC4SuXmL79N9VVIW] Patron's Claim
+  [VBwNo2Wbfd4n4Y3g] Patron's Presence
+  [7NQGN3kxiXetaTT4] Perception Filter
+  [2Vrg2RkEdOteyp5O] Perform a Trick
+  [zLFfwNmmPTND6OMO] Pincer Attack
+  [NVLqYqkkQaCdnWWk] Piranha Assault
+  [bCDMuu3tE4d6KHrJ] Pistolero's Retort
+  [ri6ZVR7nhFOvZfVa] Pitch-Perfect Projection
+  [lLWkoGiNLNIEm5Sp] Plant
+  [57b8u8s3fV0UCrgJ] Plant Form
+  [cfQb0mBbyrjhyGf5] Plant Thirty Barbs
+  [pX73zPGaazVJ0lKO] Play Dead
+  [02pkkhes1AlItIit] Play the Fool
+  [XiiR6WwfTcwIUvHG] Plummeting Roll
+  [sn2hIy1iIJX9Vpgj] Point Out
+  [xccOiNL2W1EtfUYl] Pointed Question
+  [kFv54DisTfCMTBEY] Poison
+  [8Z1UkLEWkFWIjOF8] Poison Reservoir
+  [6YIG6eVGTplWubGb] Pop, Drop, and Lock
+  [236E6kEEayy8h2CF] Position the Hunters
+  [pWxRtCeAw4XnyzoM] Post Snipers
+  [u4Sp4K4WOi461xo1] Pot of Tea
+  [0B39GdScyZMPWalX] Power Attack
+  [CIqiFw9rqYnuzggq] Practical Research
+  [2Kz5whXqnRsL4fEl] Practical Research
+  [tay92zbn04IR40qv] Prepare Firepots
+  [VF2Gw89uNHSUIiFr] Prepare the Processional
+  [wnZhAUiYcs2mv8sZ] Primal Howl
+  [kbUymGTjbesOKsV6] Primal Roar
+  [lD2RA75awEu4cG7e] Promote the Circus
+  [qL44lR8sZMWgY1r7] Propelling Winds
+  [vdnuczo4ktS7ow7N] Prophecy's Pawn
+  [5yBBgZ7OCWWJsnLo] Protective Screen
+  [KIU5eDZP9VyQIfas] Protector's Interdiction
+  [Ma93dpT4K7JbP9gu] Prove Peace
+  [QW2gYIKce3W31xXf] Prove Peace
+  [iTx0vXAhiS4lKwEi] Psychic Defense
+  [jZQoAHmGJvi53NRR] Psychometric Assessment
+  [BYF0XL1ZtdkRda3u] Pull
+  [43xB5UnexISlfRa5] Purify Air
+  [xTK2zsWFyxSJvYbX] Pursue a Lead
+  [t6cx9FOODmeZQNYl] Push
+  [yzNJgwzV9XqEhKc6] Quick Alchemy
+  [QHFMeJGzFWj2QczA] Quick Tincture
+  [a9PzINjFTO5GvAJN] Quick-Tempered
+  [MrTULCUsE9naPxXg] Race the Skies
+  [RADNqsvAt4gP9FOX] Raconteur's Reload
+  [3y6GGXQgyJ4Hq4Yt] Radiant
+  [Ah5g9pDwWF9b9VW9] Rage
+  [MLOkyKi1Y3N6y56Q] Raise Neck
+  [m9UGL3VWfg9r6xHQ] Raise Ramparts
+  [0VwLAKI7QP6mib88] Raise Slabs
+  [xjGwis0uaC2305pm] Raise a Shield
+  [ND1G3s4lXNUAXc1q] Raise the Horde
+  [IBEbFlMmDbGsrN4G] Raise the Walls
+  [xJEkXFJgEfEida27] Rally
+  [LVSGvlzI1rGWtGJA] Rallying Display
+  [FkfWKq9jhhPzKAbb] Rampaging Ferocity
+  [CLX9WEYXdntl2wrt] Reactive Falsehood
+  [kfmEGGs8DbIL9JuF] Reactive Scorch
+  [KAVf7AmRnbCAHrkT] Reactive Strike
+  [W7SbTykXrNwxDzJc] Reactive Strike
+  [dLgAMt3TbkmLkUqE] Ready
+  [iuFPNbfhVXvbCPRO] Ready, Aim, Fire!
+  [24k7qCV8S95yYK3y] Reap the Field
+  [OqKYkzbc7NEWmJWB] Rearrange Bones
+  [cp8eFBCr1n7xIaxq] Rebuild Battlements
+  [5QQqv1A3aG6G2Sui] Rebuild Collapsed Stairs
+  [DYn1igFjCGJEiP22] Recall Ammunition
+  [REJfFezELjc5Gzsy] Recall Familiar
+  [1OagaWtBpVXExToo] Recall Knowledge
+  [lH3mlvs1rCyXw6iY] Recall Under Pressure
+  [kRxWINkrHUPSHHYq] Recall the Teachings
+  [5p2AMqM9bOVnhwPT] Recenter
+  [rqT4LMH7qbfyScBi] Reclaim Destiny
+  [QIrJJ1pl4H6DctaQ] Reconnoiter
+  [sWTvJahHpdz4CC6E] Recruit Wildlife
+  [cd34tQpOVbaGuv5p] Redistribute
+  [OSefkMgojBLqmRDh] Refocus
+  [lR9R5Vld8Eu2Dha5] Regeneration
+  [I08t3hnpMZSRX5Ug] Rejoin in Flight
+  [wQYmDStjdjn0I26t] Release
+  [NjS64g60oV74XZjq] Reload!
+  [jSC5AYEfliOPpO3H] Reloading Strike
+  [AHCMtFUZXpw98PqS] Remove Head
+  [3JOi2cMcGhT3eze1] Rend
+  [aUgAKW3SWhU9ATl8] Repair Crumbled Walls
+  [KmpPAOjNP980NuCY] Repair Huntergate
+  [OQaFzDtVEOMWizJJ] Repeat a Spell
+  [SN3sVsU7rD2eBfkf] Repel Ambient Magic
+  [lOE4yjUnETTdaf2T] Reposition
+  [oUP8jylH97ZbRvfw] Reposition Chains
+  [0HbksdcT2zNV5CUt] Repository of Knowledge
+  [DCb62iCBrJXy0Ik6] Request
+  [xklnt1hmdFnix64F] Rescue Citizens
+  [t5nBkpjroaq7QBGK] Research
+  [On5CQjX4euWqToly] Resist Elf Magic
+  [XeZwXzR1KBlJF770] Resist Magic
+  [FcQQLMAJMgOLjnSv] Resistance
+  [Q42nrq9LwDdbeZM5] Restorative Familiar
+  [jjxxWxnlEqWjTUur] Restorative Teleportation
+  [XkrN7gxdRXTYYBkX] Restore the Mind
+  [0jJQglG57R6ss04M] Restore the Moment
+  [24PSsn1SKpUwYA1X] Retraining
+  [EAP98XaChJEbgKcK] Retributive Strike
+  [IQtb58p4EaeUzTN1] Retributive Strike
+  [SNjmjFw30KQxIP4A] Rewrite Fate
+  [EbF9U21iMu0JkTzG] Righteous Call
+  [ublVm5gmCIm3eRdQ] Ring Bell
+  [mBqZ2IahMT9Jvo7k] Ringing Challenge
+  [ILwYke30PIAr2CVX] Roaring Charge
+  [nmgmPqExUZt5u5Wr] Rotate the Wheel
+  [SowCo0BXngrpatgn] Royal Grace
+  [lID4rJHAVZB6tavf] Run Over
+  [rPefHA2zqmUvGXQ7] Runelord's Response
+  [b6CanpXyUKJgxEwq] Salt Wound
+  [ZI7TLmmUu7fYLrP0] Sanguine Revitalization
+  [FlRUb8U13Crj3NaA] Scent
+  [rqfnQ5VHT5hxm25r] Scent
+  [kV3XM0YJeS2KCSOb] Scout
+  [I19VNyhXYaFCpsxl] Scout Duneshadow
+  [EcDcowQ8vS6cEfXd] Scout Location
+  [GhahZSxNPSrabaA6] Scout the Facility
+  [2GMAPffXVayRFsLM] Seal-Bearer
+  [TiNDYUGlMmxzxBYU] Search
+  [OSFi8oH5ndLgnksD] Search the Laughing Jungle
+  [1pkGuWi0YdP0v6g2] Searing Wave
+  [RDS7V0K5i8x4pvTY] Seasonal Boon (Close Ties)
+  [x4MzouaZk5193zFr] Seasonal Boon (Folklore Enthusiast)
+  [k1uJji3XkGe1rZ5z] Seasonal Boon (Northridge Scholar)
+  [BATtnqQpm9kISgv1] Seasonal Boon (Outskirt Dweller)
+  [b5BwpJVxTQNDr9E4] Seasonal Boon (Southbank Traditionalist)
+  [WDSbI48ikMbO9ZLJ] Seasonal Boon (Willowshore Urchin)
+  [j9vOSbF9kLibhSIf] Second Opinion
+  [iEYZ5PAim5Cvbila] Secure Disguises
+  [XTDd73QzhETeXY3g] Secure Disguises
+  [IQewgylxmkmBYcoY] Secure Invitation
+  [BlAOM2X92SI6HMtJ] Seek
+  [YvSjpOAI9bCDQU5h] Seek the Animals
+  [Ys6rFLuyxocQy2hA] Seek the Hidden Forge
+  [nSTMF6kYIt6rXhJx] Seething Frenzy
+  [enQieRrITuEQZxx2] Selfish Shield
+  [52zcawpATnCLh4J9] Send in the Clowns
+  [1xRFPTFtWtGJ9ELw] Sense Motive
+  [uWTQxEOj2pl45Kns] Sense Weakness
+  [vvYsE7OiSSCXhPdr] Set Explosives
+  [vFaNE7s7vFs9BxJW] Set Free
+  [z1noqZiavhnqQL50] Set Traps
+  [EhLvRWFKhZ3HtrZO] Settle Emotions
+  [VCUz5EnBUJF07j1a] Sever Conduit
+  [XFdTDDAPO7U0r4Et] Sever Four Dragonfly Wings
+  [yiIE9iWx6OLd61Qs] Shadow Projection
+  [LuUOQ5HvoFK9xUs4] Shadow Smith
+  [VQ5OxaDKE0lCj8Mr] Shadow Step
+  [j1qZiH50Bl2SJ8vT] Shadow Step
+  [wGTHH6v25CDavO6g] Shake It Off
+  [bwXH0zItp8p8sSjn] Share Death's Promises
+  [MY6z2b4GPhAD2Eoa] Share Life
+  [3ZzoI9MTtJFd1Kjl] Share Senses
+  [gPceRQqO847lvSnb] Share Senses
+  [Xj3LvT3I78cVwzer] Shatter Glass
+  [1mir8ZPc1sJNEKVM] Shattered Earth
+  [uruoG0PuuA0CqEG7] Shed Spirit
+  [LRuwz61jNmIfQYby] Shed Time
+  [rU3CE5niG8vHc5x4] Shed the Mortal Skin
+  [m4HQ2o5aPxjXf2kY] Shield Block
+  [yOk8s1pftOe5I9Sg] Shielding Wave
+  [LAo3ERyiaHx3E8qg] Shields Up!
+  [9cGJBXSJW6EpgibP] Shift Immanence
+  [Bh1Qnh8JP4CMysRK] Shootist's Draw
+  [O4MWAxAYxNkndVnt] Shortcut Through the Wastes
+  [7blmbDrQFNfdT731] Shove
+  [x73LKNcaRwurr0fR] Sickening Assault
+  [gCVox3KLuKFXCUqZ] Sidestep Through Time
+  [A4L90h7FIgO5EyBx] Siegebreaker
+  [jevzf9JbJJibpqaI] Skilled
+  [exuTl8tvVlewxVGJ] Skirt the Underworld
+  [JpcegMRqdizrkG0m] Slayer's Identification
+  [OULAoPQYFoiRhjXP] Slip and Sizzle
+  [pTHMZLqWDJ3lkan9] Smoke Blending
+  [3E5TMUDCSEI5x2bv] Smooth the Path
+  [dqE9pP9Pv0JG9d8X] Smuggled
+  [VMozDqMMuK5kpoX4] Sneak
+  [AWvNPE4U0kEJSL1T] Sneak Attack
+  [fmsVItn94FeY5Q3X] Snoop
+  [mVscmsZWWcVACdU5] Soaring Flight
+  [ZEsBPUmxNJ0nod2Z] Sorshen's Devotion
+  [MGcVYSWZvaoEAISV] Soul Bond
+  [o0fxDDUu2ZSWYDTr] Soul Sight
+  [TM4pOPSM9r7XEM64] Soul Ward
+  [tHHpBREXDaafK3TF] Spasm of the Berserker
+  [zyMRLQnFCQVpltiR] Speech
+  [plLX3yDcKo2YiJ0j] Speed of Arms
+  [Xanjwv4YU0CBnsMw] Spell Battery
+  [wOgvBymJOVQDSm1Q] Spell Delivery
+  [3MiV0maH8imtnVwS] Spell-Woven Shot
+  [asOhEdyF8CWFbR96] Spellcasting
+  [VNuOwXIHafSLHvsZ] Spellsling
+  [QDW9H8XLIjuW2fE4] Spellstrike
+  [hPZQ5vA9QHEPtjFW] Spin Tale
+  [6OZfIjiPjWTIe7Pr] Spinning Crush
+  [am7GMqh4t7m7bbaW] Spirit Sanctification
+  [nrPl3Dz7fbnmas7T] Spirit Touch
+  [SPtzUNatWJvTK61y] Spirit's Mercy
+  [GmqHs4NEhAjqyAze] Spiritual Aid
+  [dwA0wfUaRf4aT0eB] Spit Ambient Magic
+  [VTm9ourfz7mO5Syx] Spread Propaganda
+  [Ssp7CCGMJhcAfeYw] Spread Realm
+  [DFRLID6lIRw7CzOT] Spring the Trap
+  [kMcV8e5EZUxa6evt] Squeeze
+  [OdIUybJ3ddfL7wzj] Stand
+  [M4ALaFXoQDJGxSsI] Starlit Transformation
+  [RDXXE7wMrSPCLv5k] Steal
+  [XUNM9eqfhnSaPVov] Steal Keys
+  [Mr0acrql7LqT5wam] Steal Luck
+  [D2PNfIw7U6Ks0VY4] Steel Your Resolve
+  [GPd3hmyUSbcSBj39] Stellar Misfortune
+  [PqGX4Dgy9siZJitH] Stench
+  [UHpkTuCtyaPqiCAB] Step
+  [PTEiTXsObvtke43x] Stitching Strike
+  [k5S2a2a6o2GS5l01] Stonestrike Stance
+  [9gDMkIfDifh61yLz] Stop
+  [Bcxarzksqt9ezrs6] Stride
+  [VPl4pifKcq7ecK87] Stridulating Song
+  [VjxZFuUXrCU94MWR] Strike
+  [73W3mBLXRPfeVl3G] Strike Hard!
+  [oaJeGdGPmHiNT5mP] Strike, Breathe, Rend
+  [sL1J8cFwpy1lI359] Study
+  [Vt6CuD83hPiyoiOZ] Study
+  [oOpppkBhLcfaKZN4] Stunning Flare
+  [7HRhXh46dJVb241Y] Stupefying Raid
+  [S2WNjzwdnwziZSee] Summon Sloth
+  [NdMSHDtV9G7MbdP2] Survive the Wilds
+  [3f5DMFu8fPiqHpRg] Sustain
+  [UqUDWO0TuSzEAKpw] Sustain an Effect
+  [uJSseLa57HZYSMUu] Swallow Whole
+  [E48YTUyreo1kc9GM] Swarm Forth
+  [baA0nSMhQyFyJIia] Swarm Mind
+  [Wukpm200zHDuS85V] Swarming Assault
+  [cyl7y8GcGjd8ENC7] Swift Choreography
+  [c8TGiZ48ygoSPofx] Swim
+  [Gu0QsFvWoR9EP5SE] Swirl Crimson Shroud
+  [jPvjeX1CsUZQSszu] Synchronize Spirit
+  [KInVpdfrxg0AqjRt] Tactical Retreat
+  [KtxzyElOleyy74Lg] Tactical Takedown
+  [ev8OHpBO3xq3Zt08] Tail Toxin
+  [ust1jJSCZQUhBZIz] Take Cover
+  [qc0VsZ0UesnurUUB] Take a Breather
+  [HUJBYqs2vTTBeZgO] Take the High Ground
+  [IR95FFdO7MtC8C0E] Talon Stance
+  [cGCQkCz14sF238gE] Tangle in Riddle
+  [gxtq81VAhpmNvEgA] Tap Ley Line
+  [jsEBrm8SPcsokJLw] Tap the Past
+  [tEWAHPPZULvPgHnT] Tattoo Transformation
+  [4DYFJ4TUsNkgFBDb] Taunt
+  [kdhbPaBMK1d1fpbA] Telepathy
+  [W87FYSsY21BFQWNU] Tell Me More
+  [EeM0Czaep7G5ZSh5] Ten Paces
+  [5HZ4cYDowUw2oUbZ] Tenacious Stance
+  [YpuEmI1fJBZD3kMc] Tendril Strike
+  [kUME7DMhhHH6eIiH] That's My Number
+  [Czcdh3pPzQ7y1cV7] The Bigger They Are
+  [cx5tBTy6weK6YSw9] Thermal Eruption
+  [9kIvFxA5V9rvNWiH] Thoughtful Reload
+  [JcaIJLGGmst79f1Y] Thoughtsense
+  [aEKA3YWekLhEhuV8] Threat Display
+  [W4M8L9WepGLamlHs] Threatening Approach
+  [a0tx6exmB9v9CUsj] Throw Rock
+  [6SAdjml3OZw0BZnn] Thundering Roar
+  [gohBPHf4dxi4PkBk] Timely Dodge
+  [uUrsZ4WvhjKjFjnt] Toolbearer
+  [o3u4snDwjBDcNlG3] Topple Crates
+  [Ypwa9HIw7uXdt25D] Topple the Pillar of Heaven
+  [XCqYnlVbLGqEGPeX] Touch Telepathy
+  [WpCs3QmPVn8SRbXy] Touch and Go
+  [Le8UWr5BU8rV3iBf] Tough
+  [kKKHwVUnroKuAnOt] Toxic Skin
+  [Rp7gcG6Mxasurr8o] Toxic Touch
+  [EA5vuSgJfiHH7plD] Track
+  [UNah0bxXxkcZjxO3] Trample
+  [97jWk4XbIrGQK4Cp] Transform Ammunition
+  [Z8aa6afUterlfh5i] Travel
+  [LrDnat1DsGJoAiKv] Tremorsense
+  [j2wsK6IsW5yMW1jW] Tremorsense
+  [kWrks0NxMQH39JHD] Trench Digging
+  [ge56Lu1xXVFYUnLP] Trip
+  [EawOw47nHueUPnYc] Troop Defenses
+  [MXI6zwrvbQNIv7ji] Troop Movement
+  [pn557VVMaNJyq0jX] True Shapeshift
+  [21WIfSu7Xd7uKqV8] Tumble Through
+  [5g0gCXJnUVipYtW0] Turn Aside Ambient Magic
+  [cwBsPU24715fUCub] Ultimatum of Liberation
+  [ZFM7vgRwRqdNOelg] Underground Bounty
+  [tzpffovSRKkBEsN5] Uniter of Clans Enhancement
+  [7GeguyqyD1TjoC4r] Unleash Psyche
+  [mpFTlTGmPBKXMq2C] Unleash Realm
+  [TIIM35m8aDUEU4gF] Unravel the Future
+  [KofrLYBif2QKyiqe] Unwavering Resilience
+  [cGgeAlsnsSQPSPDQ] Upgrade Defenses
+  [F0JgJR2rXKOg9k1z] Upstage
+  [9PsptrEoCC4QdM23] Valet
+  [DGmzeAr4IfCnKN0R] Valkyrie's Charge
+  [B7wDxyjX66JkiCOV] Venom Draw
+  [SKIS1xexaOvrecdV] Verdant Burst
+  [JAka1VWMPGOm5JpR] Verdant Rest
+  [0rq3ufpxB9iHlIkd] Versatile Form
+  [nLrXleY20sESisoW] Vina Song
+  [iJLzVonevhsi2uPs] Visions of Sin
+  [vO0Y1dVjNfbDyT4S] Vital Shot
+  [TTCw5NusiSSkJU1x] Void Healing
+  [7pdG8l9POMK76Lf2] Warding Sign
+  [eBgO5gp5kKhGtmk9] Water Transfer
+  [Amzezp93MZckBYRZ] Wavesense
+  [VdSMQ6yRZ3YXNXHL] Wavesense
+  [nYR1q5D1jLiJj4JM] Weaponsight
+  [tu5viJZT4zFE1sYn] Whirlwind Maul
+  [ncdryKskPwHMgHFh] Wicked Thorns
+  [UEBVXi4VSQf70ggQ] Wind Barrier
+  [UyMkWfVqdabLTgkH] Wind Them Up
+  [5vLvLriQQGwgIIfz] Winged Leap
+  [N6U02s9qJKQIvmQd] Wish for Luck
+  [fSX1Ccn4GVD7OGzV] Word of Faith
+  [GSLSCo0OWDUtET4e] Wrestle
+  [OJ9cIvPukPT0rppR] Wyrm's Breath
+Ammunition
+  [vExfAIHZ2WaJPfMp] 8-Round Magazine
+  [NSQOijKqomyotXkj] Antler Arrow
+  [iYsDDvFduPhtaIOr] Aromatic Ammunition
+  [w2ENw2VMPcsbif8g] Arrows
+  [J3gd5vhcxwFbpCXe] Awakened Adamantine Shot
+  [kwp0N4MdOgRpdKi6] Awakened Cold Iron Shot
+  [asuxBXmrZErr9tep] Awakened Silver Shot
+  [NELpewmAIxQXaMtv] Backpack Ballista Bolts
+  [1UWYVwWVnp8Vng5t] Backpack Catapult Stones
+  [qZvCxp4noVqYGkT0] Bane Ammunition (Greater)
+  [arNOPU7h8nNbnZ1N] Bane Ammunition (Lesser)
+  [RL2VI9IGuOtXsEX6] Bane Ammunition (Moderate)
+  [kIz1DYlJdkPc95zb] Battering Ammunition
+  [taAjenWKjBJpQyrE] Beacon Shot
+  [ud970e7uPVEqx1FO] Big Rock Bullet
+  [FHsRKAdiLlxfSOqy] Big Rock Bullet (Greater)
+  [Fz6jQ0M3v55R8CqA] Big Rock Bullet (Major)
+  [NOPrIz6UNxof1M5d] Black Tendril Shot (Greater)
+  [T7o5nMvWS8YeJOst] Black Tendril Shot (Lesser)
+  [16INAWEN5mkuGTga] Black Tendril Shot (Moderate)
+  [cYkmDxRFtwQRvwVh] Blindpepper Bolt
+  [xm8FszDcmRrnlk09] Blister Ammunition (Greater)
+  [uoWWFCt1B0lKtjwZ] Blister Ammunition (Lesser)
+  [xKME7GEjssNkyTgt] Blister Ammunition (Moderate)
+  [sqhr1crb184s3Vnd] Blowgun Darts
+  [mzk9ekUydT8zpy4A] Bola Shot
+  [AITVZmakiu3RgfKo] Bolts
+  [6zkI2QVa8UxgjpQS] Burrowing Bolt
+  [HAXiBgieevN13XlF] Burrowing Bolt (Greater)
+  [n5L7HE9H8jn8ftQy] Climbing Bolt
+  [aBN9WkTHUCtE259N] Conduit Shot (Greater)
+  [tO6nucXnHAhCpD6n] Conduit Shot (Lesser)
+  [66yY2SClvqj0lMFX] Conduit Shot (Moderate)
+  [yaKQS5aG2i7IioyH] Corpsecaller Round
+  [903CuhvVUhE1lmoB] Corrosive Ammunition
+  [VctYvRnaKXjKlqQ7] Cutlery
+  [Yp1eRc7NmzSa5KYZ] Depth Charge I
+  [1VZpMEBamUpWADNZ] Depth Charge II
+  [Sg9KRxEaRBCRCUhp] Depth Charge III
+  [nsNFSjNZNVGEGTK4] Depth Charge IV
+  [95ki5dSg5Porv04G] Depth Charge V
+  [pkb6lKSanfcxvLtQ] Depth Charge VI
+  [nkozt1tueA0Xz6VF] Depth Charge VII
+  [KMcYZKGlsjKMjSNi] Dimension Shot
+  [Gfew65lwkzZc3mUV] Disintegration Bolt
+  [j3Pe1dyszbOT9c6Y] Dispersing Bullet
+  [6Qq7F1wlH5cx189e] Dreaming Round
+  [q2TpCwdlLGdcasKD] Elemental Ammunition (Greater, Acid)
+  [98t5XqMj2wRKjGsI] Elemental Ammunition (Greater, Cold)
+  [xsuxsWD8OT11adpI] Elemental Ammunition (Greater, Electricity)
+  [mwT86aIYuKy9mWHY] Elemental Ammunition (Greater, Fire)
+  [oS43VwmYZlSLxx1G] Elemental Ammunition (Greater, Poison)
+  [zHzAZRDVtl2NFqyh] Elemental Ammunition (Lesser, Acid)
+  [WnNvHEYObRivN1wI] Elemental Ammunition (Lesser, Cold)
+  [IhRPEmA2JlYNiCPK] Elemental Ammunition (Lesser, Electricity)
+  [CGmJzsdRb5aJ4eFn] Elemental Ammunition (Lesser, Fire)
+  [EVaMsTsWhdPkCtrg] Elemental Ammunition (Lesser, Poison)
+  [2pB7AsbE0c7HvoZZ] Elemental Ammunition (Moderate, Acid)
+  [zG5ErG09BZiVIGcP] Elemental Ammunition (Moderate, Cold)
+  [39kmT1vcfywtQtg9] Elemental Ammunition (Moderate, Electricity)
+  [xUMgX1vrP4EfLlw2] Elemental Ammunition (Moderate, Fire)
+  [xZ9fSlTKVpKOCOQm] Elemental Ammunition (Moderate, Poison)
+  [Y0oi9tSJYgfEQIxt] Enfilading Arrow
+  [rab0x5F9KpRxxlnH] Eroding Bullet
+  [rKknk8odXDBpON5l] Explosive Ammunition
+  [g27kK39Nzqphl1Tb] Explosive Ammunition (Greater)
+  [QMTW4MjXMIUGp41b] Exsanguinating Ammunition
+  [5Q6EFM1MSRX6WNTE] Exsanguinating Ammunition (Greater)
+  [c6HS4K7omXsmZiZT] Exsanguinating Ammunition (Major)
+  [rt5CcqcOxZDqkYwD] Extinguishing Ball
+  [QfdcOOHve9eNpsB9] Fairy Bullet
+  [xX9mq2iACVOas26l] Fate Shot
+  [BUZ8yiAXgXH8otmM] Feather Token (Chest) (Ammunition)
+  [eONI7XvfdGF34z74] Feather Token (Holly Bush) (Ammunition)
+  [RmVh6urcDFWrcLxq] Feather Token (Ladder) (Ammunition)
+  [BbhoGheRSwcfQ5z2] Feather Token (Swan Boat) (Ammunition)
+  [wRBz9mjTO9ZqXch6] Feather Token (Tree) (Ammunition)
+  [x6raxwPPL4Y8Zynr] Fishing Lure
+  [7fS4k3K3p6SFLxKe] Freeze Ammunition
+  [Xnmx6SJ6OkJOfYxF] Freezing Ammunition
+  [R8ZmXOfbfrp54VVB] Garrote Bolt
+  [XQjGhnBWOIh1uB2w] Garrote Shot
+  [Zjevw0WzUs1IIUAL] Ghost Ammunition
+  [L1tqtTYU8kk7G7h6] Glue Bullet
+  [0PGauxNX76JaaREG] Godrending Ammunition
+  [Irl1fogVpiKWJpCV] Godrending Ammunition (Greater)
+  [T1FiDItPqd2xkYpt] Golden Chrysalis
+  [5ucWbzvEQhd2eSJk] Golden-Cased Bullet (Greater)
+  [bKc5f8dAOjv1kwQ2] Golden-Cased Bullet (Major)
+  [LlmRVR4qv6H2AGPT] Golden-Cased Bullet (Standard)
+  [IAeGh5qvu7ob4yad] Grappling Arrow
+  [sAI6yzB11LlxisD7] Grappling Bolt
+  [ZZaEVS1Vw2a8cqWS] Harpoon Bolt
+  [XaHXxSpSCgLGYhbs] Imp Shot
+  [9kSITyK5yPTgTaQO] Juxtaposition Ammunition
+  [MpuFL2midIke1Sbn] Life Shot (Greater)
+  [hguIfHmI3LjhvlWO] Life Shot (Lesser)
+  [R6qfTzNv79GH1xHU] Life Shot (Major)
+  [Oo0KZTmFsu9iCAR9] Life Shot (Minor)
+  [l3itUlHLuWP6qlA0] Life Shot (Moderate)
+  [UzyjCLHxs3JQuFt5] Life Shot (True)
+  [MdX3CWn1nJhOkqSr] Lightning Rod Shot
+  [vbH19NIBChzdEn4R] Lodestone Pellet
+  [NiioDSvyhhY4IWVH] Magazine with 6 Pellets
+  [hXZrMJPlw1UvVzjC] Magazine with 8 Pellets
+  [JqKNiEJxSZX1sD06] Magnetic Shot (Greater)
+  [A8Rv4EWEiQEaNSEX] Magnetic Shot (Lesser)
+  [5RJivM5SShjbqFf0] Magnetic Shot (Moderate)
+  [2Rnw5hTlMd0YSozb] Meteor Shot
+  [ENrhapQe2Gw8HdwR] Meteor Shot (Greater)
+  [mPta1oQq0IWp5uE3] Meteor Shot (Major)
+  [9X77WeRsr543QKfz] Mindlock Shot
+  [SEToMRNTXAVVRwyd] Ooze Ammunition (Greater)
+  [fSO6mFltCGuSapsi] Ooze Ammunition (Lesser)
+  [qJaIfdtDrysjcy37] Ooze Ammunition (Major)
+  [SfqfTak3o0cuSqhL] Ooze Ammunition (Moderate)
+  [tOg1nt08dBTZbkwR] Penetrating Ammunition
+  [ZbI3V7ddjcKz1jch] Preserving Shot
+  [WKp751kO2ba4qPeN] Ranging Shot
+  [1B0672tSm46YQXSh] Rattling Bolt
+  [8qT6Jxy97jfdXfGi] Rattling Bolt (Greater)
+  [qFEoXkORtrHfoMwx] Reducer Round
+  [Dlsv1n0Bk1zVJaJM] Repeating Crossbow Magazine
+  [xk9bw9ccupAIx7xT] Repeating Hand Crossbow Magazine
+  [F5JDZSMYYKYfyeEE] Repeating Heavy Crossbow Magazine
+  [JMvp1ca4IhLy4cGj] Resonating Ammunition
+  [LLkl4mTbV9q4iDHJ] Rhino Shot
+  [lHyguikeoZlFlYdx] Rounds (Arquebus)
+  [VeeH30MvHyTX4QAT] Rounds (Axe Musket)
+  [KODdKPhwSQ9t4LKx] Rounds (Black Powder Knuckle Dusters)
+  [dSZz8B96D20IWKZ5] Rounds (Blunderbuss)
+  [oGKa9TWCrFC2LkBU] Rounds (Cane Pistol)
+  [58fs0VsG71A9gyEk] Rounds (Clan Pistol)
+  [oX2Ra68qKcixAxbm] Rounds (Coat Pistol)
+  [FCoziiYnBoRJFVaM] Rounds (Dagger Pistol)
+  [XnU7QmGlvBHzxkiJ] Rounds (Dawnsilver Tree)
+  [P5RvQfgQNCgxpdPU] Rounds (Double-Barreled Musket)
+  [h7jTMfYGQau1PBBz] Rounds (Double-Barreled Pistol)
+  [154C222Y7M96nvrL] Rounds (Dragon Mouth Pistol)
+  [FKPuzveKRNJhA1mi] Rounds (Dueling Pistol)
+  [HUgVrYvdy9SkqRZ9] Rounds (Dwarven Scattergun)
+  [zxnBe0wgTAEXXzUU] Rounds (Explosive Dogslicer)
+  [2ayp6yyQDr3iliBp] Rounds (Fire Lance)
+  [RQlZFVXv4LOxGyyn] Rounds (Flingflenser)
+  [Fy63rwYVBq0hXh0T] Rounds (Flintlock Musket)
+  [3QGZS6l7NrX4auyR] Rounds (Flintlock Pistol)
+  [V9QG93vXuh8d4sJQ] Rounds (Gnome Amalgam Musket)
+  [ckxYpfX3jTcZZOAz] Rounds (Gun Sword)
+  [GyzinRH2ZSHANAFc] Rounds (Hammer Gun)
+  [CmWkSgFyb6HB9KVK] Rounds (Hand Cannon)
+  [BZCzkDWQP3TU1Bbp] Rounds (Harmona Gun)
+  [eCRZcG7ZxFRP8bpx] Rounds (Jezail)
+  [V2CfXehNhCcxApbg] Rounds (Mace Multipistol)
+  [20h1dSg7IVJ5NxNa] Rounds (Pepperbox)
+  [sfMHQsOv3W8jFFop] Rounds (Piercing Wind)
+  [oQr0x30JoLrWxQdA] Rounds (Rapier Pistol)
+  [xwHTZGzD8HQrVSal] Rounds (Shield Pistol)
+  [lLR2wkdzr0iJ6o5y] Rounds (Shobhad Longrifle)
+  [L2df9pyWLFNgjfNh] Rounds (Slide Pistol)
+  [useyu9PIrr7QXUUh] Rounds (Spike Launcher)
+  [11b6MN3UQ8XKqAer] Rounds (Three-peaked Tree)
+  [Z333awQuoTxGkbgG] Rusting Ammunition (Greater)
+  [lQn0OkifOW0Grp9z] Rusting Ammunition (Moderate)
+  [Cs96jFDDcL9sX4Hv] Sampling Ammunition
+  [gogjNYjbw0rKUJ7r] Scouting Arrow
+  [NI7twU2G6UCDmvCO] Shining Ammunition
+  [Y2dyidYfphGo7qvs] Sighting Shot
+  [kv0Hg5RPROT4xqmh] Silencing Ammunition
+  [PkksgUAYXJeewn7T] Silencing Shot
+  [Pde3rUX3rx7VSCHn] Singularity Ammunition
+  [GyqCW00omWWQ2C4e] Sky Serpent Bolt
+  [MKSeXwUm56c15MZa] Sling Bullets
+  [RcQ4ZIzRK2xLf4G5] Slumber Arrow
+  [SxXy4a8uHf88iCf9] Spell Echo Shot
+  [NSo0bFX7DGGjqKKl] Spellstrike Ammunition (Type I)
+  [mmsuA7qPxFLLghtx] Spellstrike Ammunition (Type II)
+  [mz0GbCF2WT1DSYac] Spellstrike Ammunition (Type III)
+  [WSZl9S0Nui7pTMa8] Spellstrike Ammunition (Type IV)
+  [aAGjV3wkopQ44VX3] Spellstrike Ammunition (Type IX)
+  [XyrFcBF5ygIFFGes] Spellstrike Ammunition (Type V)
+  [n4FF7K3SLb7q1v6v] Spellstrike Ammunition (Type VI)
+  [WearPqN56FQofpF6] Spellstrike Ammunition (Type VII)
+  [oqiC4Mc5qKNCl88e] Spellstrike Ammunition (Type VIII)
+  [4dwBcqeuXePd89qW] Starshot Arrow (Greater)
+  [HUPCdlFkJQC7Krim] Starshot Arrow (Lesser)
+  [uNdRC0j1hY3F4pP1] Stepping Stone Shot
+  [H2Xcd1nzesEeY96V] Stepping Stone Shot (Greater)
+  [wTVBD8XHPG810rlH] Stone Bullet
+  [4F87PHMIzLHOUABL] Stonethroat Ammunition
+  [RpvH9EDquO0jS3Jz] Storm Arrow
+  [DKsfWwWZ23PHPIa1] Sun Shot
+  [ROdjFw7wby982qf5] Terrifying Ammunition
+  [YCFiwaS94TyfYtOe] Transposition Ammunition
+  [9CNxvAalHBPdSUFl] Transposition Ammunition (Greater)
+  [zle8PCLlI8jIkgiY] Tripline Arrow
+  [cVntDkkZP9mcuFHU] Trustworthy Round
+  [eEnzHpPEbdGgRETM] Vine Arrow
+  [ilB279mxqXnlaSFj] Viper Arrow
+  [Pp4JyxzRSqpOiQyL] Weapon Shot (Greater)
+  [kR53wN4yZ30PxysG] Weapon Shot (Lesser)
+  [jOuY6D1XmtHeax9H] Weapon Shot (Major)
+  [9Brjb8WQMVCT0P2v] Weapon Shot (Moderate)
+  [YrNmw0Rn3MqT0yKP] Wooden Taws
+Ancestry
+  [TQEqWqc7BYiadUdY] Anadi
+  [Cg1AMgp3zrGmimWd] Athamaru
+  [kYsBAJ103T44agJF] Automaton
+  [GFOgV3MzWkYwJoJW] Awakened Animal
+  [yFoojz6q3ZjvceFw] Azarketi
+  [972EkpJOPv9KkQIW] Catfolk
+  [pJkQlFTvpQ5GjZ5e] Centaur
+  [tZn4qIHCUA6wCdnI] Conrasu
+  [B5Ewz31nJBOzHSMg] Dragonet
+  [BYj5ZvlXZdpaEgA6] Dwarf
+  [PgKmsA2aKdbLU6O0] Elf
+  [hIA3qiUsxvLZXrFP] Fetchling
+  [FXlXmNBFiiz9oasi] Fleshwarp
+  [tSurOqRcfumadTfr] Ghoran
+  [CYlfsYLJcBOgqKtD] Gnome
+  [sQfjTMDaZbT9DThq] Goblin
+  [c4secsSNG2AO7I5i] Goloma
+  [GgZAHbrjnzWOZy2v] Halfling
+  [piNLXUrm9iaGqD2i] Hobgoblin
+  [gayvFCiQcGNCA7aM] Jotunborn
+  [dw2K1AJR9mQ25nDP] Kashrishi
+  [vxbQ1Yw4qwgjTzqo] Kholo
+  [4BL5wf1VF9feC2rY] Kitsune
+  [7oQxL6wgsokD3QXG] Kobold
+  [cdhgByGG1WtuaK73] Leshy
+  [HWEgF7Gmoq55VhTL] Lizardfolk
+  [FUqZRllwn6kmFA8K] Merfolk
+  [3wQ49DoWFYQgVsq6] Minotaur
+  [J7T7bDLaQGoY1sMF] Nagaji
+  [lSGWXjcbOa6O5fTx] Orc
+  [6F2fSFC1Eo1JdpY4] Poppet
+  [P6PcVnCkh4XMdefw] Ratfolk
+  [l7vjMIbPAUvEIosU] Samsaran
+  [7mpMGhVoaPANJnZ8] Sarangay
+  [x1YinOddgUxwOLqP] Shisk
+  [q6rsqYARyOGXZA8F] Shoony
+  [58rL5sg2y4arW1i5] Skeleton
+  [TRqoeYfGAFjQbviF] Sprite
+  [GXcC6oVa5quzgNHD] Strix
+  [ALOmLePjbc37ca3Y] Surki
+  [pILFsoGsUQkVF5dZ] Tanuki
+  [18xDKYPDBLEv2myX] Tengu
+  [hXM5jXezIki1cMI2] Tripkee
+  [cLtOGIkuSSa4UDHY] Vanara
+  [u1VJEXsVlmh3Fyx0] Vishkanya
+  [8FpI46oVxYVku04u] Wayang
+  [k3zyr6du4gV0Ftuh] Yaksha
+  [dnk0Rf7AUmyR5b8z] Yaoguai
+Armor
+  [Gu7T3wisuQh7MU0Z] Alkenstar Phalanx
+  [yNteshMHb0xIXFlC] Ancestral Embrace
+  [o5R57SGSmoIbQ6wj] Ankhrav Carapace
+  [ZsMwDe78kIqZj5de] Anti-Dragon Barding
+  [YPnmDZMcGaMyCHpZ] Anti-Dragon Barding (Greater)
+  [JG7p7yI12cAPuJ8X] Arachnid Harness
+  [NIyJqiW1Wci6gP9m] Arachnid Harness (Greater)
+  [nLhb0w0DbtUC6weH] Armor of the Holy Warrior
+  [GvAGrcl14Ywcgm2I] Armored Cloak
+  [txBx1I37esf3IgqM] Assassin's Skin
+  [hCutQISjPJaKGYtj] Aurochs Hide Armor
+  [QxdWm4xkTx9LGs8C] Autoload Leathers
+  [l3BVdNdtv3486bOk] Autumn's Embrace
+  [mrgtvEbYTjGpOi7F] Bakuwa Lizardfolk Bony Plates
+  [GmcgsiCi4EVFMJWz] Balloon Padding
+  [qZUo5SmGxp5BlqFN] Barbed Vest
+  [eoI3M6FXtcPWeg7i] Barding of the Zephyr
+  [oGVtymwknrJS8gWW] Bastion Plate
+  [IAPztxiK2T5mC2Y5] Bastion of the Inheritor
+  [TFfqyV6HIFKK8AtI] Bismuth Armor
+  [DUTKrSu5iJMktfZI] Black Hole Armor
+  [JDgFHv334yCrBY38] Blade Byrnie
+  [qdUlmO7XfBWQU3p5] Blade Byrnie (Greater)
+  [fHkVbTtjhITsE2NJ] Blade Byrnie (Major)
+  [GPrjYsQiC3jKdQmO] Blast Suit
+  [7qBpWdPZ0X8HoH9X] Bone Dreadnought Plate
+  [r0ifJfoz8aqf0mwk] Breastplate
+  [JU6gJSmibl5Q3k6F] Breastplate of the Mountain
+  [emh9kvqSJtxTX8He] Buckle Armor
+  [TXN2QFzKLAnjFSLw] Buoyant Buckle
+  [tCys8Qwo2zs3ZDCY] Canopy Bulwark
+  [Hg7btiITMu6Zf2EU] Ceramic Plate
+  [Kf4eJEXnFPuAsseP] Chain Mail
+  [MPcM4Wt6KmWE2kGL] Chain Shirt
+  [jau3C5ao3vm2gt8c] Clockwork Disguise
+  [EHMRryMB3s6XdkRz] Clockwork Diving Suit
+  [XPIDpF7dP6VyGKOM] Cloister Robe (Greater)
+  [gawhJLVsVsUFAPd6] Cloister Robe (Lesser)
+  [mhCLoihjfhoqpiVp] Cloister Robe (Major)
+  [VMksM7bLAZW9LxH4] Cloister Robe (Moderate)
+  [6eBv81PifFDgRo3x] Command Cuirass
+  [mHHvzxHtlLbkbStG] Containment Contraption
+  [bZHqPBdQjPS02Rd4] Coral Armor
+  [wkQRlMup84B6wYsC] Crafting Leathers
+  [HsfoHX1B6ocflitz] Crushing Coils
+  [0kI2hUftHbBCn74x] Deep Pockets
+  [x37tk2H4kVtrnnrA] Deep Sea Plate
+  [WOwVBsiwLQxnIJRV] Devil's Bargain
+  [YFAaJntmFK2fPqi5] Dragon Turtle Armor
+  [u9BdrpYhJDUPQFCF] Dragon Turtle Plate
+  [5Ic9C7Rj8eJ35sD9] Dragonaut's Wingsuit
+  [3xsQ1AA4dyMHLxpw] Dragonplate
+  [lGzS7hBXNrbzSbrj] Eagle Wing
+  [8HxM35X8DDt2gw9d] Electric Eelskin
+  [PuqdH7DmNsN79HyE] Elven Chain (High-Grade)
+  [peAvz7u35GEfTXxp] Elven Chain (Standard-Grade)
+  [AqVJOBjXbeao5An7] Energizing Lattice
+  [dDIPA1WE9ESF67EB] Explorer's Clothing
+  [WgxgGLp3q9Et6BwC] Faerie Queen's Bower
+  [zPSImy0ENQjnRJNs] Forgotten Shell
+  [FSDEuHDr1I4JVIJg] Fortress Plate
+  [115xzkNatlElbfVw] Frost Furs
+  [Gq1cZWSKOtJhKd2p] Full Plate
+  [TJsmB2aHk9Yogqup] Fungal Armor
+  [hRwnNTMj7wa8S4Ji] Ghoul Hide
+  [yiU4osCo6ql28r6M] Gi
+  [tLNsmY90aN668PMG] Glorious Plate
+  [M6b20zZTGNWrx5oM] Gray Maiden Plate
+  [7IXAEgZDlaxwbLoG] Grisly Brigandine
+  [pRoikbRo5HFW6YUB] Half Plate
+  [iwsNMFqLdORjkotL] Hardshell Surki Carapace
+  [n4kPBFzVh5LcJAMA] Harmonic Hauberk
+  [MUtAHJXf22SiVBeH] Heavy Barding (Large)
+  [juQGJI9deskAVfm7] Heavy Barding (Small or Medium)
+  [LF7HSNnlGxLJyDZS] Hellknight Breastplate
+  [U6XqhSFUUowHnnkk] Hellknight Half Plate
+  [lCgXeV52eYYl5cUX] Hellknight Plate
+  [qiRJhMvDnuorQZ62] Hero's Plate
+  [ziESwPW9EostyeQn] Hero's Plate (Greater)
+  [AnwzlOs0njF9Jqnr] Hide Armor
+  [SMruq5revpHcKDdt] Highhelm Stronghold Plate
+  [EnTfjcVhcdgd1sLW] Hodag Leather
+  [NYLdJKlM44kgqlUx] Hollow Robes
+  [2uHcTZ40oZ62R9gy] Holy Chain
+  [qSqx72639EJTzBam] Immortal Bastion
+  [aLA7pikfeNIAAGLw] Impenetrable Scale
+  [37Qd1hp9EosNTzww] Incendiary Plate
+  [BK1AKKi1gDMn5uBs] Invisible Chain Shirt
+  [COsToVFlA36UmkB7] Jerkin of Liberation
+  [yjtOmmTYhlUke0Xo] Juggernaut Plate
+  [QprqsAVxZvmhoBKb] Kilted Breastplate
+  [3ZfGYXKfBjHOZO7d] Lamellar Breastplate
+  [IyBL38UtL4MDN6b5] Lattice Armor
+  [zVSBjb6o5RudKA9c] Leaf Weave
+  [4tIVTg9wj56RrveA] Leather Armor
+  [wx7WY6YGvgMphDL1] Leather Lamellar
+  [jAKYIqG2BNO7yffJ] Leopard's Armor
+  [SS1lwhzx0hne1Ljh] Library Robes
+  [HoL83ca2TqEnnErs] Library Robes (Greater)
+  [RtJvTDFNPhJSPmWP] Library Robes (Major)
+  [TBmDARyj67joVe4m] Library Robes (True)
+  [h9sZfo6UmHIOU5wb] Life-Saver Mail
+  [oRBcuFdQDRCn1pwo] Life-Saver Mail (Greater)
+  [cKMqVQSU3iGTiiF6] Lifting Leather
+  [5yL2D3GPAggadZQN] Light Barding
+  [XKsPGGbPKLkrqHwM] Linnorm's Sankeit
+  [EBuQjgVZaQpjQUjc] Lion's Armor
+  [dmEmxoEVzOeEkscr] Lion's Armor (Greater)
+  [kPHVVkNSEi1QeEIO] Lion's Pelt (Chain)
+  [dXCdg96HwVGT1URT] Lion's Pelt (Leather)
+  [uPy4iagJMWRi1vNd] Living Leaf Weave
+  [5sBRskeiJgEBtcJw] Locust Leather
+  [AdJgj7vVvNGvPIEj] Mail of Luck
+  [l3ZsKprMlJCRbgb6] Mamlambo Scale
+  [w21zEmBFQmf25GCk] Mantis Plate
+  [8WVYOughRWLb7kGF] Mantis Shell
+  [YfRwH0wIEmuNDL7I] Mariner's Splint
+  [Iic9QpNemaumfkHc] Medusa Armor
+  [DuV6MVFjwbssZ4N1] Message Mail
+  [zaqwfgmFMHUIq4lh] Mitigation Mail
+  [OdF2XdbXJczSn83Q] Mitigation Mail (Greater)
+  [f7ccIV9tllxCxEdg] Mitigation Mail (Major)
+  [vHZSx5f093Wrivzn] Moonlit Chain
+  [I8b3oNLl5MIMrG4r] Niyaháat
+  [GAu6v14pCSgLJh2D] Noxious Jerkin
+  [GDSclGF1yk0sw86V] Numerian Steel Breastplate
+  [U2liOd8kJasy0Ghd] O-Yoroi
+  [C4XKMcHZoGzrAZBl] Onslaught Hide
+  [3ZBFkXQC7jgZ8kx9] Ooze Skin
+  [o4U9Nt7ac7AlolNQ] Ouroboros Buckles
+  [zBYEU9E7034ENCmh] Padded Armor
+  [QP6giHFBNqFJKSVj] Parachute Mail
+  [gp5kgCySEOuntQPF] Plate Armor of the Deep
+  [E47syLjnN3KXr0bW] Plate of Yled
+  [8EO2ibeDloBIVFF4] Plate of Yled (Greater)
+  [NhyID8liSflMQ7ti] Plate of Yled (Major)
+  [GBleItbLFB08D8C5] Plate of Yled (True)
+  [N42lmp3Ft6EsSvzg] Power Suit
+  [3mmS3Y291h6Ckgin] Powered Full Plate
+  [630xJ5zceXFXiTi2] Prismatic Plate
+  [iCJrRoIsjdf665yE] Psychic Brigandine
+  [oCLYbeDKhhv7yEzK] Rattan Armor
+  [ip041iF27ZY52G6s] Reactive Mail
+  [Y5ru5YAL5LDMscx6] Reactive Mail (Greater)
+  [ZXvCmnud6spsJ2FX] Reactive Mail (Major)
+  [FKNgrFDIRBumr6P5] Rebounding Breastplate
+  [uuBhzN6xrplrwKyI] Reef Heart
+  [RODC2TYO4cUg6fXu] Reef Heart (Greater)
+  [U5IGgD7Z225OPnhK] Reinforced Chassis
+  [0KHgAaDi3tmu32Hq] Rite of Reinforcement Exoskeleton
+  [Wkh5rQx3IqInEKdT] Robe of the Archmagi
+  [7ynjS9llFg7tPMoj] Robe of the Archmagi (Greater)
+  [Yzsxn8w4Uuf9awBy] Robes of Xin-Edasseril
+  [Wfu6R7y4w9iTZcDs] Rusting Carapace
+  [3O1Iv7ztIPKhKWwe] Sankeit
+  [VyQZVv31q3CjCAQz] Sarkorian God-Caller Garb
+  [YMQr577asquZIP65] Scale Mail
+  [b8bVEp4qOorBDsAF] Scarab Cuirass
+  [fhhM7nTxxXm09Zz9] Scene Stealer's Tunic
+  [VJ4s6ABlkimSyjjZ] Scroll Robes
+  [QVJirPfPdU3S6F7H] Shadow Shroud
+  [bu4IrYBeE68KeEOW] Shared-Pain Sankeit
+  [9DuwR6Z1P5PuQwS3] Slithermaw's Bane
+  [2IRTceMDqmHfEwcf] Slithermaw's Bane (Heroic)
+  [oE6tZBBbP59DOWFM] Smoldering Armor
+  [TYs0oqRjEa9wBJ7N] Sorshen's Scintillating Garment
+  [Blp9Ha1YeIJOeFls] Spangled Rider's Suit
+  [6AhDKX1dwRwFpQsU] Splint Mail
+  [ewQZ0VeL38v3qFnN] Studded Leather Armor
+  [56CTZheeNhNPpLo1] Subterfuge Suit
+  [OlGFuOcqy0bSdtTl] Suit of Armoire
+  [3ytZSLqXQdNCuV4l] Swarmsuit (Impenetrable)
+  [gg6XF2dWafE0pcHu] Tales in Timber
+  [4XYnZij3BqhFuayG] Tales in Timber (Greater)
+  [o9y5aRGsbH5x77Mn] Tales in Timber (Major)
+  [V9sGPys7ewedE6t9] Thunder Mail
+  [7jGnVnqFt2gFtU1g] Tideplate
+  [KA0Ku5qOQfXqw3BK] Titan Nagaji Scales
+  [7cy9gLlKX2vNja0a] Tough Skin
+  [1X0E707FWf9jJgPK] Troll Hide
+  [tzFMetc4VK6goDm2] Trollhound Vest
+  [s6E2ZdtEUz3Lxx3B] Umbral Armor
+  [hYBZK1kaGPeR85CH] Unholy Plate
+  [bjTM1SvFvFyJLkuI] Vernai Shell
+  [nVlKU2et4EeReayr] Victory Plate
+  [ed2F0L3R6UNSFUmS] Victory Plate (Greater)
+  [RUEAV5LMUGFHcXcW] Warleader's Bulwark
+  [XKON66YXYLXlGPPg] Warleader's Bulwark (Greater)
+  [uV8fEVUuSyMsh1xF] Wasp Guard
+  [me7GsgRKnqA7vaB5] Waverider Barding
+  [5dsKAhyjaU6tgaH1] Wilderness Weave
+  [bosOCvsQb8tG8fuD] Wisp Chain
+  [M7H8LNnmUA17oqsW] Wisp Chain (Greater)
+  [BTHxd53T6xttQ0d9] Wisp Chain (Major)
+  [4Zxm46hCidf2GmvV] Wisp Chain (True)
+  [tBGhH7AHyvJQZC5d] Wolfjaw Armor
+  [QPgkjNm2uIV5tsRd] Wooden Breastplate
+  [LTQDnvgZtY495c3x] Zetogeki Hide Armor
+Background
+  [LHk50lz5Kk5ZYTeo] Abadar's Avenger
+  [mWpNrTiREluJ6fLB] Able Carter
+  [Y0ht4JteTUS5pace] Academic Scion
+  [1bjReaLqCD9pvBJ3] Academy Dropout
+  [CAjQrHZZbALE7Qjy] Acolyte
+  [IFHYbU6Nu8BiTsRa] Acrobat
+  [0dv9Qun0pFdgroOs] Acupuncturist
+  [qY4IUwVWIKPSFskP] Aerialist
+  [PutqlPJTPUBkMmSn] Aeronaut
+  [3kXTGUvodNMnJTxb] Aiudara Seeker
+  [fyKPDYFeIrgzADJB] Alkenstar Outlaw
+  [Yuwr2pT3z3WYTX9T] Alkenstar Sojourner
+  [0c9Np7Yq5JSxZ6Tb] Alkenstar Tinker
+  [zwjoAOGkT44MmDKT] Alloysmith
+  [G3GIfGLY1xSNqj17] Almas Clerk
+  [8Mej6lV95XkJgdHY] Always Chosen Last
+  [LH2xktS54P9aa2uY] Amateur Director
+  [0ZfBP7Tp2P3WN7Dp] Amnesiac
+  [5RGLAPi5sLykRcmm] Animal Whisperer
+  [K35I1WCbzT5xnJ6N] Animal Wrangler
+  [byyceQSVT0H5GfNB] Anti-Magical
+  [MgiZ25JdT6O3fLbO] Anti-Tech Activist
+  [3Ax5uJqoRPnBQyQy] Arcane Revolutionary
+  [IoBhge83aYpq0pPV] Archaeologist
+  [gF0rOdWCQPHVgrvL] Archdevil Apostate
+  [VW8YNoIFhYD3UuyX] Art Tutor
+  [6irgRkKZ8tRZzLvs] Artisan
+  [y9OyNsxGfmjqdcP0] Artist
+  [ap25MWBuFGwwhYIG] Aspiring Free-Captain
+  [gfklP8ub45R4wXKe] Aspiring River Monarch
+  [3YQ1Wcjzk8ftoyo7] Astrologer
+  [5lcDlcXKD8eji6n3] Astrological Augur
+  [nXnaV9JwUG1N2dsg] Attention Addict
+  [eYY3bX7xSH7aicqT] Atteran Rancher
+  [eK8jNZvTwo2iPdEC] Awful Scab
+  [1W1MSkqSi7ysK6Hv] Bachuan Revolutionary
+  [0wzTmGUb8yvzMrO0] Back-Alley Doctor
+  [pDTQMksSVi77uqJk] Badlands Scout
+  [6abqATPjYoF946LD] Bandit
+  [U1gbRkmZqJ7SmpeF] Banished Brighite
+  [ySWc2RRRb7jnadSg] Banished Celestial
+  [wudDO9OEsRjJsqhU] Barber
+  [a8BmnIIUR7AYog5B] Barkeep
+  [z4cCsOT36MB7xldR] Barker
+  [Phvnfdmz4bB7jrI3] Barrister
+  [P77k0P5em9Yvm9bk] Battle Mechanic
+  [Szv9uCC6bLf814Uc] Battlefield Scrounger
+  [KboE8OcjCLD7oFWQ] Beast Blessed
+  [J0SCT6yZgdf0DTTD] Beast Seeker
+  [9LnXsMRwYcxi7nDO] Bekyar Restorer
+  [zAE9QOrE4DzEFS1Y] Belkzen Anthropologist
+  [EJRWGsPWzAhixuvQ] Belkzen Slayer
+  [6K6jJkjZ2MJYqQ6h] Bellflower Agent
+  [xvz5F7iYBWEIjz0r] Bibliophile
+  [I0vuIFypx8ADSJQC] Black Market Smuggler
+  [9pK15dQJVypSCjzO] Blessed
+  [TaIF4CqKl8ffT3Lo] Blight Survivor
+  [qNpLqx6LhBo1jY4A] Blow-In
+  [kLjqmylGOXeQ5o5Y] Bonuwat Wavetouched
+  [GeIFY5C1BxuWQGc7] Bookish Providence
+  [o1lhSKOpKPamTITI] Bookkeeper
+  [4II2KZpizlBBcfCy] Borderlands Pioneer
+  [OL58pki9nNu608hp] Breachill Survivor
+  [U8347JbRAjhowP1q] Brevic Noble
+  [HiOvPmXEXBjUy0VZ] Brevic Outcast
+  [JfGVkZkaoz2lnmov] Bright Lion
+  [LWoPiYHAyLp8pvYx] Broken Tusk Recruiter
+  [jN3Ww8tBsTaOVX4t] Bully or Baiter?
+  [nhQKn1tVV6PKCurq] Butcher
+  [8CLTXqyjdzEMKnZC] Cannoneer
+  [qLr9HMlDTWS81NVj] Cathedral Child
+  [t0t1ck8iKpaI4o5W] Charlatan
+  [Qg8bHCKrj1t1tPUo] Chelaxian Exile
+  [tA0nggrWfBEhvsKA] Chelish Rebel
+  [KLWxwhCOdqrbepbu] Child Of Notoriety
+  [uNvD4XK1kdvGjQVo] Child of Westcrown
+  [eHttcx3UN9GSzlA7] Child of the Colony
+  [ovDOXEuRumNhMU5T] Child of the Polis
+  [irDibuV3Wi7T43sL] Child of the Puddles
+  [0FgYkkKv9u8zxWiO] Child of the Twin Village
+  [w2GSRC5uMcSUfPGJ] Chosen One
+  [2TImvKwcFLDVhzUC] Circuit Judge
+  [YJpEdmSOjlA2QZeu] Circus Born
+  [pPR0HAeXLUxP3rx4] Clan Associate
+  [dSYel8ABTevOc5YA] Clockfighter
+  [xKEQvxDMHWRUkL6i] Clockwork Researcher
+  [uker8dnTA7WhzXSR] Close Ties
+  [DHrzVqB8f1ed3zTk] Clown
+  [4XpWgGejwb2L6WpK] Codebreaker
+  [hdvllwAIooBX2Fib] Combat Carpenter
+  [SAm5AeDB2AjjMnDK] Combat Chaplain
+  [zhSGlVwl75CfVKfR] Company Agent
+  [biCstJF0OGvC5NKW] Concordance Researcher
+  [idFSq3DYBRomYmZt] Concordance Scout
+  [Asg9Edqh95eSZBE9] Conscript
+  [Ods1qOZ8CTCru8XQ] Conservator
+  [DpmWrtkrmmgnVtAc] Construction Occultist
+  [gyqIA8jb50AnYCvw] Convocation Scout
+  [3gN09dOT2hMwGcK2] Cook
+  [ChAoT1V3Nc4sKXz4] Corpse Stitcher
+  [9lVw1JGl5ser6626] Criminal
+  [bdeuzUMiPjEdlPS8] Crown of Chaos
+  [44T9XsTcTbmMhtc1] Crystal Healer
+  [fuTLDmihr9Z9e5wa] Cultist
+  [Uk4W7mKQbLtDDHwo] Curandero
+  [mtrkW0CSqrZVswkz] Curious Apprentice
+  [j2G71vQahw1DiWpO] Cursed
+  [ajcpRVb5EG00l7Y4] Cursed Family
+  [0ncxOTCDptu01nR8] Dauntless
+  [IObZEUz8wneEMgR3] Deckhand
+  [a57iBUZBQtXWZc36] Dedicated Delver
+  [tGtrad5lJzXPZCx6] Deep-Sea Diver
+  [QoLKbkrudnJmhq9y] Demon Hunted
+  [NywLl1XMQmzA6rP7] Demon Slayer
+  [29mBzKZ7TRm2TizG] Dendrologist
+  [KC5oI1bs6Wx8h91u] Deputy
+  [2qH61dLeaqgNOdOp] Desert Tracker
+  [3wLnNwWnZ2dHIbV4] Diobel Pearl Diver
+  [7fCZTzmv5I2dI4sr] Discarded Duplicate
+  [V9VsomfjbPQNfaSL] Disciple of the Gear
+  [A1gDZbfIPEqHClsL] Distant Traveler
+  [7z33GaNsmSxel1xJ] Doomcaller
+  [GPI5kNu0xfom9kKa] Dragon Scholar
+  [vBPu7RwNXGDQ1ThL] Dreamer of the Verdant Moon
+  [fo2nGLI1t1b7nAHK] Dreams of Vengeance
+  [kmhZZgR7KlBzRBX0] Driver
+  [XHY0xrSSbX0cTJKK] Droskari Disciple
+  [Zujpf2cxjwaHHnpO] Eager Scofflaw
+  [dy0D2mkooBgt06VW] Eagle Hunter
+  [p27PSjFtHAWikKaw] Early Explorer
+  [g7kBsG5VKCaMYEZj] Eclectic Scholar
+  [oj4B6KLAOlUbY0wr] Eclipseborn
+  [BRXXlw03K6ZeB2Li] Eidolon Contact
+  [MiRWGXZnEdurMvVf] Eldritch Anatomist
+  [YGJzgmHNqw9C72Kb] Elementally Infused
+  [oEm937kNrP5sXxFD] Emancipated
+  [FMk4eGzPulZoYNqG] Empty Hand Loyalist
+  [g8xUX7DAu2ShZ90Q] Empty Whispers
+  [xbyQ1RAF6x4ceXLf] Energy Scarred
+  [i4hN6OYv8qmi3GLW] Entertainer
+  [To76BxkBS2ErAdgv] Escaped from Time
+  [CKU1sbFofcwZUJMx] Ex-Con Token Guard
+  [ynObDI0VbZ4sqeMI] Ex-Mendevian Crusader
+  [HKRcQO8Xj7xzBxAw] Faction Opportunist
+  [nAe65lvsOJAIHGGT] False Medium
+  [SOmJyAtPOokesZoe] Farmhand
+  [mcL4WLO2yxBGlvuG] Farmsteader
+  [lq7uhfPMcJgn1z7u] Fated Rival
+  [eeCM8QwOkhatdStO] Favored
+  [Q2brdDtEoI3cmpuD] Feral Child
+  [hqtL8A3LVrEFI46f] Fey Friend
+  [ppBGlWl0UkBKkJgE] Feybound
+  [FKHut73XDUGTnKkP] Field Medic
+  [O8iPkxpWxUZHmE7j] Fiendbreaking Pilgrim
+  [KaIeesLNmn3s1Y1I] Fightbreaker
+  [NZY0r4Csjul6eVPp] Finadar Leshy
+  [tQ9t7uIssRCR2y3W] Final Blade Survivor
+  [QGji0lMUo6to2h2k] Fire Warden
+  [gsyTHkbGRaiHgs6p] Firebrand Follower
+  [2lk5NOcu1aUglUdK] Fireworks Performer
+  [3M2FRDlunjFshzbq] Fogfen Tale-Teller
+  [ia5aFzfmfnMjhcms] Folklore Enthusiast
+  [vmdhw37F22FCMm50] Food Trader
+  [1SdtFFVDXpTz4Ksx] Foreign Aid
+  [wqzFhMzGYKsfrgyo] Foreign Diplomat
+  [vgin9ff2sUBMpuaI] Former Aspis Agent
+  [3frMfODIYFeqTl2k] Fortune Teller
+  [eHfsMNiVeqwnrpG3] Framed in Ferrous Quarter
+  [r2ZRAcoDp6EdwNrh] Free Spirit
+  [a5dCSuAwGE2hqQjj] Freed Slave of Absalom
+  [FlXu29r5C4CborZv] Friend of Greensteeples
+  [vEl3OBUsSmPh8b4N] Friendly Darkmoon Kobold
+  [bDyb0k0rTfDTyhd8] Geb Crusader
+  [LoeTd2SS6jfEgo1H] Genie-Blessed
+  [MXd6IBBivfMprkO5] Ghostwriter
+  [88WyCqU5x1eJ0MK2] Gladiator
+  [B3Z5gbhMDRUATTrE] Gloriana's Fixer
+  [Lue29rc3ZDt64iyL] Glory Hound
+  [4fBIXtSVSRYn2ZGi] Goblinblood Orphan
+  [cfFQituks3OSgpRg] Goblinblood Survivor
+  [1VdLr4Qm8fv1m4tM] Godless Graycloak
+  [FovAoohhvG7vIbX9] Gold Falls Regular
+  [B6kNrX1y8XNbQYea] Goldhand Arms Dealer
+  [0w9T1SAF6mmqLoWY] Gossip
+  [yK40c3082U30BUX5] Grand Council Bureaucrat
+  [7QkQQsHjv2iNFIsF] Grave Robber
+  [32S5SSVPCbod2GSl] Green Faith Pilgrim
+  [xCCvT9tprRQVFVDq] Grizzled Muckrucker
+  [6UmhTxOQeqFnppxx] Guard
+  [5RhHdnzWWKfh5faz] Guest of Sedeq Lodge
+  [5dezuNcZJ6wfecnG] Gunsmith
+  [Mz7G3rTPxV2Xzy18] Hammered by Fate
+  [lCR8gyEZbwqh3RWi] Harbor Guard Moonlighter
+  [X1YhwDic2ugT9RuQ] Harrow-Chosen
+  [2jeonnY3GZTdEMsm] Harrow-Led
+  [18Jzk3gAsXspFOYC] Haunted Citizen
+  [0z0PSizHviOehdJF] Haunting Vision
+  [vNWSzv36L1GBPPoc] Hellknight Historian
+  [ZdhPKEY9FfaOS8Wy] Herbalist
+  [bh6O2Ad5mkYwRngM] Hermean Expatriate
+  [mxJRdRSMsyZfBf5c] Hermean Heritor
+  [b3UC18ueX8m9Ov0W] Hermit
+  [COUnnZRnoNb8bzan] Heroic Ancestry
+  [OfdT8v9apVNZyYqt] Highborn Snoop
+  [1M91pTjatEejBjEl] Hired Killer
+  [2zYdTia5t7w6J2ey] Historical Reenactor
+  [aWAfj7bhTZM2oK81] Hookclaw Digger
+  [T537wo3aem8GvnmR] Hounded Thief
+  [N0CRYmDCw8bgNxLl] Hunted by the Night
+  [5Z3cLEpsx9nHVwhM] Hunter
+  [UK40FVVVx6IKxipW] Inexplicably Expelled
+  [6vsoyCZKqxG0lVe8] Inlander
+  [HdnmIaLadhRfZq8X] Insurgent
+  [fML6YrXYDqQy0g7L] Iolite Trainee Hobgoblin
+  [wKyURsaOFQL8TKSg] Isgeri Reclaimer
+  [8UEKgUkagUDixkL2] Issian Partisan
+  [bNsYkUGMKmtc28MX] Issian Patriot
+  [SbfTiwTt7KJEQX4a] Jeweler
+  [HSNUDvPgO1NESW7S] Junk Collector
+  [IqzUSp32OFwCxk33] Kaiju Stalker
+  [hPx0xiv00GQqPWUH] Kalistrade Follower
+  [UTqLL3df0thC36QK] Kartaji Epicurean
+  [m2sWdTIXlyXmqsuC] Keys to Destiny
+  [ZOT2ztnh6PdqV5EJ] Knack for Contraptions
+  [pBX18FI1grWwkWjk] Kyonin Emissary
+  [2bzqI0D4J3LUi8nq] Laborer
+  [ffcNsTUBsxFwbNgJ] Lastwall Survivor
+  [OD8RTS7cTeMJJFcR] Learned Guard Prodigy
+  [qzKT7L1qldz14q8M] Legacy of the Hammer
+  [84uVpQFCqn0Atfpo] Legendary Parents
+  [BBeJA7n0xpSsBCGq] Lesser Scion
+  [YHXFr9JV6gPIK9NT] Library Dweller
+  [TQBYPTRTVGLMv7cx] Local Brigand
+  [p6ABkjwqe6gMi5BW] Local Savior
+  [4a2sVO0o2mMTydN8] Local Scion
+  [dxWY1emPz8Jr0fyG] Lost Coast Local
+  [2wGmG7ntcnkvtw8l] Lost Loved One
+  [wU1qd8tZNcYn43y2] Lost and Alone
+  [uJcFanGjVranEarv] Lumber Consortium Laborer
+  [HsAZDAPpqynArFAp] Magaambya Academic
+  [WIWR8jURAdSAzxIh] Magical Experiment
+  [I5cRrqrPCHsQqFI9] Magical Merchant
+  [EYPorNgoYcp37akm] Magical Misfit
+  [D00NdG0WtUNMO546] Mammoth Herder
+  [76RK9WizWYdyhMy5] Mammoth Speaker
+  [V1RAIckpUJd2OzXi] Mana Wastes Refugee
+  [4aVFnYyRajog0mNl] Mantis Scion
+  [n2JN5Kiu7tOCAHPr] Market Runner
+  [lX5KDS2hU5LihZRs] Martial Disciple
+  [ZQuUl50C2x6evtGJ] Martial Musician
+  [cODrdTvko4Om26ik] Mechanic
+  [wGB222d5UIBGYWsK] Mechanical Symbiosis
+  [x3fFxtLogoy5hZfe] Medicinal Clocksmith
+  [q1OCPBAgYgvwy1Of] Megafauna Hunter
+  [YyzIzLxn2UCFubj4] Menagerie Dung Sweeper
+  [a45LqkSRX07ljKdW] Merabite Prodigy
+  [KMv7ollLVaZ81XDV] Merchant
+  [jYhazaOT8FTrBFPx] Militia Member
+  [bCJ9p3P5uJDAtaUI] Miner
+  [GNidqGnSABx1rQUQ] Missionary
+  [lqjmBmGHYRaSiglZ] Molthuni Mercenary
+  [KEG5KFNrXKhTsj6J] Money Counter
+  [L9WwmLaDVmu5yleq] Moot Guard
+  [M1NWZS3WFzzns1fY] Mortuarium Survivor
+  [HNdGlDHkcczqNw2U] Musical Prodigy
+  [Y50ssWBBKSRVBpSa] Mystic Seer
+  [Tujic4RHrQJmEYX4] Mystic Tutor
+  [npn3oYZtmkPTtlBn] Newcomer
+  [QnL7hqUi9HPenrbC] Newcomer In Need
+  [Y35nOXZRryiyHjlk] Nexian Mystic
+  [RxhdWJUoRTBEeHYZ] Night Watch
+  [E2ij2Cg8oMC0W0NS] Nirmathi Guerrilla
+  [Yu7Cl0Lk94LdPRi6] Noble
+  [StWWI7Wi0WRgRmxS] Nocturnal Navigator
+  [8UXahQfkP9GZ1TNW] Nomad
+  [xyHndp512sLU4UOL] Northland Forager
+  [2nt2nsQMBXgQRlOu] Northridge Scholar
+  [KrlSyOoVcND109iT] Obari Wanderer
+  [jpgO5zofecGeyXd5] Occult Librarian
+  [e0K95Uyo5tQEdlXt] Ocean Diver
+  [iWWg16f3re1YChiD] Oenopion-Ooze Tender
+  [jjkY6r7NNWhxDqja] Once Bitten
+  [WueM94C9JXk10jPd] Onyx Trader
+  [AJ41zFEYwlOUghXp] Osirionologist
+  [mh0hj27ZO5qDWat1] Osprey Barnraiser
+  [v319qChG1uAQkGEe] Osprey Fisher
+  [PJxPNMEUTimop4Lq] Osprey Scion
+  [v8pS4UCYjt9OTtQL] Osprey Scout
+  [JjAh5pxgHrW3fwaH] Osprey Scribe
+  [AJuE41aToGs9tbcM] Osprey Spellcaster
+  [f7ZTF8tnZUmTXwwF] Osprey Warrior
+  [d5fKB0ZMJQkwDF5p] Otherworldly Mission
+  [UgityMZaujmYUpil] Out-Of-Towner
+  [dAvFZ5QmbAHgXcNp] Outrider
+  [GyFfqCZZVtazmwPD] Outskirt Dweller
+  [CjNA8ippwoAvpxeI] Ozem Experience
+  [DKuRnepoyl8qwjLX] Party Scholar
+  [j9v38iHA0sVy59SR] Pathfinder Hopeful
+  [NXYce9NAHls2fcIf] Pathfinder Recruiter
+  [P65AGDPkhD2B4JtG] Perfection Seeker
+  [8hsMIh3lVGfZwjG5] Pillar
+  [jvegfAMdri6J2VzZ] Plague Doctor
+  [2sRZ6OsvHIpwGCAg] Planar Migrant
+  [76j9ds5URXv1dqnm] Plant Whisperer
+  [JauSkDtMV6dhDZS8] Political Scion
+  [f0YEqRFDdrWmfTj1] Portal Scholar
+  [DVtZab19D1vD3a0n] Post Guard of All Trades
+  [M8EfhY6Knb2iQm6S] Press-Ganged (G&G)
+  [4yN5miHoMvKwZIsa] Press-Ganged (LOWG)
+  [qJNmSgzq0ae29qCC] Printer
+  [rAvoo4cwdkWiGNe0] Professional Letter Writer
+  [9uqDWl8V2AgGMRXi] Propaganda Promoter
+  [IfpYRxN8qyV4ym0o] Purveyor of the Bizarre
+  [a9YjyQRNEOyespFf] Pyre Tender
+  [wrNTaSFFTxznOZLF] Quartermaster
+  [i6y4DiKvqitdE0PW] Quick
+  [22X8QMu7Z1mJzNWC] Quick Refugee
+  [bxWID85noazU72O3] Ratted-Out Gun Runner
+  [9uTdwJaj27F18ZDX] Razmiran Faithful
+  [HrWEyXTgIj16Z1RR] Reborn Soul
+  [HMIfr9N4rco1dzBO] Reclaimed
+  [pChM2ApTVEQ8SohP] Reclaimer Investigator
+  [HDquvQywAZimmcFF] Refugee (Fall of Plaguestone)
+  [i28Z9JXhEvoc7BX5] Refugee (PC2)
+  [7OAX5QMd15svZJzX] Relentless Dedication
+  [E1Ii36z4mtC8YxNe] Remittance Agent
+  [dQxmaPCHTor36bll] Report Runner
+  [TPoP1mKpqUOpRQ5Y] Reputation Seeker
+  [EnmmHDtINbQrqXTU] Respected Mentor
+  [rzyRtasSTfHS3e0y] Returned
+  [iaM6TjvijLCgiHeD] Returning Descendant
+  [W6OIPZhjcV45gfoX] Revenant
+  [7IrOApgShgnmp1A5] Rigger
+  [6c0rsuiiAaVqGTu7] Rivethun Adherent
+  [ns9BOvCyjdapYhI0] Root Worker
+  [8q4PhvpmIxZD7rsV] Rostland Partisan
+  [wKiFedYlHCsM5wN4] Rostlander
+  [uC6D2nmDTATxXrV6] Royalty
+  [7K6ZSWOoihZKSdyd] Ruby Phoenix Enthusiast
+  [uF9nw15tK6b1bgre] Ruby Phoenix Fanatic
+  [5qUQOpdlNsJjpFVX] Ruin Delver
+  [bvasHD1irJBoKVbB] Runaway Noble
+  [JvsjDU6mKKLl0NK4] Runelord Researcher
+  [hF75xM3HwTVay1jf] Runelord Scholar
+  [Nq36wlDc9A8ldu55] Runelord Survivor
+  [kkPdZsf61qySImQD] Runner
+  [4Vc8uXVHonrasFnU] Saboteur
+  [Zmwyhsxe4i6rZN75] Sailor
+  [vE6nb2OSIXqprDXk] Sally Guard Neophyte
+  [4KCa67gyxUn60zdf] Saloon Entertainer
+  [MrZvq1ebEgEN9cIv] Sandswept Survivor
+  [khGFmnQMBYmz2ONR] Sarkorian Reclaimer
+  [B8kEwzPUMIjhofUm] Sarkorian Survivor
+  [yZUzLCeuaIkNk4up] Saved by Clockwork
+  [locc0cjOmOQHe3j7] Savior of Air
+  [7fONTw7ykwEKwZqJ] Scarnetti-Connected
+  [vHeP960qjhfob4Je] Scavenger
+  [v0WPfxN6G8XFfFZT] Scholar
+  [i5G6E5dkGWiq838C] Scholar of the Ancients
+  [UyddtAwqDGjQ1SZK] Scholar of the Sky Key
+  [ahdyHviGqtnE7eBk] School Medic
+  [RPU1aNfVz3ZbymvV] Scion of Slayers
+  [o7RbsQbv5iLRvd8j] Scout
+  [wz4fDeZtCvxC4vyO] Second Chance Champion
+  [y0WZS51fSi6dILHq] Secular Medic
+  [UU4MOe7Lozt9V8tg] Seer of the Dead
+  [0WHhhWcbI0N7wFJx] Self-Made
+  [lav3yRNPc7lQ7e9k] Senghor Sailor
+  [cCi1Lsld9Umz1uHs] Sense of Belonging
+  [1Fpf40RBd0EgwP7R] Sentinel Reflectance
+  [UdOUj7i8XGTI72Zc] Servant
+  [OhP7cqvNouFgHIdJ] Sewer Dragon
+  [V31KRG7aA7xS0m8L] Shadow Haunted
+  [HEd2Lxgvl080nRxx] Shadow Lodge Defector
+  [b9EPEY09dYOVzdue] Shadow War Survivor
+  [AqhHif8mzYjlGMxJ] Sheriff
+  [Vq6kOTBm114bV9y7] Shielded Fortune
+  [H3E69w8Xg0T7rAqD] Shoanti Name-Bearer
+  [HZ3oBBdEnsH3fWrm] Shory Seeker
+  [CFyrlDzkSXgI1OAI] Sideshow Scion
+  [5Bfzt3sZyiaKrBO0] Sign Bound
+  [0w8QWZdorISJk4al] Silk Farmer
+  [lMJYIXSh3NSJslmi] Sky Rider
+  [AfBCrHsw1xbRFejN] Sleepless Suns Star
+  [4lbfPXwZEf3eE0ip] Snubbed Out Stoolie
+  [93icIDHD4IrqI2oV] Sodden Scavenger
+  [o3ArTg5c8pLe7iGm] Song of the Deep
+  [ECKic2p6yIyoGYod] Songsinger in Training
+  [2W2jadmj4gPNfdQ9] Southbank Traditionalist
+  [LbuWzGpCIP79UwVB] Spell Seeker
+  [T8SlgHjj0hVjKW2Q] Sponsored by Family
+  [p6Asr6f2cI2BWorr] Sponsored by Teacher Ot
+  [FznrY4fZASquT6hY] Sponsored by a Stranger
+  [8usMHYAmFdqmmkTS] Sponsored by a Village
+  [XcacLiaGDgjzHS3T] Spotter
+  [qbvzNG8hMjb8f66D] Squire
+  [Rme15tfbKstg8Kcy] Star Athlete
+  [HWOGbaRGXazklBMT] Stargazer
+  [KHMEcCCG132ILkuU] Starless One
+  [sR3S7Xn15drU6rOF] Starwatcher
+  [UURvnfwXypRYYXBI] Storm Survivor
+  [9IZNPa577ZyKB0la] Story Collector
+  [tqnrnXVTbdehohPL] Street Preacher
+  [moVRsnpjB5THCwxE] Street Urchin
+  [rUMHUzZhOMOVbxRO] Streetfood Vendor
+  [pZg3dGKD5jAfcJ0E] Student of Apotheosis
+  [qzzGLtQCPBTgKYAk] Student of Archery
+  [FVE2mg6EEyPVLz3M] Student of Magic
+  [RrqQ3hddhSldU5ml] Student of the Ancients
+  [UNbV4UwZEXxJy703] Sun Dancer
+  [EdkfixYpKyX3KPCL] Supportive Sponsor
+  [0otxwSLobUCf0l1I] Surge Investigator
+  [IuwNiQSSeRMQyDE7] Sword Scion
+  [PhqUBXLLkVXb6oUE] Taldan Schemer
+  [uwZ0emSBFNMGA74j] Tall Tale
+  [n7tPT1SfVTcHjrj3] Tapestry Refugee
+  [ixluAGUDZciLEHtb] Tax Collector
+  [WrKVeUQ6KeRCm9uH] Teacher
+  [h98cEl4DY75IL6KJ] Teamster
+  [2FUdcPsXwoWT1bms] Tech-Reliant
+  [vjhB0ZTV9OZgSuSz] Thassilonian Delver
+  [su8y75pGMVTUsNHK] Thassilonian Traveler
+  [2UXBsyJFimwYOUFQ] Thrill-Seeker
+  [m1vRLRHTpCrgk89G] Thrune Loyalist
+  [MslumKt6iwJ85GKZ] Thuvian Unifier
+  [5Oh9SdD4rhwlpHzg] Tide Watcher
+  [6Cv7L2gaZuSscd8s] Tiffin Box Deliverer
+  [IOcjPmcemrQFFb2b] Time Traveler
+  [i79pgNIAtJfkkOiw] Tinker
+  [JBRBb2818DZ4hjXw] Total Power
+  [4naQmCXBl0007c2W] Touched by Dahak
+  [pMntBDuzRu5dTeJQ] Town Troublemaker
+  [Sj91CUyEUeWoPh2R] Toymaker
+  [tcsSxwkl4wCsfO3k] Trade Consortium Underling
+  [BS8YxexDhD0VdsQV] Trade Representative
+  [LwAu4r3uocYfpKA8] Trailblazer
+  [7AfixHrjbXgDPPkp] Translator
+  [3G7dv8w7umrLhobL] Traveling Gourmand
+  [D05fsi5puOWstByA] Tree Friend
+  [TC7jpN5EA4UBIYep] Truth Seeker
+  [90vPOBrSXY27k0bL] Tyrant Witness
+  [V3nYEAhyA54RtYky] Ulfen Raider
+  [Am8kwC9c2GQ5bJAW] Undercover Contender
+  [86TbxxwfpWjScwSQ] Undercover Lotus Guard
+  [Ty8FRM0k262xuHfF] Undersea Enthusiast
+  [2Mm0BHMJZhqIqoQG] Undertaker
+  [T8YNd9Jg6XBJvNBQ] Union Representative
+  [xkRZUxWna7BcNnHZ] Unremarkable
+  [l5Kj0owzxfPcTvIb] Unsponsored
+  [x2y25cE98Eq4qxbu] Ustalavic Academic
+  [uNhdcyhiog7YvXPT] Varisian Wanderer
+  [gacjZkMkeVsrCt4A] Verduran City Folk
+  [uS1T7SpCtT0lZxep] Veteran
+  [mrkgVjiEdlPjLUsN] Vidrian Reformer
+  [5L2EYBOziW9Fqyav] Wandering Libertine
+  [UFHezf1LXUwcQIAQ] Wandering Preacher
+  [b1588nhgRoYMef44] Wanderlust
+  [wZikbWmCWYpjFxQF] Wanted Witness
+  [QQxXV2zHATLZ07rA] War Orphan
+  [IXxdCzBS0xP20ckw] Ward
+  [jCZtgtSKcK9uXKKz] Warded by Kami
+  [r0kYIbN06Cv8eNG3] Warrior
+  [9l6q90sk8UM292CY] Waste Walker
+  [nLN6E15Q5YzufqoM] Weaver
+  [aisuJF1A98bHfkLH] Whispering Way Scion
+  [R1v4gUu8oRMoOASM] Wildwood Local
+  [0oTvU8dNFcT42CWV] Willowshore Urchin
+  [SJ3nNOI5A8A4hK0Q] Winter's Child
+  [vMyMUZpg8MYZT2AZ] Wish for Riches
+  [O4xKRtHb21DCTvQ0] Wished Alive
+  [yAtyaKbcHZWCJlf5] Witch Wary
+  [BZhPPw9VD9U2ur6B] Witchlight Follower
+  [qB7g1OiZ8v8zgvkL] Wonder Taster
+  [t799dIUj6hlICExG] Wood Warden
+  [rESZQqHDJxZNqyR6] Working Student
+  [maxaKunHAOKUrR4q] Writ in the Stars
+  [Sq3jh7PnlRT6Jt5S] Zodiac Bound
+Campaign Feature
+  [JHdIw0ADSRVSo0YP] Abandon Hex
+  [wHoXoyci1lddRR2R] Advance
+  [Z6jMZgAxI1zRO7Sl] All-Out Assault
+  [4h7c6C5doDA5rxyO] Ambush
+  [qCxyuNhzaaYlYBum] Battle
+  [agjqRWTTIWHwiKsd] Battlefield Medicine
+  [GhNppJC2nzceW8FC] Bloodied but Unbroken
+  [EgUxcWpmUaVrHP3L] Build Roads
+  [NpVIqD3LgI0Kb9RA] Build Structure
+  [x2a7kuyipzczqsFc] Capital Investment
+  [3e1qshiIssEUbNw3] Cavalry Experts
+  [3IHNdiGw6klNARiM] Celebrate Holiday
+  [AK3JMI3Bgz5QQw03] Civic Planning
+  [KSqdhh3JYt5wTbEd] Civil Service
+  [cvOXpo1Sy8nfXfPO] Claim Hex
+  [2WrcEhR8WzgHOoZE] Clandestine Business
+  [JHLZPhd9APIqJHsA] Clear Hex
+  [77aIhr8LOfTt1QHp] Collect Taxes
+  [gb1LQ2vw8hUelVDU] Cooperative Leadership
+  [8wjiF3ctXUjP9oyX] Counterattack
+  [GIbm9qo8VuFgPywJ] Covering Fire
+  [B70XC3Ci1SqemPlT] Craft Luxuries
+  [i7nsYS9lgFlgBXnl] Create a Masterpiece
+  [Sc4nKtdFqZqeh86f] Creative Solution
+  [WGpkcIChjIk1i0q0] Crush Dissent
+  [y1JGtzGmMtVh5USK] Darkvision
+  [1U9SbpBDXgsLGlzq] Defensive Stance
+  [VJ8S2h9D8ksQ5O1w] Defensive Tactics
+  [rw2BHBpLyh5Xvqw5] Demolish
+  [ysKkyZp02RMujObE] Deploy Army
+  [G2eBcOnUHb3yT7JL] Dirty Fighting
+  [IWanYXCWh3cvC6ti] Disband Army
+  [Pu5bptxLrKFyEzFh] Disengage
+  [U19mDhbYbOBQmbO9] Endure Anarchy
+  [8bBRW8SxM5bgwjXJ] Engines of War
+  [FQJqfnB9FDaLttWa] Envy of the World
+  [yrmHICfnXFGP5fJf] Establish Farmland
+  [RPUUcyuMbvud45TS] Establish Settlement
+  [3qJcDEZNwJV6hpkg] Establish Trade Agreement
+  [8B6PmgtMH2TthBSX] Establish Work Site
+  [kiiKY1n1EVnuzEDK] Expansion Expert
+  [E7B8TQD1Z9HCwqkr] Experienced Leadership
+  [ZSUPsqeMBDTaX2H4] Explosive Shot
+  [AOFU8pOTMjVdiyNd] False Retreat
+  [3jYTaOb8FQJueNzz] Fame and Fortune
+  [Rej53lopIy2DKQm6] Favored Land
+  [Hi4LKGOKe6yMDOH5] Feint
+  [AF9U2WOkD9dDlIXE] Field Triage
+  [CtNmx1wUgHDikQqI] Fine Living
+  [HUGtP04pX8h0vgUc] Flaming Shot
+  [mHWF5XwUi8RK2lET] Flexible Tactics
+  [QbzN7Ip8LWRLqAes] Focused Attention
+  [DxZRVOsPVnQvI0fe] Focused Devotion
+  [JYY8vQxPe9AIGTvv] Fortified Fiefs
+  [ie9Wuohdx3JgzRbP] Fortify Hex
+  [O58VXVbilHphAKDp] Free and Fair
+  [iYLFBep0kddHQkW9] Garrison Army
+  [l0Wlgj6LaDNRRUa6] Gather Livestock
+  [rXNZTmesfoBln2vs] Go Fishing
+  [phtwOol1wETryF7b] Guard
+  [o81alpjEki9cESun] Harvest Crops
+  [bBXJdNxd0Pa1qScw] Hire Adventurers
+  [899sW8mbJSn16zga] Hold the Line
+  [nWAGfa4DoEODaKsq] Improve Lifestyle
+  [DrUT5sE0EuU5dtPa] Increased Ammunition
+  [NPUQJAt6lzBGRPZf] Infiltration
+  [9dkyZ7r1z7loOxI7] Insider Trading
+  [H9myGV9t4SdcadA9] Inspiring Entertainment
+  [J1yiZK4gr5c9zFOl] Irrigation
+  [FBjZ1aAE6a4jt8r2] Keen Eyed
+  [UvIWZAPm8kfq3hDq] Keep up the Pressure
+  [BK0mMlFP2jIS4xGl] Kingdom Assurance
+  [sMBQ8i8xN1X0rSs9] Life Of Luxury
+  [NsehZsc6lmPje8YS] Liquidate Resources
+  [sdwSrVfu9yG1uwio] Live off the Land
+  [o4LgcCVBBpf0wpfD] Low-Light Vision
+  [LhefN6fEfIRuRozx] Manage Trade Agreements
+  [QRwIcmCEHpDQm9DO] Merciless
+  [WFng3pxgEAdpdy1p] Muddle Through
+  [vHKPoZycxZAA1vpz] New Leadership
+  [4QbqwZxEbSt3qcHw] Offensive Gambit
+  [G6MAyRjG91I8iNLR] Opening Salvo
+  [WuSEEEP2rEEz1d9t] Outfit Army
+  [dEdTJgaaYiDitp5O] Outflank
+  [ib8BcumGskNVJdZS] Overrun
+  [HLu1o1RzCZxWjOJJ] Overwhelming Bombardment
+  [nc4XV5NFuHDz93O0] Pledge of Fealty (Trained)
+  [nDDEbrWj2JouxlRw] Practical Magic
+  [u8LpoCGIo22kw00n] Prognostication
+  [ofQBVTc54viN8v6C] Provide Care
+  [BChcBEZpcqMnLISC] Pull Together
+  [VadpbmRYNXSX7g8z] Purchase Commodities
+  [OMSi4mgHqoBqUFuj] Quality of Life
+  [s6WMS915YCbbfty4] Quell Unrest
+  [35z42dfsd7zHZIoP] Quick Recovery
+  [8XXylMGJuqe1ozMk] Rally
+  [Y8Gpb1Ma8w3Gb8qX] Reckless Flankers
+  [1wzNJEvPCuMwJdHe] Recover Army
+  [Fko5kdpi9Oxas6Ty] Recruit Army
+  [XaK0Q9fda8IiIvrz] Relocate Capital
+  [li7WowfuIbGmCxKo] Repair Reputation (Trained)
+  [QKBoVicXa0GfKrYG] Request Foreign Aid
+  [G6UuSaPpXYa80qDw] Rest and Relax
+  [IhjlbJinff1wUSjL] Retreat
+  [0yeq1xgdscswGtRZ] Ruin Resistance
+  [FGQfcX6BelYrJatp] Send Diplomatic Envoy
+  [M4MFMxGyZZyGOAKh] Settlement Construction
+  [lcNZMlMNPUrnMgQ2] Sharpshooter
+  [3tI2d60BTA3hN2MW] Skill Training
+  [NF4ftwc8fPG2xXRE] Supernatural Solution
+  [QtSFmMG3Yos0JFSD] Tap Treasury
+  [ggVahjiAlVICpiPA] Taunt
+  [IiD3kKszFfHZ9cZ1] Toughened Soldiers
+  [swAA2zetF14HIhUc] Trade Commodities
+  [bc9JdbyJ8HWrpLLx] Train Army
+Class
+  [XwfcJuskrhI9GIjX] Alchemist
+  [9KiqZVG9r5g8mC4V] Animist
+  [YDRiP7uVvr9WRhOI] Barbarian
+  [3gweRQ5gn7szIWAv] Bard
+  [x8iwnpdLbfcoZkHA] Champion
+  [EizrWvUPMS67Pahd] Cleric
+  [Oyee5Ds9uwYLEkD0] Commander
+  [7s57JDCaiYYCAdFx] Druid
+  [vZ0jL7pwthV2pm4A] Exemplar
+  [8zn3cD6GSmoo1LW4] Fighter
+  [1L7geK3aoosye3Xj] Guardian
+  [Z9li154CPNmun29Q] Gunslinger
+  [30qVs46dVNflgQNx] Inventor
+  [4wrSCyX6akmyo7Wj] Investigator
+  [RggQN3bX5SEcsffR] Kineticist
+  [HQBA9Yx2s8ycvz3C] Magus
+  [YPxpk9JbMnKjbNLc] Monk
+  [pWHx4SXcft9O2udP] Oracle
+  [Inq4gH3P5PYjSQbD] Psychic
+  [Yix76sfxrIlltSTJ] Ranger
+  [LO9STvskJemPkiAI] Rogue
+  [15Yc1r6s9CEhSTMe] Sorcerer
+  [YtOm245r8GFSFYeD] Summoner
+  [uJ5aCzlw34GGdWjp] Swashbuckler
+  [Y5GsHqzCzJlKka6x] Thaumaturge
+  [bYDXk9HUMKOuym9h] Witch
+  [RwjIZzIxzPpUglnK] Wizard
+Condition
+  [XgEqL1kFApUbl5Z2] Blinded
+  [6dNUvdb1dhToNDj3] Broken
+  [i3OJZU2nk64Df3xm] Clumsy
+  [DmAIPqOBomZ7H95W] Concealed
+  [yblD8fOR1J8rDwEQ] Confused
+  [9qGBRpbX9NEwtAAr] Controlled
+  [zXZjC8HLaRoLR17U] Cursebound
+  [TkIyaNPgTZFBCCuh] Dazzled
+  [9PR9y0bi4JPKnHPR] Deafened
+  [3uh1r86TzbQvosxv] Doomed
+  [4D2KBtexWXa6oUMR] Drained
+  [yZRUzMqrMmfLu0V1] Dying
+  [D5mg6Tc7Jzrj6ro7] Encumbered
+  [MIRkyAjyBeXivMa7] Enfeebled
+  [AdPVz7rbaVSRxHFg] Fascinated
+  [HL2l2VRSaQHu9lUw] Fatigued
+  [sDPxOjQ9kx2RZE8D] Fleeing
+  [v66R7FdOf11l94im] Friendly
+  [TBSHQspnbcqxsmjL] Frightened
+  [kWc1fhmv9LBiTuei] Grabbed
+  [v44P3WUcU1j0115l] Helpful
+  [iU0fEDdBp3rXpTMC] Hidden
+  [ud7gTLwPeklzYSXG] Hostile
+  [eIcWbB5o3pP6OIMe] Immobilized
+  [fuG8dgthlDWfWjIA] Indifferent
+  [zJxUflt9np0q4yML] Invisible
+  [axtAzam8kiKbTD2c] Malevolence
+  [1wQY3JYyhMYeeV2G] Observed
+  [AJh5ex99aV6VTggg] Off-Guard
+  [6uEgoh53GbXuHpTF] Paralyzed
+  [lDVqvLKA6eF3Df60] Persistent Damage
+  [dTwPJuKgBQCMxixg] Petrified
+  [j91X7x0XSomq8d60] Prone
+  [nlCjDvLMf2EkV2dl] Quickened
+  [VcDeM8A5oI6VqhbM] Restrained
+  [fesd1n5eVhpCSS18] Sickened
+  [xYTAsEpcJE1Ccni3] Slowed
+  [dfCMdR4wnpbYNTix] Stunned
+  [e1XGnhKNSQIm5IXg] Stupefied
+  [fBnFDH2MTzgFijKf] Unconscious
+  [VRSef5y1LmL2Hkjf] Undetected
+  [I1ffBVISxLr2gC4u] Unfriendly
+  [9evPzg9E6muFcoSk] Unnoticed
+  [Yl48xTdMh3aeQYL2] Wounded
+Consumable
+  [Qm0ZiyXail7Lv0dq] Ablative Armor Plating (Greater)
+  [U9XNSFQzCOo6KMD1] Ablative Armor Plating (Lesser)
+  [xXvuQABxlRH2HXsO] Ablative Armor Plating (Major)
+  [P7Evi8Wv8zIwLYtU] Ablative Armor Plating (Moderate)
+  [RdsQliP7Gi1xe8xH] Ablative Armor Plating (True)
+  [SUn5qFbHYTLobgTt] Ablative Shield Plating (Greater)
+  [qF2GDYQCpSZ12Nk7] Ablative Shield Plating (Lesser)
+  [dwRqo9KQki2iCwHu] Ablative Shield Plating (Major)
+  [aY6Ukb7ZsMDelhmH] Ablative Shield Plating (Moderate)
+  [HD0RIJcRIIKKAdkn] Ablative Shield Plating (True)
+  [jdkMRl7zxOVGUuGI] Absolute Solvent (Greater)
+  [QSVIv5obLhKkmy67] Absolute Solvent (Lesser)
+  [mR9RD9S08jIX1IPm] Absolute Solvent (Moderate)
+  [sav38slFFlUVu75Z] Abysium Powder
+  [NUlz1XulrXqhpd2w] Achaekek's Kiss
+  [1Cj3rG1ugNPcWaPA] Acid Spitter
+  [H3nAm1FFvuG7j4TN] Adaptive Cogwheel
+  [ZOOrK4yEW6rFpPJ1] Addiction Suppressant (Greater)
+  [SNMggNsvgPoAYjpU] Addiction Suppressant (Lesser)
+  [esDSCEI1cf8Op93I] Addiction Suppressant (Major)
+  [cWYa0i1BqhbEruD6] Addiction Suppressant (Moderate)
+  [d5aCuFS1dhKXhsZ0] Addlebrain
+  [3v03D7qP6ewN03SN] Admonishing Band
+  [LjTbLOTj0K0CKvsd] Aetheric Irritant (Greater)
+  [3jUoOPFVoYtM7A9F] Aetheric Irritant (Lesser)
+  [7jUxSSn0SFkSvUsq] Aetheric Irritant (Major)
+  [sY3Do9bKjwAC9TMV] Aetheric Irritant (Moderate)
+  [F9VX2CR9NaFmbTj4] Affliction Suppressant (Greater)
+  [2Vd9v0TvEXdVyMTP] Affliction Suppressant (Lesser)
+  [njXFDv63y1w0qvz0] Affliction Suppressant (Major)
+  [CrOj1a997n9tku6x] Affliction Suppressant (Moderate)
+  [tZiCnERZB6ww4eBu] Aged Arbor Wine
+  [AFX1V0Go9DqPWBlN] Alarm Snare
+  [M0DMGUN84FQHapsF] Alchemical Fuse
+  [NKOAAPYL5RxReuKi] Alchemist's Damper
+  [UMAXLDpI6YLSfYX1] Alcohol
+  [dXhHBfDg1OxtSaOg] Alicorn Hair
+  [fz2OlQ9IYIcVASiv] Alkenstar Ice Wine
+  [ECjche2BfpWHZ3vU] Alloy Orb (Exquisite High-Grade)
+  [tTrJnXJYt15arH6G] Alloy Orb (Exquisite Standard-Grade)
+  [s0DffbZbYlav3mu1] Alloy Orb (High-Grade)
+  [X345VfEx9DZwO47G] Alloy Orb (Low-Grade)
+  [OOli8iQmLZoMOoG0] Alloy Orb (Standard-Grade)
+  [gn5ITN5GILHKxGA4] Ambrosia of Undying Hope
+  [5jUIOETCI3QG69cS] Amnemonic Charm
+  [Hoe17WNDQ2PQd9JZ] Amphisbaena Spittle
+  [IEvaUZHbxI4o1B8o] Analysis Eye
+  [ne00KCUcrmRT3PM9] Anathema Fulu
+  [suTxnYr8arqC9pt7] Animal Nip (Lesser)
+  [8XFicWnOf9VwSklQ] Animal Nip (Major)
+  [d6u3xqPPvx3xWaqF] Animal Nip (Moderate)
+  [GxVwATDdSGbZbx9B] Animal Pheromones (Greater)
+  [HHsMAKU0fPgYWspm] Animal Pheromones (Lesser)
+  [erLH6cQYhyZB5CLM] Animal Pheromones (Moderate)
+  [OjNaLZI13rWlyqmM] Animal Repellent (Greater)
+  [YVLwV9IGzNqIzbmV] Animal Repellent (Lesser)
+  [PxrYRcawI6a3lRcf] Animal Repellent (Major)
+  [7V5fKnnvW7DUgbAd] Animal Repellent (Minor)
+  [OHxRdRv4ZLBGPQi6] Animal Repellent (Moderate)
+  [GZo6icE8v07xQKKc] Animal-Turning Fulu
+  [89955RkZoEmVNo3V] Anointing Oil
+  [znITT3WIS59TYtCu] Anointing Oil (Greater)
+  [ICDQcwf2U7bSoieB] Anticorrosion Oil
+  [XWkeL34yJK6t5qUE] Antidote (Greater)
+  [ktjFOp3U0wQD9t0Z] Antidote (Lesser)
+  [ANzB9WzlGQXDn76G] Antidote (Major)
+  [AJ1dC7EtTIfBey0M] Antidote (Moderate)
+  [8v5fKBgw7jsCBu8U] Antifungal Salve (Greater)
+  [TEd1rxn3CfPeh0jZ] Antifungal Salve (Lesser)
+  [rS3DCw5B0fEVICVW] Antifungal Salve (Major)
+  [QPaArkVoNOBv5YRU] Antifungal Salve (Moderate)
+  [737LQfIaLXBPEzc3] Antimagic Oil
+  [ORDaAzMZLrf6Hn8A] Antiplague (Greater)
+  [UqinuuCWePTYGhVO] Antiplague (Lesser)
+  [kajpTXg3oHIJStQa] Antiplague (Major)
+  [biRbqKo2C97XLfQ0] Antiplague (Moderate)
+  [7iZCCqXDGiTv0ar3] Antipode Oil
+  [N3jcmW5XzEJZQVtJ] Antivenom Potion
+  [UuNVe6SDNztreNEN] Apotropaic Fulu
+  [60RuBISKBTuYquBe] Appetizing Flavor Snare
+  [vTEWlRBUD4VzVwxK] Applereed Mutagen (Greater)
+  [0RTsyWutvO42O0zK] Applereed Mutagen (Lesser)
+  [8e37h6HBr4ZyBSGt] Applereed Mutagen (Moderate)
+  [O4SbscW0mhRRSbRK] Apricot of Bestial Might
+  [aSvDtG5i5l7scgru] Arbor Wine
+  [MXK38neBJmy2n2AE] Arboreal Wand (Rank 2)
+  [x6Yc3ig6qCYw5cMj] Arboreal Wand (Rank 3)
+  [eOtQtVRLeGH39dNx] Arboreal Wand (Rank 4)
+  [YynRLFPm1yt6nDAQ] Arboreal Wand (Rank 5)
+  [gSstSNe0sxB2mIKW] Arboreal Wand (Rank 6)
+  [CMcUibNLDN9xhqJO] Arboreal Wand (Rank 7)
+  [CbZ72wdo1jiWLXeY] Armor Polishing Kit
+  [poHyu9ZhQPudhPPu] Aroma Concealer
+  [OIirLySQDLZgT15S] Arsenic
+  [Y7VAygKtMnE6HaXJ] Artevil Suspension
+  [7fN8xgFBxqrOkCJW] Ascendant Dragon Spirit
+  [pZB0Gsv1SoPkmzkY] Ashes of the War God
+  [7tqSRAuOgqt3CFhM] Astringent Venom
+  [qQ9Rros3GdPDRLBg] Auric Noodles
+  [pGnoCqFy0ESPbuGv] Aurifying Salts
+  [CNDOlR00gFm3DDAu] Aurochs Jerky
+  [nlm26zGDAHTISTh6] Avalanche of Stones Snare
+  [MvMa010Je10GN5dx] Azure Lily Pollen
+  [R4UPjbSDwDEmDJBA] Azure Worm Repellent
+  [eZIOsvyFRkqU43f8] Baleblood Draft
+  [Do8vjuUBOslgPtyw] Balisse Feather
+  [K2Exm6VVe9XXCdZe] Balisse Feather (Greater)
+  [F8jLnpBuvzM0nBp4] Bane Oil
+  [jiDzJKmdK2BAOh1x] Banquet of Hungry Ghosts
+  [VFUOEkaCaSCJsu6U] Bargainer's Instrument
+  [eVowRVEo42PBFvNK] Barricade Stone (Cube)
+  [uswFgspZL8QrHecL] Barricade Stone (Cylinder)
+  [RBjyD36IrrFOwFXR] Barricade Stone (Sphere)
+  [kKnMlymiqZLVEAtI] Basic Ingredient
+  [vL6AtFbcxbipGvtf] Basilisk Eye
+  [nz4riYwJiko98Mva] Battering Snare
+  [HU9eYAAfZMYnFMd9] Beckoning Cat Amulet
+  [FL8QU8TcNauBMMhD] Belladonna
+  [RsAoEbp28Za4hlLH] Bendy-Arm Mutagen (Greater)
+  [9F3d43xMDCJNIkDo] Bendy-Arm Mutagen (Lesser)
+  [bvIVxDq1wh6IavHP] Bendy-Arm Mutagen (Major)
+  [6VCaHBbUBk4eBlPC] Bendy-Arm Mutagen (Moderate)
+  [gDheph8YteBtnyKp] Bestial Mutagen (Greater)
+  [IQK9N2mEOyAj3iWU] Bestial Mutagen (Lesser)
+  [nS75vsM3x5jxlUqn] Bestial Mutagen (Major)
+  [VISk5uLPVIvNWovB] Bestial Mutagen (Moderate)
+  [6xS59NsgGLTEUW4m] Bewildering Spellgun
+  [mBwtPr9SGyuq0vPW] Binding Coil
+  [ah9jxSBerznPowW7] Binding Coil (Greater)
+  [sQM4J9Ek5GThLsjf] Binding Snare
+  [9EZb1hmSKOGrU4Cf] Biting Snare
+  [BmQKGejPtbgL8qwT] Bitterblood Elixir
+  [ScclzFrjyB0YJlrb] Black Adder Venom
+  [mcFc9HoKTwWyJiSH] Black Ash
+  [iXXseeKrvAD95H1i] Black Ash (Greater)
+  [zrCRbt6DUo6i2K7t] Black Ash (Major)
+  [x04huvOBBXmExTDl] Black Dragon's Breath Potion (Adult)
+  [LR7Ke2V8vHjQYBni] Black Dragon's Breath Potion (Wyrm)
+  [qNIv0owESzOzo1s0] Black Dragon's Breath Potion (Young)
+  [xQS1MSqGQz44FWUh] Black Lotus Extract
+  [AOOQJfSkTPiSzfB9] Black Powder (Dose)
+  [sHBk2pY0I6dCW2Mw] Black Powder (Horn)
+  [3bZcqRUWQcPe2y8M] Black Powder (Keg)
+  [cTBmQgWUyf50x3dY] Black Smear Poison
+  [WvDbdESFJY6Be2u1] Blackfinger Blight
+  [jTWDq3pEZzzRYswm] Blade Phantom's Guide
+  [bwqyL0H9Ssa7dedV] Blast Boots (Greater)
+  [nybZVDfQWMhwvL2C] Blast Boots (Lesser)
+  [sK2zEyhxxP6UnhQk] Blast Boots (Major)
+  [FVB9noeUXXyau029] Blast Boots (Moderate)
+  [q5Hr2nZr8RQ9DSZM] Blaze
+  [9Kk6P7idLGRhZJ2q] Bleeding Spines Snare
+  [ioCGarugWKBHqE5L] Blending Brooch
+  [skMIwUIMjWzgkZ5B] Blessed Ampoule
+  [4XpPgF5smMjCCHRF] Blight Breath
+  [Cc4SokzVBoBCkHId] Blightburn Resin
+  [E7BcwZy8nTpTLYf1] Blindpepper Bomb
+  [81XVuTsF1zD6EXmN] Blindpepper Tube
+  [F0x5a1MI3k9Du9j3] Blisterwort
+  [3UXsXwUbvOdpPg6b] Blood Booster (Greater)
+  [8g2U2PMC0lkPZEvq] Blood Booster (Lesser)
+  [LNzJ2WwTg58g7vam] Blood Booster (Moderate)
+  [h22AqOJjFiIXCda6] Blood Pack Squib
+  [PNwgGnN081l0cETR] Blood Sap
+  [PWh9oBvwMmItEmHH] Blood Sight Elixir (Greater)
+  [Lz643qJldVUItZOS] Blood Sight Elixir (Lesser)
+  [ECJCsH4a1qHSk1JW] Blood Sight Elixir (Major)
+  [lQATunGUOqGVpaxE] Blood Sight Elixir (Moderate)
+  [2DoUHoueAyyP4lMN] Bloodeye Coffee
+  [CrIolPhNv3W9lJns] Bloodhammer Reserve
+  [3viqxerOKUlf7mV0] Bloodhammer Reserve Black Label
+  [U6wnudbnHP2RMKpN] Bloodhammer Reserve Select
+  [2x8F5s3PyKzYsRrZ] Bloodhound Mask (Greater)
+  [mDJSaarQsIMX7Opi] Bloodhound Mask (Lesser)
+  [qasFfdiZKIczoZ9p] Bloodhound Mask (Moderate)
+  [k6D64EAjcKMf8NZB] Bloodseeker Beak
+  [oTRUHPASPD4USU4o] Bloodseeker Beak (Greater)
+  [4NCo6f0aMnIgA5jw] Bloodstone Doll (Major)
+  [TU9wvn31TE2Mz9UW] Bloodstone Doll (Minor)
+  [aWqnw30XavBrcKTp] Bloodstone Doll (Moderate)
+  [3cMFVAOHXHOHUvSW] Blooming Lotus Seed Pod
+  [rfyWXgrVD2lm91CC] Blue Dragonfly Poison
+  [rzRI8taFlNY8lbkl] Body Recovery Kit
+  [nn9X4cswWWo2QTwL] Bogeyman Breath
+  [axU0I9xIm4xm2VPH] Bomb Snare
+  [lasqzrPVEHI5MkQd] Bomber's Eye Elixir (Greater)
+  [T4ouD4mVFHA3EHs6] Bomber's Eye Elixir (Lesser)
+  [eoSvkOAkx4YGLQ2O] Bonmuan Swapping Stone (Greater)
+  [ARY8jRkg8aUJ6Zdv] Bonmuan Swapping Stone (Lesser)
+  [X3DCIU2fmj97pi1J] Bonmuan Swapping Stone (Major)
+  [JukXiZWas5RJaE3M] Bonmuan Swapping Stone (Moderate)
+  [PLun5Enmp8ZbjogV] Bookthief Brew
+  [1oWATIKLaZBXzw9N] Boom Snare
+  [SN3zU6CpyN79OINk] Bortled Favorite (Lesser)
+  [DVPP0DF0ijId1ZYO] Bortled Favorite (Moderate)
+  [vMs9n8oXlZttcJkX] Bottled Catharsis (Greater)
+  [8KbayiwrUJtvif0a] Bottled Catharsis (Lesser)
+  [Pnw4A7fhUhTS85Te] Bottled Catharsis (Major)
+  [e2II4yMBFBqVivnk] Bottled Catharsis (Minor)
+  [XfcSVHwMA60JxUXJ] Bottled Catharsis (Moderate)
+  [p4ZEGzwteCB5fz6i] Bottled Night
+  [nUaNtynMzD1DpHkB] Bottled Omen
+  [kOHWKOo4DFS8wQbE] Bottled Roc
+  [GIsGVMzTw7JfWweP] Bottled Screams
+  [7VNwyrkZS8ui4HmF] Bougainvillea Blossom (Greater)
+  [gEDLO9RQ1Qs6x5aO] Bougainvillea Blossom (Lesser)
+  [Tm1MfO24oe8NsxbY] Bougainvillea Blossom (Major)
+  [kaYxmbz5arHnCkLn] Bougainvillea Blossom (Moderate)
+  [I0eUrgVGl8a2ZjFc] Boulderhead Bock
+  [9nrB5W2evrc2U3op] Bower Fruit
+  [rOQlcAV4m8Zaebue] Brass Dragon's Breath Potion (Adult)
+  [idtIMGkFmIe958Et] Brass Dragon's Breath Potion (Wyrm)
+  [TqX34x9CijryfrlM] Brass Dragon's Breath Potion (Young)
+  [sWPkbSlWAEAStBqD] Bravo's Brew (Greater)
+  [zM9VX3QwM81DzDUA] Bravo's Brew (Lesser)
+  [oCuwJ9IUDAuzsUwa] Bravo's Brew (Moderate)
+  [WoNs6LUNKgHKC8Yu] Breath of Freedom
+  [wZ0ysKZ6FRW2ahAg] Breath of the Mantis God
+  [H20eUVst7rgwhUb6] Breathtaking Vapor
+  [bMbWbKEbKSmVgoGT] Breech Ejectors
+  [MlzPOG2v9bO4XoLg] Brewer's Regret
+  [RN8TnAhWQ4tNKHgP] Brewer's Regret (Greater)
+  [NAkbCs6NqqPWnp5H] Brightshade
+  [9nhvZ7VnDQHuyBdf] Brimstone Fumes
+  [yVCZrZLrLcIsR8aH] Brine Dragon Scale
+  [oJTIjBsOu9vLBjBD] Broken Ram's Thorn
+  [nXStoLxPrrP2b6WB] Bronze Bull Pendant
+  [vXLZfi5iCSKb96tW] Bronze Dragon's Breath Potion (Adult)
+  [lJTl2SuUaluMzPBl] Bronze Dragon's Breath Potion (Wyrm)
+  [TzXNMv7tnFy1FYgg] Bronze Dragon's Breath Potion (Young)
+  [mvrpdVyFJc5eOoE9] Bubbling Scale
+  [CvrP46hl92nk8OxF] Burglar's Rosebud
+  [o5bvKVQbeFD0nBBL] Burglar's Rosebud (Greater)
+  [M1rX9EahXV9pa0Ui] Burial Oil
+  [UOt1kd4ccF9sX9bt] Burial Oil (Greater)
+  [W9j0jc5Ekvweo7MY] Burning Badger Guts Snare
+  [kF761P3ibBIFmLm9] Caltrop Snare
+  [4TzKhSM0gD9czMdC] Camouflage Dye (Greater)
+  [RBYn6syZKENT0UiZ] Camouflage Dye (Lesser)
+  [AGD0qLB8zKGinKwv] Camp Shroud (Greater)
+  [1XoBUEUearOzrwEs] Camp Shroud (Lesser)
+  [HgI87CKuhY8IbFWG] Camp Shroud (Major)
+  [Yqz5M71vM1RcvlCx] Camp Shroud (Minor)
+  [JPNKZPtsdNpoLsBT] Camp Shroud (Moderate)
+  [Ti4gWILk69LPxKuU] Candle
+  [aZSuB6RTb14XE2N3] Candle of Inflamed Passions
+  [WAUq4TB4Q9FDxWFz] Candle of Invocation
+  [XpmPX3ScEOBgAoKd] Candle of Revealing
+  [61mFRFnaCLHDtvdv] Candle of Truth
+  [tLa4bewBhyqzi6Ow] Cantrip Deck (5-pack)
+  [xTdrhiLqFYUllrpK] Cantrip Deck (Full Pack)
+  [ShFbUrFrQg7Ung8D] Capsaicin Tonic
+  [FmfgfAW5MZ1mTH4T] Captivating Bauble
+  [If2zV787OCMXVTUS] Captivating Rosebud
+  [idZvtwLg0E3AWnur] Captivating Score
+  [QbuAXdWjwXlSk1pa] Careless Delight
+  [bQPRKEpnLakJBAAh] Cat's Eye Elixir
+  [GXH1PSioEkxTDceK] Caustic Deteriorating Dust
+  [e20qv4NhYsoTlXtw] Cauterizing Torch
+  [iRDCa4OVSTGUD3vi] Cave Worm Venom
+  [wtNZDBNjFsrrFjOR] Cayden's Brew
+  [g1aarurTGfb7QDTO] Cayden's Brew (Double)
+  [UpUJ6NHBin7bubeX] Cayden's Brew (Triple)
+  [FB7qAHjiiHTGhRnn] Celestial Hair
+  [ktAjhlI9NxpFJMdp] Celestial Peach (Life)
+  [KsoofB7FCppaBTdK] Celestial Peach (Rejuvenation)
+  [9hdT05ywPVyh9vQX] Cerulean Scourge
+  [gckU3BF9uQompDOy] Chain of Stars
+  [xShIDyydOMkGvGNb] Chalk
+  [pbQXfUhBfGeg4Bc1] Chameleon Suit
+  [o7kaj57buBADMLhV] Chameleon Suit (Greater)
+  [E8pKcXFDiCWz68Db] Chameleon Suit (Major)
+  [0WIzDXaihyzPERdn] Champion's Laurels (Amateur)
+  [5w7BqWBjsmPVpGyB] Champion's Laurels (Professional)
+  [H7MTPfM3PsK6H26n] Champion's Laurels (Renowned)
+  [gUdXcEZQ7mGB8JW1] Chaos Falcon Feather
+  [tB1NYErrB94dTFuh] Charm of the Ordinary
+  [t4X6GDybqLmt7UkN] Cheetah's Elixir (Greater)
+  [tyt6rFtv32MZ4DT9] Cheetah's Elixir (Lesser)
+  [AqLxu3ir4UGzdOaz] Cheetah's Elixir (Moderate)
+  [lXQ9ATsfuBo1MRko] Chilled Fire Noodles
+  [LY4HQe0WfYy95d6M] Chilled Fire Noodles (Greater)
+  [mxnlzHb86s56F5wc] Chimera Thread
+  [V8QY1LaaV8azWg7r] Chivalric Emblem
+  [TSMeh3NfrVEMulWR] Choleric Contagion
+  [pV5M6IYoPDhTy6FA] Chopping Evisceration Snare
+  [mqej0vAHvtCDhPAp] Chroma Kaleidoscope
+  [SeIweTBlvD1EipTQ] Chromatic Jellyfish Oil (Greater)
+  [BFre5eREvbqQdwPC] Chromatic Jellyfish Oil (Lesser)
+  [fDLABfn3nY1R670j] Chromatic Jellyfish Oil (Moderate)
+  [yYe4drMnjGWtUMb7] Cindergrass Poultice
+  [Hm0dZYfXHMNcTCo3] Cinnamon Seers
+  [haDkOWAZClCQA6Yq] Clinging Bubbles (Greater)
+  [5iNNOlIqvN1zb8v7] Clinging Bubbles (Lesser)
+  [MLbE6FZGXKcoTB52] Clinging Bubbles (Moderate)
+  [zpaWTsviTO16biJi] Clinging Ooze Snare
+  [03Jfj5QE7twaY5nW] Clockwork Chirper
+  [jVJwCB5ztkXHD5ML] Clockwork Goggles
+  [6Frd3SmMZZ49DnUZ] Clockwork Goggles (Greater)
+  [MywpJQc2lVjWvAGA] Clockwork Goggles (Major)
+  [9fKNH0ktIYs4f7Dl] Clockwork Monkey
+  [Ksz7kd6P9uKR8uLo] Clockwork Rejuvenator
+  [gQuQetoDwP3GLtQy] Clockwork Spider Bomb
+  [6CzLtRHIBfhMpyv2] Cloning Potion
+  [NZDZzVgW2Pu8blar] Cloud Buns
+  [TioBntQv3VAnS7Wb] Cloud Buns (Greater)
+  [Tccy21bO1sDb6hQM] Clown Monarch
+  [Tqtcy25OCiNlWqF6] Clubhead Poison
+  [ZGojRKG1yYiVWemR] Cognitive Mutagen (Greater)
+  [wbr6rkyaVYnDhdgV] Cognitive Mutagen (Lesser)
+  [VBK9i74dry8yf8f0] Cognitive Mutagen (Major)
+  [qpzL9UnTi4cDhy6J] Cognitive Mutagen (Moderate)
+  [sVTg7RMv8qFuQD3y] Cold Comfort (Greater)
+  [t3NpyArNDTpY6qU8] Cold Comfort (Lesser)
+  [WXnGIl4d62detRlf] Cold Iron Blanch (Greater)
+  [cImNgwDCqwa6Dil1] Cold Iron Blanch (Lesser)
+  [jnCP2zYJamUeZsJC] Cold Iron Blanch (Moderate)
+  [aJrMyopbSzvXn5Zl] Colorful Coating (Blue)
+  [EbqQbozqVGEVxEG9] Colorful Coating (Green)
+  [MMloq9cUKNJYCDLW] Colorful Coating (Indigo)
+  [A4mt1d9CK9lpLiqa] Colorful Coating (Orange)
+  [1AFWnVcoYvLcKtL9] Colorful Coating (Red)
+  [eyWT7VKdba72hKMw] Colorful Coating (Violet)
+  [KPKmM9qSdQ5X587J] Colorful Coating (Yellow)
+  [OcBPjVplvy2GbQ8P] Comprehension Elixir (Greater)
+  [3Klm2gPmzOw6ntVb] Comprehension Elixir (Lesser)
+  [XfQSkbjxVHF82ael] Condensed Mana
+  [SHQv4yntEoU4uYRJ] Conrasu Coin (Arbiter)
+  [FgZCLBhOOhhXDdvI] Conrasu Coin (Bythos)
+  [i9aUncOpesTJpyX0] Conspirator's Cookie
+  [ommn7wIgLyWHGL11] Contagion Metabolizer (Greater)
+  [EKhROfCklhZ7Je7h] Contagion Metabolizer (Lesser)
+  [GWMrc8hZINhmDwvt] Contagion Metabolizer (Moderate)
+  [XMuLrJYL6fxv4YNA] Cooling Elixir (Greater)
+  [Ekk7o1gPu8RotixD] Cooling Elixir (Lesser)
+  [EEJiqzU89Ofk7dr6] Cooling Elixir (Moderate)
+  [T28lI7becoK1ZGqr] Cooperative Waffles
+  [awPkC6AWcHS3T4oz] Cooperative Waffles (Greater)
+  [yqbW1T3Eu9KHRs1U] Copper Penny
+  [ByaYlK0QmnqEbCE2] Covenant Tea
+  [ex1kVj3SUbTd1smt] Crackling Bubble Gum (Greater)
+  [0Y0fmvvKSgFvUtA2] Crackling Bubble Gum (Lesser)
+  [rpqgJkCepHecj1eA] Crackling Bubble Gum (Major)
+  [Bajwrol5y2n2ZIVm] Crackling Bubble Gum (Moderate)
+  [lExsX8c5VUxiu05y] Creeping Death
+  [jkjqpRWXdi0rGWey] Crimson Godsblood Serum (Greater)
+  [bO6CN8rkGo7f14rk] Crimson Godsblood Serum (Lesser)
+  [e2iOKWEs2PsAbgmo] Crimson Godsblood Serum (Moderate)
+  [nctubaNAmzvXYDkc] Crimson Worm Repellent
+  [HHELOoN5GVonUiIa] Crying Angel Pendant
+  [j7VThCkenoE4giZt] Cryomister (Greater)
+  [UYj4AxqiwtlTW8Kl] Cryomister (Lesser)
+  [OkYPLMDxprdm24hH] Cryomister (Major)
+  [2EC73UbxVP9f0SR9] Cryomister (Moderate)
+  [VvN9EjaBLwYg13z3] Curare
+  [DPNuM3699xULCbmF] Curled Cure Gel
+  [rjUJEY424jyG9dGn] Cytillesh
+  [aZm1x9tpvBAT8YCd] Cytillesh Oil
+  [WMdHOfjjBtJAEvqU] Dancing Lamentation
+  [LniGjFmZyw90Rdcj] Dark Pepper Powder
+  [zXcCVIzDCq3P1pqT] Darkening Poison
+  [bz8Y8bVUe7QfBk9g] Darkvision Elixir (Greater)
+  [88pGCHV0uKMskTVO] Darkvision Elixir (Lesser)
+  [Y8115p3cmQJBqk5d] Darkvision Elixir (Moderate)
+  [6vyr3drpizIrd5PS] Daylight Vapor
+  [ClKb4YQn8TfPIclE] Dazing Coil
+  [xcH5IW7ahE3q8cPq] Dazzling Rosary
+  [xnIEWJYmJh6j58Wd] Dazzling Rosary (Greater)
+  [KuTwNrDpuYVAPu7c] Deadlock Mint
+  [Vk5VzPB2fj3Ym1Ia] Deadlock Mint (Greater)
+  [xanr7nay2UQeR4Ec] Deadweight Mutagen (Greater)
+  [JPALWW3w4z8STAYV] Deadweight Mutagen (Lesser)
+  [Wx5WhSNOmeICgHSC] Deadweight Mutagen (Major)
+  [qLwwxk1j04rgXSF9] Deadweight Mutagen (Moderate)
+  [craWRj7jI2mLs1Ok] Deadweight Snare
+  [zZZRK9AJ5VGIcbzU] Death Coil
+  [87AzvRja9uQOLJCC] Deathcap Powder
+  [nvjEr2dlbtMV0q3d] Deathless Light
+  [HHJboKeB1AXzIKCs] Deathstalk Mushroom
+  [Bgslo3kDz8bTiYie] Defiled Costa
+  [oO0DqxI7EGkTYJzv] Defiled Costa (Greater)
+  [1PH7kb7ZVSrfQsgD] Delve Scale
+  [VXxwxLwJiDODlUZq] Demolition Fulu (Greater)
+  [7WuJbX5c3SCB04Uw] Demolition Fulu (Lesser)
+  [pAldqSrzPotjYQe6] Demolition Fulu (Moderate)
+  [7ztQ3uhnJYVzAA2l] Demon Bone Tiles (Brimorak)
+  [kxeAuCejzM44gsLN] Demon Bone Tiles (Pusk)
+  [k58XPeaA3qcPJIhg] Demon Bone Tiles (Seraptis)
+  [ZROIWl7TLxKbPDLr] Demon Dust
+  [fru7xyHYTuw0R46v] Demon-Hunting Bands
+  [Cu2zf4wi8UGzsyVC] Demortification Oil
+  [0Wxiz4hJPERJPDAF] Detect Anathema Fulu
+  [SGS7fA2hcElw1EaL] Deteriorating Dust
+  [V18pnbAay4iG7O6C] Detonating Gears Snare
+  [64aQTlUq7VaBTjpd] Devil's Breath Incense
+  [HWInHkg9upnnSJi2] Digly's Oil of Sympathy (Greater)
+  [Mgrrrb7iWmDTCd2u] Digly's Oil of Sympathy (Lesser)
+  [cEHi51OKIQ4wEPFc] Digly's Oil of Sympathy (Major)
+  [upgNYvc48y8jUUEO] Digly's Oil of Sympathy (Minor)
+  [T2DGpe7qXEuQEKWH] Digly's Oil of Sympathy (Moderate)
+  [1CAPGpQczfq5exrs] Diluted Hype
+  [RxhVolMBRtriFUUO] Dimensional Cleavestone
+  [ydsXPuDjG2hPspw6] Dimensional Knot
+  [3tCtnomxBkdyG43X] Diplomat's Charcuterie
+  [BXb0tzJHOAB8whWB] Dischoran Rubble
+  [aKrslrjq22S9uRgF] Discord Fulu
+  [mGIJCGFkBQLkzhTg] Dispelling Sliver
+  [bLmuVUkaMeyq5QlI] Djezet Dose
+  [S5FMXJdf9ktWXJRp] Dr. Ushernacht's Astonishing Ink (Major)
+  [tk7LRIidkTl9dYPw] Dr. Ushernacht's Astonishing Ink (Minor)
+  [0Pa0XDVF3DwRPqCu] Dr. Ushernacht's Astonishing Ink (Moderate)
+  [OzSfVy1SoKzCWG8q] Draft of Stellar Radiance
+  [6swrLimere2nZtz9] Dragon Bile
+  [Kmf5F06GucKhY6hK] Dragon Breath Scale
+  [Lehtsf2QWj3bQnTV] Dragon Eye
+  [g6agII64qc6wuSiP] Dragon Pearl
+  [989VZoKytQMJYRuR] Dragon Scute (Greater)
+  [PjGZEG8hnzcYc6vm] Dragon Scute (Lesser)
+  [wZU5FVR7ifZbhuv6] Dragon Scute (Moderate)
+  [C35j9PXcyDdrTsat] Dragon Throat Scale
+  [GnXKCkgZQG0UmuHz] Dragon Turtle Scale
+  [4MfrhRlz4VeYtYVn] Dragon Turtle Scale (Greater)
+  [xky9NMHpP3yqzYOj] Dragon's Blood Pudding
+  [QrjeT3xBssyjvEHQ] Dragon's Blood Pudding (Greater)
+  [kUvjWSGWpwBvTVax] Dragon's Blood Pudding (Major)
+  [fzAkwYDi8sXWfCNu] Dragon's Blood Pudding (Moderate)
+  [y8x66ougD79IuhI3] Dragonbone Arrowhead
+  [3joQBdbHQo66FT6S] Dragonclaw Scutcheon
+  [2UQANe2ca1c8MO6Z] Dragonfly Fulu
+  [82f7CTK0HxvitMLP] Dragonfly Potion
+  [CkrsPua4g1IlcBO0] Dragonscale Cameo
+  [EmnU1xFDutJ70HaI] Dragontooth Trophy
+  [WuzLBK78DgIt8SsN] Drakeheart Mutagen (Greater)
+  [GS4YvQieBS11JNYR] Drakeheart Mutagen (Lesser)
+  [M4ZOHOlne43ArjOC] Drakeheart Mutagen (Major)
+  [xY2MogTwH9Fd8UPG] Drakeheart Mutagen (Moderate)
+  [hw81uONdpyUbdWUJ] Dream Pollen Snare
+  [dwaF9zHPK9823COa] Dreamtime Tea
+  [3XVNEpLdHIdQ8IYq] Drop of Convergent Waters
+  [4gAndhLFJ4Is3NJ2] Drought Powder
+  [aUzX848Ygqicy2qs] Drowsy Sun Eye Drops
+  [39cQgs70GbP7KZdy] Dupe's Gold Nugget
+  [azFpL1NLBJB7xuli] Dust Pods
+  [8iGmSwTTUdj6gqN5] Dust of Appearance
+  [2koNKqbQV05myfuL] Dust of Corpse Animation
+  [yPFHTY1GH3rdWwds] Dust of Corpse Animation (Greater)
+  [9XSOAzq3xp9g6qkF] Dust of Disappearance
+  [xWCdsGSwLLTeX6tQ] Eagle Eye Elixir (Greater)
+  [7Y2yOr4ltpP2tyuL] Eagle Eye Elixir (Lesser)
+  [kicNrnZz1KjJYRVI] Eagle Eye Elixir (Major)
+  [lPcnDlBGz5QwCMYw] Eagle Eye Elixir (Moderate)
+  [qLjWaRljNIb1uuLO] Echo Token
+  [mYVUS8p9gA3mCLES] Ectoplasmic Tracer
+  [VPvyyQXjn2HBjnTS] Effervescent Ampoule
+  [EOk6kNsNJOhoSbRZ] Effervescent Decoction
+  [wYYKU4iO1q9b8MDm] Effortless Garden
+  [5a6pudUj6WG8RITy] Egg Cream Fizz
+  [7b6jSbZ7Xu88wyi8] Eidetic Potion
+  [uf05VGoYSaeKtUG1] Elder Seed
+  [aOFly4vZu24x85b0] Eldritch Flare
+  [ntrmM8yBysmeqt71] Electromuscular Stimulator
+  [BiFzQ1MlxK7F7jkE] Elemental Fragment
+  [1iIb8vL2WQHOqN46] Elemental Fragment (Greater)
+  [2iWD3YHmsQ9uicIF] Elemental Fragment (Major)
+  [TgZdamADHuaKyriW] Elemental Gem
+  [rDM6rxWVzKtFQOKg] Elixir of Gender Transformation (Greater)
+  [GfegrEtbEs9L6NOg] Elixir of Gender Transformation (Lesser)
+  [0KXqdhz2MYV0LBm2] Elixir of Gender Transformation (Moderate)
+  [mYozcVg9fQY6zO7C] Elixir of Life (Greater)
+  [TZUskLT7yvP7N2co] Elixir of Life (Lesser)
+  [AmxSqEoFhRLMYd1W] Elixir of Life (Major)
+  [hDLbR56Id2OtU318] Elixir of Life (Minor)
+  [c21stU5rhN4F2fZl] Elixir of Life (Moderate)
+  [qK964kZz1ALcysOa] Elixir of Life (True)
+  [UHrLqWCnFEUspSQj] Elixir of Rejuvenation
+  [uS04H5rQ3mGny9Kl] Elixir of the Peaks (Greater)
+  [8RMUxzQuyGA5ainJ] Elixir of the Peaks (Lesser)
+  [ZF7dbHcqnnyFl7nY] Elixir of the Peaks (Major)
+  [h3ZAXh2w4JIhju4a] Elixir of the Peaks (Moderate)
+  [SrjykpB3nEAQmgj5] Elsie's Excellent Bottled Vim
+  [26bM70yn28MjDT9A] Elven Absinthe
+  [8vN6vm2fKB4rE86U] Elysian Dew
+  [vAMgDuD3BphJL8EJ] Ember Dust
+  [3uhaf2YL9hmix3pe] Emerald Grasshopper
+  [VeqgYabyGPd7kuSg] Emerald Grasshopper (Greater)
+  [BjCGt377LpCwbtyS] Emergency Disguise
+  [KlrP8xrqFcbDkGLF] Emergency Eye
+  [Qcla3yTa1MzcpMjb] Emetic Paste (Greater)
+  [cHKqK8g9dS3GJ58F] Emetic Paste (Lesser)
+  [HNacrCOSJKJ6zn5t] Emetic Paste (Moderate)
+  [C5RNvjvyq655pphC] Empath's Cordial
+  [NtUFIAMm2raeq5lr] Energized Cartridge
+  [u4R5KKvgKU0jOkjb] Energizing Pill
+  [RK03uy9os4H0dUfS] Energizing Tea
+  [O3xp1TzJgSTEeqz9] Energizing Treat
+  [2JXUER4xY8s36HUv] Energy Breath Potion (Acid, Greater)
+  [vPcDIowg3LAqZYAE] Energy Breath Potion (Acid, Lesser)
+  [2VC7FLItVrFWNe4L] Energy Breath Potion (Acid, Moderate)
+  [OiQDcUMrlrYXDgEf] Energy Breath Potion (Cold, Greater)
+  [xRrMmFzpa0WU9uV4] Energy Breath Potion (Cold, Lesser)
+  [WwWssHoEhyh7Yrrw] Energy Breath Potion (Cold, Moderate)
+  [ltILKAEnrZ8vKwY0] Energy Breath Potion (Electricity, Greater)
+  [xpVHMxLcwgXzL39e] Energy Breath Potion (Electricity, Lesser)
+  [zQnidYCmLCBPfdii] Energy Breath Potion (Electricity, Moderate)
+  [KZbAqbt7qxJPPkii] Energy Breath Potion (Fire, Greater)
+  [3fSc2e5xRjJ7w4g3] Energy Breath Potion (Fire, Lesser)
+  [NqNwLeqto2isVWNL] Energy Breath Potion (Fire, Moderate)
+  [4vb8fplhdtLDBxxh] Energy Breath Potion (Sonic, Greater)
+  [zAn1SNGYW93kmzdn] Energy Breath Potion (Sonic, Lesser)
+  [jjfxEYViPr4FDeMH] Energy Breath Potion (Sonic, Moderate)
+  [xVtyaEnYZ1aJT4ki] Energy Mutagen (Greater)
+  [mbrwudO35tItsldq] Energy Mutagen (Lesser)
+  [34MbgwW1SGlowyk2] Energy Mutagen (Major)
+  [SLJTJwyIRjuWjfuK] Energy Mutagen (Moderate)
+  [fVKiVp6yG85ADrR6] Energy Toxin Bottle
+  [ca2lzxfJxvuLDrKu] Enervating Powder
+  [DIQg2Tml1wWjSC1q] Engulfing Snare
+  [EmuRXJpGelePyaO5] Enigma-Sight Potion
+  [PhtAfMPSrppdM9wT] Ensnaring Disk
+  [EN6Kdc6q5aRTlPS5] Envenomed Snare
+  [53mPIEbUw5RzQ6pc] Escape Fulu
+  [xAgcrpDlBU77FNlf] Essence of Mandragora
+  [wYDTn07x34o2slUD] Ethereal Crescent
+  [4BoDAxtqWYIgXayF] Ethereal Crescent (Greater)
+  [LcNUAglIYiTxwmNo] Etheric Essence Disruptor (Greater)
+  [SRMgleqCK2tsZjvS] Etheric Essence Disruptor (Lesser)
+  [KO7ZftYQrcE5GFkJ] Etheric Essence Disruptor (Major)
+  [d49GcmPZ2xWxU8Zj] Etheric Essence Disruptor (Moderate)
+  [DqgkcKJL6ASqwuio] Euphoric Loop
+  [vRO9Orlts0jP7nCx] Euphoric Loop (Greater)
+  [6nIwxBKmmYvTGNip] Euphorium
+  [7IrQPyMm76nLVoXx] Everlasting Adhesive
+  [8qUja4YdvewN4es0] Execution Powder
+  [e2Von0aDHB03Iz3f] Explosive Mine (Greater)
+  [7e57yUVtRgYLOFwT] Explosive Mine (Lesser)
+  [FBS2dhoOfSlcuPt6] Explosive Mine (Major)
+  [aiL53pkt0wFrsAQb] Explosive Mine (Moderate)
+  [ZtfkPBCvHTmHCTix] Explosive Missive
+  [gYYlqHTW1lgwd6ri] Expulsion Snare
+  [sAMzkU7kzUZfqTPV] Extended Deteriorating Dust
+  [cplkaokMiskvFgAe] Exuviae Powder
+  [cxOf1V1kN9tnj1g9] Eye of Apprehension
+  [vNxKM5J5TqrbJKYk] Eye of Enlightenment
+  [FrbvejTNfS5fep9f] Fade Band
+  [2VS3S2E3dbqvGifH] Fake Blood Pack
+  [iUOcC9vFboSFI8fU] False Death
+  [RtU28UqJuqJQMJym] False Death Vial
+  [FZxrYMcH0uH617EQ] False Death Vial (Greater)
+  [bASMkq9syBtpaXok] False Hope
+  [lkbmxnhvWKhO0cFt] Familiar Morsel
+  [YYD82q2NfAbuDmgf] Fang Snare
+  [ZAtwiAPkk1zwCf82] Fear Gem
+  [JnGeiRdprh1j0qnT] Fearcracker
+  [ALS7pobHFmOnR4yX] Fearflower Nectar
+  [RH1fNsslZ1wdeqy2] Fearweed
+  [mBvMWiFb6VB0P3Fk] Feast of Hungry Ghosts
+  [0CNSvLpeSM4aIfPJ] Feather Step Stone
+  [VvljzRwthKMgqUR3] Feather Token (Anchor)
+  [cgWT0BUa6b6V7zDg] Feather Token (Balloon)
+  [fFq8nsGvSUgzVeND] Feather Token (Bird)
+  [3Fmbw9wJkqZBV9De] Feather Token (Fan)
+  [cwurQLvQaqjK70UI] Feather Token (Holly Bush)
+  [vQ2XU6y1MBVDtQgr] Feather Token (Puddle)
+  [4owFeOy4zxy8rv7W] Feather Token (Tree)
+  [XAuWVlZYGgCguzwz] Feather Token (Whip)
+  [FkZxKNSw75YWoA32] Featherlight Fletching
+  [g190hQLpwU0jrSNa] Feed (Standard)
+  [nb83vPkRwm47cu3z] Feed (Unique)
+  [FO2QKhTLyjbwrCrZ] Feral Linguist
+  [iUwss4XHPassdhV3] Feral Linguist (Greater)
+  [dhn6dx5bvZBgZGHs] Ferrofluid Urchin (Greater)
+  [vqGAy24GXV3jyGoZ] Ferrofluid Urchin (Lesser)
+  [4DfaAHIxnWPMoWb5] Ferrofluid Urchin (Moderate)
+  [CtePdUJWKgjwpatZ] Fey Dragonet Liqueur
+  [sd3H2Nir3qLFNVI3] Fey Dragonet Liqueur (Greater)
+  [NKRuXILXLlDbxTs9] Fey Dragonet Liqueur (Lesser)
+  [9wwCHxuCfBA9w6Ik] Feyfoul (Greater)
+  [JbkAk2j7h31izKyR] Feyfoul (Lesser)
+  [LbRuAXvoACxPqHqn] Feyfoul (Moderate)
+  [gXqU9CInB05jdxh6] Fire Box
+  [KadHRRccZ5rWRl7c] Fire and Iceberg
+  [jNdAX4hBp0pzWalL] Fire and Iceberg (Greater)
+  [9Fps57Xc1XxxWK0j] Fire and Iceberg (Major)
+  [76vu5p2S0wN77fJw] Fire-Douse Snare
+  [G3EIZLApRwt3hq13] Firecracker Fulu
+  [AYKjrJnMo6mWCt2e] Firefoot Popcorn
+  [VmMSP1EbMVnj2pZ2] Firestarter Pellets
+  [SsWxgxols1Q1qPVf] Firestarter Pellets (Greater)
+  [kFqPDnz0dYvK0mIG] Firestarter Pellets (Major)
+  [kaIKYTrvw4qa1khc] Flame Drake Snare
+  [4Pmo9gc81JAOzdke] Flame Navette
+  [9UGxCsNE778Y5rk0] Flare Beacon (Greater)
+  [aP5wvs60j6VaKvWL] Flare Beacon (Lesser)
+  [VJ9mXi70JprHHA0z] Flare Beacon (Major)
+  [WAQABCTFGuHvC0yR] Flare Beacon (Moderate)
+  [riLNCaVS9zGvt4Nn] Flare Snare
+  [PTwm2NAcReBw2iUY] Flayleaf
+  [qvfO0jFIvIM8hReG] Flying Blade Wheel Snare
+  [NHSYMJmi4vjrg1r9] Foe-Sensing Rod
+  [UYCQoe8sKZgbKYHg] Follypops
+  [TBuLxrVXa4UGHzb9] Force Tiles
+  [8eTGOQ9P69405jIO] Forensic Dye
+  [qhn0PSd5TPGpblbg] Forgetful Drops
+  [iCRoLguNunOjIM7L] Forgetful Ink
+  [AqslI71DReZOzgAW] Formulated Sunlight
+  [aQ4Q8Rq6ntWaHcIv] Fortifying Pebble
+  [vAEQsYQbOYmqfIc0] Fraudslayer Oil
+  [sfx2plFpqrc3nsvH] Frenzied Quintessence
+  [7p3C9xf3XgUbvKHL] Frenzy Oil
+  [oEOfOdcxkSnzSHPC] Frogskin Tincture
+  [PVpViB2Wg3f61dFa] Frost Breath
+  [Mqayp3cYaZItkPsj] Frost Worm Snare
+  [5lpBiEqrxiyj48JB] Frozen Lava
+  [ugxI9kH7osJ3J5qG] Frozen Lava of Barrowsiege
+  [bh3HJkgWC05VSXgs] Frozen Lava of Blackpeak
+  [YS7LJSvooG7mfwH1] Frozen Lava of Droskar's Crag
+  [gJboDbIGscCvSlFc] Frozen Lava of Ka
+  [X1KGaXLDUxNJ1XXB] Frozen Lava of Mhar Massif
+  [QGgTedo2uMi6e9PR] Frozen Lava of Pale Mountain
+  [lvsQe0qLzhnWYqa0] Frozen Lava of Sakalayo
+  [xDWUGwLpKLm8WdQP] Fu Water
+  [yYkxdzogiH7FPWVP] Fulu of Concealment
+  [89uak2oyHnEuIn0b] Fulu of Fire Suppression
+  [ZvOaZLwTT4kDbrF7] Fulu of Flood Suppression
+  [NJOOeJc7bpE7gkUn] Fulu of the Drunken Monkey
+  [G8h3vA0bSewbdrDS] Fulu of the Stoic Ox
+  [bVsNvqhfvDKGbRhd] Fundamental Oil
+  [JgZIWU1KaVL2pnAr] Fungal Walk Musk
+  [MUL0ABe8h7Ugc1Jt] Fury Cocktail (Greater)
+  [BeX3ForBrKTQD4T5] Fury Cocktail (Lesser)
+  [JmxKmYQPQmUlauO4] Fury Cocktail (Moderate)
+  [8pQw1HUzJ4duZbio] Gadget Skates
+  [u6g7AClRFEAj4lf4] Gallows Tooth
+  [zg4aR2ndtTzO1osa] Galvanic Chew
+  [RtTzHaHMrXiml7ut] Galvasphere
+  [OtFKHfUQnn97ILBC] Gearbinder Oil (Greater)
+  [wyD9xIa4TAxoHnuQ] Gearbinder Oil (Lesser)
+  [A3rdTH2lpqQMoX6N] Gearbinder Oil (Moderate)
+  [L5AaEekLZ7Xt80FZ] Gecko Pads
+  [rEx0S0p3cIzybhvV] Gecko Pads (Greater)
+  [hGw7Q1y2IEXRGAfv] Gecko Potion
+  [553H2rzgaHeY1VB4] Ghost Ampoule
+  [mIqL9F9e1F1FmVgF] Ghost Courier Fulu
+  [3hhRWYl1O2FRfAbn] Ghost Delivery Fulu
+  [dmQAN56aMro0gecx] Ghost Dust
+  [Vemy5QGbLRdPedcP] Ghost Fowl Porridge
+  [qnvq3PSTiejQTSi9] Ghost Ink
+  [MIP28AmODXgyF2D2] Ghost Oil
+  [Uzf9hqwec8fY2j4G] Ghostbane Fulu
+  [VrZiS4hVpzWk2p2z] Ghostcracker
+  [F4WcgJ3NB1kiF7OL] Ghostly Portal Paint
+  [XbyPBiZnoKDK9vbH] Ghostshot Wrapping
+  [txmX5ghhPS72GKXy] Giant Centipede Venom
+  [QGXNqpP5KvSldoZz] Giant Scorpion Venom
+  [aBOPYlfHAcXUmhF7] Giant Wasp Venom
+  [CXCWF6jQQHKHFhpR] Gift of the Poisoned Heart
+  [uPP678KODkgDy8UO] Ginger Chew
+  [omZLCSIxiF9oXyH2] Glimmering Missive
+  [NtUB9xqRZQ2duOUo] Glittering Snare
+  [y4WJY8rCbY6d1MET] Glow Rod
+  [INyiWvehFuo8nGaa] Glowing Lantern Fruit
+  [8GEsRsQAdDljRT1s] Gnawbone Toxin
+  [fv10pyjxJtrxMaQ4] Goblin-Eye Orb
+  [8wlCeramJW5cLw6e] Golden Branding Iron
+  [tNs0FKSthYCM7ivx] Golden Branding Iron (Greater)
+  [kVng8qcoHLBORFIc] Golden Branding Iron (Major)
+  [4642hELMtWF9jywN] Golden Breath Fulu
+  [PkrpCUXdV3I1boRQ] Golden Silencer (Greater)
+  [M7Ful1B1IWeibSm7] Golden Silencer (Standard)
+  [QSofPEx2sjztUNao] Golden Spur
+  [QImdOdyolrMWwuxD] Gorgon's Breath
+  [fqFOdsUJdvgZCs1U] Gorum's Tear
+  [Q3ZYTbPGPDG6WINq] Gossamer Sash
+  [TFnr9Gq7VXPJu0GQ] Grasping Snare
+  [hxYxRz9nOECtLak5] Grasping Tree
+  [THfWJr1qr3jrncYZ] Grave Token
+  [Wn0H58sAkUtIaPPd] Gravemist Taper
+  [qQqAY59NgGNoy2xr] Graveroot
+  [A7tMFLBkzhU0I0WN] Gravity Inverter
+  [KVrCsckKUW68FWcV] Grease Snare
+  [5ayGokKzSBMCGJD8] Greased Axle
+  [eV0owvv0lYQph0nn] Green Dragon's Breath Potion (Adult)
+  [OJvCWeJPHEc7GpFG] Green Dragon's Breath Potion (Wyrm)
+  [vvgCQzWkScCzte7K] Green Dragon's Breath Potion (Young)
+  [qvAtAv211cVqktgU] Greengut
+  [eEIWjTvZyKsKhYaz] Grim Trophy
+  [lbr6acClmnMmB7QZ] Grim Trophy (Greater)
+  [ALfqpWLbLPSXxZVG] Grindlegrub Steak
+  [mJSCOIJllj2GtACC] Grinning Pugwampi
+  [vl5dww56cbXo9QnP] Grit
+  [I2ZbXsfm0c9Eep4I] Grolna
+  [SH0WmAdjIaNN3OiN] Grudgestone
+  [rEev4xrQyMvjz7W7] Grudgestone (Greater)
+  [Odl2SyKw8Zg6ckKb] Hail of Arrows Snare
+  [Km4lSOsyrip5q6iD] Hampering Snare
+  [ida2fLjVX5gbZHBE] Hand of Mercy
+  [rJqth4cFwWnSiCr1] Harpy's Talon
+  [3M7iB9tfrsWTccZ0] Healer's Gel (Greater)
+  [q8aRbsKX93R5AXNb] Healer's Gel (Lesser)
+  [ZxkTbyq61JTQ7Zkt] Healer's Gel (Moderate)
+  [TSrbwHW8zm0mhkwb] Healing Potion (Greater)
+  [e0vSAQfxhHauiAoD] Healing Potion (Lesser)
+  [p3ppzFSsZXFRe3H8] Healing Potion (Major)
+  [2RuepCemJhrpKKao] Healing Potion (Minor)
+  [G7haQ5gDt30ftJLC] Healing Potion (Moderate)
+  [sMrOHuFHjtLDOzp4] Healing Vapor (Greater)
+  [6G088rA3TjiuQ5NA] Healing Vapor (Lesser)
+  [UOvDye8obnqjfMQG] Healing Vapor (Major)
+  [Xjjj7uHQzbOwENYV] Healing Vapor (Moderate)
+  [ZJE92c4sE6cu8l8l] Heartblood Ring
+  [6iqRv3TGKt6DyIBs] Heartening Missive (Bull)
+  [U9LhV1IBLbRug7uz] Heartening Missive (Butterfly)
+  [MMInXBlOscwZVXsm] Heartening Missive (Rabbit)
+  [SRaVakPZeb81ZLfL] Heartening Missive (Turtle)
+  [MP7updiiSct04vno] Hemlock
+  [tdwPBrchFga79M9Q] Hero Killer
+  [7k0lrb4I47mDIBj1] Hippogriff Feather
+  [YeQjs2DarMVIPVjq] Hippogriff in a Jar
+  [cmiWGrdUFyd8ihf1] Hive Mother Bottle
+  [0lhh2l4kh3QrwYH9] Hobbling Snare
+  [eVI81XML1c9jqhIx] Holy Steam Ball Refill
+  [7TT0XIb8ovLFOP2e] Honeyscent
+  [Qx6CAAbSQ0RpruJH] Hoof Stakes Snare
+  [GNy0YEusxjcGMCNn] Horned Dragon Breath Potion
+  [CfM2q0UgtG6gkPku] Horned Lion Amulet
+  [QLmgHzDlWuwaylPm] Hovering Potion
+  [alUdoHA3sbaSJL9f] Hungering Maw
+  [Yew9oddFsH0KeDLh] Hunter's Bane
+  [iN4giDBCWlc19Jsc] Hydra Mutagen
+  [z3IG6t2o0zsfP2XQ] Hype
+  [2EigJwHDmem3YggO] Ice Slick Snare
+  [uwVTuejjSLl82jiA] Ichthyosis Mutagen
+  [odzeu3176i96fF9n] Illusory Program
+  [UlZ6s3Wox11ApisX] Immovable Potion
+  [cjAyXfWmn0IpOsaY] Impact Foam Chassis (Greater)
+  [2kFaQDsMZmPIEOct] Impact Foam Chassis (Lesser)
+  [YvmRcEky6fuIR0xp] Impact Foam Chassis (Major)
+  [CM0Hq7KKCwUv0BV6] Impact Foam Chassis (Moderate)
+  [KMuzxjJehmJgoQ7h] Impelling Symbol
+  [ye6XAJY21YQqRnKH] Implosion Dust (Greater)
+  [LKTbRpaw8bH3WHv1] Implosion Dust (Lesser)
+  [ve73Sb8MwLY9GDBD] Implosion Dust (Moderate)
+  [hOemslrdMyHCgSBk] Impossible Cake
+  [RkZgEViFodxXsLu3] Impossible Cake (Greater)
+  [IBJIBTkTilVV0BdC] Impossible Cake (Major)
+  [Mtqc1UzOotdclIEb] Incense Bundle of Annual Blessings
+  [4RKfLoqVluZGWzLc] Incense of Distilled Death
+  [ibxFkN7NGB1pybWx] Indomitable Keepsake
+  [nrY1yxGbl5MFUyea] Indomitable Keepsake (Greater)
+  [SBpUiOJiap2cZk2Z] Indomitable Keepsake (Major)
+  [cuomhpenkqGM5lLG] Infiltrator's Elixir
+  [CorMilTH3XKGW49D] Insight Coffee (Greater)
+  [sPceDzKeOA8PpK2v] Insight Coffee (Lesser)
+  [vzP0pLxes9bn0zV8] Insight Coffee (Moderate)
+  [xqCz2vStMNJujfpp] Instant Evisceration Snare
+  [aBGKmzkHsaNH07Di] Instant Spy
+  [B3QOvE43Qn1H8t8n] Inventor's Fulu
+  [qrgUIr4PAvLvHn5C] Invigorating Soap
+  [bikFUFRLwfdvX2x2] Invisibility Potion
+  [LBhzIWBH9TJ8A2K5] Invisible Net
+  [StsE5POM7OSE36Ia] Iron Cube
+  [XvmYNnQ4vg8GREH7] Iron Cudgel
+  [KrtZmC3qfZIGXu76] Iron Equalizer
+  [ewzJzyJ4Vo9lZKvp] Iron Medallion
+  [DOJxQLwkDvebbLWJ] Iron Wine
+  [hSJWv6aOwlJyKSLs] Irondust Stew
+  [9jUxAAt0hj9luWKK] Irritating Seedpod
+  [Lq823hDvDNP5321d] Irritating Seedpod (Greater)
+  [a7apCVmrBGGIK3fZ] Irritating Seedpod (Lesser)
+  [iXKdE5ZdENm6a1ig] Irritating Seedpod (Major)
+  [77D3QdU33DLcwNrJ] Irritating Thorn Snare
+  [VwzIiWAtbJCgGOEz] Isolation Draught
+  [Dc9BJcvL5zOoxAJd] Ixamè's Eye
+  [cKqZe5imzxqSnzwD] Jade Bauble
+  [2MgFoNXTccL8Own9] Jade Cat
+  [pBq1cHXnic8dGxx8] Journeybread
+  [7Sm8NhvQcwi84Nsh] Journeybread (Power)
+  [TMtQnY6yvIRCpK9v] Juggernaut Mutagen (Greater)
+  [xE0EdDrf734l2fQH] Juggernaut Mutagen (Lesser)
+  [1kNp6yOS0aZPBPzZ] Juggernaut Mutagen (Major)
+  [mj9i9GeQTADByNPZ] Juggernaut Mutagen (Moderate)
+  [FETCOUQa6rYtlAHB] Kaiju Fulu
+  [fkvKBZGyibWAfZ7b] Key of Unwinding
+  [bG6O3g0tu43Ue21A] Kimanéz Luminescent Toadstool
+  [RkI3jKKrCozvEvfr] King's Sleep
+  [Ia3z1nC3LBulMFMs] Kirin Echo Chime
+  [0XSl2DU7JvKXOqTo] Knockout Dram
+  [lu3kPHtKZTHPx4Fx] Kraken Bottle
+  [Hiu4tSd0Ol8HvmaN] Krasovnatype
+  [EBAgEC9YyNC9NTmY] Kushtaka Relic
+  [qkPlUzyNLmLKVtBL] Lady's Blessing Oil
+  [VeCNWhvEr82ZNoSV] Lastwall Soup
+  [ed8gAxli6Of58kAM] Lastwall Soup (Greater)
+  [VcEd9Bh4q5vQfpLv] Lastwall Soup (Improved)
+  [QJ1fTrX42PoEWpK5] Leadenleg
+  [6eQvHNHf1IC2X5Rx] Leaper's Elixir (Greater)
+  [uG3xtNrs26scOVgW] Leaper's Elixir (Lesser)
+  [wJZQiPEMzPLQnDYk] Leeching Fangs
+  [zo0ophqfKunJFxZN] Lethargy Poison
+  [ChIhgRwtnhTukICY] Liar's Demise
+  [PTEQ6NCrFkYQCURJ] Life Salt
+  [3kELQauVoYunyFcd] Life-Boosting Oil (Greater)
+  [AFFaFaAW3IbbYqkL] Life-Boosting Oil (Lesser)
+  [UOH0A4xNSMnpV6i4] Life-Boosting Oil (Major)
+  [9zyrMZF76hMxwizY] Life-Boosting Oil (Moderate)
+  [cSrCTi2zE5OU5ylH] Lifeblight Residue
+  [1bLvKfodvgrIG4hp] Light Writer Plates
+  [30DfCYSs3dxb8Sjy] Limning Gem
+  [2n8pySCWPa5s5LX9] Lion Badge
+  [4upzgnkxdGn2Fy9c] Lion Claw
+  [Upso2k53BUfmeays] Liquid Gold
+  [D8aBxqJW61WFiQM2] Liquid Gold (Greater)
+  [n5xlR7ApXgfJRkbF] Longnight Tea
+  [p3RduziOxQxtREg9] Looter's Lethargy
+  [AALcDOpwxCBN50lA] Lover's Ink
+  [l8wky2NQduHYsY9B] Lover's Knot
+  [3IknuOpIV1OSNl98] Lucky Rabbit's Foot
+  [9TAYUFDOJa0kvk9m] Mad Mammoth's Juke
+  [JcFofHcCc2FDN99x] Maelstromic Destabilizer (Lesser)
+  [xsPP4JVf1NJX0s7u] Maelstromic Destabilizer (Major)
+  [P1DyjpDWtnMrXX1e] Maelstromic Destabilizer (Moderate)
+  [8uyRlAkWdEyfOziq] Mage Bane
+  [UJWiN0K3jqVjxvKk] Magic Wand (1st-Rank Spell)
+  [vJZ49cgi8szuQXAD] Magic Wand (2nd-Rank Spell)
+  [wrDmWkGxmwzYtfiA] Magic Wand (3rd-Rank Spell)
+  [Sn7v9SsbEDMUIwrO] Magic Wand (4th-Rank Spell)
+  [5BF7zMnrPYzyigCs] Magic Wand (5th-Rank Spell)
+  [kiXh4SUWKr166ZeM] Magic Wand (6th-Rank Spell)
+  [nmXPj9zuMRQBNT60] Magic Wand (7th-Rank Spell)
+  [Qs8RgNH6thRPv2jt] Magic Wand (8th-Rank Spell)
+  [Fgv722039TVM5JTc] Magic Wand (9th-Rank Spell)
+  [I2FmQuFJiJYmsTUd] Magical Lock Fulu
+  [XLJc4GDQmeAv1cmG] Magnetic Suit
+  [R8FHP4u80ee7PgWa] Magnetic Suit (Greater)
+  [hlXXODDYeRzWuPCK] Magnetic Suit (Major)
+  [gMjoALuwSUdTmqqZ] Malleable Clay
+  [TKOe8epJTCef87Bj] Malleable Mixture (Greater)
+  [p0TKEjVqYFZmfz6v] Malleable Mixture (Lesser)
+  [q07Ej07uIsKx5zab] Mana-Rattler Liniment
+  [oplQpQSTyTvHDDtq] Marking Snare
+  [WzsKbMMewXbf1nws] Marvelous Miniature (Boat)
+  [24hmJWXhSmfVebEE] Marvelous Miniature (Campfire)
+  [Dn2KQgIeWNijaUzL] Marvelous Miniature (Chest)
+  [TknN7T2RDy9cUtKU] Marvelous Miniature (Horse)
+  [3cWko20JPnjeoofV] Marvelous Miniature (Ladder)
+  [AB9MZTjKQMTBXyi4] Marvelous Miniature, Swift Sparrow
+  [jIlFuZaIgMPEzoyP] Matchmaker Fulu
+  [ylUdMTsfOQGJ3MN3] Matchstick
+  [byFW6sILekJaPERu] Material Essence Disruptor (Greater)
+  [wu9cqBx65txvAODd] Material Essence Disruptor (Lesser)
+  [omWrYy6RY9rxeF50] Material Essence Disruptor (Major)
+  [rfU6tyzEadCXHSSN] Material Essence Disruptor (Moderate)
+  [5lhQ79p0Z3j1VsY3] Matsuki's Medicinal Wine
+  [282vQmBPwx1sZIqp] Memory Ribbon
+  [oZBafUU1tk4tgwye] Mender's Soup
+  [JSmdTDUEGwHVbV7g] Mending Lattice
+  [tspcGx4OrZEv2gQX] Merciful Balm
+  [C8kQuf7gqpjEDmib] Merciful Charm
+  [aKbrBW1SnFDxya5J] Mesmerizing Opal
+  [NK0wjH9m32sjaeQe] Messenger Missive
+  [Kc4d504GnbS0NcoS] Messenger Missive (Multiple)
+  [dyvwp4EHgJDzVjJh] Metalmist Sphere (Greater)
+  [llqztgP14IJGSxU4] Metalmist Sphere (Lesser)
+  [KgF3nPT2tEskXqSS] Metalmist Sphere (Moderate)
+  [thqCdyIkkPUl2N3Y] Midnight Milk (Experimental)
+  [L5cDsqIYsDsW7BKA] Midnight Milk (Pure)
+  [EX8Ta6J56SNrYbqJ] Midnight Milk (Refined)
+  [j0YMP7LLSzhBDsEB] Mighty Counterweight
+  [VqJuhN2Ba1DnrJNW] Mind-Swap Potion
+  [GMi5tw0cbMx3ZQPg] Mindfog Mist
+  [qsPCBxSDbXacCnMB] Mindmurk Oil
+  [FW1Ml15eeMItIxS2] Miraculous Paintbrush
+  [LPSSrlS1Op6l9Kn5] Mirror-Ball Snare
+  [mYfK7M3BhB57LmAl] Missive Mint
+  [04giYigfDL5geu5f] Mistform Elixir (Greater)
+  [GyO89RBVjAKFxsFm] Mistform Elixir (Lesser)
+  [Ax8XcBd0rRd1Z7hN] Mistform Elixir (Moderate)
+  [DZHV8R2908H2cVWM] Mistranslator's Draft
+  [YnhcVcTbXrVfiH83] Mnemonic Acid
+  [jdDDqv9LbEYX2wAE] Monkey Pin
+  [Sq4MIaXhb2zcCT6y] Moon Blossom Tea
+  [PPd89jN2a4rFoVHm] Moon Radish Soup
+  [fmoxVHQAAdkWCiK3] Moonkeep Hyacinth
+  [1jE0ICfi75fh5PZy] Moonkeep Lily
+  [FRDafjyewsEsUuTP] Moonkeep Orchid
+  [QyEp8sN9mn36K5El] Moonlit Ink
+  [Hh2qMYtJU4WTOUFC] Moonlit Spellgun (Greater)
+  [7VjM9vjBMxhukiTf] Moonlit Spellgun (Lesser)
+  [iYOBu0hMYzqFYvZN] Moonlit Spellgun (Major)
+  [wU8HH03cNxe6Pkfi] Moonlit Spellgun (Minor)
+  [LbgblC0CzbTWJTmC] Moonlit Spellgun (Moderate)
+  [bU41sQCtuZKkmezD] Moritype
+  [nw5PAxxVQOKihmNn] Moritype (Greater)
+  [58RUkhvWrdgqiC3c] Morph Jewel
+  [bc3orvzCjY28HeQi] Mortalis Coin
+  [g6NpdrVR56B2jI64] Mourner's Dawnlight Fulu
+  [Ap2Styg25sZMx3wn] Mudrock Snare
+  [hnBcuuzzrBT0L0CL] Mukradi Jar
+  [UnDjPxFOs6bldlcM] Mummified Bat
+  [YGaO4HyH6jn3P731] Murderer's Knot
+  [lzjx7KiuoaQuh025] Mustard Powder
+  [MZ5fWDqpKEMv2d1Q] Mutagenic Renovator
+  [VSHaRjuJF6A5CH0E] Mutator Onyx
+  [i5DbxSLYu0LE52CV] Mythotoxin
+  [rpyBAmS3jeJdYsbz] Nap Gas Dispenser
+  [MbPboT76BBKVGepB] Nauseating Snare
+  [KG3sg9YF3sQL8lsP] Navigator's Feather
+  [UUriyvai2k6COWpS] Necrobinding Serum
+  [cDyoBhYeAMkCmjiP] Necrotic Cap (Greater)
+  [sUZxDEiwCKiMpN7T] Necrotic Cap (Lesser)
+  [CM3GrNvvZBdPmxe5] Necrotic Cap (Major)
+  [Oxai9zyjeocPNUzO] Necrotic Cap (Moderate)
+  [ukTlC4G83aVQEg7u] Nectar of Purification
+  [WETEtFdpuXa1c7Zc] Neophyte's Fipple
+  [Wjkw0lEUOhypYvzo] Nethershade
+  [Ga6uMdVOSpYIJyvS] Netherwalk Incense
+  [KdeeRCrtsDCJLfgc] Nettleweed Residue
+  [dEU38O24zT6JCfEZ] Nevercold
+  [smPuKlJLRyoYaDpR] Nevercold (Compressed)
+  [aMXCMLI3spk0d7tq] Nevercold (Refined)
+  [dRi775Uhzqgn7aBs] Nightmare Salt
+  [X6vNtRjyHIuN7vqj] Nightmare Vapor
+  [hH63OWEVoMEr4ypr] Nightpitch
+  [NLUsrnvQsYK0CYp3] Nimbus Breath
+  [bqbCL8ZTeAa9EfcR] Noisemaker Snare
+  [0GY1BYECGqz6YJ88] Noxious Incense
+  [EDjJy68ZFLu57ldN] Noxious Incense (Greater)
+  [wuVD3kolQaFAEeBK] Numbing Tonic (Greater)
+  [7D6ENmL3mRfUOMwf] Numbing Tonic (Lesser)
+  [EAgWYY1C4mDRfwqo] Numbing Tonic (Major)
+  [V35j3JEJMUbuJZNX] Numbing Tonic (Minor)
+  [WnJwPbObxmTNvYJy] Numbing Tonic (Moderate)
+  [7VDf5tQKh01XV6HQ] Numbing Tonic (True)
+  [zC7LipQPHRYw2RXx] Oak Potion
+  [QD5rDuk0OHadPGuh] Obfuscation Oil
+  [5hGJ6CZi0A9OjMd4] Oblivion Essence
+  [etgPdPhPviKkaFO8] Octopus Bottle
+  [igJxUzuMlYdrwSU2] Octopus Potion (Greater)
+  [QWKDGY62Buq9dryf] Octopus Potion (Lesser)
+  [0jhX5ibOIt77UmPP] Octopus Potion (Moderate)
+  [jnw6iyevvDSISGsn] Ogre Spider Filament
+  [Du05UxCyCM0ZWH8z] Oil (1 pint)
+  [KVrmsNbro6mJ9wuT] Oil of Animation
+  [Ja0KlgXV8DsOEkif] Oil of Corpse Restoration
+  [C0kSU5KWMzLngvTa] Oil of Dynamism
+  [EP8f2NL28vPlmX7k] Oil of Dynamism (Greater)
+  [1DHjXJEdJ7GlGSzg] Oil of Keen Edges
+  [QN8UIz0nMcnLUWHu] Oil of Mending
+  [3TxupnJlz7qXfdIr] Oil of Ownership (Greater)
+  [6XMuLT5QKkoznKz9] Oil of Ownership (Lesser)
+  [dUREATQUwEOGiV13] Oil of Ownership (Moderate)
+  [j2CHumvbjmlLQX2i] Oil of Potency
+  [PLuJEzJWaWamW0Fc] Oil of Potency (Greater)
+  [B9NVsgy2jvd6sJID] Oil of Potency (Major)
+  [IZRfgOYlZ3HRBkYX] Oil of Repulsion
+  [o9k5L682AlZfhpRu] Oil of Revelation
+  [yUPRtHCpAPx3EBUq] Oil of Skating
+  [TZJKwkvJD4NGXCG8] Oil of Swiftness
+  [RhOx5wenvlljzOku] Oil of Unlife (Greater)
+  [BSInwFNVBVkfFK0B] Oil of Unlife (Lesser)
+  [obER4cKi8UbGhSg7] Oil of Unlife (Major)
+  [fTQ5e4utVfgtXV1e] Oil of Unlife (Minor)
+  [YHev1WJ2tOiTBg9o] Oil of Unlife (Moderate)
+  [6DmHDtIsGzH1s5JO] Oil of Weightlessness
+  [Ru4xaA4kjdZ4IFS5] Oil of Weightlessness (Greater)
+  [xAEbIQTNonVjCg38] Oily Button
+  [MBL8rOfvokYmUvwc] Olfactory Obfuscator (Greater)
+  [R0gsYr0jD1giTzpx] Olfactory Obfuscator (Lesser)
+  [I1GapZnTPSlbvX2Z] Ommatophoric Mutagen
+  [tnCKwIsRsKj3FtG6] Omnidirectional Spear Snare
+  [VdHD6t20H081MKJQ] One Day's Breath
+  [25Otz4JdRm7Dus6N] One-Hour Flower
+  [0aSdDSjJ5sMzBz1U] Onyx Panther
+  [hKed91BOXjyaNG3x] Oozepick
+  [HwWrR4CG3Fe7QZrO] Oozepick (Greater)
+  [gM1ZYvJacCdZsWo0] Orchestral Brooch
+  [npSWkkSsQfiKixPO] Origin Unguent
+  [98KlJPs0tPFq4qKv] Overloaded Brain Grenade
+  [mAgIN0A0ywnhtefw] Owl Screech Egg
+  [JkQsRx2vwFqLLJmm] Oxygen Ooze
+  [m16rhrqO81674IxV] Pale Fade
+  [vLBXDJfFvXAkuCYc] Pallesthetic Mutagen
+  [LRSiYsgEz3e0PEwX] Panacea
+  [9WenEIQrBV8POQU1] Panacea Fruit
+  [V3qaNCEFpG0dCFl5] Panaceatic Salve
+  [qzT0myaHAiSqnwWW] Parchment of Secrets
+  [Cz0XxRVMma7cllCd] Peace in Dreams Tea
+  [yO0CjTBpv5O9HhTJ] Peacemaker
+  [GiiBkaa5JaJ5msPS] Peachwood Talisman
+  [kE9wXSAAATbqB5AU] Penultimate Heartbeat
+  [KlI5oBAsPCL5OyH5] Pepper Poultice
+  [00p14e3pfEMBB1Xq] Perfection's First Step
+  [kO31GgqGY37MDRff] Periscopic Viewfinder
+  [j08PcMwLhz7lWY3M] Persistent Lodestone
+  [awavOTGutIrLRQyq] Phantom Roll
+  [xBf7GSdt555t7IAm] Phasing Trine
+  [p2bU2w6qbtgrBchc] Pheromone Flare (Greater)
+  [5QuImSHXH5QTDju1] Pheromone Flare (Lesser)
+  [1AxZlZmCuOK3NtVs] Pheromone Flare (Moderate)
+  [Fv97oB3iEIFAyzTu] Philosopher's Stone
+  [aEiop0DEVm4WpkPx] Philter of Empty Dreams
+  [po3Lhiccc0RQYikr] Phoenix Cinder
+  [xAoRfG7uxFFjOHoT] Phoenix Flask
+  [ymSbtkmW9xg9kWyN] Piercing Whistle Snare
+  [dpm95A5WroXlGMbG] Pinpoint Arrowhead
+  [bRqczrlQDaeUvg6b] Plasma Hype
+  [YeF05oItxHNdOi6z] Poison Barbs Snare
+  [D8i3OBVMkxmCCREV] Poison Fizz (Greater)
+  [XdHMroAomWalt7I9] Poison Fizz (Lesser)
+  [GDbDpe7W7vOEwnEr] Poison Fizz (Moderate)
+  [GWTSMcXocmUsNLmN] Poison Sedum
+  [7tweUS8kQ6N45fEu] Popdust
+  [igqlI1SbRPrXMtLT] Poracha Fulu
+  [XYweIphfMqFeEo7D] Portable Seal (Lesser)
+  [VGQ18qI1Y8sLORuG] Portable Seal (Major)
+  [OfIhe6Fa6J4ZfZeL] Portable Seal (Moderate)
+  [ZCsksGf6NPUKz2Uw] Potency Crystal
+  [aSRUX4WGfalK4A5J] Potency Crystal (Greater)
+  [9a7nJAErs4dfetFJ] Potency Crystal (Major)
+  [VbVw8IDiYczzbIHt] Potion Patch (Greater)
+  [pSAnfP76xGS9aVec] Potion Patch (Lesser)
+  [hdxm6sdXLzI7ozul] Potion Patch (Moderate)
+  [vDgDrbSoGuiUIz2R] Potion of Acid Resistance (Greater)
+  [u1gZaIZHnEfZDc1o] Potion of Acid Resistance (Lesser)
+  [yG6Za8FaG3hpXUGh] Potion of Acid Resistance (Moderate)
+  [jVmTtUeNxDZMP5dU] Potion of Acid Retaliation (Greater)
+  [omRmCbkQoK5YmCGv] Potion of Acid Retaliation (Lesser)
+  [fabw5fDuaTMUF0tb] Potion of Acid Retaliation (Major)
+  [apGQcVMSRprFEeKt] Potion of Acid Retaliation (Minor)
+  [OWPOTwMsrYma9d0v] Potion of Acid Retaliation (Moderate)
+  [J5LsHDGEv4CVN7vr] Potion of Annulment (Greater)
+  [a46f60lt7NEUvNEy] Potion of Annulment (Lesser)
+  [4B8jRW7jGybSlovV] Potion of Annulment (Moderate)
+  [VZmUrseCZs9xMaxt] Potion of Cold Resistance (Greater)
+  [mRs24OwmGPjoIDvO] Potion of Cold Resistance (Lesser)
+  [evdDpgFpiFZt9UyA] Potion of Cold Resistance (Moderate)
+  [tW2rmGSanKQlUkiU] Potion of Cold Retaliation (Greater)
+  [Uq3rnsAHbLKyW49E] Potion of Cold Retaliation (Lesser)
+  [bCPAiqiWmH7pVxNE] Potion of Cold Retaliation (Major)
+  [zExWH2EsY9STTORq] Potion of Cold Retaliation (Minor)
+  [M6pES1Nck1S6SWX9] Potion of Cold Retaliation (Moderate)
+  [ThX0ntpTqonGqguT] Potion of Disguise (Greater)
+  [QNub2kTE7LpdMPII] Potion of Disguise (Lesser)
+  [25Rr05SIfTj0GA31] Potion of Disguise (Moderate)
+  [F8vrGctUqYIEkKOz] Potion of Electricity Resistance (Greater)
+  [cAyxcRSSnfscGyMa] Potion of Electricity Resistance (Lesser)
+  [MHoghQhxbvZRyyaB] Potion of Electricity Resistance (Moderate)
+  [QsYfjRMBz48H6UAp] Potion of Electricity Retaliation (Greater)
+  [TG4SnQCGOsgQfrE1] Potion of Electricity Retaliation (Lesser)
+  [bEaiID2KLQ8lTCai] Potion of Electricity Retaliation (Major)
+  [w0S1SIRsHgGdRh1d] Potion of Electricity Retaliation (Minor)
+  [oDfucsKeWpJmmWN1] Potion of Electricity Retaliation (Moderate)
+  [jTfacZ4SRuQd7Avh] Potion of Emergency Escape
+  [1OJxRnPs0viJVrZq] Potion of Fire Resistance (Greater)
+  [bDnk4TSzvD5BQmE5] Potion of Fire Resistance (Lesser)
+  [m99u0zXVbyPdK8Mf] Potion of Fire Resistance (Moderate)
+  [hMUYvp0neF0LAFqc] Potion of Fire Retaliation (Greater)
+  [67KiGZtoTMbl7nv2] Potion of Fire Retaliation (Lesser)
+  [TalLb1YlvXzutuPc] Potion of Fire Retaliation (Major)
+  [ugIxgGIkJh2aXE2N] Potion of Fire Retaliation (Minor)
+  [AgBIZtwciSsCZeNN] Potion of Fire Retaliation (Moderate)
+  [E999hL7XlAlfZhjK] Potion of Flying (Greater)
+  [KlJSw919hpN6V9oK] Potion of Flying (Standard)
+  [27aqRraefLK7x7m3] Potion of Grounding
+  [rzEQvcWfhR3T4FNd] Potion of Leaping
+  [PTSdJqjiybZDxi4r] Potion of Minute Echoes
+  [2n8vqBGfqrBt4FZp] Potion of Passing Fancy
+  [kORpovlPYicysr2g] Potion of Quickness
+  [ywYt2SyZaV95KcZH] Potion of Resistance (Greater)
+  [V2TUEoiDwJ125qzN] Potion of Resistance (Lesser)
+  [dzfmP3WsA15puenS] Potion of Resistance (Moderate)
+  [ezSqiHhz2OYTzoF2] Potion of Shared Life
+  [jlFx4JIBKJuaINpv] Potion of Shared Memories
+  [GcllrP56XWEsYQ4j] Potion of Sonic Resistance (Greater)
+  [eSHX07MqMT4SM1zY] Potion of Sonic Resistance (Lesser)
+  [kbjspHV7kwKKULmd] Potion of Sonic Resistance (Moderate)
+  [cEfqMV1lFaT7s0QC] Potion of Stable Form
+  [KOWn72lufGfszQXr] Potion of Stable Form (Greater)
+  [Eb4dEuV22QVlMumS] Potion of Swimming
+  [OMJgFmy3jut79Iaj] Potion of Swimming (Greater)
+  [drxEWZl8mqMOZ23E] Potion of Truespeech
+  [UblsH5cGyUdXypek] Potion of Undetectability
+  [WQhnfj1LbrEzvh8z] Potion of Water Breathing
+  [UZGfofcq560tw43N] Powder
+  [pErNGR7u7SJDq1o0] Practice Target
+  [qoM7Va5GqcLLBzgu] Predator's Claw
+  [ebpO5kKJBEvbZQrQ] Preserved Moonflower
+  [qoyelABKtk9DRSEk] Prey Mutagen (Greater)
+  [60DuFyGQoZhPj4To] Prey Mutagen (Lesser)
+  [fiBThkOOXEdcTSMf] Prey Mutagen (Major)
+  [JiMljGYKx60DHs8O] Prey Mutagen (Moderate)
+  [xKVtAqqVUPWjKFBJ] Primal Pollen
+  [m9SJD8XUZ4IV7c3F] Prismatic Dust
+  [pDbWjlhIoQpUIvLb] Privacy Ward Fulu (Chamber)
+  [UaSVmCl0JQ76kiYY] Privacy Ward Fulu (Hallway)
+  [PfVTTuTsErku7vss] Privacy Ward Fulu (Room)
+  [eOUZqtwBKdXagplE] Psyche Salts (Greater)
+  [ue0MB4HnIQ9iCwWb] Psyche Salts (Lesser)
+  [aQ2PgxzGbqU5rKx9] Psyche Salts (Moderate)
+  [KsAygNRyR2FdwuOm] Psychic Colors Elixir
+  [hoX2sJiYtJrSp6BH] Psychic Warding Bracelet
+  [VnUXcWG4xWGcb7sc] Pucker Pickle
+  [mtfdonWkYLj0BuW3] Puff Dragon
+  [m1XubXwbBy3JzMkY] Pummel-Growth Toxin
+  [aVW5OAwSlz5rsjtB] Pummeling Snare
+  [3Byr7YKaNlZl474Y] Puppetmaster Extract
+  [IouqNbVVqt2oJDri] Purple Pepper Powder
+  [BxzwmwQ5O4fewa4w] Purple Worm Repellent
+  [TSbuKm91qmqdqQW3] Putrescent Glob
+  [8ijfXMMKWeUp6yoO] Putrid Sack of Rotting Fruit
+  [iSwJvnJ6LuoQUi8f] Pyrefeather Token
+  [6CnuU7AhzzAMGzAM] Pyronite
+  [JPGOrHeYxjdnUogT] Qat
+  [8RcvD4xTCKpsJBLj] Quartz-Coil Rail Transport (Greater)
+  [KFCXhqEAEMN7IH6p] Quartz-Coil Rail Transport (Lesser)
+  [iVhkA8bpG2phbb0Q] Quartz-Coil Rail Transport (Major)
+  [2JrQLWnVE4DrOLUE] Quartz-Coil Rail Transport (Moderate)
+  [WyOF9Zy2FHtZsCa7] Quenching Potion
+  [jUiva1MoZDtbi6xI] Quickmelt Slick (Greater)
+  [ENAlE5JV00GFkGjb] Quickmelt Slick (Lesser)
+  [8D71bv2HsX29ZtwC] Quickmelt Slick (Moderate)
+  [iNR6t5dDiYGQYTeA] Quickpatch Glue
+  [eQDTsetadI8u8Kc0] Quicksilver Mutagen (Greater)
+  [5MKBwpE401uz4kNN] Quicksilver Mutagen (Lesser)
+  [4GXzTN6iSDGfYEAi] Quicksilver Mutagen (Major)
+  [n52BSbZsnx4Vmt2p] Quicksilver Mutagen (Moderate)
+  [iq7hL6HDsPCPU4pt] Rainbow Vinegar (Greater)
+  [NVssWHKyKlaRmHog] Rainbow Vinegar (Moderate)
+  [rOicLo9vsSWCUSLu] Raining Knives Snare
+  [3Wb0N7iqmTn6e2Xc] Ration Tonic
+  [EkC2W5A5fohoIKSd] Ration Tonic (Greater)
+  [L9ZV076913otGtiB] Rations
+  [owOmSBSeNZ8Lp859] Reactive Flash
+  [ehd8FIXgo4S24TKV] Reaper's Shadow
+  [vjwdfXDWSe7L3zwl] Reaper's Spellgun
+  [nYFnlWTNS6s7EcyF] Rebirth Potion
+  [tEI0hGZyPWYwVhJU] Rebound Fulu
+  [1Nez8K5C4fwgFrTz] Recording Rod (Basic)
+  [jrLgEJxPvUKtSMMO] Recording Rod (Reusable)
+  [guUmnzyZVuzJO9oD] Recovery Bladder
+  [Bn1o5foPq1kqZKf0] Red Dragon's Breath Potion (Adult)
+  [d2sU6nOtBdIVJMVI] Red Dragon's Breath Potion (Wyrm)
+  [fkGHYeGVK6O2VW1s] Red Dragon's Breath Potion (Young)
+  [fpqYMeX0GXvTSlVQ] Red-Handed Missive
+  [Wyh13xRaOL57fve7] Red-Rib Gill Mask (Greater)
+  [x4QLLKEShYqUjCCn] Red-Rib Gill Mask (Lesser)
+  [J7ZoRlhqiP6988t2] Red-Rib Gill Mask (Moderate)
+  [Vy3z2cIQ8uJRUMYw] Refined Pesh
+  [mWOxG8asXbjCRVG9] Reflected Moonlight Fulu
+  [cRtDr8WhXhxkGrmx] Reflecting Shard
+  [MpyuCFBQwbOQhhm0] Reflecting Shard (Greater)
+  [5koINU0dy5nPL8Cg] Rending Snare
+  [ws3OXRgAawwYIKK6] Repulsion Resin
+  [M7lC4RUuPlx2I8fP] Restful Salve
+  [UtT7TVT7M6uJTlJH] Restful Sleep Fulu
+  [qyjaueXduvCUeDbp] Resurrection Tea
+  [HVPbv5n2e1vcT9Ug] Retrieval Prism
+  [xK3rWA6HtaJvKSuC] Retrieval Prism (Greater)
+  [5OiGlKiNFKlcP4k1] Revealing Mist (Greater)
+  [F5LJiS0wcwSqRrQ9] Revealing Mist (Lesser)
+  [fTpJc3XoC2gzhuSN] Reverberating Stone
+  [FJw54ZPLuJpChJbe] Reverberating Stone (Greater)
+  [D2h1E7fXsQfyjFcv] Rhino Hide Brooch
+  [m6oNZUSSWYMnk7ii] Roaring Potion (Greater)
+  [oYjlcrarrZoA01D0] Roaring Potion (Lesser)
+  [Vm0xyg3xE4iMq3V3] Roaring Potion (Moderate)
+  [jg3gsPDcrA5xUogf] Roc-Shaft Arrow (Greater)
+  [7pHKxibsckGy220n] Roc-Shaft Arrow (Lesser)
+  [wzZbMIlvKbAwaYC0] Roc-Shaft Arrow (Moderate)
+  [DnFmNx99xYsYxNfO] Rock Ripper Snare
+  [D2iSFSgRq2jSov76] Rose of Loves Lost
+  [pXV4ov0DJHzIHSEW] Rovagug's Mud
+  [aMbJl8eTV3Ri5O6e] Rovagug's Mud (Greater)
+  [kksRfBsWEPYt8jpN] Ruby Capacitor
+  [P3EL4ntkd5InC3YB] Ruby Capacitor (Greater)
+  [PFr49j091jjb8363] Ruby Capacitor (Major)
+  [j77uu6eFlsYoZApx] Ruby String
+  [p070A88bOm8gi0sS] Runescribed Disk
+  [ev3F9qlMNlNdCOAI] Runestone
+  [fRVCVfoV8KzmZsKs] Rust Scrub
+  [NXYEgMq4ERIzbJKx] Rusting Snare
+  [V7UcnQ0cXh1QSwo6] Saboteur's Friend
+  [nrAaCGSppPhPxOj3] Sack of Rotten Fruit
+  [wXFSigsdLO8zjgXo] Sage's Bloom
+  [ktRGlgegUBZcr0aJ] Saints' Balm
+  [BYl1jXHOpDJVYsvY] Sairazul Blue
+  [4l3NyEhXW6nct5cN] Sakura's Sprig
+  [ZEKmCg8K2hUHbmnT] Salve of Antiparalysis
+  [ybu2BMu2oWj74wl8] Salve of Antiparalysis (Greater)
+  [vmsKlURWyWTGoO6o] Sanctified Beans
+  [se2g3LNsmQSsRv9w] Sanguine Mutagen (Greater)
+  [VIHsu1q3078gdQut] Sanguine Mutagen (Lesser)
+  [vmwrU3lz1HFfadAS] Sanguine Mutagen (Major)
+  [pP7RqEkNYg5ayWqx] Sanguine Mutagen (Moderate)
+  [gi1zuwWrwcW7OKlK] Sanitizing Pin
+  [hyZQx9PlWgmF9RAw] Sargassum Phial
+  [qeTWg0TWw9CwMKCO] Savior Spike
+  [mQSV1gq64kKeAfuN] Scarlet Mist
+  [SlQ6KsMUnmG6FhtW] Scholar's Drop
+  [8BDBsf55gP0UW07Y] Scour
+  [o1XIHJ4MJyroAHfF] Scroll of 10th-rank Spell
+  [RjuupS9xyXDLgyIr] Scroll of 1st-rank Spell
+  [Y7UD64foDbDMV9sx] Scroll of 2nd-rank Spell
+  [ZmefGBXGJF3CFDbn] Scroll of 3rd-rank Spell
+  [QSQZJ5BC3DeHv153] Scroll of 4th-rank Spell
+  [tjLvRWklAylFhBHQ] Scroll of 5th-rank Spell
+  [4sGIy77COooxhQuC] Scroll of 6th-rank Spell
+  [fomEZZ4MxVVK3uVu] Scroll of 7th-rank Spell
+  [iPki3yuoucnj7bIt] Scroll of 8th-rank Spell
+  [cFHomF3tty8Wi1e5] Scroll of 9th-rank Spell
+  [mWXaROc9ytjdGVVP] Scything Blade Snare
+  [i4D4B7tpYv9vMvQY] Sea Touch Elixir (Greater)
+  [zcJgT5RS8p2MEbOB] Sea Touch Elixir (Lesser)
+  [2hc1EEcb3pfr7Hac] Sea Touch Elixir (Moderate)
+  [bImVngTkDNsdWIjr] Searing Suture (Greater)
+  [dymL1IbxU5zR9fqo] Searing Suture (Lesser)
+  [hYNKpzgUbHHyvh5t] Seed Pod of Rooted Wisdom
+  [CwFqyOn3h5aFdF8V] Seeking Bracelets
+  [g91dodJKrkQ2gCA6] Self-Immolating Note
+  [KQfx4Ae8c3iMlwXM] Sense-Dulling Hood (Greater)
+  [YoYqtOXWo5reE2ql] Sense-Dulling Hood (Lesser)
+  [qJMcnWmzColtya0Z] Sentry Fulu
+  [Yej7lnnDYDZybGqo] Serene Mutagen (Greater)
+  [bOPQDM54W8ZDoULY] Serene Mutagen (Lesser)
+  [ccrdVliTNBh2mNZf] Serene Mutagen (Major)
+  [XEYveTvLH1lJ4jeI] Serene Mutagen (Moderate)
+  [TaC5Eln00j3PMyiu] Serene Smelling Salts
+  [BnYABzPAgdU89nLk] Serpent Oil (Greater)
+  [K6D2Ld8Md6PVsAaV] Serpent Oil (Lesser)
+  [VTuKWBEGuBS3HqF4] Serpent Oil (Major)
+  [l2M9P6kI3z3xPBOa] Serpent Oil (Moderate)
+  [1DmcPUZERWeKpiMM] Serpent Oil (True)
+  [9ignmYCACjfzkxDQ] Serum of Sex Shift
+  [zFYyegCfUlyCJhgu] Server's Stew
+  [20fPmTHmGRyYXIgm] Setup Snare
+  [cvkKe1FUVW9kOKcC] Seven-Color Raw Fish Salad
+  [B3zoAu9NpUEHGe22] Seventh Prism (Pentagonal)
+  [zAfSy6fshSGUtYF6] Seventh Prism (Triangular)
+  [zAlDcTlvCd3MxXmI] Shadow Ash
+  [aV7OJjzuh6zVDCx2] Shaping Sweet
+  [Tj4uaNw2lgevxGl7] Shark Tooth Charm
+  [EWujUs3YmlBu2jhm] Shielding Salve
+  [ZiD7kDxU4KEkO6XH] Shimmering Dust
+  [UfoaNXFA7AWZiXxI] Shiver
+  [HTH445aey1x9RoeG] Shockguard Coil
+  [sM0Cbkn8cQN4pUsp] Shortbread Spy
+  [ulGv1u9BAqRYYe4H] Shrapnel Snare
+  [LhlsZogLBPLx5Tcf] Shrieking Skull
+  [lAmwzpbGaARQ2eP4] Shrine Inarizushi
+  [FqbDpztscJfM4XMe] Shrinking Potion
+  [5xsfj30uXMKINxnk] Shrinking Potion (Greater)
+  [xvJ2jzqipBNrwZ2w] Sightless Tincture
+  [XcD8p1o71tPohZWT] Signaling Snare
+  [XWO5pMQcYNybqWzf] Silver Crescent (Greater)
+  [Pjxotvrj7uXe92Qc] Silver Crescent (Lesser)
+  [2wV9SHAWbC4rUlcc] Silver Crescent (Moderate)
+  [t9wFCiFkCRcSLtaG] Silver Dragon's Breath Potion (Adult)
+  [PW3H8TnouiLaTC8G] Silver Dragon's Breath Potion (Wyrm)
+  [LKwI47eeJC0Y4hGu] Silver Dragon's Breath Potion (Young)
+  [8fbsKEEbZ0CfBMIr] Silver Salve
+  [9EVzmy4dY9LpUgyC] Silver Tripod
+  [Xd96IsYFLmjWnWHk] Silvered Marp Fur
+  [uggpIk6vguWFXVli] Silvertongue Mutagen (Greater)
+  [YwRAHWW8yUI07sy9] Silvertongue Mutagen (Lesser)
+  [uD5vRYVOXNJ53sEE] Silvertongue Mutagen (Major)
+  [lIExlUFBKvBue8hb] Silvertongue Mutagen (Moderate)
+  [NhCFZ043brhFTsni] Singing Muse
+  [6odVabL0WL2H89Ic] Sixfingers Elixir (Greater)
+  [JAOWw2GhupaYoYg9] Sixfingers Elixir (Lesser)
+  [ieVRS2BjiWqauly6] Sixfingers Elixir (Moderate)
+  [SjbenbdzV4rgGxZP] Skeptic's Elixir (Greater)
+  [eHVZBmtzEcnsHSk8] Skeptic's Elixir (Lesser)
+  [xGmX6Vuuhivyal8v] Skeptic's Elixir (Moderate)
+  [FgAPV0iLE6R1QMJ5] Skinstitch Salve
+  [1GT08roPjKBbJ5lG] Skitter Knot (Greater)
+  [JZvkPv1Vj6mpSA9P] Skitter Knot (Lesser)
+  [R0CLbiSu4sst4Hf9] Skitter Knot (Major)
+  [9FwGY0X3v4ZksZH7] Skull Bomb
+  [keaNrIPYQYP02acm] Skyfisher Vapors
+  [uBWC2YHCeAz0WejP] Slayer's Stone
+  [fW6Wd9egnYdfwQw4] Sling Darts
+  [H2BqcfujumZVWF69] Slippery Ribbon
+  [JvpiniS6wTHsDoFX] Sloughing Toxin
+  [z7eOUqVwyht6tj11] Slumber Wine
+  [ehss8yPTXxiUdVlJ] Smoke Ball (Greater)
+  [MoBlVd36uD9xVvZC] Smoke Ball (Lesser)
+  [T6jPmGyInYATYOzr] Smoke Fan
+  [k1S8AdYhi5JGRLh1] Smoke Fan (Greater)
+  [AUHgdsygq9gaOZh4] Smoke Screen Snare (Greater)
+  [BJtpbzjSza4wUlQX] Smoke Screen Snare (Lesser)
+  [pF4ggWXiiNksDKsU] Smother Shroud
+  [4jjhUwHiEY2v8afe] Smuggler's Padlock
+  [j9G3tnrKQ1N1dLzN] Snagging Hook Snare
+  [xBZCVHAa1SnR8Xul] Snake Oil
+  [5KYn9J1Hj4IG3Z0X] Snapleaf
+  [po9gLNA6GjystED5] Snarling Badger (Greater)
+  [qnR646Oph1q88RNo] Snarling Badger (Lesser)
+  [0ySQli0JRrkZySOB] Snarling Badger (Moderate)
+  [1v1OK06JxdXn6MP4] Sneaky Key
+  [gB9Qp85rpuNtPVGx] Sneezing Powder
+  [WeiUTSRc17HLNehg] Sniper's Bead
+  [R9EZOG8Zeeo2RnwO] Sniper's Bead (Greater)
+  [e90XsQumDxHzqS7z] Sniper's Bead (Major)
+  [qnBpdjITfJFSO7T8] Soldier's Syrup (Greater)
+  [5AD7oDOGBd7CrqL5] Soldier's Syrup (Lesser)
+  [lgQK6qzBkEZOUr7k] Soldier's Syrup (Major)
+  [6VbMcDOjk4OHzEfx] Soldier's Syrup (Minor)
+  [Vnl0tgVKGKsqHvny] Soldier's Syrup (Moderate)
+  [4hJDqukTYPMZv2vg] Soothing Powder (Greater)
+  [OymrUAv6RGFaI1nm] Soothing Powder (Lesser)
+  [uCt7Kc2MXzRMc0GD] Soothing Scents
+  [Jgv2PAJic7LPoGQx] Soothing Toddy
+  [HIPkTfJLlLu4bWE3] Soothing Tonic (Greater)
+  [zA2UPGE9RYwlLPZJ] Soothing Tonic (Lesser)
+  [UeUPNFw600HEdDgF] Soothing Tonic (Major)
+  [RM7WoJYfd2edlNZ8] Soothing Tonic (Moderate)
+  [2n6BXtjZ7T6NJtXq] Spark Wafer
+  [JE2PATrlNNz23yaF] Sparking Pepper String
+  [AvbQWGCBZIOsK45X] Sparking Spellgun (Greater)
+  [Jc0OJe0fRDdHXXWu] Sparking Spellgun (Lesser)
+  [6UoPcaXO70MNyU6W] Sparking Spellgun (Moderate)
+  [hd8D1Dm6aVhMYpEL] Sparkler
+  [CeKPffF0FaEyhLMp] Spear Frog Poison
+  [OCTireuX60MaPcEi] Special Ingredient
+  [C0Zhu7Vwy9Aipwoh] Spectral Nightshade
+  [YScPBPwB4t9sydp0] Spell-Eating Pitch
+  [4p5yYuHRhr0bcwgE] Spellslasher
+  [FmD9KGFpKC5aEa2r] Spiced Demonade
+  [gza0CcZEYhPKIYEk] Spider Mold
+  [oOXvk18K4izaJzG7] Spider Root
+  [5RGNjhDxZ0yMhTds] Spider Venom
+  [ETLSXa4Po518z9Qx] Spiderfoot Brew (Greater)
+  [HuyWiPnkDZoAVhW9] Spiderfoot Brew (Lesser)
+  [L4Db3CncPcZFPzGN] Spiderfoot Brew (Moderate)
+  [3V2U720YhW2nyGVx] Spike Snare
+  [AeL8qd4hqaNN5MxP] Spirit Bulb
+  [w492F18MtpqNu2X7] Spirit Bulb (Greater)
+  [p7kWhbRrUCbMzd7A] Spirit Bulb (Major)
+  [uy2U0qftoOEOpygw] Spirit Snare
+  [x6V1tlDDBTVj5XnW] Spirit Trap
+  [9FiSGqe8s8531Tyh] Spirit-Sealing Fulu
+  [NQvLv4qcTfK21y3H] Spirit-Sealing Fulu (Greater)
+  [EMviiUBFb5hB1X5Q] Spiritsight Tea
+  [mMP0ycsdW2nLlCeO] Spiritual Warhorn (Greater)
+  [9MpwTXDxblLFgx2J] Spiritual Warhorn (Lesser)
+  [NfMteX8WWC5mxc52] Spiritual Warhorn (Major)
+  [TWSdWjp6dpodZkeV] Spiritual Warhorn (Moderate)
+  [Ary0uHNPkoFHX40N] Sportlebore Capsule
+  [qaAQnuLVia6vS1LU] Spray Pellets
+  [0QiHkpL9mFwNU0Ts] Spring-Loaded Net Launcher
+  [IOurUQgkm7oKnyrt] Sprite Apple (Chartreuse)
+  [Lbe9L9ZDBJgjDIhT] Sprite Apple (Golden)
+  [3AjyXlvLUx4c2RCi] Sprite Apple (Pink)
+  [EeqvTTUpqHobTs6u] Sprite Apple (Teal)
+  [0Lz5mlbB6QTZIYLf] Spun Cloud (Black)
+  [PEjGV24mOK5gPPPS] Spun Cloud (Blue)
+  [9BNMhEZ2ztFtu2WU] Spun Cloud (Green)
+  [qDvsHszooFbPAqlN] Spun Cloud (Red)
+  [a05LWc1gKq0NwRfs] Spun Cloud (White)
+  [RLkHxGBbVRAT6AOL] Stage Fright Missive
+  [RcVJ30230zAeLILV] Stalagmite Seed
+  [s9dtRS2SRTqzGdOF] Stalker Bane Snare
+  [LDiF0GRYAiW2mool] Star of Cynosure
+  [pbsrb7FMMHQBd5CO] Starsong Nectar
+  [b2t3kttZipvg826A] Static Muscular Relay
+  [66EBP5Ii9QMlZdDx] Static Snare
+  [hWXRen2x3kBxeYlh] Statue Skin Salve
+  [KaUMLt7iYTmCLby3] Steadfast Sentinel
+  [cqTCg6C0lvYUKQmx] Stone Body Mutagen (Greater)
+  [5ftFTiKY0BMvhzL9] Stone Body Mutagen (Lesser)
+  [FZ6SMwiei6NnEp3e] Stone Body Mutagen (Moderate)
+  [YcvSw7Zn3oyqlJaw] Stone Fist Elixir
+  [XPIsejlpyvHvR0Ma] Storm Breath
+  [NQuE19X1YMWjiWHl] Stormbreaker Fulu
+  [OCAwJ6CAqS0YkHCU] Stormfeather
+  [6KdYdFovFBivwI8M] Striking Snare
+  [s0btfYXKuufJhbyx] Stumbling Fulu
+  [a2XaerM1KkPyLIPM] Stunning Snare
+  [nn2HAN1XKkKHfVnM] Stupor Poison
+  [qwCefJjr7AJSqYay] Succubus Kiss
+  [P9dhnMcr3lbHBn2E] Sun Orchid Elixir
+  [1LKJvK9ofzIIkQX3] Sun Orchid Poultice
+  [pufVrJqj63H7kvAZ] Sure-Step Potion
+  [62HxCEDwhlZaeR0Q] Surging Serum (Greater)
+  [1TWHN8RbimPVXM0U] Surging Serum (Lesser)
+  [YIgIF1845n5UBFnE] Surging Serum (Major)
+  [yE7PPagK0wsHMA8l] Surging Serum (Minor)
+  [tslVf3qtQE7V1YvG] Surging Serum (Moderate)
+  [6P6lDnIxK7plyCEI] Swamp Lily Quilt
+  [4tnPWyApPZP1P1yO] Swift Block Cabochon
+  [Fgcc2OXLIKXWjbSp] Swirling Sand
+  [bvT6uMBD8MALvZAZ] Tailor's Boll
+  [knQ5MnAIvKdXSpcQ] Talespinner's Lyre
+  [pKQwOJsBAcNcXwe6] Taljjae Tassel
+  [LCw1mtusKGterDR4] Tangibility Resonator (Lesser)
+  [tJquEIyMHgbFEH9N] Tangibility Resonator (Major)
+  [Om6RqpjwuPINOepb] Tangibility Resonator (Moderate)
+  [76T49dJYfxIrPvQe] Tangle Root Toxin
+  [vp3Yr59O9dO9MDlb] Taper of Sanctification
+  [zJZ5DObRUdTk6HUL] Tar Rocket Snare
+  [aP6dJkd3pBNGXwiy] Tarantula Ampoule
+  [pvsJXFfbwGWhoG5N] Taster's Folly
+  [V3f0hQdWoWMWF5RU] Tatzlwyrm's Gasp
+  [gDGPvobJV1QGYBPy] Tears of Death
+  [hl9eFPC7YoeT1lgR] Ten Day's Breath
+  [ipaBbiROyAN4McWA] Tentacle Potion (Greater)
+  [pzUHY3C7JfmUgjuO] Tentacle Potion (Lesser)
+  [DFxyS72Uh2vqT2MZ] Tentacle Potion (Moderate)
+  [4AqxogIf4G5qZsq3] Terror Spores
+  [U5G4FXAUvtxhYLYj] Thawing Candle
+  [2Ub3nAwaQXyzyAbz] The Dancers' Song
+  [BB9ErvPViT4TtiYp] Theatrical Mutagen (Greater)
+  [kScHu3XS3XPvN9Db] Theatrical Mutagen (Lesser)
+  [Wv0ck7AMP0s0jIue] Theatrical Mutagen (Major)
+  [8rQ7HkUtSa8so0Et] Theatrical Mutagen (Moderate)
+  [s0iiOMicSe4EspMM] Therapeutic Snap Peas
+  [TzGABJvUoCJVmLlE] Thorn of Milani (Lesser)
+  [hkcRHApzlqRVhfEv] Thorn of Milani (Moderate)
+  [TXkHGUqvqIko7W9m] Thousand-Pains Fulu (Blade)
+  [vuJi1kahoCAHHTSX] Thousand-Pains Fulu (Burl)
+  [Pb0WOuCR34FYGmuy] Thousand-Pains Fulu (Icicle)
+  [7PhPuAFP4mQz9jDr] Thousand-Pains Fulu (Needle)
+  [aH5MLDdkZ7aJA7hP] Thousand-Pains Fulu (Stone)
+  [Im9LfiRTfAJxPvzS] Thousand-Pains Fulu (Void)
+  [xVK6dbAIUJqNFYoI] Thousand-Year Dragonroot
+  [1INJVAVazL6p4gea] Three Day's Breath
+  [TmXTijJIpOxLJLXb] Thrice-Fried Mudwings
+  [3GUiG3raeyIwW4av] Thumper Snare
+  [yUYr8j65fC7EN0NY] Thunder Snare
+  [sYTvRLIlhfUd1Dm5] Thunderbird Tuft (Greater)
+  [Led9ciHzpF8uPN6Y] Thunderbird Tuft (Lesser)
+  [xYJwgmn2Nmthztb7] Thunderbird Tuft (Major)
+  [ik15k2r6znOdguXo] Thunderbird Tuft (Moderate)
+  [zrZ1FaaqW6VIajj7] Tiger Menuki
+  [1YROvQsCdq8WFWRj] Time Shield Potion
+  [Ha6n30Tj3TNru9Dj] Timeless Salts
+  [0XUENeLPEG73uiP7] Tin Cobra
+  [mDNDs5P8ZAJXYbDL] Toad Tears
+  [ANQz5rzp5kKe7ul6] Toadskin Salve
+  [RuGGAFaTHMCC6chN] Toadskin Salve (Greater)
+  [dlaDnZFsy4JCYmEO] Toadskin Salve (Major)
+  [k5A8zFQuDtGqNnk5] Toothwort Extract
+  [axX8gAJvIGWrmHJ0] Toothy Knife
+  [A5pqQcVhPVtNc7Ol] Toothy Knife (Greater)
+  [PblDdXHm98XWs9ba] Topology Protoplasm
+  [nPWDuoe2PcgE0z2S] Torrent Snare
+  [xBZniAmkWcLfQ48d] Torrent Spellgun (Greater)
+  [0rxTsnAGYWYaQaMl] Torrent Spellgun (Lesser)
+  [zELyHWSfkD4yRUjZ] Torrent Spellgun (Major)
+  [G1YeBTz26wnL2Meo] Torrent Spellgun (Moderate)
+  [vHAetFCiVDxAPdPD] Toxic Effluence
+  [GNM1LvqENq8WqT9C] Tracker's Stew
+  [qSmhcV5NLzlBjfAz] Tracking Fulu
+  [LLz0OwCi13ZUQwhc] Transmuting Ingot (Adamantine)
+  [nQP4DaV2DihDZRmv] Transmuting Ingot (Cold Iron)
+  [UpTnJeRbeviJNAFA] Transmuting Ingot (Silver)
+  [5DiekAhNEjr6Vwi3] Traveler's Fulu
+  [NF8dWgLTxj8QRrmg] Treat (Standard)
+  [3nDKWIydNEfhJ8XJ] Treat (Unique)
+  [MobYbxEL4KgxVi63] Tricky Liniment
+  [wDhqRxuXPQfyD0eX] Trident of Lightning
+  [SWqzv0hYCIczICeR] Trip Snare
+  [CoMwPsQ8mPj5Evti] Truesight Potion
+  [HAEz4sSa6OH6C7Cs] Truth Potion
+  [hHsU2sRW47Rge8fU] Tteokguk of Time Advancement
+  [dIqIuqjPbIuh9TYn] Tusk and Fang Chain
+  [cw05uEofzYkHwv8p] Twig of Knowledge and Memory
+  [CnPEbCCfRE8MJmdz] Tyrant Ampoule
+  [gxnMdbLRgWsWyVGA] Unassuming Face Paint
+  [VJs47kgqu1ziZBRU] Undead Detection Dye
+  [px55EOmlMx8xtEgM] Unending Itch
+  [3YnHsf98MAe3lcdH] Unsullied Blood (Greater)
+  [605M9h4bMsNCQne6] Unsullied Blood (Lesser)
+  [62IVHZyHA6239PHe] Unsullied Blood (Major)
+  [FClD2GoWpq3qdPQl] Unsullied Blood (Moderate)
+  [9mXjEGJaESesndWh] Vaccine (Greater)
+  [nzeTcOyQmZNrurVF] Vaccine (Lesser)
+  [JZZmDY1IJmKcdR2D] Vaccine (Major)
+  [yi1iL9dbLDSr4NZd] Vaccine (Minor)
+  [HilBL7oeSSXqDor7] Vaccine (Moderate)
+  [KIkLIYOKBiwd7mNd] Valorous Coin
+  [dBevXop3G2P3PGjp] Vanishing Coin
+  [vR2EZPD9TcLrkBz6] Vanishing Shocker (Greater)
+  [l5V2Bbik0g6eLBUA] Vanishing Shocker (Lesser)
+  [zftpNNqFzlmeuWl6] Vanishing Shocker (Major)
+  [NnoESOFI359hAYjT] Vanishing Shocker (Moderate)
+  [HBlUlkSlIQ0NQA9N] Vapor Sphere
+  [IzniYBi8QYxHnffr] Vat-Grown Brain
+  [Ut6fuRkMsydWVlSb] Vengeful Demon's Tears
+  [097NJos0T8o7AMLi] Venomous Cure Fulu
+  [U0jReHtTNpb0eH58] Verdant Poultice
+  [CReWZjAd3szYQ6Mx] Vermin Repellent Agent (Greater)
+  [lgqyRmQ3GZbbxQsD] Vermin Repellent Agent (Lesser)
+  [C6v5p0ZtIUroYlU2] Vermin Repellent Agent (Major)
+  [WGbE7qAGw8O5yH07] Vermin Repellent Agent (Moderate)
+  [Oip645RjC5y57wFa] Violet Venom
+  [sjxhPujyv6rJJRWO] Viper's Fang
+  [avCckBXMRbzAudZG] Viperous Elixir (Greater)
+  [LmNp6og59w1KhlIX] Viperous Elixir (Lesser)
+  [HwDlOobl1bsTG5mA] Viperous Elixir (Moderate)
+  [2pfQkBdEfA5Fxuqg] Vital Earth
+  [u1ouo0mH0sS6QoGw] Void Fragment
+  [1gBkH409yTYM6jeZ] Void Salts
+  [DDsCScnV4QfWlfeF] Vulture's Wing
+  [MXVPJpqMloFlwGBL] Vyre's Bliss
+  [epES0Dpk4FqRmZEz] Wand Of Splintered Sorrows (Rank 2)
+  [6VLzI3shCnzDb5aG] Wand Of Splintered Sorrows (Rank 4)
+  [105IJO0JyDdj22xA] Wand Of Splintered Sorrows (Rank 6)
+  [ktWJ6Xx4B2AgPQ6n] Wand Of Splintered Sorrows (Rank 8)
+  [xlwcMtJTKpS6EkSw] Wand of Caustic Effluence
+  [Rhr6rkOwjFwCJV0T] Wand of Choking Mist (2nd-Rank)
+  [GL1C4vC6mmXFm25L] Wand of Choking Mist (4th-Rank)
+  [hgWCwA6Yfqiz9tyr] Wand of Chromatic Burst (4th-rank)
+  [0KaC1NryNfckdS7T] Wand of Chromatic Burst (7th-rank)
+  [OpEFPyX1jwuV7ljp] Wand of Clinging Rime (7th-rank)
+  [Z8o1V947lwkhPhzI] Wand of Clinging Rime (8th-rank)
+  [P112tFaNhgJrBhmu] Wand of Clinging Rime (9th-rank)
+  [oOtrCBGLqNLdiOuF] Wand of Contagious Frailty
+  [NmhKGflbT5NnKduz] Wand of Crackling Lightning (3rd-Rank Spell)
+  [oyjDCHscjcLhzall] Wand of Crackling Lightning (4th-Rank Spell)
+  [1SdtzFpjKIwuQ7Nh] Wand of Crackling Lightning (6th-Rank Spell)
+  [U28jkj5ZDl2drtEH] Wand of Crackling Lightning (8th-Rank Spell)
+  [WAYGyAaH7rtpX1y4] Wand of Crushing Leaps
+  [m3XmIRwYoGGxZQgu] Wand of Dazzling Rays (3rd-rank)
+  [cH5uD83e3hC9MEvZ] Wand of Dazzling Rays (4th-rank)
+  [CXjHjdGVlOoXeYpr] Wand of Dazzling Rays (5th-rank)
+  [OzChAzd0UR37bEOR] Wand of Dazzling Rays (6th-rank)
+  [YPBMrIvJOZ6zSZVm] Wand of Dazzling Rays (7th-rank)
+  [8QValKGj7oZKnqw1] Wand of Dazzling Rays (8th-rank)
+  [gv5IRHrmGoSu7Dzv] Wand of Dazzling Rays (9th-rank)
+  [bv1bQGFywtNkYWWD] Wand of Dumbfounding Doom (3rd-rank)
+  [80HjjtcTF6DS1w30] Wand of Dumbfounding Doom (4th-rank)
+  [xC4W6YAcu0rQFmgm] Wand of Dumbfounding Doom (5th-rank)
+  [W6QXdPS9d0eoBAuw] Wand of Dumbfounding Doom (6th-rank)
+  [SkBZG0AO2wpuKBLT] Wand of Dumbfounding Doom (7th-rank)
+  [UC7YCJmKbuau54fS] Wand of Dumbfounding Doom (8th-rank)
+  [FagkWG1cXRucHcQ6] Wand of Dumbfounding Doom (9th-rank)
+  [CKmIgVzlcN7g1YT4] Wand of Hawthorn (2nd-rank)
+  [ooaErd0DHZYju9rF] Wand of Hawthorn (4th-rank)
+  [uo6fVL0r0S1vM61n] Wand of Hawthorn (6th-rank)
+  [rZKiSwhCT5xkBVLy] Wand of Hawthorn (8th-rank)
+  [ZJ3ahspZOXL4CK4J] Wand of Hopeless Night (2nd-Rank Spell)
+  [9ftc8XfloerPcJnI] Wand of Hopeless Night (4th-Rank Spell)
+  [xTcQPSZlZ231gPWk] Wand of Mental Purification (1st-rank)
+  [Yq3l3eB70BsbQFj6] Wand of Mental Purification (2nd-rank)
+  [25WDsZPxt4tjgovE] Wand of Mental Purification (3rd-rank)
+  [ntpPBKRcihHyER5V] Wand of Mental Purification (4th-rank)
+  [xVQkxZJYx2tonOqO] Wand of Mental Purification (5th-rank)
+  [tI2bx8U4Ibwq25ya] Wand of Mental Purification (6th-rank)
+  [vVJy2xHuzOgm7e6Y] Wand of Mental Purification (7th-rank)
+  [KY9gDuSeB1tgT3cp] Wand of Mental Purification (8th-rank)
+  [YBWZ1Qexhe6PuiuO] Wand of Mental Purification (9th-rank)
+  [JN2wkB9JG4nklVKP] Wand of Noisome Acid (2nd-Rank)
+  [Nv4DjyBqIMXQ4KM4] Wand of Noisome Acid (4nd-Rank)
+  [ljZwHU5BMnFafVa3] Wand of Noisome Acid (6th-Rank)
+  [T1XSnU0bwrn3m520] Wand of Noisome Acid (8th-Rank)
+  [qQpcBE7ngv7TIAW3] Wand of Overflowing Life (3rd-Rank Spell)
+  [85GqeSGXjSQwLy07] Wand of Overflowing Life (4th-Rank Spell)
+  [aj2eTtEAgLu4f14b] Wand of Overflowing Life (5th-Rank Spell)
+  [VtzChvlCG2TQRrgu] Wand of Overflowing Life (6th-Rank Spell)
+  [grRxpX1iE3zOJA1q] Wand of Overflowing Life (7th-Rank Spell)
+  [xZFbFeJckiQS7smT] Wand of Overflowing Life (8th-Rank Spell)
+  [qqT5PVPnjBST4fZb] Wand of Paralytic Shock (3rd-Rank)
+  [ZjcRzYBjtPtb01MB] Wand of Paralytic Shock (7th-Rank)
+  [kBCdBFb9IWlwy81B] Wand of Pernicious Poison (1st-Rank)
+  [QC4TXwjteVhwRSNO] Wand of Pernicious Poison (6th-Rank)
+  [cMErkgi3GjwT0bTz] Wand of Refracting Rays (4th-Rank)
+  [cIYjYb9e5ieQmHo7] Wand of Refracting Rays (7th-Rank)
+  [U4FSOEH2Z6NDpN39] Wand of Rolling Flames (2nd-Rank)
+  [Qquz4V1hKndtXSvw] Wand of Rolling Flames (3rd-Rank)
+  [Deyo6pk3OXthFx9Q] Wand of Rolling Flames (4th-Rank)
+  [kRemZF5AgTzHRHM6] Wand of Rolling Flames (5th-Rank)
+  [z5NBeuQezm3ABup2] Wand of Rolling Flames (6th-Rank)
+  [kSsjGICDkNRuD7fV] Wand of Rolling Flames (7th-Rank)
+  [SmMfd6rYUJ8vDGzM] Wand of Rolling Flames (8th-Rank)
+  [MBMiRXM0xC4aS6Xj] Wand of Rolling Flames (9th-Rank)
+  [KPWN5tGGkvZR7K3K] Wand of Shardstorm (1st-Rank Spell)
+  [3Lexs7KnhbV0HgFh] Wand of Shardstorm (3rd-Rank Spell)
+  [y6if8e8OB3RUywF8] Wand of Shardstorm (5th-Rank Spell)
+  [WeX7rAO2kAyP0QnG] Wand of Shardstorm (7th-Rank Spell)
+  [iZSGA67xqjk68PHm] Wand of Shocking Haze
+  [QRzpVYuATBjyBojJ] Wand of Shrouded Step
+  [CjfBdn0fOIarWzBc] Wand of Slaughter (7th-Rank Spell)
+  [LnXYSaLxWMyAT3Ef] Wand of Slaughter (8th-Rank Spell)
+  [mMZWdoHvP2yYJzrR] Wand of Slaughter (9th-Rank Spell)
+  [c2Oa9UbhjwAsZaPp] Wand of Smoldering Fireballs (3rd-Rank Spell)
+  [zToq18jKonWIp48U] Wand of Smoldering Fireballs (5th-Rank Spell)
+  [YR8IAV94fPo0kfBz] Wand of Smoldering Fireballs (7th-Rank Spell)
+  [tBwMPimZ6A93XpHf] Wand of Smoldering Fireballs (9th-Rank Spell)
+  [yWlQQOs0A3ApEc1J] Wand of Teeming Ghosts (2nd-Rank)
+  [SVEPGvNFj95HjlAE] Wand of Teeming Ghosts (3rd-Rank)
+  [ofhqc85Z3Rt7dcrQ] Wand of Teeming Ghosts (4th-Rank)
+  [JWacChecDZbdo6sT] Wand of Teeming Ghosts (5th-Rank)
+  [4Lhy6pAOIZdOufu3] Wand of Teeming Ghosts (6th-Rank)
+  [sLnkcAGiRQkwQrla] Wand of Teeming Ghosts (7th-Rank)
+  [ASroFtAWLwn6HJJH] Wand of Teeming Ghosts (8th-Rank)
+  [Y7xHJEyX5Mm3gpq3] Wand of Teeming Ghosts (9th-Rank)
+  [G8Jy1VK6JIg1hfKp] Wand of Tormented Slumber
+  [7AdpzgqC9wCVyeoe] Wand of Toxic Blades (6th-Rank)
+  [m7oTstzUfkFfaaLc] Wand of Toxic Blades (7th-Rank)
+  [s9ciKYFPOepnHpxG] Wand of Toxic Blades (8th-Rank)
+  [1kWWhTpXf68BdCWe] Wand of Traitorous Thoughts
+  [1U382qwyTktH9h3j] Wand of Wearying Dance
+  [JzGuXGSjsfWDMu7P] Wand of the Ash Puppet
+  [JlI0oubjxL9WOt4p] Wand of the Pampered Pet
+  [ut83Grf73Z8ZTaV1] Wand of the Snowfields (5th-Rank Spell)
+  [q2kE0mEUAEL3gQv0] Wand of the Snowfields (7th-Rank Spell)
+  [tf69NMnUoUAYrWtj] Wand of the Spider (2nd-Rank Spell)
+  [9YtYO8u5UOg4q64Y] Wand of the Spider (4th-Rank Spell)
+  [oaGUNWmrqtKhy1HP] War Blood Mutagen (Greater)
+  [H3KAt7cHJ6ZLTJQE] War Blood Mutagen (Lesser)
+  [Qa4qjxk5aPzx7HTR] War Blood Mutagen (Major)
+  [AOAXZzH4AOsQqYYv] War Blood Mutagen (Moderate)
+  [ChPOYRnhwpkEJExQ] Warding Element Draught
+  [GBaUehNIPMxLS5KN] Warding Paste
+  [XU8u9F3uoesGDjgM] Warning Snare
+  [xcwPOFTAjQpmiFsN] Warpwobble Poison
+  [1ZcywTbxv9UH13T3] Wasul Reed Mask
+  [qqiD1FLntgShkCVY] Watchful Portrait
+  [ZVaiCVMdkakXagIU] Waterproofing Wax
+  [BzGI4g44y6LiHEPp] Weapon-Weird Oil
+  [mamIdMfPguGM8QV7] Weeping Midnight
+  [jdBSk1eH1qPsCNi6] Wemmuth Trinket
+  [0G3OmRIlDaPZyurj] Wet Shock Snare
+  [10ddNHYJJOvEhEFD] Whelming Scrimshaw
+  [aQMmbIF0I8zMyzN4] Whirlwind Vial
+  [kzfRjSrq4JNZlc32] Whisper Briolette
+  [PaHw4xIxBujlCaqN] Wind Ocarina
+  [TUya8pXhEa70ahAi] Wind-Up Cart
+  [LWS9CaCwSOpQYdYo] Windstep Sheath
+  [YnkfinMN0l06iR1t] Wine of the Blood
+  [8eKDnjLeP9KpZFD3] Winterstep Elixir (Greater)
+  [6nmOC0blUxtrlLaY] Winterstep Elixir (Lesser)
+  [R3AnwcaHru4PFHJ4] Winterstep Elixir (Minor)
+  [NZ1z3ee75XfctFwM] Winterstep Elixir (Moderate)
+  [C1mX0irc7zvLqDEs] Witch's Finger
+  [aDn5blt2iiYJpzbe] Witchwarg Elixir (Greater)
+  [n9VrmK9Us0viv20P] Witchwarg Elixir (Lesser)
+  [2prxM8Q0F4sdSwPx] Witchwarg Elixir (Moderate)
+  [vmAZrNtftTBOyTVx] Witchwarg Fur
+  [clyXfh0aVXgij2Hb] Wolf Fang
+  [NRoA1HpA3ElPGBEQ] Wolfsbane
+  [GzcCAMqagCxy18tF] Wolliped Fleece
+  [1PG9vWx48TWopxpm] Wood-Rotted Root (Greater)
+  [JQqtNuiMQrU3DW11] Wood-Rotted Root (Lesser)
+  [vIMax5wxd9zS1MpW] Wood-Rotted Root (Major)
+  [dFHJyZV5Kx6IRbWC] Wood-Rotted Root (Moderate)
+  [z8lwQLmqyhjcvibq] Wooden Nickel
+  [Xzuya7EEF5FwVGFr] Worm Vial
+  [lvGSfPbpAd9lHeX5] Wounding Oil
+  [WL4O32qFifxnMj0H] Wyvern Poison
+  [rBZSDgJeCknH7G2o] Yarrow-Root Bandage
+  [bJVk50mhaODgsOUe] Yellow Musk Poison
+  [eKpL2j1JA92wndO6] Zerk
+Container
+  [5uFUIRw4YUIn0OR7] Alchemist's Haversack
+  [3lgwjrFEsQVKzhh7] Backpack
+  [MN8SF2sArQhJg6QG] Bag of Devouring Type I
+  [EIBmADRICTyYzxik] Bag of Devouring Type II
+  [n3kJYoTrzXYwlYaV] Bag of Devouring Type III
+  [W5znRDeklmWEGzFY] Bag of Weasels
+  [k5y89wYu3NX1AhVI] Bomber's Saddle
+  [ildZ7xmEjj5vdrT0] Box of Unspoiling (Type I)
+  [GZzVx6uDu60Uiwx7] Box of Unspoiling (Type II)
+  [HcJF7ZA8QfnK8eDw] Box of Unspoiling (Type III)
+  [QtF4zZrg9pTqmA1g] Box of Unspoiling (Type IV)
+  [HgS4FYX0itxQvwub] Chair Storage
+  [OdVDPN9vIpu3Zud3] Chest
+  [HEvuhktgeFXdlDKm] Extradimensional Stash
+  [vLsoZKRzYQV6FQve] Gunner's Bandolier
+  [kF6oa9xUGAz4zF11] Horn of Plenty
+  [6uHwCTK8dX1reraz] Immaculate Holsters
+  [rdF2RKgFK0vOlaeV] Knapsack of Halflingkind
+  [9cK0QVSjNd8tQtiQ] Knapsack of Halflingkind (Greater)
+  [yUPUxRqyYdZaPhkF] Lucky Draw Bandolier
+  [iAfqKpHyJ6beLGjB] Lucky Draw Bandolier (Greater)
+  [NBmOTmE2GAEI766h] Misdirecting Haversack
+  [DtEhaF5fZcqgcQ3H] Mother Maw
+  [Kd1WUWQnhagZGzjQ] Oilskin Pouch
+  [0c7zLY9c88K2n0GC] Pathfinder's Pouch
+  [ulgsKBzOXJbjqnmW] Planar Tunnel
+  [EoDLnd7KTtVL8mGp] Red Hand's Satchel
+  [ngz7dYysC1NkBBRK] Retrieval Belt
+  [8jNsUCsNe6PyenNZ] Retrieval Belt (Greater)
+  [V1XhLQPWjdQz759K] Retrieval Belt (Major)
+  [DujblC14ytJEZMaz] Sack
+  [mBziC8v2eOtTs0f5] Saddlebags
+  [1pglC9PQx6yOgcKL] Sleeves of Storage
+  [3hv6NVC2rVu4QCNt] Sleeves of Storage (Greater)
+  [6z7VUJanx7nPwhk6] Smuggler's Sack (Type I)
+  [eZ2kfpjboRrFWK9R] Smuggler's Sack (Type II)
+  [fPOidyARnS0McvHx] Smuggler's Sack (Type III)
+  [jEnDLdcuOgXDf0I6] Smuggler's Sack (Type IV)
+  [JL0j0AtJZYEaKeOa] Smuggler's Sack (Type V)
+  [jaEEvuQ32GjAa8jy] Spacious Pouch (Type I)
+  [JBMBaN9dZLytfFLQ] Spacious Pouch (Type II)
+  [jkb2WNby4mjcYqq9] Spacious Pouch (Type III)
+  [34DA4rFy7bduRAld] Spacious Pouch (Type IV)
+  [KxUJu1IHY9FxxAGV] Sturdy Satchel
+  [G4luLo1IEtDben39] Thousand-Blade Thesis
+  [LRSIRUERqBAJ1HGT] Voyager's Pack
+Deity
+  [0xCttKr5oqjirGCe] Aakriti
+  [d56paSkcwvll2OhR] Abadar
+  [bLI1JMpI2GXQT5AC] Abraxas
+  [XP0SPRL92tAPMV0K] Acavna
+  [51kMMWaT6CqpGlGk] Achaekek
+  [gutbzYTZvRTnq4on] Adanye
+  [4Rjj2SA7xSxT1ftC] Aegirran
+  [gndfKuUTVDOubob2] Aerekostes
+  [JXAg05NcjHZbDqxl] Aesocar
+  [dkKnv37c8RBPblgV] Ah Pook
+  [pCtJONJlhAugUXaG] Ahriman
+  [yxttKoBEx93T3dWl] Alazhra
+  [2XM5clKBu67zJEwW] Aleth
+  [uXkMGx0OD896ZQlT] Alglenweis
+  [VRPVppdQ4W0oXeB1] Alocer
+  [9n2CI0B3EA4y3BuU] Alseta
+  [iFF8oXwt6yePcwko] Amaznen
+  [JFyAEoCo32fl3b74] Aminara
+  [hT2prXTvejvNoCPB] Ananshea
+  [CDkr6eXR1lgu7g6A] Andoletta
+  [cHAbE86pto5bvIWo] Angazhan
+  [Xb1N5YfxboJH26Jh] Angradd
+  [rXtm3Jbs7BBrxjk4] Anogetz
+  [edfGQKkGBODi2BN0] Anras
+  [5YUNikBpJZ596MRD] Anubis
+  [BlHzQ693N9UdLVrR] Aonaurious
+  [8xrpo05lZvTQaAkJ] Apep
+  [oJPwMa9xG8oMnC14] Apollyon
+  [o8ayCv3LAHWlu0vQ] Apsu
+  [HtRxo4J3elFteIqu] Arazni
+  [uydTiyN5AzhBnQY8] Ardad Lili
+  [BRqiW7ZvzhFDuiIw] Areshkagal
+  [neoMBrfYuNsmQagi] Aroden
+  [akcmQbvNWfhEfEhf] Arqueros
+  [KDFujU3Yug6AwCOz] Arshea
+  [jrPmEfubRDzMKbxl] Arundhat
+  [DJ7LDFTtns6YFodT] Ashava
+  [RbslST0RZPXj6Eby] Ashukharma
+  [QRkcFciCOmFoxF1B] Asmodeus
+  [JDbrj8aKkLzdn8BU] Atheists and Free Agents
+  [R0DvoLO8WbYIYhb3] Atreia
+  [ChiKlaNDNYgGqtF7] Atrogine
+  [IY6fWfuIwSSIBb0Y] Atropos
+  [aChBtIDfA59QQ7SN] Ayrzul
+  [sILda7I8Ak20Ioj9] Azathoth
+  [9WD0hbUT0IbnuTiM] Baalzebul
+  [cSakUTwOtxe6Y0rH] Baekho
+  [1fmTXGRPa8fLXZKL] Balumbdar
+  [aj4ChTlDcZCmrtJD] Baphomet
+  [oiEo6tDP3gICHtfZ] Barbatos
+  [UUcAqU3KeJSMNxGF] Barzahk
+  [zRmAXj7FSlrMfDeA] Bastet
+  [fbpYf8NcLTzuBjua] Belech
+  [remyY1BwhEVmBwya] Belial
+  [30uY6NkhYmPI3Oii] Bergelmir
+  [eyGEoggFlTEUQmvJ] Bes
+  [bc2B53BGQ7OOwZg6] Bharnarol
+  [oKuNQPNRHGong4jo] Bifrons
+  [c9NFjRR8gr6CWpjl] Black Butterfly
+  [aUkAP1fVqOjtRzkc] Blooms of the Spreading Weald
+  [Tqk5xJpDKI2MXO1R] Bokrug
+  [HD7g8T8ioy1EH3M8] Bolka
+  [q8DsNpcH49PxObcd] Breath of the Endless Sky
+  [vEMCpm7iidycRT5D] Brigh
+  [ColsorVmocw5Plmg] Brixori
+  [AlL9GtlTldbqNoVm] Calistria
+  [Byw9omVSNwYKcauw] Camazotz
+  [soiVh53y9RAeSLEk] Casandalee
+  [v67fHklTZ6LoU54q] Cayden Cailean
+  [EE8sNM4JraOPN669] Cernunnos
+  [SeD3n4VMk5EQJ2CI] Ceyannan
+  [4GO4iT585ynLJnc8] Chaldira
+  [W7GPA9QiSrcbN7bX] Chamiaholom
+  [yiKle2URZ43KYVKQ] Chamidu
+  [kKdvt2m8MdsJ5aFb] Charg
+  [tcXrtRYCOr2EmgGB] Charon
+  [zQbb1kAQJkPfiDIh] Chavazvug
+  [BjOTP1lUHouAQzt4] Children of the Night
+  [LidhlajmOHnmWDze] Chinostes
+  [OlVCyRgOaPJji4qt] Chohar
+  [fZ5caXxpdV1MErsa] Cihua Coatl
+  [q4SyvGotD0LprYar] Cixyron
+  [LqJkd54Vtq9yMduS] Cong
+  [yX5U1Uvdug9i08nU] Conqueror Worm
+  [YLftgCdyOyF22Gt6] Cormigus
+  [KMS0QEsoh4nzKkmu] Cormion
+  [Adk14fcM9UHCQWb1] Corosbel
+  [oV5cnlPJQS8JfMIg] Cosmic Caravan
+  [vSUz97Y29l1O50bC] Count Ranalc
+  [tnAmR9WxWoEehDZw] Cthulhu
+  [gXHoxuuiAD54LnWV] Cyth-V'sug
+  [qfbZbNGQiiJ9hciP] Dachzerul
+  [AHX89nhuVhmg8k6w] Dagon
+  [Bzfc5mIUfMxOnQWu] Dahak
+  [M3eb94Nd6uXti2IK] Daikitsu
+  [XaaDDVS4sEJd4m99] Dajermube
+  [hV4OjuhTOFG7jUB4] Dalenydra
+  [eTzCA17qD0Tabq3i] Dammar
+  [H1VrZ1QX0d2aPXT8] Dammerich
+  [y3RlZ3FnbZN8wv8j] Demon Bringers
+  [w4aANcazJr1dSH0c] Deshto
+  [JgqH3BhuEuA4Zyqs] Desna
+  [dcbf3pBSNa2q1Kkq] Dhalavei
+  [XHDlP7o1jNz9851v] Diomazul
+  [CzHjFLx4hpIEIoWt] Dispater
+  [BYx7QoQhCBUGlWpl] Dolok Darkfur
+  [AMFkYKUNQ3kCD0ob] Doloras
+  [f890Kbsk5dxrmU5h] Dramindyr
+  [oyp2E685VsQFKMXi] Dranngvit
+  [DUaWAIn8nUMx5AIE] Drokalion
+  [39z55kowQFOUH2v0] Droskar
+  [aVyxfqY9GBjTqQul] Eiseth
+  [29jHeZ1jA23AnZrV] Elion
+  [hDNLCRnDjYqmPYv6] Embaral
+  [K4s8a6gI1OmuWhMk] Emmeton Galardaria
+  [upRQcwjjaksc1g7h] Enkaar
+  [mm1j6UbHqFCI8fwB] Erastil
+  [Dm8qlzpUj7g82QFv] Erecura
+  [8DXel4AvpyUy6oJ0] Eritrice
+  [3lgzcg84J0fsVqjh] Esoteric Order of the Palatine Eye
+  [1wKxFamTt3A3ZohD] Essence Dancers
+  [AEj745gVsRehu2EL] Etaris
+  [pqrmviqboqjeS4z8] Eyes That Watch
+  [8xYnD5FuLI4RSJN8] Faith in the Fallen
+  [IXLzDSMGndFb5rGY] Falayna
+  [9vcKBv8h5vugb8lL] Fandarra
+  [RnS5P7zX0HRPsDnt] Ferrumnestra
+  [0BH54ZVR8NcrGlMu] Findeladlara
+  [VEyowuhC4FsBnG8c] Folgrit
+  [zhXBavaHMCwnVpYA] Fortune's Fate
+  [6O4UGWcYERDEugzk] Fumeiyoshi
+  [qmAMERMn2FvvvQwc] Furcas
+  [f3DIcotFvBkldMUO] Gaasham
+  [yyqLBsREH5PGMPxm] Garhaazh
+  [3ffVxwgtvR1imHm8] Gendowyn
+  [Zi1UARhode3FSFLr] General Susumu
+  [auHS1P7mXJjO2QlY] Genzaeri
+  [WOiSJ4IWjaRsSgRO] Geryon
+  [oRvuLq3o2FxXizt9] Ghlaunder
+  [oduHa5yyTisFsIRD] God Calling
+  [RUzMtIQal0drPwQY] Gogunta
+  [kqO3mcoq1EVRSYxF] Good Neighbors
+  [88vRw2ZVPax4hhga] Gorum
+  [swwwP7eVmlNuWTb7] Gozreh
+  [fuPTR1laXO6EionS] Grandmother Spider
+  [1TDsbM52mkWBxlur] Granduncle Taproot
+  [6gxC5awANDFs1kLM] Grask Uldeth
+  [XxIxEaW8NG952Bc0] Grasping Iovett
+  [QArqJ387HeYgGZxG] Gravelady's Guard
+  [KT7HKL7vbZEwbzX4] Green Faith
+  [McUqN13BGLTpYWCg] Green Man
+  [WloVxo6HXJdS4YTt] Groetus
+  [tcvobm8O84qv0aO5] Gruhastha
+  [tk7gRxXsqvBwQrUF] Grundinnar
+  [0uKqA42aPdHEqESI] Guardians of the Sacred Self
+  [zlJGKpeLBwajP91o] Gyronna
+  [Y6tbAWlcccGlUH0z] Haagenti
+  [JEZ6ZZc2aCzWyu8P] Haborym
+  [3c15mKInre8c2iRo] Hadregash
+  [xpny4ZzlExIbGs6a] Haggakal
+  [K1tzUClsozKcdpIe] Halcamora
+  [QlDnoOwf0PppymTn] Hanspur
+  [WvoMr86bSSYxXKtI] Hastur
+  [19qKU9wPd0JctskB] Hataam
+  [TpAMy8tb5LrRgvqN] Hathor
+  [w7B4HD5XOFaLb3ZG] Hearth and Harvest
+  [DEKKbg6riAdL2ARf] Hei Feng
+  [rRuxBgC58PxrLzRv] Horus
+  [A37XqON6QRPzQhp7] Hshurha
+  [Gy78DCwfY4ltBGI6] Husk
+  [bmOKsNOZymMijc4m] Iapholi
+  [EDmAlxCXJHv8rZs2] Iggeret
+  [i79OCvsFlDGqYjTk] Il'Surrish
+  [VvxEvEKhCGRwrMJp] Imbrex
+  [CnEpvcfRgtAp1V31] Immaculate Growth
+  [smGfeOk8Jgcz0Qkv] Immonhiel
+  [KIEgpcmHYtFu1dpg] Imot
+  [pEm6tEGOhUbnwX4p] Inna
+  [eErEiVmBqltYXFJ6] Iomedae
+  [lSciGZGcbU9PJxQy] Irez
+  [qqqrbq4uCrelQvgH] Irori
+  [EFyDjlH7XjGq7Erd] Isis
+  [Ig2ZSxvJ0K7F2Bb7] Isph-Aun-Vuln
+  [LJr99kbbzzgh4IZm] Izuyaku
+  [aLCfEgt48SRUHnMC] Jaidi
+  [bF77ydtptI54STl9] Jaidz
+  [5QjycohRhMIejeN7] Jezelda
+  [w9vtltygWNG4eZDR] Jin Li
+  [sezTnLBBCYv3ZrZN] Jukha
+  [V5PbbkZUP9N7kl6h] Kabriri
+  [GFDsfRLFINnaHDTw] Kagia
+  [hLq1IF3mT8zOfUaE] Kaldemash
+  [kiTcZxmKxGPCwDpg] Kalekot
+  [iXvyp9rGnqvFfy4q] Kazutal
+  [AJ7Wgpj5Ext9wbtj] Keepers of the Hearth
+  [u0H9wcgttBI9Ef1j] Kelinahat
+  [14GLsVobnZTEmJrs] Kelizandri
+  [u5z1YYlpuBGdTzS9] Keltheald
+  [s81N9hxffmRuy3ik] Kerkamoth
+  [wjXNXFWBLbJaeZQR] Ketephys
+  [OkEJdnT0HyjLjrg9] Khepri
+  [TW7Q6O928YWNME9r] Kitumu
+  [AIcDyoff265z9285] Kofusachi
+  [zhPhYge7VJbIlJvA] Kols
+  [5ZIvg8CkqRMepVcX] Korada
+  [JcIf4uwKLxEWdplI] Kostchtchie
+  [r5vooG7NfvA9prJK] Kurgess
+  [zI3qO0KCBKxe0Ui1] Kzininn
+  [xu05XGotyT5st56H] Lady Jingxi
+  [r6SFB1PzKsagDXff] Lady Nanbyo
+  [1LiO5bDQIlJmXk35] Lady Razor
+  [ItYptsfjV8XvfhOV] Lahkgya
+  [Mum7kJFrNOpVrxxP] Laivatiniel
+  [xyHhtBdNQGyldsKQ] Lalaci
+  [aipkJQxP4GBsTaGq] Lamashtu
+  [xLbSMedLDFyb8sFw] Laudinmio
+  [4I1aVKED08cwcC4H] Laws of Mortality
+  [H3qCK0Qq1bK0uM9o] Light of the Everlasting Flame
+  [t6Vn590vTLDlVUdo] Liisglan
+  [lUFMwdv1UOyzFhIM] Likha
+  [CewJyduCTUyW7x2u] Lissala (The Order of Virtue)
+  [ykqWA3pS0045DRs4] Lorris
+  [idAu7puhPp3kFTnl] Lorthact
+  [CnDEoo6WruQCXo1o] Lubaiko
+  [ub0PJ5QkrdoGzzb2] Luhar
+  [VVUS4JWxWDd5ByJC] Lurlup
+  [QibpLccM5bLUMopj] Lymnieris
+  [SCMlQDcoU1QcF3AS] Lysianassa
+  [ArmPZQrl0SFAKvrY] Ma'at
+  [iMRXc519Uepf8yH3] Magdh
+  [nsiDGdgbAzkTQzOt] Magrim
+  [Af4TSJjutVi9Vdwi] Mahathallah
+  [rdA9jbvUZdT1Zr8Q] Mahja Firehair
+  [qMwLAXcjZ16qkMml] Malthus
+  [sNjPI1iaS8Z43YJf] Mammon
+  [9LwncUwHbG1f6qIt] Marishi
+  [hWTTS0e7J9hJfsp3] Matravash
+  [v1fsLP6nTkiy5ghB] Mazludeh
+  [KWVdoAm3b01M8Lcp] Mephistopheles
+  [Cme0TBL9QeusAUKE] Mestama
+  [FHZ2DZEJzjrPfyjH] Mhar
+  [fTJLgTfEMZreJ19r] Milani
+  [bIl8GkwYltjsAMcm] Minderhal
+  [g1VxllMjs2YRIJAm] Moloch
+  [W4QGkdn9V5ACRpkh] Monad
+  [E1dUhoSEf2XfklU2] Mother Vulture
+  [01liRoMjNR5XgorX] Mrtyu
+  [omUWo1TQ6PDm5oeW] Mugura and Nrithu
+  [FktAD5GCv60OdSAB] Myr
+  [pm8H2DbtrHM01KNV] Naderi
+  [gsFaxWHbZmc1moY6] Nalinivati
+  [Tn8rVCvsjrPyzKWC] Nameless
+  [hhV2g6aU8jKLEca1] Narakaas
+  [65o189p2eUPbqaDK] Narriseminek
+  [BVF5L71JblkYUW5E] Neith
+  [EbiJVJN86Q5SfDOt] Nephthys
+  [VlgaeJlpl2ubDv4a] Nergal
+  [uTRswfDyjndlQZJ1] Neshen
+  [9EKyWmjLUu42evxC] Nethys
+  [RzTd9PmgnfHNlFVf] Ng
+  [8Oy4qHylOOp79JxD] Nhimbaloth
+  [4HJKRGYIVKeUdOwf] Nin
+  [Mv6uTJLh3VGEoGLH] Nivi Rhombodazzle
+  [jL1qiVOZBKXETtVD] Nocticula
+  [GX6PF9ifR47Xyjg9] Norgorber
+  [psUfw455soFiUNlF] Norns
+  [0cimyk6ZbdvGOmwC] Nulgreth
+  [SAuFz101iP6VVwvw] Nurgal
+  [iKgERiIc8rt3fatf] Nyarlathotep (Haunter in the Dark)
+  [3nxIpMGeCvcBIVov] Nyarlathotep (The Crawling Chaos)
+  [PYQnJe4ZXPzEnukx] Nyarlathotep (The Faceless Sphinx)
+  [NXmqXck4jUfSY2ns] Nyarlathotep (The Veiled Voice)
+  [2mZmXeokndl2ocWK] Nyuo-Ogh
+  [Y6EnZjtBOHBs5O8D] Oathos
+  [6YX5wtiLvDhwk1iZ] Oaur-Ooung
+  [8hsVGRyq0dKMwwXT] Obari
+  [dQb1y00PCsWIFcX4] Olheon
+  [tOXJ90TOPlzfNdql] Ongalte
+  [IAGkKOJ0Pu0Bous3] Onos
+  [b7H379HnCOv9UZtd] Orcus
+  [gUyP9Ir8FTaZeV9D] Orgesh
+  [nuvfUC4TcOvFbKxx] Osiris
+  [SHSMB0WvrJB4E8rU] Otilaz
+  [JgDqFUB1NtQkGmzp] Otolmens
+  [wXRJe0QsebyqQ1L0] Ozranvial
+  [mIoXpTRhcCs4PTdN] Pahti Coatl
+  [0UunUljPt3uZGuMj] Pavnuri
+  [IZcdF1G8ZsnMotaM] Pazuzu
+  [0Hc2HqseslZifEk6] Pharimia
+  [0EXQHfNN11AfDqNm] Phi Deva
+  [e6IGAMPvaGqwZPkI] Phlegyas
+  [CeBP002LcMfqgIRl] Picoperi
+  [WO9UsCY41oTtC2G0] Pillars of Knowledge
+  [lZ74P8kUA1ti808w] Prophecies of Kalistrade
+  [RoBL67dQIQgIahtY] Ptah
+  [Vzxm5FyIA40b2OSP] Pulura
+  [giAsBYiL2omr0x2L] Qi Zhong
+  [woDEgBs1MznhzpJ4] Ra
+  [JxigqtJO2juuBh8V] Radiant Prism
+  [XYJupIPx0GW4s7eu] Ragadahn
+  [GEBaoeiv5CB9h2Bn] Ragathiel
+  [o9tK1T28LNEVzpFV] Ragdya
+  [Ij1KRM8ufkEjGnR3] Ranginori
+  [u3YfcJh1C4w6n75j] Raumya
+  [1nQVLOyWv5kC0bCU] Ravithra
+  [hv7poWIKVN1AT51p] Razmir
+  [FeMWwhaVbaoqu3q6] Reshmit of the Heavy Voice
+  [baMgw2Jw17dlmMzj] Reymenda
+  [7Gs5SnHEd4IciJIw] Rhan-Tegoth
+  [GYmwlpH8zou0Mkap] Ristrentho
+  [eayZ9moMzAGotO01] Rivethun
+  [7l8fDCLz8fo4qEib] Rokoga Gin
+  [Bhxji0kxIbMKqdkw] Rovagug
+  [44fcXgp3fnkoyb4R] Rowdrosh
+  [BlLaiS1cWDhmXcBf] Rull
+  [1NxkZf6ndijKeufX] Sairazul
+  [1xHnoMlCyCV70TnT] Saloc
+  [WfqLY2Fm1LGCcG5X] Sangpotshi
+  [BNycwu3I21dTh4D9] Sarenrae
+  [Em8MqxFDNofBUuBH] Sarshallatu
+  [LIqW0cgGWFQln1Lk] Scal
+  [Vk1FM54rJx1RHtUA] Seafarers' Hope
+  [0nQItOlce5ua6Eaf] Sekhmet
+  [xTD0XFaguBX6QQ2L] Selket
+  [ctTBqyrSRpfL33jE] Seramaydiel
+  [EfHlurXdqkdRXaqv] Set
+  [Rz7C08TWmj87WNR6] Shadow Cabinet
+  [D8lFcjLj5sd25BRk] Shapes of the Fading Luster
+  [58gSanY90BSz9Uwa] Shawnari
+  [zzhYFcShT9JoE2Mp] Shax
+  [ra7mnjAZcEuJxI37] Shei
+  [gxwmzxUWBOhdgFSN] Shelyn
+  [p4tkVSULWGHhYPGU] Shivaska
+  [s9opv94lGDRKnw6W] Shizuru
+  [s1PgIQ8Oi35oS2Et] Shoanti Animism
+  [hAoVzkeFjTwh5Ykl] Shumunue
+  [3INt1X4ijBYnZYbU] Shyka
+  [YnOxUUJz1dzocG6N] Sicva
+  [BrbXGyzCeORNyJT5] Sifkesh
+  [Uz7DDxMvWjSXUrmX] Sithhud
+  [iJyhAFmHOLZBvWnJ] Sivanah
+  [IK2AL3bL6htrrnnC] Skode
+  [Y0TY7oerRZ0pLbOB] Skrymir
+  [yIfdsL1788boOOYk] Sky Keepers
+  [5dhBYY6sWOJotbpU] Smiad
+  [TvxsVRztDlGcWpcI] Sobek
+  [vnmoAGURp8oWCY6R] Soralyon
+  [gpS3hv7LP2IRwEHT] Sorrow's Sword
+  [3vzvggkPuLkTF6So] Sovyrian Conclave
+  [ox0AaGLIyzCUrre2] Srikalis, Sritaming, and Sribaril
+  [9MhgyxTfsffWzDbU] Ssila'meshnik
+  [fTs56epghXwclPcX] Stag Mother of the Forest of Stones
+  [2uY2CDR2DyBqxbVU] Stone's Blood
+  [97Qe42wJN5EVUS14] Sturovenen
+  [BLNXYqvzmLgjMq2p] Sun Wukong
+  [u2tnG7fKkZ2KHMcT] Suyuddha
+  [rDTXcBJ8LyqA2TkL] Szuriel
+  [Pq9PT7dqRrQ3nnNx] Talons of the Godclaw
+  [DFxbPmQLOqcmbPTz] Tanagaar
+  [vjG96N3HYdK7xvh6] Teki Stronggut
+  [OoPq9MtnAcrHBumx] Telastmar
+  [f8fQIrsOdKVucT1G] Telvrys
+  [nawnLEk0rr7BgF1K] Teshallas
+  [9Z1vOSaLsEiAs2yN] Thalaphyrr
+  [PFp4Sdp2TDDKD62l] Thamir
+  [bNEq1DQKYUVHVKC1] The Anointing of Kings
+  [HR563VdVbW8aUdqM] The Curtain Call
+  [zgM2jsxw52HjALV0] The Deliberate Journey
+  [PIMd4yRGj8XQgGbW] The Divine Dare
+  [p4TbCVOwHB4ccmT4] The Endless Road
+  [Oci540vcXkJKR0gW] The Enlightened Scholar's Path
+  [KPrtgoIcgiBSKzS3] The Freeing Flame
+  [JndhOIHnQoMwnsw3] The Godclaw
+  [pVQzTL5elNTxvffu] The Green Mother
+  [GBdxyS79vTozcv3P] The Laborer's Bastion
+  [JzaazIXXvAW02Cip] The Lady of the North Star
+  [nuqIimigyt986WLE] The Lantern King
+  [7zyxg8TlXCDzHGMf] The Last Breath
+  [HbuynQRCjGKtbhcC] The Lost Prince
+  [YeUhlOt3c98ocwjZ] The Offering Plate
+  [cICflsnWTdwTtxx0] The Pale Horse
+  [XFqgtfxc47LPFjLZ] The Pandemonia
+  [VG51y4FbTLdeGHZB] The Path of the Heavens
+  [Ons4JwstcXOlkaRF] The Perplexing Jest
+  [QTvR7ZqUrNMG56Nr] The Readied Strike
+  [RlOuyadtreI7pht1] The Resplendent Court
+  [G5g4Xa0KjKA2T65I] The Spirit Wall
+  [IDOd8Ph9tbVAkHBV] The Tides of Chaos
+  [m6UYxDnwGkOo8IY5] Thisamet
+  [aievwuZalZ2abs2q] Thoth
+  [y7aYkVd72Kh6ydWi] Thremyr
+  [mwqdXCX19j7ammfh] Thuskchoon
+  [2fVbLwfQjyHSoSVy] Titivilus
+  [wtXlsIbYRjwuCexX] Tjasse
+  [0R2BjVb7d9tYCIbk] Tlehar
+  [wyKJRFrEJdRFtsha] Tolte Coatl
+  [sZrdzh0ANQnZGXJb] Torag
+  [LGOkWwN6AZhLiZpl] Touch of the Sun
+  [bOnXaO1xTvkvCBoN] Treasures of the Eternal Delve
+  [ENzMYuzBZGIujSMx] Treerazer
+  [9eltBjLngkR9x1Xm] Trelmarixian
+  [81EbN765Clkvwyqi] Tresmalvos
+  [N8a76dkGfUvxvSW0] Trudd
+  [aTYy1WHwAZiuei4h] Tsukiyo
+  [RKCISPRJMRz9FR4n] Turvu
+  [DnBpqbMjRe2TwVZF] Uirch
+  [lvCryIEcfy7XIbAc] Ulon
+  [hUuM7HI7bw5aYUVr] Umarik
+  [xDHJU43e9Bw7GwYm] Upion and Warrik
+  [Qr8BqULcaBAiIKUY] Urazra
+  [KB6O6dvwJj7wuwO7] Urban Prosperity
+  [v03ImN8VkF3cz7MI] Uskyeria
+  [w8Pfl5syV0vaEuTM] Ussharassim
+  [w4fDrwL8VIqJDPfR] Uvuko
+  [fFoqdiTV2YuITZSd] Valani
+  [F7Y83d8keV9CAhP2] Vale
+  [9FWBJcADLEeP8Krf] Valmallos
+  [DWIGqLu8iQnZYS26] Vapula
+  [Up2Wv097dRjoClSw] Varg
+  [KIbuRCeRdfOwxUXX] Vavaalrav
+  [NkKdZor1FAePE5z9] Velgaas
+  [jCryzaFDLRL192Vv] Venkelvore
+  [pafYqAGj47TmGBib] Verilorn
+  [boSRWIodYDIPlZ4W] Vermilion Mother
+  [y93whGnGZjFyw5A0] Vildeis
+  [d47XTSODGAKANu3d] Vineshvakhi
+  [iB7v8EkkQzCmdZ5X] Vonymos
+  [q5Rov9T1KTA0nJnm] Vorasha
+  [JMRGy8Fb1ZYeSbcK] Vudravati
+  [J33L1nYGD06FcxYF] Vulot
+  [GUmYLD7PGmE2TOx6] Wadjet
+  [g1AVEGi8QibhS007] Walkena
+  [ZynnoQJFz12FD0Xn] Wards of the Pharaoh
+  [avyBK4NbMllCvRj8] Waves of the Boundless Sea
+  [JeGR8YCpbmQAhxhF] Weight of the World
+  [rji8c4S3dZJIy4VU] Wheels of Innovation
+  [EUOAV02rHz96jMPh] Whispering Way
+  [8wOAwLMgB1HFLo9n] Winlas
+  [GuUn4gElGNAT3Rbc] Wulgren
+  [mebdNVKeKuTmDDHj] Xhamen-Dor
+  [DikXombRpmC8P1Lc] Xiquiripat
+  [FREFauCaKxzGNuxE] Xoveron
+  [OLHByk9LF3QG2x41] Xsistaid
+  [83jKKHQPoqVylmrF] Yaezhing
+  [6j37TAv5BdOmrsUV] Yamasoth
+  [tb0oADxOoMhyrYRA] Yamatsumi
+  [iEt6idGIEPXY2HzV] Ydajisk
+  [4bEPoujxhYdUyUOg] Ydersius
+  [1xG0PDxn0rhmJhMS] Yelayne
+  [kvMjvTyMNODBA1N2] Yhidothrus
+  [oxORi6rZmqZNdJyJ] Yig
+  [YXmeBdOZfWgUljW1] Ylimancha
+  [DHqB2r4JEJPs16Ek] Yluma
+  [7L9KIqixgseSCY3X] Ymeri
+  [SUaGdvQXxSAQAw03] Yog-Sothoth
+  [HCBsEO4bxbAxSWEN] Yrmidar
+  [y1aoHudIXFqYwWXP] Ytildos
+  [uYpxTi4byHc5w78R] Yuelral
+  [lDYntNcMZ8AKdlIU] Zarongel
+  [v1HIqHBRvpUUbKgY] Zeaki
+  [1CqGgDeEuaVOgFFE] Zelishkar
+  [8roijlQ03l9rWFFe] Zevgavizeb
+  [DN0urKdPPqhXFzTq] Zibik
+  [jGENfggMNVR9ObAb] Zipacna
+  [kBuCFUp4KYJEnMLk] Zjar-Tovan
+  [OS9vZh5GYrNHahZq] Zogmugot
+  [SCGdJmm7Wzle9jFP] Zohls
+  [ZfN7jkK6boU1FuiS] Zon-Kuthon
+  [lPU0bl88a7cWWuyu] Zugero
+  [8ZSywyo8YQPduo92] Zura
+  [CezU0sI58mzkvAz3] Zursvaater
+  [LLMTMgARSTlO7S9U] Zyphus
+Effect
+  [jPZXZjetdauqYuEH] Aura: Angelic Halo
+  [RfCEHpMoEAZvB9IZ] Aura: Bless
+  [9BunTo2HasWB0vwc] Aura: Demon's Knot
+  [KQnDfdYxyg5FhyCX] Aura: Elysian Dew
+  [wdOBAcEkC7L0NdJ8] Aura: Form a Flock
+  [fElGbAOJJm4Iv9rU] Aura: Fuming Cloak
+  [WtuhkNCNAW1JaGSe] Aura: Manifest Will
+  [5p3bKvWsJgo83FS1] Aura: Protective Wards
+  [3bcUiWwc5KLc4X0T] Aura: Protector's Sphere
+  [3BZisQv0wVLGEvzp] Aura: Righteous Call
+  [4XO5mkjnh5riwZPM] Aura: Searing Blade (Greater)
+  [NNxguHneoM3NvW1S] Aura: Shining Symbol
+  [HF1r1psnITHD52B9] Aura: Spiral of Horrors
+  [tWS8aMCyeGKcnFh1] Concealed
+  [eu0ttUFovbgmyLJ5] Defeated
+  [aWIjuZ4sJI8SnK2D] Destroyed
+  [8upne4E6Q7Da5T5w] Distant
+  [IUvO6CatanKAgmNr] Effect: +1 circumstance bonus to attack rolls for 3 rounds
+  [QGTMOcJ1Dq5bk0GG] Effect: +2 circumstance bonus to AC
+  [HLBhINtyRcHk6d7h] Effect: +2 circumstance bonus to attack rolls
+  [sq8lhVfn0pl5WJ4t] Effect: +2 status bonus to AC and all saving throws
+  [lTwF7aCtQ6napqYu] Effect: +2 status bonus to attack rolls
+  [PaS2kwv4vueI4PC7] Effect: +2 status bonus to saving throws against spells for 1 min
+  [pbKvPM4cnmGTkDiZ] Effect: +4 circumstance bonus to AC against your ranged attacks
+  [fqk0ESqJACXqz21k] Effect: -1 circumstance penalty to attack rolls until you score a critical hit
+  [5gX3PZztMecmWxX9] Effect: -2 circumstance penalty to attack rolls
+  [i5WccD9u62QPRZI8] Effect: -2 circumstance penalty to attack rolls made with this attack until healed
+  [Ck0MQP9og75AWix7] Effect: -2 circumstance penalty to attack rolls until healed
+  [UZabiyynJWuUblMk] Effect: -2 circumstance penalty to attack rolls with this weapon
+  [c6cwOc4Zri6QiqsR] Effect: -2 circumstance penalty to checks and saving throws until healed
+  [wVGSlZEGxsg1s8AZ] Effect: -2 circumstance penalty to ranged attacks
+  [BjkhK1nFUw3vNKg2] Effect: -2 circumstance penalty to spell attack rolls and spell DC's
+  [Fky50BHCHmRTnHas] Effect: A Challenge for Heroes (Ally)
+  [pUXV4sks4p9Jc8Wb] Effect: A Challenge for Heroes (Enemy)
+  [Tlb2xfEhGLHjwPHy] Effect: A Little Bird Told Me...
+  [qeI9fX7X2IzSZLoL] Effect: Abadar's Warning
+  [UQ7vZgmfK0VSFS8A] Effect: Aberrant Blood Magic
+  [1FIje7Y5zIbf9V0p] Effect: Abjure Harm
+  [DlqcczhwjfaEf7G1] Effect: Ablative Armor Plating (Greater)
+  [jlVYoiPVRRVGBj5G] Effect: Ablative Armor Plating (Lesser)
+  [OMW71UJzYCUr4ubh] Effect: Ablative Armor Plating (Major)
+  [mn39aML7EWKbttKT] Effect: Ablative Armor Plating (Moderate)
+  [yt8meGTS7wLa6Fg2] Effect: Ablative Armor Plating (True)
+  [9DXdG20VAIGnFweU] Effect: Absolve Sins
+  [1jrrnMwsfO97LXi4] Effect: Absorb Memories
+  [LWXdHlZQ2mttrp6R] Effect: Absorb Shock
+  [BJldFHlx4kwMY3rX] Effect: Accelerating Touch
+  [2ca1ZuqQ7VkunAh3] Effect: Accept Echo
+  [hjYNxH7BwkrzwVsE] Effect: Accursed Breath (Critical Failure)
+  [bvk5rwYSoTtz8QGf] Effect: Accursed Clay Fist
+  [ya8r3IdzQ7QGNH8N] Effect: Activate Defenses
+  [wE4S9lwOhtaRAm9n] Effect: Active Mutagen
+  [fHM9xvCBWrBqcDQY] Effect: Acupuncturist
+  [ReqVLQUQy7Y91IiB] Effect: Adamantine Body
+  [361dIAAhiZE0wg8v] Effect: Adaptive Strike
+  [wHWWHkjDXmJl4Ia6] Effect: Adverse Subsist Situation
+  [dFNh66uyI5yxVKbt] Effect: Aegis for the Innocent
+  [p2aGtovaY1feytws] Effect: Aeon Stone (Black Pearl)
+  [HcUltKEnhktxcp4T] Effect: Aeon Stone (Pink Rhomboid)
+  [eyXUwWx5omiQWGZw] Effect: Aeon Stone (Sprouting)
+  [kdcVvwVVsttZgX1Y] Effect: Aeon Stone Resonance (Amplifying)
+  [NZAMd9wCof7xxzUr] Effect: Aeon Stone Resonance (Black Disc)
+  [Ik2fSeOnaKYy3mkP] Effect: Aeon Stone Resonance (Pearly White Spindle)
+  [L8m3L4MCGDZJISp0] Effect: Aesir Blood Magic
+  [WQsMv2KlURI9OKQQ] Effect: Aggravating Aura
+  [AHMUpMbaVkZ5A1KX] Effect: Aid
+  [Df5j0AitqDVE08hL] Effect: Air of Authority
+  [XSXMGb5h4Um6YXiT] Effect: Air of Sickness
+  [ucAwSIZsGrpBLg6G] Effect: Alchemical Crossbow
+  [HVGl2hSrfqHE4OZ2] Effect: Alchemical Embalming
+  [yrenENpzVgBKsnNi] Effect: Alchemical Strike
+  [SZWxyXOTZtGvZbN7] Effect: Alchemist Goggles
+  [aEuDaQY1GnrrnDRA] Effect: Aldori Parry
+  [eJyyBqrXLOE4R9JI] Effect: Aldori Swordlord (Temporary Hit Points)
+  [MLwB5v5DffmfUTWe] Effect: Align the Stars
+  [BXFP2EC8HIVZ7h9r] Effect: Align the Stars (Ephemeral)
+  [Rs64h4dLbYVWvFJe] Effect: All Are One
+  [AdUcSxWFj7IVcVma] Effect: All-Consuming Hunger
+  [JzVfTeHDopKAA5P0] Effect: Alloy Flesh and Steel
+  [o6GSF420m6cdTkZo] Effect: Alloy Orb (Exquisite High-Grade)
+  [BjF0eOao5UuOOKMP] Effect: Alloy Orb (Exquisite Standard-Grade)
+  [15qCI8sWaEwPkWiQ] Effect: Alloy Orb (High-Grade)
+  [9MU9d8tmJg3thkSc] Effect: Alloy Orb (Low-Grade)
+  [GXEkmsf4Wre6zqG1] Effect: Alloy Orb (Standard-Grade)
+  [s0Qfrd9asEgT9wUL] Effect: Amphisbaena Spittle
+  [94Vuzui165y0rgP5] Effect: Amplifying Touch
+  [90dTxPhFtbhK6Nv4] Effect: Amulet's Abeyance
+  [qzQo3qETndgRZKcO] Effect: Amulet's Abeyance (Adept)
+  [gN1LbKYQgi8Fx98V] Effect: Anadi Venom
+  [oI7DVO9uKNG4zGtZ] Effect: Ancestral Geometry
+  [Iwn7XovHu9HXp129] Effect: Ancestral Geometry (Save Type)
+  [vkgmMBMd2e2BwiwJ] Effect: Ancestral Influence
+  [wHQZO70bSECtSUZn] Effect: Ancestral Journey
+  [qKS1TilScX0SmesO] Effect: Ancestral Might
+  [gxBjyPaYDdhjAImf] Effect: Ancestral Response
+  [R6mx6EfLxSrQlrRa] Effect: Anchored
+  [s1tulrmW6teTFjVd] Effect: Angelic Blood Magic
+  [TJXXAp7MunXcZTCP] Effect: Animal Blind
+  [wQy8QddWBtzXYjw3] Effect: Animalistic Brutality
+  [eaKB3rIkJyfsow5H] Effect: Animate Net
+  [KE4ahbTX3DufZKXP] Effect: Ankhrav Carapace
+  [iK6JeCsZwm5Vakks] Effect: Anklets of Alacrity
+  [nnF7RSVlC6swbSw8] Effect: Anoint Ally
+  [TjBxxlTvb6tJP1jS] Effect: Antidote
+  [MN7OSIN1oeRfV0h6] Effect: Antifungal Salve
+  [mVgLCbZgafIylRzh] Effect: Antiplague
+  [C1SVTVEwhKpqSs6B] Effect: Apparition's Enhancement
+  [tTBJ33UGtzXjWOJp] Effect: Applereed Mutagen (Greater)
+  [xVAdPzFaSvJXPMKv] Effect: Applereed Mutagen (Lesser)
+  [fYjvLx9DHIdCHdDx] Effect: Applereed Mutagen (Moderate)
+  [4QPXRx8RuZLNSFvw] Effect: Apprentice's Ambition
+  [WQ0DxUzMgAvo0zy9] Effect: Apricot of Bestial Might
+  [TPbr1kErAAJKBi3V] Effect: Aquatic Combat
+  [omyZyfTnx3uYVgiP] Effect: Arachnid Harness
+  [QCqYiSIR9DVPAHgR] Effect: Arbor Wine
+  [Hx4MOTujp5z6SlQu] Effect: Arboreal's Revenge (Speed Penalty)
+  [EVRcdGt4awWPgXla] Effect: Arcane Propulsion
+  [bQZLdVsSrDhYkfrO] Effect: Arcane Standard
+  [IlNjAwsIZShlVsCT] Effect: Architect's Pattern Book
+  [w74r3xO0rsowT5ra] Effect: Archon's Aegis
+  [98ChTLCwnGo9ksZq] Effect: Area Armor
+  [rzcpTJU9MvW1x1gz] Effect: Armor Tampered With (Critical Success)
+  [IfRkgjyh0JzGalIy] Effect: Armor Tampered With (Success)
+  [Ddp2VNh2ldMhWJGQ] Effect: Armored Courage
+  [0qJEtpXWPb7JJBbY] Effect: Aromatic Ammunition
+  [FjcvJWPFwkyy5vEk] Effect: Artificer's Command
+  [5rypwpGjbu4aCAHh] Effect: Ascend
+  [vJfRASrNBBYW6MEC] Effect: Ascendant Dragon Spirit
+  [7UWKpTquSpP6Pgzh] Effect: Ascended Celestial Nimbus
+  [1zvAMG6E9xTsY2Au] Effect: Asper's Elemental Aura
+  [t8Yxrx3XgjS78Hxt] Effect: Assimilate Lava
+  [zcJii1XyOne9EvMr] Effect: Assisting Shot
+  [ggqCmAH0a7cmAdA3] Effect: Assured Fate
+  [kTnRp6zfI32iqjHc] Effect: Attitude
+  [JwDCoBIwyhOFnDGZ] Effect: Augment Senses
+  [Mnvd3jV4EW6nAJKI] Effect: Aura Junction (Air)
+  [QOWjsM4GYUHw6pFA] Effect: Aura Junction (Fire)
+  [MFCcEWCC9PR46qPy] Effect: Aura Junction (Metal)
+  [s8LMK2zCQgUT3HoY] Effect: Aura Junction (Water)
+  [su5qLXoweaHxt6ZP] Effect: Aura Junction (Wood)
+  [OxOMYmlPtjsEkRtY] Effect: Aura of Command
+  [7L6Gltxxkjq9eyXN] Effect: Aura of Confidence
+  [3MIZf42EhhKbIwLQ] Effect: Aura of Corruption
+  [MNkIxAishE22TqL3] Effect: Aura of Despair
+  [T7GGNvfqowFrRcKW] Effect: Aura of Determination
+  [3oF2DVXCmJ7VloBb] Effect: Aura of Disquietude
+  [VOOShYoB4gTopZtg] Effect: Aura of Faith
+  [xOD3ufpzA8H7W4sP] Effect: Aura of Good Cheer
+  [PR0YzItS9R60X3Zc] Effect: Aura of Growth
+  [FPuICuxBLiDaEbDX] Effect: Aura of Life
+  [QoneHsjZKtGHWlam] Effect: Aura of Misfortune
+  [18FHJoazfEmgNkfk] Effect: Aura of Preservation
+  [J3beTsJS9DBkJuVJ] Effect: Aura of Protection
+  [s16XQpDz2HNzR9BB] Effect: Aura of Protection (Solar)
+  [BmptyIaMhq7siOqR] Effect: Aura of Reflection
+  [I5Fd4TkIKRJT6WXf] Effect: Aura of Righteousness
+  [L0hDj8vFk1IWh01L] Effect: Aura of Righteousness
+  [8sXm5FX6qsMDYcba] Effect: Aura of Smoke
+  [dgZYRgGzwdWyZFOh] Effect: Aura of Sophistry (Holy)
+  [JksGGYzQqsNqeTQj] Effect: Aura of Sophistry (Unholy)
+  [Rr4stNn2zqzspjQu] Effect: Aura of Sophistry (Weakness)
+  [RjrsiEloXs7ze1TZ] Effect: Aura of Vitality
+  [LHRl8n9SQIWHrnis] Effect: Aura of the All-Seeing Eye
+  [uijpoXaiKXcCYrSD] Effect: Auric Noodles
+  [4p6rOPyQ5ziKp1VP] Effect: Aurochs Jerky
+  [mIZVE5kyzxScpaS5] Effect: Aurochs' Endurance
+  [JQUoBlZKT5N5zO5k] Effect: Avenge in Glory
+  [X2R07pnGkxvKi6pV] Effect: Avenge the Fallen
+  [P4EkIpTqPDB3gNba] Effect: Avowed Insight
+  [f2U0pvTwqrLYyOlC] Effect: Azarim
+  [8rDbWcWmQL0N5FFG] Effect: Azarketi Purification
+  [7pTfh1NwnXhEX7Lq] Effect: Azata's Grace
+  [U37oY6akeNfTtgLk] Effect: Bad Deal
+  [dCNQpHO0Ka8PW3z5] Effect: Banner Bearer
+  [pqXu9dJaIMw3yOdc] Effect: Banner of the Restful
+  [HafP5vrdGdoqoFMo] Effect: Barbed Net
+  [P7Y7pO2ulZ5wBgxU] Effect: Barding of the Zephyr
+  [Hv4NO0HADyAAdS4F] Effect: Bark Orders
+  [PvOaRjOnUrPkfbxe] Effect: Bark Orders (Hold Sergeant)
+  [4tGVIEqwH4TQoF0O] Effect: Bastion Aura
+  [PT1g0Ar47FVo2O4D] Effect: Batsbreath Cane
+  [Yqq4AkZ9lrm4CcID] Effect: Battle Cry
+  [2XEYQNZTCGpdkyR6] Effect: Battle Medicine Immunity
+  [ZkYDgSSlKML9BUjg] Effect: Battle Planner
+  [vO8lhZvkN8u5MCqg] Effect: Be the Band
+  [2nO2p8n3j5t6MINY] Effect: Be the Band (Sustain)
+  [6KebCyP5O7Gl9baR] Effect: Beacon of the Rowan Guard
+  [M1HKNPpqkjFI9A4q] Effect: Beastmaster's Sigil - Armor
+  [rdHzCYZEWpy2rTfI] Effect: Beastmaster's Sigil - Melee Weapon
+  [EPqnA5OlNpwr41Os] Effect: Beastmaster's Sigil - Ranged Weapon
+  [PUCeFY8Ps0CP3w2g] Effect: Bedroll of Deep Slumber
+  [pPmtUt7lPYfbVqbR] Effect: Beguiling Presence
+  [6wyzhmElDV8IP0qM] Effect: Belief Fortification
+  [tnIjFwv55sDPZxlb] Effect: Belief Fortification (Mark)
+  [fbSFwwp60AuDDKpK] Effect: Belt of the Five Kings (Allies)
+  [cg5qyeMJUh6b4fta] Effect: Belt of the Five Kings (Wearer)
+  [HlUL7FmGLyS35Jpp] Effect: Bendy-Arm Mutagen (Greater)
+  [FDSl6DFblUjITOgP] Effect: Bendy-Arm Mutagen (Lesser)
+  [pZjJv8r28uASg6zp] Effect: Bendy-Arm Mutagen (Major)
+  [IBu1RWKW5JX70nse] Effect: Bendy-Arm Mutagen (Moderate)
+  [xPHUZgr0XEyP1Nof] Effect: Benefactor's Majesty
+  [k8gB0eDuAlGRoeQj] Effect: Benevolent Spirit Deck
+  [JSruXKRV7iJv8Se0] Effect: Beseech the Spirits
+  [lPtt7PojWBwPOaYt] Effect: Bespell Strikes
+  [kwD0wuW5Ndkc9YXB] Effect: Bestial Mutagen (Greater)
+  [fIpzDpuwLdIS4tW5] Effect: Bestial Mutagen (Lesser)
+  [1ouUo8lLK6H79Rqh] Effect: Bestial Mutagen (Major)
+  [xFQRiVU6h8EA6Lw9] Effect: Bestial Mutagen (Moderate)
+  [ri5qxyVViva60ilN] Effect: Bewitching Bloom (Lotus)
+  [qLl1jwybXY6EbOoI] Effect: Bewitching Bloom (Magnolia)
+  [1iIObOrXUGA3RwQ9] Effect: Bickering Family
+  [G7tYqJYFX8YBnF3r] Effect: Big Debut
+  [GGxPoUu7tcASRY0G] Effect: Biggest Fan!
+  [LRLc8KQIJa4FhvvW] Effect: Binding Oath
+  [tiJwcsZeWeS3FttZ] Effect: Bismuth Armor
+  [4FginnDcOt4wfedf] Effect: Bittersweet Dreams
+  [8z4Q84UlS8cMYVWu] Effect: Black Cat Curse
+  [aMQxiTCdTxVcradv] Effect: Blade Barrage
+  [v20pbW7ZabrqqB9U] Effect: Blade of Four Energies
+  [5yfA4sAo0CjXIYDr] Effect: Blade of the Heart
+  [D32aR6cVq0YyHEP6] Effect: Blanket Defense
+  [jrfuplUEq3PIo6j1] Effect: Blasphemous Utterances
+  [oiO3cQfqp8MuxR82] Effect: Blast Boots (Major)
+  [PFtYVamw7de2cozU] Effect: Blast Suit
+  [VlfuBfWkygsG8u5h] Effect: Blaze
+  [7FPIQyPcq2R4L1ZQ] Effect: Blazing Banner
+  [niYOLA6l44U2NMM3] Effect: Bless Ally
+  [sCxi8lOH8tWQjLh0] Effect: Blessed Armament
+  [A1VCJqeusccB7OOH] Effect: Blessed Coins
+  [rYYU6UVHblaJBxFB] Effect: Blessed Counterstrike
+  [bqbliPkslR5hkAcB] Effect: Blessed Swiftness
+  [N2XR9v6Vo13SJZXV] Effect: Blight Breath
+  [GzDBmtKQY0cHSGM3] Effect: Blistering Touch
+  [JF2xCqL6t4UJZtUi] Effect: Blizzard Evasion
+  [Eu3hA5BrHX9u9Bjc] Effect: Bloc Tactics
+  [LfhCO3rP5ImzPyNY] Effect: Blood Booster
+  [ScZ8tlV5zS0Jwnqn] Effect: Blood Frenzy
+  [LOLoQpaAp5cC0hbm] Effect: Blood Fury
+  [4GAJHkurmZ1ttKDv] Effect: Blood Magic
+  [ceOkHxhJNTcvZkCy] Effect: Blood Siphon (Critical Failure)
+  [wPIGBcpCqCWgrCiq] Effect: Blood Soak
+  [7hiwUPQY5aBEkpIt] Effect: Blood Sovereignty
+  [oORIapm28xioxPDp] Effect: Blood Wake
+  [tu36I5HWaqOjaLVu] Effect: Blood and Spirit
+  [FHcvd2XHBdqKg5KT] Effect: Blood-Drinker Blade
+  [MI5OCkF9IXmD2lPF] Effect: Bloodhound Mask (Greater)
+  [S4MZzALqFoXJsr6o] Effect: Bloodhound Mask (Lesser)
+  [wFF0SZs1Hcf87Kk1] Effect: Bloodhound Mask (Moderate)
+  [VVXjPCummVHQp7hG] Effect: Bloodhound Olfactory Stimulators
+  [fLaHBJFV02m25j4c] Effect: Bloodletting
+  [tvybMInVm415jA3p] Effect: Bloodline Magic
+  [EqdXFH2l0TyeOTQz] Effect: Bloodline Magic (Stirvyn Banyan)
+  [5XdkHIUgc6psBxQq] Effect: Bloodseeker Beak
+  [BKZS6xpUndRSnxK1] Effect: Bloom Regeneration
+  [LJOZk2O6KS3iulXy] Effect: Boar Form
+  [0BNGjyW5WigX1FIs] Effect: Boaster's Challenge
+  [xdlAursiOE9A9rK7] Effect: Boaster's Challenge (Critical Success)
+  [ZUwlipd2iB75RVbh] Effect: Bob
+  [YH57XXyIQCRe6pcR] Effect: Body Shield
+  [IfUod2VxNmZMGGPq] Effect: Bodyguard's Defense
+  [Q5pWxWsb4MIgfwxd] Effect: Bogwid Fever
+  [xYd4G4yPLHSWWWvT] Effect: Bold Defiance
+  [bmVwaN0C4e9fE2Sz] Effect: Bolera's Interrogation
+  [gKnoF5VKTCyl4JaN] Effect: Bolster Flesh
+  [VOorielY4wCSfqOr] Effect: Bolster Torag's Chosen
+  [lgs9NGaWM53EEawX] Effect: Bolstering Croak
+  [HmpYVsyiCq8XDlop] Effect: Bomber's Eye Elixir
+  [YlIESAmhjHJHGzmi] Effect: Bomber's Eye Elixir Cover Reduction
+  [GoSls6SKCFmSoDxT] Effect: Bon Mot
+  [4bR1i7qzmSJ5No6O] Effect: Bond in Light
+  [P6f6UnvYSF5zATyu] Effect: Bone Flense (Damage)
+  [5Zof6sC46ms4JLIl] Effect: Bone Flense (Reaction)
+  [ZsO5juyylVoxUkXh] Effect: Bone Spikes
+  [r4kb2zDepFeczMsl] Effect: Bone Swarm
+  [GqXIV46JqB8x8eEN] Effect: Book of Warding Prayers
+  [88kqcDmsoAEddzUt] Effect: Boots of Elvenkind
+  [yvYzIb8Ca4rzC4yt] Effect: Boozy Bottle
+  [uaWIJU1m2eHgfkDp] Effect: Born to the Trees
+  [WfiaKdXNSxC3POcs] Effect: Bosun's Command
+  [pmWJxDjz3gqL29OM] Effect: Bottled Omen
+  [2C1HuKDQDGFZuv7l] Effect: Boulderhead Bock
+  [cvbjBqSLYDSqoXGP] Effect: Bound in Death
+  [lLP56tbG689TNKW5] Effect: Bracelet of Dashing
+  [RwDdIlkzt8TpEjHD] Effect: Bracers of Devotion
+  [PeiuJ951kkBPTCSM] Effect: Bracers of Missile Deflection
+  [PJUNqF2k9x8IiZhb] Effect: Bragging Rights (Failure or Worse)
+  [AnpRfQm6dFSa9e8t] Effect: Bragging Rights (Status Bonus)
+  [ZnJhU0SIlE3DCxZB] Effect: Bragging Rights (Status Penalty Critical Failure)
+  [WsFkAE6J704k4Tt3] Effect: Bragging Rights (Status Penalty Failure)
+  [wlxxUXlTB8J8BCzF] Effect: Bragging Rights (Success or Better)
+  [BmAw66zEkifSvOtg] Effect: Brand of the Impenitent
+  [Zqs1VvRm5Oq7DwX0] Effect: Brass Dwarf Weakness
+  [B7SJSaYOT1Uq4WLo] Effect: Bravado Aversion
+  [eh7EqmDBDW30ShCu] Effect: Bravo's Brew
+  [68oispwYGLUUxjzt] Effect: Breach the Outer Rifts
+  [zOaP4yGwbFOszxeJ] Effect: Break Legs!
+  [N54jx6GEz2NpGobK] Effect: Breastplate of the Mountain
+  [9e6iVkPpGqJYwMyb] Effect: Brewer's Regret
+  [xPg5wzzKNxJy18rU] Effect: Brightness Seeker
+  [Hmj1N4JkqQHIxb7i] Effect: Brimstone Blessing
+  [4Zj71naHbY6O9ggP] Effect: Bristle
+  [Cxa7MdgMCUoMqbKm] Effect: Bronze Bull Pendant
+  [7x0O2GqWBJiAk5PF] Effect: Brutal Rally
+  [gHczZWA34WQx4px0] Effect: Bully the Departed
+  [a0nJK2mKHwWYzpdG] Effect: Bully's Rage
+  [6E8blr21VWk0L4sv] Effect: Burned Fingers
+  [nwFhhgZRggDoDgdk] Effect: Burned Mouth and Throat (Linguistic)
+  [CS1XbH7GYfP6Ve61] Effect: Burned Mouth and Throat (No Singing or Yelling)
+  [lZ4DA81o4kbL8nve] Effect: Burned Tongue (Linguistic)
+  [XOE1gp3phFyxL4Dq] Effect: Burned Tongue (No Singing or Yelling)
+  [P6druSuWIVoLrXJR] Effect: Calculate Threats
+  [iOBkeWz0gTzplbXJ] Effect: Call Upon Razmir's Benevolence
+  [6ReMiLTAc70nbzAC] Effect: Call Upon the Ancients
+  [l2fxGJVR9ffNI8uC] Effect: Call Upon the Sovyrian Stone
+  [kdZEZ6iBYQPVGzYD] Effect: Call to Action
+  [EfjkHfrNUsmCoNl4] Effect: Call to Arms
+  [v54mj5jknAynlCM9] Effect: Call to Blood
+  [pvA97TXnq7wCbXp6] Effect: Call to Halt (Success)
+  [63ia9YXlCIX7PXyp] Effect: Called Foe
+  [9yDGgsjW3vTZt0ez] Effect: Called Shot
+  [kcxz1zHReNt8zm8Y] Effect: Called Shot (Critical)
+  [pfG1S7yShwkHT9e0] Effect: Calming Bioluminescence
+  [5DaEI4I7cVdOD507] Effect: Caltrops
+  [j6DbvXzg5lTgw3Bq] Effect: Can't Fall Here
+  [9ZrfvQxxcdzlND3y] Effect: Cantorian Rejuvenation
+  [wdN3sa1Qs2rEdiDC] Effect: Cape of Justice (Distracted)
+  [UzSrsR9S2pgMDbbp] Effect: Cape of the Open Sky
+  [E0fYyli4aCVmevgJ] Effect: Capture Magic
+  [Ve1CRFI8ikL6dqcL] Effect: Cast Down
+  [BTI4obxa5UmNltyU] Effect: Castigating Weapon
+  [l3S9i2UWGhSO58YX] Effect: Cat Nap
+  [zTrZozbWDd1A5L5S] Effect: Cat Sith's Mark
+  [4NC6sIgh6LUEbBiU] Effect: Cataclysm Brand
+  [BJLvQd1xCagDFxwy] Effect: Catch Pole
+  [A81HpA9cBUgGRsqx] Effect: Catch your Breath
+  [wFpKEx9KSjoVg9xq] Effect: Catchy Slogan
+  [5bEnBqVOgdp4gROP] Effect: Catfolk Dance
+  [5M3RGpOuxizPM5Iy] Effect: Caustic Drool
+  [0YkzZEywOgVdcMHc] Effect: Caustic Jabs
+  [TbmkcfpKIs558skY] Effect: Caustic Mucus
+  [xDT10fUWp8UStSZR] Effect: Cavalier's Banner
+  [PNIIxE6wJCZTRNQR] Effect: Cayden's Brew
+  [h8BLaHUFnzCDJf5I] Effect: Celestial Armaments
+  [ORbgwLZpFFHsaJxm] Effect: Celestial Armaments (Allies)
+  [D1SUxDvtDyqwdXqO] Effect: Celestial Yaoguai Might
+  [9kNbiZPOM2wy60ao] Effect: Ceremony of Protection
+  [Sq558879cgEc1lGC] Effect: Chalice Adept Benefit (Self)
+  [KuCh1JGrAidkKBav] Effect: Challenge Foe
+  [xLy4bBwk50AGbd7w] Effect: Champion's Aura (Champion of Rovagug)
+  [2a6fuugiPpICe3Li] Effect: Champion's Extra Damage
+  [DawVHfoPKbPJsz4k] Effect: Champion's Resistance
+  [Q8pD29NcGGuRxWwh] Effect: Change Shape (Werecreature)
+  [kyX0DvZEXR4Xrbdp] Effect: Channel Divine Spark
+  [DkdAPJohjgtnCIJe] Effect: Channel Draconic Essence
+  [7hQnwwsixZmXzdIT] Effect: Channel the Godmind
+  [UookwOq46zEokGOM] Effect: Channeled Protection
+  [BZPPcHtYugsNKz4Z] Effect: Channeler's Stance
+  [Rzg3c7hfkvTlxPDp] Effect: Channeling Block
+  [yZTpWRNrg2jZMZpM] Effect: Chant of Dominance
+  [jhPkOUdLPSQ46vkU] Effect: Chaotic Spawning
+  [sgK3JkyLbXLoNjPI] Effect: Chaotic Spell
+  [mQJk8R0vHzvpTz0e] Effect: Chatterer of Follies
+  [PeuUz7JaabCgl6Yh] Effect: Cheetah's Elixir (Greater)
+  [lNWACCNe9RYgaFxb] Effect: Cheetah's Elixir (Lesser)
+  [j9zVZwRBVAcnpEkE] Effect: Cheetah's Elixir (Moderate)
+  [s4XFUgK8UgKnpKrX] Effect: Chemical Fertilizer
+  [iIC9uGfg0rnYSRZ2] Effect: Chivalric Emblem
+  [PJxUFFeAvQJ4l52f] Effect: Choose Weakness
+  [VlBozDEaEaKE1A3O] Effect: Chosen Ward
+  [YUj20zJ4bNAoc0nJ] Effect: Chromatic Jellyfish Oil
+  [uZ2mAwpVz1bkw5GK] Effect: Chthonic Mucus
+  [cpeMnTLFpi106fjg] Effect: Chthonic Mucus (1-2)
+  [zBbmuudbWY8FaOwZ] Effect: Chug
+  [Thd0XXhunYNk6jD7] Effect: Cinnamon Seers
+  [KOLOAj7EYHkoNmlY] Effect: Circle of Horns
+  [KdV8UtN8Af5oCerj] Effect: Cite Precedent
+  [auJ02rr1Jr88oD3Z] Effect: Claim Corpse - Fleshy
+  [3np7EyJ8pyrVlpie] Effect: Claim Corpse - Skeletal
+  [Uadsb25G18pKdZ2e] Effect: Clandestine Cloak
+  [uXEp1rPU5fY4OiBf] Effect: Clandestine Cloak (Greater)
+  [EBE2Oid75GC4n5vG] Effect: Class Might
+  [lh2YM9yNJixOC8RI] Effect: Clawed Bracers
+  [fLcp28dxFCOcBibw] Effect: Clay Sphere - Armor
+  [La2ziyuLYKG0thOj] Effect: Clay Sphere - Weapon
+  [SMsTQhsPJ58WqPKy] Effect: Clay Sphere - Weapon Damage Increase
+  [wLQEa9xChzWEc7Mn] Effect: Cleansing Earth
+  [hHALCOBKk1j8yRfv] Effect: Clinging Smoke
+  [ZAEn7KA7Vdb1ruIr] Effect: Cloak in Embers
+  [eeGWTG9ZAha4IIOY] Effect: Cloak of Elvenkind
+  [v4furpS1e0hiey4R] Effect: Cloak of Subversion
+  [Qf7ksK6sjC4x7SWw] Effect: Cloak of Swiftness
+  [ioGzmVSmMGXWWBYb] Effect: Cloak of the Bat
+  [3LhreroLRmI4atE6] Effect: Clockwork Cloak
+  [oaR6YGiZKg8a2971] Effect: Clockwork Goggles
+  [yryez4kaltjOUm7C] Effect: Cloister Robe
+  [4uh4EP1sxKRYx7kg] Effect: Close Contract
+  [YcHGSplvY5Vbqfc8] Effect: Cloud Buns
+  [bDcRrcC6VlkenVK4] Effect: Cloud Buns (Greater)
+  [pVd4mbG2u8Y1mqgL] Effect: Cloud of Allergens
+  [vhSYlQiAQMLuXqoc] Effect: Clue In
+  [yZW8I6G2Di6gdd16] Effect: Codex of Destruction and Renewal
+  [ApGnHnZEK7nv3IqL] Effect: Codex of Unimpeded Sight (Greater)
+  [qit1mLbJUyRTYcPU] Effect: Cognitive Mutagen (Greater)
+  [jaBMZKdoywOTrQvP] Effect: Cognitive Mutagen (Lesser)
+  [RT1BxXrbbGgk40Ti] Effect: Cognitive Mutagen (Major)
+  [ztxW3lBPRcesF7wK] Effect: Cognitive Mutagen (Moderate)
+  [OFJVaPxdafc4ezWB] Effect: Cold Iron Blanch (Greater)
+  [i5agc4lBE6GfeCXq] Effect: Cold Iron Blanch (Lesser)
+  [uK2vXk4WnleihqYI] Effect: Cold Iron Blanch (Moderate)
+  [0PDng7D5Aj0szeSU] Effect: Combat Mentor
+  [CdWAXaePkMP4hts9] Effect: Combat Premonition
+  [k29Ao7wxjPVqxuez] Effect: Come and Get Me
+  [9O4q3bYlWkuC24vh] Effect: Come and Get Me (Circumstance Bonus)
+  [CYmipBeliNuymENB] Effect: Come and Get Me (Temporary Hit Points)
+  [iMY1ClfWdn50s0PM] Effect: Command Attention
+  [G0lG7IIZnCZtYi6v] Effect: Command Bravery
+  [T9dTK6oNzA6utSLj] Effect: Command Cuirass
+  [elbRo41iHweUkXtJ] Effect: Commandant's Scabbard
+  [5NSWRxAsJuvwyl0E] Effect: Commander's Aura
+  [JZWi6512m9RlMrNO] Effect: Commander's Banner
+  [S7CMUc27ClPBvyVS] Effect: Commanding Aura
+  [iDLu83vhWoNIE7xt] Effect: Commanding Aura (Quara)
+  [dpoQrtDsUeEILBJ3] Effect: Commanding Draw
+  [F1JHRa75KBAjHOs1] Effect: Commanding Shout
+  [Yb5rg3MEojIHQX8H] Effect: Compelled Performance
+  [NKa2EMtpcatohaKJ] Effect: Competitive Taunt
+  [I4C55X7AzchlF9FM] Effect: Conduct
+  [lU8IO9FIGK1DXVMy] Effect: Conduct Energy
+  [m3bDBF65IMjaUlo1] Effect: Conduct the Experiment
+  [5Todv39Zj63IyQCZ] Effect: Conductive Downpour
+  [sl3umfGcLROU3U5U] Effect: Conductive Sphere
+  [4a7g78DOZqHE9pRD] Effect: Connect the Dots
+  [Up4O78PvSYAlXxDA] Effect: Consecrated Altar to Ydersius
+  [92D7H9SiMSK3rNlM] Effect: Consecration Vulnerability
+  [lhgGLGL8phfu0bOL] Effect: Construct Trap
+  [sEv8H8PrMd0C3wJ7] Effect: Consult the Spirits
+  [eMsI1lR0SuJBCYjn] Effect: Consume Energy (Augment Strike)
+  [ZZdkqqERUoCHrapf] Effect: Consume Flesh
+  [0jAT2TJoqC1z6NCf] Effect: Consume Memories
+  [Qa0HP5uCuqh4vxBh] Effect: Consume Organ
+  [m5kXngVAHiprZea1] Effect: Consume Power
+  [YOH7YsdlsLzlMu69] Effect: Consume Soul
+  [l9sm9MVVzWlx010m] Effect: Consumed by Bloodlust
+  [SqN1FGSgdNlyvRu9] Effect: Containment Contraption
+  [DVIxPdgUN8T5LwIp] Effect: Continuous Flair
+  [mkIamZGtQaSsUWLk] Effect: Control Tower
+  [YUj8kxyGTWRbbyBu] Effect: Convert Arrows
+  [FngohajUtnPe9vmJ] Effect: Cooperative Hunting
+  [Ljrx4N5XACKSk1Ks] Effect: Core Cannon
+  [c7Bzxc5gxkRfXNme] Effect: Cornucopia of Plenty
+  [3WzaQKb10AYLdTsQ] Effect: Corpse-Killer's Defiance
+  [ctiTtuRWFjAnWdYQ] Effect: Corpse-Killer's Defiance (Lower Level)
+  [a4bZrBNL17zPjDiH] Effect: Countered by Fire
+  [81XYZZ3H0GL8thdQ] Effect: Countered by Water
+  [JRaFM5Ic4xR8WGgs] Effect: Coven Spell
+  [NAWKV7G4kBpPHWqL] Effect: Covenant Tea
+  [I9lfZUiCwMiGogVi] Effect: Cover
+  [fH4SxaerUGXqIOIJ] Effect: Cozy Campfire
+  [GUHNFlNYiR38sTDE] Effect: Crackling Bubble Gum
+  [bMZ6Gw58sK8sFp5n] Effect: Crackling Bubble Gum (Failure)
+  [ogzkGtUR9vMt47ts] Effect: Crash Against Me
+  [sEWwGSuXxcTl020D] Effect: Crash Against Me (Clang)
+  [5dxWxTDjPPT79xpn] Effect: Crash Against Me (Note)
+  [IPfr5O7bTwJhRB5v] Effect: Create Opening
+  [dZxFehDfiKu3M8GT] Effect: Creature of Myth (Energy Aegis)
+  [ybc7tZwByenCzow8] Effect: Creeping Ashes
+  [ytqvHyF0oMKbo65P] Effect: Crimson Fulcrum Lens
+  [m942gdWRO19p0QS8] Effect: Crimson Godsblood Serum
+  [6YhbQmOmbmy84W1C] Effect: Crimson Shroud
+  [gvE0iQ7h6263Mkhi] Effect: Crimson Shroud (AC)
+  [lHbTN7jk1zuER92O] Effect: Cringe
+  [NyUWMdcABrlVsSBy] Effect: Critical Moment
+  [USMuxi8ACBJRUrdS] Effect: Crocodile Form
+  [hD0dUWYKM8FrVDZY] Effect: Crown of the Kobold King
+  [dZT1w2EciqaR2NRz] Effect: Crownhold Consecration
+  [7OJrBAEah6YFLzcK] Effect: Crush Chitin
+  [R8clbf7gtIlU3fIj] Effect: Crush of Hundreds
+  [zNHvhwHsC8ckhKVp] Effect: Crushing
+  [czdEHtLsrUcZxSDx] Effect: Crushing (Greater)
+  [U05L8bPBcRHTtTB3] Effect: Crushing Spirits
+  [AsYHSc1sNEXYELj7] Effect: Cry of Rebellion
+  [1bzFIIEw2K1CAUe9] Effect: Crystal Luminescence
+  [HKC4IZOzbvtjsp77] Effect: Crystal Shards
+  [C9nb9XbnQgbnXpTq] Effect: Crystalline Dust Form
+  [QjgLHIgRXIk3KAOY] Effect: Curl Up
+  [8HGz3rQCHNgdAqFC] Effect: Current Spell
+  [85w9OI1gMd6uJRKh] Effect: Curse Maelstrom State
+  [SN2UAhPQROyvuj6c] Effect: Curse Trespassers
+  [V6lnFOq998B76Rr0] Effect: Curse of Ancestral Meddling
+  [CUgmb7g65vYNT2hn] Effect: Curse of Boiling Blood
+  [G4L49aMxHqO2yqxi] Effect: Curse of Creeping Ashes
+  [hqeR9faxHj0NDFFP] Effect: Curse of Engulfing Flames
+  [VFIVdYmS3XTdd3hj] Effect: Curse of Fire
+  [sI73mEP9wZRvMpWw] Effect: Curse of Frost
+  [8YjmPizeglw83W9E] Effect: Curse of Inevitable Rot
+  [6fObd480rDBkFwZ3] Effect: Curse of Living Death
+  [EtFMN1ZLkL7sUk01] Effect: Curse of Outpouring Life
+  [s95P3L72BDKvzYhn] Effect: Curse of Potent Poison
+  [UgoM6FBiZfc7KqCV] Effect: Curse of Stone
+  [Tju9kpQlwcKkyKor] Effect: Curse of Torrential Knowledge
+  [oSzUv21eN9VS9TC1] Effect: Curse of Turbulent Moments
+  [Tkf33YglEZcZ6gOT] Effect: Curse of the Baneful Venom
+  [pQ3EjUm1lZW9t3el] Effect: Curse of the Hero's Burden
+  [I0g5oaSwaqZ8fFAV] Effect: Curse of the Perpetual Storm
+  [rwDsr5XsrYcH7oFT] Effect: Curse of the Sky's Call
+  [qPul8V5LMyHNpsOa] Effect: Curse the Intruders
+  [gWwG7MNAesJgpmRW] Effect: Cut from the Air
+  [SZY4zxhxoeehYRdN] Effect: Cyclonic Ascent
+  [VJj190x4E8Xayg0O] Effect: Dagger Defense
+  [F4fWxN5WREaoWz19] Effect: Damned Restoration
+  [FL24cTM3EDqWLgHA] Effect: Dancer in the Seasons
+  [w0kwwWC7QTmytbVt] Effect: Daring Attempt
+  [1toVzNVJZx0RwG1v] Effect: Darivan's Bloodline Magic
+  [7vCenP9j6FuHRv5C] Effect: Darkvision Elixir (Greater)
+  [7UL8belWmo7U5YGM] Effect: Darkvision Elixir (Lesser)
+  [bcxVvIbuZWOvsKcA] Effect: Darkvision Elixir (Moderate)
+  [1k4tfR8wHeaW6ahR] Effect: Dawnfire Beacon (Major)
+  [RATDyLyxXN3qmOas] Effect: Daydream Trance
+  [uwYGEeqvt8pwjhXa] Effect: Dazzled until end of your next turn
+  [ryz7DdJTTXEgj9jf] Effect: Dazzling Rosary
+  [ed9iJxdHuft6bDFF] Effect: Deadly Poison Weapon
+  [IFHqrbQUOT2LzNDB] Effect: Deadweight Mutagen (Greater)
+  [T7C0HaGu1Cn6Pt5j] Effect: Deadweight Mutagen (Lesser)
+  [7eCUXYunzGVEsaKh] Effect: Deadweight Mutagen (Major)
+  [xV8fmSn12652usGC] Effect: Deadweight Mutagen (Moderate)
+  [Gj6u2Za5okFlsTvT] Effect: Deadweight Snare (Failure/Critical Failure)
+  [NYOi1F9cW3axHrdc] Effect: Deadweight Snare (Success)
+  [W2OF7VeLHqc7p3DO] Effect: Deafened until end of your next turn
+  [lyeRL7khixdlJsaf] Effect: Death Gasp
+  [5x0XpNftvx9uGbXt] Effect: Death Gasp (Etioling)
+  [VIYfrecOd54NUPur] Effect: Deathdrinking
+  [VTJ8D23sOIfApEt3] Effect: Debilitating Bomb
+  [MIznUE9YmCI01ZMr] Effect: Debilitating Sneak Attack
+  [yBTASi3FvnReAwHy] Effect: Debilitating Strike
+  [vc3AOrJpacJ7T1hO] Effect: Deceitful Feast (Failure)
+  [NZ3MrmXkmfQuJp7S] Effect: Deceptive Heads
+  [5fPfP74t4NYnRnnc] Effect: Deck of Destiny
+  [gyfPLgqeIgW7fYD0] Effect: Declare Anathema
+  [FyaekbWsazkJhJda] Effect: Decry Thief
+  [BBGg5gpMmuBSo7Mi] Effect: Deep Freeze
+  [g3jJKZ36kF3YHFtU] Effect: Deep Sea Plate
+  [wIaXcsccLYf1Wi6Y] Effect: Defender's Grit
+  [51PsXKJFe6XQ9WEX] Effect: Defense of Liberty
+  [pMPe01GWvfwcYwUR] Effect: Defensive Assault
+  [pTYTanMHMwSgJ8TN] Effect: Defensive Instincts
+  [jwxurN6JPQm9wXug] Effect: Defensive Recovery
+  [BsuYuFxE20mnRxbs] Effect: Defensive Slam
+  [EwhWYPCNM8bIIYEI] Effect: Defensive Slice
+  [Zy7rrPCgMTeSzKj9] Effect: Defiant Banner
+  [Q5FUu7yhWPJlcXei] Effect: Dehydrated
+  [3xsComVKLuLn7etk] Effect: Deity's Protection
+  [rQV8Azb3FeUJJ3fG] Effect: Delve Scale
+  [GnIAh8I8Ln8IQao8] Effect: Dematerialize
+  [WMbwQNRLQ9boujz4] Effect: Dematerialize (Ephemeral)
+  [WMKjWH4gyUrky4Hy] Effect: Demon Dust (Stage 1)
+  [XlHbUOTbK6PfBfCv] Effect: Demon Dust (Stage 2)
+  [4j5J4IM9sWNe1UcT] Effect: Demon Hunted
+  [IxhKGd3nK2lcIpMw] Effect: Demon's Knot
+  [3PiE6Wka0ylO5V1x] Effect: Demon-Touched Weapon
+  [aKRo5TIhUtu0kyEr] Effect: Demonic Blood Magic
+  [91qBP1n04xsKeXkE] Effect: Demoralizing Charge
+  [U2RNTMsZJqtVryK7] Effect: Demortification Oil
+  [izuJvgHjqI6kQNbK] Effect: Denounce
+  [1UHjPz8hgdnrN3zL] Effect: Deny Fate
+  [cs9UyOf4D3hh7cDG] Effect: Depth Charge
+  [vqKBIflXiAmCx5QQ] Effect: Dero Medicine
+  [tVw3srxbsQ8PjBfy] Effect: Dero Medicine (Deg)
+  [uAWWAiuo5mSJSVY4] Effect: Designate Ally
+  [WJ9L6rgUTZVV7vEE] Effect: Desolation Locket - Armor
+  [NwEVRZmLbM9QKoIH] Effect: Desolation Locket - Weapon
+  [1bOSJ2LbEC28aI9f] Effect: Despair
+  [Bjwlrq0mF64nZJjK] Effect: Desperate Swing
+  [sfUsodcGb4atcSyN] Effect: Desperate Wrath
+  [itdoXvcDo8wwmTME] Effect: Despoiler
+  [3PmBgt8SkkHqhRh1] Effect: Destined Victory (Note)
+  [6pLYKcDawL5JUBkK] Effect: Destructive Vengeance
+  [nvYBuNuu0pfCQPPt] Effect: Desynchronized Motions
+  [94MzLpLykQIWKcA1] Effect: Deteriorated
+  [3Qej6bMkgJ5ntllg] Effect: Devil You Know
+  [khL2A1slsnufpJp4] Effect: Devil's Cursed Breath
+  [IdlSIN88G5Ca7TLe] Effect: Devilwing Badge (Armor)
+  [JuyEDBlFwyDguEzG] Effect: Devilwing Badge (Weapon)
+  [XQpTyjXFYYNexyOk] Effect: Devise a Stratagem
+  [QpG9AaYpXJzDEjZA] Effect: Devour Soul
+  [S38CM3hyr7DnsmRR] Effect: Devour Soul (Victim Level 15 or Higher)
+  [jACKRmVfr9ATsmwg] Effect: Devrin's Cunning Stance
+  [n1vhmOd7aNiuR3nk] Effect: Diabolic Blood Magic (Self)
+  [6bGS19fnwbv4E7mn] Effect: Diabolic Certitude
+  [72THfaqak0F4XnON] Effect: Didactic Strike
+  [eAkGNoob2HWHXNP7] Effect: Dinosaur Boots
+  [pAMyEbJzWBoYoGhs] Effect: Diplomat's Badge
+  [inqXnzrqYzbUBuOj] Effect: Diplomat's Charcuterie
+  [reA6nqZH7Rj5OJ0E] Effect: Diplomatic Immunity
+  [Cc5WsKkbOPOzopCY] Effect: Dire Warning
+  [5ZK22sNW7o26aST0] Effect: Dirty Bomb
+  [ryY6fdqpC5Ztnagd] Effect: Dirty Bomb (Critical Failure)
+  [EpvyTaklBQAOr1eT] Effect: Disarm (Bonus)
+  [PuDS0DEq0CnaSIFV] Effect: Disarm (Success)
+  [mo4IRyv7GGRBJihU] Effect: Discerning Aura
+  [b1y4mJG0CeNIuhc0] Effect: Discord Fulu
+  [oXG7eX26FmePmwUF] Effect: Discordant Voice
+  [nb2Qy9XpdH4X3yQl] Effect: Dismal Harvest
+  [ewfHVi6NWBGM8B6f] Effect: Disrupting Strikes
+  [QcReJp7kgURdQCGz] Effect: Disruptive Stare
+  [EcVitI0Wqu3uNfaK] Effect: Dissolution's Sight
+  [6jjIDZ2ezcoWTJ1p] Effect: Distant Traveler
+  [ngwcN8u7f7CnqGXp] Effect: Distant Wandering
+  [7hRgBo0fRQBxMK7g] Effect: Distracting Feint
+  [E10qJgInN8Fx3yhW] Effect: Distracting Frolic
+  [6TKI9EZKvusrPLHU] Effect: Distracting Giggle
+  [qsvSWxRqVQofjDdH] Effect: Distracting Whisper
+  [AThOnEYzPO9ssYTB] Effect: Disturbing Vision
+  [Twno1jQEtPlrLOvK] Effect: Diverting Vortex
+  [e4HoYakV7SvwvcrH] Effect: Divine Aegis
+  [K1IgNCf3Hh2EJwQ9] Effect: Divine Aegis
+  [U2Pgm6B4nmdQ2Gpd] Effect: Divine Castigation
+  [1zAL0XwjCx6koYWL] Effect: Divine Frenzy
+  [DrM8d4joWHAaGlbe] Effect: Divine Health
+  [eecIuD6sGPX0FJcT] Effect: Divine Infusion
+  [OWFMglWgeCjRhqLK] Effect: Divine Invulnerability
+  [WdxPp1pTQTUYRTA3] Effect: Divine Invulnerability (Domain Spell)
+  [jMQi2kDirzGgddti] Effect: Divine Rebuttal
+  [K1brBNe37GzceN0N] Effect: Divine Weapon
+  [zZ25N1zpXA8GNhFL] Effect: Divine Weapon
+  [BWmrfNcFfjvWh8SV] Effect: Divine Weapon (Chelaxian Cleric)
+  [HfXGhXc9D120gvl5] Effect: Divine Wings
+  [BEou3aEkDXsQaTp3] Effect: Do No Harm
+  [Nwgp2UbfTXHxuInm] Effect: Don Mask
+  [ooX6QMPFfah5Yk5t] Effect: Don Thy Fervor
+  [zjVBG6uDd4WKWeKU] Effect: Downcast
+  [FNTTeJHiK6iOjrSq] Effect: Draconic Blood Magic
+  [lJGAJF9QiXCOPd2I] Effect: Draconic Breath Weapon Aura
+  [e183eoJd714WEi6J] Effect: Draconic Resilience
+  [XKsqQrabRlg9klGp] Effect: Draft of Stellar Radiance
+  [iqbWgT2TTJLGSkTL] Effect: Dragon Breath Scale
+  [TxGrhZe4NUSOpCxt] Effect: Dragon Chill
+  [K3nzzDkz8dNwAd1a] Effect: Dragon Eye
+  [APYXxkfZ9xf7HNf9] Effect: Dragon Pearl
+  [Ou8TRYpigcZZEjC2] Effect: Dragon Throat Scale
+  [4tepFOJLhZSelPoa] Effect: Dragon Turtle Scale
+  [nbMEBxeqZIdOgysR] Effect: Dragon's Blood Pudding
+  [0YbNzbW0HSKtgStQ] Effect: Dragon's Blood Pudding (Major)
+  [Hgs0mzN8lRHjcfAJ] Effect: Dragon's Eye Charm
+  [wmBSuZPqiDyUNwXH] Effect: Dragon's Rage Wings
+  [X82D9UtXUbr4eLyj] Effect: Dragonfly Fulu
+  [9j1uTGBGAc7GIhjm] Effect: Dragonfly Potion
+  [okDw1dRcrQafunTV] Effect: Dragonhide
+  [vH4bEu3EnAhNpKEQ] Effect: Dragonscale Amulet
+  [0ExJcZM3X51B0Ok3] Effect: Drain Blood
+  [LRIYUFQ7FE9H4RWD] Effect: Drain Life
+  [7EBdAHY7y06Bk4un] Effect: Drain Life (Wight Spell Sniper)
+  [fGI77mVeCQKBAP0f] Effect: Drain Luck
+  [E3TwqqTQwbTRQBrn] Effect: Drain Luck (Critical Failure)
+  [iiUIZj9xW79GE3U2] Effect: Drain Luck (Failure)
+  [c00YBD9y6ANnjTdF] Effect: Drain Luck (Success)
+  [cSH9aXM0hQlF5pgp] Effect: Drain Realm
+  [wBFtXxByOza6N9hs] Effect: Drain Vigor
+  [iAZ7k5JkbEzuPYZW] Effect: Draining Bite
+  [s79LDAwEZex6sy14] Effect: Drake Rifle (Cold)
+  [qwoLV4awdezlEJ60] Effect: Drakeheart Mutagen (Greater)
+  [GBBjw61g4ekJymT0] Effect: Drakeheart Mutagen (Lesser)
+  [vFOr2JAJxiVvvn2E] Effect: Drakeheart Mutagen (Major)
+  [BV8RPntjc9FUzD3g] Effect: Drakeheart Mutagen (Moderate)
+  [zgRWm8KRquDzd1iC] Effect: Draw From the Land
+  [KBEJVRrie2JTHWIK] Effect: Dread Marshal Stance
+  [2gKeytEnwpXhaLXM] Effect: Dreamcrusher
+  [wL4QI1h4YvdHoOuG] Effect: Drink Emotions
+  [LfzQ05hYrxPGrsMU] Effect: Drink Life
+  [gjxSQgN3MopLxM35] Effect: Drink from the Chalice
+  [cm31PGuq09sAzf3Y] Effect: Droning Wings
+  [YjcV6eW4u9OpSNC2] Effect: Drop of Convergent Waters
+  [vX8SE5SXnspdzMYZ] Effect: Drowsy Sun Eye Drops
+  [QVLX06QevxTcuZxU] Effect: Drunken Stumble
+  [F1HQADu6wNdT5ctT] Effect: Dual Mind
+  [7dLsA9PAb5ij7Bc6] Effect: Dueling Cape
+  [lWciVCnKhwp8cF6E] Effect: Dueling Dance
+  [1nCwQErK6hpkNvfw] Effect: Dueling Parry
+  [maBSHuVHyGwga9uC] Effect: Duelist's Challenge
+  [lR49i3wO6TxJAK9o] Effect: Dust Eternal
+  [VOSQ77DV4BnAkP7m] Effect: Eagle Eye Elixir
+  [hPxrIpuL54XRlA2h] Effect: Earplugs
+  [09oP0FBBAhXOS4JW] Effect: Earth Impulse Junction
+  [EBtQyoX3wTwlDMwP] Effect: Eat a Pickle
+  [u35Qzft0c84UySq2] Effect: Ebon Fulcrum Lens (2 Action)
+  [dmLcrEtn48rBajt0] Effect: Ebon Fulcrum Lens (Incorporeal)
+  [IZkHdaqWBJIIWO7F] Effect: Ebon Fulcrum Lens (Reaction)
+  [XIYWFGHBlcc79YI5] Effect: Echoes in Stone
+  [8uXXaQ3Y5FP2mwn6] Effect: Echolocation
+  [QMcmhifNQOPguv2t] Effect: Ectoplasmic Form (Physical)
+  [WrWSieH9Acy6XuzV] Effect: Educate Allies
+  [C3VRrOCZndaBIE1q] Effect: Egg Cream Fizz
+  [TfhcbqC3cjFdimeh] Effect: Electric Counter
+  [ULyqs7fSvFG5mdK0] Effect: Electric Surge
+  [s6qaLMRWaByX6t5T] Effect: Electricity Absorption
+  [lO9uGNY8qBNDJI8M] Effect: Electromuscular Stimulator
+  [sUcGXoEOuTC1fqpu] Effect: Electromuscular Stimulator (Failure)
+  [XaZdQHF9GvaJINqH] Effect: Elemental Assault
+  [3gGBZHcUFsHLJeQH] Effect: Elemental Blood Magic (Self)
+  [U6BAwYT5iC8cmBDG] Effect: Elemental Bulwark
+  [f8HuM5Ar6SSHNHBx] Effect: Elemental Field
+  [O8qithYQCv3e7DUQ] Effect: Elementalist Dedication
+  [lPRuIRbu0rHBkoKY] Effect: Elixir of Life
+  [jgNp0xehXyEp5CxY] Effect: Elysian Dew
+  [J0YS8mQsQ1BmT6Xv] Effect: Emberheart
+  [RyGaB5hDRcOeb34Q] Effect: Emblazon Antimagic
+  [CXMDSu8pKh0OJkUo] Effect: Emblazon Armament
+  [jUUjgpEEOeZeG7II] Effect: Emblazon Energy
+  [VGSHg5UEqgp5WhjV] Effect: Embody the Storm
+  [RiplRZUwR6vq5A5A] Effect: Embolden
+  [ZNpDvK1r9B8d7aZp] Effect: Emboldened with Glorious Purpose
+  [vlTiBE0h2kyw5J9o] Effect: Emerald Fulcrum Lens
+  [rH6RHxy6sNTLusKX] Effect: Emerald Fulcrum Lens (Saving Throw)
+  [bxXZYHCp6ftPSMCC] Effect: Emergency Medical Assistance
+  [gFsYqrYJk7ZPvygY] Effect: Emotion Vulnerability
+  [JysvElDwGZ5ABQ6x] Effect: Emotional Fervor
+  [dTymNXgTtnjqgYP9] Effect: Emotional Surge
+  [tI2fM9pAOpCWP2V9] Effect: Empathetic Plea
+  [ik5QuOpF0IO275Nm] Effect: Empowered Onslaught
+  [cqgbTZCvqaSvtQdz] Effect: Encroaching Presence
+  [NviQYIVZbPCSWLqT] Effect: Endemic Herbs
+  [datPIlarC3SudOSd] Effect: Endure the Onslaught
+  [PX6WdrpzEdUzKRHx] Effect: Enduring Debilitating Strike
+  [0AD7BiKjT8a6Uh92] Effect: Energetic Meltdown
+  [WQ48SJOWNuNMJ07l] Effect: Energize Bite
+  [8E5SCmFndGAvgkTw] Effect: Energize Wings
+  [UjXwDvLoSe9infGg] Effect: Energized Cartridge
+  [cOcHWeogJFIkEI0d] Effect: Energizing Lattice
+  [YsgABP1Ya0QJoiKt] Effect: Energizing Pill
+  [R5ywXEYZFV1WBe8t] Effect: Energizing Rune
+  [AJLURqXGLalmV9wN] Effect: Energizing Tea
+  [WEP9Oe1D9WsWSOU8] Effect: Energy Ablation
+  [RfRoAdN9r06xId6r] Effect: Energy Adaptive
+  [JbJykktAYMR4BRav] Effect: Energy Mutagen (Greater)
+  [C9Tnl6Q7Z5Sbw5EY] Effect: Energy Mutagen (Lesser)
+  [RIozNOntRJok5ZJt] Effect: Energy Mutagen (Major)
+  [na2gf5mSkilFoHXk] Effect: Energy Mutagen (Moderate)
+  [c0URo81HpSmCkuQc] Effect: Energy Robe of Electricity
+  [6alqXfVq0qWQC359] Effect: Energy Robe of Fire
+  [zocU4IYIlWwRKUuE] Effect: Energy Shot
+  [No817gKxdliCVQ9K] Effect: Energy Ward
+  [ipaniua1HJ4qGzcr] Effect: Energy Ward
+  [LF8xzzFsFJKxejqv] Effect: Enforce Oath
+  [Lingp4fGpZuj9eJB] Effect: Engaging Duel
+  [lgXXJFF0JstWTwom] Effect: Engaging Duel (Unengaged Target)
+  [nlMZCi8xi9YSvlYR] Effect: Engine of Destruction
+  [1cbIe569UD6paXad] Effect: Engulf and Swallow Whole
+  [T27uDXdMVc5ZFwKw] Effect: Enhanced Hearing Aids
+  [4USRFNH06dwOlgL5] Effect: Enjoy the Show
+  [XM1AA8z5cHm8sJXM] Effect: Enlightened Presence
+  [4fmRhCljZ9l0Tr3J] Effect: Enliven Foliage
+  [DPN3d9EZM9XqktWT] Effect: Enraging Whistle
+  [fPhbDSTPuT01f0Kn] Effect: Ensnare
+  [jQmfZcPD6xVYx5nb] Effect: Entangling Slime
+  [dNs30jfFOJqhjFW7] Effect: Entangling Train
+  [2O1MmFvLdGZodvVc] Effect: Enter Spirit Trance
+  [yr5ey5qC8dXH749T] Effect: Entity's Resurgence
+  [yqCzUxrdLlk6Q9VW] Effect: Envenom Fangs
+  [w0k59TPWUZ9Me4yF] Effect: Equitable Defense
+  [wmrINlK6twqfbJjo] Effect: Erraticannon
+  [IURDAutTgGTKW1ks] Effect: Erraticannon (Extra)
+  [eWDmS4QTwmwPbBTb] Effect: Escape Fulu
+  [61qS86bjxg8HCJBY] Effect: Eternal Torch
+  [Vk9Fwo0Xl1EF9fEF] Effect: Ethereal Crescent
+  [8ersuvNJXX00XaIQ] Effect: Euryale (Curse) Card
+  [58QyKgMWfsUPqZn1] Effect: Even the Odds
+  [xxkCSwizAu2wC7Fo] Effect: Even the Odds (Eagle Knight)
+  [rZR7o9uj598vLVaY] Effect: Evoke Fault
+  [iscmAwLoNKLQ2vnU] Effect: Exalt the Little Ones
+  [Ef63SlxSKlZmHosM] Effect: Exalted Reaction (Desecrator)
+  [GFLiTESBmoyQ3sLx] Effect: Exalted Reaction (Redemption)
+  [KzwcLwJ4c6hon0pu] Effect: Exalted Retributive Strike
+  [fgz7lwg1xHsVW4dX] Effect: Exemplary Finisher (Rascal)
+  [cu10OjQUdY0a9gpj] Effect: Exemplary Finisher (Wit)
+  [OwrgpWYQTCLM6Ye7] Effect: Exotic Edge
+  [lc8ez8O4eN73hNpR] Effect: Expel Maelstrom (Failure or Critical Failure)
+  [N27voDwKbzs7EZVt] Effect: Expel Maelstrom (Misfortune)
+  [fIRJftsmd83iSoR4] Effect: Expel Maelstrom (Success)
+  [Fz3cSffzDAxhCh2D] Effect: Exsanguinating Ammunition
+  [j1KR4TXzER3RYiqp] Effect: Extend Neck
+  [vSUyph3Z6wKl2l6Q] Effect: Extra Alchemy
+  [XlCcp2Jlwteqpm3z] Effect: Extra Warming
+  [G1wD9ERJPWMNmXOc] Effect: Extract Bones
+  [FkouUFpwUrPjhMNw] Effect: Extravagant Parry
+  [Luti1qjFOKYwZio0] Effect: Extreme stomach cramps
+  [HVNXglbd6fI36e6u] Effect: Eye Pluck
+  [5IGz4iheaiUWm5KR] Effect: Eye of the Arclords
+  [aXDtl9vMp1vIznya] Effect: Eye of the Unseen
+  [1ihy7Jvw5PY4WYbP] Effect: Eye of the Unseen (Greater)
+  [N8d1R833ojGFj1Mt] Effect: Eye-Catching Spot
+  [LGxrp2XkcOJHRPLz] Effect: False Flag
+  [0JvxhEv83bAD5PGv] Effect: Familiar of Balanced Luck
+  [IgLMAwovQ9roTsRN] Effect: Familiar of Bolstering Aid
+  [4wJM0OA9y2gsBAh7] Effect: Familiar of Keen Senses
+  [twvhTLrLEfr7dz1m] Effect: Familiar of Restored Spirit
+  [6I4qWkHzxj4MAt6g] Effect: Familiar's Resolve
+  [seWuw1GMSm3kzCWV] Effect: Fan Bolt
+  [1MvAqwGlG2umgOSE] Effect: Fanatical Frenzy
+  [3Wtzyb0ZgkaC7vHY] Effect: Fanatical Frenzy (Legacy)
+  [zDQmjp5YSwZtrgX9] Effect: Fanged Rune Animal Form
+  [rjQyiAqxvVzYUpqV] Effect: Favor of a Future Ally
+  [G8YANJEFkHebehZh] Effect: Favor of a Past Benefactor
+  [HTPJ0ciyeaIgrPzQ] Effect: Favor of a Present Foe
+  [WWevYlEmHFDBiOLe] Effect: Favor of the Oliphaunt
+  [X1pGyhMKrCTvHB0q] Effect: Favorable Winds
+  [sDftJWPPSUeSZD3A] Effect: Favored Terrain (Gain Climb Speed)
+  [OhLcaJeQy4Nf5Mwo] Effect: Favored Terrain (Gain Swim Speed)
+  [IpRfT9lL3YR6MH6w] Effect: Favored Terrain (Increase Climb Speed)
+  [HKPmrxkZwHRND5Um] Effect: Favored Terrain (Increase Swim Speed)
+  [jjSMbM3FCI3gLXCz] Effect: Feast on Illness
+  [WXVOuzbFCs7rGpF9] Effect: Featherlight Fletching
+  [OMJnZspk5YHai8yn] Effect: Fed by Metal
+  [35OHxyrZA43S8rtL] Effect: Fed by Water
+  [4FMFRlEC923CnLI7] Effect: Fed by Wood
+  [i4S6h5c1KK4FLq6w] Effect: Feed
+  [4EeKKdeKIO8Wc4jf] Effect: Feel No Pain
+  [raZ8SIBYyFux8L3U] Effect: Feral Swing
+  [mD44D9I05NQaXiED] Effect: Fetid Fumes
+  [lIEc8Lx3ROm17Dqa] Effect: Fetid Screech (Critical Failure)
+  [FQrNDisx6noJnFaQ] Effect: Fettering Fedora
+  [rJpkKaPRGaH0pLse] Effect: Fey Blood Magic
+  [KFnOWk5e7nwXT8IE] Effect: Feyfoul (Greater)
+  [Fngb79C1VDGLJ1EQ] Effect: Feyfoul (Lesser)
+  [IlTS2LTwYTyGXY49] Effect: Feyfoul (Moderate)
+  [GXQg0rAJGgk7Kfx9] Effect: Fickle Prophecy
+  [wJsOZsYI2ZUVcGxc] Effect: Fiddle
+  [eS9I5kaig0i1j3z0] Effect: Field Discovery (Chirurgeon)
+  [y6fibVDs9QF2vbwu] Effect: Field of Past Regrets
+  [EhEXb0arrl2tc1HB] Effect: Field of Slaughter (Bleed)
+  [LFJppLCe4JAWrzPs] Effect: Field of Slaughter (Keen)
+  [x8e0MXrPgdRYQqBm] Effect: Field of Undeath
+  [3hyrbOFyIPF99hcY] Effect: Field of Unholy Undeath
+  [ywP3B88P2gfsYhQ0] Effect: Fiendish Order
+  [MrdT7LiOZMN8J4GK] Effect: Fiendish Wings
+  [H99PJXU5cvJ4Oycm] Effect: Fiery Form
+  [Sekb8YSa36xlqcgk] Effect: Fiery Rhetoric
+  [pXHLq8EZyxGBhHSL] Effect: Fight On
+  [Qomp2EujVCbzJb4X] Effect: Filth Wave
+  [FOZXp7QQDnny1600] Effect: Fire and Iceberg
+  [VsHhBBLApZsOCJRL] Effect: Fire and Iceberg (Greater)
+  [yP45Rqu4jvCfXBkp] Effect: Fire and Iceberg (Major)
+  [UNq3f2ALPG1b67ar] Effect: Fish From the Falls' Edge
+  [nQ6vM1CRLyvQdGLG] Effect: Five-Feather Wreath - Armor
+  [v2HDcrxQF2Dncjbs] Effect: Flamboyant Cruelty
+  [PuWZyFzJCkbq1Inj] Effect: Flaming Star - Armor
+  [OxCVZSvWVJsOGAZN] Effect: Flaming Star - Weapon
+  [insc09aslLptd0dN] Effect: Flammable
+  [cjQHrvoXDCGOsptN] Effect: Flask of Fellowship
+  [pQ9e5njvIOe5QzFa] Effect: Fleet Tempo
+  [bdq8ulAzatPMX8iK] Effect: Flensing Slice
+  [5w675gmnZqbND0mt] Effect: Flesh Mutation
+  [MRPaYmohQ5FZkrZj] Effect: Fling Magic (Adept Cold)
+  [QjvNcjLMaDJ0ig0D] Effect: Fluid Motion
+  [R1qtHjX6esNgNash] Effect: Flutter Net
+  [1aMjsd08O2v5TNG2] Effect: Fluttering Distraction
+  [LhHJkfS5VhfJss6p] Effect: Fly on Shadowed Wings
+  [AFwm9Q3R3WT0rw5z] Effect: Focus on the Doomed
+  [ofEoHZzaVmpKrMVH] Effect: Focus on the Doomed (Fear Penalty)
+  [7wDH2q0UcFdu2w58] Effect: Focused Assault
+  [ojzyLjd9094jkTPy] Effect: Fog of Chance
+  [513Y2ZSzvm8rijkp] Effect: Fold Form
+  [EJVV3zsMOhDBqxGM] Effect: Follow Me
+  [VCSpuc3Tf3XWMkd3] Effect: Follow The Expert
+  [A4FWOpQ8G45LMocX] Effect: Force Shield
+  [PD1tyMvE75VU2qVi] Effect: Force of Nature (Silver Damage)
+  [0Ai0u9kNJrEudPnN] Effect: Forcible Energy
+  [IwcnAH2a7JVwskO7] Effect: Forge Warden
+  [0TZLR0PO5TJm9F4l] Effect: Forgefather's Seal
+  [Elj69wSjv91ouC7v] Effect: Forgefather's Seal (Stalwart Sacrifice)
+  [tWFcPYueuOdSgSgg] Effect: Forgive Foe
+  [SLVQVIE1AjOc73jU] Effect: Forgiven Defaced Naiad Queen's Thanks
+  [7k5oCD4wQUNFZYkC] Effect: Form a Flock
+  [l62iAFL3EO7wSsLL] Effect: Form a Phalanx
+  [LVPodfYEWKtK3fUW] Effect: Formation Training
+  [ghZFZWUh5Z20vOlR] Effect: Fortify Shield
+  [x9xNnTl1sRGCqthu] Effect: Fortunate Blow
+  [yQd2Yoht8libCMCv] Effect: Fortune's Favor
+  [rKDTseFqWUuMJX9p] Effect: Forward March!
+  [V7cIpoJL9Zm4TiUT] Effect: Four-Tiger Blade
+  [Hc0BhuLHaldO3vqG] Effect: Fox's Wager
+  [2GWZgsvMJF9DN0DO] Effect: Fresh Produce
+  [enrTKgEzu2quCj0z] Effect: Frill Defense
+  [r4nq5JzY8U1lXsAY] Effect: Frost Breath
+  [LdmzgBOTjCete4F7] Effect: Frost Vial
+  [yeK8zmBJvam75Fp7] Effect: Fueled by Spite
+  [UE0yky6aW0WCF0Qg] Effect: Fulminating Shot
+  [WuWktq2gkRSCzfBp] Effect: Fuming Cloak
+  [8ecPVgMeWDxc4jI4] Effect: Funereal Dirge
+  [v9ujShXxA76JL8kh] Effect: Fungal Rot
+  [VxaHh8r8QVfPfxcw] Effect: Furious Finish
+  [KpRRcLsAiIhJFE03] Effect: Furious Possession
+  [Tw9MjeQHL3qFY1PO] Effect: Furnace Form
+  [6lzmzeWRo6mv6g2C] Effect: Fury Cocktail (Greater)
+  [6Ao5NDu2J7qGwZxW] Effect: Fury Cocktail (Lesser)
+  [QaiSmpjSUhORG800] Effect: Fury Cocktail (Moderate)
+  [XGnaMNt1iBkOwENY] Effect: Galvanic Chew
+  [lfbDqyKUMssoxUTZ] Effect: Game Hunter (Critical Failure)
+  [eTosCwuCMf09fYYH] Effect: Game Hunter (Failure)
+  [PFeGCDFOo2AjI6ib] Effect: Ganzi Resistance
+  [rkirKFneWDdCjU7a] Effect: Gasp for Air
+  [p0S3VHkRgMye7RSI] Effect: Gathering Moss
+  [buJnkFBzL4e22ASp] Effect: Gecko Potion
+  [9AUcoY48H5LrVZiF] Effect: Genie Blood Magic
+  [GboCEoWR636VR9Z6] Effect: Geobukseon Retaliation
+  [wPW6kVscJgBLPVKZ] Effect: Ghonhatine Feed
+  [mq5J4p6vLenAuqsC] Effect: Ghost Fowl Porridge
+  [fRQUwVDXWQMxEtW9] Effect: Ghost Lantern
+  [sk5LgfXestDKxCnK] Effect: Ghost Oil
+  [vOwZlSNCS35GULgL] Effect: Ghost Scarf
+  [IAwtIy6VVel7NexY] Effect: Ghost Strike
+  [SiegLMJpVOGuoyWJ] Effect: Ghost Wrangler
+  [02LNcIl70TTy9XS1] Effect: Ghostbane Fulu
+  [EjLVjt3GMeHM0Ai3] Effect: Ghostcaller's Planchette - Armor
+  [grXFmNl8Zy3VRVpR] Effect: Ghostcaller's Planchette - Weapon
+  [mmaJYXBUxVncsOsx] Effect: Ghosts in the Storm
+  [Sb3ZdFs61atILypS] Effect: Ghosts in the Storm (Move)
+  [N2CSGvtPXloOEPrK] Effect: Giant's Lunge
+  [6VrKQ0PhRXuteusQ] Effect: Giant's Stature
+  [dVxUCuu1ZjfWkKtx] Effect: Gift of Hospitality
+  [Prn00DwJJHbfIp74] Effect: Ginger Chew
+  [3K8fNQKjmrHU8dzi] Effect: Gird Champion (Hierophant)
+  [VLOvyQiZKeXppS2L] Effect: Gird in Prayer
+  [DdDjfNeoYxcKIxnq] Effect: Gladiator Dedication
+  [EpNflrkmWzQ0lEb4] Effect: Glaive of the Artist
+  [CoPPOCyfADvybcxV] Effect: Gleaming Armor
+  [H35En2lHCVzOOUMf] Effect: Glimpse Vulnerability
+  [xdcblhm5Ie3CG9wS] Effect: Glimpses to Beyond
+  [GNFNDyx8nfNXrgV6] Effect: Glittering Snare (Critical Failure)
+  [D7teqZ68L21aZCpd] Effect: Glittering Snare (Failure)
+  [w0LUnfS2whVhDBUF] Effect: Glittering Snare (Success)
+  [Me16QQGxpivWE2WW] Effect: Gloom Aura
+  [8x5T5e5Gzh3NJ86H] Effect: Glorious Banner
+  [BaosUEePGMqw0nWn] Effect: Glow Rod
+  [JCMACUq7FkEksV0Q] Effect: Glowing Lantern Fruit (Lantern Light)
+  [eZL4B1P4H8hr1CAn] Effect: Glowing Spores
+  [sgQknR94qDt5ILBx] Effect: Glue Bomb
+  [ww0Wu8majCej2tVF] Effect: Glutton's Feast
+  [rflbFzV44Fd6aBLE] Effect: Goading Feint
+  [ckL8iL7BKBPteEVL] Effect: Goblin Song
+  [bIRIS6mnynr72RDw] Effect: Goblin Song (Critical Success)
+  [5veOBmMYQxywTudd] Effect: Goblin Song (Success)
+  [KqyxpiGpEuju3d4z] Effect: God's Palm (Temporary Hit Points)
+  [ePvCQNEIhq1iQkuq] Effect: Godspeed
+  [hwrH1R1ecWI16liX] Effect: Golden Breath Fulu
+  [bP40jr6wE6MCsRvY] Effect: Golden Legion Epaulet
+  [5JYchreCttBg7RcD] Effect: Goo Grenade
+  [Vd2wb7EO58q41HWm] Effect: Goz Mask (Major)
+  [bhSG1uP41ilmyzPu] Effect: Grab Debris
+  [L2gnvfJ5y2cTNryW] Effect: Grand Finale
+  [iy6ZAMWyOLEKnOrl] Effect: Grandmother Spider's Underdog
+  [no7vnIiNBwWjh3w8] Effect: Grasp of Droskar
+  [HzPg4iUmO3F6tbK6] Effect: Grasp of the Deep
+  [N5L79du6FpRgc9Cd] Effect: Grasping Snare
+  [ddfrT7Q9Qe2IzKRB] Effect: Grasping Tendrils
+  [6rnB7nK6J6zF4vea] Effect: Graveknight's Curse
+  [k75TZi11cy23WoQj] Effect: Greased Axle
+  [XwFoyhCUU5TCtG50] Effect: Greased Palms
+  [PZuICqcgpErGQcqG] Effect: Great Bear
+  [BC92TyFzRCWq8fu0] Effect: Great Tengu Form
+  [ko1fCuxWxBKErSfr] Effect: Grief's Fury
+  [V4JoVnOfKze8cRan] Effect: Grim Sandglass - Armor
+  [m4WpxepWRV1u1Kcw] Effect: Grim Sandglass - Weapon
+  [Eh4ezYhfUlNc775v] Effect: Grindlegrub Steak
+  [e3RzlURndODzBnMt] Effect: Grit (Stage 1)
+  [4aSqtBgvQr2TI3XT] Effect: Grit (Stage 2)
+  [ZV9rtVOD1eDTwcY4] Effect: Grit (Stage 3)
+  [Hq1FthmyHvDDuESp] Effect: Grudgestone
+  [epegxXDsuc5cG32F] Effect: Gruhastha's Inspiration
+  [EmfxjNH1uxtDDqZu] Effect: Guard (Critical Success)
+  [rF8Nsas5KrrBEeqr] Effect: Guard (Success)
+  [qTbVcHLfFDuyJTTG] Effect: Guard Charge
+  [vGW3GPd2HO2ecgJX] Effect: Guard's Parry (Guard)
+  [57gVKu4lxbGhBpQf] Effect: Guard's Parry (Liege)
+  [oKtMGJa0qbxuZD7w] Effect: Guardian Staff
+  [AL7E03DYahfDhbcR] Effect: Guardian's Aegis
+  [w6X7io56B2HHTOvs] Effect: Guardian's Deflection
+  [X19XgqqItqZ4tfmq] Effect: Guardian's Embrace
+  [3LyOkV25p7wA181H] Effect: Guidance Immunity
+  [bxxek5BP4zqP5GzM] Effect: Guide the Timeline
+  [UiISDbCjK6AUDsll] Effect: Guide's Warning
+  [iaZ6P59YVhdnFIN8] Effect: Guided Skill
+  [raLQ458uiyd3lI2K] Effect: Guided by the Stars
+  [21pCT4n3Aixyvp4h] Effect: Guiding Shot
+  [uqjx1bwYduHwwC7d] Effect: Guiding Words
+  [9hIzh4UvjSTyYBby] Effect: Guiding Words
+  [wxu8CmL75ZxhCJmG] Effect: Guiding Words (Guide)
+  [dVVc5MYx4G3QPHoa] Effect: Guildmaster's Lead
+  [YsuyQ9QFbRvIZJoE] Effect: Guillotine Blade
+  [FaEvoqZXfQ7xnpRo] Effect: Gunpowder Gauntlet
+  [6fb15XuSV4TNuVAT] Effect: Hag Blood Magic
+  [LYxKPQYeiD4S5tQP] Effect: Hair Snare
+  [RAKgTTFKc2YEbvrc] Effect: Hallucinogenic Pollen (Critical Failure)
+  [GstmxSP75eKmHtCQ] Effect: Hallucinogenic Pollen (Failure)
+  [GFR5RwR8qW2jIJKP] Effect: Halt Death
+  [3bAtqn2WPSqxCYPY] Effect: Hampering Fusillade
+  [otUESSH8BDdPKHtb] Effect: Hamstring
+  [ESnzqtwSgahLcxg2] Effect: Hamstringing Strike
+  [UrNdfN1da9V3aFM4] Effect: Hand Chords
+  [hyyVAOi1My9PKKqo] Effect: Hand of Mercy
+  [WqjTa5mnBnBFRxqu] Effect: Harbinger's Armament
+  [kcsn4iCOkl9KaFQx] Effect: Harden Chitin
+  [Np3OSqKxuB9rTbij] Effect: Harden Flesh
+  [31nnjHZqiaqaWBUi] Effect: Harmonizing Aura (Allies)
+  [tSF9z5VTeevxoww3] Effect: Harmonizing Aura (Enemies)
+  [T7GQbAbS6jh7Au15] Effect: Harness Wickedness
+  [3aJ9AiJdOrwdjYPF] Effect: Harpy's Talon
+  [eqzDPseLIfWJMxAR] Effect: Harrow Burst
+  [rp6hA52dWVwtuu5F] Effect: Harrow Omen
+  [MSkspeBsbXm6LQ19] Effect: Harrow the Fiend
+  [1Azz9TSWXrX4aNX4] Effect: Harrow-Chosen
+  [7PYhxmQxCD5kzMlw] Effect: Harrowing Misfortune
+  [raoz523QRsj5WjcF] Effect: Harsh Judgement
+  [jp1oRa3wEHT7hKBX] Effect: Harvest Blood
+  [J8WkLtuY0RpcjI8q] Effect: Hasty Celebration
+  [JUo3BTRaRHkL9ZBC] Effect: Hasty Traps
+  [EoSs09JUy4Maq296] Effect: Haunting Wail
+  [XaYM6Td0yhx2POau] Effect: Haywire
+  [yPgxSoEilFI7tTPZ] Effect: Heads Up!
+  [NuCwsyydiaBQpwiL] Effect: Healer of the World
+  [sOwAqyQ6MaoSqaY1] Effect: Healer's Gel
+  [QKpx9S3JeIMeqFnw] Effect: Healing Sanctuary
+  [VdT6ALv7LnCNOjUq] Effect: Heart Break
+  [o86YugTsxhm1T86j] Effect: Heartening Aura
+  [r6hDgfVLod0AmU7J] Effect: Heartripper Blade
+  [L9g3EMCT3imX650b] Effect: Heaven's Thunder
+  [Rz35d02dUtAjKtMB] Effect: Heightened Awareness
+  [00gozjbtueYWop0w] Effect: Hell's Bane
+  [wZcxrAL40jM5I5Dm] Effect: Hellbreaker's Resolve
+  [aCBAyXq3yecE8aIP] Effect: Hellfire
+  [MbtWd4PvUHmwPtFO] Effect: Helpful Tinkering
+  [GAtTLwi0JIOg3Htq] Effect: Helt's Spelldance
+  [qcmJGJEKHhqOhQh4] Effect: Herald's Weapon
+  [BHnunYPROBG5lxv4] Effect: Heroes' Call
+  [a8LGc1NEXXBTvvy3] Effect: Heroic Aegis
+  [6OFJhFsw78w7ogW5] Effect: Heroic Defiance
+  [i5PHb9yR33Cr6XMK] Effect: Heroic Hustle
+  [53nP5ljwRhD9BlUk] Effect: Heroic Inspiration
+  [7ogytOgDmh4h2g5d] Effect: Heroic Recovery
+  [LjaEu7gAGO77uVs2] Effect: Hexing Jar
+  [OokULq8Ubpw9PzKr] Effect: Hexwise Banner
+  [oqdxD6NhawryOAOr] Effect: Hexwise Banner (Major)
+  [FlwmvnPH3Fu62hTE] Effect: High Alert
+  [tx0S0fnfZ6Q2o80H] Effect: High-Speed Regeneration Speed Boost
+  [lvK0DAuTYOnT6E5f] Effect: Hobble Pursuit
+  [cCyXnyhrW4pUQIz3] Effect: Hobbling Snare
+  [5fQ0GU0sVIh1TzRA] Effect: Hobgoblin Phalanx
+  [gDefAEEMXVVZgqXH] Effect: Holy Chain
+  [5dhm66yN0LQTOePw] Effect: Holy Steam Ball
+  [cYtUBB2cO0FOUU8D] Effect: Hone Claws
+  [o1Fzi94EODK3fa4A] Effect: Hongrui's Gratitude (Lantern)
+  [g1EdALRxZmmEkSd7] Effect: Hongrui's Gratitude (Umbrella)
+  [loZq6FcqwFXedI6W] Effect: Hope Vulnerability
+  [meTIFa2VsIzRVywE] Effect: Hope or Despair (Critical Success)
+  [Px7sSipQxHdOMSjk] Effect: Hope or Despair (Failure or Critical Failure)
+  [bmcvernfk6l4EbAG] Effect: Hopeful Athamaru
+  [WBqZA9z7ZbhcR2ye] Effect: Horn of Exorcism (Sacred Seeds)
+  [O8JjATMWOoRzMTId] Effect: Horned Lion Amulet
+  [Cg6UOjRe7epZHyqp] Effect: Horned Lion Amulet Recovery
+  [3bvYym3Dz6b6xmEK] Effect: Hot Foot (Critical Success)
+  [X1Q1uBiylZoJg3Co] Effect: Howl of Vengeful Fury
+  [HohNWN5sdJW3naYe] Effect: Howling Aspect
+  [blwrnLLvtR6PVJlp] Effect: Hungry Blade
+  [4xtHFRGI05SNe9rA] Effect: Hungry Goblin
+  [MeXyXqWY9qN42bSQ] Effect: Hunt Prey
+  [s7qDwnyVqMqDaFal] Effect: Hunt Runelord
+  [9Uwt9cfXOKAl8cD5] Effect: Hunt Will
+  [PYyJjl5EEXs0IswY] Effect: Hunt the Razer's Pawn
+  [uGNTOgns4lZ0HW08] Effect: Hunt the Razer's Pawn (Ephemeral)
+  [mFnSXW6HTwS7Iu1k] Effect: Hunted Fear
+  [1TsRE7J3BZrcyogi] Effect: Hunter's Aim
+  [COVEnItnyRmx42EY] Effect: Hunter's Brooch
+  [2eQDm7Oor2hSZKyf] Effect: Hunter's Onslaught
+  [q2D1QBalqBQfKzTc] Effect: Hurl Net
+  [HKyMZobjOsd6WFuo] Effect: Hurtful Critique
+  [qIOEe4kUN7FOBifb] Effect: Hybrid Shape (Beastkin)
+  [uZJOdounIHaFDC1t] Effect: Hydra Heads
+  [jJ038JXfHdvDindo] Effect: Hydra Mutagen
+  [IfsglZ7fdegwem0E] Effect: Hydraulic Deflection
+  [wacGBDbbQ1HaNZbX] Effect: Hyldarf's Fang
+  [zzhRh3aMh3ZRcIEo] Effect: Hypnotic Gaze
+  [qFDiWpzk8cuwQGyH] Effect: Hypnotic Stare
+  [y3D02GsvQHveTnuz] Effect: I Am the Law!
+  [hAdyMxuWJu7piQSS] Effect: Ichthyosis Mutagen
+  [MwKc08dMPAFlAwrw] Effect: Icy Protection
+  [zXzXDlh0HkyPJu8f] Effect: Ill Omen
+  [8YZX34sJOIH32VwI] Effect: Illuminated Folio
+  [QbkOLg8ZoIg1gUNB] Effect: Imbue Righteousness
+  [QWW4hNCtLkOK1k71] Effect: Immediate and Intense Headache
+  [bri7UVNCfHhCIvXN] Effect: Immolation Clan Pistol
+  [eLQABqabYp41Mw1R] Effect: Immortal Bastion
+  [R5rsGfIIkpNxbU9z] Effect: Imp Shot
+  [gjo8LR6uOhDM5W7L] Effect: Impaling Chain
+  [4xeFMXOsfrNZ3Ijv] Effect: Impelling Symbol
+  [ZRr3fsaw9676L4JT] Effect: Impenetrable Scale
+  [vguxP8ukwVTWWWaA] Effect: Imperial Blood Magic
+  [kkP0tagXmAYuSH3u] Effect: Impersonated Ability
+  [H29JukjrSpHe5DXR] Effect: Impossible Cake
+  [KAEWiyE8TQwofNj9] Effect: Impossible Cake (Greater)
+  [ohMdE8BmQHuLs40b] Effect: Impossible Cake (Major)
+  [HgWSyf7jULisWIlG] Effect: Impossible Shot
+  [C6H3gF5HTdsIKpOC] Effect: Improved Poison Weapon
+  [4vnF6BFM4Xg4Eg0k] Effect: Improved reflexes
+  [eSIYyxi6uTKiP6W5] Effect: Improvised Weapon
+  [ZouxY0u1dKQEHQ6E] Effect: In Lightning, Life
+  [wsDecJEF8va4EAei] Effect: In Our Wake, Hell Will Break!
+  [Z6cOCgyVwTr5t3yQ] Effect: Incendiary Dollop
+  [A06Qu3BNMQ4FGinM] Effect: Indomitable Spirit
+  [HcNa7gv7a357CnFi] Effect: Inertial Barrier
+  [dDdxIy1bAvwfuhx0] Effect: Inescapable Grasp
+  [gszL5RAakyyYfBMb] Effect: Inextinguishable Aura
+  [T2tfacwoOozQfsIz] Effect: Infectious Aura
+  [inLBsuLRE5xmVHdn] Effect: Infernal Wound
+  [li52UFA2ErqRLeer] Effect: Inflammation Flask
+  [yKFV294LeXzrvF8K] Effect: Infused with Belkzen's Might
+  [ANZPiu3eb3byDRUk] Effect: Inhale Light
+  [EeU33F3eBq5OPYp0] Effect: Injigo's Loving Embrace
+  [2qHgwcYtCg4csC2w] Effect: Insight Coffee
+  [CiCG3r7SHYMJeUxz] Effect: Inspirational Presence
+  [jFCNPTgcIouJ6EsC] Effect: Inspirational Salute
+  [uFi8GhPkYY3ti40N] Effect: Inspire Courage (Love Siktempora)
+  [MKC2ne315YiCUiWd] Effect: Inspire Defense (Love Siktempora)
+  [YDJnC3Bdc2GI6hX5] Effect: Inspire Envoy
+  [EM0VP31B8CyjFD15] Effect: Inspired Feast
+  [MT5gxuuxBaN2RdYf] Effect: Inspired Recitation
+  [K0Sv9AHgq245hSLC] Effect: Inspired Stratagem
+  [lM0swBGK6CfkMb6E] Effect: Inspiring Aura
+  [smk2cD6M3dsEPBCY] Effect: Inspiring Display
+  [kzEPq4aczYb6OD2h] Effect: Inspiring Marshal Stance
+  [UxeoSRmPbD5hjiEi] Effect: Inspiring Presence
+  [tgF8r8uXyw3IFWBp] Effect: Inspiring Presence (Empyreal Dragon)
+  [5FRnceccGyLcnVlv] Effect: Inspiring Recitation
+  [qM4bQfcwZ0EOS2M9] Effect: Inspiring Resilience
+  [E4B02mJmNexQLa8F] Effect: Inspiring Spotlight
+  [1eoxVAx1z9AoNKTt] Effect: Instinct Crown
+  [TEzLEXBZzNCp6flg] Effect: Instinctual Tinker (Critical Success)
+  [GAKXSLDwFpE5VLyx] Effect: Instructive Strike
+  [Y2xjlHMGvr8Mkg3r] Effect: Instrument of Death
+  [T13bc44lsaOUjJa9] Effect: Interest is Due!
+  [7PjBr9LsVB0Jjzyu] Effect: Interpose
+  [nOYXxWUT9i3z75GI] Effect: Invented Vulnerability
+  [SITsBOnOG1EJsEpl] Effect: Inventive Offensive
+  [tl94WHJ2Hg0akK2o] Effect: Invigorating Breath
+  [5syHrFGAE6lo0FUr] Effect: Invigorating Passion
+  [6vJacr4iXeYf44Vd] Effect: Invigorating Spores
+  [ynJ0UNfAwV0Bcdn7] Effect: Invigorating Spores (Resistance)
+  [iGJ6C4AUQZcSEx1W] Effect: Invigorating Surge
+  [uqtXEAWwHhA2xShg] Effect: Invincible Army
+  [32QaXCRgU5l5lMIa] Effect: Invoke Defense
+  [iN7j0d5LE7OwZlAo] Effect: Invoke Movement
+  [0h6dhuMU0fOr1OS5] Effect: Invoke Offense
+  [5Gol6tr9MtL9eR1u] Effect: Invoke Rune
+  [yZGqaYXpuZ3NfbNB] Effect: Invoke the Witchbole's Spirit
+  [upPUhhjz3stTWRsy] Effect: Iron Command (Extra Damage)
+  [xV9rME2l1f10mnF9] Effect: Iron Medallion
+  [cUm05scv7getd79d] Effect: Iron Wine
+  [nQ1LawgHvC7NZmiN] Effect: Iron Wine Weakness
+  [nAHRwy8agswzdgFh] Effect: Ironblood Stance
+  [niFS8JHJFwnLQ2Gg] Effect: Irondust Stew
+  [ghQ6Bmlycf9DVSll] Effect: It Can't Hurt You
+  [WXsWkFosSGBrptwF] Effect: Ivory Baton
+  [vj2hkcSbwwRYNLk5] Effect: Jack's Tattered Cape
+  [uJyFG2gxW29bXNfu] Effect: Jann's Prism (Jann's Light)
+  [9mIS76oZkxXQ4g3T] Effect: Jolt Coil - Armor
+  [mHIdEC7RX6isILiM] Effect: Jolt Coil - Weapon
+  [LIhJbq72TiDu5kGs] Effect: Journeybread (Power)
+  [xLilBqqf34ZJYO9i] Effect: Juggernaut Mutagen (Greater)
+  [1l139A2Qik4lBHKO] Effect: Juggernaut Mutagen (Lesser)
+  [2PNo8u4wxSbz5WEs] Effect: Juggernaut Mutagen (Major)
+  [fUrZ4xcMJz0CfTyG] Effect: Juggernaut Mutagen (Moderate)
+  [WYJdjmvfm8J6sG6g] Effect: Jury-Rig
+  [Rn2Nl2iXlRMijTNb] Effect: Juubun's One Thousand Poems
+  [0JrHvdUgJBl631En] Effect: Juvenile Flight
+  [hozXQvKqp62DnawX] Effect: Jyoti's Feather - Armor
+  [KJXNLvJAl0mNnGvn] Effect: Jyoti's Feather - Weapon
+  [yJWWTfZkAF4raa4R] Effect: Keen insight
+  [TMxGd734w9od0C8O] Effect: Keep Up With Me!
+  [AwJBbxeoE0YhmT57] Effect: Keep Up the Good Fight
+  [SCQZCtRTHBqqOUOA] Effect: Keeper's Ward
+  [zNdEXVVMbC9i4Yox] Effect: Kettle Up (Boiling)
+  [St2QzqQvKN0IaXxG] Effect: Kharna's Blessing
+  [bWvOkRT3alzllsiG] Effect: Kindle Inner Flames
+  [Pe4qwrE1oU68iW4g] Effect: Kindling
+  [pLurcSPQb2gjAzoP] Effect: Kinetic Aura
+  [X40cigEVNNMBtOre] Effect: Kingpin's Presence
+  [TKuUezmnwVftoCcL] Effect: Kishin Rage
+  [mGozE5ZdZlQiIr8y] Effect: Knave's Standard
+  [kZdVPBO58uq38KIR] Effect: Kneecap
+  [DvyyA11a63FBwV7x] Effect: Known Weaknesses
+  [wFP3SqPoO0bCPmyK] Effect: Kraken's Guard
+  [6hrbTLlSyhL2W9Nf] Effect: Lantern
+  [37wbBpPBi5eBtNqM] Effect: Lantern of Hope
+  [hdsl0XexqEL2emE3] Effect: Lantern of Hope (Gestalt)
+  [6A8jsLR7upLGuRiv] Effect: Lastwall Soup
+  [GnEzDtPBQ1lDwmZI] Effect: Lava Leap
+  [bRYIsyDIsZNaLUEe] Effect: Lawbringer
+  [TVWgsv3ypaqh5Y8T] Effect: Lead by Example
+  [Df5CnXnVHC1mVINK] Effect: Leader's Command
+  [QUelSJzS2EIEkoD7] Effect: Leech-Clip
+  [9rUzqHni8LE19Gu5] Effect: Left-Hand Blood
+  [ELCODoiGDBEqRAtT] Effect: Legendary Monster
+  [LB0PTV5yqMlBmRFj] Effect: Legendary Monster Hunter
+  [aUpcWqaLBlmpnJgW] Effect: Legendary Monster Warden
+  [LVy8SfUF8Jrd6X18] Effect: Leopard's Armor
+  [45nzYsMBTP6PIxDN] Effect: Lepidstadt Surgeon Dedication (Stop Bleeding)
+  [U7gwOeKsIsz2zhDE] Effect: Lesson of the Broken Wing
+  [QhUiGUBuCV1bSu1q] Effect: Lesson of the Splintered Aegis
+  [n6vsjGq2CDZDW3U1] Effect: Liberating Step
+  [tAsFXMzNkpj964X4] Effect: Liberating Step (vs. Aberration)
+  [iyONT1qgeRgoYHsZ] Effect: Liberating Step (vs. Dragon)
+  [9dCt0asv0kt7DR4q] Effect: Liberating Step (vs. Fiend)
+  [ZnKnOPPq3cG54PlG] Effect: Liberating Step (vs. Undead)
+  [ya5dwx5pxUKeWn3z] Effect: Life Burn Aura
+  [GPWMktaOERQIx83M] Effect: Life Shot
+  [49e80oS2x19jiGw9] Effect: Life-Boosting Oil
+  [iAePXmGL9bMKBTpv] Effect: Life-Draining
+  [YKJhjkerCW0Jl6HP] Effect: Life-Giving Magic
+  [UQP2A7EMKIKPMQxK] Effect: Lifting Leather
+  [j2xuFnWfTov0VQoG] Effect: Light in the Dark
+  [hekJBWsLxkt8zd7x] Effect: Light of Truth
+  [QVk0oRgc1pRwhG7U] Effect: Lightning Armillary
+  [MxFFGo4WJpHh1e70] Effect: Lightning Powered
+  [f3I8KyhABpDBwdwB] Effect: Lightning Rod
+  [LqeLET7SuBja2ck9] Effect: Lightweave Scarf (Armor)
+  [cP9oWbEa7cJnnK9j] Effect: Lion's Bite
+  [GBaN8XZrzFp7C7fL] Effect: Little Ripple's Blessing
+  [UE312nw1ihsc0stp] Effect: Living Epic
+  [fRlvmul3LbLo2xvR] Effect: Living Fortification
+  [Xu7QxeF9S8ysJpuI] Effect: Living Shield
+  [NXnngvaJXHtskVjU] Effect: Living Shields
+  [YMdRmEcOlM3uU9Em] Effect: Living for the Applause
+  [LgZx5xotO08JzhVc] Effect: Loathsome Bite
+  [xtqOIXCe0Nsd0QCt] Effect: Lock On
+  [AStWCzJcQCwO9Fjr] Effect: Longnight Tea
+  [hhW265JTxuLr1EP5] Effect: Look at Me!
+  [iYHNKt2eailYxNXc] Effect: Lord of the Fiends
+  [lt2t24E4hiByHhi3] Effect: Lost Plates
+  [s5mS7CyE0oOYlecv] Effect: Lost Red Cap
+  [Jt7NnE7WeR7e9V6Q] Effect: Lost in the Crowd
+  [3O5lvuX4VHqtpCkU] Effect: Lover's Gloves
+  [8WnFg5HMKX8JEDLl] Effect: Lumber Lord's Axe
+  [fUTRC90zRQiXJ1k1] Effect: Luminous Lure
+  [SWngTPtwUi0aOHcH] Effect: Lunar Blaze
+  [6E8bOkwFzFuQ3ZAw] Effect: Lurker's Glow (Critical Failure)
+  [b1sZC0knPcr7B6Gz] Effect: Magical Mentor
+  [UoTJv0GODidag5Ik] Effect: Magnetic Bola (Damage)
+  [7GJnkRhlqPwq3nSX] Effect: Magnetic Bola (Speed Penalty)
+  [OBzvZ9LoZLiPyHEW] Effect: Magnificent…!
+  [FIgud5jqZgIjwkRE] Effect: Maiden's Mending
+  [BZRMacgSXzjVUDNZ] Effect: Malleable Clay
+  [kMPPl4AqFb6GclOL] Effect: Malleable Mixture (Greater)
+  [cozi2kUELY40Dcv3] Effect: Malleable Mixture (Lesser)
+  [Dby3ecpqPheBrgnT] Effect: Mammoth Land Star Limbs
+  [S1phrCuGYR8NtV5l] Effect: Mana-Rattler Liniment
+  [5roCV7EbPx1G5xOd] Effect: Mangling Rend
+  [VrTaP6BcXo6sizn6] Effect: Manifest Realm
+  [zzdOof9hHUf9s13H] Effect: Manipulate Luck (Bad)
+  [2DlOfFoYLGSlfugH] Effect: Manipulate Luck (Good)
+  [WKQNGK6hd5O7uLC1] Effect: Manipulate Luck - Drusilla (Good)
+  [yHI1DhZkAyqwRpDh] Effect: Mark of Fate
+  [mNc42XjBVlxcr9k8] Effect: Marked for Rebuke
+  [Ru4BNABCZ0hUbX7S] Effect: Marshal's Aura
+  [5r7uhVQJQoyk6s4i] Effect: Martyr's Parry
+  [zZsdex5orF5Odpus] Effect: Mask of Allure
+  [tsxBwSRFqMoorMJ3] Effect: Matsuki's Medicinal Wine
+  [qrsvaUIMdC0Uq9fQ] Effect: Matting Paint
+  [06oOr07YORG2km9C] Effect: Meddling Futures
+  [m8RWVvhQ3LCMGQzs] Effect: Medical Malpractice
+  [jS1J008XoEo50adu] Effect: Memories of Failure
+  [K0VkhTXXmyGPilVN] Effect: Memory of Skill
+  [tcdIBJTHuexSKJ6S] Effect: Mental Balm
+  [jw5uOE1sJ9o9bUEb] Effect: Mentor of Legends
+  [ycKxoeZwg7g9Ivh5] Effect: Merciful Balm
+  [FzPtx8PEjusAlV7u] Effect: Merciful Charm
+  [YIShkE3JCEuwCAxl] Effect: Metallic Skin
+  [kL6L3eXJfnUaLpVx] Effect: Metallify
+  [4HNPQ6pnMDRe8jaN] Effect: Methodical Debilitations (Cover)
+  [emSh1VxHVtTmt925] Effect: Methodical Debilitations (Flanking)
+  [tGeMT4iHJcsjVbl3] Effect: Metuak's Pendant
+  [P7cVUjF59y0XHmLw] Effect: Mighty Counterweight
+  [abFGWIZZf5nyGYMk] Effect: Mind's Light Circlet
+  [0q1sI5pgZs0eHydw] Effect: Mineral Deposits
+  [ubHYfNIf0pAwzAum] Effect: Mirrored Aegis
+  [IIjE6NOYpOfRuCBR] Effect: Mirrored Wall
+  [5SLAqVPYa0kliRDt] Effect: Mist Cloud
+  [WFwdWcD1xhO44n2d] Effect: Misty Chill
+  [UKNtAmCdczhWB4xI] Effect: Moisture Bath
+  [nMMqJQsdV37TLfTu] Effect: Monarch Wings
+  [pzeGJHUdODOQslZO] Effect: Monologue
+  [W2tWq0gdAcnoz2MO] Effect: Monster Hunter
+  [nlaxROgSSLVHZ1hx] Effect: Monster Warden
+  [zoMGcJxA4kH20Zzw] Effect: Moon Blossom Tea
+  [dRe8n1nBWMIXd8jh] Effect: Moon Frenzy
+  [gzfoCKld88wHzi2g] Effect: Morning Glow
+  [ihZsJpB9v90EFQSG] Effect: Morph Jewel
+  [vUFIbQ74jz22rOXw] Effect: Mortal Reflection
+  [ocjUbOrpnJeGb3iP] Effect: Mortalis Coin
+  [XH49blfNDjkqnH5N] Effect: Motivating Assault
+  [O7OO1kWFEFv6vl3E] Effect: Mountain Strategy (Critically Hit)
+  [EfMaI6AnROP4X9lN] Effect: Mountain Stronghold
+  [IPznWmsoaoT2zhgU] Effect: Mountaineering Training
+  [9c93NfZpENofiGUp] Effect: Mounted
+  [6p2Sjl7XxCc55ft4] Effect: Mudrock Snare
+  [VM3A4YSG72JCpWMg] Effect: Multifaceted Will
+  [3dvpk7jwcQbmLsUA] Effect: Mummified Bat
+  [Mz1ihIHaHngdFhsA] Effect: Musk
+  [3MVVaD8hAJnGSyfm] Effect: Mutagenist Field Benefit
+  [ITvyvbB234bxceRK] Effect: Mutate Weapon
+  [tvVFra3BqfyATahM] Effect: My Turn!
+  [X22o74v8rk7ySnzX] Effect: Mythic Allies
+  [SX5csPb38vTBjHOb] Effect: Mythic Allies (Circumstance Bonus)
+  [ErLweSmVAN57QIpp] Effect: Nanite Surge
+  [pFo9DVyaDb4LdURY] Effect: Nanite Surge (Bonus)
+  [rRgVlTHiNEJ86T7N] Effect: Nanite Surge (Glow)
+  [ppYqbg4erAFt8C9W] Effect: Natural Disguise
+  [0vJlwvjFghLdfvn5] Effect: Nature's Infusion
+  [LCU3Lv6ojuTl4DSY] Effect: Naval Training
+  [3HaT8gBo8krdVniF] Effect: Near-Death Experience
+  [ejnUAEdbvj6uPuNJ] Effect: Near-Death Experience Healing
+  [wQDfwrrvfRxwG5CY] Effect: Necrotic Cap
+  [kjP0J97hhoIhbF3M] Effect: Necrotic Field
+  [UzaM1jejUKNpVfoA] Effect: Never Enough
+  [hJJzppHOKE6g6iEJ] Effect: Never off the Hook
+  [rEQP3SwRF9Zb1ppV] Effect: Nexian Researcher
+  [fszJ9ZaslnrW5m5z] Effect: Nimbus Breath
+  [mfJIVTQ8drSzsrQc] Effect: No Fight Fair
+  [TjRZbd52qWPjTbNT] Effect: No Quarter!
+  [4uy4Ygf5KD2WrtGW] Effect: Nosoi Charm (Diplomacy)
+  [NdfhpKCjSS80LiUz] Effect: Nosoi Charm (Greater) (Diplomacy)
+  [VVWvXiNudYYGV9sJ] Effect: Nosoi Charm (Lifesense)
+  [YJPiAE71tq3bp74B] Effect: Nothing Personal
+  [G1pvduwOVRz4YFUF] Effect: Noxious Exhalation
+  [AL14FXSxpKyyfnOn] Effect: Noxious Smog
+  [cBxjqExA5RZ4UNAz] Effect: Numbing Strike
+  [rmVyC6Xb8O9WPvZz] Effect: Numbing Tonic
+  [SVGW8CLKwixFlnTv] Effect: Nymph Blood Magic
+  [iSyyR4QVOaY6mxtg] Effect: Nymph Queen's Inspiration
+  [nBQZdTtwNLJ70J6C] Effect: Oath of the Defender
+  [zY7cemRcFD2zAVbC] Effect: Oath of the Devoted
+  [KSvkfMqMQ8mlGLiz] Effect: Obsidian Goggles
+  [d7BDxmsnM1BUoEeT] Effect: Obsidian Goggles (Greater)
+  [WXrqEuLT4uP48Bvo] Effect: Obsidian Goggles (Major)
+  [uG1EljvrnC9HGwUh] Effect: Ocean's Balm
+  [0jo8CUzw5lWehNg3] Effect: Oceanic Armor
+  [5KXsyN9J78glG25I] Effect: Ochre Fulcrum Lens
+  [y1GwyXv7iOf8DhBg] Effect: Off-Guard until end of your next turn
+  [ut5SVyCSXel69nnd] Effect: Offensive Boost
+  [dzYnksinvWvfgBVt] Effect: Offer Story
+  [xiG3kmPJBpX2KA7l] Effect: Oil of Corpse Restoration
+  [dVvMomZnSTq1wOJd] Effect: Oil of Keen Edges
+  [1OLlwExJz7ii2Lu2] Effect: Oil of Potency
+  [ZxT8Shp8NZaQRjlQ] Effect: Ommatophoric Mutagen
+  [MLwh53NzVrfN5Bbc] Effect: On Guard
+  [xHbMPpYEPwI0tmcV] Effect: One Moment till Glory
+  [CR2D12ZAhwmnbz15] Effect: One for All
+  [WUvjLX4ieyISdNbr] Effect: One with the Spirits
+  [seOQfjfjrDyK6rCo] Effect: Ongoing Selfishness
+  [8iLsH0McVDbPGMJ3] Effect: Oni Form
+  [ZdPLjPFwp9JuVRFf] Effect: Only You and I
+  [m77YnEX1T7bdk7Qa] Effect: Ooze Ammunition
+  [7XxZ4YJ6c97D9Fc9] Effect: Oracular Warning
+  [ETZHTCjlOUHHSE0Z] Effect: Oracular Warning (Initiative)
+  [FHBYfq3w7ddLvzrK] Effect: Orchard's Endurance
+  [WHAp9cDOqnJ1VCcg] Effect: Orchestral Brooch
+  [KbhyBlEERhMvGwbk] Effect: Ouroboros Buckles
+  [MwOIzOn144wosWHQ] Effect: Ouroboros Buckles (Swarm of Snakes)
+  [feQwOL1QfZDfVrt8] Effect: Overclock Senses
+  [I0dtunqG9psJpc64] Effect: Overconfident Facade
+  [1XlJ9xLzL19GHoOL] Effect: Overdrive
+  [a4C89wVlcwV6Uxx4] Effect: Overdrive Ally
+  [EEujvJ9UzzK7fvqG] Effect: Overdrive Ally (Shared Overdrive)
+  [SyLqg8SffVlA7fi7] Effect: Overdrive Engine
+  [x7CjbOQZUgZKW16M] Effect: Overextending Feint
+  [ewEZ9zB5cjdUMtQj] Effect: Oversized Throw
+  [xiOi7btey4AS6jhe] Effect: Overtake Soul
+  [AKKHagjg5bL1fMG5] Effect: Overwatch Field
+  [pZ0Vr0Pe3LHe4ptx] Effect: Owe Money
+  [yDut6pczQVRJqt2L] Effect: PFS Level Bump (NPC)
+  [U9tJvfQDdpsf5Ipd] Effect: Packed with Flavor
+  [unMxC3XGviRjC1CH] Effect: Pact of the Final Breath
+  [tJx9B2e3AET6PbJD] Effect: Pain Frenzy
+  [YAWfkGBnDwimMtJ8] Effect: Pain is Temporary
+  [nW9GbEP1NqFodqE0] Effect: Paired Spikes
+  [21P9Xc6DslCjfq0Y] Effect: Pale Horse
+  [k3P0APls0jHEYdHz] Effect: Pall of Silence
+  [weKnwX64fD5fuPjy] Effect: Pallesthetic Mutagen
+  [QBujqOaTXzqM13Cy] Effect: Panaceatic Salve
+  [uBJsxCzNhje8m8jj] Effect: Panache
+  [fJD0yIkVPMwdNjLy] Effect: Panache (Ephemeral Note)
+  [paKKHPds77fq5VTH] Effect: Panache (Temporary)
+  [fRlvmul3LbLo2xvR] Effect: Parry
+  [itVZwwvaXYN2zOR8] Effect: Parry Dance
+  [QlgqJXCQkpCzpJZG] Effect: Partial Armor
+  [0nkzRcjN9iOSFUf9] Effect: Pass Vengeful Judgment
+  [2CJwgnCsYtk4R5sO] Effect: Path of the Tempest
+  [7BHF5iUHtCvfHAie] Effect: Peace in Dreams Tea
+  [covFunty2HlvEN9K] Effect: Pearl Dragonet Breath
+  [aQkzGG9RCII50a4b] Effect: Pennant of Victory
+  [VZCcjwsQX1wnYlTn] Effect: Perfect Droplet - Armor
+  [PXVtir1Z88UpxBHR] Effect: Perfect Formation
+  [fDLJIA6Kl81WA6gy] Effect: Perfect Protection
+  [DyX4E7KDkzRnDxzc] Effect: Perfect Resistance
+  [CM14G9kLI97aIC5h] Effect: Pest Haven
+  [KjWPSJonzrZ8jv7X] Effect: Phalanx Fighter
+  [zGWc4q0rXW9eMoYT] Effect: Phantasmagoric Fog
+  [PBvLrztlLIfr2dlV] Effect: Phantasmal Doorknob - Armor
+  [5mQ51m1lqQlvfi8n] Effect: Phantasmal Doorknob - Weapon
+  [R5zy2SnV5GSgKeiL] Effect: Phasing Trine
+  [NETXs01Vn0Q7ZRAs] Effect: Phasing Trine (Reduce AC)
+  [1ssTlwNcRRkatmPC] Effect: Phenom Verve
+  [RXhGjWqBqmQOlaRV] Effect: Phoenix Blood Magic
+  [z8FvdsKEY4lB2L8b] Effect: Phoenix Flask
+  [PSRUF9Elf05KtgvF] Effect: Phytohydra Heads
+  [WRvZ2Nq3wquisD4Y] Effect: Pickled Demon Tongue - Armor
+  [LbaYzs0dQuFj8FXJ] Effect: Pickled Demon Tongue - Weapon
+  [QjIiY4ofmhCspUJb] Effect: Pierce the Eye
+  [zy4PDhXnaZh6e6iT] Effect: Pilgrim's Ward
+  [XAdhPJqssO3v4Zvw] Effect: Pinpoint Poisoner
+  [Il7YN8zlu3dfw3IE] Effect: Pinpoint Weakness
+  [0kO3M46aK64a8ru8] Effect: Pistolero's Challenge
+  [3KhE0e2CWU7F27bJ] Effect: Plane-Stepping Dash
+  [KsUQjLQO62BY0lk4] Effect: Plant Banner
+  [5yP9Y2iSOmy4hsrW] Effect: Platter of Putrid Dreams
+  [f4IRnmOVesolJhVO] Effect: Play Scape
+  [cz33s6SyIavmL9wA] Effect: Play to the Crowd (AC Bonus)
+  [9oQkkOXX1tmVgPBA] Effect: Play to the Crowd (Attack Roll Bonus)
+  [4TMf6LVNMakqj7Bt] Effect: Play to the Crowd (Temporary Hit Points)
+  [SScln8qRQgVC6Brz] Effect: Pointed Question
+  [AJNUrLJgTC0AdBhS] Effect: Poison Fizz
+  [u2z1BgpZsxl7Zc2z] Effect: Poison Frenzy
+  [SXYcrnGzWCuj8zq7] Effect: Poison Weapon
+  [ft5LjQSa8mZkklhM] Effect: Polished Demon Horn - Armor
+  [WARLTi8unmPgmnNw] Effect: Polished Demon Horn - Weapon
+  [gORyINQLvplfthlm] Effect: Pollution Infusion
+  [ALYd08DB00ZeoHAp] Effect: Pompous Rage
+  [lpEPfVGRArMYFM2W] Effect: Portable Animal Blind
+  [klZVVIetJlR99cT6] Effect: Portentous Spell
+  [l5NDN9V3DwFYPIsD] Effect: Portents of the Haruspex
+  [m1Vd997DEVoOeaJu] Effect: Posse's Edge
+  [R5ugeFK3MPwkbv0s] Effect: Potency Crystal
+  [k8Gt8zfPOhkYOn1A] Effect: Potion of Acid Resistance
+  [Iw3CtHFpD3gGVjis] Effect: Potion of Cold Resistance
+  [DbUEGIKxH6d1GgVw] Effect: Potion of Electricity Resistance
+  [EZsHuGGSLER67CiM] Effect: Potion of Emergency Escape
+  [34gtdURRTZMS5bDK] Effect: Potion of Fire Resistance
+  [Zdh2uO1vVYJmaqld] Effect: Potion of Flying (Greater)
+  [Mf9EBLhYmZerf0nS] Effect: Potion of Flying (Standard)
+  [HaZ5LB1wh1LY5wUy] Effect: Potion of Minute Echoes
+  [nBGodDOQTCWBXjNd] Effect: Potion of Sonic Resistance
+  [uVxs1qFMQsGWXNs6] Effect: Potion of Stable Form
+  [W9tKQlA7tVIcAuzw] Effect: Potion of Stable Form (Greater)
+  [W3xQBLj5hLOtb6Tj] Effect: Potion of Swimming
+  [ModBoFdCi7YQU4gP] Effect: Potion of Swimming (Greater)
+  [6OpwHz0f55wPawHI] Effect: Powder Burst
+  [OJibRFm4JCVGQZnx] Effect: Practiced Medic
+  [qddahkHks1iLZ4sM] Effect: Praise Adachros
+  [iPk9Pphkq4Zuzvuj] Effect: Pray to the Rotting God
+  [cA6ps8RKE0gysEWr] Effect: Prayer-Touched Weapon
+  [KpEtIFwjj0ZrSVbD] Effect: Precious Ammunition
+  [ZZXIUvZqqIxkMfYa] Effect: Precise Debilitations
+  [c5zOwEre2Uy9MCFo] Effect: Predator's Advantage
+  [Vvl1GFfuvFzvOkbD] Effect: Predator's Claw
+  [5v0ndPPMfZwhiVZF] Effect: Predictable!
+  [MqUZKmLRL3ntnCZS] Effect: Predictable! (Saving Throw)
+  [YIpFCMT8AKKhgbAF] Effect: Premonition of Clarity
+  [ZqEOsqnGFLI2ob9m] Effect: Prepare Elemental Medicine
+  [HF2kOaqrjCkaZnK9] Effect: Prepare Fangs
+  [jgaDboqENQJaS1sW] Effect: Prepared Camouflage Suit
+  [4efZ33Gx1kqqTysd] Effect: Prescience
+  [32VbgOcmqIqRpWIU] Effect: Preserved Moonflower
+  [5Su0OWWN5VLL3fsw] Effect: Press On
+  [COsdMolZraFRTdP8] Effect: Prevailing Position
+  [JBWZkGkNikSlQfNr] Effect: Prey Mutagen
+  [oqRIuChjaSRKKEes] Effect: Prey Mutagen (Bonus)
+  [HLn9nQY4SAvyhaom] Effect: Prey Mutagen (Lesser)
+  [KUNJk4bsCRDzArdK] Effect: Prey Mutagen (Moderate)
+  [pvkrl2F0ghYgZXnR] Effect: Pride in Arms
+  [5PIaLkys5ZqP2BUv] Effect: Primal Aegis
+  [45iy8x9ObfnkM97c] Effect: Primal Sink
+  [qOBdeZ4FXYc5qHsm] Effect: Private Workshop (Using for Crafting)
+  [w4EdnGI8i4UIkzWp] Effect: Proclaim Resilience
+  [g5Yen1FhEMCzCJkv] Effect: Profane Gift
+  [RU6D7pNQSBt1zSuK] Effect: Propulsive Leap
+  [c6SiBB3mzV8lZUQr] Effect: Protean Anatomy
+  [exwQF6E1FWmuxwBc] Effect: Protective Barrier
+  [1VwsQa7SyUviSoFA] Effect: Protective Cycle
+  [IlSPZvli2IcLVPyi] Effect: Protective Mentor
+  [qIPl31SfvT993Lyz] Effect: Protective Pose
+  [kzSjzK72CQ67wfBH] Effect: Protective Spirit Mask
+  [D7JhDc4dcWhORY9h] Effect: Proud Mentor
+  [BIHU3o499fsa1bwt] Effect: Psi Strikes
+  [wEFRo8enunRLFsVE] Effect: Psychic Daze
+  [Dbr5hInQXH904Ca7] Effect: Psychic Rapport
+  [7BFd8A9HFrmg6vwL] Effect: Psychopomp Blood Magic (Self)
+  [lcB7s9zxqoB42eG1] Effect: Pucker Pickle
+  [GC5441z8i7N8swk1] Effect: Pulse of Rage
+  [7MQLLkQACZt8cspt] Effect: Purifying Breeze
+  [G2QC7QCEsPth2pUd] Effect: Purple Pepper Powder
+  [OeZ0E1oUKyGPxPy0] Effect: Push Back the Dead!
+  [AOqlEOF3Q7w9XYFp] Effect: Pushing Wind
+  [hQsqr2sRPp9rNm4U] Effect: Putrid Blast
+  [xmES7HVxM7L3j1EN] Effect: Putrid Stench
+  [u3Qy9t7RuE4wKV0O] Effect: Pyre's Mercy
+  [rVFDLzYrJVYLiQBL] Effect: Qat (Stage 1)
+  [MNITD4PrcyRCqPbK] Effect: Queen Sorshen's Aid (Aid Ally)
+  [KFmJLxZAFQ2Q7C1N] Effect: Queen Sorshen's Aid (Indulgent Arcana)
+  [a2XvUg92diojK9EA] Effect: Queen's Presence
+  [8lQneh5ZjMDqmBys] Effect: Quicken the Rot
+  [2Bds6d4UGQZqYSZM] Effect: Quicksilver Mutagen (Greater)
+  [6PNLBIdlqqWNCFMy] Effect: Quicksilver Mutagen (Lesser)
+  [988f6NpOo4YzFzIr] Effect: Quicksilver Mutagen (Major)
+  [VPtsrpbP0AE642al] Effect: Quicksilver Mutagen (Moderate)
+  [RLA7eqF2wjUPS2mf] Effect: Race the Skies
+  [263Cd5JMj8Lgc9yz] Effect: Radiant Circuitry
+  [7fTxNaznBfjrGTjt] Effect: Radiate Cold
+  [z3uyCMBddrPK5umr] Effect: Rage
+  [MaepXeSHiMoWDm7u] Effect: Rage Temporary Hit Points Immunity
+  [B09MScCT7fhtBW5S] Effect: Rage and Fury
+  [drh6p7VWdByUvRlf] Effect: Rage of the Sky Father
+  [bHCpqwKH9JM8FZa6] Effect: Rainbow Vinegar
+  [wY7yV6a3SICudb1w] Effect: Rainbow Vinegar Weakness
+  [szOyQaUgKZ09q4Ux] Effect: Raise Defenses
+  [LohrnRXCQ0yVt8MK] Effect: Raise Guard
+  [DKCoW3A6Tz799Uq9] Effect: Raise Jar
+  [AggnVD5loQHLb7zj] Effect: Raise Menhir
+  [A6i55HQ59lzsHXVQ] Effect: Raise Symbol
+  [2YgXoHvJfrDHucMr] Effect: Raise a Shield
+  [dn7P5RzMZugxiWri] Effect: Raise the Walls
+  [TrCwynU02vy5rdJr] Effect: Rally
+  [Lx5EEENaikPf2dBn] Effect: Rally the Troops
+  [wjNNHgX6ceKLbn8Q] Effect: Rallying Charge (Marshal)
+  [DWrsDJte9sez0Ppi] Effect: Rampaging Form
+  [WRe8qbemruWxkN8d] Effect: Rampaging Form (Frozen Winds Kitsune)
+  [RBfd5qwFkuKxNb57] Effect: Rapid Evolution - Energy Gland
+  [iuy6AA6sQZUZkN9X] Effect: Rapid Evolution - Husk
+  [WzvOyycUlTsCXt3M] Effect: Ravenous Young
+  [78Dfh5ghvULGiyzk] Effect: Reactive Detach
+  [ivGiUp0EC5nWT9Hb] Effect: Read Shibboleths
+  [8tCNgEE9OsQE9Xnh] Effect: Read the Cards
+  [rbgXQqXbpaQCcNNx] Effect: Read the Stars (Critical Success)
+  [EQCnu8DGHDDNXch0] Effect: Reanimator Dedication
+  [zqgOjMU9TGoGwJWc] Effect: Rebirth in Living Stone
+  [CW4zphOOpeaLJIWc] Effect: Recall Under Pressure
+  [rvyeOU7TQTLnKj03] Effect: Reckless Abandon (Goblin)
+  [82PN02Yy4GXcswy1] Effect: Recount Epic
+  [A0w4C7GsqgFmkR8u] Effect: Recruit the Recent Dead
+  [e1XDZsMrytC0K3k8] Effect: Red Tape
+  [QrsPKOFuo3qzgxw5] Effect: Red-Rib Gill Mask (Greater)
+  [UDfVCATxdLdSzJYJ] Effect: Red-Rib Gill Mask (Lesser)
+  [2iR5uP6vgPzgKKNO] Effect: Red-Rib Gill Mask (Moderate)
+  [pQUNwvvBfApjL3Ma] Effect: Reef Armor
+  [DOxl0FDd21VMDOMP] Effect: Reflection of Life (Fast Healing)
+  [owOGKBjP7tlyQD5o] Effect: Reflective Arrows (Penalty)
+  [pwbFFD6NzDooobKo] Effect: Reflexive Shield
+  [fOypEG6eeTwfM6c3] Effect: Regalia
+  [dA8AzlayuQ1hIeEx] Effect: Regional Specialty
+  [Rn1aE4uvq30iiH0Y] Effect: Regression
+  [0jKdU1YdER9dLBdx] Effect: Rejuvenating Touch
+  [6M6JRjWjJy0rwtX2] Effect: Relinquish Control
+  [2u26bmArDPuoCljc] Effect: Remaining Air
+  [ESvcHy4CQbYLaZVu] Effect: Remember, You're Under Oath
+  [IrXb05caCTkP792e] Effect: Reminder of Doom
+  [NLjzI7gt6djXSoXc] Effect: Remove Face
+  [CBEHOTjal3nllTtt] Effect: Rend Armor
+  [jlZjUtrfcfIWumSe] Effect: Renewed Vigor
+  [hGj6fnFwQwczmubB] Effect: Renewing Cycle
+  [wnCKvlOecXAmtWII] Effect: Repel Ambient Magic
+  [is84dtk4w3W62L7D] Effect: Repentant Defiance
+  [BJc494USeyM011p3] Effect: Replenishment of War
+  [XE2YhBMl7wc6nQAZ] Effect: Replenishment of War (Endlo)
+  [MiucWR2AbIhr34qD] Effect: Resilient Touch
+  [EdYvHSzJC5pGLdoV] Effect: Resist Corruption
+  [WqgtMWgM9nUjwQiI] Effect: Resistance 5 to all damage
+  [sbxGrVdEsYZ5KiCj] Effect: Resolute Mind Wrap
+  [Plga97M3LVFZqhiP] Effect: Resonating Fork - Armor
+  [NMmsJyeMTawpgLVR] Effect: Resounding Bravery
+  [BKyq3deWdCbYzAHA] Effect: Resounding Cascade
+  [ycalVFivloJ14yhA] Effect: Resounding Finale
+  [eFb1PU15j7t7wxqp] Effect: Restorative Halo
+  [jYxWTG5J171XVa5r] Effect: Restorative Strike
+  [Wa5s0Perw2DGHGCA] Effect: Resurrection Tea
+  [YaSxccYfE5ShFdFd] Effect: Resurrectionist
+  [AwMp9BwvNMrLylDJ] Effect: Revealing Hypothesis
+  [SA5f54t1dVah5fJm] Effect: Revert Form
+  [EgOcWruvNdVIpNAC] Effect: Revitalizing Finisher
+  [dIBSsWCw5tNtokxu] Effect: Rhino Hide Brooch
+  [lgvjbbQiHBGKR3C6] Effect: Rhino Shot
+  [2zc0u52oNcqziwnV] Effect: Ride Them Down!
+  [QzJv3TybABeCjwQc] Effect: Riding Zogototaru
+  [ywrtR63bJqpN0FsK] Effect: Righteous Call
+  [gAQaizpMbZLDbzg7] Effect: Rime Crystal - Armor
+  [IiDpW99zrh7zHxmQ] Effect: Rime Crystal - Weapon
+  [gvCHmUQ2WxTdBKLq] Effect: Rime Shield
+  [K2hqRFjGMX0GCIUi] Effect: Roaring Heart
+  [IySCRGYxxLFDlIZI] Effect: Roast
+  [XyhPcnlkg3mGqEwT] Effect: Rockfall Critical Failure
+  [vuaungtl9VCBoHDK] Effect: Rockfall Failure
+  [ixAmr0VkB6q6LpGq] Effect: Rod of Rule
+  [gtpqoCOWhF9Pjb8G] Effect: Roll the Bones of Fate (Good)
+  [DXVnnltqkfFglbrn] Effect: Rolling Flight
+  [T2eCVO5lN8cNMzyq] Effect: Root Boots
+  [jO7wMhnjT7yoAtQg] Effect: Root Magic
+  [NAdAO5ElcSlSBkza] Effect: Root in Place
+  [o0zqsH5kYopRanav] Effect: Rope Snare
+  [xXfzzNaBOqDUbYBD] Effect: Rotting Stench
+  [epHQeILdRs3NuxMZ] Effect: Rovagug's Destruction
+  [d84cOfu0bEF8RBvK] Effect: Rovagug's Mud
+  [1tweTwYQuQUV45wJ] Effect: Rowan Rifle (Cold)
+  [9kOgG7BPEfIyWyqm] Effect: Rowan Rifle (Electricity)
+  [KiurLemTV8GV7OyM] Effect: Rowan Rifle (Sonic)
+  [84OsM8ml9VUAlNze] Effect: Rugged Mentor
+  [Ny6kEKDxr9GhLoTC] Effect: Runelord Researcher
+  [P4bNtDVyknQwjTPo] Effect: Runic Resistance
+  [lWi5NjGv16mGpncU] Effect: Ruthless Orator
+  [og3gUpF2Ti64Py8t] Effect: Ruthless Orator (Enemy)
+  [1wCgwFLJByW8YKyM] Effect: Sacrifice Armor
+  [tlft5vzk66iWCVRq] Effect: Safeguard Soul
+  [pdEXnJrIHIEX9NM4] Effect: Sage's Analysis
+  [K21XQMoDVSPqzRla] Effect: Sage's Lash (Turquoise)
+  [hexHnjCuq6vaEZEx] Effect: Sairazul Blue
+  [PPdAw4msUtLgxpWI] Effect: Sakura's Sprig
+  [ImkjllInxmrdDCOq] Effect: Sanctify Armament
+  [f8rncEs06bqcn3LZ] Effect: Sandstorm
+  [mQgA7XmjVI6WG6oq] Effect: Sanguine Fang - Armor
+  [bKEx53h6lrFOYvpu] Effect: Sanguine Fang - Weapon
+  [FtBfE4yrbg9fxtxr] Effect: Sanguine Mutagen (Greater)
+  [5VI5NCEhuorERXTi] Effect: Sanguine Mutagen (Lesser)
+  [yY8vPNmDdQQ5d7n6] Effect: Sanguine Mutagen (Major)
+  [sZPXKQACna6YDsVX] Effect: Sanguine Mutagen (Moderate)
+  [nP1KEogCiRdVq0UB] Effect: Sanguine Rain
+  [kJndFOHNBH8SR5IM] Effect: Sanguine Revitalization
+  [6ACbQIpmmemxmoBJ] Effect: Saoc Astrology
+  [CIfqUEC0mITBjwmL] Effect: Sarkorian God-Caller Garb
+  [P3lpqXMd5FbUF57c] Effect: Sash of Books (Bonus)
+  [7DJEJZP2ZfYGfuaO] Effect: Sash of Books (Recall Knowledge)
+  [AYLthNtyUlWmKqhW] Effect: Saurian Spike - Armor
+  [94ZHsHjS1OWHa2rg] Effect: Scent of Blood
+  [EMqGwUi3VMhCjTlF] Effect: Scout
+  [la8rWwUtReElgTS6] Effect: Scout (Incredible Scout)
+  [RxDDXK52lwyHXl7v] Effect: Scout's Warning
+  [wcNGbhwn3AuamtsX] Effect: Scraping Clamor
+  [TvctK2VAteHbnKXk] Effect: Scream of Despair
+  [GAuA1XLLO4vkF3OJ] Effect: Sea Chantey
+  [LOql7Rc5anCse9Nx] Effect: Sea Glass Guardians
+  [RRusoN3HEGnDO1Dg] Effect: Sea Touch Elixir (Greater)
+  [thOpQunbQr77XWdF] Effect: Sea Touch Elixir (Lesser)
+  [9keegq0GdS1eSrNr] Effect: Sea Touch Elixir (Moderate)
+  [jqbEIA6249vqgqwq] Effect: Searing Blade (Greater)
+  [d6VzjIU3ajRX0pyF] Effect: Season of Grit
+  [8KtjzHHR7n7ALvQc] Effect: Seasonal Boon (Outskirt Dweller)
+  [wQDHpOKY3GZqvS2v] Effect: Seedpod
+  [h6nyMp4dtPXBfCJc] Effect: Selfish Shield
+  [VDSJn9vhVRh5V4Kq] Effect: Sense-Dulling Hood (Greater)
+  [L2l6FobAaPv13ypY] Effect: Sense-Dulling Hood (Lesser)
+  [zrW4ETHiYN2r7Hks] Effect: Sentinel's Aura
+  [HiLwUXS35dNZgnfC] Effect: Sepulchral Drain
+  [jw6Tr9FbErjLAFLQ] Effect: Serene Mutagen (Greater)
+  [5xgapIXn5DwbXHKh] Effect: Serene Mutagen (Lesser)
+  [t7VUJHSUT6bkVUjg] Effect: Serene Mutagen (Major)
+  [yrbz0rZzp8aZEqbv] Effect: Serene Mutagen (Moderate)
+  [9lQFQoORorhPMvmE] Effect: Serpent Mode
+  [ehYmO1rFBt35zoOw] Effect: Server's Stew
+  [19YECUFY5of8c0yl] Effect: Seventh Prism (Pentagonal)
+  [josVmrDMWcTinHFK] Effect: Shackling Cold
+  [Nv70aqcQgCBpDYp8] Effect: Shadow Blood Magic
+  [TSdrv1FmLHJnk9AD] Effect: Shadow Rapier
+  [je3lgJso1WmyC81w] Effect: Shadow Sheath Weapon
+  [3GPh6O3PJxORytAC] Effect: Shadow Sight
+  [UWm7dYJvAz9fCGXT] Effect: Shadowpiercer
+  [zqgntQXIEbulBgZX] Effect: Share Defenses
+  [uXCU8GgriUjuj5FV] Effect: Share Hunter's Edge (Flurry)
+  [4UNQfMrwfWirdwoV] Effect: Share Hunter's Edge (Flurry, Masterful)
+  [ltIvO9ZQlmqGD89Y] Effect: Share Hunter's Edge (Outwit)
+  [iqvurepX0zyu9OlI] Effect: Share Hunter's Edge (Outwit, Masterful)
+  [mNk0KxsZMFnDjUA0] Effect: Share Hunter's Edge (Precision)
+  [Lt5iSfx8fxHSdYXz] Effect: Share Hunter's Edge (Precision, Masterful)
+  [LpudOmKE8bHZgYeL] Effect: Share Hunter's Edge (Vindication)
+  [iXVsVqttUGlfdIHS] Effect: Share Pain
+  [RoGEt7lrCdfaueB9] Effect: Share Rage
+  [svVczVV174KfJRDf] Effect: Shared Avoidance
+  [CUtvkuGSxq1raBIB] Effect: Shared Clarity
+  [uKJRRrlReO0CceVc] Effect: Shared Confidence
+  [0v30plBl9TuuJQ5F] Effect: Shared Sight
+  [KC8mrGFXs5hIhjXt] Effect: Sharkskin Robe
+  [6hh788S8hznyD66m] Effect: Shattershields
+  [2Cdf49eccdwBh40X] Effect: Shed Cinders
+  [OK7zMlYy25JciBp6] Effect: Shed Tail
+  [m0hi0jpIF6tNJzzo] Effect: Sheltering Pulse
+  [4siBPDdWmwks1bI5] Effect: Sheltering Wing
+  [qACkkLk3F5WeACHO] Effect: Shelyn's Love
+  [s3Te8waFP3KEb2dN] Effect: Shield Ally
+  [QF6RDlCoTvkVHRo4] Effect: Shield Immunity
+  [NUOfUPboXVEVQNBE] Effect: Shield Paragon Benefit
+  [YU6NYuil87dSrRh7] Effect: Shield Your Eyes
+  [XFnNmos2R1nOFl9O] Effect: Shield from Arrows
+  [5uMMLUvJOEmfMgeV] Effect: Shield of Faith
+  [ah41XCrV4LFsVyzl] Effect: Shield of the Unified Legion
+  [JMkGtyRU4bTSL2sB] Effect: Shield the Faithful
+  [KOVUFiN6nkttuiRb] Effect: Shielded Recovery
+  [16tOZk4qy329s2aK] Effect: Shielding Salve
+  [xYCoyHRLdOXm8Ndr] Effect: Shielding Wave
+  [uxZSx9JfzwxdJg51] Effect: Shielding Wing
+  [EkXmCnn0wdTgzLoM] Effect: Shields Up!
+  [ImGkGl9OeK1zyxYJ] Effect: Shift Scales
+  [F6YMKMbhzWBd9A07] Effect: Shimmering Dust
+  [Sf6UO6vgCeicggOK] Effect: Shining Ammunition
+  [s5OHkf1HkLwgvZT7] Effect: Shining Arms
+  [aLrFDxT2dhIEwcQr] Effect: Shining Glory
+  [gn7kNxKGUsKwnv1L] Effect: Shining Symbol
+  [MFbOXncTwYaskdfG] Effect: Shining Symbol Weakness
+  [i8hVCNQTBFPJ1qEG] Effect: Shizuru's Light
+  [U7QM4yqxcoGSysoG] Effect: Show Off
+  [ORdhj3IAvYACNGkJ] Effect: Shrine Inarizushi
+  [o0baLY5VdjLhdsS7] Effect: Shrinking Potion
+  [zd85Ny1RS46OL0TD] Effect: Shrinking Potion (Greater)
+  [iFPNXFOCYHIxIKBw] Effect: Shroud of Burning Pages
+  [o1VvOndRq2pNhSeK] Effect: Sic 'Em!
+  [tuFMtIJXeI4yAXeD] Effect: Sight Prey
+  [WK55ybwI2Tn5OW5x] Effect: Sight Prey (Speed Penalty)
+  [OqZtUOemGXgi9HDM] Effect: Signature Weapon
+  [YKCsmlMgI0aS7joO] Effect: Silent Aura
+  [RmJ5qosNpE8DUX2a] Effect: Silk Bracelet
+  [dchlrZqQ2oEmgNlN] Effect: Silkspinner's Shield (Animated Strike)
+  [SbYcOry1cxbndSve] Effect: Silkspinner's Shield (Climb)
+  [KFq5wnjdzyrycEnB] Effect: Silver Crescent
+  [dfnhwI5pJgLtXh2k] Effect: Silver Salve
+  [oAewXfq9c0ecaSfw] Effect: Silvertongue Mutagen (Greater)
+  [dpIrjd1UPY7EnWUD] Effect: Silvertongue Mutagen (Lesser)
+  [9FfFhu2kl2wMTsiI] Effect: Silvertongue Mutagen (Major)
+  [v5Ht1V4MZvRKRBjL] Effect: Silvertongue Mutagen (Moderate)
+  [9Qyu0HN5j6DO8Izc] Effect: Sinful Bite
+  [czysaN0cMLJSOH4t] Effect: Sip of Justice
+  [7j1fMrkI40XIlTUt] Effect: Siphon Life
+  [cmwlVYHtp3a1OipU] Effect: Siphon Torment
+  [unwNPDLmReEQy700] Effect: Siphon Will
+  [jCwXeDnqBTw9pyhg] Effect: Siphoning Grip
+  [TkRuKKYyPHTGPfgf] Effect: Sixfingers Elixir (Greater)
+  [XrlChFETfe8avLsX] Effect: Sixfingers Elixir (Lesser)
+  [qzRcSQ0HTTp58hV2] Effect: Sixfingers Elixir (Moderate)
+  [zXIpCkTtFRkhwI4x] Effect: Sixfold Flurry
+  [DX6v0lcI2uA99Yjv] Effect: Sixth Pillar Mastery
+  [TsWUTODTVi487SEz] Effect: Skeptic's Elixir (Greater)
+  [5Gof60StUppR2Xn9] Effect: Skeptic's Elixir (Lesser)
+  [mG6S6zm6hxaF7Tla] Effect: Skeptic's Elixir (Moderate)
+  [n6PAwAqignNXd75G] Effect: Skillful Mentor
+  [2tOVDTjCZVx4uEjP] Effect: Skin Net
+  [zlSNbMDIlTOpcO8R] Effect: Skinstitch Salve
+  [Z7KzhGhAWzgXIEkp] Effect: Skyfang Crystal
+  [Nbgf8zvHimdQqIu6] Effect: Skyrider Sword
+  [xLKLKfm0p8ubp4Fe] Effect: Slayer's Stone
+  [XSAmMuMgMvdjdpHc] Effect: Slime Trap
+  [1N28rGPbAl2IkGUf] Effect: Slime Whip
+  [W3BCLbX6j1IqL0uB] Effect: Slippers of Spider Climbing
+  [CqMaZrZfU3Qtf3MI] Effect: Slithering Vine
+  [n96DB8vpPr1Fu6GZ] Effect: Smash Kneecaps
+  [PeQ2isu6YFcHhQyp] Effect: Smeltable
+  [AlnxieIRjqNqsdVu] Effect: Smite
+  [2MIn8qyPTmz4ZyO1] Effect: Smite Good
+  [z480XhE3nft1TQDj] Effect: Smoky Protections
+  [d0aJSi7GI6AhBlAJ] Effect: Snack
+  [YIXeQFdrt0vPvmsW] Effect: Snake Form
+  [hfhdvgObjnGStW07] Effect: Snap Out of It! (Marshal)
+  [ehcAvmjZVzyFJclB] Effect: Sneaky Key
+  [zQHF2kkhZRAcrQvR] Effect: Sniping Duo Dedication
+  [ytG5XJmkOnDOTjNN] Effect: Soaring Flight
+  [1XmE0W0tVH5NXGL2] Effect: Soaring Wings
+  [UbDVVOjTMLXdKMb8] Effect: Solidarity
+  [ATeiWcHcjoTvIbkk] Effect: Song of Freedom
+  [kjiNrDuqyTXDlH3m] Effect: Song of Soothing
+  [dZDpfgU63rXbBHpe] Effect: Song of the Skies
+  [hftFxE8JGJGzXAtU] Effect: Song of the Swamp
+  [dtgI6eol6GWNipmt] Effect: Sooth Serpents (Speed Penalty)
+  [kIzYHyIN6xzbocuh] Effect: Soothing Toddy
+  [p5KpVsJVzhoJ4OrS] Effect: Soothing Tonic
+  [fqK8TsXmHr1JiM5e] Effect: Soothing Vials
+  [k8bmDh3nWi2FUyz5] Effect: Soul Anchor
+  [oKNFSWJW2jat8Dli] Effect: Soul Crush (Healing)
+  [JgJ4Iw8BvJ4tWkah] Effect: Soul Lock (Healing)
+  [TbQiJxLfEF6P1HnO] Effect: Soul Oubliette
+  [SrUJbUErv3pjBRCw] Effect: Soul Roar (Ally)
+  [SjrM6XVTLySToS12] Effect: Soul Siphon
+  [jeBDJW383w5jv1BG] Effect: Soul Vessel Mount
+  [9YO84RSGcq3XcA0E] Effect: Soul Well
+  [HKk3oUYJNN82heeH] Effect: Soul Well (Additional Damage)
+  [5OABp099y6w3didN] Effect: Soulspark Candle
+  [hy6LAC13QIJNDYXm] Effect: South Wind's Scorch Song (Damage)
+  [eQqi3tWSHwV4SHqK] Effect: South Wind's Scorch Song (Speed Boost)
+  [7juD2XQ7wKI5pjPW] Effect: Spark Fist
+  [nwSZL6EgG8KarNOT] Effect: Spark of Courage
+  [DlG2V9RklmeukTvF] Effect: Sparking Pepper String
+  [uYWi2vxFQVBJgJR6] Effect: Sparkler
+  [GLvCZJmTRxfjxGDZ] Effect: Spear Parry
+  [Zzes9C7ftjUHIJos] Effect: Spell Break
+  [su2HbEdb4IYB7r5l] Effect: Spell Parry
+  [OochfTTXnDLVXeSS] Effect: Spell Protection Array
+  [zqKzWGLODgIvtiKf] Effect: Spellguard Blade
+  [lBMhT2W2raYMa8JS] Effect: Spellguard Shield
+  [4JULykNCgQoypsu8] Effect: Spiderfoot Brew (Greater)
+  [wNCxSxruzLVGtLE4] Effect: Spiderfoot Brew (Lesser)
+  [YI7QQqXO6nosaAKr] Effect: Spiderfoot Brew (Moderate)
+  [pFEk5cwegWqXvX4D] Effect: Spike Skin
+  [FtYnwBGZscmV8Fow] Effect: Spill Secrets
+  [UzIamWcEJTOjwfoA] Effect: Spin Tale
+  [AUoiLqENVZlZohsn] Effect: Spined Shield Spines
+  [bHBehLniirjNAnVh] Effect: Spiny Lodestone - Armor
+  [m6z7OrJgF4XQFNpa] Effect: Spiny Lodestone - Weapon
+  [2gVP04ZWYbQdX3uS] Effect: Spiral Sworn
+  [2SzLumWCqZQAetcx] Effect: Spirit Fan
+  [KanP6trNwPOggb7P] Effect: Spirit Guide Form
+  [UQmizjvdBfSVYoZe] Effect: Spirit Power (Flight)
+  [ECCyLvt5uRw8Qv8V] Effect: Spirit Power (Passion)
+  [Rzlo3kvFUavFQJ3S] Effect: Spirit Powers
+  [nV2zH7OcQeoQrrvB] Effect: Spirit's Mercy
+  [RIBExSLZDxRUqPPT] Effect: Spirits' Interference
+  [parbYdReJWd08fGl] Effect: Spiritsight Tea
+  [kOGRUuyK04MjLc3m] Effect: Spiritual Warden
+  [Hjb8iwGGxkyhiz7E] Effect: Spiteful Eye
+  [86uYNsVXzYWxqLTV] Effect: Splintered Ground
+  [hc7kR6quUE9ryRyj] Effect: Splintered Ground (Critical Failure)
+  [nTTqHZGSub9kmpOr] Effect: Spore Feedback
+  [irSKPLF5oLfnqUNW] Effect: Spotlight
+  [75B7z49jfQbWcSy9] Effect: Spray Toxic Oil
+  [FV5d8zdo8CGZuRbg] Effect: Spun Cloud (Blue)
+  [vrQeNhy3M48RBH4B] Effect: Spun Cloud (White)
+  [Sv99eNoXedd9Zw26] Effect: Stab it! Stab it! Stab it!
+  [XgIY3j2VFUSQ5Or9] Effect: Staff of Illumination
+  [TQQN1nBvrnUfnx5y] Effect: Stag's Helm
+  [qaIqu9H9OdX1B5wy] Effect: Staggering Fire
+  [g8JS6wsw5sRWOJLg] Effect: Stalk Goggles
+  [f2r7r0t8n7LKuj6C] Effect: Stalwart's Banner
+  [5uK3fmGlfJrbWQz4] Effect: Stalwart's Ring
+  [jlYPMOHplgkvzLa9] Effect: Standard of the Primeval Howl
+  [TM0LFTy30FG2wwI2] Effect: Star of Cynosure
+  [Y96a1OedsU8PVf7z] Effect: Starlight Armor
+  [JmAYeBSVvr5QMNis] Effect: Starlit Transformation
+  [ENUkD70XmIP4Hekz] Effect: Starsong Nectar
+  [MGlENdqYCAwBkyXt] Effect: Static Field
+  [8YVHpRLCIUkf67OL] Effect: Static Muscular Relay
+  [2ytxPqhGyLtEjYxW] Effect: Static Snare
+  [80JoiuYxrzoEPfVw] Effect: Statue Skin Salve
+  [1zwFkM7KSsuMrAD3] Effect: Stay Strong!
+  [WF0Ydce6nmFDNnrf] Effect: Stay in the Fight!
+  [d0TYadetRJvNb2Au] Effect: Steal Death
+  [HoNojV4S2Yb6CoZR] Effect: Steel Yourself!
+  [wX9L6fbqVMLP05hn] Effect: Stench
+  [Fjyhw3lhuHCz01xS] Effect: Steward of the Faithful
+  [K3r1lfbtCTf3dFhV] Effect: Stick a Fork in It
+  [g4CRjb2zS1pkVDbk] Effect: Sticky Spores
+  [EZVgNBwMrJWeKLXp] Effect: Still Got It!
+  [6GC248hHu3LdOAtS] Effect: Sting of the Lash
+  [TcgvhgpUkJFjVqBx] Effect: Stink Sap
+  [eE3FEpjk2HdZDzSA] Effect: Stoke the Fervent
+  [J6EwMsXtXg30eaiB] Effect: Stoke the Fervent (High Tormentor)
+  [i0tm2ZHekp7rGGR3] Effect: Stole of Civility
+  [7cG8kpQvh2oyBV8d] Effect: Stone Body
+  [b9DTIJyBT8kvIBpj] Effect: Stone Body Mutagen (Greater)
+  [PEPOd38VfVzQMKG5] Effect: Stone Body Mutagen (Lesser)
+  [1xHHvQlW4pRR89qj] Effect: Stone Body Mutagen (Moderate)
+  [AMhUb42NAJ1aisZp] Effect: Stone Fist Elixir
+  [m9hevf7O7XMUgG83] Effect: Stone Flesh (Weakened)
+  [AJx8i8QX35vsG5Q4] Effect: Stonethroat Ammunition (Success)
+  [ecWVnrjsjubZ4On6] Effect: Stoney Deflection
+  [IRmIB2435SCvoSTS] Effect: Stoop
+  [zmow6d0PswEqLcrM] Effect: Storied Companion
+  [CDfixYwjfjoXkOVq] Effect: Storm Breath
+  [uC6KjfiWrTBXYtP8] Effect: Storm Chair
+  [FnCC5RNvnlWB2bmb] Effect: Stormbreaker Fulu
+  [nWrUYrSFScwURSTs] Effect: Strain Mind
+  [lZPbv3nBRWmfbs3z] Effect: Strained Metabolism
+  [7HXxtWO5MAJWkwnt] Effect: Strangle
+  [no8vv18N7YmEKvOH] Effect: Strategist Stance
+  [0bwavSwP7XUMO9J1] Effect: Strength Through Pain
+  [l9bMRAoKnFP8vb3D] Effect: Strike True
+  [EzgW32MCOGov9h5C] Effect: Striking Retribution
+  [ogtcaPeypLDiUXMS] Effect: Strum of Thunder
+  [bbZkyKT6MzaX4FHI] Effect: Stubborn Skin
+  [1bnJJb4hsnMOw9cQ] Effect: Stymie the Gods
+  [Pkk8m79MoT1RgtfW] Effect: Succubus Kiss (Stage 1)
+  [zDuuHVeHgd175pGf] Effect: Succubus Kiss (Stage 2)
+  [cy42NXgx1vjYzSxN] Effect: Suit of Armoire Frustration
+  [fuQVJiPPUsvL6fi5] Effect: Sulfur Bomb
+  [kwOtHtmlH69ctK0O] Effect: Sun Orchid Poultice
+  [f1w5p5AVfAajZi9t] Effect: Super Qi Blast
+  [qSKVcw6brzrvfhUM] Effect: Supercharge Prosthetic Eyes
+  [aMmQY3YvufchsXGT] Effect: Surge Forward
+  [9iL6CeZlmtIuAZOJ] Effect: Surgical Rend
+  [tMsVpICbBU3kL1lp] Effect: Surgical Shock (Failure)
+  [KR391Ltqp0d3EWg1] Effect: Survive the Wilds
+  [APJJCYdq4gNe0PF4] Effect: Susceptible to Mockery (Critical Failure)
+  [Y1dCVl3Wh4pBetm6] Effect: Swagger
+  [0aRm0b55015XPj7Y] Effect: Swarming Bites
+  [JlaO7fgm53Om1DxB] Effect: Swell
+  [4IwCyYdSn2gUYAwL] Effect: Swift Block Cabochon
+  [EgAmT4WENb6UNSdJ] Effect: Swift Standard
+  [HArljmKc2IR7rtfc] Effect: Swig
+  [AelmQNBS2ZDuYs7k] Effect: Swig (Clumsy)
+  [h8kgxDMclDHj6bIr] Effect: Sword Practice
+  [QDs8t1U1IepzYlyi] Effect: Sylvan Wine
+  [us3KiMrcGM8e6ri3] Effect: Sylvan Wine (Horned Hunter)
+  [QMRMgU8l697aBcxj] Effect: Symbol of Loyalty
+  [qBTJYpopY3AwFFUJ] Effect: Sympathetic Strike
+  [RtLFTZmVtYKf0p6j] Effect: Tactical Command
+  [JUgx48XHMz4QM4Ir] Effect: Tactical Debilitations (No Flanking)
+  [vgsV7eEYQ7W1fHqR] Effect: Tactician's Helm (Move It!)
+  [nLwtvyLZZTZgFmKq] Effect: Tactician's Helm Charges
+  [QqC9xymSXSVunDgl] Effect: Tail Lash
+  [Q0DKJRnDuuUnLpvn] Effect: Tail Toxin
+  [u1Z7i2RyL6Sd9OVU] Effect: Take Them Down!
+  [bsumFksktyHssfrf] Effect: Taldogis Badge
+  [8n0wqGpz28lfnLsQ] Effect: Talented Tap Shoes
+  [X2ZZgTqanpoCMDmd] Effect: Taljjae's Mask (The General)
+  [fYe48HmFgfmcqbvL] Effect: Taljjae's Mask (The Hero)
+  [rXM6njevpwqSMNRt] Effect: Tallowheart Mass
+  [m8QCmsy4WFQCIC7t] Effect: Tap the Past
+  [j8dPwfhUuIeDgHYT] Effect: Taper of Sanctification
+  [se36qcZiG3T0ps5U] Effect: Targeting Finisher
+  [hbWnrLZpqemQVdvb] Effect: Targeting Finisher (Critical)
+  [VBsWZHdYymig9WsH] Effect: Targeting Strike
+  [zcGenQGOjZgFuqzs] Effect: Tarnbreaker Champions
+  [FlyWq9znOHvpISNW] Effect: Taunt
+  [XmNIl5QrNXy88Fk8] Effect: Technological Defence
+  [2ccLQxmTlTPySnOR] Effect: Technology Control
+  [ERBJL8rBEURa05N8] Effect: Temper Armament
+  [u9b233QynLAPKPty] Effect: Tempest Rage
+  [ekpt4mFw1kJkZ2pK] Effect: Tenacious Flames
+  [pkWudzFWfKnggT1f] Effect: Terrain Attunement (Aquatic)
+  [E9GohJi4hZ4vSLNu] Effect: Terrain Attunement (Arctic)
+  [ag1Ix1cnhcV4k9iu] Effect: Terrain Attunement (Gravelands)
+  [78Il8Sx0iB0TuLZv] Effect: Terrain Attunement (Mountain)
+  [KSXdpnGIaxe08v2G] Effect: Terrain Attunement (Plains)
+  [lUTUBYnA0GKYR5m5] Effect: Terrain Attunement (Underground)
+  [qZ2FIUz1ZXnS0T7N] Effect: Terrain Shield
+  [9p4Ieqw6qAkhc4m3] Effect: Terrifying Mien
+  [GdkIUl4w8yAJxqdO] Effect: Thaw the Heart
+  [wvzrq1Lh9Y8PpxBs] Effect: Thawing Candle
+  [SLXhPgaeKB0W3k1D] Effect: The Bigger They Are
+  [9Kjnwzu3DWs5U7NH] Effect: The Bigger They Are (Commander)
+  [y8YmJhZiycxiQfs2] Effect: The Hammer of Hooves
+  [dutfhbcXR6Vi8ddV] Effect: The Hammer of Hooves (Mount Speed)
+  [oSieXBuCjz6r72uz] Effect: The Hollow Star
+  [m4DFGd0gUTJsNBxa] Effect: The Kardosian Fragments (Temporary Hit Points)
+  [2JnREGOAqZCZPfdK] Effect: The Proud
+  [ahBcuJWrRXEGvwxb] Effect: The Truth As I See It
+  [o2yteYPGqEjpPAZ5] Effect: Theatrical Mutagen (Greater)
+  [euBiKyqrcefeuv4H] Effect: Theatrical Mutagen (Lesser)
+  [bZPjDwwyPT0iKBE9] Effect: Theatrical Mutagen (Major)
+  [G1IwG9HRH9CRtHqj] Effect: Theatrical Mutagen (Moderate)
+  [0eO7QaOjKDxKv65V] Effect: Therapeutic Snap Peas
+  [1WqXbwhfT1f6OrPU] Effect: Thermal Nimbus
+  [eeZkQOCKjJN5JXZU] Effect: Thesis Shield
+  [JaPNzmgD7p7hHH8o] Effect: Thorn Triad - Armor
+  [FTj94xTqZbaCs4jT] Effect: Thorn Triad - Weapon
+  [XjMGlQTXx13OMAkN] Effect: Thorn of Milani (Spirit Damage)
+  [ThhQDjUXKL7DcdbF] Effect: Thorn of Milani (Unholy Weakness)
+  [ByXEvk0gyFwUk5gU] Effect: Thoughtform Summoning
+  [p1pxUzwgWZ9l9jmD] Effect: Thousand-Year Dragonroot
+  [Zb8RYgmzCI6fQE0o] Effect: Throne Card
+  [XEP4Ox6NZDGgba1r] Effect: Thundering Fury Dadao
+  [lO95TwgihBdTilAB] Effect: Thurible of Revelation
+  [UBC6HbfqbfPQYlMq] Effect: Tidal Shield
+  [PnAzso0F6XUvbYKb] Effect: Tiger Form
+  [ci2oacfcvNyjR1Kn] Effect: Tiger Menuki
+  [4alr9e8w9H0RCLwI] Effect: Tiller's Drive
+  [FISKjI7bal26AnyL] Effect: Timely Advice
+  [CV9YMSNtTV9gQJ3g] Effect: Timepiece Standard
+  [hWA3l5Rix9irkqCu] Effect: Timepiece Standard (Major)
+  [haDTCFX3EhkdF9sz] Effect: Tip the Scales
+  [9VD3ngP8HzbEqm20] Effect: Titan's Standard
+  [RcxDIOa68SUGyMun] Effect: Titan's Stature
+  [vaqiHzEewOKDx6rP] Effect: To Shreds (AC Penalty)
+  [3zNPch2pttYW2n1j] Effect: To War!
+  [vm8Ir6qfvb3BaNUs] Effect: Tome Adept Benefit
+  [r1IsOaxM5tgVU29b] Effect: Tome of Restorative Cleansing
+  [4q8Of8NM9DC8kWyK] Effect: Tooth Tug
+  [1AOfjwg2uZQUcgQC] Effect: Toothy Knife
+  [vZPyQAt5T2L0Dfmq] Effect: Topology Protoplasm
+  [W8HWQ47YNHWB8kj6] Effect: Topple Giants
+  [HN5Fp1pNudfwzyx2] Effect: Torag's Repairs
+  [UuEUZU1fSUb23yOk] Effect: Totems of the Past
+  [Df9NeqlUatsTVvy9] Effect: Tough Cookie
+  [XJtlvaqAHseq1yoz] Effect: Towering Presence
+  [PxLWRiCbgpqOTLO9] Effect: Towering Stance (Disbelieved)
+  [qecXxM3ERv8MvTPh] Effect: Toxic Effluvium
+  [sAs4lPQ2wXEh2dPN] Effect: Tracker's Stew
+  [IzmXq1LycaKNqGIt] Effect: Trance of Celerity
+  [kHRbOHKEedKaBFH5] Effect: Transfer Protection
+  [VECHAM3D71GWHw3A] Effect: Transmuting Ingot
+  [TGGdM7XnjQkkijK7] Effect: Treat Disease
+  [1FrAlPeNseApVrX3] Effect: Treat Poison
+  [Lb4q2bBAgxamtix5] Effect: Treat Wounds Immunity
+  [uHZ23fBG9HIdK5ht] Effect: Tremorsensors
+  [cEGqwfN7EIpMCkNM] Effect: Triangular Teeth
+  [xatDR4tSzpu3qddJ] Effect: Tributary Circulation
+  [MCny5ohCGf09a7Wl] Effect: Tricky Liniment
+  [oqwrw6XztVlS9tEG] Effect: Trinity Geode - Armor
+  [WRV0XjiEHdlBpduS] Effect: Trinity Geode - Weapon
+  [q2t1ZtSPP1p0lz3R] Effect: Tripartite Omen
+  [9PASRixhNM0ogqmG] Effect: Triton's Conch
+  [GZAVAOj0s73Swc0e] Effect: Troop Harrowing
+  [cB5nrsadZxDaxFjz] Effect: Trudd's Strength
+  [M0hhLRC86sASVOk7] Effect: Tteokguk of Time Advancement
+  [uRwnbZ0xWrB5ZzZ9] Effect: Turn Aside Ambient Magic
+  [LbICHKe5jLMxhaOw] Effect: Turn Back The Clock
+  [eu2HidLHaGKe4MPn] Effect: Twin Parry
+  [EDpjey6SCdvIYqEc] Effect: Twin Parry (Parry Trait)
+  [oBOYt4Aon6Po1hwa] Effect: Twist the Skeins of Fate
+  [6enQGnnlgGY6ZWgS] Effect: Ugly Cute's Gift
+  [RPfpy4WzUzdwTeo0] Effect: Ultimatum of Liberation
+  [aA2JwRWclQJbfVMT] Effect: Unassuming Face Paint
+  [Q4LJQDtEYEYw5Sjo] Effect: Unbelievable Connection
+  [FMfcQ2EvQT8QV3V0] Effect: Unbreaking Castle
+  [ukdRbANZICKl29k9] Effect: Uncanny Bombs
+  [BTSstQAn4Xlm1PWV] Effect: Uncanny Tinker
+  [2wCAEtshgSzRuYNK] Effect: Undead Blood Magic
+  [4M2K16mH4gndHAKa] Effect: Undead Mastery
+  [T9wQ1LvsvPWTefQR] Effect: Under Command
+  [cGwFYusGTsJR3x3P] Effect: Under Control
+  [e6mv68aarIbQ3tXL] Effect: Undying Conviction
+  [Px4E3Hyx2pmvSWAA] Effect: Undying Ferocity
+  [ACnP67mu97ZZMEz0] Effect: Unending Subsistence
+  [OWCoFC1Q8AflBGAY] Effect: Unfazed Assessment
+  [939OHjW9y8uCmDk3] Effect: Unleash Psyche
+  [OBsItGQScxHyUcmR] Effect: Unleash Yaoguai Might
+  [yxgHWK2rTZKKAzDN] Effect: Unluck Aura
+  [aOpSI5tApXF5xHCM] Effect: Unsettled Aura
+  [MxArXuo8JRCm1hus] Effect: Unsettling Attention
+  [olpkQDGDzmYZCvQH] Effect: Unstable Check Failure
+  [uUIpCXtvKvPVNunx] Effect: Unsteadying Strike
+  [lBpprC8VD4GRzTtg] Effect: Untamed Shift (Oaksteward)
+  [wAvcGfatk9H3TblG] Effect: Unwavering Resilience
+  [fSZH0aVKyPxatE6i] Effect: Upstage
+  [m5xWMaDfV0PiTE6u] Effect: Ursine Avenger Form
+  [ob00D61F0c4PIvj1] Effect: Utter Despair
+  [fhcpgC3RX1CEGTC9] Effect: Utter Treerazer's Name
+  [nBlTMBTX6owUiyCF] Effect: Vainglorious Whispers
+  [8wGzXqCOUvPw8oMy] Effect: Valorous Coin
+  [xhkVNfgFMUhalqib] Effect: Vamollaroth Stench
+  [PkqVO9070jh8F6sq] Effect: Vanguard's Shield
+  [9VBrrYXFR3EdGptG] Effect: Vapor Sphere
+  [05mIW5FMX2socBY9] Effect: Vashu's Ninth Life
+  [p0piyFHae9uBfNRa] Effect: Vashu's Ninth Life (Diehard)
+  [7MgpgF8tOXOiDEwv] Effect: Vaultbreaker's Harness
+  [KHxkVwXSFsN3eATu] Effect: Vellumis Excision
+  [2TlbtDHEGcFG8NPF] Effect: Venator's Mark
+  [5S2jlx6WZMAF4sxg] Effect: Vengeful Demon's Tears
+  [zNOomUXHZHcc1PWD] Effect: Vengeful Fibers
+  [0o21uiVJUpYCO7Zj] Effect: Vengeful Remnant
+  [HpX3bGlOkSp1PeWg] Effect: Vent Energy
+  [Kwz70TYirPYYL3J3] Effect: Verdant Aria
+  [UhV9TLdFjtSOppog] Effect: Vermin Repellent Agent
+  [P8LdA05tK20u98MF] Effect: Vicious Bluster
+  [Ty2YFxv2EDBOSjxl] Effect: Vicious Bluster (Critical Success)
+  [Rgt9hH3W1oh9dvku] Effect: Vicious Debilitations
+  [N82KSgJMeMse7uPW] Effect: Victor's Wreath
+  [0pq3MPLH0C9z4tj3] Effect: Victorious Vigor
+  [7AzGhIOx4Df5Cicr] Effect: Vigorous Anthem
+  [3wA2IOyZXjFssheT] Effect: Vindication Edge
+  [yykiQBIGqwxIDRZq] Effect: Viper Rapier
+  [zW8adCNIRo46mfEH] Effect: Viperous Elixir (Greater)
+  [zao2sENSQlMLYhyr] Effect: Viperous Elixir (Lesser)
+  [FgwkowiWGfZpnIAc] Effect: Viperous Elixir (Moderate)
+  [Eh0uLxzYfheAWDpG] Effect: Virulent Strike
+  [7txhqKeWFyTJhrEE] Effect: Viscous Breath
+  [iWLAcND0iyW4NUZm] Effect: Viscous Trap
+  [bwEZazVhE5KkLfwA] Effect: Vitality of Hell
+  [5KatA3QnT1zYLxGv] Effect: Vitriolic Miasma
+  [T7AJQbfmlA57y625] Effect: Vivacious Bravado
+  [pDErD7SHcOxYAbqf] Effect: Voice of Oceans
+  [i3942RucZD9OHbAE] Effect: Void Shroud
+  [dl8qj25dK6PtO5Y7] Effect: Void Tendrils
+  [UMLqhBMT98flcmJi] Effect: Volatile Grease (Failure)
+  [jDlnvm9QjA7A2weD] Effect: Volatile Grease (Success)
+  [7qoZauizAKfPIXeu] Effect: Volcanic Purge
+  [4X4wCxkxr9rJdoT1] Effect: Vomit Tar
+  [V60TWjo1G1r5ZtPM] Effect: Vulnerable to Curved Space
+  [kui8yKIVsxfJnrYe] Effect: Walking the Cardinal Paths
+  [x95cRqu4JjgCO0xQ] Effect: Wallow
+  [VIzeuA9tQEQ7V1Ib] Effect: Wand of Fey Flames
+  [8RNPIAuV7ixaXeq5] Effect: War Blood Mutagen (Greater)
+  [aIZsC56OdotiGb9M] Effect: War Blood Mutagen (Lesser)
+  [S3Sv7SYwxozbG554] Effect: War Blood Mutagen (Major)
+  [AvXNZ9I6s1H8C4wd] Effect: War Blood Mutagen (Moderate)
+  [9MKYHKHbfHGbJlU3] Effect: War Cry
+  [64wrP9IbfHbj1mrA] Effect: War Leader
+  [dLqBmcqrLnw0lPHK] Effect: Warded Casting
+  [Ewb35HkmaoBV5iLL] Effect: Warding Paste (Attacker)
+  [CvnIiMOigw3TeHYC] Effect: Warding Paste (Wearer)
+  [Empv55xGFN2Mk3cu] Effect: Warding Statuette - Armor
+  [gwiyabYi92R97bXZ] Effect: Warding Statuette - Weapon
+  [RbyXD99lybxPK6yS] Effect: Warning Hoot
+  [CZVBffAIoVorKpmA] Effect: Warshard Healing
+  [ttIvoQUl1yG5K62o] Effect: Watch Your Back
+  [a7qiSYdlaIRPe57i] Effect: Watchful Gaze
+  [UxNq9uo1GpDYTi5Z] Effect: Waterlogged
+  [lj1Oju2DvOTvByMa] Effect: Watery Form
+  [zezKegTvOArcDQ0x] Effect: Weapon Infusion
+  [FYdyPSPz6566GlUs] Effect: Weapon Siphon
+  [S2BhyDioaXgB5y4W] Effect: Weapon Siphon Bomb Fitted
+  [o7qm13OmaYOMwgib] Effect: Weapon Tampered With (Critical Success)
+  [4QWayYR3JSL9bk2T] Effect: Weapon Tampered With (Success)
+  [tCMVyxQhzYCjBQtK] Effect: Web
+  [mS82CkuoGfOfQ9Jt] Effect: Wemmuth Trinket
+  [rpxdrOlzY2SOtMWB] Effect: Whirlwind Form
+  [bzwFaDNBYsGpC4ed] Effect: Whisper Earworm (Critical Failure)
+  [VKdiRnhrsgQTFSCM] Effect: Whispering Staff (Ally)
+  [NBxTbdCCqmilAxqA] Effect: Whispering Staff (Enemy)
+  [xr4bNJvtrHSqWkrF] Effect: Whispers of Weakness
+  [nP3k4N52NzrR3KKf] Effect: Whose Cry is Thunder
+  [iE8dnbDLiAFcaOT8] Effect: Wild Calm
+  [G6ytTRTwu9kBi59S] Effect: Wild Mimic Dedication
+  [N402OXwxrqVkcK87] Effect: Will Not Falter
+  [MH3VWOysJ8XboONX] Effect: Wind Barrier
+  [KkFk8PZ2ZZVUrdgj] Effect: Wine of the Blood
+  [1S51uIRb9bnZtpFU] Effect: Winged Sandals
+  [k1J2SaHPwZb2Y6Bp] Effect: Wings of Air
+  [uZ5yEWZK9PSlsLyn] Effect: Winning Smile
+  [AxdLeZcz2VVdfvRo] Effect: Winter's Bite
+  [lFIUuFrNey4kD4Md] Effect: Wish for Luck
+  [ugeStF0Rj8phBPWL] Effect: Witch's Charge
+  [sHOx852VoPinsQGY] Effect: Witch's Finger
+  [McawF8weCe7O81um] Effect: Witchflame (Critical Failure)
+  [L7SiTshdimUPWfnB] Effect: Witchflame (Failure)
+  [NHwmrSyF0e8HUE3m] Effect: Witchflame (Success)
+  [ICUcmwY504WHCs3N] Effect: Wither Away
+  [o6ZI01zZBQDASuaw] Effect: Wolf Shape
+  [JvwzM4rJWwtB9HAP] Effect: Wolfjaw Armor
+  [rCsmv66TzQhte4Gp] Effect: Wood Impulse Junction
+  [iTjPZQneHwBqlRiq] Effect: Word of Advice
+  [jQdNEbZ7n7B10aZC] Effect: Word of Caution
+  [F2vfkxDnMjBZt91r] Effect: Word of Heroism
+  [VdQthM85CHkHZd8a] Effect: Word of Vigor
+  [GPcmgpyTtPoXu5N1] Effect: Words of Encouragement
+  [ICT4vGhOmPbriy16] Effect: Worldly Mentor
+  [gDlOd7z3EUkjW7DU] Effect: Worm Form
+  [2gRnUwzPylifTrUO] Effect: Wounding Oil
+  [QSy3KaLI1AYTR7rP] Effect: Wrath of Fate
+  [he0QiJSgJWNeIoxt] Effect: Wrath of Spurned Hospitality
+  [mq351Vs8ATFa5nYv] Effect: Wreath of Holy Light
+  [WLvFC2eE80SEZpUg] Effect: Wyrm Claw - Armor
+  [C8LxBHncfvvofXfj] Effect: Wyrm Spindle - Armor
+  [fILVhS5NuCtGXfri] Effect: Wyrmblessed Blood Magic
+  [2Co7H8w20nOwCCoN] Effect: Xenia Spirit Grand Feast
+  [uB3CVn3momZO9h0L] Effect: Xulgath Stench
+  [EIERHL5oo4OlBkAZ] Effect: Yobnobby Overdrive
+  [Q2qCKyL63QzXsdGq] Effect: You Can't Kill an Idea
+  [Xf5zZEYgLL4ku11j] Effect: You'll Pay for That
+  [zUvicEXd4OgCZ1cO] Effect: You're an Embarrassment
+  [NDCeLFdp5eJ1VYjm] Effect: Zealous Inevitability
+  [dslTaCkliOH5lZ6k] Effect: Zinba Restoration
+  [ScZGg91ri19H4IIc] Effect: –10-foot circumstance penalty to all Speeds
+  [NU5wAbJLZO6T86eB] Effect: –10-foot circumstance penalty to your land Speed
+  [zDV1wo2ytNTbyTB0] Effect: –10-foot status penalty to your land Speed
+  [0r8MznJe5UugViee] Effect: –15-foot status penalty to your land Speed
+  [RcMZr0wSjrir1AnS] Effect: –5-foot circumstance penalty to your land Speed
+  [HTwG0F0LDu5ihBUm] Effect: –5-foot status penalty to your land Speed
+  [DURRMyANFnFccM24] Efficient
+  [2IqM1XHELKwARAx1] Engaged
+  [c8lNjzrY2WM60Zsv] Fortified
+  [Ei8EMUwVxUNyMQJJ] Lost
+  [oVhkdym3D6TiTbrN] Mired
+  [JnQi8whNqY7sPW7x] Mixed Drink: Dancing Lights
+  [cESIlNrgjo1uW71D] Mixed Drink: Guidance
+  [e8K0YTKxzf0bhayh] Mixed Drink: Luck
+  [j8hA7CsmSY90tBqw] Mixed Drink: Prestidigitation
+  [ibcMcEGRbPRtk9Pu] Outflanked
+  [d5CJgabylXtTD2qj] Pinned
+  [aupG5cvPAfJszMfO] Reduced Accuracy
+  [aZImSBBmTHff2POP] Routed
+  [7LMDwpVijK7x5Jst] Shaken
+  [OH3sdHE6xWwOjq9v] Spell Effect: Aberrant Form
+  [6TGcfVyzzVHEo7ke] Spell Effect: Acid Grip
+  [0gv9D5RlrF5cKA3I] Spell Effect: Adapt Self (Darkvision)
+  [2SWUzp4JuNK5EX0J] Spell Effect: Adapt Self (Swim)
+  [6GAztnHuQSwAp1k1] Spell Effect: Adaptive Ablation
+  [jvwKRHtOiPAm4uAP] Spell Effect: Aerial Form (Bat)
+  [0QVufU5o3xIxiHmP] Spell Effect: Aerial Form (Bird)
+  [UjoNm3lrhlg4ctAQ] Spell Effect: Aerial Form (Pterosaur)
+  [xgZxYqjDPNtsQ3Qp] Spell Effect: Aerial Form (Wasp)
+  [y9PJdDYFemhk6Z5o] Spell Effect: Agile Feet
+  [b8BZHeuz5jH8E2SG] Spell Effect: Albatross Curse
+  [QFeJq767fymcw6LA] Spell Effect: Albatross Curse (Circumstance Bonus)
+  [jSvpjSGnIVBAuFDu] Spell Effect: Albatross Curse (Critical Failure)
+  [Y8OGpgAEgISpTwYd] Spell Effect: Albatross Curse (Failure)
+  [l8HkOKfiUqd3BUwT] Spell Effect: Ancestral Form
+  [FlmR5n228jLHuLQG] Spell Effect: Ancestral Memories
+  [Fi66csT9OiBGmPZ0] Spell Effect: Angel Form
+  [3vWfew0TIrcGRjLZ] Spell Effect: Angel Form (Monadic Deva)
+  [Bd86oAvK3RLN076H] Spell Effect: Angel Form (Movanic Deva)
+  [4xtce4xbwZ9wjwMW] Spell Effect: Angelic Halo
+  [iZYjxY0qYvg5yPP3] Spell Effect: Angelic Wings
+  [0koqUuC1YW4F1l5z] Spell Effect: Anima Invocation
+  [Dcva6SCHr9vWE7nJ] Spell Effect: Animal Feature
+  [tk3go5Cl6Qt130Dk] Spell Effect: Animal Form (Ape)
+  [gQnDKDeBTtjwOWAk] Spell Effect: Animal Form (Bear)
+  [BT1ofB6RvRocQOWO] Spell Effect: Animal Form (Bull)
+  [sN3mQ7YrPBogEJRn] Spell Effect: Animal Form (Canine)
+  [ptOqsN5FS0nQh7RW] Spell Effect: Animal Form (Cat)
+  [1Gax900IAwhLCi4q] Spell Effect: Animal Form (Crab)
+  [0B3noZtrBfeHC7ye] Spell Effect: Animal Form (Crocodile)
+  [F4DTpDXNu5IliyhJ] Spell Effect: Animal Form (Deer)
+  [j2LhQ7kEQhq3J3zZ] Spell Effect: Animal Form (Frog)
+  [rmtCkBCEwyg919N0] Spell Effect: Animal Form (Orca)
+  [tUelWvSaNZBng42K] Spell Effect: Animal Form (Seal)
+  [qPaEEhczUWCQo6ux] Spell Effect: Animal Form (Shark)
+  [kz3mlFwb9tV9bFwu] Spell Effect: Animal Form (Snake)
+  [OwvrQKuMLEktNWzA] Spell Effect: Animate Rope
+  [Wlg9dAFQBuuv9oVa] Spell Effect: Anointed Ground
+  [5yCL7InrJDHpaQjz] Spell Effect: Ant Haul
+  [4ag0OHKfjROmR4Pm] Spell Effect: Anticipate Peril
+  [NXzo2kdgVixIZ2T1] Spell Effect: Apex Companion
+  [14m4s0FeRSqRlHwL] Spell Effect: Arcane Countermeasure
+  [T0eQfYKgejJqZiBA] Spell Effect: Arcane Explosion
+  [6BjslHgY01cNbKp5] Spell Effect: Armor of Bones
+  [zPPZz6lcp87ALUde] Spell Effect: Ash Form
+  [AocUY91Tpy1QCdyu] Spell Effect: Ash-Strewn Ending
+  [57lnrCzGUcNUBP2O] Spell Effect: Athletic Rush
+  [CVR6mkf5bVIK9KjU] Spell Effect: Augmented Body
+  [UTLp7omqsiC36bso] Spell Effect: Bane
+  [kMoOWWBqDYmPcYyS] Spell Effect: Bathe in Blood
+  [F1APSdrw5uv672hf] Spell Effect: Battlefield Persistence
+  [GogALNdgQ7Fn5oMG] Spell Effect: Benediction
+  [3CzDP9Bamc1aVLyh] Spell Effect: Beseech the Sphinx
+  [KtAJN4Qr2poTL6BB] Spell Effect: Bestial Curse (Critical Failure)
+  [8wCVSzWYcURWewbd] Spell Effect: Bestial Curse (Failure)
+  [rVkUzqS4rpZp9LS3] Spell Effect: Bind Undead
+  [C9IBDViaUxVq0Jzn] Spell Effect: Bit of Luck
+  [Gqy7K6FnbLtwGpud] Spell Effect: Bless
+  [FD9Ce5pqcZYstcMI] Spell Effect: Blessing of Defiance
+  [lUL4nvIVYqFOwxAZ] Spell Effect: Blink Charge
+  [buXx8Azr4BYWPtFg] Spell Effect: Blood Vendetta (Failure)
+  [aDOL3OAEWf3ka9oT] Spell Effect: Blood Ward
+  [eotqxEWIgaK7nMpD] Spell Effect: Blunt the Final Blade (Critical Success)
+  [h0CKGrgjGNSg21BW] Spell Effect: Boost Eidolon
+  [GlggmEqkGVj1noOD] Spell Effect: Bottle the Storm
+  [9yzlmYUdvdQshTDF] Spell Effect: Bullhorn
+  [Lno61HwUJaE4eLo8] Spell Effect: Call the Ten
+  [PNEGSVYhMKf6kQZ6] Spell Effect: Call to Arms
+  [Qr5rgoZvI4KmFY0N] Spell Effect: Calm
+  [mojpoFI7eni1RaRB] Spell Effect: Canopy Crawler
+  [Of5VbKBH0fLZHm8Z] Spell Effect: Capital Dividend
+  [SAkdopdD8IzOeqs1] Spell Effect: Cascade Countermeasure
+  [sdKsB8dmIiPEHePZ] Spell Effect: Cauterize Wounds
+  [A61eVVVyUuaUl3tz] Spell Effect: Celestial Brand
+  [QrigfqVwBCGPylth] Spell Effect: Charged Javelin
+  [aNomC4orI44YGBGU] Spell Effect: Charged Javelin (Attacker)
+  [4tLmwa9cTzsYERi3] Spell Effect: Charming Push
+  [DHYWmMGmKOpRSqza] Spell Effect: Chromatic Armor
+  [myWvjlGLvbzkSCNO] Spell Effect: Cinder Gaze
+  [UPisuG2cfjMIJOPa] Spell Effect: Claws of the Otter
+  [CWC2fPmlgixoIKy5] Spell Effect: Clawsong
+  [2sMXAGZfdqiy10kk] Spell Effect: Clinging Ice
+  [eRRiss7y7TsneiEu] Spell Effect: Cloak of Light
+  [K1AHF9KV47PsPka1] Spell Effect: Coiling Dance
+  [dU4viL9kh554TKeB] Spell Effect: Community Repair
+  [Be5TFiSqhRDvrm2J] Spell Effect: Community Restoration
+  [iJ7TVW5tDnZG9DG8] Spell Effect: Competitive Edge
+  [WdXLgPashH5in5eB] Spell Effect: Conductive Weapon
+  [VqcFP9hwyCrnbDZp] Spell Effect: Conquering Soldiers (Depart)
+  [VVSOzHV6Rz2YNHRl] Spell Effect: Contagious Idea (Pleasant Thought)
+  [LT5AV9vSN3T9x3J9] Spell Effect: Corrosive Body
+  [IUxQCyO3EXSkId5F] Spell Effect: Corrosive Body (Temp HP)
+  [tfdDpf9xSWgQer5g] Spell Effect: Cosmic Form
+  [BfaFe1cI9IkpvmmY] Spell Effect: Countless Eyes
+  [beReeFroAx24hj83] Spell Effect: Courageous Anthem
+  [cdrLQ9FvILde7pku] Spell Effect: Courageous Anthem (Kanya)
+  [C2jiokGoehvLu0fi] Spell Effect: Crown of Prophets
+  [7YcVBf3OTyozFOVV] Spell Effect: Crushing Ground
+  [P4PRme5opSzyPIM2] Spell Effect: Curse of Recoil (Critical Failure)
+  [sxIEPmpuBfqSeck3] Spell Effect: Curse of Recoil (Failure)
+  [tlbv3TAD2xPDFnAf] Spell Effect: Cutting Eye
+  [IKdTcUwGtnkvrCed] Spell Effect: Daemon Form
+  [1n84AqLtsdT8I64W] Spell Effect: Daemon Form (Ceustodaemon)
+  [0W87OkYi3qCwNGSj] Spell Effect: Daemon Form (Piscodaemon)
+  [2KQSsrzUqAxSXOdd] Spell Effect: Dancing Shield
+  [znWiM5RYLvf8STmR] Spell Effect: Darkened Sight
+  [IXS15IQXYCZ8vsmX] Spell Effect: Darkvision
+  [inNfTmtWpsxeGBI9] Spell Effect: Darkvision (24 hours)
+  [98XT2QUk6wvXIqf7] Spell Effect: Death Knell
+  [s6CwkSsMDGfUmotn] Spell Effect: Death Ward
+  [sipLHLOyS7sQ0KQV] Spell Effect: Debilitating Terror
+  [UAiaJYUDLtLToRUU] Spell Effect: Deep Sight
+  [Ptnncwp118gIvmvG] Spell Effect: Demon Form
+  [X1kkbRrh4zJuDGjl] Spell Effect: Demon Form (Babau)
+  [sXe7cPazOJbX41GU] Spell Effect: Demon Form (Hezrou)
+  [hnfQyf05IIa7WPBB] Spell Effect: Demon Form (Nabasu)
+  [20egTKICPMhibqgn] Spell Effect: Demon Form (Vrock)
+  [83md7JyfA5WnWaOZ] Spell Effect: Devil Form
+  [0yy4t4UY1HqrEo70] Spell Effect: Devil Form (Barbazu)
+  [BDMEqBsumguTrMXa] Spell Effect: Devil Form (Erinys)
+  [HEbbxKtBzsLhFead] Spell Effect: Devil Form (Osyluth)
+  [Le5Sewk43o7V60nO] Spell Effect: Devouring Dark Form
+  [1kelGCsoXyGRqMd9] Spell Effect: Diabolic Edict
+  [Hc8e3aU9yLKPSw8o] Spell Effect: Diadem of Divine Radiance
+  [0Cyf07wboRp4CmcQ] Spell Effect: Dinosaur Form (Ankylosaurus)
+  [KkDRRDuycXwKPa6n] Spell Effect: Dinosaur Form (Brontosaurus)
+  [oJbcmpBSHwmx6FD4] Spell Effect: Dinosaur Form (Deinonychus)
+  [T6XnxvsgvvOrpien] Spell Effect: Dinosaur Form (Stegosaurus)
+  [iOKhr2El8R6cz6YI] Spell Effect: Dinosaur Form (Triceratops)
+  [542Keo6txtq7uvqe] Spell Effect: Dinosaur Form (Tyrannosaurus)
+  [pzbU0cdyRvE66XBi] Spell Effect: Discern Secrets
+  [JfvVyMWuD8yvSrIe] Spell Effect: Discomfiting Whispers
+  [iwzKtzNV5t1op2xs] Spell Effect: Distracting Decoy
+  [LiQDQYAYYE6Qg4yI] Spell Effect: Divine Keystone (Critical Failure)
+  [GDzn5DToE62ZOTrP] Spell Effect: Divine Vessel
+  [dIftJU6Ki2QSLCOD] Spell Effect: Divine Vessel (9th level)
+  [IMKuG3m72BYeGSXS] Spell Effect: Domora's Defense
+  [LMXxICrByo7XZ3Q3] Spell Effect: Downpour
+  [iXQCXCMiiJ8WV6K7] Spell Effect: Draconic Barrage
+  [7zy4W2RXQiMEr6cp] Spell Effect: Dragon Claws
+  [jy4edd6pvJvJgOSP] Spell Effect: Dragon Wings
+  [0WYy3bY7HJ7TDSYD] Spell Effect: Draw Ire
+  [PDoTV4EhJp63FEaG] Spell Effect: Draw Ire (Success)
+  [fCIT9YgGUwIc3Z9G] Spell Effect: Draw the Lightning
+  [FT5Tt2DKBRutDqbV] Spell Effect: Dread Ambience
+  [UH2sT6eW5e31Xytd] Spell Effect: Dutiful Challenge
+  [09rtx50laDw68FGT] Spell Effect: Earthquake (Shaking Ground)
+  [BGv44XBGtD4zOJBd] Spell Effect: Eat Fire
+  [J60rN48XzBGHmR6m] Spell Effect: Element Embodied (Air)
+  [jp88SCE3VCRAyE6x] Spell Effect: Element Embodied (Earth)
+  [lmAwCy7isFvLYdGd] Spell Effect: Element Embodied (Fire)
+  [lRfiYmsoQMJZ81NQ] Spell Effect: Element Embodied (Metal)
+  [w1HwO7huxJoK0gHY] Spell Effect: Element Embodied (Water)
+  [xPNKt1aQc3dquKlt] Spell Effect: Element Embodied (Wood)
+  [LldX5hnNhKzGtOS0] Spell Effect: Elemental Absorption
+  [y4y0nusC97R7ZDL5] Spell Effect: Elemental Betrayal
+  [Qp0dlhJaCzXIx73r] Spell Effect: Elemental Form
+  [AF4vQ1xoOiJ1ewH1] Spell Effect: Elemental Gift
+  [uPmHi7ZiCj7PWM9N] Spell Effect: Elemental Motion
+  [fEtZHzAhRYuNX2u1] Spell Effect: Elemental Sheath
+  [IWD5RehCxZVfgrX9] Spell Effect: Elephant Form
+  [uiXWJVwWuMS3KvkV] Spell Effect: Embodiment of Battle
+  [fVEevbKVBbCc1x2F] Spell Effect: Embrace Nothingness
+  [gX8O0ArQXbEVDUbW] Spell Effect: Embrace the Pit
+  [AAypmg9Jz6Ysf02a] Spell Effect: Endure
+  [ZHVtJKnur9PAF5TO] Spell Effect: Enduring Might
+  [lEU3DH1tGjAigpEt] Spell Effect: Energy Absorption
+  [4Lo2qb5PmavSsLNk] Spell Effect: Energy Aegis
+  [sPCWrhUHqlbGhYSD] Spell Effect: Enlarge
+  [r3SWKHCXxahSV54y] Spell Effect: Enlarge Companion
+  [rjM25qfw5BKj9h97] Spell Effect: Entangling Flora
+  [Fms3IfhXqHiKAxlC] Spell Effect: Entreat Spirit
+  [znwjWUvGOFQ6VYaE] Spell Effect: Entropic Wheel
+  [nFOJ53IkO5khO4Rr] Spell Effect: Entwined Roots
+  [zPGVOLz6xhsQN35C] Spell Effect: Envenom Companion
+  [MFvCd82lxTQGZERm] Spell Effect: Equal Footing (Failure or Critical Failure)
+  [HjYFYIlwraTRSHOX] Spell Effect: Equal Footing (Success)
+  [16QrxIYal7PJFL2W] Spell Effect: Euphoric Renewal
+  [hpbCDbDOoVyhOmck] Spell Effect: Everlight
+  [1XlF12UbvJsTZxfp] Spell Effect: Evolution Surge
+  [fEhCbATDNlt6c1Ug] Spell Effect: Extract Poison
+  [4iakL7fDcZ8RT6Tu] Spell Effect: Face in the Crowd
+  [pcK88HqL6LjBNH2h] Spell Effect: Faerie Dust (Critical Failure)
+  [LHREWCGPkWsc4GGJ] Spell Effect: Faerie Dust (Failure)
+  [PANUWN5xXC20WBg2] Spell Effect: False Vitality
+  [qD1OA6dx8h33nKFC] Spell Effect: Ferrous Form
+  [jeH78c7kyk376PKS] Spell Effect: Fey Form
+  [uIMaMzd6pcKmMNPJ] Spell Effect: Fiery Body
+  [2Hg3a06gZCSnUgSA] Spell Effect: Figment
+  [3Gv18zyrm1BQLPI5] Spell Effect: Filter Air
+  [1RsScTvNdGD9zGWe] Spell Effect: Fire Shield
+  [UXdt1WVA66oZOoZS] Spell Effect: Flame Barrier
+  [1cBl1gVcpzOqlluC] Spell Effect: Flame Dancer
+  [ei9MIyZbIaP4AZmh] Spell Effect: Flame Wisp
+  [wSlBL3pDzvwMxCSV] Spell Effect: Flaming Fusillade
+  [4vlorajqpFcS5Ozi] Spell Effect: Flashy Disappearance
+  [ThFug45WHkQQXcoF] Spell Effect: Fleet Step
+  [ZlsuhS9J0S3PuvCO] Spell Effect: Flicker
+  [MuRBCiZn5IKeaoxi] Spell Effect: Fly
+  [Bc2Bwuan3716eAyY] Spell Effect: Font of Serenity
+  [ctMxYPGEpstvhW9C] Spell Effect: Forbidding Ward
+  [X9Na6IK8FSPcTuoc] Spell Effect: Foresight
+  [zbTpf11NtbmizuzR] Spell Effect: Forge (Critical Failure)
+  [UtIOWubq7akdHMOh] Spell Effect: Fortify Summoning
+  [IhorZCrhO4dCq6n3] Spell Effect: Fortifying Brew
+  [rAW5o8MjjuIhYhLg] Spell Effect: Fortissimo Composition
+  [Jbj3aIUeDc7LOXH6] Spell Effect: Frenzied Revelry
+  [ldl1aU5ovTQMUHJ2] Spell Effect: Frenzied Revelry (Critical)
+  [DdqWMj7cuf4S1bgr] Spell Effect: Frostbite
+  [EftEpvhOKwDn63eL] Spell Effect: Frozen Fog
+  [NRGAkp9i7j0sWeM7] Spell Effect: Funeral Flames
+  [6gRRjn0h0DAUh7nQ] Spell Effect: Fungal Infestation
+  [5xCheSMgtQhQZm00] Spell Effect: Garden of Death (Critical Success)
+  [JhxAUu3JEyERedMd] Spell Effect: Garden of Healing
+  [qn7uO5Ih01yLJot7] Spell Effect: Gecko Grip
+  [vUjRvriyuHDZrsgc] Spell Effect: Ghostly Shift
+  [EScdpppYsf9KhG4D] Spell Effect: Ghostly Weapon
+  [QJRaVbulmpOzWi6w] Spell Effect: Girzanje's March
+  [0lYbjDI2N3xVl24E] Spell Effect: Glass Form
+  [oDDS6D2KTjpbA491] Spell Effect: Glass Shield
+  [VJpRUgSDtAO2TSRR] Spell Effect: Glimpse Weakness
+  [mrSulUdNbwzGSwfu] Spell Effect: Glutton's Jaws
+  [ppVKJY6AYggn2Fma] Spell Effect: Goodberry
+  [tNjimcyUwn8afeH6] Spell Effect: Gravity Weapon
+  [7tYv9lY3ksSUny2h] Spell Effect: Gray Shadow
+  [3qHKBDF7lrHw8jFK] Spell Effect: Guidance
+  [Me470HI6inX3Bovh] Spell Effect: Guided Introspection
+  [Ore1RvtyWdioF5QW] Spell Effect: Halcyon Mists
+  [yb9q5nVA1N0FfO6D] Spell Effect: Hallowed Ground
+  [MsXuzUrCGVuRGWK7] Spell Effect: Hand of the Apprentice
+  [LfxwvZRwtrh8mQN0] Spell Effect: Harrowing
+  [ElkXovNrHB0Doi6O] Spell Effect: Haste
+  [IjoYgBgEYSTZKmab] Spell Effect: Healer's Blessing
+  [yKPb3VrVzBkr34eR] Spell Effect: Helpful Reload
+  [l9HRQggofFGIxEse] Spell Effect: Heroism
+  [DBaMtFHRPEg1JeLs] Spell Effect: Hidden Mind
+  [70tKwsgD8aOj9SxG] Spell Effect: Hidebound
+  [85S2TWoiPwtFsDT3] Spell Effect: Hippocampus Retreat
+  [WiGopdQekyLAa8mj] Spell Effect: Holy Host (Azata)
+  [vWEYKF37OexA14Ki] Spell Effect: Holy Host (Garuda)
+  [6vodhSeI3ClMfOGd] Spell Effect: Honeyed Words
+  [B9Hzt4ki8eqlXxyh] Spell Effect: Humanoid Form
+  [C1GAlZ6Gmmw0QIJN] Spell Effect: Hymn of Healing
+  [qQLHPbUFASKFky1W] Spell Effect: Hyperfocus
+  [VYr6IyfCWUMcYLJH] Spell Effect: Ibex's Harvests
+  [AmsVO5Q6078mEvNt] Spell Effect: Ill Omen
+  [3Ktyd5F9lOPo4myk] Spell Effect: Illusory Disguise
+  [b8JCq6n1STl3Wkwy] Spell Effect: Illusory Shroud
+  [yGedCb78XX6TtTq3] Spell Effect: Imitate Fauna
+  [slI9P4jUp3ERPCqX] Spell Effect: Impeccable Flow
+  [TrmNSuv6zWEiceqn] Spell Effect: Incendiary Ashes (Failure)
+  [4dnt1P2SfcePzkrF] Spell Effect: Incendiary Ashes (Success)
+  [pE2TWhG97XbhgAdH] Spell Effect: Incendiary Aura
+  [nU4SxAk6XreHUi5h] Spell Effect: Infectious Enthusiasm
+  [XDqtLdHnjLVhtqAW] Spell Effect: Infectious Melody (Critical Failure)
+  [yl0Pm78RXW5R2k50] Spell Effect: Infectious Melody (Failure)
+  [i9YITDcrq1nKjV5l] Spell Effect: Infectious Melody (Success)
+  [X7RD0JRxhJV9u2LC] Spell Effect: Infuse Vitality
+  [8olfnTmWh0GGPDqX] Spell Effect: Inner Upheaval
+  [IcQMLYWYDMZbq3XE] Spell Effect: Inscrutable Mask
+  [6IvTWcispcDaw88N] Spell Effect: Insect Form (Ant)
+  [amTa9jSml9ioKduN] Spell Effect: Insect Form (Beetle)
+  [DENMzySYANjUBs4O] Spell Effect: Insect Form (Centipede)
+  [llrOM8rPP9nxIuEN] Spell Effect: Insect Form (Mantis)
+  [bOjuEX3qj7XAOoDF] Spell Effect: Insect Form (Scorpion)
+  [782NyomkDHyfsUn6] Spell Effect: Insect Form (Spider)
+  [T3t9776ataHzrmTs] Spell Effect: Inside Ropes (3rd Rank)
+  [kZ39XWJA3RBDTnqG] Spell Effect: Inspire Heroics (Courage, +2)
+  [VFereWC1agrwgzPL] Spell Effect: Inspire Heroics (Courage, +3)
+  [Chol7ExtoN2T36mP] Spell Effect: Inspire Heroics (Defense, +2)
+  [BKam63zT98iWMJH7] Spell Effect: Inspire Heroics (Defense, +3)
+  [Fjnm1l59KH5YJ7G9] Spell Effect: Inspire Heroics (Strength, +2)
+  [8XaSpienzVXLmcfp] Spell Effect: Inspire Heroics (Strength, +3)
+  [jj0P4eGVpmdwZjlA] Spell Effect: Instant Armor
+  [hXtK08bTnDBSzGTJ] Spell Effect: Iron Gut
+  [XTgxkQkhlap66e54] Spell Effect: Iron Gut (3rd Level)
+  [0bfqYkNaWsdTmtrc] Spell Effect: Juvenile Companion
+  [VzokjUa8RMYo5Id6] Spell Effect: Keen Smell
+  [Wwg9pqrgRHhWlxw9] Spell Effect: Kgalaserke's Axes
+  [IFbDmy0HhKa8XaEU] Spell Effect: Ki Cutting Sight
+  [OSapCU8heNHst21y] Spell Effect: Knock
+  [nUJSdm4fy6fcwsvv] Spell Effect: Lashunta's Life Bubble
+  [lyLMiauxIVUM3oF1] Spell Effect: Lay on Hands
+  [QjZ1PpYIeWh9SbmD] Spell Effect: Leaden Steps
+  [JqrTrvwV7pYStMXz] Spell Effect: Levitate
+  [NQZ88IoKeMBsfjp7] Spell Effect: Life Boost
+  [j9l4LDnAwg9xzYsy] Spell Effect: Life Connection
+  [yYDj0G4O3q5iGexx] Spell Effect: Life's Fresh Bloom
+  [lIl0yYdS9zojOZhe] Spell Effect: Life-Giving Form
+  [h2JzNunzO8hXiNV3] Spell Effect: Lifelink Surge
+  [ihv1azg80N3kj7Vo] Spell Effect: Lift Nature's Caul (Bonus)
+  [cVVZXNbV0nElVOPZ] Spell Effect: Light
+  [CTdEsMIwVYqqkH50] Spell Effect: Litany of Depravity
+  [46vCC77mBNBWtmx3] Spell Effect: Litany of Righteousness
+  [ceEA7nBGNmoR8Sjj] Spell Effect: Litany of Self-Interest
+  [0TB7pLXBiVPMB08U] Spell Effect: Loremaster's Etude
+  [fvIlSZPwojixVvyZ] Spell Effect: Lucky Number
+  [qhNUfwpkD8BRw4zj] Spell Effect: Magic Hide
+  [YzZs7r8VUOp7PiAW] Spell Effect: Magic Stone
+  [zpxIwEjnLUSO1B4z] Spell Effect: Magic's Vessel
+  [FxB7DS6CFPhd2hBr] Spell Effect: Magic's Vessel (Resistance)
+  [1jX8W0eyMPJ0MFKY] Spell Effect: Malediction
+  [tjC6JeZgLDPIMHjG] Spell Effect: Malignant Sustenance
+  [Vd72sGiTl7Pq8iQv] Spell Effect: Manifest Will
+  [K8NWxqtnrSg26KPJ] Spell Effect: Mantle of the Frozen Heart
+  [34yP4e2e6jpY1Bsi] Spell Effect: Mantle of the Magma Heart
+  [T2wbyGJrH9XY24o6] Spell Effect: Mantle of the Melting Heart
+  [OlkrQOPjLclyyxCw] Spell Effect: Mantle of the Unwavering Heart
+  [8brCESGTl4pUIjhY] Spell Effect: Mental Map
+  [xPVOvWNJORvm8EwP] Spell Effect: Mimic Undead
+  [4FD4vJqVpuuJjk9Q] Spell Effect: Mind Swap (Critical Success)
+  [7IUPl6dQUktXZh5t] Spell Effect: Mind of Menace
+  [mzDgsuuo5wCgqyxR] Spell Effect: Mirecloak
+  [0PO5mFRhh9HxGAtv] Spell Effect: Mirror Image
+  [oMtbVNQ5YFmmQUlU] Spell Effect: Monstrosity Form
+  [bzpW0owbAV3UX7UA] Spell Effect: Monstrosity Form (Kaiju)
+  [zRKw95WMezr6TgiT] Spell Effect: Moon Frenzy
+  [JHpYudY14g0H4VWU] Spell Effect: Mountain Resilience
+  [rZRCgogKkUERRy6Q] Spell Effect: Murmuration
+  [nLige83aiMBh0ylb] Spell Effect: Musical Accompaniment
+  [1W1LZ3qrZLXr2Mn7] Spell Effect: Musical Shift
+  [qkwb5DD3zmKwvbk0] Spell Effect: Mystic Armor
+  [hfcFc8cV5wF2evWP] Spell Effect: Nature Incarnate
+  [cwetyC5o4dRyFWJZ] Spell Effect: Necromancer's Generosity
+  [ndj0TpLxyzbyzcm4] Spell Effect: Necrotize (Legs)
+  [lTL5VwNrZ5xiitGV] Spell Effect: Nudge the Odds
+  [zjFN1cJEl3AMKiVs] Spell Effect: Nymph's Token
+  [HoOujAdQWCN4E6sQ] Spell Effect: Oaken Resilience
+  [mCb9mWAmgWPQrkTY] Spell Effect: Oaken Resilience (Arboreal's Revenge)
+  [uDOxq24S7IT2EcXv] Spell Effect: Object Memory (Weapon)
+  [Mp7252yAsSA8lCEA] Spell Effect: One with the Land
+  [ciQhlQbQcarzRYzf] Spell Effect: Ooze Form
+  [lGU4GIF2GUn21zFa] Spell Effect: Open the Wall of Ghosts (Critical Success)
+  [Uj9VFXoVMH0mTTdt] Spell Effect: Organsight
+  [QccOlLHtnVEmD67m] Spell Effect: Outcast's Curse (Failure)
+  [hlgCesYXXHG8r9X4] Spell Effect: Outcast's Curse (Success)
+  [wdA5DW7YiYR4jXPs] Spell Effect: Overwhelming Perfume
+  [vFZ7hG2j2DIQGkXg] Spell Effect: Pact Broker
+  [mAofA4oy3cRdT71K] Spell Effect: Penumbral Disguise
+  [ZwTwuNuvHuQhIjcu] Spell Effect: Personal Runewell
+  [ydsLEGjY89Akc4oZ] Spell Effect: Pest Form
+  [ZVPlFsk5Zimd8Mc9] Spell Effect: Phase Bolt
+  [61Hl31nyzt63vvX9] Spell Effect: Phase Familiar
+  [0eP0JRBPwfRyu7gN] Spell Effect: Phoenix Ward
+  [XT3AyRfx4xeXfAjP] Spell Effect: Physical Boost
+  [tu8FyCtmL3YYR2jL] Spell Effect: Plant Form (Arboreal)
+  [JrNHFNxJayevlv2G] Spell Effect: Plant Form (Flytrap)
+  [fIloZhZVH1xTnX4B] Spell Effect: Plant Form (Shambler)
+  [9ZIP6gWSp9OTEu8i] Spell Effect: Pocket Library
+  [XMBoKRRyooKnGkHk] Spell Effect: Practice Makes Perfect
+  [ojC0jckNHOEIFFtB] Spell Effect: Precious Gleam
+  [vf2KJ4oGJY4efnKE] Spell Effect: Precious Metals
+  [gOeu0lPtKQcLh1Xz] Spell Effect: Primal Herd
+  [PQuQtDixruZmmvT4] Spell Effect: Primal Summons
+  [8gqb5FMTaArsKdWB] Spell Effect: Prismatic Armor
+  [Pfllo68qdQjC4Qv6] Spell Effect: Prismatic Shield
+  [pPMldkAbPVOSOPIF] Spell Effect: Protect Companion
+  [RawLEPwyT5CtCZ4D] Spell Effect: Protection
+  [dWbg2gACxMkSnZag] Spell Effect: Protective Wards
+  [XXtz5BDNNBmP9ub2] Spell Effect: Protector's Sphere
+  [4ne9K5IQm2whokHP] Spell Effect: Purify Tanglebriar
+  [rQaltMIEi2bn1Z4k] Spell Effect: Qi Form
+  [DLwTvjjnqs2sNGuG] Spell Effect: Rallying Anthem
+  [fGK6zJ7mWz9D5QYo] Spell Effect: Rapid Adaptation
+  [n4aQ7fwJ5ogn1ekG] Spell Effect: Rapid Retreat
+  [I4PsUAaYSUJ8pwKC] Spell Effect: Ray of Frost
+  [J6OhRNSN23KzOPRL] Spell Effect: Read Aura
+  [a3uZckqOY9zQWzZ2] Spell Effect: Read the Air
+  [dXq7z633ve4E0nlX] Spell Effect: Regenerate
+  [UVrEe0nukiSmiwfF] Spell Effect: Reinforce Eidolon
+  [06zdFoxzuTpPPGyJ] Spell Effect: Rejuvenating Flames
+  [vhFnQBvguBXo6vxx] Spell Effect: Repel Metal
+  [con2Hzt47JjpuUej] Spell Effect: Resist Energy
+  [cSoL5aMy3PCzM4Yv] Spell Effect: Return the Favor
+  [3TRArzn1UdcWHkja] Spell Effect: Revel in Retribution
+  [rnkQKEwUxrGruE1e] Spell Effect: Revel in Retribution (Temp HP)
+  [j7A1QXHJNxt1d1ED] Spell Effect: Rite of Cleansing Flame (Critical Success)
+  [KhBRuP0Wl2P5okGo] Spell Effect: Rite of Cleansing Flame (Failure)
+  [aaA6cgroFMRMsisy] Spell Effect: River Carving Mountains
+  [0s6YaL3IjqECmjab] Spell Effect: Roar of the Dragon
+  [IYvzqymG4xOhqFir] Spell Effect: Rousing Splash
+  [MqZ6FScbfGtXB8tt] Spell Effect: Runic Body
+  [Vc97f8ChfcZzprlZ] Spell Effect: Runic Impression
+  [GnWkI3T3LYRlm3X8] Spell Effect: Runic Weapon
+  [W4lb3417rNDd9tCq] Spell Effect: Sacred Form
+  [5blVLpIH65hvFJpn] Spell Effect: Safe Passage
+  [3HEiYVhqypfc4IsP] Spell Effect: Safeguard Secret
+  [DAAtzP2QYmCzSNXk] Spell Effect: Sage's Curse (Failure)
+  [6SAUuqvptTeXtyfH] Spell Effect: Sage's Curse (Success)
+  [qO1Gj9l8gh5CMEbf] Spell Effect: Sand Form
+  [TjGHxli0edXI6rAg] Spell Effect: Schadenfreude (Success)
+  [XstFvzPDKCfmoIED] Spell Effect: Scintillating Safeguard
+  [r4XX7yzeEOPK7l2a] Spell Effect: Seal Fate
+  [T5bk6UH7yuYog1Fp] Spell Effect: See the Unseen
+  [TER4qOsYPTszhhDG] Spell Effect: Sepulchral Mask
+  [CDNKDV3UsAp95D1m] Spell Effect: Serrate
+  [eQzFYXLYPrGc9EBI] Spell Effect: Share Vision
+  [Jemq5UknGdMO7b73] Spell Effect: Shield
+  [N1b28wOrZmuSjN9i] Spell Effect: Shield (Amped)
+  [mVG67GUmiEUApbpX] Spell Effect: Shielding Formation
+  [mlvDokpnQBhvQrSk] Spell Effect: Shields of the Spirit
+  [5AIV3cCLUt442Mmp] Spell Effect: Shields of the Spirit (Security)
+  [iN6shVYuzvQ4A95i] Spell Effect: Shifting Form
+  [deG1dtfuQph03Kkg] Spell Effect: Shillelagh
+  [LXf1Cqi1zyo4DaLv] Spell Effect: Shrink
+  [mmJNE57hC7G3SPae] Spell Effect: Silence
+  [2W4qAipPVlapaWbc] Spell Effect: Silver's Refrain
+  [ubKx634Kbl1hHzL9] Spell Effect: Snake Fangs
+  [BdgWuULYjFwlVkr7] Spell Effect: Song of Silver
+  [8adLKKzJy49USYJt] Spell Effect: Song of Strength
+  [nkk4O5fyzrC0057i] Spell Effect: Soothe
+  [nIryhRgeiacQw1Em] Spell Effect: Soothing Blossoms
+  [an4yZ6dyIDOFa1wa] Spell Effect: Soothing Words
+  [mhklZ6wjfty0bF44] Spell Effect: Speaking Sky
+  [5gpsh5UviUnFIRXY] Spell Effect: Spectral Advance
+  [ubHqpJwUwygkc2dR] Spell Effect: Spiral of Horrors
+  [uHUcP59Z5fAdomda] Spell Effect: Spirit Sense
+  [0P4JYUQO20mX4rCS] Spell Effect: Spirit Ward
+  [l9kHsnm7dBQx52JI] Spell Effect: Spirit of the Beast
+  [rtkSifnBQaf0TEPo] Spell Effect: Spiritual Renewal
+  [GA8SSGtpuyUunP4D] Spell Effect: Sting of the Sea
+  [TpVkVALUBrBQjULn] Spell Effect: Stoke the Heart
+  [8GUkKvCeI0xljCOk] Spell Effect: Stormwind Flight
+  [pW1jauNjZ1owaciQ] Spell Effect: Strength of Mind
+  [ViBlOrd6hno3DiPP] Spell Effect: Stumbling Curse
+  [T3NbslG6huktyNRm] Spell Effect: Summon Healing Servitor
+  [0OC945wcZ4H4akLz] Spell Effect: Summoner's Visage
+  [4wZaiZJtAA0iyWR5] Spell Effect: Sun's Fury
+  [fpGDAz2v5PG0zUSl] Spell Effect: Sure Strike
+  [fcalovjrB3bzpiDH] Spell Effect: Swampcall
+  [tC0Qk4AjYRd3csL7] Spell Effect: Swarm Form
+  [GcEFca6I8f5Y06z7] Spell Effect: Swear Oath
+  [yEQXaB7XyaROVqyb] Spell Effect: Sweet Dream
+  [HDT5oiQXXnRdDIKR] Spell Effect: Sweetest Solstice
+  [PQHP7Oph3BQX1GhF] Spell Effect: Tailwind
+  [7vIUF5zbvHzVcJA0] Spell Effect: Tailwind (8 hours)
+  [ZGzhNFB3SM8owk85] Spell Effect: Take Root
+  [nHXKK4pRXAzrLdEP] Spell Effect: Take its Course (Affliction, Help)
+  [R27azQfzeFuFc48G] Spell Effect: Take its Course (Affliction, Hinder)
+  [TwtUIEyenrtAbeiX] Spell Effect: Tangle Vine
+  [5RiskDnSXaRI6F4n] Spell Effect: Tangling Creepers
+  [8y6Ap9xIsnseYYvk] Spell Effect: Tempest Cloak
+  [mKw9WvqnhaUsPvvy] Spell Effect: Tempest Form
+  [NY4oUb2RNgkY0AfL] Spell Effect: Tempest Touch
+  [AJkRUIdYLnt4QOOg] Spell Effect: Tempt Fate
+  [Bfcl6jQBEv505DM2] Spell Effect: The Four Hunters
+  [3wvfYn9CujpwAjZ3] Spell Effect: Thematic Action (Ally)
+  [7wHYSgNG6LaxxlOz] Spell Effect: Thermal Remedy
+  [Y6aNYnGVXdAMvL7Y] Spell Effect: Thermal Stasis
+  [8ecGfjmxnBY3WWao] Spell Effect: Thicket of Knives
+  [cfREcFI2ZhrOlm3C] Spell Effect: Threefold Limb (Ice)
+  [81TfqzTfIqkQA4Dy] Spell Effect: Thundering Dominance
+  [SyF5kpZlZuBF4lMf] Spell Effect: Tomorrow's Dawn
+  [3hDKcbhn0j6DsRgm] Spell Effect: Touch of the Moon
+  [GhNVAYtoF5hK3AlD] Spell Effect: Touch of the Void
+  [oNAqqcxPjzPCJJmW] Spell Effect: Trade Death for Life
+  [8jaYbxnP4Z5wvnQs] Spell Effect: Transmigrate (Encounter)
+  [FqG4zXjSoxq9qTlf] Spell Effect: Transmigrate (Skill)
+  [Ig9p2rDXGYHpEuTx] Spell Effect: Traveler's Transit
+  [qXWCvqt24iczeN8V] Spell Effect: Traveling Workshop
+  [7cYUiOONB2lZfSaA] Spell Effect: Tremorsense
+  [HtaDbgTIzdiTiKLX] Spell Effect: Triple Time
+  [HuvucQ5nfpuVWNrw] Spell Effect: True Target
+  [HoCUCi2jL1OLfXWR] Spell Effect: Unblinking Flame Aura
+  [hya8NfBB1GJofTXm] Spell Effect: Unblinking Flame Ignition
+  [v09uwq1eHEAy2bgh] Spell Effect: Unbreaking Wave Barrier
+  [m6x0IvoeX0a0bZiQ] Spell Effect: Unbreaking Wave Vapor
+  [CdAyAiMGESvgNQtz] Spell Effect: Unfettered Movement
+  [nTISJz13lhHlc9pk] Spell Effect: Unravel Knowledge
+  [a5rWrWwuevTzs9Io] Spell Effect: Untamed Form
+  [rTVZ0zwiKeslRw6p] Spell Effect: Untamed Shift
+  [4ktNx3cVz5GkcGJa] Spell Effect: Untwisting Iron Augmentation
+  [BHGiy85Xm74JsL0B] Spell Effect: Untwisting Iron Buffer
+  [p8F3MVUkGmpsUDOn] Spell Effect: Untwisting Iron Pillar
+  [LMzFBnOEPzDGzHg4] Spell Effect: Unusual Anatomy
+  [ITErgFRfydm1xmnW] Spell Effect: Uplifting Overture
+  [0px2AJh9TBgU4iao] Spell Effect: Valiant Anthem
+  [sILRkGTwoBywy0BU] Spell Effect: Vapor Form
+  [28NvrpZmELvyrHUt] Spell Effect: Variable Gravity (High Gravity)
+  [hkLhZsH3T6jc9S1y] Spell Effect: Veil of Dreams
+  [0L9LAkGW2FtmZOgb] Spell Effect: Veil of Spirits
+  [cSlCn3KoAhsKxm4y] Spell Effect: Vicious Howl
+  [zdyelSV3S2ZFHsT4] Spell Effect: Vindicator's Mark
+  [70qdCBokXBvKIUIQ] Spell Effect: Vision of Weakness
+  [WWtSEJGwKY4bQpUn] Spell Effect: Vital Beacon
+  [6ArAZeZyYSNLI0X5] Spell Effect: Vital Luminance
+  [UFfItbPq9cVq3LNa] Spell Effect: Vitrifying Blast
+  [8UqFvOCZqecPam4Y] Spell Effect: Volcanic Eruption
+  [7zJPd2BsFl82qFRV] Spell Effect: Warding Aggression
+  [7OrZBwdgj563YzlW] Spell Effect: Warding Aggression (Critical Success)
+  [9Tl9jGUKoj0wS73d] Spell Effect: Warp Step
+  [uHNehgyXeNsdd3or] Spell Effect: Warping Pull
+  [npFFTAxN44WWrGnM] Spell Effect: Wash Your Luck
+  [uD13zIE22foqmFgt] Spell Effect: Weaken Earth
+  [qlz0sJIvqc0FdUdr] Spell Effect: Weapon Surge
+  [FInDzRVFPfiRQl6l] Spell Effect: Weapon Trance
+  [5MI2c9IgxfSeGZQo] Spell Effect: Wind Jump
+  [5Jc2MvOCgMszPulx] Spell Effect: Wings of the Valkyrie
+  [U5opnfw3DB1szFvV] Spell Effect: Wings of the Valkyrie (Heightened)
+  [bBD7HFzBPlSxYrtW] Spell Effect: Wish-Twisted Form (Failure)
+  [qzZmVjtc9feqoQwA] Spell Effect: Wish-Twisted Form (Success)
+  [z2PYQCsDDoBZUwR5] Spell Effect: Wooden Fists
+  [Wsgum7pZrPtASRf6] Spell Effect: Word of Truth
+  [SjxqjPDILhQWUcWf] Spell Effect: Wrathful Storm
+  [nemThuhp3praALY6] Spell Effect: Zealous Conviction
+  [yCDQ8lW7e01maOXc] Spell Effects: Divine Dragon's Watch
+  [XFc3dVzTe7KnpjuP] Stance: Air Shroud
+  [fsjO5oTKttsbpaKl] Stance: Arcane Cascade
+  [QrJ06Sc2GiloQ6hB] Stance: Assume Earth's Mantle
+  [UbyVJdH8p3FM6pXw] Stance: Bite of the Asp Stance
+  [PS17dsXkTdQmOv7w] Stance: Buckler Dance
+  [6ctQFQfSZ6o1uyyZ] Stance: Bullet Dancer Stance
+  [KoHUnnrrcCHRkmJQ] Stance: Cenotaph Stance
+  [CxT12G5HXpGL6xu0] Stance: Claw Stance
+  [uFYvW3kFP9iyNfVX] Stance: Clinging Shadows Stance
+  [CgxYa0lrLUjS2ZhI] Stance: Cobra Stance
+  [2Qpt0CHuOMeL48rN] Stance: Cobra Stance (Cobra Envenom)
+  [nwkYZs6YwXYAJ4ps] Stance: Crane Stance
+  [woKCbf1kXPrPjeZG] Stance: Crowned in Tempest's Fury
+  [T4w2mURZqsdQHi8V] Stance: Defy Hell
+  [gcR66Xgi12ICOVt7] Stance: Desert Wind
+  [kyrvZfZfzKK1vx9b] Stance: Devrin's Cunning Stance
+  [LxSev4GNKv26DbZw] Stance: Disarming Stance
+  [qBR3kqGCeKp3T2Be] Stance: Disruptive Stance
+  [rOKA405aECklgq42] Stance: Divine Presence
+  [qUowHpn79Dpt1hVn] Stance: Dragon Stance
+  [qX62wJzDYtNxDbFv] Stance: Dread Marshal Stance
+  [8hmw9L2ORKz6Z6Bc] Stance: Drifting Pollen
+  [KiuBRoMFxL2Npt51] Stance: Dueling Dance
+  [ebqKAQowcYjHyLHe] Stance: Duelist's Form
+  [GGebXpRPyONZB3eS] Stance: Everstand Stance
+  [GvqB4M8LrHpzYEvl] Stance: Fane's Fourberie
+  [yBJPNp0mKjMkKe1w] Stance: Flood Stance
+  [ebCWQB5nfK19GpY5] Stance: Geologic Attunement
+  [sPIaly8bgNxgcNvT] Stance: Ghosts in the Storm
+  [RozqjLocahvQWERr] Stance: Gorilla Stance
+  [UZKIKLuwpQu47feK] Stance: Gorilla Stance (Gorilla Pound)
+  [mark4VEQoynfYNBF] Stance: Graceful Poise
+  [F9Wz99k6pXJYOfrC] Stance: Hunter's Precision
+  [sgRIIdKNXbBAv4dk] Stance: Immovable Object
+  [zzC2qZwEKf4Ja3xD] Stance: Impassable Wall Stance
+  [er5tvDNvpbcnlbHQ] Stance: Inspiring Marshal Stance
+  [EWiuxy4H1mCVcmud] Stance: Intensified Element Stance
+  [tPKXLtDJ3bzJcXlv] Stance: Ironblood Stance
+  [pkcr9w5x6bKzl3om] Stance: Jellyfish Stance
+  [9CJ7kzRLDo5VAC4n] Stance: Jotun's Battle Stance
+  [fo8kb5GW0OF3HPKK] Stance: Kaiju Stance
+  [hrEG2smy3tZyGxIn] Stance: Kindle Inner Flames
+  [W8CKuADdbODpBh6O] Stance: Lunging Stance
+  [PdFisHX9ZJmKEKCv] Stance: Magnetic Field
+  [6IsZQpwRJQWIzdGx] Stance: Masquerade of Seasons Stance
+  [NWOmJ6WJFheaGhho] Stance: Mobile Shot Stance
+  [1dxD3xsTzak6GNj5] Stance: Monastic Archer Stance
+  [gYpy9XBPScIlY93p] Stance: Mountain Stance
+  [l4QUaedYofnfXig0] Stance: Multishot Stance
+  [YNoBbHUu7enOSKyv] Stance: Orchard's Endurance
+  [6EDoy3OSFZ4L3Vs7] Stance: Paragon's Guard
+  [vjvcccAwdkOLA1Fc] Stance: Peafowl Stance
+  [9HPxAKpP3WJmICBx] Stance: Point Blank Stance
+  [kDTiRg9vVOYNnTyr] Stance: Powder Punch Stance
+  [Im5JBInybWFbHEYS] Stance: Rain of Embers Stance
+  [JW93FDTAOUNuCgIu] Stance: Ravel of Thorns
+  [QDQwHxNowRwzUx9R] Stance: Reflective Ripple Stance
+  [Unfl4QQURWaX2zfd] Stance: Ricochet Stance
+  [YkiTA74FrUUu5IvI] Stance: Rough Terrain Stance
+  [5Z250imfYqYGU2AP] Stance: Rushing Goat Stance
+  [buCKRBDZi27shB3X] Stance: Sea Glass Guardians
+  [Njb4eLx5VngDIDpo] Stance: Shattershields
+  [RXbfq6oqzVnW6xOV] Stance: Shooting Stars Stance
+  [P80mwvCAEncR2snK] Stance: Six Pillars Stance
+  [CQfkyJkRHw4IHWhv] Stance: Sky and Heaven Stance
+  [VfXwZXZaVq9u4GHo] Stance: Spear of Doom
+  [cmCLIMgtd4TLA23p] Stance: Steam Knight
+  [rp1YauUSULuqW8rs] Stance: Stoked Flame Stance
+  [RDKbWKphiD9ippAv] Stance: Stonestrike Stance
+  [z6oLNlBs724PCcR6] Stance: Strategist Stance
+  [IhwcqxPt1SkgXQB0] Stance: Stretching Reach
+  [BCyGDKcplkJiSAKJ] Stance: Stumbling Stance
+  [Ei6ACyEsNGLidvSv] Stance: Stunt Performer Stance
+  [cvIwUEempg0cfhFB] Stance: Talon Stance
+  [PMHwCrnh9W4sMu5b] Stance: Tangled Forest Stance
+  [Ms6WPXRWfXb2KpG2] Stance: Tenacious Stance
+  [2EMak2C8x6pFwoUi] Stance: Thermal Nimbus
+  [pf9yvKNg6jZLrE30] Stance: Tiger Stance
+  [3eHMqVx30JGiJqtM] Stance: Twinned Defense
+  [7Eh8gHNcRNs9iIR8] Stance: Twisting Petal Stance
+  [wxVHqB06oB9yRIhT] Stance: Unified Stance
+  [h45sUZFs5jhuQdCE] Stance: Vitality-Manipulating Stance
+  [ko8I8OCPddWA9U8v] Stance: Waterfowl Stance
+  [JefXqvhzUeBArkAP] Stance: Whirling Blade Stance
+  [q6UokHWSEcEYWmvh] Stance: Whirlwind Stance
+  [eeAlh6edygcZIz9c] Stance: Wild Winds Stance
+  [lge4vtZdfZOCWAch] Stance: Winter Sleet
+  [b2kWJuCPj1rDMdwz] Stance: Wolf Stance
+  [dmzpRlOrorEFUETl] Weary
+Equipment
+  [R09AZzvyNA3Jginm] Abadar's Flawless Scale
+  [gezd29Qmvtv8xeXu] Abidance Blinders
+  [AYVswE7nZuPOUjlU] Aboutface Figurehead
+  [GOSnin5vDXi7DX1f] Abrogail I Script
+  [oLLpwiNApEEAFbXF] Abysium Chunk
+  [VbjANEHtdxO8kV1n] Abysium Ingot
+  [D8VKhm7rSBozJkMN] Accolade Robe
+  [ZdAZ1ALZ28QOeCN7] Accolade Robe (Greater)
+  [EKYjF0GuuBkmMD1J] Accompaniment Cloak
+  [Zo5MZWVBKssVPEcv] Adamantine Chunk
+  [BMhTM2TfK06pEZ3Q] Adamantine Echo
+  [8WH6ub3FVFYtcXCT] Adamantine Ingot
+  [Hrz5Uv7wG4UZCR4F] Admiral's Bicorne
+  [GW45HOqel23w465z] Admirer's Bouquet
+  [gjjF0sQMpXf3CrTF] Advanced Book of Translation (Tien)
+  [45zjE7pj6FUHuz3K] Advancing
+  [1neYjXMc4srH7KQ0] Advancing (Greater)
+  [47FmnpSOE96SJ8H4] Aeon Stone (Agate Ellipsoid)
+  [3Nb9R3lIOy1tiMqv] Aeon Stone (Amber Sphere)
+  [MO8J2IcBhiTnm9D8] Aeon Stone (Amplifying)
+  [f9vNVQ2v45mDI8Xr] Aeon Stone (Azure Briolette)
+  [ffQwBOmyy2NyatnC] Aeon Stone (Black Disc)
+  [J7vQowV531Sz73Gw] Aeon Stone (Black Pearl)
+  [d0ponRhw0JhSM4iH] Aeon Stone (Clear Quartz Octagon)
+  [CVTbxCY85nLoHYuw] Aeon Stone (Consumed)
+  [sPvip91GX8TYvr8Q] Aeon Stone (Crescent)
+  [kNJADasb0PatkMlc] Aeon Stone (Cymophane Cabochon)
+  [kSaUlWgYMywIRV3C] Aeon Stone (Delaying)
+  [TKr8IL5F3cxsfHPH] Aeon Stone (Dusty Rose Prism)
+  [rAkxflw4pNrPAq4p] Aeon Stone (Envisioning)
+  [4VZeiIiJl13Bhyxo] Aeon Stone (Flickering)
+  [upwbVWWYP6QED8wC] Aeon Stone (Formulating)
+  [odSvUKzphdwvDqgE] Aeon Stone (Gold Nodule)
+  [5sMAAIymln2yIl4q] Aeon Stone (Lavender and Green Ellipsoid)
+  [7cOczTK4yQkuK5J9] Aeon Stone (Mottled Ellipsoid)
+  [M2CPAgSAoEL4oawq] Aeon Stone (Nourishing)
+  [pGZqqxYzZpe3iaiS] Aeon Stone (Olivine Pendeloque)
+  [B4R0LK8bgw0Vjtf0] Aeon Stone (Pale Lavender Ellipsoid)
+  [U1GAAGhbzX9Lynq0] Aeon Stone (Pale Orange Rhomboid)
+  [5SKGqxahAGsJgzRF] Aeon Stone (Pearlescent Pyramid)
+  [4A8SFipG78SMWQEU] Aeon Stone (Pearly White Spindle)
+  [r8i96DqaLYfWDW1T] Aeon Stone (Peering)
+  [lJ3BzUZkGTOCWleL] Aeon Stone (Pink Rhomboid)
+  [PlB4I1LFOpRYwvEg] Aeon Stone (Polished Pebble)
+  [xwX93cp1GiTwgtBj] Aeon Stone (Preserving)
+  [2jUWEHkn0XmNuGCh] Aeon Stone (Rainbow Prism)
+  [4qr2tS58bBYxQvAz] Aeon Stone (Repairing)
+  [3obTVPkQ5mGwXJat] Aeon Stone (Smoothing)
+  [BYr1DRYmiRsyr4po] Aeon Stone (Sprouting)
+  [ZtiSyJMXellZRPRB] Aeon Stone (Vital Amplification)
+  [V5kv7e1r2qV2k3lf] Aeon Stone (Western Star)
+  [3R13WDcHOnc5pzfm] Aerial Cloak
+  [GkyZl0UeUAS5YaHA] Aether Appendage
+  [9BvimbwCCrQw3kyD] Affinity Stones
+  [mKlUg7SWC5LcOqaj] Aim-Aiding
+  [rHugmTjO3kgyiTH0] Air Bladder
+  [gvtFrrvCSdsCOlOj] Air Cartridge Firing System
+  [peoheZMxdPHUNo93] Alacritous Horseshoes
+  [t0pzdb54KD2JQcEa] Alacritous Horseshoes (Greater)
+  [whShgzN5YBzrXV3r] Alchemical Atomizer
+  [MnKL30xS3FHlwdS1] Alchemical Chart (Greater)
+  [cKYWot4ifTOa6ans] Alchemical Chart (Lesser)
+  [dtQnQn4LBSIAzQCZ] Alchemical Chart (Moderate)
+  [7JVgLiNTAs4clEW8] Alchemist Goggles
+  [8XZqdeZStFAM4XnH] Alchemist Goggles (Greater)
+  [bnmfBLXOBd3ah6GK] Alchemist Goggles (Major)
+  [gdaLHiWRhB1l2Xr3] Alchemist's Flamethrower
+  [k6xZkDUpF7E1Totd] Alchemist's Lab
+  [uhka9LHEP3wDKytG] Alchemist's Lab (Expanded)
+  [4ftXXUCBHcf4b0MH] Alchemist's Toolkit
+  [AoTTRsojnlfrTIe4] Alluring Lantern
+  [GM9Ky5LEkPHZqme0] Alluring Scarf
+  [LKNsUuhm1CcUIWMh] Alluring Scarf (Greater)
+  [oRQFgqcl8L5ix8h1] Alluring Scarf (Major)
+  [vWlyeU8ViCX8YatO] Ally's Kerchief
+  [bU731I8njNmSAQhQ] Aluum Charm
+  [FzwSBVaSTt1s4A66] Amazing Pop-up Book
+  [MtSUaIZ1gThCrNNj] Amphibious Chair
+  [GbR8rgZMCVBn3Evb] Amulet Implement
+  [P9v4lpVpLlL7AGnw] Amulet of Kinship's Strength
+  [xqnADOBdW77FvzNu] Amulet of the Hellcat
+  [mNgScZVAq037JuNb] Amulet of the Third Eye
+  [oL8G6OqITPJ5Fd6A] Ancestral Echoing
+  [PSKFnWMq5daOJa1R] Ancestral Geometry
+  [pnUZKqJilb3aEVz5] Anchor of Aquatic Exploration
+  [SuKERInt6Z3I3bCa] Anchoring
+  [kY41VIXUSEJYEznp] Anchoring (Greater)
+  [OsUMak2bLZ5H3lTY] Angelic Opera Cloak
+  [pD9H7z7NB3o5dvPN] Anglerfish Lantern
+  [TA3QxxYcaGy2MYCk] Anglerfish Lantern (Submersible)
+  [OKJYb2UuJ1aAKlJ3] Anima Robe
+  [jVBXBsulk4ZlvRs4] Anima Robe (Heroic)
+  [TqqWFIiJYA5tXlSE] Animal Bed
+  [40T4HrQdIIwGHMDq] Animal Blind
+  [pr2xsD4tk0mzWhms] Animal Call
+  [DCPsilr8wbPXxTUv] Animated
+  [9IwSktj0Xj7A2Ruh] Anklets of Alacrity
+  [YC6kyZGOKZmONbVM] Anointed Waterskin
+  [o02lg3k1RBoFXVFV] Antimagic
+  [EVq8BRD0HO63S1GF] Anylength Rope (Greater)
+  [V5oTXRa6Jk8KXyXl] Anylength Rope (Lesser)
+  [l4FxEma0PrvUPeMe] Anylength Rope (Moderate)
+  [JsRaJz8Lo1FE1R0P] Apocalypse Seed
+  [eYemXoYEObmaeOAE] Apparition Gloves
+  [8Rels5G8re0MXFAS] Aquarium Lamp
+  [DP1ONNSs427HjgVc] Arachnolute
+  [amJW9azNUSJLmWGP] Arboreal Boots
+  [rRAx62TLPTZSiaLD] Arboreal Boots (Greater)
+  [vxBcsWCjWd6DZ0Jz] Arcane Scroll Case of Simplicity
+  [j86sLZkEN6TVfW1E] Arcane Standard
+  [eX15uF7JR1jWDFHs] Arcane Standard (Greater)
+  [hyMbJb2MRF5beIaU] Archaic Wayfinder
+  [Kx1Se9u0LU1ZS5R1] Architect's Pattern Book
+  [XORmdC62imVhz1BD] Archivist's Gaze
+  [nowjVXddPXr6fMnR] Arctic Vigor
+  [nSG5bwiZBEjj53Ya] Arctic Vigor (Greater)
+  [wI4Tj8bNwpZHequC] Armbands of Athleticism
+  [FNccUmKsyXKmfe5c] Armbands of Athleticism (Greater)
+  [dxRKFkFeCDQLLEyT] Armbands of the Gorgon
+  [HuC6uonXt6YXePjb] Armor Latches
+  [Ro3g2JpJXrKXVyEr] Armor Potency (+1)
+  [4Hb8tvvWFtykbZhG] Armor Potency (+2)
+  [6ELjUFY0sEJ7nZlZ] Armor Potency (+3)
+  [bkbL0YitEh46Ne0f] Armored Skirt
+  [4Rc4arQ7p61MCb0p] Armory Bracelet (Greater)
+  [DmzkzKB4EBleK0DA] Armory Bracelet (Lesser)
+  [bz052lqiBuGmD790] Armory Bracelet (Major)
+  [u6BZFzBYUnCmfnRr] Armory Bracelet (Minor)
+  [X5QdnhQyF5Lk1VWV] Armory Bracelet (Moderate)
+  [1ZOTwnqA9ccfdrey] Aroden's Hearthstone
+  [VVymhIF6UBThdHP9] Artificer Spectacles
+  [y34yjumCFakrbtdw] Artisan's Toolkit
+  [0QgniSjpzksm5riV] Artisan's Toolkit (Sterling)
+  [lxIwa8sbAsfyREYE] Ash Gown
+  [KwkZfSgS1z3XM0nl] Ash Gown (Greater)
+  [yMEDmJWDPv2i78WO] Ashen
+  [lo5QOMA9VAUwUVl7] Ashen (Greater)
+  [LWMlDUCdDGo1wJnF] Assassin's Bracers (Type I)
+  [dtiYqfBG2BcLHX92] Assassin's Bracers (Type II)
+  [9pUwExXYzndCJFYj] Assassin's Bracers (Type III)
+  [Rm2cojERpLEWB9B3] Assisting
+  [6llILJtsTPgtYXgx] Astral
+  [hebf5k3cd7LO6luX] Astral (Greater)
+  [NZJkdq4AezyeUvGi] Astrolabe of the Falling Stars
+  [6i3q957IuvoSJwMA] Atlas Arcane
+  [kyTJrlBDdil7mA5d] Atmospheric Breathing Suit
+  [pX31bW6RrpxJNJms] Aurochs' Might Tattoo (Greater)
+  [rU9KFul4FRiIGgr4] Aurochs' Might Tattoo (Lesser)
+  [tJhgV3lPtgaSmI41] Aurochs' Might Tattoo (Moderate)
+  [tEXUCp02ylyoJoyP] Authorized
+  [755XG3gP2MWYBXy5] Avalanche Boots
+  [eDO54Z8RdjL2ymgW] Avernal Cape
+  [Uc88bGfysDAeaAD8] Backfire Mantle
+  [LD2cFdr3IntL71oP] Backfire Mantle (Greater)
+  [kJSB09q2KTAcWZy9] Bag of Cats
+  [y8nPmHXIdt4KhMQU] Bagpipes of Turmoil
+  [7eggb7exEAbZABrd] Bagpipes of Turmoil (Greater)
+  [nhyXfERJ0SNFmcb0] Bagpipes of Turmoil (Major)
+  [A1CDXAP4bNGgntE7] Ball
+  [Hl2JP8PQKrKxAfAD] Bandalore
+  [02q8s6sSicMkhs1l] Bands of Force
+  [8mhSUxEvNuXDP8Ki] Bands of Force (Greater)
+  [rqJzQawe3CbXiWnG] Bands of Force (Major)
+  [G72UFwPRKBdfqib9] Bands of Imprisonment
+  [hnbbqvzYDyhDiJnf] Bane
+  [n6ZmkKhxd0iuS1RG] Bangles of Crowns
+  [BkC3xfOIOZ365gST] Banner of Creeping Death (Greater)
+  [VkbmZ9gkhuPTz6dn] Banner of Creeping Death (Lesser)
+  [eFIReVuLOx0GzArc] Banner of Creeping Death (Major)
+  [qssQ3oMvONWZCX8u] Banner of Creeping Death (Moderate)
+  [rEuz05qaDTX5oxMi] Banner of Piercing Shards
+  [FSr3pbQJpaENl59R] Banner of Piercing Shards (Greater)
+  [oknxWGSQPJzN2SvX] Banner of Piercing Shards (Major)
+  [xldy59c3WDGYlAYs] Banner of the Restful
+  [gIzTEarIzmm037vP] Banner of the Restful (Greater)
+  [NpyFguDxjWng8MLU] Banner of the Restful (Major)
+  [J9CaXPcb931XRZev] Banner of the Rising Star
+  [oqqHMA3eHBwJ2BlB] Barding Saddle
+  [ZWTK4Q2JlvJ5Bx6A] Basic Chair
+  [8SkeqnhhYm4QGuJQ] Basic Companion Chair
+  [w4Hd6nunVVqw3GWj] Basic Crafter's Book
+  [IGgK7NAdfyAPm8V0] Basic Face Mask
+  [YE3KSsxd4veXGPtJ] Baton of the Fallen
+  [8kv4fmpE1geu4bFx] Battle Medic's Baton
+  [aZXfzcH3Es2ezs6T] Beacon of the Wilds
+  [JWFR4O5V06UUvx6W] Beastmaster's Sigil
+  [fWgH0JxNCOpI7SVr] Beastmaster's Sigil (Greater)
+  [ZxOoQ4cHfJXXbP9F] Beastmaster's Sigil (Major)
+  [fagzYdmfYyMQ6J77] Bedroll
+  [NDoHsLu2FYjafFRa] Bedroll of Deep Slumber
+  [jNwkyXQtJwelQWgX] Beekeeper's Smoker
+  [4BDf1LVyQyNyOwka] Beguiling Crown
+  [f0A1zqCFiUJuXc9U] Bell Implement
+  [ifsBwfIhd6UcoUCI] Bellflower Toolbelt
+  [rpJkRikW4wYibApn] Bellows Pipes
+  [kbQVI1VS6yekJe86] Beloved's Bracelets
+  [7utuH8VJjKEzKtNw] Belt of Giant Strength
+  [AhvjU4QbinWPM9t3] Belt of Good Health
+  [K2rMmiBlzcysNuj6] Belt of Long Life
+  [YCjVrQnHfOtpmjYW] Belt of the Five Kings
+  [FNkak1PoL9vDWiGL] Benthic Drums
+  [DwLaGtbBdCh2NFbT] Berserker's Cloak
+  [OGKI8NS8Er3qumJS] Berserker's Cloak (Greater)
+  [vT2OibHsrq7M6MMO] Bestiary of Metamorphosis
+  [EcdwnJMuYRqQ9uh7] Bewitching Bloom (Amaranth)
+  [ErqxXatIYbv2WcsE] Bewitching Bloom (Bellflower)
+  [duiTS3Y9JJUsJByq] Bewitching Bloom (Cherry Blossom)
+  [CF2BYEQnAmSwmPPE] Bewitching Bloom (Lilac)
+  [3Ucc6E5V6bzdgFLE] Bewitching Bloom (Lotus)
+  [LDtIZ822rqBD88U2] Bewitching Bloom (Magnolia)
+  [2Xpjq6eYMqvBL6eg] Bewitching Bloom (Purple Iris)
+  [BZImrMVyqeZ0RfF8] Bewitching Bloom (Red Rose)
+  [LhpRuLfxuR3t819V] Bewitching Bloom (White Poppy)
+  [LDVqBvMNNcRBucW1] Bi-Resonant Wayfinder
+  [kLQdzIl2lfGIR3sy] Bioluminescent Stripes
+  [nGZPhGpCxM8U1JXv] Bitter
+  [n5Or4nmtKPoFr6Hm] Blade Launcher
+  [lMeEiOr6Z1t7cva4] Blakenshipper
+  [U0R8AHRhK0Wu9r2i] Blast Foot
+  [yo6kdcUhqv5YyMM5] Blast Foot (Greater)
+  [LTepkOAQfuMKj401] Blazing Banner
+  [WZjEGBpI5evPkZTj] Blazing Banner (Greater)
+  [6ULZ5To69HSNrfzE] Blazing Banner (Major)
+  [P8hf8WT6oRxYmfLB] Blazons of Shared Power
+  [ZR3Kekd3hrWmAv6d] Blazons of Shared Power (Greater)
+  [LKtbZiY5lmD7ohcD] Bleachguard Doll
+  [HSrZ0rm4GOPLmUNK] Bleeding Canines
+  [y0ngvQ7ArcUuoEHT] Blessed Tattoo
+  [2HCiVszUnIPJwvQV] Blightburn Necklace
+  [keFeNqSR7W35aCeT] Blightburn Ward
+  [IM2pz0wnO4OEMr1f] Blocks
+  [C9wOlvuVCjVbz1YQ] Bloodbane
+  [zEys8FeMMAwTqwgW] Bloodbane (Greater)
+  [VhKukQF3cm04yiUm] Bloodburn Censer
+  [P1hk0BO89ihEAw8g] Bloodhound Olfactory Stimulators
+  [07Nu4AC0B5CI3zpc] Bloodline Robe
+  [PdTOhCwNutBjmEkh] Bloodstained Waistcoat
+  [AgDNThyJHtsp1Vjt] Bloodthirsty
+  [fqnjZzwBi9GH4CXO] Bolka's Blessing
+  [mcBXIHJGVQrbDLxi] Bolka's Blessing (Greater)
+  [B4wxZ7mvBDJPWPvZ] Bomb Coagulant Alembic
+  [ApMC9PSOnj7cPAGL] Bomb Launcher
+  [U5MKmx60jAX4xV8x] Book of Lingering Blaze
+  [9IckeffVxmxX0cwV] Book of Lost Days
+  [5Dk8NQMW8NXFEKPy] Book of Warding Prayers
+  [9jnzgwNZMs5GbaRn] Booming Bell
+  [ecqz1iUGtyQEkZwy] Boots of Bounding
+  [31knfVD7lEd8BPrQ] Boots of Bounding (Greater)
+  [oxL8uExmIomunm5g] Boots of Dancing
+  [T00Xa9aDwHxd60Zh] Boots of Elvenkind
+  [8NgA4PFFXZPZ9SSg] Boots of Elvenkind (Greater)
+  [NQGVqxIWaa2fize3] Boots of Free Running (Greater)
+  [0T7JuFupBTfDBiHv] Boots of Free Running (Lesser)
+  [kcRQT67sLes1cC72] Boots of Free Running (Moderate)
+  [icDqgI8s1MbR12w5] Boots of Quick Marching
+  [KJoSUpK6kqLXi4K6] Boots of the Blight
+  [VaBeln7Uy8wHiQVW] Boots of the Dead
+  [cz1yiCKq0EQSDfRL] Boots of the Secret Blade
+  [9xlRrLI0ZIzSUhTd] Boots of the Secret Blade (Greater)
+  [jHUZiSnMkn7EmrPH] Boots of the Secret Blade (Major)
+  [2APHVWkqnFvecrfx] Bootstrap Respirator
+  [Lj6diNjoD5ilz7jd] Boozy Bottle
+  [iS7hAQMAaThHYE8g] Bort's Blessing
+  [1js23swxZ38ZGh2d] Bottle of Infinite Dust
+  [7TQw7V1zZKl0a0Xz] Bottled Air
+  [Y8kiHC9keql957uo] Bottomless Purse
+  [BJxnnY9ap2wMDnRN] Bottomless Stein
+  [tO5zXmyoBsa0lIDd] Bound Guardian
+  [MBF9bZCwkJp2RZoN] Bountiful Cauldron
+  [BKdzb8hu3kZtKH3Z] Bracelet of Dashing
+  [fZLZGO0YLY8xYPh5] Bracers of Devotion
+  [tIta1GNQK6sSWnr6] Bracers of Hammers
+  [eurAnvH8bK0ZctOR] Bracers of Missile Deflection
+  [P5nasaE0JgvkZyZp] Bracers of Missile Deflection (Greater)
+  [Difes7udDkLfkzvb] Bracers of Pain
+  [WOiCJSS2MicKCMVs] Bracers of Strength
+  [pRjJ2aBDpCH1NKRz] Brain Cylinder
+  [1bippAJ938UHQQQV] Branch Attendant's Mask
+  [M91ye9B7IdxDIDsS] Brass Ear
+  [PQ74afm5YWessacn] Bravery Baldric (Fleet)
+  [R4yGXp42qXaWEhLQ] Bravery Baldric (Flight)
+  [7ER2xl3PKcvaVqNI] Bravery Baldric (Greater Healthful)
+  [6xDxnI4Z9syXq8Ec] Bravery Baldric (Haste)
+  [IUZT7A6QZteLyHZI] Bravery Baldric (Healthful)
+  [3TQ9oSETsOHcHRBF] Bravery Baldric (Restoration)
+  [byIihT9MMpTFvyYT] Bravery Baldric (Restoration, Greater)
+  [5LfD4O0zakN0fw7b] Bravery Baldric (Stone)
+  [0ykBs92jTd4dmNqb] Brazier of Harmony
+  [LqAf5RwxiZJredii] Brightbloom Posy
+  [GHaUZqivF30WJHS3] Brightbloom Posy (Greater)
+  [XazXltJ0tsYy1xXQ] Brightbloom Posy (Major)
+  [LbdnZFlyLFdAE617] Brilliant
+  [n8MonEa4ZBdvEovc] Brilliant (Greater)
+  [Yv6WDpfxcukReBl4] Bring Me Near
+  [sTs1xUtk0PoeAtes] Bristling Spines (Greater)
+  [4Pb2znon7PTxVtqM] Bristling Spines (Lesser)
+  [3qTVRohDdcCyDA0w] Bristling Spines (Moderate)
+  [c9GaJKCxxqXKZokZ] Broken Tusk Pendant
+  [hEIqSfSNBWwEkldc] Broken Tusk Pendant (Greater)
+  [Xnhp7g1UOPVPZx7u] Brooch of Inspiration
+  [M0tbJD3SEW4pClpb] Brooch of Inspiration (Greater)
+  [IxcUx7trxUdhF9DQ] Brooch of Inspiration (Major)
+  [TmQalYKNNRuEdoTh] Brooch of Shielding
+  [2EOeljZiUdNVf8s2] Bullhook
+  [Yguqipt5N29Bkz0d] Bullhook (Greater)
+  [2fVNJ23gb3dixVu8] Buoyancy Vest
+  [4qhnEsaypUjLm7eP] Burnished Plating
+  [z5u7z3zBHZcCxfyX] Busine of Divine Reinforcements
+  [EcLENuK2LXZdigTu] Cage
+  [efm6thOteY7PWEvg] Calamity Glass
+  [QHc7AnKoMpcqsI2d] Called
+  [6XX3tYxkyQXCMAbd] Called (Lastwall)
+  [7fSnvJ2xoSfa6JXD] Caltrops
+  [UXsHBUyx4b0dIPDf] Camouflage Suit
+  [Z8RZfkIrsifYeWg4] Camouflage Suit (Superb)
+  [v2aOpKhNP0uIZFER] Camouflaging Chromatophores (Greater)
+  [RmIA4czgAOH8Ml7e] Camouflaging Chromatophores (Lesser)
+  [XZleXDXQ5eThTLWd] Campaign Stable
+  [UwGcNJS5jjjUssPb] Candlecap
+  [3ZHl40YXlI47uIrT] Cane
+  [6QS9p7IWfRoplIwk] Cape of Grand Entrances
+  [3Q8nG1JW4FMMJ4l7] Cape of Illumination (Greater)
+  [HM0uhpM9t97MAABn] Cape of Illumination (Lesser)
+  [vsTtpwdYANxP4EPZ] Cape of Illumination (Moderate)
+  [vXMIKXn3RHh3UET8] Cape of Justice
+  [fw1lODFkJJk3umz0] Cape of the Open Sky
+  [8MclH3pggVkHGYnJ] Carrion Cask
+  [YBKhjWqFuvgkArba] Cassisian Helmet
+  [62vH66XLehPiRwwo] Cassock of Devotion
+  [LSx0quwrsOtdcHL2] Catch Pole
+  [OoYfDIq8VoVX38Ds] Catching
+  [UvABdSnNZ9gr2IkF] Cauldron of Nightmares
+  [C7LDHqjqxpmhn8QY] Cauthooj Bagpipes
+  [IA7ySNhJxINR7x2e] Cavern's Heart
+  [V78itAtTHI4ugy0P] Chain (10 feet)
+  [6MIBHKMJmD8uQVam] Chain of the Stilled Spirit
+  [mb59fHB9IPExjqam] Chair of Inventions
+  [FodtZGtCsH9NDXlC] Chalice Implement
+  [53GW1hwgeub8MqZv] Chalice of Ozem
+  [3vxoffA4slKHXtj2] Channel Protection Amulet
+  [73lxT8RrbKtoHvty] Chaos Collar
+  [uiJAR3jQbQHhiP3Q] Charlatan's Cape
+  [LKdgj4UVmOvUwkZu] Charlatan's Gloves
+  [t8RXms7xq8atF9W7] Charlatan's Gloves (Greater)
+  [EkZVXMdtqTTgahiJ] Charm of Resistance
+  [X3Nfa7bByYFrg1lU] Charm of Resistance (Greater)
+  [zyAzx6fLsPurRFQO] Charm of Resistance (Major)
+  [3sGpEBXsZwjGnoES] Chime of Opening
+  [TacKaUs8cIddqiCU] Choker of Elocution
+  [br4eClrcGeLTL6Ba] Choker of Elocution (Greater)
+  [PiAvPmwq1VFboGwX] Choral Toga
+  [ONjmHKPfUOmQt9bC] Chromatic Robe
+  [MoL5LLA4Cuxz27h7] Chromatic Robe (Greater)
+  [KlkPJgiCiHpuyNpv] Chronicler Wayfinder
+  [99B5wzvBZ8jZ4Ie7] Cindergrass Cloak
+  [YSXwrbnxc8OX0jBm] Cipher of Elemental Planes
+  [0yeM77XLNrB0a0LF] Circlet of Persuasion
+  [hmmDa6LCS22dZT7P] Clandestine Cloak
+  [6jRXUXzYKIpm2uNp] Clandestine Cloak (Greater)
+  [fbhRZskdWPrh4ML8] Clarity Goggles (Greater)
+  [UgfTCOJjjMsrqynr] Clarity Goggles (Lesser)
+  [mDIxIVMhbZ7voLhU] Clarity Goggles (Moderate)
+  [fVOObByW6XHADQ2J] Clawed Bracers
+  [WnxXVCjZcMHy4eGO] Clay
+  [WuSXfv87YBSzqJ66] Clay Sphere
+  [OksiiEBiiGatAM9e] Clay Sphere (Greater)
+  [BdLtvg3zUKypgYdS] Clay Sphere (Major)
+  [6Vg2ugx0hdazJ57g] Cleft Head Marking (Greater)
+  [bfDByCXIwWxX7Fiz] Cleft Head Marking (Lesser)
+  [9UJbMaglf35GVzaZ] Climbing Kit
+  [TWv2EeDJaCjtmGUN] Climbing Kit (Extreme)
+  [jYQy2jFxbQL5y36L] Cloak of Devouring Thorns
+  [MNBnZn0b80Q7yHJM] Cloak of Elvenkind
+  [ZelCRLDI6M5IfjAI] Cloak of Elvenkind (Greater)
+  [fXD42N5cGUYCtvp2] Cloak of Feline Rest
+  [RxBVbQEd4DArkpKl] Cloak of Gnawing Leaves
+  [0HvjITehMdaFYUkb] Cloak of Illusions
+  [I0XiBnHFCXi64XiD] Cloak of Illusions (Greater)
+  [nOI2irf1OifSdp9P] Cloak of Immolation
+  [oC4ZMEdBJ3ia4ALm] Cloak of Repute
+  [xzN8mFG2Z70SaXLa] Cloak of Repute (Greater)
+  [NFFgDfLBkCjkj0dc] Cloak of Repute (Major)
+  [C3SwBSW8XzzBPDVT] Cloak of Swiftness
+  [TxB1a2DrhRZABRjV] Cloak of Thirsty Fronds
+  [qVmOQFcsVQkOn4zM] Cloak of Waves & Clouds
+  [dipcMOtBFxtmsjkS] Cloak of the Bat
+  [ifAp8wHKBZltgHG0] Cloak of the Bat (Greater)
+  [yI6L5ZHRxWpZmOP0] Cloak of the False Foe
+  [MJ1wJbEXRw5KcvwN] Clockwork Bookshelf
+  [15nkBxrvIrbGQCdS] Clockwork Box Packer
+  [v9tI40skGswMQTVN] Clockwork Cloak
+  [937vrPcl9rpzdtJw] Clockwork Dial
+  [VMIwKvpQHh91cQoa] Clockwork Heels
+  [zJKEDSxn2lhPamKS] Clockwork Helm
+  [LiK84TSQJoe1e6D7] Clockwork Megaphone
+  [NLC3c1mudubNNekY] Clockwork Recorder
+  [mnEj7ll9WffO8WLu] Clockwork Songbird
+  [eLB9htTAvZeiXgW6] Clockwork Sun
+  [W8Vh7KTl3Ux7VYVU] Cloth of Nullification
+  [SLQgdLk5K9JV4ACF] Clothing (Cold-Weather)
+  [eH9QuNtPi5BkeKO7] Clothing (Desert)
+  [jJZbdMHMdh8UL2j8] Clothing (Fine)
+  [rXZxM7SbqEnvXyal] Clothing (High-Fashion Fine)
+  [ilbLQNy6TbBPW7sQ] Clothing (Ordinary)
+  [hcGvN03ieNWlSQYa] Cloud Pouch
+  [y9RUbQec9zGeqqcE] Coating
+  [pkD8SLooxP55tibr] Codebreaker's Parchment
+  [PMCk6NCDvJs1MBcg] Codebreaker's Parchment (Greater)
+  [UlvlWbC7iipuENa1] Codebreaker's Parchment (Major)
+  [AVBhZdhq6qCp96Se] Codex of Destruction and Renewal
+  [qO1swPrA14AnuyBD] Codex of Unimpeded Sight
+  [nQIIO6LIot0ISQXH] Codex of Unimpeded Sight (Greater)
+  [QSeDIyIr2A7PNy6u] Coin of Comfort
+  [rEz9WYhlx2Pm0gKk] Cold Iron Chunk
+  [eQjibJl41aQpQ47d] Cold Iron Ingot
+  [vQiH5HYTsSRIsdK5] Collar
+  [cO7ANYLkcmfCn9c9] Collar of Empathy
+  [Rsoh0Y3RQD8x8ito] Collar of Inconspicuousness
+  [BOjMAfhfDYc3MTLQ] Collar of the Eternal Bond
+  [QiYXHgbAv29OuaWS] Collar of the Shifting Spider
+  [4QufuSeCbjDD2hMa] Comealong
+  [Dk7cs7rj82ORgxFg] Commandant's Scabbard
+  [thWEk8pHq1hqyhMn] Communication Bangle
+  [0Ju6ETQiDvz9qpi5] Communication Pendants
+  [0wcZzk6ZgvxRBsBx] Communion Mat
+  [wob6DB1FFdWs0mbp] Compass
+  [xVhd8NF9KQ6VWfMu] Compass (Lensatic)
+  [geSsIAYv85MZtppg] Compass of Transpositional Awareness
+  [EV97k4OZ3tDesk8X] Compound Eyes
+  [3fHdvyWq5A9jvT9W] Concealed Holster
+  [laU7xnX42wXch2Dv] Concealed Sheath
+  [e0hrybnm5FBr28Su] Concealment Coin
+  [cvO0dLw2B1Zno8rv] Conch of Otherworldly Seas
+  [cHCaDiKel0qAIQmC] Conducting
+  [gSf5aYA9D8MSolc9] Confabulator
+  [5LCgBAYZmnVLm7xN] Constant Crosier
+  [bYrcZ0Oj3c10FZzP] Constricting Whip Tail
+  [pASszbK2LjpNUJY1] Conundrum Spectacles
+  [HY6ZJpn5t0FDMTKM] Conundrum Spectacles (Greater)
+  [Yf7maiRDmmHAyF82] Cookware
+  [UBfAwXBU5iQ59Bz7] Cordelia's Construct Key
+  [rUxQi4pUbMeHrnSX] Cordelia's Greater Construct Key
+  [NynlyTZiZ8h9Ntfx] Core Bugle
+  [wfJwzkH6UFSD7adC] Cornucopia of Plenty
+  [urneQVi0N613KnwP] Coronet of Stars
+  [0yLfPmzRtBd6Avac] Corpse Compass
+  [8YnlhfZSQ89FjDZ2] Corpseward Pendant
+  [QFzn6s5w9tzhcoM6] Corrective Lenses
+  [Wm0X7Pfd1bfocPSv] Corrosive
+  [vQUIUAFOTOWj3ohh] Corrosive (Greater)
+  [yAG9XjecF5xpOEvg] Corrosive Engravings
+  [Y23lqGpVYNacdUUl] Corruption Cassock
+  [dvHvLFTbjnsE0xoN] Countering Charm
+  [rrWSGLJVxXAMeP07] Countering Charm (Greater)
+  [39wTBxfaHkAHwXhw] Countering Charm (Major)
+  [LBoSycoKAXrp76zA] Courtier's Pillow Book
+  [Fc8uMYwTDQkeyeOF] Cowl of Keys
+  [mvMeloQxSiEGIlhL] Coyote Cloak
+  [sls3pfkhgCbW723f] Coyote Cloak (Greater)
+  [RgNBGpBc9G2yw1C2] Crafter's Eyepiece
+  [JSYtBZ7XblyAEFoV] Crafter's Eyepiece (Greater)
+  [Wf5KDIF4gauHQmy2] Cresset of Grisly Interrogation
+  [yAqGhT0GuZrkvWZl] Crimson Fulcrum Lens
+  [LEs9c5GqdGk5aWcP] Crimson Tome
+  [R5llqYr6ruAiq4EU] Crooner's Cravat
+  [44F1mfJei4GY8f2X] Crowbar
+  [4kz3vhkKPUuXBpxk] Crowbar (Levered)
+  [FUzPnIXLHZenTtYo] Crown of Insight
+  [1FKDq4Gfev5GObDT] Crown of Intellect
+  [4v8FIJSPaJUbccLz] Crown of Witchcraft
+  [4v850xbHgUdlvamn] Crown of Witchcraft (Greater)
+  [3jd8wUCHH5WhCTEJ] Crown of the Companion
+  [gxzlLfvXeZ8BGlf4] Crown of the Fire Eater
+  [qHwbdYOPZ9mwmru1] Crown of the Fire Eater (Greater)
+  [vfVpgUuieLdPoqY7] Crown of the Fire Eater (Major)
+  [B5ZfLr6Ox816FBEc] Crown of the Kobold King
+  [JY8X4RSfg6xIqAC9] Crushing
+  [t6SSQYruLsDWj5Tl] Crushing (Greater)
+  [tF3DzH1vOBEC8syP] Crushing Bough Bracers
+  [h4fhKJmmx232FGd2] Crutch
+  [Duj5vC7F5588ugS6] Cryolite Eye
+  [RM3SR1omNZfppZGl] Crystal Ball (Clear Quartz)
+  [S0IshWO7Vx29PKaq] Crystal Ball (Moonstone)
+  [WKdI4LbwgcNHhMdp] Crystal Ball (Obsidian)
+  [ByRyBRjNBcK5rwQ9] Crystal Ball (Peridot)
+  [VDMYyVQUWJAjVyru] Crystal Ball (Selenite)
+  [TAHcYiBzvg8F1AwY] Cube of Force
+  [1kLz3leyfccLcAMK] Cube of Nex
+  [qnj1999r0BXo4C31] Cube of Recall
+  [bqUAjBYBI3Avb1hf] Cultist Cowl
+  [GWaTch1J0tPjoi8s] Cultist Cowl (Greater)
+  [uKB9FBAoAsj46UgA] Cultist Cowl (Major)
+  [T4gTHDKJ0HI10p3y] Cunning
+  [k17YXdpqoVycF57F] Curious Teardrop
+  [idw9HdfR4QvseXsc] Cursed Dreamstone
+  [iVlNLbLCT3KKjBsW] Cursed Immaculate Instrument
+  [V8cYi1Gawe71d0rE] Curtain Call Cloak
+  [qEPyzpoZOygWRn09] Cyrusian Wand (1st-Rank Spell)
+  [ZWroGcapvICFAQZt] Cyrusian Wand (2nd-Rank Spell)
+  [paMCEopsN26PQLXb] Cyrusian Wand (3rd-Rank Spell)
+  [goPuyEiD7614ZEet] Cyrusian Wand (4th-Rank Spell)
+  [EGvqYHkEw3k7wGL8] Cyrusian Wand (5th-Rank Spell)
+  [jieJqVjtvIEo9IcC] Cyrusian Wand (6th-Rank Spell)
+  [DLqIHv0gvwKx8B0O] Cyrusian Wand (7th-Rank Spell)
+  [ZblyK929eFFcIZqB] Cyrusian Wand (8th-Rank Spell)
+  [jfMBFb7xTo5OK8v8] Cyrusian Wand (9th-Rank Spell)
+  [u6pDaIxMIimhQx7X] Cytillesh Toolkit
+  [Epc1e1Q9M9bcwOR0] Dancing Scarf
+  [QJ1PhbtbLzwhRlY0] Dancing Scarf (Greater)
+  [mmdnWrQsh7vDspLK] Daredevil Boots
+  [kjFFmqci69k2zMXF] Daredevil Boots (Greater)
+  [krKFJmE139HBqa9K] Darkvision Scope
+  [iPgSLZ44804wrXQC] Darkvision Scope (Greater)
+  [GhIBjLO1h90L7BCp] Dawnfire Beacon
+  [a0qkmzbhgq6o1eSU] Dawnfire Beacon (Major)
+  [rnhXFlynrb79chQ5] Dawnflower Beads
+  [1tqyghMGI6PEYFGK] Dawnlight
+  [babiGiHQwY6Bg4XP] Dawnlight (Greater)
+  [KtpxwEfpbfDDEURF] Dawnlight (Major)
+  [B0gbs7xKQc2J7AiV] Dawnsilver Chunk
+  [QpP7Mo7ad5lMOTpv] Dawnsilver Ingot
+  [85lwgBrZh0cB3PX4] Day Goggles
+  [wQUGBFZ5QNWXodU7] Deadly Slashing Claws
+  [k9BYXA4b7Z4Hy6lZ] Deafening Music Box
+  [8l3IEK409fDYgRR9] Death Tusk Helm
+  [4DXupoMmwenFn4Kc] Deathdrinking
+  [kOEZCUTCPCqCFoJf] Deathless
+  [aBVrNIPoPGOYxm80] Decanter of Endless Water
+  [fyiW23MFe8p06KL5] Decaying
+  [HGsA5gXtaAA65n9e] Decaying (Greater)
+  [FfuB86HyfwQyCgSF] Deck of Harrowed Tales
+  [Gyi4IVrAVJRPJF2s] Deck of Many Things
+  [7ZfWiHqDyb6NllN1] Deck of Mischief
+  [0zTY4ogkffTxmJUj] Deck of illusions
+  [Q4o8pEdxSY0bnJQZ] Demilich Eye Gem
+  [i9hF185TRK0cH8B4] Demolishing
+  [2gYZiUw9yjtb0yJY] Demon Mask
+  [shKPtYN0YUOe07K2] Demon Mask (Greater)
+  [2TANKQXO6xntX5MT] Demon's Knot
+  [NocVi59Vtbi3kvsJ] Deployable Cover
+  [ozOVlLALtDChFJwc] Deployable Cover (Ballistic Cover)
+  [7HHKalX0yYJSHROS] Depth Gauge
+  [Izs8R6o4mpFvz3Wf] Desiccating Scepter
+  [mOOJwTOxEFYfi9LV] Desolation Locket
+  [WC0MDw9oLnAtLmh5] Desolation Locket (Greater)
+  [3p4fk9pbwDeue1NG] Desolation Locket (Major)
+  [ItLZL9Bd6xwgfeB8] Detective's Kit
+  [znWf2DgWyElwzQwJ] Detector Stone
+  [y0cRr28w57VapTcn] Devil's Luck
+  [hQ442kcLpkHPZ7Nk] Devilwing Badge
+  [G6njXf4pRdYsE7E7] Devilwing Badge (Greater)
+  [B1SiT510ndPAP7xz] Devilwing Badge (Major)
+  [as84dZ5Hliru148n] Devoted Vestments
+  [rqwmqnCZ0xz7vF1b] Dinosaur Boots
+  [6epYSje4gOgYPvK0] Dinosaur Boots (Greater)
+  [JJZgRx6naNJmDa81] Diplomat's Badge
+  [3Un39La3zogviHgZ] Dirt Sea in a Jar
+  [Jvp0x2Sc82WVpExT] Disguise Kit
+  [IRqbsE8MgGLTfHLz] Disguise Kit (Elite Cosmetics)
+  [YhkomhtKBK3i9C7Q] Disguise Kit (Elite)
+  [FWMGkUotwUJuht7i] Disguise Kit (Replacement Cosmetics)
+  [KUMWjgUXxB2iurBP] Distracting Carapace
+  [XXz3Gt5IUb8QdnBS] Diver's Gloves (Greater)
+  [wRZGJohTF0FFJBrq] Diver's Gloves (Lesser)
+  [MlrVt5CaZ85PvEm9] Diver's Gloves (Moderate)
+  [9zdm3EyEQXgMox8b] Divine Scroll Case of Simplicity
+  [O6deRhRldwTqMP97] Diviner's Nose Chain
+  [Ln0gcJPFHU9sQ7Jd] Diving Suit
+  [O28nMnWDcXpMtrMv] Djezet Alloy Ingot
+  [nmSMa84RpsNv6pSt] Djezet Mass
+  [OVyGHaHjYI2DBV0h] Doctrine of Blissful Eternity
+  [ZPFDfWPmWLPUJeW1] Doll
+  [T99WI1hocCXE7RI0] Doll (Exquisite surprise)
+  [H5N2CacR3pNtanKB] Doll (Surprise)
+  [mslZi4vXr2qYygtm] Doom Switch
+  [ViQm1sR7y0hRb4N9] Doomsday Door
+  [DwMXEqy7Ws8NYQQh] Doubling Rings
+  [gRQXLqUuP4GWfDWI] Doubling Rings (Greater)
+  [E5EtHYETRbRXg4uE] Draconal Mask
+  [EeTbJQpWGPm7EFlQ] Draconic Verge
+  [38O6OrDAFq8K6buR] Dragon Pearl (Draconic Codex)
+  [BagxmaKWmG5SYdFV] Dragon Rune Bracelet
+  [zBXPmr6w8VxBvwZW] Dragon Turtle Artillery
+  [bCwSeD0Ub3f4BfjO] Dragon's Breath (1st Level Spell)
+  [FZ9ELiYCNBlyAz6X] Dragon's Breath (2nd Level Spell)
+  [5YZmX9AdhQxXaOzX] Dragon's Breath (3rd Level Spell)
+  [Gw9z5RUNPOjLUdRm] Dragon's Breath (4th Level Spell)
+  [kvfdd4YiO3Lyywuv] Dragon's Breath (5th Level Spell)
+  [SNxXDIoD0XE9WVQ7] Dragon's Breath (6th Level Spell)
+  [bgCBFy3yybTYo4Ec] Dragon's Breath (7th Level Spell)
+  [He5idiYCqLJJU83h] Dragon's Breath (8th Level Spell)
+  [cFJUxi5kCcBV6lz1] Dragon's Breath (9th Level Spell)
+  [A4BhFOb4iQtJYYKq] Dragon's Eye Charm
+  [USk8AnnokXPrV1Ui] Dragon-Lotus Drum
+  [bTLmJMATrrtq8NuT] Dragonscale Amulet
+  [5tyQQUdb2GtspEvy] Draxie's Recipe Book
+  [6PW3zAn8fWW3IYA0] Dread (Greater)
+  [gSSibF07emWGpGKw] Dread (Lesser)
+  [4cbe0WVSHn1FxygQ] Dread (Moderate)
+  [pDw2wi0znVb8Dysg] Dread Blindfold
+  [LSbv4rdvKfm4bPrR] Dread Helm
+  [XWWosdDg34KZhrEi] Dreadsmoke Thurible
+  [VBCZuJMisbu0OXJK] Dream Hunter's Lodge
+  [KBLQtEU6Ya9LT8WW] Dream Lens
+  [lRdrk7Dh9eVlXFHi] Dreamstone
+  [hBGFCZbI9nAjSdfE] Drover's Band
+  [b0kltGQGBUBHN8Ap] Druid's Crown
+  [9o8DDJMWoaZiC5N2] Drum of Upheaval
+  [RpGBzy2OpdfgJmpo] Drumish Pearl Token
+  [dsxATkJ2RwvYF3vm] Drums of War
+  [cHP1s9Ntki9B1HgM] Drums of War (Greater)
+  [nXq9pxB3RVnGb0rB] Drums of War (Major)
+  [DA3HgyEBGEbtRNOo] Dueling Cape
+  [1wrRaLsT6nuz8gj6] Dullahan Codex
+  [5NHciGwLcVJwEjQu] Duskwood Branch
+  [r9lPNhrvG69Ae88d] Duskwood Lumber
+  [YxZO0GO7MUR9eWQw] Dust Goggles
+  [poZ2TVzE8mUhcI10] Duty of the Oathsworn
+  [2MQsz2hdqyYiXq0O] Dweomerveil
+  [pHeqYb5gTSUSmW0j] Dweomerweave Robe
+  [ksNUlyRHFUSK9xmz] Earplugs
+  [iYiA6CMR1N2E2Ny2] Earplugs (PFS Guide)
+  [OClYfRHzoynib6wX] Earthbinding
+  [3pKIEBtZBVmSmVPl] Earthglide Cloak
+  [kZKK4Va3e7n3p3tv] Earthsight Box
+  [CTiLugp5ptSItEqN] Ebon Fulcrum Lens
+  [UQpbEAeOUkascA4L] Ebon Marionette
+  [TXANyCI2y2PsaoxJ] Echo Receptors
+  [nxAMYJrG96yn9iBq] Eidolon Cape
+  [KEICt6Tusa3JdTE8] Elder Sign
+  [njHnUB4bwW26slzD] Electrocable
+  [SMBPvsZH7yAsGSQa] Elemental Wayfinder (Air)
+  [PMmJ47MLUXAWmXFg] Elemental Wayfinder (Earth)
+  [JhDhFq2JGBGR2lwb] Elemental Wayfinder (Fire)
+  [QZliTmapMRrEJ6q8] Elemental Wayfinder (Water)
+  [rGXJKL6xfBGbbd47] Elysian Clairglass
+  [cVxHaDAouFhm0bXP] Emberheart
+  [IS1P6er2hLyKXAss] Emerald Fulcrum Lens
+  [o7JdR8SFXIf5dLIW] Empathic Cords
+  [9dKzjpAQiE48AIWD] Empathy Charm
+  [um6HjOHNXNux6WQu] Emperor's Peak Quartz Bracelet
+  [QSx4I9y38hmDwP0I] Empty Hand Marking
+  [QnuL1UEot8ptWNb1] Encompassing Lockpick
+  [XrM3Cza8vM6Jzv98] Endless Grimoire
+  [XeiuCRFzxHA7mm0X] Endless Grimoire (Greater)
+  [WT9Yh0UNBHBlLNsJ] Endless Grimoire (Major)
+  [oJBJW19ulUBMEPEY] Endless Grimoire (True)
+  [YUJrCbNopfEkFaV0] Endless Quiver
+  [Da8rPs6ksA14EN6B] Endless Quiver (Greater)
+  [Qqh586pudsEqITUk] Energizing
+  [DAWaXFtevHLUJxHB] Energy Adaptive
+  [ferPzbD9Qsta71wK] Energy Robe of Acid
+  [wdnQb4WoO0ghkCeP] Energy Robe of Cold
+  [CA4W0Dt4qeg8MLHA] Energy Robe of Electricity
+  [WPhrH1zCbP2v10aP] Energy Robe of Fire
+  [mfhcGeS0L7pPZnex] Energy-Absorbing
+  [Oj3TuNNUT3ayL3Ea] Energy-Absorbing (Greater)
+  [Lw3B9DpnyrpXD9Di] Energy-Resistant
+  [9CAWAKkZE7dr4FlJ] Energy-Resistant (Greater)
+  [sG5JfXmH9wqmqW3w] Enhanced Hearing Aids
+  [Jx7cxxTqOENzlGaj] Enigma Mirror
+  [trKFKb5BKa0kxuTJ] Enigma Mirror (Greater)
+  [Zo3uztXAa7kEUQmC] Enigma Mirror (Major)
+  [7XWN1cdprTZ8mjRr] Enkindled Quintessence
+  [IM9W5fovv44ZKDRQ] Entertainer's Cincture
+  [DrjFwJhp66GfH5Wi] Entertainer's Cincture (Greater)
+  [Jpgl3HlEd8u20fUY] Entertainer's Lute
+  [pDNlJMlF4OotsVBh] Entertainer's Lute (Greater)
+  [ytGUz1nsPSsyuEsJ] Entertainer's Lute (Major)
+  [tqgCxayEMsUxb1PV] Enveloping Light
+  [3x7YAs6nos79Dpt7] Enveloping Light (Greater)
+  [SGbEZzm5MLSv1DDX] Envisioning Mask
+  [6BGWlWFEX3gRRnWa] Essence Charm
+  [MIBPJ73gjQ17kweK] Essence Forge (Greater)
+  [LmksnUQdwRu0SPCK] Essence Forge (Lesser)
+  [tjxoE6w85Hlg2To4] Essence Forge (Moderate)
+  [kwo4VKC9Qkplusxs] Essence Prism
+  [aJEXZJYjzoMHc5Pm] Eternal Eruption
+  [ZxsPHkzzn6QwfPEz] Eternal Eruption of Barrowsiege
+  [zP7Eo57IYMUKxwPO] Eternal Eruption of Blackpeak
+  [khzffn47ZUG0tHhl] Eternal Eruption of Droskar's Crag
+  [X9ZEqWNgHPQO1SCc] Eternal Eruption of Ka
+  [YguYZuHT6k1jVBvy] Eternal Eruption of Mhar Massif
+  [FB8EAFOz2hS6Jbic] Eternal Eruption of Pale Mountain
+  [fhOnKVwftnOwayBp] Eternal Eruption of Sakalayo
+  [q70WXJO1rswduHuT] Ethereal
+  [qzgi4PCcvpH0QPVj] Ethersight Ring
+  [pVjtw5KSQF1YF4Jp] Everair Mask (Greater)
+  [cw3onzGfq0Ori5Mn] Everair Mask (Lesser)
+  [nZygpiYsx4AlQKle] Everair Mask (Major)
+  [DIBJnuEG85FYwqnM] Everair Mask (Moderate)
+  [L4pVWrrQDRVpdAlo] Everburning Coal
+  [mRz8Jmk4Q06SsZpC] Everlight Crystal
+  [P8xfjaEsrcKxl7k0] Everyneed Pack
+  [31tSOy1iHCjNNd4N] Everyneed Pack (Greater)
+  [PSITHs8LgR7OZGcA] Everywhen Map
+  [ocqIWF5PeU9BxNlM] Experimental Clothing
+  [tIZ3Wi2JInY9abu8] Exploration Lens (Detecting)
+  [RpsT84dZxLWHcoFk] Exploration Lens (Investigating)
+  [NAQ7HcM826y9fsBH] Exploration Lens (Searching)
+  [9Y86NM6nt2WtYBOy] Explorer's Yurt
+  [1YkOplOqn9OgGLyg] Extendable Pincer
+  [QuPnoGmlgYVNXeTz] Extendable Tail
+  [bJORQsO9E1JCJh6i] Extending
+  [WHwprq9Xym2DOr2x] Extending (Greater)
+  [Lafm0hXaAGRQTmN4] Extra Lung
+  [9MT4uBht72VerwfR] Extraction Cauldron
+  [FYv6k2zkd0MJ93la] Eye Slash
+  [IAJcB9cGEKl6HyGE] Eye Slash (Greater)
+  [ySZgsSBBVf3uv8Nx] Eye Slash (Major)
+  [GyDASe4CV3q3H6kh] Eye Slash (True)
+  [lKMSAlp0ZoFUK4FV] Eye of Fortune
+  [cVnLTzWdaFljFkdb] Eye of the Mantis
+  [mXz0bL0CbUu2V2Ti] Eye of the Moonwarden
+  [S4w9D1naKennNO5T] Eye of the Unseen
+  [7CCGLWYzsRuodCMM] Eye of the Unseen (Greater)
+  [eoQRjG2RjppnbYGL] Eye of the Wise
+  [tSAL09zFgPtlK4Dn] Eyecatcher
+  [dLTN4FU3qBoDZ5CJ] Eyes of the Cat
+  [rT93xVoebhCm9uVA] Faith Tattoo
+  [ywsDnHaJSD9oHvh7] Faith Tattoo (Greater)
+  [hLVRI4JS5vsyfPoV] Faith Tattoo (Major)
+  [yqAVU3Y9w4O19e24] Faith Tattoo (True)
+  [MhbeSE3RyBPyFQpq] Falconsight Eye
+  [DAqI0GwKuRwBagz5] False Manacles
+  [O6XNICvMAolYdgFP] False-Bottomed Mug
+  [xE2CGurZp4eHc1Oc] Familiar Satchel
+  [f6xV2LRekhoYJVwD] Familiar Tattoo
+  [Mz6Q1bawtWXtAifO] Fan Buckler
+  [MoXTxoH7IHgDGtXM] Fan of Falling Words
+  [rj5tlZn0yGXG5KVH] Fan of Soothing Winds
+  [CxpixKu1opjv4n9K] Fan of Soothing Winds (Greater)
+  [pcGdJvwun0tjrUTz] Fanged
+  [cvb47A6K1w7RfNiv] Fanged (Greater)
+  [qL1S3vGfv8Dh5yAE] Fanged (Major)
+  [AQBJX5RnI1YIMLmm] Farlight Stone
+  [XLGJ1bLhMtP1jc2w] Fashionable Wayfinder
+  [r3mVE6Lbkzv65A18] Fate Tempter's Ring
+  [YzHntHUBfw5MdZ9o] Fauna Guardian
+  [U2H9lboISyaYa3bP] Faydhaan's Dallah
+  [3cV1kzaP1ofw3xtU] Fearless Sash
+  [P6v2AtJw7AUwaDzf] Fearsome
+  [uz3JCjRvkE44jxMd] Fearsome (Greater)
+  [kodMiw9OjuwyTPh2] Feather of Unfounded Bravado
+  [uZvIIfZ04Q0S8UBE] Festrem Mortu
+  [wyodEqz1v4PjQFCr] Fetching Bangles
+  [2smAtaNAi2fIVTLF] Fiddle of the Maestro
+  [yxKnUBe6W3yuRiMl] Field Guide
+  [OI20gS0SRKVAORqm] Fiendish Teleportation
+  [gCzXitpdFG5hcvq7] Fife of the Faithful
+  [5Q5MfHX43Sjm8C6Z] Final Blade
+  [6EVDEQmvDnaaKQhR] Final Scalecloak
+  [QlFJyxBTYFSN2EA7] Fingerprint Kit
+  [64mxKuxc9k98FkUi] Fire-Jump Ring
+  [1RiYM3lQDx30XEfB] Firearm Cleaning Kit
+  [vQxQStEySU3IcjE7] Fireproof Gloves
+  [JmXZMyfriNPlcUpk] Fireproof Gloves (Greater)
+  [X0ropI44pV3rgTHT] Fireworks Display
+  [3tOyV4VZEZhwnAMO] Fishing Tackle
+  [ksorBjuXO0Bvdmhl] Fishing Tackle (Professional)
+  [5p4ORuCLOKePxUUR] Five-Feather Wreath
+  [alV162EF3qZrbxt0] Five-Feather Wreath (Greater)
+  [VmmlkU5qJHcTunXV] Five-Feather Wreath (Major)
+  [iJuY7fH2l0rkl5it] Flag of the Stronghold
+  [Or69xk2mRbwnOP4r] Flag of the Stronghold (Major)
+  [XszNvxnymWYRaoTp] Flaming
+  [RSZwUlCzUX7Nb4UA] Flaming (Greater)
+  [FkII0xws6an5vFSS] Flaming Star
+  [FMtUVzTDiTbxXMN9] Flaming Star (Greater)
+  [XJZTTkI3ERnu6iFf] Flaming Star (Major)
+  [vk8ruSuKiv6pUtlK] Flash Beetle Lantern
+  [VpoBYfVUEA8wtQAb] Flask of Fellowship
+  [9Ptn7yy2QeM8taU8] Flawed Orb of Gold Dragonkind
+  [iyXC3tIX3VmjCx6G] Flawless Celestial Shawl
+  [ClfUJ4AtaxglVGvs] Fleshgem (Combat)
+  [bh3zC7WcVlM0qgYZ] Fleshgem (Earthspeaker)
+  [p6RmUi2zCSmjd737] Flickering
+  [UlIxxLm71UdRgCFE] Flint and Steel
+  [XQBkuELucpI0c7XW] Floating Tent (Four-Person)
+  [1m0wiNht4sd05oL6] Floating Tent (Pup)
+  [98JIeYGEuE6pPV05] Floorbell
+  [lsIRKHX2gZFCn8zt] Flower Press
+  [Y3arObjLqt31dfNr] Flowing Water (Greater)
+  [tIFPeuMvkTun3xC2] Flowing Water (Lesser)
+  [jNuPjthEfk31Ewhb] Flowing Water (Moderate)
+  [GNX0BNOoCSOYPedi] Flurrying
+  [1erd18HS57aCyC6r] Flying Broomstick
+  [oU3dxIAnTYlGXJVC] Folding Boat
+  [FQnK379odYh4Tors] Folding Boat (Greater)
+  [QOUjYRxXHvwMkGAw] Folding Drums
+  [zDzs24ZMlzQgmTUd] Folding Ladder
+  [jpQcKMmP1I5674P7] Forgefather's Seal
+  [9SmQvhTWvk7kuvJl] Forgotten Signet
+  [qCEOZ6109Yo34tRx] Formula Book (Blank)
+  [8buhFcGwuaJRrp0y] Fortification
+  [ujWnpVMkbTljMGN9] Fortification (Greater)
+  [cuWnhVyMCHqOA2Hl] Fortune Cord
+  [2cWs7heYDt9jCSJ4] Fortune's Coin
+  [X0pjLMXjW8RGr8pg] Fortune's Coin (Platinum)
+  [6R3e78H9YwzmMbjF] Fossil Fragment (Amber Mosquito)
+  [ocEK7WNH9t3ZPIfd] Fossil Fragment (Brontosaurus Phalange)
+  [ktHdg7fqKtl5hXKJ] Fossil Fragment (Deinonychus Claw)
+  [aVHz2tXvlNDFIneB] Fossil Fragment (Eurypterid Paddle)
+  [fTnjEAHVuM0fGkL4] Fossil Fragment (Petrified Wood)
+  [l6bEZwKaxCGNgZQc] Fossil Fragment (Triceratops Frill)
+  [oPrV7aMAlBypaAMD] Fossil Fragment (Tyrannosaur Tooth)
+  [WTVLL9xk0Tk87w93] Fox Marble
+  [Wh9kusgVXera0bXh] Foxglove Token
+  [1qlc8Jxb9DM63O0y] Foxglove Token (Greater)
+  [GakendMciczlPLHQ] Foxglove Token (Major)
+  [PttRbxopuD0EpDTI] Frightful Hag Eye
+  [MmQw3qu51AuqXKCC] Frog Chair
+  [M5M1WJ5KzbYfRGsY] Frost
+  [Sexud7FdxIrg50vU] Frost (Greater)
+  [tlPwOqfjJxQQsgoc] Frostwalker Pattern
+  [JwHNSaiwwqF7VCC5] Fulcrum Lattice
+  [4CnzS57PB3Em02YN] Fulu Compendium
+  [7F6WGmvZ0r3PloXC] Furnace of Endings
+  [JC7do7p0jkkI0crM] Furnace of Endings (Greater)
+  [AslqTIjbP81m7bzk] Furnace of Endings (Lesser)
+  [Z0VXKrTDur1rgiPE] Furnace of Endings (Major)
+  [KSkIKaKM3n75BpUL] Gaffe Glasses
+  [2idzJUvuy8Zu6y78] Galvanic Mortal Coil
+  [Ua9KWFlVjXW8sSXm] Gamepiece Chariot
+  [6NEOf1UznG4Po0Qi] Games (Loaded Dice)
+  [iS8v3jXGPV8yGdcE] Gamtu Hat
+  [2mt15LcfMArk7JqT] Ganjay Book (1 bulk book)
+  [yvS4UatIZAGH4tng] Ganjay Book (Light bulk book)
+  [cRmTTrgGzaACo7R3] Gas Mask of Clean Air
+  [eCJ8mXA9VQH2P8x7] Gasping Lament
+  [Lo3IDdKzBVsLtuHG] Gasping Lament (Greater)
+  [ioiMUDqv85BI4shY] Gate Attenuator
+  [RC3axCXEWwiSEEUl] Gate Attenuator (Greater)
+  [Nd6h6E5HfsIXu0Rn] Gate Attenuator (Major)
+  [Y12bRscT79LCpz4k] Gauntlight
+  [e6lhw1SPdq3koAqG] Gelid Shard
+  [wTYxAWrdsQ6SLVr9] Genealogy Mask
+  [QZaOQ8luuxWXpFqJ] Genius Diadem
+  [CmGfVmuUH1VGISPr] Ghastly Cauldron
+  [pZhqdggB36MpDUwh] Ghost Lantern
+  [VMYiP4xRd1hPa5ny] Ghost Scarf
+  [g1AeVS3yQULgJt9X] Ghost Stone
+  [JQdwHECogcTzdd8R] Ghost Touch
+  [v7YHA9UhDgsvQ47Q] Ghostcaller's Planchette
+  [utRZnCD2XI9Q1dWE] Ghostcaller's Planchette (Greater)
+  [qrOs3jNXJol6tWS4] Giant Catch Pole
+  [EjV3Pb13DLzGTCcY] Giant-Killing
+  [CxadMTEjnuXyqmcQ] Giant-Killing (Greater)
+  [jt5WnZXTPR39epV7] Gift of Olives
+  [RiChMr22ar4ThfGF] Gills
+  [KaMBXc0Yqn2rAUec] Gingerbread House
+  [wewWxypLaXcHjJ5P] Glass Cutter
+  [Ouou5j07pm2MysXI] Glasses of Sociability
+  [A2Z7Mh8A59wZb5vv] Gliding
+  [aoQ1zaJCgbjaGb3S] Gliding Membranes (Greater)
+  [bKnEt5fSc0Swz1p5] Gliding Membranes (Lesser)
+  [PIR3RduvFcou4xz6] Glittering Scarab
+  [8c51yvwHqXqoHsEl] Globe of Shrouds
+  [ftSaD4c5io4pP4OB] Gloves of Carelessness
+  [Mpx6IFq5xMOiZQZm] Golden Gloves
+  [J4QuF3h13uFElZyX] Golden Goose
+  [jroRwrcUuYg9m1YU] Golden Greaves
+  [CDuN9kzyxBZ4cShq] Golden Legion Epaulet
+  [wUBJ6osUKvNnOtft] Golden Rod Memento
+  [d8wTwHiA09HP45IM] Golem Stylus
+  [WYg2dZ8UK1N3rpgs] Gorget of the Primal Roar
+  [Roxn4bShFBRcU2Yt] Goring Horn
+  [4TJf8zJ2yRzBy74v] Gossip's Eye
+  [dJoYIbM6GF6wgX0b] Gourd Home
+  [GLr0U1yY4hSHBApa] Goz Mask
+  [xH51QHrc9073UzH7] Goz Mask (Greater)
+  [qixSKcFT1OA4mIkp] Goz Mask (Major)
+  [3nv4JcajPAxDgGMb] Grail of Twisted Desires
+  [7C5xxZw1VTiyUg37] Grappling Gun
+  [TyWs8hIOYxjcm037] Grappling Gun (Clockwork)
+  [6DCy7tEF1cxaIJMy] Grappling Hook
+  [mCs87WJT2l0qkgcC] Graymist
+  [qUnDHEXteUQGE8yp] Grievous
+  [xdpP0y4EfRf0ALl8] Grim Ring
+  [OjOpj9u1EdEUhKuX] Grim Sandglass
+  [yQTmIcXIDg7nVpJX] Grim Sandglass (Greater)
+  [beHqICAYt9ZuyBay] Grim Sandglass (Major)
+  [oqZszBqqanONR0ng] Grimoire of Unknown Necessities
+  [CFIAFefybUC27v9I] Grippy Gloves
+  [oEfcbqK68enZLOoR] Grub Gloves (Greater)
+  [pDaFDSY1keNfbdTl] Grub Gloves (Lesser)
+  [cxVbGSUjmc2yxVh5] Grub Gloves (Moderate)
+  [c2Uo8HZng1Ne5yV2] Guangu of the Steppe
+  [enPo1dPzSQaybAfF] Guardian Aluum Charm
+  [WKT5mW2EccS22989] Guide Harness
+  [2EzUZq9pEVP4oQ0k] Guiding Cajon Drum
+  [TGCzwDIrAqo3HUhr] Guiding Chisel
+  [hwVS8uNgIEfENz6q] Guiding Star Orb
+  [F5dQEQTyOpSBeXDJ] Guiding Star Orb (Heroic)
+  [tr2eOlJMmBKBZtI9] Guise of the Smirking Devil
+  [b2shhButUcNimET9] Guise of the Smirking Devil (Greater)
+  [zSILrZ6pYWbWUm2D] Gunner's Saddle
+  [7tiAVxbZW8aGmKUO] Gyroscopic Stabilizer
+  [ACa9QlFqdmW4s2Th] Hag Eye
+  [EHMGDwY0oSZAHz8Y] Hairpin of Blooming Flowers
+  [CGcNXv33k83Gr5lf] Halcyon Heart
+  [5rpNqGkPSMkXKv0B] Hallajin Key
+  [r1hgg2rweqGL1LBl] Hand of the Mage
+  [M450qjybosAkGcdN] Hand-Hewed Face
+  [wBeljBAAFsvgkRMy] Handcuffs (Average)
+  [WR8GOQSx7B5AlzNu] Handcuffs (Good)
+  [XXALNl2JjJket1vr] Handcuffs (Superior)
+  [aGkmq9k4QIEpLFs7] Handkerchief of Disagreeable Disguise
+  [KR35T5By2iaLKEwH] Handkerchief of Disagreeable Disguise (Greater)
+  [oDyRlkRos1abOGz0] Handling Gloves
+  [FphoSIj3t6iQj3ew] Harness
+  [P4hCmpeuBochkxsJ] Harrow Carrying Case
+  [B3aJa0csNZOGXLXT] Harrow Deck (Common)
+  [OP1TkZ9ugn86W4Br] Harrow Deck (Fine)
+  [C1j0Zs26TPVjplbs] Harrow Deck (Simple)
+  [Ze64YjceQqnwRCsU] Harrow Mat
+  [57vUQS7HSln47EH8] Harrow Spellcards
+  [Hu9n7JNutzFarHe7] Hat of Many Minds
+  [2ovu1AioLLff9p8w] Hauling
+  [o0XXVVymB8kluwLK] Hauling (Greater)
+  [FA1mAc7rEyC9vzZa] Head Gem
+  [son3QT3YfrBYlWPq] Headbands of Translocation
+  [hjfoSyfsGSTLpPMr] Headwrap of Wisdom
+  [o1zKhvYUUc1hE2AE] Healer's Gloves
+  [0GOHTXBxs6H6ARBz] Healer's Gloves (Greater)
+  [s1vB3HdXjMigYAnY] Healer's Toolkit
+  [SGkOHFyBbzWdBk8D] Healer's Toolkit (Expanded)
+  [xI3obWctqdVBLzSX] Heart Bloodstone of Arazni
+  [t21l7ssk3fntP1xU] Heartmoss
+  [W2rxVEIVJoBWO7j6] Heartmoss (Greater)
+  [OQXIw3Htf0Rb14dK] Heartmoss (Major)
+  [yhw1mr4oDhzMQc3D] Heartstone
+  [e2hDvrdz0t0hzE5y] Heated Cloak
+  [WgXPnTogb3MCueKP] Heckling Tools
+  [LfiGXU03Khb1o6fs] Heedless Spurs
+  [vBgElXswf6xBx4k9] Hellfire Boots
+  [yWr6S7pytCcDlCcR] Hellhusk Shroud
+  [h2gpUvHN3hTRS7jv] Helm Of Zeal
+  [FKf6eELtbFhbK69W] Helm Of Zeal (Greater)
+  [UAJursrFNgKpY5dg] Herald's Ring
+  [o7Tr4KbPcmd3zzd1] Herd Mask
+  [0fHBB9Xb4m3oAoko] Hexing Jar
+  [VGsfKBMHnz1gDPdg] Hexwise Banner
+  [DIabdidLZbSbq767] Hexwise Banner (Major)
+  [t9NlJdAdTKWZUoYz] Hidden Pocket Outfit
+  [P8mILknZPnolGHQq] High-contrast Goggles
+  [O0iTcOhlsEPGsxtD] Highhelm Drill Mark I
+  [BcYUzXVZIiQ2eVPF] Highhelm Drill Mark II
+  [vkYWqXrHdUAggJIg] Highhelm Drill Mark III
+  [5KHp3903LnOcHp8k] Hoax-Hunter's Kit
+  [ETwv7GshGM9IXnqH] Hollowed Hilt
+  [DH0kB9Wbr5pDeunX] Holy
+  [KrmSuQIyu6OEi5ew] Holy Prayer Beads
+  [OHs7L8CJMdp2UV0P] Holy Prayer Beads (Greater)
+  [OdBdmv0Y1P7wQWTo] Holy Steam Ball
+  [w0iN9Q6UpqNp2xQs] Homeward Swallow
+  [sRpA9sGZe1P0EERB] Homeward Wayfinder
+  [sO3b9FRLFY43YQUc] Hongbao of Many Things
+  [2pzrpfYE9AHMAX9H] Hongrui's Gratitude
+  [S9eytXwDMdwdSh2z] Hooked
+  [NCE7g1U3q3RYwCY2] Hopeful
+  [WAMDYE9tt3W8obzr] Horn of Blasting
+  [xdPU7qrl5hIvaArY] Horn of Exorcism
+  [4eC5wMw1vcDDgC4x] Horn of Rust
+  [wrTvu4gU5IzDJVbA] Horn of the Aoyin
+  [eNogefkPJCWDjMyo] Horn of the Archon
+  [XPkhjxSh6tBWk50f] Horn of the Sun Aurochs
+  [0SSu1fch6ah0oTti] Horned Hand Rests
+  [uQNw11Osk2pwx6d8] Horned Hand Rests (Greater)
+  [SHzZSENlkz3Qy46j] Horns of Naraga
+  [c8v8gWJ87xiUVnsb] Horrid Figurine
+  [UN87ivaushE6xOdj] Horrific Effigy
+  [oIMtXP8y7oxvrBVP] Hosteling Statuette
+  [WAsQ6WuMYUB77Uh0] Hourglass
+  [FXdESP5mmP01tL2v] Humbug Pocket
+  [AynKTlER5ZbfF62f] Humbug Pocket (Greater)
+  [o5jn0wvPaSh65p3J] Hummingbird Wayfinder
+  [fFul37mR5DRGpQTh] Hungry Lantern
+  [JCGsj7iY88o9uTP5] Hunter's Arrowhead
+  [4ObrlZ5GhCPA2E2s] Hunter's Brooch
+  [lkIzsqI7PcymcTEQ] Hunter's Hagbook
+  [5PmuusQRWQBmexGy] Ice Forge
+  [ibA3FykNQcoEPfPC] Icy Disposition
+  [m4U2P5A1Dk1C1wr1] Ignitor
+  [8anSflDImoYUv2UK] Illuminated Folio
+  [66OFeQOV6HM29j5R] Illusory Backdrop
+  [LeKkgh335aJTQr8T] Immaculate Instrument
+  [n8nLwFR4VFFmAny5] Immovable
+  [2QZbG6FUr2AWK6km] Immovable Arm
+  [14LrP7bx8Q1jimHO] Immovable Rod
+  [QsRmhxeuf9v4h3Dp] Immovable Tripod
+  [H9qYN48voa2ZDy3i] Impactful
+  [ri9QkRCD6cAbQ6t3] Impactful (Greater)
+  [XkjOK05Gw0o3iycr] Implacable
+  [uU4VC8OlhDHslT4i] Impossible
+  [4rJjASdTnQO2zkt2] Impulse Control
+  [nv1OBtriMXhjQdmk] In the Shadows of Toil
+  [V9iVPhIk980GT6A2] Inexplicable Apparatus
+  [SemkRkQPVBljg9Id] Infernal Health
+  [hD95fU3S507iTHcb] Injection Reservoir
+  [MV9tQYR5vsjPeyar] Injigo's Loving Embrace
+  [oJLQaiCSmFJx0bxe] Inquisitive Quill
+  [I95zlGUDCply1Ydm] Insistent Door Knocker
+  [a5dEzZPuxsmTvlWS] Insistent Door Knocker (Greater)
+  [3BTIKYHck3JIAPiH] Insistent Door Knocker (Major)
+  [M1fRjN7E3P55zvmc] Inspiring Spotlight
+  [uTPqImeDq7bEsFak] Inspiring Spotlight (Mounted)
+  [C9lcnBy4pS3MIyoU] Inspiring Spotlight (Portable)
+  [EXXqJp8rU6HR5Ufg] Instant Fortress
+  [QbCraR5KFlkIJiVA] Instinct Crown (Animal)
+  [a4RIB8GPOliFoN31] Instinct Crown (Dragon)
+  [htukDa8cAycwf7zr] Instinct Crown (Fury)
+  [hA0o5qdKXcuPJVmn] Instinct Crown (Giant)
+  [MxS9ifx1gr1PKxBl] Instinct Crown (Spirit)
+  [gtDHRMgsyERaxf2c] Instinct Crown (Superstition)
+  [eTOHAULu4kgqR1S5] Instructions for Lasting Agony
+  [7kcw6FM9SH2AI07b] Instrument Harness
+  [zKrGossz3t0mQrQq] Inubrix Chunk
+  [y9Ln2q1EhD3Jdu9H] Inubrix Ingot
+  [VDudQ4x2ozosAbTb] Invisibility
+  [bxz885LMjLCkpDq3] Invisibility (Greater)
+  [yzgMOspvPTLDe6Ln] Ivory Baton
+  [ISsagQkLvsgpoLxP] Ivory Baton (Greater)
+  [SOZ7pMEzjVKbwxqe] Jaathoom's Scarf
+  [akVtwAW1b2TQRbRp] Jabali's Dice
+  [QOAjwtH9gycbDZCY] Jack's Tattered Cape
+  [JM5qwlv2bi7Zgm7n] Jahan Waystone
+  [jsTc3wyD0gSdXILQ] Jann's Prism
+  [7Qc3KezVroqC7Jve] Jar of Shifting Sands
+  [vg4p0cHrZf14VXGz] Jaws of the Grogrisant
+  [3MGQ8KxH7HNA8THZ] Jellyfish Lamp
+  [TFlgUM4CqPBmzhRC] Jiang-Shi Bell
+  [0gxqSZhYdOeJhPrp] Jolt Coil
+  [auEm7vmpG9V8xpAJ] Jolt Coil (Greater)
+  [TucjFO5NQHvUUc7a] Jolt Coil (Major)
+  [yjC2nrfqnKmFerHs] Judgment Thurible
+  [tajXzwAgjUBZLD6b] Judgment Thurible (Greater)
+  [4PtxcrCPnBhhYmg4] Judgment Thurible (Major)
+  [jOulX8kWlCF5Dveg] Jug of Fond Remembrance
+  [kDbL1zbqf76odwlU] Juubun's One Thousand Poems
+  [zAnxjSoJBggguWFP] Jyoti's Feather
+  [GtSPUCDpIMUEq9B0] Jyoti's Feather (Greater)
+  [y4dGIbK5wGUJTufR] Jyoti's Feather (Major)
+  [C9VvYnjbWertzgMc] Ka Stone
+  [P6JCnxSAzGcUl8D4] Kalmaug's Journal
+  [hg3IogR8ue2IWwgS] Keen
+  [Jp6HZr9zJP5JMEBu] Keep Stone Amulet
+  [Z1blVMXUeojHd9lE] Keep Stone Chunk
+  [X5lWxe4ChgaFGYvh] Keep Stone Ingot
+  [h96LHhdZhVYnjcYA] Key to the Stomach
+  [spqcRLBsMOC9WTcd] Keymaking Tools
+  [58mczRPEMWRcBrYK] Killer's Belt
+  [wIwtSiWfRVMF8dHw] Killer's Belt (Greater)
+  [7vwcuBIe4BNS5uuE] Kin-Warding
+  [LuW0KcoGUJ49dFCJ] Kinburi's Sandals of Bounding
+  [pW3pdFtKZLSlsqSm] Kindled Tome
+  [Da78zUcKodY81Sj4] Kite
+  [itn5hOuobNvNaHw1] Knave's Standard
+  [EMll5weE2BlIic2a] Knave's Standard (Greater)
+  [1BOmEKzD9ADuAn55] Knave's Standard (Major)
+  [Dc2DRXybi5dCxmqP] Knight's Maintenance Kit
+  [yXipdeJUEGMPT4dM] Knight's Standard
+  [ZIt62AQb997FatRw] Knight's Tabard
+  [tvFMexALNZ70NVwh] Kols's Oath
+  [BuQsMeD7IP4mvDCQ] Kols's Oath (Greater)
+  [hPhI0FWH5TtaANcl] Kora of the Unending Story
+  [UMJjOsukQATkXW3R] Kotodama Bells
+  [YEB49me6ZI2Sahuv] Kotodama Whistle
+  [yJAhgNvKFcCSPpG3] Kraken Figurehead
+  [nvYrpdzZzH50t52q] Kraken Figurehead (Wracking)
+  [qTfLcil8S2E0ffnX] Lacquered Waist Drum
+  [5j5KyZsGOfbrJNUZ] Ladder (10-foot)
+  [KeespXczBEt1ci26] Lady's Chalice
+  [l96Y0J3ZgB3dkpuF] Lambent Perfume
+  [DDkXLxbejG4g6X54] Land-delver's Chair
+  [QrNvP9SgnK9DrerA] Lantern (Bull's Eye)
+  [dIRZ0LL7G31fJNYz] Lantern (Hooded)
+  [AtiSK2lwEi25f3PT] Lantern Implement
+  [WQ3yrHtv2fN5UO57] Lantern of Empty Light
+  [N9bhBhJ6JawzVitu] Large Bore Modifications
+  [dAPTUxg2NZBwzQ9T] Laurel of the Empath
+  [TmH7coBHz9pjoDvP] Lawbringer's Lasso
+  [eRDtYkNm8lQHwo4g] Lazybones Pendant
+  [h8XkyI4OUitdxjMF] Leash
+  [4kKFzTy2Rlwg2xJG] Legerdemain Handkerchief
+  [ckJkldBWN8n1Hq2a] Lesser Cube of Nex
+  [Ee9RgoMY3XczPidF] Liar's Board
+  [oj5Lz69dxGYR6xAR] Liar's Lexicon
+  [t8U01IpeOyKv4nDN] Librarian's Baton
+  [NEbr7nKuiluJgBHT] Lich Soul Cage
+  [BByeaBDXWdmQgzz0] Lieutenant's Sash
+  [g2oaOGSpttfH1q6W] Lifting Belt
+  [P3zAUF2yTOeS1GSH] Light Writer
+  [dFYEGk1nUlHqQ5qy] Lightweave Scarf
+  [hEnITJ2bJVPrqfGG] Lightweave Scarf (Greater)
+  [Uk342C6qpSkdjHBb] Lightweave Scarf (Major)
+  [JHq8r0fGo1rWF8NS] Linguist's Dictionary
+  [wjrYnQcqimzFdswE] Linguist's Dictionary (Greater)
+  [FbboejktKOMCm181] Lini's Leafstick
+  [LpYBTsYCEjqY3yek] Liver Bloodstone of Arazni
+  [hvlEFx25ogf1K1C2] Living Mantle
+  [IdI7rfCk7WjGbJHN] Living Mantle (Greater)
+  [q2TYVAMaK6UfenbV] Lock (Average)
+  [byKAxLyN7AXySmw7] Lock (Good)
+  [PBlxTrEyr3qXFBqq] Lock (Poor)
+  [JZXCTwoIWoGKjMX6] Lock (Simple)
+  [NHQJQK9aHA1AROsi] Locket of Love Left Behind
+  [0NZuvpCVr21WcQtH] Locket of Sealed Nightmares
+  [hUhH5QeSZ8B7Yg65] Lost Ember
+  [nZE16PtiyY7DWlzd] Lover's Gloves
+  [xRQpaV9fCM7ptmVB] Luckless Dice
+  [nza9skYTNtJe2Wd3] Lucky Keepsake
+  [esk1K85W9uqxijnb] Lucky Kitchen Witch
+  [ykNkCIv2P3dfeMlR] Lung Bloodstone of Arazni
+  [bL7HnxNYGq6nTpgp] Madcap Top
+  [qtT0cgt7uUSKY2qK] Maestro's Chair
+  [rlDIbl6EQYXQpWVs] Maestro's Instrument (Greater)
+  [bAfyWCvgsYDyw3ff] Maestro's Instrument (Lesser)
+  [3mprh9aZ670HfNhT] Maestro's Instrument (Moderate)
+  [SswqJqeAWGtX3tTF] Mage's Hat
+  [Hd1AfC08ytBg67Ey] Mage's Hat (Greater)
+  [ba7Yba3Qexj4DpnD] Magical Hearing Aid
+  [vcq8mSC6518uTTAi] Magical Medal (Gorilla's Might)
+  [WrGXBxdGeLQlvE19] Magical Medal (Griffon's Heart)
+  [GffKny4ykYFkmyDZ] Magical Medal (Phoenix's Fire)
+  [CWz4kW5b5wuIDaaI] Magical Medal (Unicorn's Purity)
+  [MRbukveaBbzGzpZb] Magical Medal (Wolf Pack)
+  [20LwBpDPRaLv0dGt] Magical Prosthetic Eye
+  [Rup7OOQ8aQi3sdZr] Magnet Coin
+  [8Rt9cf86G5Ve9Ent] Magnetic Construction Set
+  [xe6I5BIYHE7SXSax] Magnetite Scope
+  [YBmrRRh0jJTOZoUe] Magnetite Scope (Greater)
+  [jrjwukkie7Y7wkxu] Magnetizing
+  [5GbC7RTgyAeaOcAI] Magnifying Glass
+  [8iet9wptkaoJzOmc] Magnifying Glass of Elucidation
+  [uTELMvkoRORmr5pm] Magnifying Scope
+  [BR2vQLRif2Pgq5eN] Magnifying Scope (Greater)
+  [7uxALss5g34y49HF] Magnifying Scope (Major)
+  [4dSzBQPb68ik7ul8] Majordomo Torc
+  [xS7hRZp6jI8jIga4] Mala Beads of Foresight
+  [5oXpYSNiqxVWSafq] Malefic Mirror
+  [eHfL8Apfx4fxGksT] Malleable
+  [lWeADBqMFwFlVIuV] Manacles (Average)
+  [5g0rE5yMsTH3E2LJ] Manacles (Good)
+  [ZPY2dOaMYciIJv1Q] Manacles (Poor)
+  [ckGYDocGEaelHfXF] Manacles (Simple)
+  [5zkoqnp6X5yPCXVy] Manacles (Superior)
+  [Fq61XZxfgsn4ZDXf] Manacles of Persuasion
+  [wJTx2kNgMQJWGvyx] Mantis Embrace
+  [oHjCgL1SoVheJwAo] Mantis Embrace (Greater)
+  [aJ3mYuV0rjFBPOsg] Mantle of Amazing Health
+  [atWlXr78lWJSNbws] Mantle of the Grogrisant
+  [iljqRzp23l8BdqVv] Mantle of the Tikbalang
+  [ge0PEbPmxFLhyy4X] Marbles
+  [O1W40RBvlZW069Mw] Mariner's Astrolabe
+  [Q4KkKGGXq4bNGHh2] Marked Playing Cards
+  [jBj8aKoQlS8ZCjXi] Marshal's Baton
+  [WKdmAhoji9Y9RC7D] Marvelous Calliope
+  [aZ8HzjZCOJCV7ZWh] Marvelous Medicines
+  [wYpWQCD2IYqDtqpc] Marvelous Medicines (Greater)
+  [OnyNpbR0dowRKg3I] Mask (Fine)
+  [2c5pF6q5XkjLn8MU] Mask (Ordinary)
+  [8SZ9FRW4rBhjyW3j] Mask (Plague)
+  [Uz5K5773R3DB3b3o] Mask (Rubber)
+  [hL6z9KnndTO2L12f] Mask of Allure
+  [NUEwFlFb7RJnLD4w] Mask of Mercy
+  [hKT6sixKQhu8f5zJ] Mask of Shifting Monstrosity
+  [D2CGb29g3ZUNZNWk] Mask of Uncanny Breath
+  [X5OGyKvpF4wcIj7m] Mask of the Cursed Eye
+  [Ku14uJEbwXi0XqD9] Mask of the Mantis
+  [lAQTAOWxU3J2onBv] Mask of the Mantis (Greater)
+  [7NLu6Vgj9clgdleR] Mask of the Mantis (Major)
+  [fvpLYx1Lo42cdleQ] Masquerade Scarf
+  [WPSp5MLb0VOfmUqH] Masquerade Scarf (Greater)
+  [8nz3fSOOkNmNduMr] Master Magus Ring
+  [Bh0coFwyMiKf8H78] Mat of Resilience
+  [nlbNhDcFrU8KIuGT] Mat of Resilience (Greater)
+  [FffMnXbwNHczb6bp] Maw of Hungry Shadows
+  [dj6sdn6b8Rw1Taih] Mechanical Torch
+  [ihIRWisdnhFUsm0I] Medic's Armband
+  [IwDKK7t6yz0Q8I62] Medic's Armband (Greater)
+  [XUEoUlpB8yGaXjLc] Membership Cords
+  [Q2MhPIDRXgD0K6C4] Memoir Map
+  [TtDWzugeKjtlWfZq] Memory Guitar
+  [KyIYS1RDED6gL33N] Memory Palace
+  [liGtU10aUlVeI6IC] Menacing
+  [kkFVSqaefWrVs50t] Menacing (Greater)
+  [AHkmoVr1NSFytJwp] Merchant's Guile
+  [o0ccn5HQAudGgNdU] Merchant's Scale
+  [dFG2yWRg5yNCfugI] Mercurial Mantle
+  [HAtj6AGCIZHpD7Nl] Messenger's Ring
+  [b9YHyjOL4sg7tjI4] Messenger's Ring (Greater)
+  [SUnKoeqNBsGvUAGe] Metuak's Pendant
+  [gvMmQh9icawtnmlR] Midday Lantern (Greater)
+  [fsqAB2lS9N8MRaO5] Midday Lantern (Lesser)
+  [W0tqTUmRE5lEhWUl] Midday Lantern (Major)
+  [8usnglqucr4Q0YO6] Midday Lantern (Moderate)
+  [FW4vzcHuehTXnCLX] Mind's Light Circlet
+  [TQsV76vrzj6WCqem] Mindsponge
+  [6BGlAjt37jE4a6st] Miniaturization Module
+  [u4mjXLioKytEZMTb] Minotaur Chair
+  [y2nb4D6iQOoc5LEX] Miogimo's Mask
+  [6cyw0yK91cNsbvSK] Mirror
+  [uT8HoQ3BKI5La8Fu] Mirror Goggles (Greater)
+  [YafmTpwzMsKiAg5b] Mirror Goggles (Lesser)
+  [KFWi1lxXJi46VDmz] Mirror Goggles (Moderate)
+  [NpNDlH8YE2i67vQV] Mirror Implement
+  [Z5eDsW2Lka2cLTVR] Mirror Robe
+  [Gzz2F90inajTPvcX] Mirror of Sleeping Vigil
+  [Ywt7p5Fyx18lK8km] Mirror of Sorshen
+  [68rHNRZmlnyaUbBF] Misleading
+  [8E7qXnNOSm51UwsG] Miter of Communion
+  [4j3mNtQNTzWs4vNW] Mocker's Swazzle
+  [QWiXrqhSCkvdHbsi] Monkey's Paw
+  [GINBGF9CosuIuXOD] Monster Suit
+  [zhC0xjOecyuT7TFh] Moonsilver Necklace
+  [8x8zqH4pJKJRlyAj] Moonstone Diadem
+  [WJTtO3mI3BlYyBMg] Morphing Weapon
+  [gxfIiPebrvjXeALk] Mortal Chronicle
+  [LmIpYZ1lS2UDGXvU] Mortar of Hidden Meaning
+  [RSxLBjGTCADULQV3] Motion-Seeking Lenses
+  [FCfFwTfe1Tn5Zlqx] Motivating Treat Bag
+  [ElHAsHIzsVQZp8WW] Mountain to the Sky
+  [bWcH5lQ3AuaQwZ08] Mudlily
+  [wRSS5vP8ltrThsoC] Mug
+  [MPv5Yx4w7scZGj2Y] Musical Instrument (Handheld)
+  [csfJtggwGCF28U2j] Musical Instrument (Heavy)
+  [3ld14dsn2RLu9owg] Musical Instrument (Virtuoso handheld)
+  [yw1kPxsdCoDUzOaE] Musical Instrument (Virtuoso heavy)
+  [fJKwvqNEkHPChfrR] Mythic Armor Potency
+  [5PuhK1jPUkMqGShH] Mythic Resilient
+  [OIvT5kbtYWcRc1k2] Mythic Striking
+  [p1oT9B3kdPGJUy3u] Mythic Weapon Potency
+  [K1sodTXiNV4NumOS] Name Pendant
+  [9s4wIWjq9z9VGxmz] Navaratna of the Solar Ruby
+  [MpgoMNvnvy3Ysskq] Navigator's Star
+  [AMOs47C4WiVY5IW3] Necklace of Allure
+  [6cV9Kpwc7aiuhqbH] Necklace of Fireballs I
+  [Zun8aKbODnBFeut6] Necklace of Fireballs II
+  [IufO3dNPhC1c2ZcL] Necklace of Fireballs III
+  [Dr9b08JhDThUenF9] Necklace of Fireballs IV
+  [hDO0vRS8r9K2Zw87] Necklace of Fireballs V
+  [ZZcIhgiKuptXRGyK] Necklace of Fireballs VI
+  [mOY0STwY5hx4UPCN] Necklace of Fireballs VII
+  [9uhJ7OB65ZTdUc8b] Necklace of Knives
+  [NLF4Z7jn44Sf3RGS] Necklace of Strangulation
+  [AavhMzpW5KBIB2DV] Needle of Undeath
+  [GwkgqHAYRrDXSW2E] Nemesis Name
+  [T8EopYZLT137CsdW] Net
+  [4CuEQqahVT8TmNld] Net Launcher
+  [7Z6cpy4rXCOaYJJH] Nightbreeze Machine
+  [TRUl7Iro5aKtqFMA] Nightmare
+  [ybtuHLHWpgMlBDed] Nomad's Shawl
+  [l5aps7Qfc0lB0LYX] Noppera-Bo Hood
+  [JxT2I1jUqJ59JM8e] Noqual Chunk
+  [qnpqMwAnRc55R7lv] Noqual Ingot
+  [DdqGs9aSwjSl0XyY] Nosoi Charm
+  [x0FUkGzr6vBZk8m4] Nosoi Charm (Greater)
+  [0meS8SH8y3qvf6PN] Nostalgic Pot
+  [PDEhZSibXvQdVsSq] Oath of the Devoted
+  [ladz0husmGO1ZYZi] Oathlamp of Accord
+  [K7VHhUamFz3kTnm5] Obsidian Goggles
+  [Tej30MsQo8Ek9aA6] Obsidian Goggles (Greater)
+  [rXXNw6dwVn96giDi] Obsidian Goggles (Major)
+  [EGYcFO9eYfajGKEf] Occult Scroll Case of Simplicity
+  [I2ul8Bzcth7sleow] Ochre Fulcrum Lens
+  [4LnRc8lZjprPPQ0z] Oculus of Abaddon
+  [ENF3Er7cJvb4oXMM] Old Tillimaquin
+  [00gDg8WcPv3TKC9N] Olfactory Stimulators
+  [XFUsIDb6RjVFz9Ce] One Hundred Victories
+  [VPjzEstF31PFSnyG] Open Mind
+  [boQHr2Z0W6TQCJo3] Oracular Crown
+  [8qR43lT8rpmlkoKs] Oracular Hag Eye
+  [L8OButuVM3PFxgrZ] Orb of Dragonkind
+  [ZEDDVQDtUZ2qOB5q] Orc Warmask
+  [YOgUBjv2YHzPFKUb] Orichalcum Chunk
+  [4AnNkIA5Ux6ePy7r] Orichalcum Ingot
+  [glAmMnHZEmlK7PB0] Orm Choker
+  [2jVtcAVrsM52LbV6] Osteomancer's Pouch
+  [R8I13CDRzvpVXOVe] Pacifying
+  [wJOW9YfEp5RDYHc1] Pact of Blood-Taking
+  [sjMDfhSGRxmDnbme] Pact of the Agonized Destroyer
+  [fzScFR5aAl0YhtDd] Pact of the Herald and Host
+  [IHybXd0JGwhMrOlr] Pactmaster's Grace
+  [jLVS6JezrxJ8G94C] Paint Set
+  [Ez0byAlwJwzRXof5] Paired
+  [We11d1zelZ1wskvN] Paired (Greater)
+  [VqT8sHEf2gcY6arL] Paired (Major)
+  [uiTJWd8IJevpkjbq] Palanquin of Night
+  [ZCWhnOmij4AFaytj] Palette of Masterstrokes
+  [1K8xqplmaXW9Yto3] Pallid Crystal
+  [gDfBzU6umebo5RXP] Palm Crossbow
+  [e011UgQLOJtdUqoW] Paper Shredder
+  [hHOi8jV85CN8WRJT] Parade Armor
+  [zZwpFG8FY0Qwgz7e] Paradigm Cube
+  [qXeHBe1gAJ6WbL7F] Paradise Light
+  [SECMe8QKVl45qUie] Parchment of Direct Message
+  [o29fgVteF3yj8NKn] Parrying Scabbard
+  [PAPA06Oe9TgKqh4B] Passage Charm
+  [YeSWRltYzLYBUJbN] Passage Pane
+  [bbSc1VU1LiQqReKd] Pathfinder Chronicle
+  [sZxPKnLtspXPRDNb] Pathfinder's Coin
+  [tNoQ2moQzt0BaHm4] Pathfinder's Mentor
+  [BifEA6ixOdQ6a0yw] Paws of the Grogrisant
+  [7XJQmpYWRZRRutc4] Peachwood Branch
+  [b4hSaH0ITd5fbR08] Peachwood Lumber
+  [cSnXSIoIMkDYSpSP] Pelagic Helmet
+  [huzq73aQUEAlAXiu] Pelt of the Beast
+  [zPhqmCvWyHO8i9ws] Pendant of the Occult
+  [1bvH8zFQvDYky9tr] Pendant of the Occult (Greater)
+  [OoDp1T4IUUsNnrV6] Perfect Droplet
+  [X1uTEyn6CRXCzgqr] Perfect Droplet (Greater)
+  [YG6HRwfMVK3jdslZ] Perfect Droplet (Major)
+  [BSIdE57Zuvv5iX93] Perfected Robes
+  [ZZnh7BkwApPyNyqc] Periscope
+  [MKupH1T018JubYJW] Persona Mask
+  [0PPQl3TEr1yNhhN6] Persona Mask (Greater)
+  [IISieImYvSQ8AqmC] Phantasmal Doorknob
+  [7dkdtY9cTXM3gMon] Phantasmal Doorknob (Greater)
+  [9BXiGLvOFxDBmQrQ] Phantasmal Doorknob (Major)
+  [ZTlTXWcCV4FGgyOa] Phantom Piano
+  [WUICjaC9LYnLRIAE] Phantom Shroud
+  [7jb5AgGsyIRcVsKw] Pharasmin Visor
+  [mH3LImCgJAkfKAA3] Philosopher's Extractor
+  [cJyDBuwgJw7lLi0t] Phoenix Fulu Holder
+  [gswNvLPc2D0n0AOB] Phoenix Necklace
+  [pPl2b7fqfB6dyQwf] Phylactery of Faithfulness
+  [hrG2w4IfF1QZhSzw] Phylactery of Faithfulness (Greater)
+  [lu42Up1309MqFya4] Pickled Demon Tongue
+  [HnOWpyuCHwewPZMu] Pickled Demon Tongue (Greater)
+  [Ug0lQVTJlGKrHQgQ] Pickled Demon Tongue (Major)
+  [nNinADW4vVC0roP2] Pickpocket's Tailoring
+  [ovXO1mVLO1Y3H5Oc] Piercing Horn
+  [JnNZjAk32269e8VO] Pilferer's Gloves
+  [gwP3Uums2ApH6o9K] Pilgrim's Token
+  [kz2Trn8ETSlGv0wy] Pinwheel
+  [V3FxGX0Yy8c7ucjH] Pipe of Dancing Smoke
+  [TTvfgU2G5n3tpTby] Pipes of Compulsion
+  [X42q1s1ZnxliirGW] Pipes of Compulsion (Greater)
+  [kakeEbGrFPwW6Rhu] Pipes of Compulsion (Major)
+  [oX39xqMLVB8kNrY0] Piton
+  [h2aVryWbNP24gC05] Planar Ribbon
+  [XxlCMccCPhl2pZMT] Plated Duster
+  [7Dj3iXpYMA7b5p74] Platter of Putrid Dreams
+  [EsqFTJXcmzfngRgL] Playing Cards
+  [LxaNamrRrGzJo6cL] Pocket Gala
+  [BNelZMBHKlPAWl9Z] Pocket Stage
+  [ONwLm7P7ICUtVN9V] Pocket Watch
+  [THXmVccS9yrcYXDn] Pocket Watch of Stethelos
+  [TieVxNRNuXsU7m7R] Poison Concentrator (Greater)
+  [vCf4otZtC4RHtXdI] Poison Concentrator (Lesser)
+  [tOYitD9BanOPovcD] Poison Concentrator (Major)
+  [PUeRq04dCRkYRx5s] Poison Concentrator (Moderate)
+  [SBQRbWKjGNkNJeG5] Poison Ring
+  [65ZhBT2S8bCeEIgz] Poisonous Cloak Type I
+  [BNShQdbxiPMisV60] Poisonous Cloak Type II
+  [f8AI23xzAHyuU35m] Poisonous Cloak Type III
+  [XbQrf5aYEWweje30] Poisonous Cloak Type IV
+  [rtfpj9WJHMnMtfuG] Polished Demon Horn
+  [62oxvKUCReo7Iah7] Polished Demon Horn (Greater)
+  [eRlOMigJjx5jAEKw] Polished Demon Horn (Major)
+  [BWxouItL1sfGTIUh] Pontoon
+  [VYXAdLJdF0XSeX5m] Portable
+  [PO0n5F4j8Pa0LB0Q] Portable Altar
+  [fOfNBgb6xbu8eA4e] Portable Animal Blind
+  [rJcynWlGp05cLsrG] Portable Gaming Hall
+  [Vr2h3E86Vaf5DJpZ] Portable Ram
+  [p8kyiYyXDapAUyfE] Portable Ram (Reinforced)
+  [5wanv9n8UnUQ852q] Portable Weapon Mount (Monopod)
+  [RKPAHGFV3mq3a3dt] Portable Weapon Mount (Shielded Tripod)
+  [vZaXDOrp5Faxw5fS] Possibility Tome
+  [dzwHxy09Xql3kIPd] Prankster's Perpetual Pieplate
+  [ZIQAzOavTXJCcCMD] Predictable Silver Piece
+  [k0AC0UxLKO4r2rwQ] Presentable
+  [Mwwgn9WVH9WbrAT0] Presentable (Greater)
+  [Gh1FVqiP7uaSwCYz] Preserving
+  [qJW6SU0hvLrxVbnV] Preserving (Greater)
+  [mqOjTuUHv4cRdt2N] Primal Scroll Case of Simplicity
+  [QbOlqr4lSkeOEfty] Primal Symbol
+  [J5MqY1P3JWrezcQX] Primeval Mistletoe
+  [HZDkF6MlNQ6yYobD] Primeval Mistletoe (Greater)
+  [8q9ylEH525g6XqFC] Primordial Flame
+  [kXK9szN2gcYoPSdN] Printing Press
+  [SoafdwQVWhs26qsk] Pristine Epaulets
+  [Mnj6K8aC7itqSIdg] Private Workshop
+  [7wuDdrF6HKPXyxqj] Prognostic Veil
+  [2FlazfdJE2XPRba8] Prognostic Veil (Greater)
+  [Ck5k13uTNqibLFJk] Propulsive Boots
+  [VBaxMSVNY2n6kLzT] Prosthesis
+  [xtbNgp2Imlmvj81r] Protective Netting
+  [i5SEEbSALTzH9rgg] Psychopomp Mask
+  [J3KhiuihoyDjshWr] Purifying Spoon (Ladle)
+  [ZDoB4t7P2OBMRwvh] Purifying Spoon (Tablespoon)
+  [nbRNjXYEx6T0G8AW] Purifying Spoon (Teaspoon)
+  [q11aZe8Gc09QkP0y] Purloining Cloak
+  [naxISKMwhLQ5F9yS] Puzzle Box (Challenging)
+  [1uwONfUHwHjRJp6o] Puzzle Box (Challenging) (Hollow)
+  [6lmTRwT1dNzgWcUd] Puzzle Box (Complex)
+  [9wBwuCi6jo4sfaLb] Puzzle Box (Complex) (Hollow)
+  [ZRaZSTEOpTC1ObdE] Puzzle Box (Simple)
+  [2qJyAnnVIMFIdeTD] Puzzle Box (Simple) (Hollow)
+  [eqrqkIdQHYzueKmj] Pyrefeather Cloak
+  [YmTGzsenhogSNDXK] Pyrite Rat
+  [ToSrWLocAD4AffSB] Queasy Lantern (Greater)
+  [rJan8OyK6gmtxXmt] Queasy Lantern (Lesser)
+  [lqzVHgmpCDnOVZs3] Queasy Lantern (Moderate)
+  [tpkkAtlMIOL8TnW6] Quenching
+  [HhtZl2pr7xChKu2c] Quenching (Greater)
+  [3rlu75EjB2SVAuOI] Quenching (Major)
+  [hGZNrPMdxsabNFLx] Quenching (True)
+  [OFo1349Pems2mboB] Quick Runner's Shirt
+  [hwszIqJguVfoc3ZD] Quick Runner's Shirt (Greater)
+  [teSZWABjhXM4EKXM] Quick Wig
+  [5TX0wX3VtMqriZSu] Quick-Change Outfit
+  [pXMofNAbzT3QbOlJ] Quickened Standard
+  [KnZL0xPWDzQx9vWQ] Quickstrike
+  [idAyVZxTkPSNLbnt] Quill of Passage
+  [xswNe3hrxy0f01QQ] Radiant Prism
+  [POKglmR5IdpEEefR] Radiant Prism (Greater)
+  [tV0vr2oVVl9fWyD9] Radiant Prism (Major)
+  [D836jcTlNR4PHgXS] Radiant Spark
+  [iTxqImupNnm8gvoe] Raiment
+  [VLtEtfIggBKXuy7S] Rappelling Kit
+  [maHPPEwKK2NxbMoV] Raven Band
+  [UaOrOGrjcXgSeBvr] Razmiri Mask
+  [HHxX5hA2RK7yI483] Razmiri Mask (Gold)
+  [Im9gFhIGtTxRJkS2] Razmiri Mask (Porcelain)
+  [eAEZWwzLf6Qr1l0Q] Razmiri Mask (Silver)
+  [fuDYKpDN9RmCX7do] Razmiri Wayfinder
+  [qdXwiDaPdsFtlXGH] Reading Glyphs
+  [k7ExX8IPY7mSzYPF] Reading Ring
+  [7U16hk57BHVM5QYs] Reading Ring (Greater)
+  [QNPwzwKervKpk6YO] Ready
+  [fumxKes1z2hLN2U7] Ready (Greater)
+  [JrvrGairz2itBqhj] Red Thread Knot
+  [Ub1GoxOzuTR1l1r4] Redsand Hourglass
+  [4J87czEOWwbGXE3r] Reflexive Tattoo
+  [7FzmHy7PugYNGkoX] Regalia Implement
+  [HB7VTopmeRZQGc0z] Reinforced Surcoat
+  [vT1LG3uNuCCnZhPq] Reinforcing Rune (Greater)
+  [o65PFCSOyMje6fwi] Reinforcing Rune (Lesser)
+  [1Nhc0C2gdJvIM7Mv] Reinforcing Rune (Major)
+  [x9SNVpAAnXKJeoqp] Reinforcing Rune (Minor)
+  [bvROhtzAez0KP7Vt] Reinforcing Rune (Moderate)
+  [0iPTcAgtbtMj6Lwn] Reinforcing Rune (Supreme)
+  [upzjwQ96cZG0Xlmx] Religious Symbol (Silver)
+  [plplsXJsqrdqNQVI] Religious Symbol (Wooden)
+  [z1okOYtNVnpBNj9F] Religious Text
+  [y8M3fBQEtddg9Lbj] Remote Trigger
+  [GgR1zcLI8daml05a] Rending Gauntlets (Greater)
+  [22mke3o7VmNt3Mvb] Rending Gauntlets (Lesser)
+  [8ypsabK300Sdf2X8] Rending Gauntlets (Moderate)
+  [vLGDUFrg4yGzpTQX] Repair Toolkit
+  [aDsdYMPpVc8hOnM5] Repair Toolkit (Superb)
+  [xIMLqveIz3DOZbRT] Repeater Bandolier
+  [khU38JBZBOAxWzhY] Replacement Filter (Level 1)
+  [vuvRsWXrzHbs0tF5] Replacement Filter (Level 10)
+  [CtAg4DpSssKBIw8R] Replacement Filter (Level 5)
+  [eSjQgsl3pYkirOwk] Resilient
+  [fCdcyCkGlmp0c34A] Resilient (Greater)
+  [WKcvvaZ0LxwYreb7] Resilient (Major)
+  [azZNewz2sEWwZwtZ] Resolute Mind Wrap
+  [PGBAg9ywfdlJCoCl] Resonant Guitar
+  [YqSSNyjG5fkI5HqB] Resonating Crystal Boots
+  [TVpEf9gMFUuwfGoU] Resonating Fork
+  [WvrPq0UGEX3wJg4a] Resonating Fork (Greater)
+  [Shbg6XeBx94DXbcd] Resonating Fork (Major)
+  [Yed5EEEWdJyf2AVX] Restful Tent
+  [pRgnCoqOntDqZchB] Retaliation (Greater)
+  [slkvVyRBrUJyZQj8] Retaliation (Lesser)
+  [XpS6X7QKtMQCVkdY] Retaliation (Major)
+  [vUXtEGa3eFLO5MCt] Retaliation (Moderate)
+  [qlunQzfnzPQpMG6U] Returning
+  [UNOHV2dnRphyNJFw] Rhinoceros Mask
+  [RRZGHR81cUOvu6Tx] Rhinoceros Mask (Greater)
+  [geAAUwfmOc5U0qOE] Rhythm Bone
+  [41MNmuj0PbHnhz0M] Rhythm Bone (Greater)
+  [ZTQLe0i6KHrhnSMm] Rhyton of the Radiant Ifrit
+  [XgO0MTOXdpbfdzr6] Right of Retribution
+  [dmsdzOxdykeWXUHr] Rime Crystal
+  [neanlQgRTZQh2zy7] Rime Crystal (Greater)
+  [p6tS5mzfGkQJLUDp] Rime Crystal (Major)
+  [24o5lk8aOcSrsas0] Rime Jar
+  [8htAYiRxpAmVn9uK] Ring Of Recalcitrant Wishes
+  [xnnVMQZl4i2NuYVe] Ring of Bestial Friendship
+  [GpuzMoZYehYvZ50E] Ring of Climbing
+  [cBKrXbxM02MlycpV] Ring of Counterspells
+  [FABVnBeYtGXshlwm] Ring of Discretion
+  [1rOwO8kOQjpjPXKQ] Ring of Fair Assessment
+  [OTeONq4r10Xm6gSy] Ring of Lies
+  [nLvP7U50hLqz26Uy] Ring of Maniacal Devices
+  [Wkm2VYPsfGjWBtQe] Ring of Maniacal Devices (Greater)
+  [3RPYWoUv1VKGjJ7i] Ring of Minor Arcana
+  [wc1T0d1mGSwJallY] Ring of Observation (Greater)
+  [WNlkRCPzc8YGQOAp] Ring of Observation (Lesser)
+  [geXmZMgU7kVbLHIj] Ring of Observation (Moderate)
+  [nv9riwCAkAXUJYX2] Ring of Ravenousness
+  [yzc8Sll1YMWq8PpR] Ring of Sigils
+  [Ld6K4snDzKbNXy2g] Ring of Sigils (Greater)
+  [GAffuPaxuhSku90B] Ring of Sneering Charity
+  [Ivqd84dkWA8DW8YJ] Ring of Spell Turning
+  [FSo4D0bnDeRAURip] Ring of Stoneshifting
+  [14rbefsoClgClRQ8] Ring of Sustenance
+  [fFx6SEyZlHZtcLGX] Ring of Swimming
+  [tUAfKD2iIrQxHYWp] Ring of Torag
+  [BKFuMxi0dXu7yFxe] Ring of Truth
+  [faKyy6ETkDgrUnvf] Ring of Wizardry (Type I)
+  [2tSDgHfSkkaX4CA4] Ring of Wizardry (Type II)
+  [otCgznS0L14Z46rf] Ring of Wizardry (Type III)
+  [8jPsriZqWY1hAgob] Ring of Wizardry (Type IV)
+  [s97FDCHi2UcfzKGn] Ring of the Ram
+  [oSltacqbeotmzLNJ] Ring of the Ram (Greater)
+  [JWUTLYX1zaBntC1L] Ring of the Tiger
+  [7q3B8wvZFltHTpPo] Ring of the Tiger (Greater)
+  [Xv6NlFohsFtIHp6K] Ring of the Weary Traveler
+  [KFfM3Y8SbhdxpbQI] Robe of Eyes
+  [VToK4BNsTPOMAhHH] Robe of Feathers Fall
+  [OUC64caWaH6xayl1] Robe of Stone
+  [Sdb13IJJMmryDqox] Robe of the Erinys
+  [PtlGktLAPSkBOlzJ] Robe of the Erinys (Greater)
+  [08w0aIB1JRipvrUN] Robe of the Erinys (Major)
+  [1n22FbWdDNC7tLT6] Rock-Braced
+  [HuGZspUvJqR09Y8u] Rod of Cancellation
+  [gEenEoxLjL5z28rG] Rod of Negation
+  [6wVWwpL9pYr3yQtt] Rod of Wonder
+  [kQiO32jZmuxAiqGV] Root Boots
+  [yGgsoSA8EaaEsYZn] Rooting
+  [T5KifnxLN3vWuUJa] Rooting (Greater)
+  [h4n9PdQrOkCrJ9sY] Rooting (Major)
+  [aXqCFjLSSjC3a1Mq] Rooting (True)
+  [fyYnQf1NAx9fWFaS] Rope
+  [gfBAxuitJje6NL7G] Rope of Climbing (Greater)
+  [G4cmHHhAChAlypFN] Rope of Climbing (Lesser)
+  [9XrsaIc80eXhKaoM] Rope of Climbing (Moderate)
+  [QFAHoE7FJ9TPCGWL] Rubbing Set
+  [fti8z0JYDxH63n0J] Ruler
+  [y8DbetZzNdng2LSi] Rune of Sin
+  [f9ASlZXozFrknwd9] Rune of Sin (Envy)
+  [Vjyt4f9XK3HXtGl2] Rune of Sin (Gluttony)
+  [bCOxPYXLL6uGuVCn] Rune of Sin (Greed)
+  [708LeeyJMXFio80R] Rune of Sin (Lust)
+  [EDIbewxih3ihNdQC] Rune of Sin (Pride)
+  [yl0r4LYPZK7DSZuW] Rune of Sin (Sloth)
+  [3vKhyjBGjaN4rNyl] Rune of Sin (Wrath)
+  [2gkG6hqPnSuPrdPD] Runewell of Lust
+  [5QE6CzD1DCnb6fLl] Runic Skullcap
+  [v9ESTiQ7uit08M8c] Sack of Hydra's Teeth
+  [VGOSmuflyPupOZas] Sacred Valkyrie Helm
+  [aQEQkwuAabZG8wY1] Sage's Lash
+  [1AFLQuqBFqGjIfZ2] Sailor's Collar
+  [IOj7cNqBU6nG08tB] Sailor's Collar (Greater)
+  [6eOp2hxFeQNr3KQA] Sambuca
+  [at6rKBw85IkdbmOO] Sandals of the Stag
+  [bbEoBR1OIqmOIX00] Sandalwood Fan
+  [E0hJQdtwwbVrziRt] Sandcastle
+  [4tBK20Atzi5AgCd4] Sandstorm Top
+  [j392AMbPfkcRbCw6] Sanguine Fang
+  [fdntl5OOhtYIPSBi] Sanguine Fang (Greater)
+  [0AxBSojJ2XhcqMvJ] Sanguine Fang (Major)
+  [xyTF5YznEskKIXpp] Sanguine Pendant
+  [6fnjxb9sjrKm0N2r] Sanguine Pendant (Greater)
+  [bQ68sHmEATwgmiyN] Sash of Books
+  [Rr7dAVnfpnnQPAWh] Sash of Prowess
+  [uj09q6x8wPAZcMs9] Sash of Prowess (Greater)
+  [hetazfspeCvrd6rY] Satchel of Numberless Seeds
+  [nx5Y4GybdZqf9rIf] Saurian Spike
+  [u7NB1e1rUqYoQ0nz] Saurian Spike (Greater)
+  [0Tu55QMhTXAijFvl] Saurian Spike (Major)
+  [Q8cPvvyxbFYedlc8] Scapular of Shields
+  [0X1s1F8HmEXu3vEj] Schematic Scanner
+  [hywANJCzT7hMgWna] Scholarly Journal
+  [5rkGXSbaqBbY4MiR] Scholarly Journal Compendium
+  [divPto5fH5FdrV1V] Scope of Limning
+  [YoPUrPBjITTTgMKS] Scope of Truth
+  [vGQ7jbZvYpsEO28r] Scroll Belt
+  [JPVQ0qvTaKkTF2z4] Sealing Chest (Greater)
+  [g9pOZsJykSihdyrL] Sealing Chest (Lesser)
+  [iwC6V10pTd6Sk0ML] Sealing Chest (Major)
+  [nI5x32JWjcEqYCq6] Sealing Chest (Moderate)
+  [RF12ziGVG9YKGaqU] Secret-Keeper's Mask (Blackfingers)
+  [q3Eyp5ncO6lzvGnI] Secret-Keeper's Mask (Father Skinsaw)
+  [OX71iN2SXMWMeI5R] Secret-Keeper's Mask (Gray Master)
+  [gScuJzOR6B0D5sHV] Secret-Keeper's Mask (Reaper of Reputation)
+  [v6J6LjXazHCHResN] Security Badge
+  [eLsmwHVW5qiwcd7c] Seer's Flute
+  [D7ARQDAr9tO61UqY] Seer's Flute (Greater)
+  [QqN3JHXXNveMnjnd] Seer's Flute (Major)
+  [5EDJgEYfktSEa1pr] Self-Emptying Pocket
+  [n528aLyM5kli91XG] Semaphore of Slanders
+  [OCJ2dnG9z5xGEh1q] Sentinel Horn
+  [SV7W0lC2d8mfYuhy] Serrating
+  [XtYQFNEDlEVOr831] Sextant of the Night
+  [DdxmBp8ULtLESATE] Shacklebreaker
+  [0BpLj6rmLsC8LMbd] Shacklebreaker (Greater)
+  [1Md7gEeGcqs7n4iU] Shade Hat
+  [jqaSdm5zp8STSW27] Shadewither Key
+  [kEy7Uc1VisizGgtf] Shadow
+  [bSm0Hki8N2L50OZw] Shadow (Greater)
+  [2FjdEflsVldnuebM] Shadow (Major)
+  [ZEf04zjwyiq1pLPj] Shadow Manse
+  [1T1TJB929nC7wBtC] Shadow Signet
+  [kOanU8MQt6KFmRy0] Shadowed Scale, the Jungle Secret
+  [3HR6rJT9NrIRUwe2] Shadowmist Cape
+  [Dntj7zwUTmj4fboD] Shapespeak Mask
+  [MjW8mZrCUw1lEhGP] Shard of the Third Seal
+  [qFgIZQhyn5JOYkKr] Sharkskin Robe
+  [CWoEVroYgXBYtYaU] Sharpened Canines
+  [o8l0mvCHAnQUfD6o] Shawl of Seasons
+  [LYT2X05grQJxx5qe] Shell of Easy Breathing
+  [QVmITUIiWDWMEPgg] Shell of Easy Breathing (Greater)
+  [fnyjcHzySnUxxSeW] Shield Augmentation
+  [XV2EHt1RWHqzPeUT] Shield Sconce
+  [8y3c9suf90ww60gU] Shifter Prosthesis
+  [roeYtwlIe65BPMJ1] Shifting
+  [obtuYCjovpcVaaHQ] Shining Hackle
+  [YVtXlsEWb3NIkDyy] Shining Symbol
+  [M7c4uXraP05HYNXs] Shining Symbol (Greater)
+  [etnis6HOeGZEbScD] Shining Symbol (Major)
+  [z6eQdPTgSxTLR1Qr] Shining Wayfinder
+  [NVst7e69agGG9Qwd] Shock
+  [TEa1oKZbwsOvC6TZ] Shock (Greater)
+  [QNaCujl2faKRyLD1] Shockwave
+  [aR0tsZ3xi1iwr53u] Shoony Shovel
+  [oJZe5rRitvioUgRh] Shootist Bandolier
+  [6o6zvitwlNHNaNJM] Shot of the First Vault
+  [rcJwqJ88ubcRDFJH] Shrieking Key
+  [XLuRWK7QluA2NUNn] Sibling's Coin
+  [KGA495XLcsDVonEt] Siccatite Chunk
+  [Y5wqlqkmWy38vgeK] Siccatite Ingot
+  [Ktqezky8OHQKFrXi] Sifting Pan
+  [9wjpW7vZJw5xA1yG] Sigil of the First Clan
+  [USHK6XQRwmq17xKh] Signal Whistle
+  [XlmoKh60WMF9ou3J] Signifer's Mask
+  [TkSY6tUfnsgd8xC7] Sihedron Medallion
+  [UfzRhqqph3CtTaKT] Sihedron Medallion (Greater)
+  [SBaAJjHhZfZTqbz5] Sihedron Medallion (Major)
+  [gXxplAToptbrUS3D] Sihedron Ring
+  [RnSXwckGSwOnHz7F] Sihedron Ring (Greater)
+  [0BEbpOMBo7ET8NsR] Silencer
+  [ojbsJu6Uq269xx3U] Silent Bell
+  [iFkgpzf67iapKfyD] Silent Heart
+  [vhhjN70J1j3RfECJ] Silhouette Cloak
+  [Ak5bxEDdFMnpYD2L] Silvanshee Collar
+  [Ld8duhvwTQ5lCQmF] Silver Chunk
+  [jerA2fFiK5wb32r5] Silver Ingot
+  [Cu9r7tKPL5lYbFSR] Silver Snake Cane
+  [A7TCZXIwyxdqYSas] Singing Bowl of the Versatile Stance
+  [MM44urhBdG0x98bc] Singing Stone
+  [QDYPr19De3TBIysx] Sinister Knight
+  [YWSHEEsfnAW1i9Od] Sinuous Recorder
+  [GGsECHQJ3RrnWXhV] Sisterstone Chunk
+  [nI4JorlalCpzsJ07] Sisterstone Ingot
+  [Z5FvYWLEpWVo3PUF] Size-Changing
+  [Jp9K5Q9t9ZiDGSaI] Skarja's Heartstone
+  [fprUZviW8khm2BLo] Skeleton Key
+  [AFE073UYI0mkWuUs] Skeleton Key (Greater)
+  [sgH9U2fKqWCedKNO] Skinsaw Mask
+  [gjigpt5xi68xm2ub] Skirmisher's Coat
+  [599vQVSFAKMzvVEt] Skittering Mask
+  [y8T7k0kkqxNbMAAD] Skittering Mask (Greater)
+  [mQTRsxgl7ST3GaRL] Skybearer's Belt
+  [vSctvZGoJYTHjpZV] Skyfang Crystal
+  [pze7NQzMOhUxvkoM] Slashing Claws
+  [1IeT2jIpBxxUo1uD] Slates of Distant Letters
+  [uQOaRpfkUFVYD0Gx] Slick
+  [LiJMupjynmkM5Mld] Slick (Greater)
+  [9imz3VgBXCg13RfT] Slick (Major)
+  [skBa6D1uxb0b2USn] Slippers of Spider Climbing
+  [td9LuqG8jhQQloG7] Sluggish Bracelet
+  [uSwylNGP5We9uUw4] Smogger
+  [eTkMiedmXpSsnaod] Smoke Veil
+  [XndR8hsJyCsVfZOi] Smoked Goggles
+  [0OzL3DdtTnZE91MU] Smoky Hag Eye
+  [4OqBL6zYcGU7ZsYw] Snagging
+  [yUSrm2I9aygMeME6] Snare of Speed
+  [AnJiuDSgJ1uBYRaZ] Snowshoes
+  [aneZJVb3sbpG2fN7] Snowshoes of the Long Trek
+  [81aHsD27HFGnq1Nt] Soap
+  [CJtn848AL7Q0Lxf2] Soaring
+  [aaua3vcUXyBFpRe9] Soaring Wings
+  [oCwTZg3JuwLSA7Yj] Soaring Wings (Greater)
+  [pIy2L56i70OUd2HZ] Soaring Wings (Major)
+  [qMmg6e6GlMAM0F39] Society Portrait
+  [eqnm5vYNmDl37V5S] Soft-Landing
+  [qFVPeeJ70B1u2n81] Soul Cage
+  [nYrOmi22AN0XDtCO] Soulfeeding Mask
+  [a2yYccCg6ZWvJkdo] Soulspark Candle
+  [9ajoltiJ2T60MLAh] Soulspeaker
+  [f0lZf1oZYDEEeyYl] Sovereign Steel Chunk
+  [xuTO0Lbu999HnBhK] Sovereign Steel Ingot
+  [cICCgx4NJKSREeZD] Spare Wax Cylinder
+  [vncchGeyuAYRtfxr] Sparkshade Parasol
+  [OdpmSFarov2qUoyN] Sparkwarden
+  [RtQwbPiJs2FRyfNE] Specialist's Ring
+  [FTTrNjLsSlrPvkLi] Specialist's Ring (Abjuration)
+  [nE12I5dTvJFPr9at] Specialist's Ring (Conjuration)
+  [nyLV5YVh90kYGaBd] Specialist's Ring (Divination)
+  [gKlxurDeLS95zuuY] Specialist's Ring (Enchantment)
+  [6MswPHUwvqPLtN5H] Specialist's Ring (Evocation)
+  [H44rJpMzx6JyoKoa] Specialist's Ring (Illusion)
+  [PjCowzEMV2aJnHkV] Specialist's Ring (Necromancy)
+  [Jt3q4i2FlRPZ14VV] Specialist's Ring (Transmutation)
+  [AbgcicGqoHJZJun3] Spectacles of Discernment
+  [mxI7Ah8eZNmonNKj] Spectacles of Inquiry
+  [uHUQnRGSKy655bTt] Spectacles of Piercing Sight
+  [x4l3JjePzROLDSK6] Spectacles of Understanding
+  [ZKFmyG9fIoQWIrql] Spectacles of Understanding (Greater)
+  [SsXS70dp2UnFCtdw] Spectral Opera Glasses
+  [adFsNoFwHnWuMgPm] Spell Bastion
+  [zFdo0aBUw6cHEucT] Spell Duelist's Siphon
+  [payq4TwkN2BRF6fs] Spell Reservoir
+  [FOWF5f0tCaApv9RE] Spellbook (Blank)
+  [k9DHki1JS7FBG0Jx] Spellbook of Redundant Enchantment
+  [qfyvOY3JTGUkOipr] Spellwatch
+  [B4DnQNcGl6nFVKHl] Sphere of Annihilation
+  [6nJZGgIJIY3x0b1Q] Spider Chair
+  [F4jOdM3qhYELTz1I] Spider Lily Tattoo
+  [GSVzDZFbnreVWGRD] Spindle Key
+  [AYg155apTZtebV4Z] Spiny Lodestone
+  [wnWo9t2mNV4YaH37] Spiny Lodestone (Greater)
+  [aBMTXPmHg9EDe2R6] Spiny Lodestone (Major)
+  [UlTQEI52DA1Z3dTc] Spiral Chimes
+  [qwHO8kRNKPqCM80x] Spirit-Singer
+  [POETsrh8lz9VnBEG] Spirit-Singer (Handheld)
+  [MHvmgUSQlMAevvoF] Spirit-Singer (Incredible Handheld)
+  [aU3vBG9EinYgYlWb] Spirit-Singer (Incredible)
+  [hAPCk1A2a4kJDzhV] Spiritsight Ring
+  [2KnSYPFGKz4MDeiW] Splatrope Extruder
+  [ci9SM1RcrbR2aIoG] Spleen Bloodstone of Arazni
+  [0VtYhRt2BneBzh32] Splendid Floodlight
+  [Z5xNCrAN3TgdFTOV] Splendid Pyschopomp Mask
+  [HYnwTFuLsFSsUAMG] Splendid Skull Mask
+  [02luiB9xtE1yaKzo] Splint
+  [MEJfmtMXXnIV4Lzx] Splinter of Finality
+  [vpIrK1jV9yFihbIm] Spotless Spats
+  [IVaQrUnLCzTZIfP6] Spring Heel
+  [dFoQzB7B1cA9dwMc] Spry Sinews (Greater)
+  [giDq25tzS7rWG9ch] Spry Sinews (Lesser)
+  [HSAj9FBx2yAyjfzf] Spurned Lute
+  [UtRH6jt3iNFCgLLG] Spyglass
+  [rV7MTDCseZmEZKDw] Spyglass (Fine)
+  [8WtXK4cyYcls72Yf] Spyglass Eye
+  [OhCgwW4g6A1mbjmH] Squid Ink Sac
+  [LIC729BMKnEJGgUW] Squire's Tabard
+  [u4mB03FhvuJ7DcX8] St. Alkitarem's Eye
+  [k8YWyDliEVj4iA0p] Stag's Helm
+  [N5jtL8lLKW0Yzd8e] Stage Magician's Cloak
+  [iKKZdkn8KQJSuRjY] Stalk Goggles
+  [U7UVGM93EaNc6lzY] Stalk Goggles (Greater)
+  [cbbPoYOil7DZO4mk] Stalk Goggles (Major)
+  [de8DDy0Qi5tdeNWh] Stalwart's Banner
+  [rZJipZrmJzfoROZI] Stalwart's Banner (Greater)
+  [uUIbYZgT6c74F6T7] Stalwart's Banner (Major)
+  [bhpYiOmBysl8ZEYn] Stalwart's Ring
+  [fUzFWIPK4mdZSGyH] Stampede Medallion
+  [vp2q2h2KoVjRs8nL] Stampede Medallion (Greater)
+  [aR4rXlJnDg61SUBL] Stampede Medallion (Major)
+  [NJtIwMIzjdRqupAM] Stanching
+  [ioLWDzXp2dG7ZMHf] Stanching (Greater)
+  [ZTdRDRew1B0zTGiU] Stanching (Major)
+  [dLYifig01WulSNVF] Stanching (True)
+  [n8nmqJdfHrDfuG1J] Standard Astrolabe
+  [c3dFpmXsIxH2i8ug] Standard Book of Translation (Tien)
+  [isWSWeuJR2cYVdfi] Standard of the Primeval Howl
+  [BxoCXx6VpeS3puog] Standard of the Sure-Footed
+  [dUKVwr8nwMgn7CiJ] Standard of the True Ally
+  [FNNfdpu1SfZtLohQ] Star Chart Tattoo
+  [oPZ2s4KmwaNXiUcc] Starfaring Cloak
+  [GuVgH50cUeytM68r] Stargazer's Spyglass
+  [mUJc8M1gKG1HkH4m] Staring Skull
+  [TYdFnzhhTlpUdtty] Starless Scope
+  [QRtsLdNvTs2C1oI2] Starless Scope Lens
+  [iX25AmfeRbV3M1EF] Steadyfoot Tassel
+  [EiCCWG0Xta0ZBUfA] Steam Winch
+  [QbyF8jJ93SnN6NVL] Steamflight Pack
+  [dRVDcmkaB2p8zPcs] Stole of Civility
+  [3GnTrwAfD00zW2cO] Stone Circle
+  [adqiLRzIEHiG356b] Stone Circle (Greater)
+  [mmQT6AZjXO1ty3dv] Stone of Encouragement
+  [JOswp4pSSevZFeNG] Stone of Encouragement (Greater)
+  [pLAggVa6iDN4cpsz] Stone of Unrivaled Skill
+  [EuEH4f3oDUQ4YFZS] Stone of Weight
+  [YoRL8PkjYInpmBWl] Stony Hag Eye
+  [AiYlhL35OEtkqsHo] Storage
+  [OOcgMpqQzk22n6rl] Storied Skin
+  [RBlbAZSGAJOBsmjv] Storm Chair
+  [E89arDdt5UWiAGMY] Stormshard
+  [0gocfTNAWRHddgua] Stormshard (Greater)
+  [NrzzXDhoWZdJvhVG] Stormshard (Major)
+  [1ii8hvKjkf71wYMx] Storyteller's Opus
+  [XPcTty0E1jh4OIzT] Strand of the Seven Births
+  [DxCuJKynlnMQZHgp] Striking
+  [KCQRFvUgbyclvOGi] Striking (Greater)
+  [woxl2FrrgAcJDu0t] Striking (Major)
+  [PBqHMoiH47uRTL3C] Sturdy Neck Stock
+  [bdbBRucjvg0eYazY] Submersible Helmet
+  [mp20ggzn4790lalQ] Submersible Helmet (Greater)
+  [j42OKMXPsp6Mg7nY] Subtle Armor
+  [6ZM8fiFi6QF7RNxM] Successor Doll
+  [ImokJgCMIb0dFyKH] Summoning Handscroll
+  [tWgN8hQbHlHNMTcF] Sun Dazzler
+  [kK0ClM2NkZYKVs2Z] Sun Goggles
+  [tULEDu1O4fzhyBeB] Sun Herald's Stylus
+  [3b0wleCdaPw3c9UX] Sun Sight
+  [WW8uv3Nhg56UTZ35] Sun Wheel
+  [ZeXTbx8MhQQ6ylhU] Sunflower Censer
+  [752IrectHHkJwxd0] Superior Catch Pole
+  [BbWTlbl43SmPNIdo] Support
+  [4aK5kCliPesu3nIK] Supramarine Chair
+  [toest6lPgkXHI3cy] Sure-Step Crampons
+  [UhcRWtnjU2WLSClx] Survey Map
+  [1M4SSDuTv2SwBltC] Survey Map (Atlas)
+  [JMp26rF8pRdL6osi] Swagger Stick
+  [BKjwg0TEGioiYpz1] Swallow-Spike
+  [ciykvIC4SFFxIfUw] Swallow-Spike (Greater)
+  [RRFyASbHcdclympe] Swallow-Spike (Major)
+  [dPQhe0tAa5LkPFoW] Swarmeater's Clasp
+  [GUyavibqPPxwFxyR] Swarmform Collar
+  [z8nKK4rSUGQVT2t9] Swarming
+  [5dM1ysuBsLj0OWIv] Swift Standard
+  [WJkVwjoSsGU2fAgi] Swift Standard (Greater)
+  [i2krvXNn4QQfh3ov] Swift Standard (Major)
+  [K0uJJSso0WGpFzYe] Swiftmount Saddle
+  [KIpkxwuPWt0rOGT1] Swim Fins
+  [ea3GR5yMleIWZmfZ] Swooping Wings
+  [BHjJpNILf85M2LJE] Symbol of Conflict
+  [Wtm4JdxeTLQi3zQI] Symbol of Conflict (Greater)
+  [C7FeT7eVuwRnLhJy] Symbol of Conflict (Major)
+  [SUgFSQJWnfTcM1ZJ] Tablet of Chained Souls
+  [Bu2xT8NfB6xaeTJa] Tack
+  [q6Wdgi5fE1zovsYh] Tactician's Helm
+  [NRXhQD5bLM3H9YGR] Taldogis Badge
+  [ktzQ3WItAfMk25hM] Talented Tap Shoes
+  [XQFEjwQUCXl68Pva] Taleteller's Ring
+  [HvmIoRCaQJmkwluG] Talisman Cord
+  [62ZOnGqCMlXCHngg] Talisman Cord (Greater)
+  [tnPteWjbm97bdTj5] Talisman Cord (Lesser)
+  [imBDGoQJnvfWYuLC] Talisman of the Sphere
+  [dPg0hrkIaCdMKQoK] Taljjae's Mask (The Beast)
+  [JSbBiTCtFctuJFhS] Taljjae's Mask (The General)
+  [ma4BlTSjaMHrQmoz] Taljjae's Mask (The Grandmother)
+  [d8w28UjKHALM2GNu] Taljjae's Mask (The Hermit)
+  [2LO9eMNpQiku5UDn] Taljjae's Mask (The Hero)
+  [4jzASWzF2riszO3U] Taljjae's Mask (The Nobleman)
+  [nbBtszla32wRC1bp] Taljjae's Mask (The Wanderer)
+  [DsZ48n6mn8uW5EIP] Tallowheart Mass
+  [JU0fzXWJIdz9WOGF] Tank (Stationary)
+  [S0hmnalGCudgXaLG] Tank (Traveling)
+  [sOaRakKoNQWTAc1e] Tasset of Flexibility
+  [OMoKdkWjmT59LCJo] Tattletale Orb (Clear Quartz)
+  [RFFUd06PQH4csvpr] Tattletale Orb (Moonstone)
+  [4j5tJ27qfBN7Xd6d] Tattletale Orb (Obsidian)
+  [skQIdQ0RKXGCHJGM] Tattletale Orb (Peridot)
+  [dgwgVWUvXGurnsQD] Tattletale Orb (Selenite)
+  [OAjI2eaXvHQRrERK] Tear-Away Clothing
+  [2VpuNz8EyXpvUf7P] Tears of the Last Azlanti
+  [KwqN8qNqp3AFwFbn] Telekinetic Converters
+  [ccsgob2TZ7WqTrp7] Ten-Foot Pole
+  [KekfZ6eRzoZVRemw] Tengu Feather Fan
+  [JlClrm1WfJ45oWcS] Tent (Four-Person)
+  [xyzmQa3nhU8HxfUL] Tent (Pavilion)
+  [Wc9og4mTKZDH3xmz] Tent (Pup)
+  [JX3jtgTsVORseYKz] The Avalanche
+  [J0xCt39KNqUunhEr] The Bear
+  [1I90sDJk6SFokiyl] The Beating
+  [MXDA5rDemvT1O9vY] The Betrayal
+  [jwEAO4hCOKrM6i6c] The Big Sky
+  [FposU3NmF0IbrOdz] The Brass Dwarf
+  [FiCTRh8rXOXlKxQB] The Carnival
+  [X28YoZkN6UJYYYYC] The Courtesan
+  [z5EYyT8CMZkcj9qW] The Cricket
+  [y1vxwZhnvjBz9HRn] The Crows
+  [04GSFcLNlw1w2lAY] The Cyclone
+  [rzcqiPZHpv0I1Jab] The Dance
+  [QPWWO89YR0uZ881r] The Deck of Destiny
+  [28euk1w2rSWTcj5Y] The Demon's Lantern
+  [xdNAAIVFQsAEiXmL] The Desert
+  [qPpfc0srQodOiEga] The Eclipse
+  [owR8clECtufA8q9h] The Empty Throne
+  [IfOwz6UoG7pnfbur] The Fiend
+  [kd4iBsB3pLkc0Lfc] The Fool
+  [ogE04B74e90cyCUz] The Forge
+  [oelHQXS1g7Xk7xKo] The Hidden Truth
+  [MPwrN4KBPycME0tl] The Hollow Star
+  [kLmUKkch8meabELi] The Inquisitor
+  [eYhUB8qyBKsmJDDf] The Joke
+  [2HByGOXi57zbP5VP] The Juggler
+  [dP5OmTGy0NJl4a1D] The Kardosian Fragments
+  [nJSlIxnU1s9H83NK] The Keep
+  [F2uej7timkyYGg83] The Lens of the Outreaching Eye
+  [DKQrQkx13z6yiUNp] The Liar
+  [yHaZJDX7xe8gPdL6] The Locksmith
+  [mFweSeoHRIiAjcqz] The Lost
+  [fqVYXvfhHIclVnu2] The Marriage
+  [3twiNkpDG862fnnY] The Midwife
+  [dB5oALF9UzMdE0MD] The Mountain Man
+  [eTerYHAbXk9qwpgU] The Owl
+  [ZcLscdldjI8xJnC7] The Paladin
+  [1qlJqqsVhocRLtS5] The Peacock
+  [XyoYrGEAhJ3iCahe] The Publican
+  [2nKh3kUMuq8I9rnm] The Queen Mother
+  [XDiBtW7A9lelBGeY] The Rabbit Prince
+  [W2yfqo9Oy8zyoOrA] The Rakshasa
+  [e1w2q9r309N5gZ7E] The Sickness
+  [cCnpBUjaGSNCT3JK] The Silent Hag
+  [RCtvSgzBCsyaztOj] The Snakebite
+  [XshcAhe0ZbhpqIq0] The Survivor
+  [85hapkvhXc6Oa8XC] The Tangled Briar
+  [Vmyrv2H5cs4H64H1] The Teamster
+  [Qh65GD5oXOhO5y3k] The Theater
+  [Suk2LiODbjftQ4lL] The Timeless Bond
+  [QuGCW9Q4n56VORV6] The Trader
+  [O1VdFSf81VZQg428] The Trumpet
+  [JwglAlCKM7FRRUxq] The Twin
+  [IVGLVPxVorpTM8GL] The Tyrant
+  [9RxwktkuKHF9ud2L] The Unicorn
+  [BdQjSNSItoruWMul] The Uprising
+  [HaakvCTFbCnwFHVY] The Vision
+  [8wjCvABdXIYQJ7bI] The Wanderer
+  [HXvS7TIFFcioESqA] The Waxworks
+  [QT1jTPlf3ATYUh4I] The Whispering Reeds
+  [9JfZz5TpX0Kt6XdE] The Winged Serpent
+  [fPqFZ2c0MWU89nNC] Theater Enhancers
+  [zvLyCVD8g2PdHJAc] Thieves' Toolkit
+  [BznmPaRjI4Orb0IH] Thieves' Toolkit (Infiltrator Picks)
+  [6nrCxNQFycUVFOV2] Thieves' Toolkit (Infiltrator)
+  [Sw7MBLASN3xK4Y44] Thieves' Toolkit (Replacement Picks)
+  [TxMFNfkoccirCitP] Thieves' Tools (Concealable Picks)
+  [Ejmv9IHGp9Ad9dgu] Thieves' Tools (Concealable)
+  [7MTjAlCVVLsNFo7w] Third Eye
+  [j1To2GxVU46H1uOG] Thorn Triad
+  [3LJ3l5QKyjxiVBbu] Thorn Triad (Greater)
+  [XIQmnhUfmhojIZT7] Thorn Triad (Major)
+  [c0tITjJAX5nc2xXx] Thoughtwhip Claw
+  [Qp3FW0dmSed1iBxA] Thousand-League Sandals
+  [TuPCnRFdvOboUzx7] Thrasher Tail
+  [PkSxW5gxIU5P83ia] Three-Pillared Yang Na
+  [HEtJeLXMcMbgamxd] Thresholds of Truth
+  [VUxPhU966hQaIq2C] Thrower's Bandolier
+  [ydpA0pz0pPNqIUXU] Throwing Shield
+  [GVgA0w4CUP4lanPl] Thunder Helm
+  [LV8nFuV3NiNYlxpo] Thunderblast Slippers
+  [cEXLUGa9qTh8Y6kX] Thunderblast Slippers (Greater)
+  [dTxbaa7HSiJbIuNN] Thundering
+  [Lb7F2BR9X9TF1vjX] Thundering (Greater)
+  [VBCk7JXGsuG0cug1] Thurible of Revelation (Greater)
+  [xaWuuQoBJiMLzggR] Thurible of Revelation (Lesser)
+  [QEPx1fCf74xdpXBH] Thurible of Revelation (Moderate)
+  [KKhw57JFYEUO4TnK] Timepiece (Desktop Clock)
+  [zVXDnx8i0KLf6fkF] Timepiece (Grand Clock)
+  [E8enukNHPfK86DGc] Timepiece Standard
+  [LLJy5YpLULtzyXWu] Timepiece Standard (Major)
+  [bEJqfbnM5QOEXXdR] Timpani of Panic
+  [erP57YMboay9Ns4L] Titan's Grasp
+  [hIDRnAzAACHOoCZS] Titan's Standard
+  [0LfgYMONUws8lzOv] Tlil Mask
+  [FPDe2DQv8HbkN4tz] Tlil Mask (Greater)
+  [OXZHwDQVxDXxEYTv] Token of Salt and Earth
+  [V9mhR91d2qWa3dGh] Tome Implement
+  [Rf9sn0afKTzyFgaH] Tome of Dripping Shadows
+  [m9v1YKUvQuFGVZ10] Tome of Restorative Cleansing (Greater)
+  [KqzTdCwrfoqfSR5b] Tome of Restorative Cleansing (Lesser)
+  [NwyyVc5G6zUbcXRs] Tome of Restorative Cleansing (Moderate)
+  [GkQJfRZC749piiBr] Tome of Scintillating Sleet
+  [wrpI5z7iWB8XvflQ] Tool (Long)
+  [Zr4PwTEuBLE30kkn] Tool (Short)
+  [aUohYRQ8lHzgblxi] Toolkit of Bronze Whispers
+  [LM5zag6Ogv1fF5zz] Tooth and Claw Tattoo
+  [Ck2nuiQXkoURspvy] Tooth and Claw Tattoo (Greater)
+  [NYehHw93LSgGG9vD] Tooth and Claw Tattoo (Major)
+  [8Jdw4yAzWYylGePS] Torch
+  [JvIqB42cTweMtxMO] Tornado Trompo
+  [tzoN71erFxQ2HVLl] Toshigami Blossom
+  [P21m8mTOynuoJXaR] Toxic Blood
+  [85FCQF18RslpIhPs] Toy Carriage
+  [SHhSOqzt89GRk9kL] Toy Carriage (Windup)
+  [ZEqAx8jEc6zhX3V1] Tracker's Goggles
+  [OYeYYJ4i66VtGY3O] Tracker's Goggles (Greater)
+  [kD9pDXNDctW6smjU] Tracking Tag
+  [QPz923dZeG1TajQE] Trackless
+  [0Oqf8wHY8PYJQQTx] Trackless (Greater)
+  [ImedbomHGVFtE3D7] Tradecraft Tattoo
+  [0zBuCoOeNkIwi8bj] Tradecraft Tattoo (Greater)
+  [vM88qqJrUo3Yqth4] Traitor's Ring
+  [nNtakXnSrcXWndBV] Traveler's Any-Tool
+  [JFd6QBDtSNC43dy0] Traveler's Chair
+  [MHJLBBESka5n3Bsg] Traveler's Cloak
+  [C5vVNVAHO5Kfaveo] Traveling Companion's Chair
+  [teMhnTeAyWnvbo2C] Tremorsensors
+  [ZIs2lAIDasxshMCf] Triangular Teeth
+  [kILYXCczAc6ZfArJ] Trickster's Mandolin
+  [Pq7JhHw3QhqqxY9d] Trickster's Mandolin (Greater)
+  [18ztTUiUZNjuc7K1] Trickster's Mandolin (Major)
+  [lN3Fn9AuNcKbXucJ] Trinity Geode
+  [5W86t6I92rRNSmwR] Trinity Geode (Greater)
+  [2sr23ZSpplB1oBHd] Trinity Geode (Major)
+  [ty9LXqqYAnlsTh46] Tripod
+  [KLWjINVkWwJlOZEX] Triton's Conch
+  [h7OCAvvnUnCIM9Aj] Troubadour's Cap
+  [I8XecIUYhwagAnXv] Trudd's Strength
+  [wvo5Qaj5qn7jFHaA] Trudd's Strength (Greater)
+  [dABsOA9Qiy0nkGgV] True Name Amulet (Greater)
+  [KnI89eneLdJeURob] True Name Amulet (Lesser)
+  [D9OGy69XaLBwjdd1] True Name Amulet (Major)
+  [t28PWYfoGoj1Sq3e] True Name Amulet (Moderate)
+  [OLM87MUxqc0ZISHr] Trundle Wheel
+  [u5f4qM8f0N4lE0Gn] Trusty Helmet
+  [aFi3p8CEYEM8ZNTT] Tubeworm Gland
+  [i8VDsM0MRVpqC8zu] Tumbler's Belt
+  [OmiMLervOVa8G8zK] Twilight Lantern (Greater)
+  [Q5YwZv3PbCHkEImh] Twilight Lantern (Lesser)
+  [0Bp6uVAX4AvjhsOI] Twilight Lantern (Major)
+  [hpNsjNQn9Gg6N8Kh] Twilight Lantern (Moderate)
+  [ldf2QDuEUN5DFjBV] Twilight Tattoo
+  [VKHKaCMRF30GWvZ0] Twining Chains
+  [ULHYQIoVL2gKN7TM] Twisting Twine (Greater)
+  [wJTpzqL8EJ0xVW0y] Twisting Twine (Lesser)
+  [5QbocabfxRZjb3qn] Twisting Twine (Moderate)
+  [jfLMxToNvg2VzjSw] Tyrant's Writs
+  [ogvooWFhMgB50iXE] Umbraex Eye
+  [NiO3YZ6e9RmajCS7] Umbral Wings
+  [fr2K2wJnSLD0ERpo] Unbreakable Heart
+  [4yUa5JicrhnHUggC] Undead Compendium
+  [vxUKhnRhTSGT19aq] Underbrush Cloak
+  [yK5maWEcZ0pNnFwq] Undertaker's Manifest
+  [5QKAoWrpSetjHVJs] Underwater
+  [E5gjsRSO6SFFlKpB] Underwater firing Mechanism
+  [gufc2pmaYn9jzFVL] Unending Youth
+  [lasRdOMO1w9IMdwx] Unexceptional
+  [7YkaMoB3YfYRZ21G] Unfathomable Stargazer
+  [NYgt3535CdDF9WJs] Unfolding Tree House
+  [gmMrJREf4JSHd2dZ] Unholy
+  [uU8bqDR4oWITWZNX] Unifying Emblem (Lyrune-Quah)
+  [NJRACLvg6ULRMtZB] Unifying Emblem (Shadde-Quah)
+  [JhSCwXhC3tLhI347] Unifying Emblem (Shriikirri-Quah)
+  [qNMOpzpeQz51vMhf] Unifying Emblem (Shundar-Quah)
+  [bw2RNhvtX1vvHi0y] Unifying Emblem (Sklar-Quah)
+  [BhSQej6dIZh6wkWC] Unifying Emblem (Skoan-Quah)
+  [zTR7xbJGFm3oppFA] Unifying Emblem (Tamiir-Quah)
+  [3zgX1Uvwv3R262IV] Uniter of Clans
+  [Oudcra1CGDmUq0BH] Unmemorable Mantle
+  [e4lHxftAOoTmGXuG] Unmemorable Mantle (Greater)
+  [HcjEb07UjWchysx5] Unmemorable Mantle (Major)
+  [3G2No6QaU1wSPTh6] Urn of Ashes
+  [QgSPvZupjCsWhqAp] Ursine Avenger Hood
+  [IIG33n6yrNjz07Ir] Uzunjati Storytelling Amulet
+  [76G48WrYc7DHoJRI] Vandal's Banner
+  [SCkQb4QdFWkATiby] Vanishing Wayfinder
+  [UMTeKNfyj95JMwMM] Vaporous Pipe
+  [LmveO9fSuEnkMKAH] Vaultbreaker's Harness
+  [Jn0PNvEONsnhYFO9] Veiled Figurehead
+  [ggAuloLn6sZpEgT9] Veiled Figurehead (Greater)
+  [GMcU4kX1ldrSQMh6] Vengeful Arm
+  [oYFeq5nbGKx7VfuF] Venom Glands
+  [dChkPrLJfZDPBvWR] Venomed Tongue
+  [1r6StS0irdvi5JHY] Ventriloquist's Ring
+  [dolBtAdB5lpQpQpp] Ventriloquist's Ring (Greater)
+  [KAOlwH6kBCCvEYbW] Verdant Branch
+  [vqHSVgQJktWTXiDK] Versatile Tinderbox
+  [PCQtpTKiGfSSRwNV] Vestige Lenses
+  [1JHPSOUD7Ij75OAf] Vial of the Immortal Wellspring
+  [1gmWdViYy3zgaW5c] Victor's Wreath
+  [4RBeMHw6u9pxNDpo] Vigilant Eye
+  [klMBWHVZ5EFU4cTI] Vigilant Eye (Greater)
+  [ONzSIJgJV27SHIMH] Vigilant Eye (Major)
+  [Jmd2LUSqdvxmxHGW] Vine Baton
+  [pXOPMJC9NAuwXz3w] Violet Ray
+  [xtSMGL3f9c5ZHUAm] Violin of the Waves
+  [LxTtq31HIP8KjBH3] Viridian Crown
+  [LwQb7ryTC8FlOXgX] Vitalizing
+  [oVrVzML63VFvVfKk] Vitalizing (Greater)
+  [sjGt3r0pgI1zwc9t] Vocal Shells
+  [AK4rHlYOHkcboCnq] Voice From The Grave
+  [uWe8GXBjAdA0q4ad] Voicebox
+  [YiitcoNxawdhTO1e] Void Mirror
+  [XJPHem2m0Yjm2VYe] Void Shackles
+  [l0UMYlCZEUaHExKt] Volcanic Vigor
+  [Eft7NqspkOtGv1Ov] Volcanic Vigor (Greater)
+  [6xaxxKfvXED6LfIY] Vorpal
+  [HfQLNzRcQNMUL6Ux] Vortex Pouch
+  [aV7cXniPdT6tEI2l] Waffle Iron
+  [TPQjZzF9yioMr9Bu] Waffle Iron (High-grade Mithral)
+  [STF54Mk8rE7uSMbv] Waffle Iron (Imprint)
+  [ADruUHNWh2AuxJFb] Waffle Iron (Mithral)
+  [Zmz2M2u7mGOCbUf4] Walking Cauldron
+  [AL46eDfKdAnXKQPV] Wand Cane
+  [ZjApNlusD5oZkPTJ] Wand Implement
+  [a60NH7OztaEaGlU8] Wand of Continuation (1st-Rank Spell)
+  [5V9bgqgQY1CHLd40] Wand of Continuation (2nd-Rank Spell)
+  [R88HWv9rw1VNMRer] Wand of Continuation (3rd-Rank Spell)
+  [bCsdAkffuk29ssUg] Wand of Continuation (4th-Rank Spell)
+  [tDEi3zLVpxwA74qz] Wand of Continuation (5th-Rank Spell)
+  [35rLqxDWgiDIkL8e] Wand of Continuation (6th-Rank Spell)
+  [H1XGrl6Z0bzXN2oi] Wand of Continuation (7th-Rank Spell)
+  [KMqHzKfpPq5H8GOo] Wand of Continuation (8th-Rank Spell)
+  [QgNp6uyKuV2PiNbf] Wand of Fey Flames
+  [zNtC1DsiAUYeHfDN] Wand of Hybrid Form (2nd-rank)
+  [rns5Uvpgf8rSbOEX] Wand of Hybrid Form (3rd-rank)
+  [jx1a74ytWBN2ylD9] Wand of Hybrid Form (4th-rank)
+  [8CmzsexkT42I30Pl] Wand of Hybrid Form (5th-rank)
+  [tFhNIL308HpiDFtS] Wand of Hybrid Form (6th-rank)
+  [3xoboDAmMZcmvK59] Wand of Hybrid Form (7th-rank)
+  [S9IVIHLrjnRu1x3o] Wand of Hybrid Form (8th-rank)
+  [v8Dx5ABBpPFafIgy] Wand of Hybrid Form (9th-rank)
+  [z2QXO8vl0VsXaI1E] Wand of Legerdemain (1st-rank)
+  [zaJ4HSNa6kMozYvM] Wand of Legerdemain (2nd-rank)
+  [XPqKEI246hsr9R6P] Wand of Legerdemain (3rd-rank)
+  [4hsPZ6rBpLKOlDjm] Wand of Legerdemain (4th-rank)
+  [pdsepgrBRgdZ4DWm] Wand of Legerdemain (5th-rank)
+  [dn53uqBi6MXg2gIM] Wand of Legerdemain (6th-rank)
+  [AYIel6a1nARjqygh] Wand of Legerdemain (7th-rank)
+  [34D6lFZ2gpZiyUU6] Wand of Legerdemain (8th-rank)
+  [qoNaajuoAnKRrFyb] Wand of Legerdemain (9th-rank)
+  [vSiePW2xIEOmXB0H] Wand of Mercy (1st-rank)
+  [6irTMXWYnysLljb6] Wand of Mercy (2nd-rank)
+  [VB9hU5JVAsvNXc1w] Wand of Mercy (3rd-rank)
+  [YU9FFzOsMDdmKW7x] Wand of Mercy (4th-rank)
+  [clcqWFuj42N28oeT] Wand of Mercy (5th-rank)
+  [MjiZtQW7QBLFbq7W] Wand of Mercy (6th-rank)
+  [K8T5OYXjmniOvhmA] Wand of Mercy (7th-rank)
+  [3DGLuHRME4e2XgvX] Wand of Mercy (8th-rank)
+  [LSf18TMRtHV6SMs9] Wand of Mercy (9th-rank)
+  [TIP4RFdWohqqpiBV] Wand of Purification (2nd-Rank Spell)
+  [OvGfkoGfqFMEhknO] Wand of Purification (3rd-Rank Spell)
+  [IaUKTq5fnWafnwO8] Wand of Purification (4th-Rank Spell)
+  [9QstkAexbb6QOwht] Wand of Purification (5th-Rank Spell)
+  [ZFx0WqzlNnIxeIII] Wand of Purification (6th-Rank Spell)
+  [4UsokByXD6h54H0F] Wand of Purification (7th-Rank Spell)
+  [LC7a0ur3o2CJDVPq] Wand of Purification (8th-Rank Spell)
+  [TBoEmxOSYSrRweBC] Wand of Purification (9th-Rank Spell)
+  [cyw2OgL4XJ9HOu0b] Wand of Reaching (1st-Rank)
+  [rmbvBjcDMDAZLJ7v] Wand of Reaching (2nd-Rank)
+  [AzLEUTp4RHYAoXIe] Wand of Reaching (3rd-Rank)
+  [XgKwydoro5eaIWC8] Wand of Reaching (4th-Rank)
+  [dPwRgQKEFLLDF2iB] Wand of Reaching (5th-Rank)
+  [pCr0zPdJoXZW3I6y] Wand of Reaching (6th-Rank)
+  [qeLAYEwUXNbri5eB] Wand of Reaching (7th-Rank)
+  [eFGpWmM8ehW9mkI4] Wand of Reaching (8th-Rank)
+  [sa9UGUMWYiZkTPjA] Wand of Reaching (9th-Rank)
+  [RoySt3EKFgcicm7D] Wand of Shattering Images
+  [Hqu2CmkLIE5Ov41i] Wand of Spiritual Warfare (2nd-Rank Spell)
+  [anZ6U7zFEAfiv3gh] Wand of Spiritual Warfare (4th-Rank Spell)
+  [bjjp7rXqikby6NU5] Wand of Spiritual Warfare (6th-Rank Spell)
+  [dR6d7wAWP9KtpWLA] Wand of Spiritual Warfare (8th-Rank Spell)
+  [ogTmuTUt52b7x5Yu] Wand of Thundering Echoes (3rd-Rank Spell)
+  [l68lJrjtjjkV7NiJ] Wand of Thundering Echoes (4th-Rank Spell)
+  [sFIKeflh6Jaac9FI] Wand of Thundering Echoes (5th-Rank Spell)
+  [UBWWeT6u5uHD5vT9] Wand of Thundering Echoes (6th-Rank Spell)
+  [VcZ5VVYMvnQQXzX9] Wand of Thundering Echoes (7th-Rank Spell)
+  [Z7xfDpdf1qwkJR94] Wand of Thundering Echoes (8th-Rank Spell)
+  [Zw3BKaJYxxxzNZ0f] Wand of Widening (1st-Rank Spell)
+  [qmWlvoIlJRJ6pAeG] Wand of Widening (2nd-Rank Spell)
+  [TJaumkbZy11sIAgR] Wand of Widening (3rd-Rank Spell)
+  [zYRzgETeR1Hs1ti1] Wand of Widening (4th-Rank Spell)
+  [TGxZ3acyWjjTvfU9] Wand of Widening (5th-Rank Spell)
+  [JDQ4jqp6O8SurQGe] Wand of Widening (6th-Rank Spell)
+  [kNfdGNIGzF0fW7aq] Wand of Widening (7th-Rank Spell)
+  [20nQTcGzpUv8jJ6R] Wand of Widening (8th-Rank Spell)
+  [t5978mZ6CqfUDCP6] Wand of Widening (9th-Rank Spell)
+  [5BzfYgmQ4m39R4wz] Wandering Pipe
+  [mdNNIF01ybgs1m3s] War Saddle
+  [ZW8W30XqgFf1KB3I] Warcaller's Chime of Blasting
+  [qDiVe9Ob04gRXLFa] Warcaller's Chime of Destruction
+  [3M3ZDW3MdfGLTZMC] Warcaller's Chime of Dread
+  [j6laknUcsOA6utvf] Warcaller's Chime of Refuge
+  [5AHJQn2QrvdsTJsX] Warcaller's Chime of Resistance
+  [aGZJ6dEHTHxUdnXz] Warcaller's Chime of Restoration
+  [zSnvJub3XMlFes1G] Warden's Signet
+  [SW6JVF5SP59W8B0Q] Warding Statuette
+  [ap9Bn8MLUJa8AtGj] Warding Statuette (Greater)
+  [Z5XaC2iyi5GLKYrI] Warding Tablets
+  [vx5bG5YNeC78u49n] Warding Tattoo
+  [V0ryBu9M5OPd4Wub] Warding Tattoo (Fiend)
+  [XFJD6eOX6H9sLcbC] Warding Tattoo (Trail)
+  [UkEDBhYxHWcTaMTG] Warding Tattoo (Wave)
+  [gbDVj8XRLN9OVVjL] Wardrobe Stone (Greater)
+  [9k7X59AB8yDlIJ4s] Wardrobe Stone (Lesser)
+  [72gfEUjIcdKVJZg0] Wardrobe Stone (Moderate)
+  [rKfPuZJyGe1os2jz] Warming Parka
+  [4ujkwYAlECBaSAoH] Warpipes
+  [c0gjWASSeNIRNmEw] Warrior's Training Ring
+  [1LJ0KMAyjwx4iP1Q] Watcher's Armband
+  [kDrlBnkDMVxPrahI] Water Purifier
+  [AxUJfrOmu7dY3XHP] Waterproof Firearm Carrying Case
+  [i2JwyZJpVZhlOObL] Waterproof Journal
+  [VnPh324pKwd2ZB66] Waterskin
+  [w5pzAwbKGLOOomrK] Wax Key Blank
+  [gbwr57aT9ou8yKWT] Wayfinder
+  [PhjutBgR1egCuHvY] Wayfinder of Rescue
+  [QOEvD3xh2qY7v0kh] Wayfinderfinder
+  [4mW1K9vZ0VIIEazS] Weapon Harness
+  [DKWuJb2rSgiotOG7] Weapon Potency (+1)
+  [pOoEiuEuITm4I2Il] Weapon Potency (+2)
+  [rvItjGQaYT7Luwtm] Weapon Potency (+3)
+  [touk9g0Lc2REwowo] Weapon Siphon
+  [JKrqKeBxSlLjF8xU] Weapon of False Wounds
+  [tL5pYmT9KUwxL2fn] What Doors We Open
+  [GpcZXdiJppItyWJg] Wheelbarrow
+  [ACdeqHG0cnSHoaOB] Whip Tail
+  [sKyJDfHdKacfbNOG] Whisper of the First Lie
+  [VeLs0UGkFu3Ga8Cd] Whispering Wire
+  [lJBKINXBmSq7njTi] Whispering Wire (Greater)
+  [MNaLwkkyKx86NKKq] Whistle of Calling
+  [us2Ypcm6qhmyQnBi] White Cleome's Eye
+  [2NKC67OBIukM4tC5] Wig of Holding
+  [uOaFBqnCYWCgyCl6] Wildwood Ink
+  [76FyZmtpHi6OXQ0B] Wildwood Ink (Greater)
+  [Lwvg9GECyIPsG8Xa] Wildwood Ink (Major)
+  [zVY6VVKrrf3K5TSC] Wind At Your Back
+  [LH9nHvta0q39JD86] Wind-Catcher
+  [wbCw7hNyQZSuy4QL] Wind-Catcher (Greater)
+  [vDQSR3fgfYqLp0aB] Wind-up Wings (Flutterback)
+  [PxHexTD0gzPtMFj6] Wind-up Wings (Homing)
+  [p0FkKcdjtQjAgEAM] Windborne Platform
+  [bfJI3xeIWaqcYRlU] Winder's Ring
+  [ds7j3D8IIyxWd2XI] Winged
+  [Ztb4xv4UGZbF32TE] Winged (Greater)
+  [aKoMqPDmVzPI7Q20] Winged Sandals
+  [mO9VXq8UkQodAucJ] Witch Token
+  [ZxwnnmMw9z1KG98W] Witchwyrd Beacon
+  [hGreHAX3WuNwhaHU] Wizard's Tower
+  [rikanygoG7zWhb59] Woe
+  [04V1qwob0JGPEx3k] Wondrous Figurine (Bismuth Leopards)
+  [6rhind8MDhtJHlwq] Wondrous Figurine (Candy Constrictor)
+  [RTxne78VqPqTz2VN] Wondrous Figurine (Golden Lions)
+  [RjJw7iHantxqeJu1] Wondrous Figurine (Jade Serpent)
+  [TXPQfQriNJqMYcfp] Wondrous Figurine (Marble Elephant)
+  [RnpzfRWsOW6zmAgN] Wondrous Figurine (Obsidian Steed)
+  [BANLXq8FhwqsDu0v] Wondrous Figurine (Onyx Dog)
+  [YO2X0EE3txascuuP] Wondrous Figurine (Rubber Bear)
+  [YXTrUT7Z7emAn2gb] Wondrous Figurine (Ruby Hippopotamus)
+  [v935rvhKtJm7PSNF] Wondrous Figurine, Stuffed Fox
+  [wOBIx55awoePSEIz] Words of Wisdom (Greater)
+  [5nqxkc2OlZAPpU4t] Words of Wisdom (Lesser)
+  [mXfoYKagvi8z4xkk] Words of Wisdom (Moderate)
+  [Im3tgXhR9W1CGaHo] Worldforge
+  [fo6Yhq5mbQXsnZs0] Wounding
+  [NjyKPRuq9siQe7gu] Wraithweave Patch (Type I)
+  [1oOalZRwSxcHewaJ] Wraithweave Patch (Type II)
+  [tFgzn2ATau3UJ8Fd] Wraithweave Patch (Type III)
+  [mcKF8McrMlp01wUP] Wrenchgear
+  [uzNB9EVGujen0cnC] Wrestler's Armbands
+  [fEc4v3EiddH2v0kd] Wrist Grappler
+  [kRBYoE6j2QUXQJGS] Wrist Grappler (Clockwork)
+  [YZxq8rGPiLPIKWIQ] Writ of Authenticity
+  [QJb8S927Yj81EgHH] Writing Set
+  [3yLu12TCwN8utY0u] Writing Set (Extra Ink and Paper)
+  [r81OfbBRPTXi0Fwd] Wyrm Claw
+  [lSpoAPC5VeGcSoDG] Wyrm Claw (Greater)
+  [orChmPy2wJ6DWwHU] Wyrm Claw (Major)
+  [QoVy8KXGBMn0OZaO] Wyrm Spindle
+  [MclG7HTygDNKH9Mk] Wyrm Spindle (Greater)
+  [j2IDa7wVQdNrPnDl] Wyrm Spindle (Major)
+  [5XfTQjS0xm0TllOE] Wyrm on the Wing
+  [TO36RKFoiPWJtuTA] Wyrm on the Wing (Greater)
+  [A9po9KInIcQXMzyp] Wyrm on the Wing (Major)
+  [WgW14gY5SPxQuf78] Wyrm's Wingspan
+  [eBUWprW319xzAh5B] Wyrm's Wingspan (Greater)
+  [ngUqDJjNCbzS3rxX] Wyrm's Wingspan (Major)
+  [WcSPyUIYVEZw0cQp] Wyvern Nafir
+  [vKzbNBm01hlp3jiO] Zarothrask's Contract
+  [ZOhmP9diADFlkUfG] Zealous Banner
+  [vK05bQ3gPAJvkjMx] Zuhra's Gloves
+Feat/Feature (Ancestry Feat)
+  [ClVSyZxWk5L5KVLd] Aberration Kinship
+  [P40wHiI9uidwPkTW] Abjure the False Kin
+  [Thhcli0PR7HBBcPX] Aboleth Transmutation
+  [iFSy6WtIUUKSYP2C] Absorb Strength
+  [vyb3BYDiIl2MiZp4] Absorb Toxin
+  [v1jdgQuqFtMJoo6w] Accommodating Mount
+  [KsFrWhIPVLOqxV07] Accursed Claws
+  [nCVX6szvnW1Js57w] Adamantine Mantra
+  [X9tKWtQrAcmn26Nv] Adapted Cantrip
+  [DBWfPOYZaupwo3rz] Adaptive Adept
+  [z92LsdpE98QdwILa] Adaptive Vision
+  [gJDTS7eeIxZws5Lr] Adhyabhau
+  [Ugw1zZStQhg6iz8h] Adroit Manipulation
+  [Ht6b8H9DpA9lWzAg] Advanced General Training
+  [ThqMksZRxNB18ivs] Advanced Targeting System
+  [Pr9TPmybBaTP818y] Aegis of the Dissolution
+  [SXaQi6cZ58mvz9rV] Aeonbound
+  [5oazhjGmSwfPTlh3] Affliction Resistance
+  [n46s9MB8LLRQKwOp] Agathion Magic
+  [k8nWKHLYvAKMuwLd] Ageless Patience
+  [wylnETwIz32Au46y] Ageless Spirit
+  [G6rCbMrHacYWNu1K] Aggravating Scratch
+  [7hwTeZNq6Jmzmtz4] Agonizing Rebuke
+  [hOD9de1ftfYRSEKn] Airy Step
+  [e0Gz3tjd55A5ggYK] Alabaster Eyes
+  [oGUF5vdAsrt3tjq2] Alarming Disappearance
+  [nyNsIePvpovlDAws] Alchemical Scholar
+  [ch3BWG3Z4kDEmuZW] Alghollthu Bound
+  [A2X3EBf8s5XSCYG0] All This Has Happened Before
+  [Un8aEKnVULYAzP5L] All This Will Happen Again
+  [VtFuhfIIw8OoLF6v] Alluring Performance
+  [j0mlvJcuYGFuMG2S] Ally's Shelter
+  [iLBT6IVCYO34Roeg] Along the Deep River
+  [Z15QFC45psi0txWg] Alter Resistance
+  [4fK5Ydicz76coNkj] Ambersoul
+  [7w8O3g3KM1HCDBSL] Ambush Awareness
+  [VWGoFBdfvIkG5T4i] Ambush Hunter
+  [KiakLUgowQFyz5Ka] Among Humanity
+  [aZIdjtIYlLtJJP3g] Amorphous Aspect
+  [j54VJmwwAQZBlS6J] Anadi Lore
+  [RTxPL1reRcJhhYeG] Analyze Information
+  [ngNzsvIpnj1iLfSC] Anarchic Arcana
+  [ytgmam8COVq8B7Do] Ancestor's Rage
+  [3X8BkDZEDWp90U4u] Ancestor's Transformation
+  [UWOSRX6FH6MZDlEw] Ancestral Form
+  [PajUTojvRtTTEPPQ] Ancestral Healer
+  [n7JXquVGxQOfrCsf] Ancestral Insight
+  [eCWQU16hRLfN1KaX] Ancestral Linguistics
+  [WoLh16gyDp8y9WOZ] Ancestral Longevity
+  [scNrNhnGTgPIzoj7] Ancestral Suspicion
+  [kin3aIJssaI6VFoD] Anchoring Arrow
+  [1miLVRtvsnZU6TTk] Anchoring Roots
+  [ptEOt3lqjxUnAW62] Ancient Memories
+  [lT2sOwC6Pi5P4Yq0] Ancillary Motes
+  [9nkcjb63ibLJrzRV] And Will Do So Once More
+  [ydgCsYsgqSkFWEDK] Angelkin
+  [ED58GzldWb82yc2q] Animal Accomplice
+  [evwCimenReYvcruj] Animal Elocutionist
+  [JeMGDAD5s9AXCZ2G] Animal Magic
+  [AKrxQ2JuDObM8coY] Animal Senses
+  [OpSHTPkoZDrqR0Mq] Animal Shape
+  [3omfgwa6waDNj0Eg] Animal Soul Siblings
+  [z0Bwy7lxU3DIugpo] Animal Speaker
+  [0hmGJt1GiGYYxFFA] Animal Summoner
+  [5Unc9AhGAAw1klFN] Animal Swiftness
+  [CnKc1kBejFV5gWtN] Animalistic Resistance
+  [PncXj46fgSwTWRl6] Ankle Bite
+  [ZhXlvowfVIAr8E2x] Apprentice Sea Witch
+  [l11OWMFUixCcRYGm] Aquatic Adaptation
+  [hXfyIWMtvB2kAEvA] Aquatic Camouflage
+  [ZOOP2RzRJnpVqnCr] Aquatic Conversationalist
+  [Kz4MLcrfXFrdKhyS] Aquatic Eyes
+  [P4qFFAjB4UnecVNH] Aqueous Dragonblood
+  [AO45is6WXyK9XzMl] Arboreal Conversationalist
+  [N8Ci3w5gQ68rj6a6] Arcane Camouflage
+  [Lb8mrOF3W2VGSOpA] Arcane Communication
+  [oqWclVuvEOh7R5og] Arcane Dragonblood
+  [YG6OCTbbqZwqRTr3] Arcane Eye
+  [FI4MnH0KQfIKJRNT] Arcane Locomotion
+  [YgytD4HGjWNFwiev] Arcane Propulsion
+  [bJzANqEGTkho1bv6] Arcane Safeguards
+  [EIyazsXwM7Zc2XGO] Arcane Sight
+  [xfbPSP9tl1N95xDF] Arcane Slam
+  [Dq4JSejEdCzGNeTc] Arcane Tattoos
+  [YryDlMt3zARg6j7T] Arise, Ye Worthy!
+  [5myj1WCLzifR2ev6] Artisanal Crafter
+  [HTy9bQsVkKnS8bLT] As in Life, So in Death
+  [TafPYNuDBD2GEAxQ] Ascendant Blood
+  [glu6XiN7A3C5jMA9] Ascended Dragonet Heritage
+  [OOfnNPATNt6Tvji4] Ash-Piercing Gaze
+  [Om6WLsTsIt6Ku3JQ] Ask the Bones
+  [BTQj2N5erpJDWNFA] Astral Blink
+  [gOv0OGTzKUhMoI8d] Asura Magic
+  [IK0WZloS3Hiqn4Uc] Athamaru Lore
+  [gtUU8CmyUMzsU5eX] Athamaru Weapon Familiarity
+  [Wwr8VilSybQgVtin] Athletic Might
+  [hHeh1ct8YceyeykX] Attuned Electroreceptors
+  [Y5ompgSd1JGSHt0C] Augment Senses
+  [0DSCucjk9WZAw4xT] Automaton Armament
+  [CF43oiymCFVVEkVS] Automaton Lore
+  [LTcpBbnngfuYTdB0] Avenge Ally
+  [gKDRnsBPBdhJB0FI] Avenge in Glory
+  [G0Iw8ltK3Dfav8B8] Avowed Insight
+  [IsQEDgcyM10kyHTq] Awaken Others
+  [XECkaKwvc8M8ec9H] Awaken the Obake
+  [0faPAjBozoKxMAo3] Awakened Animal Lore
+  [XVQ0grwx919KQ6ak] Awakened Jewel
+  [LaThPZtOGJ1VTNxl] Awakened Magic
+  [ECgtOFAvecaDU6xj] Awakened Stride
+  [s1XVDFbnP7visLI5] Awakened Yaoguai Heritage
+  [h9b5CId7S7gV7j2t] Axial Recall
+  [eWUTE7Ln3MwX6uer] Axiomatic Lore
+  [LoZY48txEgHZxewj] Azaersi's Roads
+  [xjwI1DlJvb7Rg6TG] Azarketi Lore
+  [u94fcPT5Oukqzql5] Azarketi Purification
+  [ALR9knJdktuMWzr4] Azarketi Weapon Aptitude
+  [ECcFHAeAmh5F3mxg] Azarketi Weapon Expertise
+  [WUMnFrehmFbj2PIm] Azarketi Weapon Familiarity
+  [6Qd7AA3Hp0KlALnF] Bamboo and Silt Repose
+  [2kAyZ3LB28BDhXKa] Bark and Tendril
+  [eAAPdjByxKA1ILaX] Battleblooded
+  [mnH68QcFRtkMbNE0] Battleforger
+  [wtTye8OrC9cuK7YP] Beast Trainer
+  [ra23dnNfwyIE3vTY] Beast of Burden
+  [yHHXrITmD70VteIn] Beastbrood
+  [e1Dc8fxK8NoSvYdT] Begin Stampede
+  [715iDDXFPguSO9Or] Bend Space
+  [v0kwHxBXfTihnNSq] Benefactor's Majesty
+  [DFSeNLLmFyUzprIx] Benefactor's Resistance
+  [9tO7Kovo3Ugy0175] Benefactor's Strike
+  [w4CJl4oyNcMPIle1] Bestial Brutality
+  [eUyZBi8vV5QDxOXD] Bestial Manifestation
+  [zL6zUrt44tZYyuh4] Between the Scales
+  [fX5FybM93HIQRRd1] Black Cat Curse
+  [3fLfHrJbMy2ayLMQ] Blast Resistance
+  [hkU92nqUYBQLQSMt] Blazing Aura
+  [BuaOQzmRNgIhGsfN] Blessed Blood (Nephilim)
+  [iqgAmntmu3udEgEI] Blood And Spirit
+  [UzYLSiDBFCGewhFi] Blood Like Water
+  [lzXVF6VTaPRfGDgj] Blood Must Have Blood
+  [YDHr12qVA3XRjkLP] Bloodletting Fangs
+  [EW6uZKpD0axk3VTg] Bloodsoaked Dash
+  [JvTSfyCkG70bmY7f] Bloody Blows
+  [oDFvdHVfrBzt16js] Bold Defiance
+  [T86thkbU4X2FdLwd] Bond Companion
+  [B53sWzd5irAoLn2U] Bone Caller
+  [XuL3g2ExgadFtWbb] Bone Investiture
+  [fLDhS0e6fBDjiCUA] Bone Magic
+  [FGbrxFmNeOfPHFOG] Bone Missile
+  [E4MS2wnRQJfyldrT] Bone Swarm
+  [8q0L0OWsagcCieL3] Bonekeeper's Bane
+  [fjzxzlHhiORtV7Ll] Boneyard Acquaintance
+  [wfOGyLnuVMFo7Rwy] Boneyard's Call
+  [ZZxePfQkBPuTHkt1] Boulder Roll
+  [MR4X38qgBj5tmkMw] Bounce Back
+  [AlhyF8LCW011w9kq] Bouncy Goblin
+  [FZZXgmVMAmvKHWIo] Breath Like Honey
+  [BaVO8UU5ZkL8OZZj] Breath Unleashed
+  [rq0lnwZ51AtJ0aux] Breath of Calamity
+  [7y8DKd24c7eqzJGV] Breath of the Dragon (Dragonblood)
+  [xM8IWff5yfbQGk4s] Briar Battler
+  [8aRa9VHoDKl9B1Z1] Brightness Seeker
+  [ICLUKJc9P0LgwVyt] Brightsoul
+  [b95x1RNTFtp5TCM3] Brilliant Vision
+  [jEJ6AWCctirMT7p0] Brine May
+  [dmEMftRe8P5iPDKo] Brinesoul
+  [leVsltEM29FfKSr0] Briny Beverage
+  [1gAehVvstGY885kJ] Bristle
+  [Yzw1v2JLRO0G59bz] Build the First Walls
+  [sJ7WTLDwAbIA9Elc] Burn It!
+  [Cf0CDTZvGaYDAXUN] Calaca's Showstopper
+  [EVUNTiG34WnamSzF] Call of Elysium
+  [uDFgL6uCwJsaTHi3] Call of the Green Man
+  [3uuP1MYBdLAXE7VL] Call the First Tools
+  [8azOq906HL0pFqTc] Call the Swarm
+  [5yV41pARitDoPUen] Call to Battle
+  [2vlQ09QIBli5u9Gz] Called
+  [IFvjnLMw3ht8f84U] Callow May
+  [OK68KJemI43q6DvQ] Camouflage Coat
+  [XJfUj2o4HdL5waZL] Can't Fall Here
+  [lIzsj8XlcL0tqQcm] Cannibalize Magic
+  [akrj9t0lTrndmf0q] Canopy Sight
+  [0qshtd4mBcjFAxA8] Cantorian Reinforcement
+  [56HvICglqH7uR3AY] Cantorian Rejuvenation
+  [Qc9MH7wT182qasSV] Cantorian Restoration
+  [uOFzs058hy144rzm] Captivating Curiosity
+  [ZFDb4EsYReQUdBPG] Caretaker's Intuition
+  [5lqVFVTA98M6E80o] Caretaker's Restoration
+  [zvtYsz9jk8tPvlpS] Cat Nap
+  [7qBuzHY8kEG8SdEP] Cat's Luck
+  [9eDA2RLnrBBlCvce] Catch the Details
+  [ACXWB7a38ETc32Qj] Catchy Tune
+  [nePEcAp7lTL35uyx] Caterwaul
+  [Iqv8qj7ym63YjexN] Catfolk Dance
+  [eqBWab1J5Be24YAl] Catfolk Lore
+  [bEh5qUgX5eFaQwzU] Catfolk Weapon Familiarity
+  [pt4oMtjAVGFQHtVw] Catrina's Presence
+  [646yQ0IDwe9BqHtv] Cattle Speech
+  [3wYqZuyaIredjSZ6] Caustic Nectar
+  [ZPK2Un5ChzeNc9Dx] Cautious Curiosity
+  [bo4JG09pkoS7ywSZ] Cave Climber
+  [PfHvTR0L9ShjhWiP] Ceaseless Shadows
+  [keMP6xVg4fMloczj] Cel Rau
+  [esKk5XrnlqRayDPG] Celestial Magic
+  [V6iJ4v15Qc8awVCH] Celestial Mercy
+  [6dlwZBjBnKtuq9HD] Celestial Strikes
+  [tymFMTQHBXwdUoUg] Centaur Lore
+  [dz3z1DLxV6GYH45Y] Centaur Weapon Familiarity
+  [nYSSdczKdRj7pdW6] Ceremony of Aeon's Guidance
+  [qAdlJvAHkWBisDJ0] Ceremony of Aeon's Shield
+  [rzBC5bHAWWpjHMEw] Ceremony of Fortification
+  [JAl4t2KINE8nI8KY] Ceremony of Growth
+  [73JyUrJnH3nOQJM5] Ceremony of Knowledge
+  [VSINzKESKAw2zA20] Ceremony of Protection
+  [bpNpqxtsBJIPYSX9] Ceremony of Strengthened Hand
+  [hZUFP1NPwdGMzs1y] Ceremony of Sun's Gift
+  [ZwvSiuFFsyNGJiB3] Ceremony of Sunlight
+  [Cb44J1g1nO43DEBd] Ceremony of the Evened Hand
+  [uiNRrdnJe0GOzy6Q] Chance Death
+  [4mLlHpD41101H0Iy] Changeling Lore
+  [DYFOlJlMoDuHjrZx] Channel the Godmind
+  [61X88ODYwZtwH6np] Charmed Sleep
+  [zsWIZQeVhIihNw6M] Charred Remains
+  [Pox93XMBaFmeLIDM] Cheek Pouches
+  [QHmODlkNgCvcXqPz] Chemical Trail
+  [rypk6QBqwz9biJuF] Childlike Plant
+  [eVn6hBjNjTB4liKw] Chosen of Lamashtu
+  [HZJqMESaEHTfefz3] Cindersoul
+  [g388ImzpenYBoiEF] City Scavenger
+  [AJHMnoK9Xp1DTj4g] Clan Lore
+  [LvVg83ZDj8mabcWF] Clan Pistol
+  [ya9YlhUA4WspUlHB] Clan Protector
+  [X7wFUWjYjYhzpejU] Clan's Edge
+  [gXAAJCnjfCDK7YV2] Cleansing Light
+  [EEJKztPOpy5utha9] Cleansing Subroutine
+  [KcbSxOPYC5CUqbZQ] Clever Improviser
+  [IsNs6hXQm9pJcXB1] Clever Shadow
+  [0u1SZ1c6gDo6l0hS] Climate Adaptation
+  [1XuytsxHDUMgyVH1] Climbing Tail
+  [SiedJ6hnDLEGeeBj] Cling
+  [vAGs7shxc8vhySpI] Clinging to Life
+  [fnMT0AsZXFW9Ppyp] Cloak of Poison
+  [StsFnks3lQU9YYpB] Clone-Risen
+  [rU9Aw05FFLVq0MTV] Close Quarters
+  [SzZFmcfLoHMAS0gt] Cloud Gazer
+  [pr7e8xzrl8OLp6U9] Coating of Slime
+  [MII0ybm76DkDxsId] Cobble Dancer
+  [o8DJyu5JJLppnDCS] Cold Iron Stomach
+  [w1UrOqEYVuJDgRZZ] Cold Minded
+  [TtlbpGchHOoWc4HN] Collapse
+  [xlPT1vT8pkgV3iCp] Colugo's Traversal
+  [rR8cnLpOqgSOgxLq] Combined Form
+  [d8SK0BQmTZiJ0VT7] Community Knowledge
+  [a4iFLiSDBO4fzCvu] Community-Minded
+  [q2SlRECDwGBtlMl9] Conductor's Redirection
+  [kBxgo589ctJsBwJj] Conrasu Lore
+  [Gh0rJNsdxBacK9b8] Conrasu Weapon Expertise
+  [1xDMyQ8IHuhDHSXy] Conrasu Weapon Familiarity
+  [NPATYCDg2cryH0Ya] Conrasu Weapon Understanding
+  [O65q744snXtC5Uc4] Consistent Surge
+  [kPyyZGD5L6b2Kl8C] Constant Gaze
+  [NySPRgD0FjZY2QGs] Consult the Stars
+  [Q6UONcwTlZL4F8Fw] Consume Magic
+  [I3Md8XYhuMVSJqKI] Continuous Assault
+  [Jfq7VKkSc6TY7MEl] Convocation of Earth and Moon
+  [lwLcUHQMOqfaNND4] Cooperative Nature
+  [Z2EiYMtGoNnwW6Tk] Cooperative Soul
+  [6jSRLRk7XkKHJqy2] Coral Detoxification
+  [wRIX0I4DPqebMGqh] Coral Growth
+  [E1QLW9gFsK0jVysV] Coral Lifeline
+  [KN6IxTO7H5WGYh3W] Coral Reserve
+  [1UPzQIIa4i1dsg68] Coral Symbiotes
+  [AYXqqeLSqCYhgUY7] Core Attunement
+  [zeyrLJr6b7hPdx4w] Core Cannon
+  [uclbKFsrqCW6tQmB] Core Rejuvenation
+  [9OdLdxvH5M9FyYSm] Corgi Mount
+  [DwnnmTNOvpLbp7jJ] Courteous Comeback
+  [zoZRiXMyAuULzChA] Covet Hoard
+  [j8tukQK5FT1Vfx2G] Crafter's Instinct
+  [eQl4yt4oZp8U0Sfr] Crawling Form
+  [3J0NxeHcA1h9eToK] Creative Prodigy
+  [WoKiYMCXV27szBdy] Cringe
+  [F6C25qZ9UNYPw7pj] Critter Shape
+  [FCGUAdseGVq6nhUw] Croak Talker
+  [jRtQgOVZMr3QobG1] Crocodile's Twin
+  [kt5UJEfTzO3LiInN] Crone's Cruelty
+  [pC9sGxKBOGWQLOuw] Crown of Bone
+  [aOhZUMCn0o2ZMkdW] Crunch
+  [TLuFqQwvnlJNeEsv] Crystal Luminescence
+  [Z56DtGBd3AcZOCeG] Cultural Adaptability
+  [swsMURQBMXZpjWl8] Cunning Climber
+  [otr60veuPNygNDFY] Cunning Hair
+  [m64PtRsaiOkylVVk] Cunning Tinker
+  [Vxs9btOk61C7KpP2] Cynical
+  [2jd9qqXPPXKDxBBZ] Dalang's Ally
+  [O9z1MJpEaf6Y1Acd] Dance Underfoot
+  [ycmxU7gySnfsO1Se] Dance of the Jester
+  [1sojLNzisrsw0dhW] Dance of the Mousedeer
+  [3xKOqBaPApgsnRtB] Dance of the Tiger
+  [AGznaQpn2cE6jz9H] Dangle
+  [ieFjiZSlT9J4boqP] Dangle (Vanara)
+  [XM4zR0q9rBxjR3lG] Darkseer
+  [4tZbjb1ote8Nij8I] Darting Monkey
+  [gwzjvKQQ6zmgVVmS] Daywalker
+  [zeXHH7xFOOFXH9gB] Dazzling Dragonet Disappearance
+  [7EbfPEq1Hd2s2wAh] Deadly Aspect
+  [ZcKW5n7F0oAqRw5o] Death's Drums
+  [6VvvcS067uytDv76] Debilitating Breath
+  [xruqgywumtExg8me] Debilitating Venom
+  [qVk9htKv47niPmXS] Deep Vision
+  [RxA1PdgGbijkieJD] Defensive Instincts
+  [B9IytVeJ1SMSJawB] Defensive Needles
+  [5AnJTAZnuWrkL8fa] Defiance Unto Death
+  [e7nTmdVOcaVkn2Q9] Deflecting Jewel
+  [OXhrwQgnZdOi81Yi] Defy Death
+  [G1BPXzTzrUE4IndV] Defy the Darkness
+  [30e9SdbmI3t5OJQE] Deliberate Death
+  [LxAEF9VPwUVttA0F] Delver
+  [WldISqAE5Rw3Ewzn] Demolitionist
+  [7Jc5gVUNcEBriL9G] Demon Hunter
+  [OLa87RacjBfMIVEQ] Demon Slayer
+  [ng9H9flz4H6agiiV] Demonbane Warrior
+  [ehPnY1PuPK7EXkYc] Demonblood Frenzy
+  [j3dTFgfzmW8AmRxB] Devil in Plain Sight
+  [8nF3r3NHW2uSRgwb] Devil's Advocate
+  [z0v9ENqGAwVodXpu] Devilish Wiles
+  [PsLne80WUsD4IFa6] Dig Quickly
+  [Zr1sspa9Q16V8uZV] Dig up Secrets
+  [fPYf0uKRz3ce29PR] Digger
+  [X5NRdQ1W0Y5t6MFi] Dire Form
+  [DLE2rr5I1TBAk0I3] Disorienting Venom
+  [d3J74jmGOrPBWUm9] Disruptive Stare
+  [foMds7Wn9iavRuHx] Dissolution's Clarity
+  [wiV1CBh1OBhQCfbp] Dissolution's Sight
+  [PbSyQ8PRlG3x42zY] Dissolution's Sovereignty
+  [UlbviuA09S5bldJE] Distant Archer
+  [P19AnciwNcSqxU7z] Distant Cackle
+  [vcfeHDoaWEZtEcfz] Distracting Shadows
+  [ovMIxhiStlPE7tty] Divine Countermeasures
+  [KL3Pk10ReItAHTw9] Divine Declaration
+  [axDwTLGN32Qfv0SD] Divine Dragonblood
+  [vtCrMziYxNyj8kP7] Divine Wings
+  [nHoRM1gLL7MtIiCS] Djinni Magic
+  [wigOSPSxXnapFxeh] Dogfang Bite
+  [gRa4bvQn7rI1LoRl] Dokkaebi Fire
+  [HX12ulixkeYeWZUU] Dominion Aura
+  [qvxHGcOUYVG7Tqt4] Dongun Education
+  [gnwKHXKxMbJ2RoJ2] Doom of Sailors
+  [lbiFj4At5BxotaNY] Dracomancer
+  [U38YThMudfDihnj1] Draconic Aspect
+  [PF8qHT4zd0loLQeJ] Draconic Paragon
+  [mI6dFvu28r66SfY0] Draconic Resistance
+  [2UKf5IiUbpUbOC9a] Draconic Scent
+  [8JyyB66LK0pOpnYv] Draconic Sight
+  [HauCZuLvIthFe2we] Draconic Sycophant
+  [VDOROn71nTjuQ7To] Draconic Veil
+  [0Iv3VbR1DMPbZIjD] Drag Down
+  [WSxHCapuTn8uRdLI] Dragon Grip
+  [vXNWjiUxu79S2vUN] Dragon Lore
+  [Q1lGguNI4SqPwgVn] Dragon Prince
+  [UsJtnrqWOs7puRZa] Dragon Spit
+  [zQgdTW7CPYw8km5F] Dragon's Flight
+  [SPyvwsiSghySIEw2] Dragon's Presence
+  [4EgueMqUm0ebKV4J] Dragonblood Paragon
+  [RaqjaXp2miOq4Bis] Dragonet Breath
+  [wYcpXyGuZQaBkv4w] Dragonet Immunities
+  [isWArbW4C1Xbd5gR] Dragonet Resistances
+  [CO7O8PT8RSAR2S1I] Dragonscaled Lore
+  [ZvrzK8NM390k139E] Drain Emotion
+  [kqnFdIhToKTnOpMl] Dream May
+  [mmYAiK3x0UMcgiNv] Dualborn
+  [VHOsMzpzQUX7AEau] Duck!
+  [O5v8yaeCbjKeXfyi] Duskwalker Lore
+  [PxWdf4HAhZ8fUB3R] Duskwalker Magic
+  [8rKlptZ7ArtJ6cI8] Duskwalker Weapon Familiarity
+  [yEbXxbD317IZgtsN] Dustsoul
+  [UJ8AqzkkDqRCMNFW] Dwarven Doughtiness
+  [9bnkx6VgcO5mOk5b] Dwarven Lore
+  [FGrIFDobGRFBPOuM] Dwarven Reinforcement
+  [CXS0ryG2SODSobm9] Dwarven Weapon Familiarity
+  [nfERPRCITBp970HO] Earned Glory
+  [ED4CiawXGklyubnk] Earthbond
+  [kjRMXN95lQmIi2hP] Earthsense
+  [ZRI1OXaaa4ZC6EK1] Easily Dismissed
+  [rFmJVDdB313EibTs] Eat Fortune
+  [nKkbEKbE9vfKWKdd] Echoes in Stone
+  [0ihK3qYItmi8eVZs] Eclectic Obsession
+  [DNZlWe2V28KoajoN] Eclectic Sword Mastery
+  [4cH2RoWsgXYaWIPa] Eerie Compression
+  [AJVx3sHm6f6i8ZQW] Efreeti Magic
+  [5lZBacKOZOgIx4Pi] Eidetic Ear
+  [5q8a36QyYAslgnsk] Eldritch Calm
+  [OKSsFlHY5UKc4dKu] Elemental Assault
+  [IUVzB39pRVyBFOEx] Elemental Bulwark
+  [VZDJgGm5LGb1Pdck] Elemental Embellish
+  [6ENHSzqg88J6dri6] Elemental Eyes
+  [RJClD7YYsAFutxNs] Elemental Lore
+  [JMB4ldz7BQ5tx0hM] Elemental Spark
+  [QsPvKvt4S1PR7kr7] Elemental Trade
+  [yMfZulJcoSomQ6dO] Elemental Wrath
+  [7BVl9lFf0wuTjBgM] Elf Atavism
+  [aIm2qi4JZerthZmF] Elf Step
+  [I9cJYC7anz7HmpcJ] Elite Dracomancer
+  [mAhmb9CkYe0J2bCD] Elucidating Vision
+  [04dRwEQh2ToqEm8u] Elucidation
+  [5qVCl5MwPcx0sS7T] Elude Trouble
+  [y7Or0CbcQBDdS9yG] Elven Aloofness
+  [4M36jGbeSDfZFM38] Elven Instincts
+  [zki5qdM5IQcAiscM] Elven Lore
+  [y1Jp8e5zmO1InHMe] Elven Persistence
+  [eD3KZJV8ACLt2xns] Elven Verve
+  [4NKyZVkmWjDyyIYZ] Elven Weapon Familiarity
+  [aBa7dGY2TuDE4R7A] Elver Pet
+  [yQZ6naE8AP6JYTSH] Ember's Eyes
+  [l6Atklyi9p93IFRj] Emberkin
+  [YSEqqNx3McbS7k4n] Embodied Dragoon Subjectivity
+  [4RUTJC42ZaENYh9T] Embodied Dreadnought Subjectivity
+  [5qJBjjitpHjkX5Wh] Embodied Legionary Subjectivity
+  [4Pttzj49WiROm3ua] Emissary Assistance
+  [dpwUwH1xX48ufXVy] Emit Defensive Odor
+  [ojykhaQkT8IU7ouc] Emotional Partitions
+  [MS53Ds75BT379ZFm] Empathetic Plea
+  [llWKddRiyUHouaZx] Empathic Calm
+  [9USZSLGG4zmdZquw] Empathy Incarnate
+  [aSgLhr8mM53DWbFc] Endless Memories
+  [3Xc0jsbXBsF4FSui] Energize Bite
+  [cmhfYMEM4uzrNIiV] Energize Wings
+  [NBDwiz1NDioc2eMP] Energized Font
+  [AMbYEv9rUt2fcR7F] Energy Beam
+  [B5HiNholWMwYdHTC] Energy Blessed
+  [WWCZef1PBliiot9Q] Enlarged Chassis
+  [Zz5A8Yg0jGSK8GNu] Enthralling Allure
+  [IY86Kvopp4ACuQsw] Envenom Fangs
+  [6px0s2nE8fHVWswz] Envenom Strike
+  [oaqkhZ6c0Dbk78wi] Envenomed Edge
+  [gC5EnlP38t1vTlWt] Esteemed Visitor
+  [14dFcInubWcPnFzR] Eternal Memories
+  [OWL6ZNVWMU0AFqvZ] Eternal Wings (Nephilim)
+  [8ZWMJYNgyH5zh1yH] Eternal Wings (Sylph)
+  [l4ux6Mn2fklB2cXM] Evade Doom
+  [ryRpqixE7cN8svwB] Evanescent Wings
+  [fsovjV7yFMGiVs6z] Everyday Form
+  [ELbjdZtAGppc1b30] Evolved Spellhorn
+  [69h9D3syUYLgIPr7] Expanded Luck
+  [Fj3ufCawOM6fZB24] Expert Drill Sergeant
+  [vfuHVSuExvtyajkW] Expert Longevity
+  [TYe3dsNlks91YAks] Explosive Expert
+  [6EgHimhCuS8L0xDE] Explosive Savant
+  [SBhzem6n3buoxlG5] Extinguish Light
+  [2bNd89jYmEO8wSay] Extra Squishy
+  [KxBrjGgSYyb1Rsbh] Extraplanar Cloud
+  [Ewk7h9aQpKvy1RJo] Extraplanar Haze
+  [n3CbbtK4fgBznIMf] Extraplanar Supplication
+  [ULa46pgES3yWw3NJ] Eye for Masonry
+  [nB8BD9rIg9hfFGns] Eye for Treasure
+  [5EpkOj9CFOjt8vsK] Eyes of Night
+  [qr1E37Tla555tvIO] Fade Away
+  [UJdKgw8rbpkyoaeR] False Priest Form
+  [FnGOkNyLF4w3FyqZ] Fang Sharpener
+  [Y8sKn8NH1wC7Mrui] Fangs
+  [lbcsniPkdSKIOnU2] Fantastic Leaps
+  [NB8AiwWXLbOsKhOE] Fascinated by Society
+  [D5beAl2SwNcT3brp] Faultspawn
+  [VbHuOvF1MM9ls6Tg] Favor of Heaven
+  [OK8Fm7EG8wjoYZBX] Favorable Winds
+  [WlVPcOUu1GfbRSZy] Fearsome Form
+  [zwqawaXccARDV0jL] Feathered Cloak
+  [48crF8lpg78fRdhJ] Feed on Pain
+  [mXNwdRSM9kZrT2Um] Fell Rider
+  [wteuGNhOXLvBudRQ] Ferocious Beasts
+  [Sav50NxWdLnbaDWQ] Ferocious Gust
+  [rdvwYaVN1Cnlm52A] Ferocious Will
+  [y48ig9zN5ZvPbB9o] Ferrousoul
+  [b4YmWetKmNww6r9j] Ferry Through Waves
+  [izuErgHfh90KctAL] Fetchling Lore
+  [IzNyByUBNH94MDOr] Fey Ascension
+  [gozOYxLVx7PQvOSj] Fey Cantrips
+  [GTA6QM7cH40L8H5Q] Fey Disguise
+  [FWCULKnVXhSPL0ST] Fey Fellowship
+  [dIIqejy4JAVuF0I8] Fey Influence
+  [Qe9IUDVo7gsowMHq] Fey Magic
+  [hSHteYr1g1gKHcwM] Fey Skin
+  [EEnL4zyCDo4HD6Rn] Fey Transcendence
+  [nk8jtjNodT15IU1N] Fiend-Trampling Stature
+  [UKYO5kiOnCY1hgCD] Fiendish Magic
+  [EyG0zdHA9NbavYlC] Fiendish Strikes
+  [SEtFRKVV9bt4MJEn] Fierce Competitor
+  [2phzdvmFJaUUGDmY] Fierce Grasp
+  [g0hHetVM9UmmIDKU] Fighting Horn
+  [NIwocFnVpyzjeNUC] Final Form
+  [IpTsQMpwrsBUCjFX] Finest Trick
+  [LC2EnXQ4MkhDLViM] Finned Ridges
+  [W5hgaJvaCrTKfYbC] Fire Savvy
+  [DmYbGBC2ukp8tYD4] Firesight
+  [WUVNZoIZvr9XFv2x] First World Adept
+  [yJ8Ez5dEscIk1xr5] First World Magic
+  [2z9OyJNiVPNwJeDS] First to Strike, First to Fall
+  [ZBm542xaWmneueq4] Fishblooded
+  [6k2wqSQrwThpW7mq] Fisheye
+  [bzlmlI3dIzz7hXHw] Flame Jump
+  [3OmL54xnVTx1pW25] Flames of Vision
+  [UuVz1QY7QXD5cnLu] Fledgling Flight
+  [oOicdaf3WvT1i5ft] Fleeing Shriek
+  [u7FPgOjbSOmCTSD9] Flexible Form
+  [VLCAFIXzUtiv1VuE] Flexible Tail
+  [U9nJy5suyYDE0b20] Flourish and Ruin
+  [F6bfZLBMS9fUtQiQ] Flower Chimera
+  [oGPX29AOsyHj18mK] Flower Magic
+  [V6b42u8dNn7K6FwJ] Flowering Path
+  [CdSWMqPOVWIEzyUA] Fluid Contortionist
+  [O89mwKPRg0up0J0I] Focused Cat Nap
+  [ua0O6tQ3D5099mmH] Folk Healer
+  [0YXRPqCaOQ3G73hh] Folksy Patter
+  [zgriBCYR4TmBoDqO] Forest Stealth
+  [0QmONgl21le7URxP] Forever Among Humanity
+  [9cq4j15EbVyrHKFX] Forge-Blessed Shot
+  [ZxiAMposVPDNPwxI] Forge-Day's Rest
+  [AogIo1gHLdz7DyHx] Forlorn
+  [VaxsPPPsgXzNxQVI] Form a Flock
+  [H965m1koFvY4FQkF] Form of the Bat
+  [GDyYYA91A3r80Oec] Form of the Beloved Mother
+  [ehiLW2Kjl5csT3fk] Form of the Dragon
+  [QHPtlFvTpgx1GE7S] Formation Master
+  [aoz9dCq2NynyUYEf] Formation Training
+  [gnDQSlSVh6KCnq8t] Formidable Breath
+  [0R15gtdXoXbrD8As] Fortified Mind
+  [DidzozerKLZ2UYLx] Fortify Shield
+  [Twhkz2FfzaZezVnG] Fortuitous Shift
+  [IOlvpmeIwlk0IACr] Fossil Rider
+  [MzdoJWpqyMmMDI1F] Fountain of Secrets
+  [10bkE3TZsr7kvdn4] Four-Armed Aspect
+  [N8PVMhhGgkJr41yj] Fox Arson
+  [3naQHzExExCzrjyI] Fox Possession
+  [g9AOSz4QDAlUee9M] Fox Trick
+  [qCV04rZMty2TJBrX] Foxfire
+  [hTdf9tpuImptkZLM] Free Heart
+  [LhpE0NsfNwYP6MOz] Freeze It!
+  [UpHZIBq0ECtgUS6T] Friend of the Family
+  [qkXRucQCLLS3VoMa] Friendform
+  [YN0QYUCb8Q3PtUJy] Friendly Fling
+  [8PmPjoqqbOzvUmO2] Friendly Nudge
+  [nN2zGODUOmkoxZgj] Full Flight
+  [J2CPfHKPvu6RGfY6] Fully Flighted
+  [vWf6uykXkQp1Li0r] Fumesoul
+  [GZrvQo5FcoP5qocX] Gaping Flesh
+  [T6yXzRKNZrYKIcDi] Garuda Magic
+  [m2C99WJ3ms0d7ZQr] Garuda's Squall
+  [kGed3uQbZ7x5SBB8] Gecko's Grip
+  [o6MXyjSgavTzU5AS] Gemsoul
+  [D3SuA5MaKucO1flE] General Training
+  [hymxSDU0vXMNuFSA] Generation Digger
+  [i3wSkeU7CSyHEi4Y] Genie Weapon Expertise
+  [8DDwqrYHie33cf6d] Genie Weapon Familiarity
+  [2kwLzw618QaIHOap] Genie Weapon Flourish
+  [2D83KOmCCNYTGX3g] Gentle Death and Rebirth
+  [PFKUr11TUN5NfOYF] Germination of Resolve
+  [JQTP0XdI1XVAvBIn] Ghoran Lore
+  [JmVuumcmqSrAmxdm] Ghoran Weapon Expertise
+  [oeVRwtBlQjsSVtXV] Ghoran Weapon Familiarity
+  [8NnYg8RUY4DQ8Wkf] Ghoran Weapon Practice
+  [4TndDyCjnF7pc1GC] Ghoran's Wrath
+  [DGtUIMliflzGXc6E] Ghost Hunter
+  [7Lx8rsEbBJkg6C17] Gift of the Moon
+  [VeTrBvxupaS4uo1B] Gildedsoul
+  [ewwhgHZbxHcpMdLn] Glamour
+  [sL2GmYve5NXJ0wc1] Gloomseer
+  [rLP6gkn74KxjqUz6] Glorious Gamtu
+  [2GrlSP1xhKIz4G8B] Glory and Valor!
+  [LNyTKhIZlM17026W] Gnaw
+  [mxhGH4FVYXJwb0BC] Gnome Obsession
+  [ccWf2F5DqiqFwiQ1] Gnome Polyglot
+  [3zr5Gt5LgHsMNpSO] Gnome Weapon Familiarity
+  [Oh2GaKh4Qc77xSoO] Goblin Club
+  [sm6Y3fTcltxE8N0p] Goblin Lore
+  [UwH0sGIthv8kiPUt] Goblin Scuttle
+  [QZb0Utg0WFPf2Qg0] Goblin Song
+  [OYjzfTeWU7RJBT7v] Goblin Weapon Familiarity
+  [Hey5rucsel7apOOi] Goloma Courage
+  [vNDCXpumBONpk5JO] Goloma Lore
+  [gx9QawjDOZSfSBlN] Goring Charge
+  [2IO2W09IvwGHvatH] Graceful Guidance
+  [Ds4MuyTe7t2Xosks] Grand Metamorphosis
+  [mU8vTzrWX9fIlG0d] Grandmother's Wisdom
+  [weYZzyMmlCIC2TZt] Grasping Reach
+  [hxCqQPjlyVI57vQt] Gravesight
+  [ABXUfGoeBgCyFasg] Great Tengu Form
+  [FayzcoNaiIdyPS2j] Greater Animal Senses
+  [5FHLom2tpC0X3nbf] Greater Augmentation
+  [VPKBjEy8frqDMxyO] Greater Enhance Venom
+  [FBT84wCK2Dv3GRVO] Greater Transformation
+  [BS6UoGLyJ12xVD9P] Greater than the Sum
+  [KMbNfO3Ljg1vY3fH] Green Dash
+  [zs2FFGI88zB7EaBT] Grim Insight
+  [nyhQ9xB0rkoAoNbf] Grimspawn
+  [4Ai8aNHYw7oEj7eE] Gripping Limbs
+  [sGdREpnSJDzEacub] Group Aid
+  [CWt2iIVRra0K3vT7] Grove-Harbored
+  [gS9FYlD0Vt8yyZkP] Grovel
+  [Rf8md5eIOxV2m4nJ] Grow Tool
+  [p4JROE4Qh8TVNnkl] Growing Eel Friend
+  [s1swBWSqtfrXTJHK] Guided by the Stars
+  [k0sXAn4PPq5nW9al] Guiding Luck
+  [Qb25uu1gT5CDMSWb] Hag Claws
+  [t6GBBIwX7hvvxYyV] Hag Magic
+  [WzJaArukCUf9hpeP] Hag's Sight
+  [jNrpvEqfncdGZPak] Halfling Ingenuity
+  [VU07hybqzUXIJ6l2] Halfling Lore
+  [ZbRVqf14RTJJIZXG] Halfling Luck
+  [2ebcYbg68pCZfAFQ] Halfling Weapon Familiarity
+  [PGVXjbAi1Fa4uTmD] Halo
+  [1newzNV5nkLvZ9KE] Handy with your Paws
+  [KRfZcToCc5nvcQRa] Harbinger's Caw
+  [0qeYP84FfQueggkx] Hard Tail
+  [7lXCPeGMB3RrDVdS] Hard to Fool
+  [aznyI5mfMdEFSDr8] Hardy Traveler
+  [IAXWdFXwjFChojeb] Harmless Doll
+  [GYdLf1LhvSUeu95Y] Harmlessly Cute
+  [Rb3ndqSyDUa6KvOL] Hasty Celebration
+  [RmiMUZlae6yGUyXY] Haughty Obstinacy
+  [Ofk2WfHbj3nWRhJy] Healer's Halo
+  [nMtcYj1DpE2V86Gt] Healing Flesh
+  [IlD1DL4kZl1tinCT] Heart of Earth
+  [bKc8MMFEOpOJJihb] Heat Wave
+  [O80QCYMqz4VZsfxT] Hefting Shadow
+  [MTp2j4N4H4wj07pH] Heir of the Saoc
+  [EXVHePH8alsTZ5TB] Hellspawn
+  [gWyCNTWUhxneOBne] Helpful Halfling
+  [ARBIhYAREcytOIaL] Helpful Poppet
+  [0EsMqnrmTEQBG65e] Herbal Forager
+  [ZOlwVqWa4hfv44xX] Hero's Wings
+  [7cM7uKRKQDWz5eeu] Heroes' Call
+  [iVwsLYjOJbfvL0Pe] Heroic Presence
+  [AoibfCoLi2FaTvcH] Hidden Thorn
+  [47ZB8mYBtBt1C7zh] Histrionic Injury
+  [nJTQIUGjzZcDsBHw] Hoarder's Craw
+  [13zaW8ZHRWnRe2pj] Hobgoblin Lore
+  [n9CBjyiB17srkyr4] Hobgoblin Weapon Familiarity
+  [aQNsD2t0Tb4vToA4] Hold Mark
+  [pYASxr38SiFDna45] Home in the Deep
+  [UKHIKipBvOGhzcSQ] Homeward Bound
+  [GU3EQVOMjD9S2YWj] Hone Claws
+  [7ntWAreQp3x4wPxT] Hop Up
+  [RkEvEqwc8pCBcusz] Hopping Stride
+  [JXKbfwsyYWcqZUUl] Horn and Bone Incantation
+  [rb0GCneYEzBi2LGr] Howling Aspect
+  [iW62jmvNlR5Y9cv3] Hungry Eyes
+  [DnfVQGLk3PAl8UWh] Hungry Goblin
+  [KYTSvAEqK7KAyVwi] Hunter's Defense
+  [PWKFdaNghx1YMKlA] Hunter's Fangs
+  [iJrjzLnLJkvQgrbS] Hurricane Swing
+  [OhyN9pBHdMpC126F] Hybrid Form
+  [M0B0rt6rk5MkHiBN] Hybrid Shape
+  [kqRFoXfErUFEndIs] Hydraulic Deflection
+  [0jJ5FG72lydY3HHR] Hydraulic Maneuvers
+  [5vipJDU5hGs0SejD] Hyena Familiar
+  [nok1dwVWHvb4SNuw] Hypnotic Gaze
+  [BaSl8PmfQwESIiY6] Hypnotic Lure
+  [aEcK9cX64xDrbzwH] I Sense Malevolence
+  [9GScusN2WjEh0afk] I Will Return
+  [asjDgf7Q9BWZoK5Y] I've Had Many Jobs
+  [PLix02TPp7VaClka] Idol Threat
+  [0bHLavDPj7KOAGEu] Idyllkin
+  [mBYXOPc37AawNza6] Iivlar's Boundary Break
+  [lu9ehnCfjYMIi1pV] Iivlar's Deflection
+  [EAoMrpAEH9VBcDHK] Ill Tide
+  [tFgsBRsEo9ZEA5fU] Illusion Sense
+  [tL3Xu0C981AdrjVh] Immobile Form
+  [ud2ulIyiwIAelWyV] Impaling Bone
+  [BoLeT3uNl7iikQuI] Imperial Dragon Potion
+  [DIjpbE2dh5MRGiYO] Impose Order
+  [5BEY7VzDVuiAg4PX] Impossible Gossip
+  [xTLy2AyVW90TrQk6] Improved Elemental Bulwark
+  [Vb0nkFoKWE7Jt8To] Improved Signature Weapon
+  [KQVE4FsDd9RFpWRz] Improvisational Defender
+  [VazbV1s93eZqUZIu] Improvisational Warrior
+  [lHcDb9oXUdFupRdi] Incredible Improvisation
+  [iTsLr3zEaGZ45zez] Incredible Luck (Halfling)
+  [lEtQVtPtoJtHVgGx] Incredible Sprint
+  [v84501yLBubHlGPz] Indomitable Spirit
+  [FrHsGqUvq6GrugC4] Inhale, Exhale!
+  [YFHZi0Yqv9IMBVfZ] Inherit the Dreaming Heirloom
+  [GhBZU3qjq4JnVKjB] Innate Understanding
+  [tyae2vpOiAMxXvQH] Inner Breath
+  [N3xyK9keDm00oUY6] Inner Fire (Naari)
+  [E1sjYRb4zsZVrzrN] Innocuous
+  [rp3mjgFXBVZYCleU] Inoculation Subroutine
+  [pqezW5dqha1I32Ld] Inspire Imitation
+  [5iHB5ZFJ25XrZHye] Inspirit Hazard
+  [jatfexNkXaTs9s5Q] Instinctive Obfuscation
+  [BcCjFVTfQZ2Q3elF] Insulated Poppet
+  [b8BZl7wbm83ObEtO] Integrated Armament
+  [db0RHtFGhCfMx8vT] Internal Cohesion
+  [upMcjxPDgNOLuu7N] Internal Compartment
+  [7eyy63BkMv3enk5r] Internal Respirator
+  [krQcx7hANwaLjoy0] Into the Labyrinth
+  [fhpCUQUKRNtJMnf6] Into the Sky
+  [AjdmoGFoSIyx1mxd] Intuitive Cooperation
+  [XKDFgBEtFdEzCz8X] Intuitive Crafting
+  [MwjnRpVn3br88Caj] Intuitive Illusions
+  [qKNo7Sr1dtVqhhAa] Inured to the Heat
+  [SrSYEHqOLXWuj65e] Inventive Offensive
+  [XzTklOArNQle7rQP] Invisible Trickster
+  [4Jwtl2FvxskruHQv] Invoke the Elements
+  [SiIha6u0XNtepG1N] Iron Belly
+  [JP5pptkl1Fx1JK4m] Iron Fists
+  [cRMUYCnkkE9lSEhh] Irrepressible (Halfling)
+  [WYEjiUZQJP3uMk4Z] Irrepressible (Nephilim)
+  [gltXysTfoyF1Ywoc] Irresistible Bloom
+  [arlZTqfppOAXBhdw] Irriseni Ice-Witch
+  [VatkAzfBYjA6z6OP] Iruxi Armaments
+  [yqtaAZR9jfen6gEW] Iruxi Glide
+  [pivX2SxPQjKDyvHU] Iruxi Spirit Strike
+  [Hf57bgbPJMkPqsfq] It Takes a Village
+  [fYkAlUeIryOw7Ht8] Jalmeri Rakshasa Magic
+  [6WwxTbX8KvU3Xxak] Janni Hospitality
+  [xDCtfNtbnaG166cy] Janni Magic
+  [3NDQGjeKLQkhDxHv] Jealous Grip
+  [eGfYZoWC6cDa2XWd] Jinx Glutton
+  [ein1K7P51cs3Qusw] Jotun's Battle Stance
+  [NDnWOqylZZ1a6BZI] Jotun's Boost
+  [RDRNtaFEq9p6KzEO] Jotun's Eyes
+  [GsICYVRwfcry2s6K] Jotun's Grasp
+  [dnqTx5rziTrcgS3B] Jotun's Heart
+  [DfsX531DADwSRb64] Jotun's Restoration
+  [TH4mB4nyHqmBAOnR] Jotun's Transposition
+  [uPatc0BGdbn5M0Hl] Jotunborn Grappler
+  [IWQsYjk17aDAZ4eM] Jotunborn Lore
+  [eQcR4pdNVOhGmPTn] Jotunborn Weapon Familiarity
+  [NHlCta7B1Lmt3S7w] Jungle Runner
+  [M41PGiFlLE2tByUL] Jungle Strider
+  [YMKtEoNwHKA713Cx] Junk Tinker
+  [pe6cHJzzMm5Tr25G] Juvenile Flight
+  [1i2Ms9egpbnzuUjQ] Kaiju's Footfalls
+  [8VXYwHE5LqAGRGTB] Kashrishi Revivification
+  [nkU7tWNTNaQKK1iU] Keen Nose
+  [pQQhrcj1u6hUUc8L] Keep up Appearances
+  [rWiddU8fHl0TraoN] Kholo Lore
+  [zb7F0M3H8PN3XsdX] Kholo Weapon Familiarity
+  [Bekco7lCUkqyLi6S] Kijimuna Whistle
+  [93vQcuKBESXUKoH5] Killing Stone
+  [AO3qHCGDU552NEIj] Kin Hunter
+  [zknpo51jJndv68Ph] Kishin Rage
+  [b60ZCgKoaVDgMhBk] Kitsune Lore
+  [JlkkYedPyWLShuka] Kitsune Spell Expertise
+  [Zz7isE8Td2xDWqR8] Kitsune Spell Familiarity
+  [RP7TlsqNuge0dltp] Kitsune Spell Mysteries
+  [j7BhuP2ccnwpbQhw] Kizidhar Magic
+  [1muxLx8Vacn2SLHc] Kneecap
+  [wGzKq2cx1b2Ycl4u] Kneel for No God
+  [shp63QZvw9xvkVvC] Know Oneself
+  [o4LycqplO14zn6It] Know Your Own
+  [PPUNMjRLQYnmwQvF] Kobold Breath
+  [IElFaS5i10MFYIvq] Kobold Lore
+  [pXwOIzZhfgJrhQxS] Kobold Momentum
+  [OTjRxyCtwPoqNFP2] Kobold Weapon Familiarity
+  [qp6O9QBifW9bj7IV] Kodama Call
+  [VQInlv7phdWErkvE] Koi Secrets
+  [aa8Qbo9D9WVeOGN5] Kraken's Call
+  [QE8asCPqyrdenll0] Lab Rat
+  [1rPcBoqCsmgFjily] Labyrinthine Echoes
+  [PcFzyNEYnw3pqI9H] Land Legs
+  [IeDxn0HzGoKCXjDJ] Landscape Form
+  [DTU4jrz9YNr7e62e] Larcenous Tail
+  [QG2L65eD1IycpImA] Larger than Life
+  [RDObXSPRehPF09cm] Late Awakener
+  [QNgnwkKZmJR5jT7K] Laughing Kholo
+  [JoeepCWheQChcQ9s] Lavasoul
+  [g3oJlWGHc74qX2z5] Lawbringer
+  [gB5H7vnYOlq2Ycv0] Leaf Transformation
+  [Z3zahFC7SzzkX6Cs] Learn by Watching
+  [OZtoTusMmCJymObT] Leech-Clip
+  [7XA3Hm2md2tU9pEz] Left-Hand Blood
+  [Y6n4EDUnWr1vMJTM] Legendary Laugh
+  [DmpJgLsHfv1kMcJc] Legendary Monster
+  [IlzUi1viWgeRolU8] Legendary Size
+  [ShH7Wl7xfJL07DZC] Leshy Glide
+  [i5W5aGWEiyo1vt2d] Leshy Lore
+  [fYVFBnv9aVHv1UNg] Leshy Superstition
+  [AQvtqj2h2n5n8YYg] Lesser Augmentation
+  [jxUPlkB2kFuZKXef] Lesser Enhance Venom
+  [XKAPPvPpS4b8rSFp] Let's Try That Again
+  [aOIZvx5fx5jVHHOO] Life Leap
+  [bebyS7XJ1Z3S4Ud1] Life's Blood
+  [hSzNtRNwrma81Eeq] Life-Giving Magic
+  [Ih85PWZSVTwU0xkI] Lifeblood's Call
+  [iNrR4WOB1UO9iiNE] Lifesense
+  [EdVMwFRNV1LX1VWh] Light Paws
+  [sSdlbJYQQD2TwIIb] Light-Bending Jewel
+  [oqoftwLB6tvoLjnL] Lightless Litheness
+  [qzalwa2Ze3dIqIrA] Lightning Tongue
+  [uUSCoVhn5pWbkLgm] Like a Roach
+  [j3An3QgKFre2KW8l] Lingering Breath
+  [ZTIM5YyCiNxIO3Mp] Lingering Echoes
+  [xSOpBaHbrjiaQsME] Linguistic Revival
+  [zi84Xt4dTsLeJ3uD] Living Weapon
+  [FhCsnHjdIUyKteCM] Lizardfolk Lore
+  [OK8X6QFRuRxpBMcZ] Long Tongue
+  [WPz97m5FNlbLIQ6p] Long-Nosed Form
+  [k2L9p4cc8RrHufut] Look but Don't Touch
+  [7AuOURsTkkjrRekp] Loud Singer
+  [VK2vAl1SfI4Qrtkt] Loyal Empath
+  [d022Gp8PjS4Q0ZAC] Luck of the Clowder
+  [lF5B49zbDG61sxXa] Lucky Break
+  [zsubK6PaY58fOYCb] Lucky Keepsake
+  [P8P5PwLgxk84bRQw] Luring Chomp
+  [jcxbTUl0gaPMkmPv] Made for Combat
+  [QXZFvsZDduxwTJYM] Magic Rider
+  [xoB4RDYkdAALt0U4] Magical Resistance
+  [z986NkK75cCcxTlB] Magitaxis
+  [NBwH9wEeUfKfOg8R] Magpie Snatch
+  [Hmgy0GJKIawAiqHE] Maiden's Mending
+  [TYGrEiOjp6pDmgO2] Majestic Presence
+  [okJjCvQ6hcCk8FOC] Malleable Form
+  [9G6wmGCdyXOgExQs] Many Faces
+  [ncVdpZFkqrMJIF75] Many Guises (Kitsune)
+  [2WiNIIvUfNxQoZH7] March the Mines
+  [hgfRHSS5BsoyQ9Fj] Marid Magic
+  [rTjGshtUMHnlBUfH] Marine Ally
+  [TmaxLWraJrvSQOkY] Mariner's Fire
+  [itjTPh76mZfJCBxQ] Marsh Runner
+  [qXl2cOh3wL3QszCy] Martial Experience
+  [KboQgBhYXI2WdCt8] Mask of Fear
+  [ByqxxJkJiNFtjghh] Mask of Pain
+  [RrtqD8WmoUumauJD] Mask of Power
+  [vxE9hBKB6F2ctOX3] Mask of Rejection
+  [XAvDZdWNTVBp68aN] Memory of Mastery
+  [7UDWeLq8OAL04gHR] Memory of Skill
+  [bLSd0y06QRjDYYMw] Mental Sustenance
+  [JBjRGWVtVaxLckfH] Mentor of Legends
+  [CLSRqsf3BDhLfku6] Merfolk Lore
+  [nmmN8AXhIGSj4GGL] Merfolk Weapon Familiarity
+  [Ekk2iEYMAXYT3EK2] Merge with the Source
+  [OslV3jav9PGFMB1A] Metabolic Control
+  [OwJRuy4EW8vW09AI] Metal-veined Strikes
+  [syyT2xBA4H72TpOt] Metallic Skin
+  [IJa7dQvH3HLCBUhC] Methodical Magic
+  [kw1N7RxV1TYywkuV] Meticulous Restorer
+  [txVv3rZuYyp0miFz] Mighty Dragonet
+  [BSrYYphRONIkM19m] Mineral Deposits
+  [Aw0kevD364Kqu1qB] Minotaur Lore
+  [gMWDVkLZMZz7Zy8F] Minotaur Weapon Familiarity
+  [LKkX8Ft92u0ax6Yh] Minuscule Mentee
+  [Q7eH9GK8HL21DKMa] Miraculous Medic
+  [fEzxwMCNyvooYqdn] Miraculous Repair
+  [xruboxaTF6nw8l7M] Miresoul
+  [Nb8iLgQeuHU73hQM] Mirror Refuge
+  [FHK4ZEl8SkGOpKdF] Mirror-Risen
+  [AxqnIMh5WbSah5OS] Mischievous Tail
+  [CXgTn2sE7Do11rlv] Mist Child
+  [ZlPCQ3Qh1cgS9r87] Mist Strider
+  [TvVqZHp7qvkPakKf] Mistaken Identity
+  [TYoE0GDF0URwQqZI] Mistsoul
+  [0BUSnsCKOeFCJKEp] Moderate Enhance Venom
+  [IwETJ7fhszmlNo7X] Moisture Bath
+  [i5VCpYIZYQEWgY5S] Moldersoul
+  [OqGNcUTqaZTp2YND] Molten Wit
+  [7NsqI50oBIJ4bFwb] Monkey Spirits
+  [ZZzgqFTOtUgnzSLZ] Monstrous Peacemaker
+  [xOCmeskMkd8nCmba] Moon May
+  [FKS9nLz07v9x49sE] Mooneater
+  [q4DpMWlSQOvl1CIw] Moray Ambush
+  [P1ADxNv3AcoM9o50] Moray Eel Mount
+  [znX4u20IFE7TPi9Y] Morph-Risen
+  [6lMKIvO6McMW0FBJ] Morphic Strike
+  [TPX0fm9wxndpIqpk] Morrigna's Spider Affinity
+  [sbAb2a6BzZpcYv8y] Mother's Mindfulness
+  [UFn85K7uDsZj5Hep] Mountain Strategy
+  [COP89tjrNhEucuRW] Mountain's Stoutness
+  [nBf0LAT4HwUCOQtl] Mud Boat's Passage
+  [Crcz9cW0To2pkfSy] Murderous Thorns
+  [eSP2938INGUG9b3w] Musetouched
+  [SWNmYaj0OSPhhIqO] Mutate Weapon
+  [djQPfxfGXJL7i04C] My Claws are Daggers
+  [l2JaSC3NA9S6Qq46] Myriad Forms
+  [E5TRKeB63rC910PC] Nagaji Lore
+  [5H2KmhiIGuPxKwBK] Nagaji Spell Expertise
+  [mW9uhe3RorEJg6Mn] Nagaji Spell Familiarity
+  [V4W2hTr5lm5vS8Dq] Nagaji Spell Mysteries
+  [sza9YDyDBSHbzCjc] Nalinivati's Light
+  [tB6V6rWv8vAFsKsX] Nanite Shroud
+  [JS24EjgLYcHB9E3T] Nanite Surge
+  [AAYN41WtyMZaLV1N] Native Waters
+  [SEvwIS22R92vDDMk] Natural Ambassador
+  [PodajLVxqYSAqVox] Natural Ambition
+  [HKGyFj2w5dzkf3SW] Natural Illusionist
+  [S6ilPkeroXoGgZXm] Natural Magnetism
+  [UBAARc8Zo3Gzfhul] Natural Mutagen
+  [JC5mUJssZQKslLct] Natural Orienteering
+  [ojp39fVYqFBGAw38] Natural Performer
+  [ZTVvk5HgcWbXegZ6] Natural Senses
+  [Rfyhlyql1GSoDkI2] Natural Skill
+  [LTIARSoQP8WYE33A] Necromantic Heir
+  [GgerQCCsGibaGWq0] Necromantic Physiology
+  [akCO62yBCJLjjCZJ] Nephilim Eyes
+  [sKDCoxMz2yKWLGRJ] Nephilim Lore
+  [8CSewrCVEmL8sjnk] Nephilim Resistance
+  [iRpVW1DPKVxlzIzt] Night Magic
+  [cixf1uAQF2Y3w1Qx] Nightvision Adaptation
+  [kCO4r8NOm8E2T3eH] Nimble Elf
+  [Ffi8L4EDO5OH5tpA] Nimble Hooves
+  [AKMx0GYKLjy7jTXl] No Evidence
+  [xunnqCkAszIlanLF] No Hands, No Problem
+  [B7VfoCspflTNfmde] Noble Bloom
+  [e3oaaoMZPzyP26QV] Noble Resolve
+  [kJfLBPtiVi5LQu0v] Nocturnal Charm
+  [BNIAfaJPNCWKs3FN] Nocturnal Tripkee
+  [LrPfGV6snjCrZ4h2] Nodal Healing
+  [qGJ9vZbDpYPdD1UR] Nodal Regeneration
+  [cpsyKarYRHiOF0Nd] None Shall Know
+  [wEtN2NkqW4z4GUON] Nosoi's Mask
+  [a5H6dJSQgWfviUHU] Nothing but Fluff
+  [pXoDLlV18D0eGhdj] Nourishing Symbiosis
+  [UiN0XrglcEfYtsSl] Noxious Odor
+  [4xP7rC0gmEb66bAY] Occult Dragonblood
+  [zPJ2NyMv97AfkN3P] Occult Resistance
+  [OuUQDwoQaubig5VL] Ocean Wariness
+  [vLFA0hxCCwINsDL9] Ocean's Bite
+  [HCxmS8QGHL5O7LUf] Offensive Analysis
+  [kQLll2MHalNgdh4s] Offensive Odor
+  [6eXffyvqxpIzig2O] Offensive Subroutine
+  [XXAqMjml33jnQiDO] Old Soul
+  [cayKGa2yK7Gwvk6m] Olethros's Decree
+  [T3cwVrRT0VMZIwpT] One with Earth
+  [pHPRIPMsoVkB6njQ] One with the Wild
+  [fD3RSV9nIkJsW6lD] One-Toed Hop
+  [iCNNMJeGvsIzza4A] Oni Form
+  [Canug4VdAMqycpAJ] Oni Rampage
+  [3o5tWjDIcfIARHIj] Oni Weapon Familiarity
+  [YrawssRNHsyqYuHi] Oni's Mask
+  [mAAlean6DuWd3wDT] Open Mind
+  [PlhPpdwIV0rIAJ8K] Orc Ferocity
+  [254C4rqrE8APDfCf] Orc Lore
+  [SCgqIo8VQZZKZ1Ws] Orc Sight
+  [EFhh3AenX7wtAmrs] Orc Superstition
+  [1HsH8hE79MDsi8kK] Orc Warmask
+  [1tVC0mcxl8sTCg4U] Orc Weapon Familiarity
+  [8RZ4VKXJgtl1aN27] Ornate Tattoo
+  [KgiYiDz1lWoBMRlF] Otherworldly Acumen
+  [Pat4H0VbmApblZxc] Otherworldly Magic
+  [KuD4Yplwcdolhjsu] Overlooked Mastermind
+  [aGpH394T1xr2ey88] Pack Hunter
+  [hc4lWhWekIVb0wjL] Pack Rat
+  [0FqbyC5tR2DC0DOk] Pack Stalker
+  [9LTBRvuQgXKZFiZc] Pack Tactics
+  [j5VRy2iVz5aulQ1h] Pain is Temporary
+  [GeDrn7Zmxt9JvHec] Palm-Leaf Silhouette
+  [WRZZItgiMmpLnhdh] Pandemonium Eruption
+  [O8FRS2PI66r73fBZ] Pantheon Magic
+  [uw6xu0H8vZLuizUf] Paralyzing Jewel
+  [U12Sh43QuY85Prdm] Parthenogenic Hatchling
+  [Z30nSkai5UmZCyKu] Past Life
+  [Y8c8hAyjNAiqgxAO] Pelagic Aptitude
+  [MbvPuMVy2VhftJgd] Perfect Dive
+  [eVXepct8mhIynP3B] Perfected Gamtu
+  [m25EfSMmEjJPSyJj] Perfume Cloud
+  [czFQyDI8Wur7F8bO] Persistent Odor
+  [VphmK5JRR35SyEhV] Pervasive Superstition
+  [MmrE6B5eM1RshXKY] Phantom Charm
+  [18B3fL77WgEY25M1] Phantom Orchestra
+  [4IXptGOASHZAptH8] Phantom Resemblance
+  [RFzYrKP3eR3WG6hV] Phantom Visage
+  [baVAW4IDiCyKN8Q1] Pheromonal Message
+  [NN1U8ifiURc0h4Fx] Pierce the Darkness
+  [ABx8keV4c43gEmeN] Pierce the Light
+  [YfjuRHzqLFhLLgCc] Piercing Quills
+  [8ukixWL8MBJOhPbW] Pinch Time
+  [ODy9tq7NPlD5fxzZ] Pit of Snakes
+  [gxQheZ4xuDWwyzy4] Pitborn
+  [iCsHR5tdSXDHGjCv] Plague Sniffer
+  [29lo48f8TrU5kdwh] Planar Resilience
+  [HWLD3zGFBIjCDATo] Planar Sidestep
+  [iA3i19eFiGt4GTF3] Planar Traveler
+  [27ruxnDDCc2rQpMX] Plane Hop
+  [wQ9aR5U9phCSM2WW] Plane Step
+  [s6C5jtru8j0sONa6] Plane-Stepping Dash
+  [mlFDIQuh84VLj5IC] Plant Soul Siblings
+  [vzKvihYNModB7sJ7] Play Dead
+  [X7s1EtZBb6m4w9u1] Plumekith
+  [h3h6QWv1m3MOpx66] Political Acumen
+  [S4rYzJqW3tbdXS1Z] Political Virtuoso
+  [JDH1AIUF0XpmXpYt] Pollinate
+  [d8lWzMTYq91wOgMN] Polymorphic Escape
+  [lqZzStaRrX6WqQtd] Ponpoko
+  [hDvjODvJXdFjZJ81] Ponpoko-Pon!
+  [Pqk5ED2YU5O8nKLX] Potent Nectar
+  [6I0iZWBdDWZ7oX5a] Pounding Leap
+  [F4W5a2vkhUP7Lr4j] Powerful Guts
+  [jABl7ROkV1tsX87g] Practiced Brawn
+  [I3EMC4pqkEWrodpq] Practiced Paddler
+  [A9HQ2bMAge2aGgWx] Prairie Rider
+  [2UhnxV2RWMmmgKja] Precious Alloys
+  [WQa6PxkOgyvRpaaM] Predator's Growl
+  [NEl8G3SlwxOR9Zx1] Preemptive Reconfiguration
+  [uQGo33E4haaFNg6u] Pride Hunter
+  [CCY6VsGjp5fdmM6K] Pride in Arms
+  [XAsPe0mfxfQpgvCR] Primal Dragonblood
+  [X1SPiYJqWzqwzPTs] Primal Rampage
+  [SFnKHPrd65RORTgN] Prismatic Scales
+  [7Te7XHgRjesDKwZn] Prodigious Climber
+  [NYcgVwO4xLerJ9lO] Progenitor Lore
+  [twnZopGlB392hmqH] Project Persona
+  [gNFPwTHDygxdf9pw] Proteankin
+  [f9YlMYWMjd0zoyy0] Protective Claws
+  [sTqdFqWVL9yxi5wt] Protective Sheath
+  [DP5VVZHERQlYuYTa] Protective Subroutine
+  [vD3l0Xn4hb7xnQic] Proud Mentor
+  [enRKfPyCLU5FMUOX] Proximity Alert
+  [HoU7pgdW7KPO347H] Pummeling Whirlpool
+  [an8sq0RaJ8PW81EW] Puncturing Horn
+  [pFd1TnqkAerGHuX7] Purge Sins
+  [0Cc2oFLuwQ6DCQCu] Puzzle Solver
+  [BF5B2kDrSruQpqgS] Pyrophilic Recovery
+  [JXBEnawN7vHFtdNp] Qlippoth Magic
+  [ZDO7foRCMd9niGsK] Quadruped
+  [liqDAd5xk2b3xzeE] Quah Bond
+  [aBbpdmbMGN5ox0WT] Quick Recovery
+  [it5yM6sbwJJysm9U] Quick Root
+  [DmcJtpMBSh3R5MHI] Quick Shape
+  [LAArv2uv6TOkTzQO] Quick Stow (Ratfolk)
+  [2piYyNIoMJAZeOOW] Quicksoul
+  [S7z1LbnSRlBep8rO] Quietus Strikes
+  [ux6kbsqRMsu9VHtn] Quill Spray
+  [kvhouG3yJ2vQkzah] Rabid Sprint
+  [9eL7W4rvs4sjhWFT] Radiant Burst
+  [2XmdYW8OsAvjGDG3] Radiant Circuitry
+  [FL5Ecvy7WYU1OzVv] Radiate Glory
+  [ZPJbjH5XCp39TVu7] Ragdya's Dance
+  [Nv9hNKVSioDw5DHC] Ragdya's Revelry
+  [llWnSLYALh88iRGQ] Rain of Bolts
+  [lftLbPzfOzqAxbGW] Rakshasa Magic
+  [jpRVp1INDAlYWvlI] Rakshasa Ravaged
+  [8l3qDZrfhxUGijjB] Rallying Cry
+  [9eaUS0jJCpxuNXO5] Rampaging Ferocity
+  [Zl6vDXJEM7Lbp8JQ] Rampaging Form
+  [iOMoUtyauZEAXYSe] Rapid Pheromone Recovery
+  [WUmeSZZ0feYyZJf1] Rapid Retraining
+  [W2LmEXJH75tyeCSn] Rat Familiar
+  [SuEmijj909yxmYOO] Rat Form
+  [8MMYFIudSDkdo8cx] Rat Magic
+  [mQYO501xyMgtIQ3W] Ratfolk Lore
+  [969mPoiYANzV2261] Ratfolk Roll
+  [VDiMapgJoFI3CCol] Ratspeak
+  [VcnOEAM3UR7oS0D5] Razzle-Dazzle
+  [tBRhYPGTb30qP34t] Read the Roots
+  [DhqsKns2SaGcOKO9] Read the Stars
+  [2jy4uh04yz0ezz6Q] Reanimating Spark
+  [95PmHIS041KiYIks] Reassuring Presence
+  [fqw1ELaqavuKLHIj] Reckless Abandon
+  [OOBSMpdAfYuiiQqo] Recognize Ambush
+  [TGDy2R6Dq8hwZir4] Redirect Attention
+  [yJhMyG1HHUZEX7SS] Refined Motion in Darkness
+  [zSJ0Ke8HWzG1krlq] Reflect Foe
+  [Bi79QIvSE9JxJGkp] Reflective Defense
+  [EIbppwlEu11ltC7n] Reflective Pocket
+  [ffjoPXtAoIR2Drwe] Regrowth
+  [XOudHBESJ192FBwF] Rehydration
+  [b5j3boj1iEcXSB9f] Reimagine
+  [SrngYpUpBOa73XTL] Reincarnated Ridiculer
+  [cilZUszwjSGB4p1W] Reinforced Chassis
+  [RXy1hARlhED1fZ5T] Rejuvenating Embrace
+  [T4OSMMEvbymMzlIJ] Rejuvenation Token
+  [eXv8ZWcASOgs8jLZ] Rekindled Light
+  [SsME16puYnUzga3O] Release the Light
+  [QgNo1s6nVbKPU4St] Reliable Luck
+  [XphnZlPp7jEqeyeo] Remnants of the Past
+  [iRztLGEK5OfjZTPg] Remorseless Lash
+  [FAUqvzfZDpRG44q0] Renewing Quills
+  [zpQEOqMDoujexNfA] Replenishing Hydration
+  [bZGCOKLtCzMnrVwk] Replicate
+  [k31sg0xBIwvkfWyg] Reptile Rider
+  [GEvaoKgQteMrd4ub] Reptile Speaker
+  [vdowlFFknihiz5pm] Resilient Physiology
+  [FqZKSSBU7M4zhsXM] Resist Ruin
+  [OP5OZFXJwxCTtJyK] Resplendent Spellhorn
+  [dftzUTOrj9dQyN3q] Restitch
+  [a3eKpbAQnxGrlnGq] Restoring Blood
+  [J7BtszszVxpETMD7] Retractable Claws
+  [daVIABU0UzyMnoiA] Return to the Seed
+  [HfebybiUNW8mXOfP] Returning Throw
+  [MR9PtioOPfTXIzHA] Reveal Hidden Self
+  [1lpygRsa487Jto4L] Revivification Protocol
+  [5S1nPoxHTgu9MGGV] Ricocheting Leap
+  [4IurxX5pB7NmQX4q] Ride On
+  [khsosF7v8FexrL2h] Riftmarked
+  [hrITlxkBqHvaiiRS] Right-Hand Blood
+  [rswkPvZvEBXISH96] Rimesoul
+  [o1LhDmwymrpEy1u2] Riptide
+  [usSE6mpdYSGmDdds] Riptide Mount
+  [kpn4R65YlD38iAIS] Ritual Reversion
+  [ruRhslwl9ReaVcY4] River Adaptation
+  [lLZ9B0KeMDf3BNuA] Rivethun Disciple
+  [uEaXm7eCfeQgtD38] Rivethun Spiritual Attunement
+  [NIUSBGMmdqhkYtmo] Rock Runner
+  [Xwk41o4fERfM07NR] Rokoan Arts
+  [ATiQDz27aiBTAt17] Roll with It
+  [DFMjIYlTeBlNhfsl] Rolling White Bottle Form
+  [GF9kkULUYowgjEWM] Rough Rider
+  [ecJms2jtd6cZ5rQK] Round Ears
+  [xtQ2OffYzLgML2DP] Rouse the Dreaming Relic
+  [23F2oqjL7SAMW3Ud] Ru-shi
+  [qUZnrueC2a0zf95N] Runtsage
+  [AL2KD88ddEl5AetZ] Saber Teeth
+  [LeQLGSemx7x0sL7s] Sage of Scattered Leaves
+  [eIXMBNTsA7yXzM9Q] Samsaran Lore
+  [5dOAR7OypjgUTz07] Samsaran Weapon Memory
+  [csoGdGuWasEw3boD] Saoc Astrology
+  [HhgIofEsA7HwjO6U] Sarangay Lore
+  [e8DABlCNZ0h0i9OA] Sash of the Wind
+  [ulQzdBOnZH9LQu8M] Scalding Spit
+  [R3erN2vKsjo84pen] Scales of Steel
+  [tEzwhF3uFIi825xj] Scaling Poppet
+  [Vp00zw92L5yGqBHB] Scaly Hide
+  [xzpMQ2ZRn9zC23XG] Scamper
+  [viFTJfZusRPx0G2q] Scamper Underfoot
+  [z2z3UTayfUhcGazv] Scar-Thick Skin
+  [n4JiVs3f72XS99f6] Scarlet Strands
+  [zaGD9Og2p8Opa0oJ] Scavenger's Search
+  [KRMdfPcNCE7AVsEo] Scholar's Inheritance
+  [wFtJlamwRc6rSQmj] Scion Transformation
+  [oM5TORDkpchJF0R2] Scion of Many Planes
+  [Xdtwvy3RrrorHEzX] Scorched on the Crackling Mountain
+  [NnpUhj7d4RmfOKTE] Scorching Disarm
+  [HpAUTAzEAK7mGsJ8] Scrutinizing Gaze
+  [TwAps3ewk7KFHKDv] Sculpt Shadows
+  [UHJ93iBd1Q5iKbKa] Scurry!
+  [nnlzI9LSvhl94U16] Scuttle Up
+  [ZYNpncz5wwJmduf2] Sea Legs
+  [rBSU5s8hsKiIqOID] Sea Witch
+  [1LFbIRhb3Fgk4203] Sealed Poppet
+  [dwleUePjjZAFRxRg] Seasong
+  [gyHAVCNjESPbc5ei] Secondary Adaptation
+  [M8pDuRo6tO0Kok9z] Secret Eyes
+  [Wu6refn3bqI1vYvi] Secrets of the Past
+  [D5atazp26amNzoqO] See You in Hell
+  [CAfrSLaDM0OBaNtp] See the Unseen
+  [dWGa6cFSVrASTEfd] Seedpod
+  [m5JYglEObpWC3dhP] Sense Allies
+  [LRBzEzpS19z3Eghd] Sense Thoughts
+  [T8cBEhuHWkh3MqgO] Sense for Trouble
+  [jOwZMv5jtwdKSfLS] Sensitive Nose
+  [2hwI3i6YKWUPZrDu] Sequestered Spell
+  [roC6o0xJ8hDzHIWY] Serpent's Tongue
+  [SxRmlDYhYEkq10Ak] Serpentcoil Slam
+  [0X4HZk036A5meZbo] Serpentine Swimmer
+  [sleWJp0dtIuZ3DPq] Seven Changes Performance
+  [ioK5GZD2dnrLB7ti] Sever the Dreaming Shadow
+  [p5MNrGSTmMATRG8C] Shackleborn
+  [H95Gh2nKUp9NKFuR] Shadow Blending
+  [ACeqRSWr4CEwLZgO] Shadow Pact
+  [7YvOqcdp9Z0RALMp] Shadow Self
+  [NjPZbQjJJIygS1ru] Shadow Sight
+  [RqViXhBIjbgH4bVS] Shadow Tempo
+  [kDklfrprKTuTpcEE] Shadow of the Wilds
+  [8Qn80RunXaChOM5p] Shadow's Assault
+  [Ic5C2y26H2mbUiUF] Shadowplay
+  [oSA1Ii6gTRGobeSO] Shadowy Disguise
+  [8buK32r3i3aGyyOR] Shaitan Magic
+  [3YByhZJi93ie5F45] Shaitan Skin
+  [q0SPmS77pNgiQk93] Shame the Sin
+  [nbWkPLiUxagX8dCw] Shapechanger's Intuition
+  [G8WgbujrrnMQUQ8E] Share Thoughts
+  [f5Vkk2rM6tCe2zQn] Shared Luck (Halfling)
+  [jP0D4CIyloiBaEh4] Sharpened Senses
+  [t3IzY8uSyFj3aGmh] Shed Tail
+  [g9nHhqb8Bl1njopV] Sheltering Jewel
+  [sGSf5BdopT0zWOWs] Sheltering Slab
+  [iY08DGiUW8MVBR5k] Sheltering Wing
+  [B7p45ZOfnpIuuTzJ] Shift the Little Ones
+  [qZUdGd2khS9cq4hJ] Shifting Faces
+  [JQxFvMHu0ffo56RT] Shinstabber
+  [eZsMl6rx8Bv6Ccnp] Shiny Button Eyes
+  [MqDLaBypDyp1VQKg] Shisk Lore
+  [B4e8V5nExlScjojY] Shoki's Argument
+  [yCaWcKlpbAfebqlO] Shoony Lore
+  [flJuFjYJ7NY9yeWD] Shore Gift
+  [plhQDES7yb6xDAXL] Shory Aerialist
+  [Eoy0zhpf8tYrTHN4] Shory Aeromancer
+  [gsDDw5KAb7qlPkms] Shrouded Magic
+  [qxQf0HiYBh26mCMT] Shrouded Mien
+  [yiZwGVErxzWCJOlW] Signature Weapon
+  [HPW7Qi02lkVprW6V] Silent Step
+  [1Doigqr1vBzg0tWU] Silent Stone
+  [Hy8SPadSjukKq078] Sinister Appearance
+  [XdicxD5jMJ8JSVqk] Siphon Torment
+  [eRSgUQLhGWhICwpT] Siren Song
+  [UojXcKf98oAFJUE0] Skeletal Resistance
+  [TtSLIMiNw1hqMui5] Skeletal Transformation
+  [rHBmZi95n0pcQqxs] Skeleton Commander
+  [exJmNR2XH1i6PGw3] Skilled Climber
+  [zR2jp5tcb8GjnR3v] Skilled Herbalist
+  [6UucEQumAx9sAEvF] Skilled Swimmer
+  [iS7MvHewCeQRT78d] Skillful Climber
+  [aVRuchEAJIvnd70k] Skillful Tail
+  [HEvk4ja8nJ3RVEqi] Skin Split
+  [dor2F3g8gL2KVwX6] Skirt the Light
+  [dtmLxbSy2H8h8e4N] Skittering Scuttle
+  [NaY9HXeQ0yhoIorO] Skittering Sneak
+  [yaacOmfmBuGDcNOs] Skittertalk
+  [VV7vbDzcO8vdD3OO] Skull Creeper
+  [xTe8lNBp76jsrhYh] Slag May
+  [tnyZHm4yz6JUi2hy] Slay Giants Unseen
+  [zz2kOAHYBxbLtOV0] Sleep of the Reborn
+  [LbyNDCxFEkjp0iG7] Slink
+  [iXhMlT5rlLngybxX] Slip Into Shadow
+  [rCajlx2KjGxzabAJ] Slip Sideways
+  [O2iFrAt7hyELJlIR] Slip the Grasp
+  [mfy0nasMIiMLUm3f] Slip with the Breeze
+  [TW5TY7kSf50uaX71] Slither
+  [Qwwq282yeMkAC0Fp] Small Speak
+  [8nz6gvymeTvEfdo0] Smashing Tail
+  [67UXSHUUH0K36xyB] Smoke Sight
+  [tBfrd9zThNw9lkTI] Smoke Through Bamboo
+  [lqhhvDJAjPw6LZy5] Smokesoul
+  [d3bonWM7JoPeOGhh] Smoothing Stomp
+  [nqDhQdkgsnvebUMr] Snare Commando
+  [8DIzXO1YpsU3DpJw] Snare Genius
+  [eMmdBpbMrpIuGowo] Snare Setter
+  [augNhQ51eSlZyead] Sneaky
+  [pP4pbFBg5GAgcOE9] Snow May
+  [Tl8yckXeTCHnwrlM] Soaring Flight
+  [WZC2XXQo6Pu2GQeo] Soaring Form
+  [JrBqOxHZX20b8gTT] Soaring Poppet
+  [tn7K5lbnF87rZ659] Sociable
+  [ttgv3PPCJLeI5pUL] Social Camouflage
+  [K9ixUl7PrNbBHGdA] Sodbuster
+  [velPTcpjLXPnaYrm] Solar Rejuvenation
+  [BiPUUNGoJIj1mqjO] Solidarity
+  [BL2nLeClO30QoQGs] Spark Fist
+  [FBtm9rZzk0tCQu9H] Spark of Independence
+  [AFXY5eM4IQuo5Ygj] Speak with Bats
+  [psgPbKsbqfz6Qt4P] Speak with Flowers
+  [KYKK1vLqGIxXH5Tu] Speak with Kindred
+  [QLd6SsRDR47hbGMa] Speak with the Sleeping
+  [gVCP5lZEWviHMGdV] Speaker in Training
+  [J7j6sSIdkwMwoZTx] Speaker's Defense
+  [pedHIDAVLFzzjGO1] Spell Devourer
+  [QkDZ96UR3PzW8FDB] Spell Survivor
+  [6ZNSMR0lRSLwBJBe] Spelunker
+  [GfpHBiOX02PQz0Pm] Spew Tentacles
+  [Bn9yK3FBndHkbVsu] Spine Stabber
+  [ky9jhAGOWGj8gAsO] Spirit Coffin
+  [2RmsQrLySNYQ4uIn] Spirit Soother
+  [kHZ6OCP0Yj2xBvHB] Spiritual Echo
+  [Y5w2BOMeZpbSC6Ss] Spiritual Headhunter
+  [c5xHL6CDFwBqXx2a] Spiteful Rake
+  [bft7gWfibx3BY5BK] Splendid Illusion
+  [a32r2n9j36khV0Cp] Spore Cloud
+  [3HuiLoQuJKLAh5rV] Springing Leaper
+  [eeXyNpzNvPcuOflc] Springsoul
+  [0fTHqIqXCwGKiykR] Sprite's Spark
+  [jzfV4lJ0721Hfzq1] Squad Tactics
+  [CCmiEmS7ZgyQUfhn] Squawk!
+  [SzkpazSZ0pi1WZsH] Squirm Free
+  [d1FTY5ai9KjpkX59] Star Orb
+  [Oa5sEYqqY8gNTo56] Starshot Arrow
+  [2VzIrCWJU4dJQV0x] Start the Festival!
+  [Iqa96LHn3Bs2xEJA] Startling Appearance (Fleshwarp)
+  [0WPoejtMjqsahdyW] Statue Form
+  [s0OqtQOeYOGkBMYG] Steadfast Ally
+  [FZuQPFnQ5UkBWLU9] Steady on Stone
+  [VFBQ1MskOascFDNf] Steam Spell
+  [eXJR3U9UcwMpSWgJ] Steelhoof
+  [aW6Fg2Nowl4oB3qP] Stem the Tide
+  [l3PosipTLXANeoT8] Step Lively
+  [3Y1k2eAMqCdcCGmK] Stone Bones
+  [Nn80wBZYJZxcuKsJ] Stone Face
+  [GYvaR6ZD8ZKdQWrF] Stone Form
+  [Anpsl8ibCaXcBNG9] Stone Passage
+  [NPVi1iPfY1GpiC8A] Stone Soul Siblings
+  [UquGIEFKhutgJsEz] Stonegate
+  [HOUHs5rahwIsQoBf] Stonemason's Eye
+  [KTLdk65OOAVixqtY] Stonewalker
+  [gLOLdDj21bTaLHp7] Stonewall
+  [FBhBnyGX0Uje0tbJ] Storm Form
+  [bWyY9NtLU5wXr03y] Storm's Lash
+  [D3usONRMsGZ7mWs1] Storming Gaze
+  [qm1lIMLVdsQtVFT0] Stormsoul
+  [IzJ76OXe1gl2hfbd] Stormy Heart
+  [Lug2p9E065L05Rhi] Story Crooner
+  [ZGnmky2B3v1pbPDA] Strand Strider
+  [PVkAEBlRSJHe3JCz] Straveika
+  [yQ3YBBgkMwK0wn5b] Strength of Eight Legions
+  [1yXmi6vKae6J1A0L] Stretching Reach
+  [TGlb3gmSKkJBZt5q] Striking Retribution
+  [L7fhh2RTCq4FlVSN] Strix Defender
+  [HOXxEa7sAeAxpKHb] Strix Lore
+  [wjhhlh82MABhfxCO] Strix Vengeance
+  [UdwXT24zrLzg2ZIV] Strong Swimmer
+  [aSS0d0elPm9hDP7d] Strong Tail
+  [eWQCoF7zeYSyLgB5] Strong of Wing
+  [KQ5xOAqZ1KPN3FgA] Stronger Debilitating Venom
+  [XluSn2ejNkvFMuB6] Stubborn Defiance
+  [55XNy1TVETEMc0vf] Stubborn Persistence
+  [C2PmqTxQgWGTHluf] Studious Adept
+  [jNDjLsqpq13RqzD4] Studious Magic
+  [95DHxSO4TOP8W7qM] Sublime Mobility
+  [qT68NpouO667sUMA] Sudden Mindfulness
+  [tXn6fJO3Q2dAvCZC] Sudden Terror
+  [7bVJEZt2vwAAnILV] Suli Amir
+  [GPsYtPdkAkk710F3] Suli-jann
+  [fDsJH3Vxnf6uZWql] Summiting Dragonblood
+  [569SxRBvTCDiHlbW] Summon Air Elemental
+  [lrTRELs8uDpVpsk0] Summon Earth Elemental
+  [cIJfKlbfKezdDbwK] Summon Fire Elemental
+  [j5AFlrvDipO0s7UW] Summon Metal Elemental
+  [L231BR4815B6hwKT] Summon Nephilim Kin
+  [Fn8dEIcUZVxuWJgN] Summon Water Elemental
+  [Mjt89h8hvZS4nl0P] Summon Wood Elemental
+  [aBCvQ1x4W9bsrYPJ] Sunlit Vitality
+  [Rr7GdUjXhGhV04Pe] Supernatural Charm
+  [ehvHedIwPcxq9cRt] Sure Feet
+  [hkMQGiTJCLVAWHy0] Surface Culture
+  [nqtO5dNnxT4nZDbB] Surface Skimmer
+  [P9KuYKeaH2Scpkgy] Surki Lore
+  [Hx4DeunGyzMsoWqv] Surki Weapon Familiarity
+  [P1dk0LTWkQ1LT1ai] Svetocher
+  [qz2gKNsHDMITpGPH] Swamp Stealth
+  [l0VBbymCVT1Qz9t9] Swift
+  [lBVzIet6IpufLXZg] Swift Application
+  [8Cq7OqVDPCnF70ay] Swift Eel Mount
+  [iliy0ONIb8Hw6muA] Swift Swimmer
+  [uHuKvex8wUrGKdCj] Swimmer's Guidance
+  [SYcTallEKEaJeNGw] Swimming Poppet
+  [nJRcbt72wRk5Rmc4] Symphony of Blood
+  [U4sO6CL7upsqAgws] Synchronous Slither
+  [sQLgEcqoQ0SYtbTg] Tail Snatch
+  [rnEfO5eyRw7Fywzb] Tail Spin
+  [agvMFNvvuQFAveP8] Take Flight
+  [ER19TNTiYbNvkhw8] Take Wing
+  [lXa8w9W4BIFkuagU] Tangle of Limbs
+  [zxozwMyJgOzxADHh] Tangle-Tongue's Wit
+  [dH7ZyYArCHJfpKRi] Tanuki Lore
+  [WWSwcvIjGUQOKKuD] Taste Blood
+  [U8rjCtUuk6qhFyZs] Teakettle Form
+  [sqLCBReZ1U13saDE] Tears of Pearl
+  [Ht21JJ95wiHOgZoT] Telekinetic Slip
+  [ADDOwO0QWOXAV85x] Telluric Power
+  [Cjl530PBu86JKL9c] Tempest Gaze
+  [I7S8Snq8FlrBHmbf] Ten Lives
+  [1KtlTS3dWcqRWwb8] Tenacious Jaws
+  [YndH82FX7KLawNBW] Tenacious Net
+  [GAh4CwCMS3Gsl8WH] Tengu Feather Fan
+  [GjQZMmw2sz8OyLxj] Tengu Lore
+  [AmFv3ClkAVRowHLI] Tengu Weapon Familiarity
+  [92fmK6O9y8Wf03P4] Terra Dragonblood
+  [FrzskqwNWexKY5BA] Terrain Advantage
+  [T8tNZANOWUZiXuzO] Terrifying Croak
+  [z54Jl3KRZpA2UaZV] Tetraelemental Assault
+  [OdfEpte6cnGB2EOY] The Cycle Continues
+  [ceQ09tTO4M7qwHXv] The Moon Weaver's Art
+  [MXkklchuimVSHZyd] Theoretical Acumen
+  [hBCK5r3Jjd719Ydk] This Time, Bring the Body
+  [dxqBfIJEzoUJapyF] This Too Shall Pass
+  [20eTy6lRpCnMymTp] This is What it's Like to Die
+  [TRC4DgVq07cZO65B] Thorned Seedpod
+  [TXWxuF8O44zNTUz8] Thousand-Year Grudge
+  [DJn652sW7nstvXf5] Threatening Pursuit
+  [XVrpC00xqwm9mO9W] Throat Pocket
+  [oEvcWFvBnsZ03OGW] Thrown Voice
+  [1jZ7f4TJqiFH8Ied] Thunder God's Fan
+  [bPPcPUZMlJ7m5lYq] Tidal Shield
+  [T4ulOYkFh8gq2kY9] Tide-hardened
+  [ILJBC1tFusaHVYQI] Tikling Bird Twirl
+  [Dc5hLCC2qxCDWjX5] Tip the Scales
+  [50CRpoP5XS1MVbu8] Titan Slinger
+  [oL6f86dy4yyx5N54] Tomb-Watcher's Glare
+  [y0Ru2hRmoRwkRsxZ] Tongue Disarm
+  [5j3nLvicUVmPqzA7] Tongue Tether
+  [hLJgvbq1uJwMMl0C] Tooth and Claw
+  [l78KwojlT0AWvS4l] Toppling Dance
+  [U5FcfRvveTKtgebq] Torch Goblin
+  [TcUpt0KaDnoYheX8] Tough Skin
+  [9CIy4cJJTcRM30Vz] Tough Tumbler
+  [fiA3rfqPcCKFCI83] Towering Growth
+  [t3Eky3ijnAJTiCV5] Towering Presence
+  [lvEcVeZdYPCGc4tQ] Traditional Resistances
+  [XMPUFhCUC9OILIJH] Traditional Ways
+  [WU9G9p2ezx2YDLhv] Trample (Centaur)
+  [7GGxoXYNA4YrtML9] Trample (Sarangay)
+  [GGlpvu7i24ZXXkmX] Tranquil Sanctuary
+  [Ce5xvrkgh9eyOJLL] Transcend the Azimuth
+  [kIIcgcc5SWFkyiBj] Transcendent Realization
+  [n82gTpAENgr6XjCM] Translucent Skin
+  [PdIN91xKsZ4z7p17] Transposable Compliance
+  [9Mmp4Pc2iBRsAbUl] Traveler's Counsel
+  [VQmKNh0QPHzYMmee] Treacherous Earth
+  [qS2VcFLez4PLOpIS] Tree Climber (Elf)
+  [XYtnVNKt6uPcRrdH] Tree Climber (Goblin)
+  [KeE8Ky38dCX8XaTg] Tree's Ward
+  [qfeyJVAMyYKXmCvx] Treehealer
+  [PtmaaJdutJwxHvfm] Treespeech
+  [oItG5dqlPEi8wNnR] Trickster Tengu
+  [PRlN77xL6Bm2gUIp] Tripkee Glide
+  [5VWItcyt3Mx6mbSK] Tripkee Lore
+  [CvtJ98EZvBGSCLOX] Tripkee Weapon Familiarity
+  [jXi4pZiYVakeqEXF] True Dragon's Flight
+  [kr537ZL3f8tCSgDK] True Gaze
+  [wB1uoMoCcoqIwVZz] True Senses
+  [gio13ryyv0SJFHPb] Truespeech
+  [7QNc7FnfT7GZa5w3] Tumbling Diversion
+  [jSZJWYHZU3hnGRcp] Tunnel Roll
+  [m9tKNsZQQjHdsmEN] Tupilaq Carver
+  [wAeI18wyWVwfUrIP] Tusks (Half-Orc)
+  [M5195FvfCN3X7gi9] Tusks (Orc)
+  [xk2gh29knxrZwFFR] Twilight Dweller
+  [6NXlg11EeCqjOmSg] Twist Healing
+  [Bni2NcuQn6Z546RE] Twitchy
+  [SjwISllgvlKEcjSv] Two Truths
+  [A1RzkLCj7mXJI1IY] Unassuming Dedication
+  [N6NRFuPvlBE1Awc2] Unassuming Heroes
+  [E0EARGd5iryHJGJD] Unbound Freedom
+  [uK8DpaOJ98BeA6KV] Unbound Leaper
+  [TZQUhuEjSPSVe0oS] Unbowed, Unbroken
+  [e9H7w0X6yFEhn3h4] Unbreakable Resolve
+  [99WRahrMC91D6MMe] Unbreakable-er Goblin
+  [C1R4wd6G46CAVIn7] Unburdened Iron
+  [qpVB9F9DURW4Lti1] Uncanny Agility
+  [yYIyAbwpdkySiCMU] Uncanny Cheeks
+  [1RygexXEjCKuR3Ps] Undaunted
+  [espST21gwaZQFxpw] Undead Companion
+  [UOL44Qm1rOVD5TFg] Underwater Volcano
+  [zZOycr00XDVTKuXa] Undying Ferocity
+  [AgR1OPBHDvwV5wKD] Unexpected Shift
+  [CFNjlHpVUit4ygaf] Unfettered Growth
+  [uuD8Z9jUG61GmenX] Unfettered Halfling
+  [IyFz7kVF8wzPdrfJ] Unfettering Prankster
+  [RFXzsfEgz7WbDCQO] Unhampered Passage
+  [EiiCCJqWnN5RYMV4] Universal Longevity
+  [fjB514XFJG4V3wMy] Unleash Yaoguai Might
+  [sbIZJnrc7r3VzSoE] Unlimited Pluripotency
+  [ko399VJY2VsKE7iM] Unlock Secret
+  [eJmloGN2jfKYUNPw] Unnerving Terror
+  [wHxXVknciaD4X8Ch] Unrivaled Builder
+  [lroRguweCwS6hosD] Unwavering Guide
+  [uW0VSyy75YrsvtWz] Unwavering Mien
+  [bJTcHDqHOI6xD4AT] Unyielding Disguise
+  [qXBSXhgQYY1wVtya] Urban Jungle
+  [i0iyW1I7TylEgpV6] Vampire Lore
+  [NN9sKez7Z9R8q1i9] Vanara Battle Clarity
+  [qZStZXyAj6kSAKQo] Vanara Lore
+  [YDfcwp0NVbmpgxej] Vanara Weapon Expertise
+  [oQzyeSUlKx6eHcZp] Vanara Weapon Familiarity
+  [v0ovKn4ZKmtXfXnu] Vanara Weapon Trickery
+  [7ZwXUlnqjj9zEYbO] Vandal
+  [pCck5GgKIiIPGGdy] Veil May
+  [cSJHihvgeDu5K44j] Velstrac Magic
+  [JQoASVxRAVnJL0l3] Venom Gulp
+  [aRqXpCBWic6a3DQH] Venom Purge
+  [6kC0OuuWHyaqR3UQ] Venom Spit
+  [oeGowXO2P6rHbZfY] Very Sneaky
+  [u0DA0gkrZxXb0Hle] Very, Very Sneaky
+  [3GjfoEl3lbmhLin5] Vestigial Magicsense
+  [1MqvE1FL2mZRCnzo] Vestigial Wings
+  [txgCXcNMDe9kO7N8] Vibrant Display
+  [QHwajD5n8P3oS9Wb] Vicious Incisors
+  [QjHZN1uAxl2hSbej] Vicious Snares
+  [FWfKbAxTct6q3AMp] Vicious Venom
+  [YeVDITJplindA27l] Victorious Vigor
+  [D2tyUKQiDSq3JO1Z] Vigorous Health
+  [BoqMvGy1jXpsaBbo] Viking Shieldbearer
+  [vWUPSvEBHr5AAPUU] Violent Vines
+  [tkY5jXELipWjC8k2] Viper Strike
+  [f6VPqhOPW9XfBKDr] Virga May
+  [Ezk3OgfPaRlEEyAD] Virtue-Forged Tattoos
+  [pgsSUJehsKZXlRp7] Vishkanya Lore
+  [OCANjuCQ1wcCRBsn] Vishkanya Weapon Arts
+  [aEhUX2c1xj57CMw5] Vishkanya Weapon Expertise
+  [sMZBH6ROL44EDpXB] Vishkanya Weapon Familiarity
+  [7vUOlVqjheZV0Nmc] Vivacious Conduit
+  [2m94GSxJIkQZ5Xnt] Voice of the Elements
+  [5VkVWZq7ZqH6RaAW] Voice of the Night
+  [MFcsGkzPYaWxwW4d] Vomit Stomach
+  [PQu5VTxtAlwhtTZl] Vulpine Scamper
+  [ne7nVluvvVXMvuB1] Wandering Heart
+  [S1Z5dFAkMKkFSofk] War Conditioning
+  [NFsQOa3ynthYLVj6] Ward Against Corruption
+  [vRX35YpaPqtwsAGD] Warding Jewel
+  [80TAzC8XeFKRl7t5] Warp Likeness
+  [yaoekizcgPIlqVcC] Warped Reflection
+  [8H72RC7QI1i8wjJ1] Warren Digger
+  [jmW8aZ5JGH3m6dL6] Warren Friend
+  [9Orkgjgfx8AILuqD] Warren Navigator
+  [fu1cTh93zgGweduf] Wary Skulker
+  [lwzspz4dktZLgqlY] Wash Out
+  [KKUDZUbX3nDdME4K] Watchful Gaze
+  [zAZJpgeEf5TWvdq4] Watchful Halfling
+  [ab7xlmUzPUOFnAl2] Water Conjuration
+  [chM3Pya6H8QGnEGo] Water Dancer
+  [U09VfgU7alL0acWv] Water Nagaji
+  [Q8fdMjZ2Wv3FawOI] Water Strider
+  [yWt2Em1Cz7mgDS1R] Water to Water
+  [JBOYcMSa7PoKLaar] Wave Speaker
+  [AcgxKcA5I3dNTWLr] Wavetouched Paragon
+  [BRGdj5leyVFRHEUM] Waxed Feathers
+  [riuC44zpzZLGJUul] Wayang Lore
+  [5ij2nnZj4v2dx5N1] Wayang Weapon Familiarity
+  [48z7BPYIZJIgj3x5] We March On
+  [InTchkd50pzQok3f] Web Hunter
+  [KXUVAI6SDtxwjO7t] Web Walker
+  [CUrxG9CzT1hSfuhP] Web Weaver
+  [VXAIElMlMnVvz3x5] Webslinger
+  [rGU4nKAPCkC0lK4Z] Weight of Experience
+  [KU488rIt9bOdTNMA] Well of Potential
+  [OjUfwxMcM91CHLHP] Well-Armed
+  [h11M3QrIHKLj2ezy] Well-Groomed
+  [9t4x8vRmQikEl4vP] Well-Met Traveler
+  [3yLdRzh16sT8RgFV] Wheedle and Jig
+  [qYJyzAk8TOWPjaAL] Whispers in the Night
+  [lLO0WSxE3tO3Ovsq] Whitecape
+  [u5ykPSdzrTTOvQ34] Wild Stride
+  [W0JwZEe2uJnSGZRN] Wild-Haired Fury
+  [3NZSRyoulnzsi3sn] Wildborn Adept
+  [af2fSePLvqMNNp0r] Wildborn Magic
+  [uUPc3k9a6gExLOnN] Wilderness Born
+  [tP8pws78OOmobWjB] Willing Death
+  [QUaSGUmRnlMbzw1P] Wind God's Fan
+  [0198lXWmDdrVWolN] Wind Pillow
+  [arR15QoJH3xokw12] Wind Tempered
+  [tPi6FAnHYe6ijuyk] Wing Buffet
+  [8znlUoKgr8mmLPe1] Wing Step
+  [kBnsLuh3eBLjwGpN] Winglet Flight
+  [juLtvliSzYPCmMa3] Winglets
+  [FUOUyhHufNH4ri7H] Wings of Air
+  [Ds1waj86N4Z2gCMN] Winter Cat Senses
+  [2HkagmqG9rsQfyfR] Wisdom from Another Life
+  [u8gmBNHgb880vN3S] Witch Warden
+  [hUVedLw6mkY4e24v] Withstand the Storm
+  [NhBKdOa02dCMxUnG] Witness of Earth
+  [qW0E05GudC6bRA2Q] Wood Ward
+  [Y1bEisU8jVCsIYk3] Woodcraft
+  [9UD7TwyMIjbUun6U] Wooden Mantle
+  [uofXCv2t8C2IRsr0] Woodworker
+  [2sVR3Z1TPZ8pQdQ0] World-Protector's Hospitality
+  [hNr4OrMdCMhQLbtB] Wyrmling Flight
+  [7iB1yacjF9fG6Rvn] Yamaraj's Grandeur
+  [FL3H9LtPQmuOKMvT] Yaoguai Historian
+  [DG3cRm3LrTEeBDMu] You Seem Somewhat Familiar
+  [z5meCd4ZidBAPtUt] You're So Cute!
+  [XbsmAJ4fOCTVvrtf] Zip! Zoom!
+Feat/Feature (Ancestry Feature)
+  [YGk41WV42aTM7CQV] Advanced Undead Benefits
+  [oj532l4YXqzedBBn] Animal Attack
+  [AzGJN1wwLFaLJIeo] Aquatic Adaptation
+  [d5TYEND07kwWRBIq] Aquatic Grace
+  [RYrY7o0i6s7KW9io] Automaton Core
+  [ItQDbIiqpb50Zbtm] Awakened Form
+  [0qHN69NF7JBWKO8v] Awakened Mind
+  [SAbzItAI4uwbdnQk] Basic Undead Benefits
+  [PCLnnWPbiiSzrxEo] Big Sharp Teeth
+  [jatezR4bENwhC6GL] Bite
+  [dtNsRAhCRfteA1ev] Blunt Snout
+  [Eyuqu6eIaoGCjnMv] Clan Dagger
+  [NfkxFWUeG6g41e8w] Claws
+  [mnhmhOKWLiOD0lev] Constructed
+  [BHPDeqQHqi7ukCUW] Constructed (Poppet)
+  [E28a45fUC2OkXZXY] Constructed Body
+  [QLSvmOid6gAdzBYi] Cryptomnesia
+  [UR8qLQdU9UOoZxXB] Draconic Benefactor
+  [egpiSWBrNBb1Fmig] Draconic Exemplar
+  [uSAYmU7PO2QoOWhB] Emotionally Unaware
+  [QyBfftocP1i43Qrp] Empathic Sense
+  [AUlPRySCqE6o6LHH] Eyes in Back
+  [dCp517IUFJk8JvQc] Fangs
+  [jS8GamSTl8yMLL4F] Fangs (Nagaji)
+  [qKh6MxgE0cwde6mC] Flammable
+  [8sxtjVsk9HBY5yAv] Glowing Horn
+  [vPhPgzpRjYDMT9Kq] Greater Darkvision
+  [HYefFkddD9lOhFM8] Head Gem
+  [hUpYTsbLcBg4UcVp] Horns (Minotaur)
+  [LhgVj9GhPsXGfwAM] Horns (Sarangay)
+  [DWNRIgt3f92fSTBM] Hydration (Merfolk)
+  [DPPFBUk0l9KfRN8h] Iivlar Weaving
+  [IXyXCMBldrU5G60e] Innate Venom
+  [y1EmCv2cEb5hXBwx] Keen Eyes
+  [sL1hHxrHdMNIZVAd] Land on Your Feet
+  [TRw4oBZBFZG96jKO] Magical Strikes
+  [oQ5478uONrGAWRgF] Magiphage
+  [VX267tc1uwocRu39] Mount
+  [gZvgt5n5OYO3av2V] Natural Climber
+  [N0zhJ0whkDJPlftl] Photosynthesis
+  [Sm3tKetM6kddTio3] Plant Nourishment
+  [PtvzTm2gjdCKao4I] Prehensile Tail
+  [dkZ8RxdQFJrdxwQo] Revulsion
+  [S5XriNcxiVvqZEu0] Robust
+  [qJD3PJdoSXFrZEwr] Sharp Beak
+  [sW4ObB8wyLPPYvGj] Sharp Teeth
+  [bHUrm79wJCcI7L3A] Sunlight
+  [BgHrucbZ9TH92RDv] Sunlight Healing
+  [kMgyOI4kBIEtFvhb] Swim
+  [mEDTJi7d1bTEiwUD] Unusual Anatomy
+  [D6AjSg0JOYtn7Coa] Wanderer's Soul
+  [oCIO7UJqbpTkI62l] Wings
+  [RjWv5oPKZtNQgEiK] Wings (Dragonet)
+Feat/Feature (Bonus Feat)
+  [cMkpLgadlLCzDOv0] Blessing of the Five
+  [UHejQS4uCNGRI45t] Dedication to the Five
+  [w7dOgJvqAqyqSeSQ] Devil Allies
+  [RkvAuikI0kIZlQTU] Disillusionment
+  [AxjjAoU1IZaNUGGS] Fear No Law, Fear No One
+  [jrDCPvkruz8y740Z] Locate Lawbreakers
+  [PPSH5vdf90KC95jJ] Reveal Beasts
+  [Kz4E8heU12IGcYoi] Righteous Resistance
+  [1xpqOpguTUAeFsdO] Seek Injustice
+  [AGiIjgLOFuahmwiT] Shackles of Law
+  [tPhhaCbaQqwenkzx] Silence Heresy
+  [FlsAYAGEiZg1gg7D] Spiritual Disruption
+  [XOAtP64xiSRIofsY] Sturdy Bindings
+  [PpJURSJFEHzhutdp] Trailblazing Stride
+Feat/Feature (Class Feat)
+  [Vm8Zhwa2zvXhfT5c] A Little Bird Told Me...
+  [N7el79c9KY4JXmUb] A Miracle of Science!
+  [wKHlsN1QpjehQrRC] A Tale To Believe In
+  [roz8IxJrkvTV16ii] A Thousand Cries for Help
+  [oYdfO7j3vnNG7SYN] Abjure Harm
+  [oSi9mUtYWYekxX0B] Able Ritualist
+  [0SjxN3nCZ2tseH5j] Abscission Shards
+  [sUMrRRFsHiJf4VXP] Absolve Sins
+  [bEdFgywri7fABhBT] Absorb Spell
+  [aiHbS8FGNYAQBF62] Accelerating Touch
+  [YINlDvUs1ptiIMHe] Acclimated Mount
+  [uhU0KajD09h5bw4e] Acclimatization
+  [oTTddwzF9TPNkMyd] Accompany
+  [84ML8enTqOOdXA8O] Accurate Flurry
+  [OeUP3ASaS5deBsWw] Accurate Swing
+  [tMsAj0H0B9XZQjtH] Accursed Clay Fist
+  [fhwO3N3VoZ0ZpfjU] Accursed Magic
+  [5Pj6pQ7N1qXCQLal] Accursed Touch
+  [BASCKOPvNGgoHGid] Achaekek's Grip
+  [arnSyCl9XfN1qviJ] Acknowledge Fan
+  [nx2nB10rypAuspAa] Acquired Tolerance
+  [aFygWxgSv82WyCsl] Acrobat Dedication
+  [dgmjiToPHC3Yf5I3] Acute Scent
+  [YdpGPLN0QFTZIhbk] Acute Vision
+  [GIr0i1ucWnMSLwJo] Adamantine Body
+  [wAljs1nQmtjh2O2s] Adamantine Fists
+  [FkOtiB52wIOi7SP7] Adaptive Mask Familiar
+  [44pzixSVmRQiUoba] Adaptive Stratagem
+  [s1eEtrNBBHpXJlEz] Add Element
+  [zBLrZE5aCkpaTK2N] Additional Companion
+  [PPbTc7LjWcH9rhrI] Additional Follower
+  [z8ZtBvlXQ4VGCpJr] Additional Ikon
+  [nU0r77AZXMXIlti6] Additional Recollection
+  [243yFdMntCMPLLrp] Additional Servings
+  [NM5a1tF0OW5mVYdR] Additional Shadow Magic
+  [Lj39KxIDs7irpOHs] Adept Storyteller
+  [BBj6jrdyff7QOgjH] Adrenaline Rush
+  [NlEZ0piDxg9buXCL] Advanced Alchemy
+  [Tg3Iyq55xW9PTSW9] Advanced Arcana
+  [S25iRw2X9hmGRMyO] Advanced Blood Potency
+  [eZrftEihfuJBldG5] Advanced Bloodline
+  [CmA8t7MRMOzLTeUj] Advanced Breakthrough
+  [HtH8MONAzx4eYuJY] Advanced Concoction
+  [cTR67ZKDD1EKntXw] Advanced Construct Companion
+  [L1rCuwsCKWd9zlS3] Advanced Deduction
+  [sabbfPz4YuVzRX1j] Advanced Defender
+  [JHJBmiyILzWdFRJO] Advanced Deity's Domain
+  [7JjNWSuutkjrMrd0] Advanced Devotion
+  [tkMEdh0gM07teWkx] Advanced Dogma
+  [uR44wELN9OlU68cL] Advanced Domain
+  [053lglnu0gsC6S2N] Advanced Domain Spirit
+  [bGCQg3XAF0twCU9w] Advanced Efficient Alchemy
+  [ztRfsRDE7hdGbgG0] Advanced Element Control
+  [DPk7a0cdFOjDOdn5] Advanced Elemental Spell
+  [mFk9QMPrubJ1xfIU] Advanced Field Training
+  [UotFrqA7zAxtpJdE] Advanced Firearm Familiarity
+  [SHhiLn0OSILEXNOj] Advanced Flair
+  [lt9bQDI7ZXPA7wPw] Advanced Fury
+  [cNYfClpqqGDC4j7A] Advanced Glory
+  [4nFsGmPdWvFrwjgF] Advanced Hallowed Spell
+  [ds4YR09PHgWMu3Fb] Advanced Herbalism
+  [f754txt1ZyhVWXHk] Advanced Hunter's Trick
+  [TYP0Ee4o3p9LDodd] Advanced Kata
+  [euWpgjPNcDjeXAWQ] Advanced Maneuver
+  [fSNgVtt8y5uTCYvf] Advanced Martial Magic
+  [Sebm8u9jyKPRguNf] Advanced Monastic Weaponry
+  [eTqWgfojpvuigdvx] Advanced Muse's Whispers
+  [PxTRE0mFEO3tyt8h] Advanced Mysteries
+  [KvKg9pBOpk2oLeO1] Advanced Order Training
+  [zeyo67DmTH0xMFa6] Advanced Poisoncraft
+  [10DbphslCihq8mxQ] Advanced Qi Spells
+  [yUZXOEGqqXKhkGNE] Advanced Reanimated Companion
+  [FPVe3o7YctBicSQa] Advanced Revelation
+  [JL8t7JFnv1xygVrU] Advanced Runelord Magic
+  [fgnfXwFcn9jZlXGD] Advanced Runic Mind Smithing
+  [5hUj7glY8YnO5sBI] Advanced School Spell
+  [UZDiqc5bBJzOTxUQ] Advanced Seeker of Truths
+  [HBZSP3ABqmsV9FXH] Advanced Shooter
+  [XkemuXgSQtxFAhZ8] Advanced Shooting
+  [lqs4MIlO1N1YglOi] Advanced Synergy
+  [FIVuc2TRaLXiCGkn] Advanced Thaumaturgy
+  [BxO5l9tH9y1xNzzi] Advanced Thoughtform
+  [rXY2fhyteYhaQnMl] Advanced Trickery
+  [it2i6OXfGIizokpg] Advanced Warden
+  [nDjTJq7PEbvRktnb] Advanced Weapon Training
+  [kFpVgcqREAfDmjXp] Advanced Weaponry
+  [l9K62T7qMCvJXUoY] Advanced Wilding
+  [pIG5hWjZtzZJ3VOZ] Advanced Witchcraft
+  [oLTAAXumySFUPwND] Aegis for the Innocent
+  [Zn2ySapQ2gtgyWgW] Aegis of Arnisant
+  [OxvZSFGOjGfcSCv8] Aeon Resonance
+  [jSSN8WF65RqNcZhF] Aerial Boomerang
+  [UEqntGzFrFA7ncUO] Aerial Piledriver
+  [nsFnOLqYSkGWFhLD] Affliction Mercy
+  [3kH0fGOIoYvPNQsq] After You
+  [tUAFOayp0DAaJDq4] Agent of all Holds
+  [19OLlTrxvEtDAOHc] Aggressive Block
+  [BJKTUGplI9nwhJxg] Agile Grace
+  [jZbhRBR2yawntSmd] Agile Hand
+  [Ba6SLqAghsZgqhua] Agile Maneuvers
+  [dFQj6gLrbQi7APiA] Agile Shield Grip
+  [pIHXinKNQ13ugBGm] Air Cushion
+  [QV4NCyZQBCABykS1] Air Shroud
+  [h8OB6zcdIqUPS6PC] Airborne Form
+  [Veaf8vm2M9w8bcBI] Alacritous Action
+  [ypir96PNY6LBSIWT] Alchemical Assessment
+  [0FNLI8APwj9NsBDa] Alchemical Discoveries
+  [loC0wIyIrsG43Zrd] Alchemical Familiar
+  [f6k9lIrIS4SfnCnG] Alchemical Power
+  [SzpurHq4k4dS5BEv] Alchemical Revivification
+  [Q1O4P1YIkCfeedHH] Alchemical Shot
+  [CJMkxlxHiHZQYDCz] Alchemist Dedication
+  [pI97a5xSg4LbBY1g] Aldori Duelist Dedication
+  [NZgjqVV2HYzLCvvA] Aldori Parry
+  [8RppI1i4LfI0CYsX] Aldori Riposte
+  [BEgz2GnG2MKmmaZX] Aldori Swordlord
+  [PiAc7BYoPrSGAUxX] Aldori's Retort
+  [6iDd7CTzxkvMp6lB] Align Qi
+  [8qawcaQAZMD7pC6Y] Alkenstar Agent Dedication
+  [tinTdUGzxWStlf44] All Shall End in Flames
+  [wqAdzjRUOvTpKFKq] All in My Head
+  [kYLtH4PYfvqruLyo] All in Your Head
+  [1BAJxKpeQc8xGaxZ] All the Time in the World
+  [rOx7r8ygmPHPC6qF] Allegro
+  [AkUvfczLFJcsv3Sp] Alloy Flesh and Steel
+  [1cjjQL0z4ZVrrSAV] Alter Admixture
+  [3r4v6W4abJnLg7dv] Alter Ego Dedication
+  [vUQ3XwCT0i3ydX1U] Always Ready
+  [BXrnQ8qKf09f3spc] Ambush Bladderwort
+  [ffdXSxl4lVFrOvyQ] Ambushing Knockdown
+  [tn1PajS2DrHeBlGg] Ammunition Thaumaturgy
+  [ikjPRBeBUWV6hYFF] Amp Focus
+  [U6lS758rtYGR6aw9] Amphibious Form
+  [Cy5W8U4yN9P1EvBy] Amplifying Touch
+  [3PHHiZjX16Dwyt65] Analyze Weakness
+  [avCmIwmwJH7d7gri] Ancestral Blood Magic
+  [YNk0BekymS3bBvCT] Ancestral Mage
+  [PGi1EtcZMolnNA1M] Ancestral Mind
+  [VQz5VypVRLCloapa] Ancestral Weaponry
+  [b5K067Pma4Il9IeD] Anchoring Aura
+  [3poGYUYCBTmbeCUs] Angel of Death
+  [kPhym38UCLJpjnJD] Angel of Vindication
+  [pShjDoTqAdX1m3DK] Animal Actor
+  [f2Pl5dWEL9ZvEyI1] Animal Companion
+  [1JnERVwnPtX620f2] Animal Companion (Ranger)
+  [cg816q76S5otM7yD] Animal Empathy
+  [54BhwBHyp2jp3e26] Animal Empathy (Ranger)
+  [7sI2tb0XRvAKmz2o] Animal Fleetness
+  [1VLOhyq0IFMY2rqh] Animal Rage
+  [ZPclfDmiHzEqblry] Animal Skin
+  [2TLn4GSwmNb3R9kc] Animal Strength
+  [m3ANSHYfBrFyFUvo] Animal Trainer Dedication
+  [L1fnOLZQX68kTmHF] Animalistic Brutality
+  [bi9w4Z9MQY8VWLZF] Animate Net
+  [5hFFM5TmhKYSQwtG] Animist Dedication
+  [1OK4gFxX0eyzuHvC] Animist's Power
+  [ifiaewasPbc091BQ] Ankle Biter
+  [7QLLwcSKNGPWdOGG] Annihilating Swing
+  [PIVC14saumGNKWbo] Annotate Composition
+  [bRftzbFvSF1pilIo] Anoint Ally
+  [Wx12NUjqTOjFrEoW] Antagonize
+  [CIRseixX8dr36ZQK] Anthemic Performance
+  [cxwDj2gZ7kJdP4hs] Anthropomorphic Shape
+  [5N6rLz4mdJg0NrQH] Anticipate Ambush
+  [L9pd3yyjVK0rgiDc] Antler Rush
+  [p353WH847errsNvh] Apex Companion
+  [KrF4qD1pvQthG3v8] Aphet Flash
+  [dpkGYM2QObR5QbBH] Apocalypse Rider Dedication
+  [ghiZ4DhdmHlBAeU0] Apocalyptic Visions
+  [lGB1C4r2EtqDY9oy] Apparition Cloud
+  [rmmqfzs9XYR9XDok] Apparition Magic
+  [0CjMvMLW6kL1TO6e] Apparition Sense
+  [wEMZv0MIBktiwgxH] Apparition Stabilization
+  [yxqNBGvFkwi3pLVD] Apparition's Enhancement
+  [yvEzj1dnBEggKuST] Apparition's Quickening
+  [fMnF8K1o0ow217GP] Apparition's Reflection
+  [5fu0H5ZpBxSOwtCL] Arc of Destruction
+  [4Ocw1VITuw3Or2Cc] Arcana of Iron
+  [DwU6CmK4KsH8A3hu] Arcane Breadth
+  [qxh4evekG28Gt1vj] Arcane Evolution
+  [L5nSP8CkHWSLp2vV] Arcane Fists
+  [QrShJGrvmWPBj4oN] Arcane School Spell
+  [z8bozNJvUjBoKLPA] Arcane Sensitivity
+  [XydqgTE4J119J5JV] Arcane Shroud
+  [PRKe5rWYZMZgEpFU] Archaeologist Dedication
+  [dmXd68ilbuGR6eUP] Archaeologist's Luck
+  [7O0PrMoXd5L8dRfg] Archaeologist's Warning
+  [4QFElZoWjg1X0vsg] Archer Dedication
+  [egmb8p3ZIYtx5aQN] Archer's Aim
+  [HPav9ntIOl5WMmFY] Archfiend Dedication
+  [cg6iASOmkTadIYCd] Architect of Flame
+  [tP26mgaFPpr6df1i] Archwizard's Might
+  [iKOcwFCbNX1a2OFT] Ardent Armiger
+  [hzJl9iJzKvPcvZcI] Area Armor
+  [jYEMVfrXJLpXS6aC] Armament Paragon
+  [Olx796SgBbHUFeHc] Armiger's Mobility
+  [SqITElkyOMAvYVhh] Armor Break
+  [81xlcIFJIAtsmXmd] Armor Rune Shifter
+  [7NdMHszAiiveihoW] Armor Specialist
+  [plEZoAyPwjAOdY4e] Armor in Earth
+  [Vj7L46PhxciFNMpZ] Armored Counterattack
+  [eje2BkIpxCrf39E9] Armored Courage
+  [9zfcIXDG2mDpiypp] Armored Exercise
+  [jwcNyPDVw313KXZU] Armored Rebuff
+  [sebJQz7jABxL0pQS] Armored Regiment Training
+  [xACFBsq6c48R0BNF] Armored Resistance
+  [OmjTt8eR1Q3SmkPp] Armored Rest
+  [6wxOKT9ApUAZMq1v] Arms That Cut the Waves
+  [0UhZ3UtSXx9qyoiZ] Army of One
+  [PFcg6OHheNy2dnoo] Artery Map
+  [txWKzKuJus7UBebX] Artillerist Dedication
+  [iJrHJKNGxV4z4Qi7] Artokus's Fire
+  [CrpntCPdBZMGhE9z] As a Thousand Soldiers
+  [ur1AMxxLAO3tPayn] Ascend
+  [zDmc6JlvdVzHEtcE] Ascended Celestial Dedication
+  [zIDG7JvwJNxybwyh] Ash Strider
+  [iBmqKjsq4iTtoqvl] Assassin Dedication
+  [iJxbrXAdxhLqdT5E] Assassinate
+  [UiQbjeqBUFjUtgUR] Assisting Shot
+  [vV0nW9OIJ0VdeVjy] Assume Earth's Mantle
+  [MfolzkTNi6V4XQ7J] Assume Godhood
+  [c6CS97Zs0DPmInaI] Assured Knowledge
+  [v482u7QboZEbhgvv] Assured Ritualist
+  [HEZeZcBWQR1QeWDo] Astonishing Explosion
+  [sM3nmDi3PHWI64SH] Astral Tether
+  [ja2HDuEC42mpxMVP] Athlete's Ally
+  [Tu1hOEr6Ko9Df54L] Athletic Strategist
+  [bkX8v744C62W8hol] Attuned Stride
+  [U1I87PGViGpGaP7D] Attunement Shift
+  [nDNmqez9McmrjBAV] Attunement to Stone
+  [o1Bj8xvco9MtBVkl] Aura Enhancement
+  [SCplu0Ewfkf0W3xZ] Aura Expertise
+  [pX3nHLodbT3BqwdC] Aura Shaping
+  [RXs4YB6Kie4MbgDs] Aura of Confidence
+  [TIwk07T0OxSbcOpJ] Aura of Courage
+  [wjnfdh6WzN7HbmeE] Aura of Despair
+  [z7kwVNaCB4oJs3Fe] Aura of Determination
+  [7sFhBYoz5GSBFNbY] Aura of Faith
+  [YawVDUc9uzREIAnO] Aura of Life
+  [erCOcFZJPT2O3gwC] Aura of Righteousness
+  [Ice8oNOTbPFXyOww] Aura of Vengeance
+  [uixN9wbfe0veOHRn] Auspicious Mount
+  [21HVwklTxmo8Dwdp] Autonomic Psychic Action
+  [S817U6nx0ayhM5Rn] Autonomous Arms
+  [SGgK4BoUooA0HhTj] Avalanche Strike
+  [opeP0JF9WGmNG0pb] Avatar's Audience
+  [MivOI7Eo6x10rtsg] Avatar's Protection
+  [qgn9YpmmmnB17mzD] Avenger Dedication
+  [tlt6Q0uPqtFxOijg] Avenger of Envy
+  [exKu8ddKy2UhjZEK] Avenger of Gluttony
+  [8zejSGmHi353ZtpL] Avenger of Greed
+  [FRCcuxb604l6PfAC] Avenger of Lust
+  [4TWrnzTzVnHU8MGz] Avenger of Sloth
+  [kIqMLraYuE8y5F4A] Avenger of Wrath
+  [Af7vcTToxetHThj4] Avenging Runelord Dedication
+  [ImXaHm8KjL9lPfLT] Avoid Fate's Gaze
+  [mXp6G4YWCXGvp7Qd] Awakened Power
+  [rCnaBbk0M1gBVHjG] Awesome Blow
+  [nAgAICjPd4BSQlAj] Axe Climber
+  [pewPAMlURmTqBqJx] Axe Thrower
+  [VhkHlkvAbhepZYFB] Azure Fins
+  [E7eceezD3NDmBVBb] Back to Back
+  [Rp8h8cmFIsfDlw7q] Banish Falsehoods of Flesh
+  [dwloLQzWgwjJWzXt] Banishing Blow
+  [9L0iFYeSCMvrzme4] Banner Twirl
+  [L2mQO4q8nPdUDVjO] Banner's Inspiration
+  [jsbe2d9lYGJ2MksT] Banshee Cry Display
+  [WVU0c8rgcpGSRqSi] Barbarian Dedication
+  [HpT1GlcnkCBnDnVF] Barbarian Resiliency
+  [dIH771mt4PcVTyAs] Bard Dedication
+  [uVXEZblPRuCyPRua] Bardic Lore
+  [to6s7QanfhHukW5r] Barreling Charge
+  [Xjn4iYzJ6rLIpLV3] Barrier Shield
+  [5FVTySSg0uYaLtMA] Barrier of Boreal Frost
+  [JX9RKSlI9jSqkXa0] Base Kinesis
+  [A4sV0cRU9I8ztbHY] Bashing Charge
+  [l64p70oQ6a3AtMq9] Basic Animist Spellcasting
+  [DBsqWivnSaEo8jz5] Basic Arcana
+  [NSyzjkDdQU2A75mX] Basic Bard Spellcasting
+  [gtHTr77BkK4CckEH] Basic Beast Gunner Spellcasting
+  [nT9Z4OPDTOg2AGYc] Basic Blood Potency
+  [wBqQsXzqObrZM9Va] Basic Bloodline Spell
+  [asPQEfYCcsbYxx6K] Basic Breakthrough
+  [kmIgbWLbaarqmMaY] Basic Captivator Spellcasting
+  [fVP8jX7yRUpyrcVO] Basic Cathartic Spellcasting
+  [gc24C5CyWgqn1Lbl] Basic Cleric Spellcasting
+  [h5ZT9i79BFVJ0VfE] Basic Concoction
+  [X0NFLIn1bqj6bnd0] Basic Deduction
+  [FQEV0unwDlvPkyGo] Basic Defender
+  [uKBT0D9gxdwMcwNl] Basic Devotion
+  [7Pb1WL8abrPBTPrH] Basic Dogma
+  [PNG7e39mEhq1MorG] Basic Druid Spellcasting
+  [5MG4dBTsFZVbHcX7] Basic Eldritch Archer Spellcasting
+  [pYG2LqJ644pzwtIG] Basic Field Training
+  [sE7x3QAel4VGdkgn] Basic Flair
+  [Sr6CcCXceV8ALAmB] Basic Fury
+  [MzlfDSCx4fLJEVS2] Basic Glory
+  [mV911W6MTGMvHPbE] Basic Hunter's Trick
+  [BridkNEysTuSOOLM] Basic Kata
+  [wsq8nncD25Q1fRn2] Basic Lesson
+  [oIfCpkpH0Jb1mzj9] Basic Magus Spellcasting
+  [baD02AcIpU7xUBlD] Basic Maneuver
+  [TltRTR1e5KGly64k] Basic Martial Magic
+  [C4ugUzUuQ4UznNhl] Basic Modification
+  [JM0umAUx30mAkuTz] Basic Muse's Whispers
+  [NdgMxlz5I1ddT0Zi] Basic Mysteries
+  [7ycF0fgSw1ovUPit] Basic Oracle Spellcasting
+  [mWbIoWKDi1wANHDZ] Basic Prophet Spellcasting
+  [ePKe13FzKWaQqLo6] Basic Psychic Spellcasting
+  [6RjilN93bgy34y3H] Basic Red Mantis Magic
+  [vqSLlUdEvkAPJIQM] Basic Rivethun Spellcasting
+  [ROAUR1GhC19Pjk9C] Basic Scroll Cache
+  [1VrV24hhPSEvuKgT] Basic Shooting
+  [xxvKWQa2olCHoJ03] Basic Skysage Divination
+  [AvfswILmh3BwNbyR] Basic Sorcerer Spellcasting
+  [B5f7eCAC3ZEmlR9h] Basic Spellcasting
+  [YY7wmYQ9ccAO8fut] Basic Summoner Spellcasting
+  [TC6zELq2BOqVfgMh] Basic Synergy
+  [YehcIyxY5KnhPlx5] Basic Thaumaturgy
+  [sHS5LQfBHdCsv6vZ] Basic Thoughtform
+  [xMTC8UOerwGyCtaN] Basic Trickery
+  [kUa8PBjKmBk04zmc] Basic Wilding
+  [nU5Pow4HMzoDHa8Z] Basic Witch Spellcasting
+  [geESDWQVvwScyPph] Basic Witchcraft
+  [SHUfHzElHZPXJFiP] Basic Wizard Spellcasting
+  [s6wXcQYmHbew14gC] Bastion Dedication
+  [QA3wy9DCOvn6UU0i] Bat Around
+  [FOk8xTCHcHYyENu2] Bat Form
+  [cJNRNyZbwVofYiUS] Battering Wings
+  [B6jXVgfPuPWWLx2K] Battle Assessment
+  [K7YK5ESDoreohCe8] Battle Harbinger Dedication
+  [UZwIVbrXuaYSJ9FS] Battle Hymn to the Lost
+  [97zURBF7RiVcbBsQ] Battle Scars
+  [ollJpDIYG2z8oSm1] Battle-Hardened Companion
+  [x2a3Qb5pWj6Bgu6a] Battle-Tested Companion
+  [UetL3DTdUa3JYSSU] Battlefield Agility
+  [SQ46dXVR0v4bZjQC] Battlefield Arcana
+  [FtnFytJxa2ix1r5z] Battlefront Sabotage
+  [WLtyRMV2phyW9Mu2] Be Right Back
+  [YYPjndZ7tqRQLtAH] Beacon Mark
+  [4w73cxvqhGRiozsK] Bear Empathy
+  [U3A0kqJ2HKBYiu7X] Bear Hug
+  [eClTKWfhyv2lFrwC] Bear Hug (Werecreature)
+  [K0x90HNHi5hONdDl] Beast Dynamo Howl
+  [L1gD3VMD5X9JNJzE] Beast Gunner Dedication
+  [DgYC8yxISZ6Dfmky] Beast Lord Dedication
+  [J8BSHRkmP3QLknwF] Beast Speaker
+  [CJHvU61UpOpgPtSa] Beastkin Resilience
+  [3R09Hl6IDMgPcSs0] Beastmaster Bond
+  [wdmUH6hdat7jpEWt] Beastmaster Dedication
+  [5kUQuIP8N57MXhuz] Beastmaster's Call
+  [Ckglzh4dXcGWPNS3] Beastmaster's Trance
+  [ANOXSBs2lm11vsWO] Beasts of Slumbering Steel
+  [XXHCdsptuHSwioYL] Become Destiny
+  [hyTd3PoXueJ6vvyb] Become Shadow
+  [5C0XMnfTuvgSKD7o] Become Thought
+  [YrdQA4HbxiZkaG7I] Behold My Creation!
+  [oO8Cj1PmuoKuwpit] Behold, a Pale Horse
+  [7FOxECsqayIulRAh] Belay That!
+  [dwL0Y0P2x4pn2cft] Bellflower Dedication
+  [Wk1qjeuofFyLFdTQ] Belly Flop
+  [muDbZAyrE1ObyuTL] Beneath Notice
+  [N6qQU07KWuxgo8Gy] Benefactor's Wings
+  [JoZRbbexF3epeREe] Benevolent Spirit Deck
+  [tWBK7Zbt80JlPryC] Bespell Strikes
+  [bHHBEVmrY61MIgsP] Bestial Protection
+  [nCmsylaV144Pr4TZ] Bestial Snarling
+  [ADgQzThbtGKvp6hy] Bestiary Scholar
+  [cXuycCR29sFLBjbo] Betraying Shank
+  [PfnlKlLuqKOOhLyK] Big Debut
+  [1j9QCzHHxi5MbIY3] Big Game Trapper
+  [um6NtNmEpWxGelom] Billowing Wings
+  [lJ9j4mtNEjXoKvei] Binding Serpents Celestial Arrow
+  [TTlZiNSIAO2R3lMQ] Binds That Tie
+  [AV6KZvUed7GdhHzc] Bizarre Transformation
+  [YrRlbIzjsFlGGmVN] Black Powder Blaze
+  [vPZxFpq7XkRmE3Uc] Black Powder Boost
+  [pWbNhfBiskV4n58a] Black Powder Embodiment
+  [VsGdiAuVbYmDTR82] Black Powder Flash
+  [PWKHlkSx7baAcPw4] Blackjacket Dedication
+  [7BuL6JqHAqRQ0dQJ] Blade Brake
+  [tBfalnbUZLkG9gs1] Blade of Law
+  [WO23FvCo8IYVB5RF] Blade of the Crimson Oath
+  [GrKurXVdm5lJkE2q] Blade of the Heart
+  [05k4nkjazjjEUoGu] Blank Slate
+  [wbKzD4D3VHbD6OiL] Blanket Defense
+  [XLoRtMn48f2KKvsu] Blast Lock
+  [r4ZVpDjX2X0yrmhw] Blast Tackle
+  [TtAvM02UvfNaXeXd] Blasting Beams
+  [nLidn7L2z61Ktjzk] Blaze of Revelation
+  [kRERboV7vHN6EiTt] Blazing Spirit
+  [oltE3dIYZlM8s5BI] Blazing Streak
+  [XYaaj872JOO9CAws] Blazing Talon Surge
+  [C5zKhps2Rv95A8yX] Blazing Wave
+  [5FbGtKWE8Qc14o0g] Bleak Humorist
+  [skPVYOSDj7oC6PSX] Bleed Out
+  [dxujgA0NgiEvA0H8] Bleeding Finisher
+  [n5T4ChWJqDUblYfR] Bless Shield
+  [82ATEfDMPkZDxV5H] Blessed Blood (Sorcerer)
+  [nSDXAFQKjMROlc2l] Blessed Counterstrike
+  [kKoqqXOTdRYROmVV] Blessed Denial
+  [eBdajOzs8kiJDic2] Blessed One Dedication
+  [NrCloSukzSUCprsM] Blessed Sacrifice
+  [K2oSXGmqTUrcQYar] Blessed Sentinel
+  [V3nNlrdU2OxYJAjx] Blessed Spell
+  [U7dntZ2dAklzsqw8] Blessing of the Sun Gods
+  [y2XeMe1F18lIyo59] Blind-Fight
+  [2DEwoWN40EPosHtv] Bloc Tactics
+  [VyErxNnOtzm9Vvkv] Blood Ascendancy
+  [svBQNCS2ZCPlKm6f] Blood Calls Blood
+  [va7YMidXZW21oFwA] Blood Component Substitution
+  [CvMCw6JqvgMPE5uk] Blood Frenzy
+  [zrSOBBQZoeewqkUk] Blood Rising
+  [oTEidzP2UmYowhud] Blood Shield
+  [WkHZbd79yfn15xod] Blood Sovereignty
+  [7spk6rZPiNk2S0yA] Blood in the Air
+  [lpG7ZXFDZygmkbH4] Bloodletting Claws
+  [UfuYHdozZD586RWd] Bloodline Breadth
+  [AmfO4FHmfFr0oNi9] Bloodline Conduit
+  [zSTPB1FFWMfA1JPi] Bloodline Focus
+  [GIKySPq1n7xUmICw] Bloodline Metamorphosis
+  [N1ajKcWRo3O0oMQg] Bloodline Mutation
+  [6SEDoht4dXEJE5SW] Bloodline Perfection
+  [zf6Poru1jNmrO3kk] Bloodline Resistance
+  [EcyPTxSwtdqrOtxY] Bloodrager Dedication
+  [QicYF43HqgpOBLzo] Bloody Debilitation
+  [8okUez3GQOdrE4Ov] Bloody Denial
+  [Fe5m807oeqJw3YUd] Bloom of Health
+  [QZ00D2xdJnbWFzml] Blowgun Poisoner
+  [UtUT6JngJbQRHySX] Boaster's Challenge
+  [w32WGAkrgXw5N7yL] Body Barrier
+  [34mcF1rw3mvntv8Y] Body of Air
+  [hLchognQOno3KWr1] Bodyguard
+  [ZNq7Qgubi9gUqR0L] Bodysnatcher
+  [cBYTVYqw1EFVEuzs] Bolera's Interrogation
+  [f0reqV8eqnCycDWk] Bolster Ally
+  [X5LxcrZbjHfmX58a] Bolster Soul Cage
+  [Bb5Z9qpVom5fcrnh] Bolstered Recovery
+  [F2VR4FPL2HdbzfXL] Bombing Run
+  [vhHKUooXX3PYqGaU] Bond Conservation
+  [QC2ecMZ57MRJlxco] Bonded Focus
+  [8cq6NO087Te3P9yw] Bonds of Death
+  [cy9jqlHz75GTjg7l] Bone Spikes
+  [U9uRb2TezYlQPNJd] Boost Modulation
+  [gHc9mqHiMqayiOIx] Boost Summons
+  [6dpBiQ9lhgrAQzCd] Born to the Trees
+  [kC92uxCvrxDkrCpO] Borrow Memories
+  [6IrNSD0G5AAXPTJq] Borrow Time
+  [v4N0tTGjKGMwjqUG] Borrowed Ability
+  [MGtlUc6cy4nCM4Lk] Bound in Ice
+  [IMArawT1Sc2PTcYM] Boundless Reprisals
+  [tKaesXO5nlZ2sspx] Bounty Hunter Dedication
+  [zQeglKcmBXvqfABR] Brain Drain
+  [Fpsd8Y8qJ3Tdbiyz] Brains!
+  [dfQdJIqngKIX24UV] Branched Tree of Pain
+  [nkYBSuqCWcIgqjj0] Brandish Authority
+  [E25gWBCsDm3DbJdO] Brandishing Draw
+  [YTZhLWtrEnV9Pjf2] Bravo's Determination
+  [VeVHWTrzE3aDm3rx] Brawling Focus
+  [5EzJVhiHQvr3v72n] Breached Defenses
+  [wPwY6ybqAkmUGgvS] Break the Causal Chain
+  [BzHRE9O7GUnnARb2] Break the Cycle
+  [AV9NkSLNvv0UcdcP] Breath of Hungry Death
+  [5p6WWNOSZ7spNCNP] Breath of Vital Ash
+  [Sr75bQtqmCM6dyAM] Breath of the Dragon (Dragon Disciple)
+  [rJ1XxUEACaQA9Lyo] Bright Lion Dedication
+  [GV0lOcVgcetsUlLO] Brilliant Crafter
+  [BA7fzRbqpmeWrgqg] Brilliant Flash
+  [KX79TV93yznyhhMJ] Bring Into the Fold
+  [dbGocwZV9vJslbgC] Broadside Buckos
+  [4vR3Z6B60cjpQ7xW] Broken Chain Dedication
+  [DYUlMxh7TDgEh9xB] Brutal Beating
+  [oUhwrijg4rClCplO] Brutal Bully
+  [oNHmfpe8ezZ3eKDD] Brutal Critical
+  [OIrBqz2nIdyu5NKR] Brutal Crush
+  [tGXJU6yx7bYuyLvd] Brutal Finish
+  [gt9pvIicabSOe6pB] Brutish Shove
+  [tDWc2LQNl0Op1Auq] Buckler Dance
+  [gFQFgREm3HaFx1mf] Built-In Tools
+  [uc6JcNrI31wzSC2h] Bullet Dancer Burn
+  [j1hhTLOq7o80XCyV] Bullet Dancer Dedication
+  [5ZX4btrw5yjBr8IM] Bullet Dancer Reload
+  [vNIimhmP636VOP01] Bullet Split
+  [0XGLdVbEIISOOuuO] Bullseye
+  [iMh9Ve8Kt8ZcdKU0] Bullying Staff
+  [vS3GSv6ndGmh8FXz] Burning Jet
+  [bVng7Mkrj4UnQzLo] Burning Spell
+  [jJuRyhcqXGP0GJQe] Burning Surge
+  [IeiTuTZExH5DQOqH] Burrowing Form
+  [G6aNxXTIJYIGeicK] Burrowing Shot
+  [txo0xFYUfAjdmyjt] Butterfly Blade Dedication
+  [zMT3etCcdPdtAdOn] Butterfly's Kiss
+  [i5LtFOpsUR5S74pC] Butterfly's Sting
+  [IGY2DVHTEWmTbfYV] Buzzing Death Cicadas
+  [0BR61rW4JFOfO7T7] Cackle
+  [a9zzu4kb7vstq0HQ] Cadence Call
+  [kh0uz44otsdQlpIk] Calcifying Sand
+  [UjWLK86BgHxz3Itd] Calculated Splash
+  [7hucfLLgeNeX5Pkw] Call Draconic Ally
+  [24giyNqSjqrEnhN9] Call From Death's Door
+  [SE38R6zpv2XelzZk] Call Gun
+  [bPMYOiiqhrb098s6] Call Implement
+  [kYYB7ziQZjlgQWWu] Call Ursine Ally
+  [9j90iE61ZToFR8cu] Call Wizardly Tools
+  [Gdr4Nn2JqPOrk50B] Call Worm Spirit
+  [SfBXPmADMFiZIBQt] Call Your Shot
+  [JOq4Xe49A04YycRz] Call and Response
+  [ZvPgibovxwiN8Wse] Call of the Wild
+  [syIPNelJTQSkErvu] Call the Hunt
+  [YUHSK1ivdT1nLJk3] Call the Hurricane
+  [qf25HIPLdGVjui88] Call the Worm
+  [b7KZ7Fg5u5z2gqvt] Called Shot
+  [qqe5VmcO1s8iTOfd] Camouflage
+  [MFsCCVgU0z4N9bmY] Campfire Chronicler Dedication
+  [9sl2t3jb5ZdQA3K4] Can't You See?
+  [pph43ZrfvEnQjJXE] Cannon Corner Shot
+  [I2DGiMcof703Cnjc] Cantrip Casting
+  [bw2atPkRJL83Av9G] Captain Dedication
+  [K9SpdinLWc7YRVHP] Captivating Intensity
+  [IrxtH1BFlUOS0DnQ] Captivator Dedication
+  [nlXyh7828TgZIewv] Capture Magic
+  [RFW7nDSqT1iupYDo] Cardinal Guardians
+  [qQh8wnslOagixxD1] Careful Explorer
+  [0fPboxvg8rbi65mf] Carried with the Swarm
+  [lmAuoHPxzQdaSUmN] Cartwheel Dodge
+  [YOU5eCD5S4cS6Qeu] Cascade Bearer's Flexibility
+  [V5FKAmcYQF4KRELG] Cascade Bearer's Spellcasting
+  [hJlLmjW0NNeV1Ous] Cascade Countermeasure
+  [oiauCibmdgJ91kNI] Cascading Ray
+  [lGCFVYjL9Lp5m9Ex] Cast Down
+  [dVzPTpZoGSi5NR6y] Cast Out
+  [tSmd0cxq9wokSCh4] Castigating Weapon
+  [Qvz6pGnwWfh4tZGC] Catch and Kill
+  [yqMBLt0GUTwiqnZT] Cathartic Focus Spell
+  [dkuY22d3yLUBcqhq] Cathartic Mage Dedication
+  [zUtdBd3IbM7UX0AD] Cauldron
+  [9p4oFIn791VAmzUn] Cauterize
+  [EpWgrMznGbm8gceW] Cautious Delver
+  [2i6sEZ4rQm1Pd5nD] Cautious Word
+  [5Q69PI8jdQVkb1ZT] Cavalier Dedication
+  [CAaXGhHDMRM3Pt4J] Cavalier's Banner
+  [Vab3XIirjs3KQh3t] Cavalier's Charge
+  [MNArjo5Z5LUYITQm] Celebrity Dedication
+  [hSm66XVNVjPdbL2c] Celestial Armaments
+  [zWbPmIQfv9VTYwwH] Celestial Cacophony
+  [yTqKHRz2Jv8KiXve] Celestial Form
+  [AE1td51wdCoBuBDm] Celestial Rebirth
+  [11mW5dOCpwROjyV9] Cellular Reconstruction
+  [oP7xcBm4BfctDMHW] Cenotaph Stance
+  [78pkCdFaY8hI07Lj] Ceremonial Knife
+  [gyrIwJN0CTPp08em] Certain Stratagem
+  [h5DzKmKDADGhvmF9] Certain Strike
+  [TubRPkKaPuqAlryS] Chain Infusion
+  [nPwzElPvV29eM5as] Chain Reaction
+  [tnjXAYaYHO13jvMr] Chaining Mutation
+  [bvyCaOChX3lwKUn8] Challenge Insight
+  [0YjetnLVIUz9zQt5] Champion Dedication
+  [qWb5IxkBUpJWKSLf] Champion Resiliency
+  [7wk6yVM3OJdc4LEU] Champion's Reaction
+  [U4AoJMBhJaFq5O1S] Champion's Sacrifice
+  [3MzFYTfhoSV6894n] Channel Divine Spark
+  [AMgTG6TwfoNmseWm] Channel Rot
+  [o5q9FBrPsAYqEl5w] Channel Smite
+  [vgR68JyGFRCcTSew] Channeled Protection
+  [oLE64eHT9sB82lTP] Channeler's Stance
+  [75Y1Lk9JE3q1vDA2] Channeling Block
+  [5uny1fH9ybbO6ytR] Chaotic Spell
+  [ADVrDjp75fr2BYMa] Charged Creation
+  [DkoxNw9tsFFXrfJY] Charmed Life
+  [m8g005RYjH7BAoyT] Chastise
+  [D2KSVHPRlBEibrV8] Cheat Death
+  [IA8p9oYmsCbipmhw] Chemical Contagion
+  [qFR5OddDBmhZe6nl] Chemical Purification
+  [XWmlGnFNfxyJWw9V] Choking Smoke
+  [c6vqVL15nSP6lVAB] Chorus Companion
+  [kTl67PlYRIOz5ptI] Chosen Ward
+  [gHcVxdMksOaGaiCx] Chronomancer's Secrets
+  [ygdbkfPPgSoWxaBa] Chronoskimmer Dedication
+  [M8jbV0il124Ve5oV] Circle of Spirits
+  [6rGdm00nWbS267LF] Claim Cardinal Domains
+  [4uZMy9yI60vU6Gyk] Claim the Field
+  [xaYEUVetHiRgmVhd] Clang!
+  [H318YDsDaFomRrjn] Claw Snag
+  [EOLcbk2ennj55eAS] Claw and Talon Flow
+  [q2Njx3zvDg2IM2sJ] Clawdancer Dedication
+  [uMjczqcXuteoP7lf] Claws of the Dragon
+  [d26S1yVaOlNgayuX] Clean Take
+  [f5P6TYwCnf56iwX7] Cleansing Spell
+  [wS9a03TKVu8FQ8wC] Cleansing Transformation
+  [4DbkL74DuVbMcYuG] Clear as Air
+  [goFxIDlbWd8GN0kj] Clear the Way
+  [GE96a0UGPYM74qjI] Cleave
+  [smCDaPlpRDA47xjK] Cleric Dedication
+  [IMPP5pa8AmvCby4W] Clever Counterspell
+  [D1o7GUraoFFzjaub] Clever Gambit
+  [74PGpEAVNS5xUDA3] Clinch Strike
+  [RL4GrJ2vTrdJuzW1] Clinging Climber
+  [QkKMile0qqmuVY67] Clinging Shadows Initiate
+  [uNop7UN5OQX951l1] Cloaking Pulse
+  [nV9ykcwI4lSmD2PV] Clobber
+  [dxUbA1dUEcVHnU5s] Clockwork Celerity
+  [jm8kchZRznjxRy0C] Clockwork Reanimator Dedication
+  [xCbvXyWZ7JyUtN2N] Close Contract
+  [rOoQcydsTLhwE51g] Close Formation
+  [vqxKsnFhzWv7AykV] Clotting Elixirs
+  [r7FGPKl5e0xB4tuj] Cloud Step
+  [XeFMWjJkZy2O7lou] Cloud Walk
+  [264KzmKMK4zqi6AR] Clue Them All In
+  [xQuNswWB3eg1UM28] Cobra Envenom
+  [AkV4Jyllo6nlK2Sl] Cobra Stance
+  [MsieJK35tAP6gFGv] Coffin Bound
+  [wPJFEUOXwf7y5jN3] Cognitive Loophole
+  [DFusBl7CyNkuDTRa] Collapse Armor
+  [wKFQreilUASJkKzV] Collapse Construct
+  [n1t6foOyrN48OVPK] Collapse Wall
+  [WY7CjISdz6uwXwIb] Collateral Thrash
+  [5FyvwI24mnROzh61] Combat Assessment
+  [dF1HR6TqyMz03o6F] Combat Grab
+  [JJPoMcxUf3QoKA6h] Combat Premonition
+  [kqW6d3Dfk4nApd7y] Combat Reading
+  [7KT4huf0iPaBGD7R] Combination Finisher
+  [jSkJIWPfSZZzvYzq] Combine Elixirs
+  [Z9gzWFk3qom2z904] Come and Get Me
+  [MfvkZ9efD013H34Z] Come at Me!
+  [N0gJ4Q69nslbdXHg] Command Attention
+  [vCsvT7xqBIolF7zH] Command Corpse
+  [7G773pjnePFgnYxw] Command Elemental
+  [xYakFeP6olBsxpZN] Command Undead
+  [e9iVLfL7KIfUG3NV] Commander Dedication
+  [cxWEBBu8oyKTrqbi] Commander's Companion
+  [OMiIO6BzaXZTKjTt] Commitment to Justice
+  [97twoPOGsPa7pnWu] Commitment to Liberty
+  [yExxOkHN1PN37hUa] Communal Healing
+  [a2wXdQHiIoj3lHoe] Communal Sustain
+  [hsMcKK92ho39djgI] Communal Tale
+  [TORYSZMLMAGgsSEW] Companion's Cry
+  [E7PFg8xua1nGIqHQ] Competitive Eater
+  [XUzuDFiQwYqL1dWc] Complete the Hero's Journey
+  [HMbpWNqksPhaxDHM] Compliant Gold
+  [NCsjkjEp6kHFS07h] Concentrated Assault
+  [BmngPSf3ZrzcmXcW] Conductive Sphere
+  [iwBUJ08g0NJ2Emdl] Conduit of Void and Vitality
+  [YTHsakqXumdMU0dn] Conflux Focus
+  [o1Vo4PvU09UY8sj7] Conflux Wellspring
+  [V3lFDAQr3PfnAxMC] Confounding Image
+  [ABPDBNWvhJRWB86m] Confusing Commands
+  [gwIgB6bMh0sruyX7] Connect the Dots
+  [3tm0TzyjO1I378fw] Conscious Spell Specialization
+  [JQs2O2TTgKWXgJgZ] Consecrate Spell
+  [j4QSlswoBCVrPYa8] Consecrated Aura
+  [qV6EuOI3UJYIL6xa] Consolidated Overlay Panopticon
+  [PiKWzPloAR2nqIcC] Constant Levitation
+  [si8FGX2ZRxetdVHp] Constricting Hold
+  [xzesXSIXTqsVxm1e] Construct Dynamo
+  [Ls3MiZ5RcAWaiQ7f] Construct Shell
+  [BnBGDllQDfbOTBhZ] Consult Celestial Advisor
+  [8cy4XIaSoL3UtpFq] Consult the Spirits (Rivethun Emissary)
+  [9Jbl71C5C6MnOqxV] Consume Energy
+  [2pJhI6FL9hvXhXUZ] Consume Power
+  [d8yggbcJsKKyHip7] Consume Spell
+  [FaNRkgN6q2QTXCmk] Contact With the Enemy
+  [nJe8eQUrIpKWLXh5] Contagious Rage
+  [ad5MsrMMu721NH59] Contagious Spell
+  [4st3fSYSrJrxwHOP] Contingency Gadgets
+  [JO3mcFvxjRp1V8XK] Contortionist
+  [wBL5h0hTmVD4EJLw] Control Tower
+  [yIDJTe4kimRoZN0L] Controlled Blast
+  [qZzRXAa9mNQPUXoW] Controlled Bullet
+  [aoZYZm2PrTKEK0Ji] Converge
+  [P3eKgdsIVYhsFbYs] Convergent Tides
+  [bSXcyu7ExWq9qUzG] Convincing Illusion
+  [KYF9e4oeSjHKgbwM] Coordinated Charge
+  [XyQpqznuO5LGFvhz] Coordinated Distraction
+  [hwHpcr1wPKfsJxv0] Coordinated Tactics
+  [PcayTyfEv6s9wRfN] Cornered Animal
+  [U5hjS5qFrtGHWlVG] Corpse Stench
+  [SNhhx0hPWlERpQRr] Corpse Tender Dedication
+  [LQ5YW01UD9hGKk0l] Corpse Tender's Font
+  [fzERYW7BJQoxlvoD] Corpse-Killer's Defiance
+  [dmw79BbtUCJd300O] Correct the Story
+  [woBni6whXkqmuuyf] Cosmic Cocktail
+  [t0ZmwquWfSX2rNUd] Costume Change
+  [qAVM65grmny3f8DP] Coughing Dragon Display
+  [3xkFb2qlAdgLmdSf] Counter Curse
+  [6Jj9YWkGaNfzLheQ] Counter Element
+  [t5zeg3m9rEnWnYXY] Counter Perform
+  [QKC9iiR4Epj1Lyc7] Counter Thought
+  [r7srDh7Iz94vfwwN] Countercharm
+  [BBPrlPncXg86I42D] Counterclockwork Focus
+  [EpBG4CFMNSZQx7vI] Counterspell (Prepared)
+  [deoHKUzpzT7iwWhL] Counterspell (Spontaneous)
+  [sv3ywEHaab9oZ3Nj] Courageous Advance
+  [Asb0UsQqeATsxqFJ] Courageous Assault
+  [8C9qo5LL9J0UTNGc] Courageous Onslaught
+  [1GxDzMf32UTTro1d] Coven Spell
+  [IzkL60LlKzbKIhY1] Cover Fire
+  [sMKUJQ29CYYoB7b0] Covering Stance
+  [n4yLaSzQlzyNOo6J] Cozy Campfire
+  [vYmun4LyWtWtoycP] Cracked Mountain
+  [zOK6IFSz3DIBRjEw] Craft Philosopher's Stone
+  [gbBUxaWSD4nA9X7d] Craft Runewell
+  [S14S52HjszTgIy4l] Crane Flutter
+  [bf7NCeKqDClaqhTR] Crane Stance
+  [vCsprcXVTwgtUYAZ] Cranial Detonation
+  [yTh9QwAf0hadP91j] Crashing Slam
+  [4PdWIMjSHRTPekAl] Cratering Drop
+  [rpBHUvBKodPCHaET] Crawling Fire
+  [E6fkmjX6b8Nz5B0y] Creature Comforts
+  [FQzAifYHaMd9Qf1R] Creature of Myth
+  [hqasqwjrTzOFkDY3] Creed Magic
+  [nLTTph2tgwcQghVq] Cremate Undead
+  [FZVKV1529A2jWYSH] Crescent Cross Training
+  [ZuslXMXlW2TzoOgU] Crimson Breath
+  [Bi4rdz48MgkSY7su] Crimson Oath Devotion
+  [M2V1vqAziOkWV30B] Crimson Shroud
+  [lPTcPIshChHWz4J6] Critical Debilitation
+  [8YSwzLNlmBLoEyUj] Cross the Final Horizon
+  [XXOc3MxbkEBMgFeT] Cross the Threshold
+  [CN7tu5H6wTe9ENmO] Crossblooded Evolution
+  [CpjN7v1QN8TQFcvI] Crossbow Ace
+  [s6h0xkdKf3gecLk6] Crossbow Crack Shot
+  [NwMiszlcqNZWtezq] Crossbow Infiltrator Dedication
+  [Xhphe5Lsa4kuU4RG] Crossbow Terror
+  [sI4f0xdCVulyK9sn] Crosscurrent Counter
+  [DR6vessIpXTLM6Xa] Crowd Mastery
+  [WT8d5pjPVnh2LPxu] Crown of Rule
+  [00uTUJPgJ6kuGR8O] Crown of the Saumen Kar
+  [8iHpUB0bYaHh86Kk] Crowned in Tempest's Fury
+  [sbYDDDUWYN6Qx71k] Crude Communication
+  [vxA0VRN10OwUkGAr] Cruelty
+  [IxgBnW2L8MpJBUG2] Crusader's Masquerade
+  [hGjmbTNBUiJqYvsE] Crushing Grab
+  [kMPnfNzTuXrLTUii] Crushing Step
+  [Qf5aimp36VcZJiYh] Cry of Rebellion
+  [6oObLoUn3MjmwbaW] Cryptic Spell
+  [ELdUj5ihdivlgb3H] Crystal Keeper Dedication
+  [NrZt98r47sPSQ06j] Crystal Ward Spells
+  [nRyfLEs9JfEX2CTc] Cultivator Dedication
+  [X9UprPmeU3ovOgwb] Cultivator's Keen Eye
+  [AsOVi8AqE3v10ee0] Culvert's Collapse
+  [CuJzCxGwd1EZDift] Cunning Trickster Mask
+  [ajesR7y0jWzqjAgc] Current Spell
+  [LJzk4Xxxs9IlbWz6] Curse Maelstrom Dedication
+  [UJcuACMlspc1raL1] Curse of the Saumen Kar
+  [f1gxSpqjYryc1yc4] Cursebreaker
+  [kPjBGlHMvBqFXNq2] Cursed Effigy
+  [6xBu4BewIkOIt9M0] Cut From the Air
+  [r0twuF5nxXN5lkLk] Cut the Bonds
+  [O8mfeWtUogB74J9E] Cut them Down, Burn them Out
+  [pe8a7WDz0MIY45uO] Cutting Heaven, Crushing Earth
+  [mg8yScrzlUVsoWJc] Cutting Rebuke
+  [yyFEWQRO91CI4lut] Cutting Without Blade
+  [EsA2F4R3UwUdI8Px] Cycle Spell
+  [rHOBdIFvsLWoZFbS] Cycle of Souls
+  [u9ZuPuXj0xA4dHxr] Cyclonic Ascent
+  [epzeES7xJxvIXDdj] Dance of Intercession
+  [bSC18SbdaNXfBHu9] Dance of Thunder
+  [OWhTAowdMvBZnCrT] Dancing Leaf
+  [4M5zIlJ8EvjQDtg9] Dandy Dedication
+  [PcLqS5h6stRtdioZ] Danse Macabre
+  [6DkylvU5RF1O6DTT] Daredevil's Gambit
+  [cny7ouhsoiNsWJ7X] Daring Act
+  [O1C6pMTOxIrWBO3G] Daring Flourish
+  [FEMXDBCf8gXBYdez] Dark Persona's Presence
+  [azyp4nQgAPDI6nKv] Dash of Herbs
+  [g6P1NvbbHpJGgoXU] Dashing Pounce
+  [d1jQ0HyIOyUdCCaN] Dashing Strike
+  [5My8JBXkQru8m2n1] Dastardly Dash
+  [7v6dG5QvXCmtm9FS] Daunting Spell
+  [l9PYldtyPr7Q8Xow] Daywalker (Vampire)
+  [2HoDwBAmPIAoKUVF] Dazing Blow
+  [9uvymmdphxsD3yEd] Dazzling Block
+  [8x3wqCZgYzJiSyR1] Dazzling Bullet
+  [lk80TBn933RECRD7] Dazzling Display
+  [NJyyxInJ743OotKf] Deadeye
+  [enPAJ1oSDutts7ic] Deadly Aim
+  [Yy9LXo2GaLT7eCOL] Deadly Butterfly
+  [e8ChYAaQ9Aa8aZES] Deadly Grace
+  [hga6Cq7gW6rL16Ra] Deadly Mutation
+  [AYXherMu9gFTyXjp] Deadly Poison Weapon
+  [DfLkIIg2reyYW3a8] Deadly Simplicity
+  [TLCeFMDRXFB46sa8] Deadly Strikes
+  [BKdKyftmphU9n3Wq] Death Dive
+  [E3kfs8Erq3iGSE78] Death Rattle
+  [6RDMR41SGsBBVqcA] Death Roll
+  [hiABcPXvcYa9QccF] Death Warden
+  [j8CLa6RoohfKCWoO] Death from Above
+  [95dHFM31VrUjn3d3] Death from Above (Eternal Legend)
+  [PSpwdvuddC9kXONz] Death's Door
+  [Ks4CgusuaXn2aE1U] Deathblow
+  [Kf7WKC8R02znYsTZ] Deathguard
+  [PjsIiVM7yI0XgaFi] Deathly Secrets
+  [sv4LeEbkOJyLen10] Debilitating Bomb
+  [iy9XKih5jIAdv67c] Debilitating Dichotomy
+  [gSc4ZUXkesN5vKrm] Debilitating Shot
+  [MuhskZsUcN6g8QK6] Deceptive Tactics
+  [7P5aKtFoPVJJPPEV] Declare Anathema
+  [Tz796Pai2YX7RU41] Decree of Banishment
+  [2mxg4JxPE8k9jSkr] Decree of Execution
+  [O31zB7jxaW2487Q8] Decree of Prosperity
+  [OaDjzK0oaKAoV6EQ] Decree of War
+  [4HHw2DjTxdv1jBZd] Decry Thief
+  [jNzjecRGyyAqkkrm] Deep Freeze
+  [iTtnN49D8ZJ2Ilur] Deep Lore
+  [jhNkuXg8vJ29GSUJ] Deep Roots
+  [TP0BKE1nrl5q1n2C] Deepening Devotion
+  [PTXZ2C3AV8tZf0iX] Deeper Dabbler
+  [sflJhnFzYfqZ2tDy] Defend Mount
+  [JDF9LWZMReqiXIUi] Defend Our Union
+  [xlparPCGhkgjdhx2] Defend Summoner
+  [QCUylerXd0VB9jU9] Defender's Grit
+  [117d4Me9nAn1GMry] Defensive Advance
+  [corjPSTUKB02gkqN] Defensive Armaments
+  [515N9nl9ChZwLWKR] Defensive Coordination
+  [aJyNVKbTdpWFoM5z] Defensive Dismissal
+  [pGjSh6qk9kQLznKn] Defensive Growth
+  [d1ktdX1Fk37dG5ms] Defensive Recovery
+  [aPt0WfFoeLTzyQRA] Defensive Roll
+  [l4CIXeffWhHbIFWU] Defensive Stratagem
+  [l3YdGb3S9f4dVdUz] Defensive Swap
+  [eAEq2FVnneuvOYUD] Defiant Banner
+  [0lHhrYVe4VXbdSkh] Define “Report”
+  [sgaqlDFTVC7Ryurt] Deflect Projectile
+  [VYdZmTifZRkRF7ey] Deflecting Cloud
+  [ohdWRVK6CNXSkETG] Deflecting Pulse
+  [ToZw6ZjB0JhWwMeR] Deflecting Shot
+  [ie64VAbWnOGg9uad] Deflecting Wave
+  [8pmd9gMl3TamFx3u] Deft Cooperation
+  [QUnN2wUfvOD6Tz69] Defy Fey
+  [rLAaQBIgnv6zeNvP] Defy Hell
+  [L9i3zTvw9htpyK6r] Defy Sorrow
+  [CjafX7d1XktxeyTa] Deific Font
+  [UFVw57jWNC4UCfyN] Deimatic Display
+  [FXKIALDXAzEBfj5A] Deity's Domain
+  [DUb1VWSbTjdsbAkQ] Deity's Protection
+  [Ar6W97iun6yYI8Df] Delay Trap
+  [XmjvHxW5f7vKFIv7] Demand Surrender
+  [n0693gmx3k9wvb1N] Demanding Challenge
+  [ogsVovr4LxFVi42V] Demolish Defenses
+  [X5SZIwtYpx0r9MPx] Demolishing Knockback
+  [KCwXj3y7Nm4e3NbI] Demolition Charge
+  [M0D2CQgASNfdZBrl] Demolitionist Dedication
+  [PDFbfCrV2z0wfMz0] Demon's Hair
+  [cTTOH6yJibgvRlLX] Demon-Hunting Companion
+  [siegOEdEpevAJNFw] Denier of Destruction
+  [SYVM6Z3sS50e5Vbd] Deny Support
+  [1F4FD5OdDCEyiEvk] Deny the Songs of War
+  [SlMkuKMny7hWdNxL] Derring-Do
+  [ti6rPcSBsCuyEHqy] Desert Wind
+  [MrBHGo9nmzcVii3k] Desiccating Inhalation
+  [nvPxCUOCMaYdhLp1] Desperate Finisher
+  [WYaKRREZUSH0jel5] Desperate Prayer
+  [ZO37MZEQVNNtg46b] Desperate Resuscitation
+  [lCE4VYWM2HRPHocD] Desperate Wish
+  [EWeso1zDkCLGlnsW] Desperate Wrath
+  [Q0A9V0zoY7MMXEqE] Destined Victory
+  [dY0jhJOEj6DHc0ud] Destructive Block
+  [5cYFHKQK6OZCwavI] Detective's Readiness
+  [wdkbfWKEjAFXAxto] Determination
+  [vgsMKjAbRDNxT5TK] Determined Dash
+  [OyOpHPOXC08bffVR] Determined Lore Seeker
+  [K5ZONljq5XzS8MQc] Detonating Spell
+  [7vL4rTAHrANk8w99] Devastating Duelist
+  [oNUIacH67QDxT5ki] Devastating Shield Wallop
+  [amPQHO9O86G6AC4P] Devastating Spellstrike
+  [Cs0hRKBfWn2gOYzK] Devastating Weaponry
+  [ncXK0Cc8dZ9TilSC] Devil's Eye
+  [FIsMdgvGji5Nci8l] Devoted Focus
+  [YwVdaszwpDJd6kf9] Devoted Guardian
+  [lix0Utu4g8mQ0ZtI] Devout Blessing
+  [jlLWz8e7PpLFt0Ed] Devout Magic
+  [OqqytsF2RIjB0EPR] Devrin's Cunning Stance
+  [woQhda2ZoO1GMYNz] Devrin's Dazzling Diversion
+  [zTulA4sVXwLRm28Z] Diamond Fists
+  [GMrJdGwajADbL1y5] Diamond Soul
+  [6fojN9yBJByTZ1Q9] Didactic Strike
+  [o8qiAUuDHfurmgpP] Dimensional Disappearance
+  [IlygXZqCaeB9X30e] Dire Growth
+  [ot0uyFtnC1Whz5bp] Directed Audience
+  [iojlXjVdbzi1fZGt] Directed Channel
+  [07YYaQBknzDTcbFz] Directed Poison
+  [ozvYhY4hG1deXly8] Directional Bombs
+  [vWrGwqy4AhHMPz8V] Dirge of Doom
+  [nL82Dzh0QwkNkJDA] Disarming Assault
+  [dSSwRyuhKTq1VubX] Disarming Block
+  [1MWL2uEmyiOfYtJn] Disarming Flair
+  [HoDs90589eYQwcre] Disarming Intercept
+  [ZGgFrQAQWk0keaFW] Disarming Smile
+  [1p5ErCp33nGOzEsk] Disarming Stance
+  [4VbfFPuFpbGLMMKF] Disarming Twist
+  [lknYlp0ekVyBWQK9] Discerning Gaze
+  [OjvE7gaQgWiBqOhY] Discerning Strike
+  [TszXKspPffCzCD0X] Disciple of Shade
+  [cHOALlKY1XsCj3Fe] Disciple's Breath
+  [8JMOgtB3XG7o6ffW] Discordant Voice
+  [W7IfFi6MkTDfO2hb] Disengaging Twist
+  [UEbBOljjXvKsGKFu] Disk Rider
+  [uaUbQsdBIqCvJc2G] Dismal Harvest
+  [j4zGMRiTi5t6guMF] Disorienting Opening
+  [6AXAJuMEMpxU27PJ] Dispelling Slice
+  [Ndxu9YVGgenYmZSb] Dispelling Spellstrike
+  [vUHDuKLKKZHzAqvZ] Disperse Into Petals
+  [qav9ec9cR4lFcz3C] Disrupt Prey
+  [P13ZhZcR67Ev0vrS] Disrupt Qi
+  [Nm8n3urzpDqXni1i] Disrupting Strikes
+  [UzuMXY8G88ULDRex] Disruptive Blur
+  [OEGhbRgW6wRbccns] Disruptive Stance
+  [YFPmD8BHv0XaF55G] Distant Wandering
+  [3HaftIWhhxIGWzE7] Distant Waterbird's Poise
+  [yLZWUZHI5SHfwL7E] Distracting Bites
+  [XPTSCUoA8c4o9RgQ] Distracting Explosion
+  [hLYoIjH8gPEVXyWG] Distracting Feint
+  [BQrhDpLIp9zjbjEP] Distracting Shot
+  [tIeVe9jOmxW7NgCK] Distracting Spellstrike
+  [lGuoGim7J8Z97kor] Distracting Toss
+  [zWEu9xuAxBnPoSrv] Disturbing Defense
+  [Y5fO1ooNuCFPCB0s] Dive of the Divine
+  [KlqKpeq5OmTRxVHb] Diverse Lore
+  [2HeRmbcHcsRMccir] Diverse Mystery
+  [pu1U9ZWVVG1Lc94t] Diverse Weapon Expert
+  [rljiwL00XW1RcnyL] Divert Destiny
+  [yFc0tN9HviAJnG1r] Divert Streamflow
+  [PqZZSo06BH5N7x7C] Diverting Vortex
+  [C10L7NG6dgsCqKG8] Divide and Conquer
+  [xoIxiRtBVHV27Rvd] Divine Aegis
+  [BAAXa4xR9mvuo7lt] Divine Apex
+  [XRIWWrXfghsQce4S] Divine Breadth
+  [142QRyK2aPIrJu48] Divine Castigation
+  [fUR72e3t7p2IcqqG] Divine Disharmony
+  [t1sM6Xj9T07fqpwN] Divine Effusion
+  [PiBXXCeDNQGfQVoJ] Divine Emissary
+  [WHOCaVobY7N3UTtA] Divine Evolution
+  [tJduF6N83l5khRow] Divine Grace
+  [6qHoUiEudUgUB1Uq] Divine Healing
+  [GNMy7NYfF3AQwHpN] Divine Health
+  [JcXzKwrdMkNszrJQ] Divine Infusion
+  [frPdltbxoYtAHpPX] Divine Invulnerability
+  [2uYigDgvlfCZVg9e] Divine Presence
+  [iLFK11lcw5hViTBS] Divine Rebuttal
+  [EvSfoYmuCDCRAvaF] Divine Reflexes
+  [jNeIaFUFSGUXoSON] Divine Wall
+  [Trj5azJlaOk5jgBi] Divine Weapon
+  [4L5pj2W7Zyf8B3kg] Diving Armor
+  [rDrEZhs59LUxzjJu] Dizzying Spin Dance
+  [1fBHZpM3Z3MQtzvi] Doctor's Visitation
+  [0qGLCpggCcOVkbtT] Dodge Away
+  [nBWoZ311FXFJC8Zl] Dodging Roll
+  [qmFWCHOuubEl7VpX] Domain Acumen
+  [MLWizLC44RZ3bYAN] Domain Embodiment
+  [ENoRkTXtdfsbs98S] Domain Fluency
+  [vVhgYkOU9mPTGTxF] Domain Focus
+  [hT4INKGtly4QY8KN] Domain Initiate
+  [DjRkD92AyHNMHOK8] Domain Spirit
+  [yqIorA6QGWmbKoOz] Dominating Gaze
+  [hbDHgTwKsXiGFT1Z] Don Thy Fervor
+  [eUv2L0CLidxtA3sh] Dormant Eruption
+  [FlZ5knPmyq4CEhl7] Double Poison
+  [pbD4lfAPkK1NNag0] Double Prey
+  [PwcmmJOLY8C9JHau] Double Shot
+  [onde0SxLoxLBTnvm] Double Slice
+  [wwnhnV3balaVdMu5] Double, Double
+  [nroOy0PBeEUGdUXD] Dousing Spell
+  [uhfn5IuLPekAYCDf] Draconic Acolyte Dedication
+  [EOmTf95t03y4IGdp] Draconic Arrogance
+  [9fTmP4NuLwSoNl8f] Draconic Familiar
+  [fMIHi9AuwZF7DufT] Draconic Fury
+  [5shHvm7YP0B5diqB] Draconic Resilience
+  [vL4Hpb7Soih4oYeV] Draconic Scent (Dragon Disciple)
+  [yAgFDUU8HfVK4KTy] Dragging Strike
+  [gMPnLWLlHoNU9Lqv] Dragon Arcana
+  [oo34CloLefFRi72w] Dragon Disciple Dedication
+  [SELSj1vvVLx5cP72] Dragon Roar
+  [p0jZhb8PSswUsZaz] Dragon Shape
+  [8sy3sHwOHS4ImwvJ] Dragon Stance
+  [lgEihn7deZwHczGE] Dragon Transformation
+  [WRtf8xhjGM5Dy2RQ] Dragon's Journey
+  [3uavnVbCsqTvzpgt] Dragon's Rage Breath
+  [bqZkAFS6eq9TKXMO] Dragon's Rage Wings
+  [0S92aZtljjTAwLdO] Drain Soul Cage
+  [bJc477EbUYW2TlBx] Drain Vitality
+  [fFVqsMseN4zA9R24] Draining Touch
+  [hh2aqd0TGsrcSXl0] Drake Rider Dedication
+  [HlqAdfxmcd9gdgHa] Draw From the Land
+  [7DKcoEIqpa8JUvYF] Dread Blade
+  [R7c4PyTNkZb0yvoT] Dread Marshal Stance
+  [9SYnbjFgyucjhN5e] Dread Striker
+  [JxZobgFhLBNcFCwE] Dream Guise
+  [dBB71rps7dbat4Vo] Dream Logic
+  [lH8FwUM9bX9rpVsa] Dream Magic
+  [6vpgAMj87J6cWN0j] Drenching Mist
+  [FNO2hfGmxqJngD4A] Drifter's Juke
+  [7W5oubPLcxHJdcHX] Drifting Pollen
+  [Fen0uXQLiKRDP4ui] Drilled Reflexes
+  [X6nwiA2uJ2UQIOKB] Drive Back
+  [Eg7YZBmeNJeY9wkD] Drive-By Attack
+  [itn27nKYb8FRsdl3] Driving Rain
+  [vhw3n86TEs6laopA] Druid Dedication
+  [XGZUjc9I3sjfniDg] Dual Energy Heart
+  [PP1gfRCc1YwnQGxp] Dual Finisher
+  [EVNd9hZs49b1pScR] Dual Onslaught
+  [2Lcwqwq8CF40TYHd] Dual Studies
+  [zfTmb78yGZzNpgU3] Dual Thrower
+  [XWtNGOkMHcrdrRw8] Dual-Form Weapon
+  [HHAGiBYVv8nyUEsd] Dual-Handed Assault
+  [04Smj4ZsEBD8WIXv] Dual-Weapon Blitz
+  [sjChYEuEWPqndCSK] Dual-Weapon Reload
+  [YhnCjiHNlS3nCeoC] Dual-Weapon Warrior Dedication
+  [9EqUTnbV8WHE2aKm] Dualistic Synergy
+  [vsSbYfsRTHveef24] Duel Spell Advantage
+  [FYz5eQeTox9IDkSd] Dueling Dance (Fighter)
+  [9VGmE7X4aK2W8YWj] Dueling Dance (Swashbuckler)
+  [n7nQQR940OvFbw7T] Dueling Parry
+  [mf2cdCRV8uowOMOm] Dueling Riposte
+  [r72qcTupGzyRDiGe] Duelist Dedication
+  [5op3m0gwZjL4udit] Duelist's Challenge
+  [Bk07joho2dUG3lVw] Duelist's Edge
+  [MXn2g1OrOOr2qqpJ] Duelist's Form
+  [wOb5YGq1EcRn3lwl] Duo Dragon Kick
+  [pu8Mg2FIrhBYTNnB] Duo's Aim
+  [W7Rkw1L5QxHvgeUW] Eagle Eye
+  [UhmPekgw2HO40zKC] Eagle Eyes
+  [2shqQYK6l3RUEqiQ] Eagle Knight Dedication
+  [UbpSGpKNGucwIcHs] Ears That Hear the Truth
+  [M5LgVNEbJeMoTMd5] Ears of the Forest
+  [5WMoaM7cH9aw3iAc] Earth to Heavens Strike
+  [AOLf6QX068LR9L9e] Earworm
+  [bDVx7hVyxjwRAxxG] Ease the Burden
+  [xSJaOcdhqDF1CBs3] Ebb and Flow
+  [pvFRMbIazwAO0fjH] Echo of the Fallen
+  [T4Xm8vYtnGMOM0Cw] Echoing Channel
+  [0gOT5o3RfUfYKj8z] Echoing Fury
+  [NvEYf0jIETEu2LtP] Echoing Spell
+  [DaW1Ugz0a24jhWLY] Echoing Violence
+  [t7SlYWC4M2JcgwRM] Echolocation
+  [yaxf1Tpk5iwPCSpW] Eclectic Polymath
+  [TOyqtUUnOkOLl1Pm] Eclectic Skill
+  [6b8DiNx4c1zPZ7RP] Edgewatch Detective Dedication
+  [9cHQua33V35JPE3U] Educate Allies
+  [a2Owk9WI4pjSPuHf] Educated Assessment
+  [po0WNUVwtaEBK8LH] Eerie Environs
+  [jPWF8Xe0UqVvbeyv] Eerie Flicker
+  [Ob4w36tsd1WKSxZo] Eerie Proclamation
+  [BaKEnNbzbGlenmRv] Eerie Traces
+  [c7jNms3ZQ8eaMUqv] Efficient Alchemy (Alchemist)
+  [2FBZ0apnmZ7b61ct] Efficient Alchemy (Paragon)
+  [UvQjCHNAQVhKvTWb] Efficient Preparation
+  [jYKKnr41OqQrf7hv] Efficient Rituals
+  [lZA7SYBmSPFlKNr2] Effortless Captivation
+  [YpRd68IAAKz64Lwt] Effortless Impulse
+  [LLCf2xPXA7FVQT1D] Effortless Reach
+  [JwosaDYoqfPiFMYa] Eidetic Memorization
+  [588O3jurogttvqgm] Eidolon's Opportunity
+  [eNeSl5UNaqDwyNkp] Eidolon's Wrath
+  [pCVegyXxNibF4ulp] Elaborate Flourish
+  [nWd7m0yRcIEVUy7O] Elaborate Scroll Esoterica
+  [VO8HbMQ79NULE4FQ] Elaborate Talisman Esoterica
+  [hENWnoZNljeJnZBR] Elbow Breaker
+  [oyLkqhDGwGGj40ME] Eldritch Archer Dedication
+  [kUv9eiP8Zhck70WZ] Eldritch Debilitations
+  [kp2brlFZEbVCeWWh] Eldritch Reload
+  [lslR2UfP3ze7TFYu] Eldritch Researcher Dedication
+  [zfnZki2CxmZXdNBO] Electric Counter
+  [LvmYfUGX3uDCpIHY] Electrify Armor
+  [20JPwspLZ0r28Jnf] Electrogenesis
+  [C5tSxOwDILefw4zq] Elegant Buckler
+  [nr2ZvNFTuvshuq3Y] Elemental Apotheosis
+  [E7j1e8R9FXaFUq0V] Elemental Artillery
+  [XjoKCfvaSVaRHIV1] Elemental Evolution
+  [IUQPZnHQYQbnxFzo] Elemental Existence
+  [uHYQ0F7FzeMDNrAD] Elemental Explosion
+  [KZJJ0WxcRd4RZKJR] Elemental Familiar
+  [iLpFiNZthfd08srv] Elemental Familiar (Kineticist)
+  [BU4NBIBkVZxdWLLH] Elemental Fist
+  [mIL5Qw3mBgvNggZ0] Elemental Overlap
+  [F0MYBfiyOD8YHq5t] Elemental Shape
+  [011wnYpjIwCEzFtl] Elemental Summons
+  [KwYtlupIsQyx7n8Z] Elemental Transformation
+  [tx9pkrpmtqe4FnvS] Elementalist Dedication
+  [wNr02jsG5nRF23YO] Eliminate Red Herrings
+  [vVyX9IG8flxg81mc] Elude the Divine
+  [TfDvkTNaC1DmsB2C] Elysium's Cadence
+  [HxO0Sh3hNFMoSsTB] Emancipator's Mask
+  [xAFdoKl7aOP9rVkl] Emblazon Antimagic
+  [7RFjTTzznsdPcaYB] Emblazon Armament
+  [DMECB9RwLAhY0T9o] Emblazon Divinity
+  [rKZE8BA9IQHSSWoW] Emblazon Energy
+  [8Y9DCalsSnXHDCeV] Embodiment of the Balance
+  [uYhaIKxlvGj4YNCc] Emboldened with Glorious Purpose
+  [j20djiiuVwUf8MqL] Embrace the Pain
+  [cxAvcFiZRT3ZVhie] Emerald Boughs Hideaway
+  [wlBDcATuqTwjOIY2] Emergency Regeneration
+  [uY03kVQBA81gbTj9] Emergency Targe
+  [GIMHF8VV1KKjuQRE] Emissary Familiar
+  [SGBLDcT4wI5VUDCZ] Emissary of Peace
+  [WLFvgbP8aQRhNHgZ] Emotional Push
+  [d8DI7wLxtUy99g9K] Emotional Surge
+  [mnHUemd21MtmV9FV] Empathic Envoy
+  [BV9k3nmVrWDLv8z6] Emphatic Emissary
+  [iKUtl2RCemX9NXOu] Empiricist's Eye
+  [4evo0jTAKBhowyDG] Empowered Onslaught
+  [5f0EbNl7DHkiKCIr] Empyreal Aura
+  [m8iP2OCzit9WUrMD] Enchanting Shot
+  [BQzExsEZrwGsJD66] Endemic Herbs
+  [RYUb5oxd46Yvdypz] Endurance of the Rooted Tree
+  [8d3QxoKmqSkB9Mcj] Endure Death's Touch
+  [jBeuyq0Aged45YAc] Enduring Alchemy
+  [RzfWrOqHL2GcK0rr] Enduring Debilitation
+  [txLcSHu6kEfmrJj1] Enduring Quickness
+  [yUpZcrQHrz4mflKQ] Energetic Resonance
+  [9rHQn9Hn8JhY2e4V] Energized Spark
+  [iS4Vc2zv7vgL5mnX] Energy Ablation
+  [MgqRwyL8PWyYvoZs] Energy Fusion
+  [0PCDkVnRxVqxsp9j] Energy Heart
+  [YezCCZgVOmgQPHhW] Energy Interceptor
+  [lVXk0fhZqjqKilhB] Energy Resistance
+  [lG4dYrnkE42IgnGG] Energy Ward
+  [VAxtUenSWEBWYBRt] Enervating Wail
+  [g0C3tqGjgShoDyif] Enforce Oath
+  [GLHh9MWlcINLC6Q0] Engine of Destruction
+  [N7dTFxpjXGn4ddq8] Enhanced Familiar
+  [4HqPkJeSDpqYeGNn] Enhanced Psychopomp Familiar
+  [8cbSVw8RnVzy5USe] Enigma's Knowledge
+  [Igt8Ml5YIdxueMlF] Enjoy the Show
+  [Tr2SnOE2WqFIIWIK] Enlarge Companion
+  [ROnjdPMvH0vkkWjQ] Enlightened Presence
+  [45F4nNN8gxoBdSnk] Enshroud Soul Cage
+  [c3PN2NvV4ailHRKm] Ensnaring Disarm
+  [muyEI60L0FmCHuWb] Ensnaring Wrappings
+  [4KxG9QC6jPn2CJeZ] Enter Divine Realm
+  [64T96eyXI0qsccsl] Enterprising Ritualist
+  [vqHF9U2RkL2NVgMF] Enticing Dwelling
+  [8nCxI2SZ64UmMuRZ] Entities From Afar
+  [1FnZhf5UwSb7Lo3t] Entity's Strike
+  [EaIczkGVI5DUo3c9] Entreat with Forebears
+  [PSqxbLzKKzbMUnU9] Entwined Energy Ki
+  [tZLixgaZKeWwPXKW] Environmental Adaptability
+  [vbHF6HEC9jQorFGl] Environmental Explorer
+  [Fzb20MxhHMmKHVtn] Epiphany at the Crossroads
+  [60o2Pf4IunqP6J0Z] Equitable Defense
+  [INqBWbbDHF4DIg8i] Escape Timeline
+  [4HZTLPKPteEFsa7n] Esoteric Polymath
+  [4n59y5tb9bxffKsi] Esoteric Reflexes
+  [YtfmSKoUFjnqEH0T] Esoteric Spellcasting
+  [P6cTyDMTXcC8HBDr] Esoteric Warden
+  [J7b0h6t09kS5e0R4] Essence Overflow
+  [pzmob1HqVKZfL0BY] Eternal Bane
+  [kMLvQnx2vY7F3bjI] Eternal Blessing
+  [czdqBRpzpml23la9] Eternal Boost
+  [yFoBVSOCnC2R2r8s] Eternal Composition
+  [giOEclnMp8txkRSU] Eternal Elixir
+  [7VTVnJFV6btUiG3b] Eternal Guide
+  [kmoigPZgEsJ2jsmp] Eternal Hero
+  [ZI7WQ1en8s5VG6fk] Eternal Legend Dedication
+  [MRT8BGiIiVYfVcXh] Eternal Torch
+  [qv5tqbukVm49kaxn] Eternity-Incinerating Blaze
+  [VD446AflrQ3kO1al] Evasiveness (Rogue)
+  [BJfIGuUMItalNYet] Evasiveness (Swashbuckler)
+  [5HDBvVbfoaXljbch] Even the Odds
+  [ccLpjnWjl62Ehegc] Even the Odds (Eagle Knight)
+  [7uofkNynjFy3ofk2] Ever Dreaming
+  [a6xUSibsRaclbSz3] Ever-Vigilant Senses
+  [EP8kaXNmrMfxOFAf] Everdistant Defense
+  [6GN1zh3RcnZhrzxP] Everstand Stance
+  [3y459uK2qfWtS9q4] Everstand Strike
+  [amf2zZuW299eiHAZ] Everyone Duck!
+  [w4dijKncXx0ssBOQ] Everyone's a Suspect
+  [8tS5NzytLmgbq5hF] Exacting Strike
+  [IySKTSfPO0Lzfm8r] Exaltation Overwhelming
+  [sJtsgS6lUBgvN02R] Exalted Greatness
+  [upsDl9drHCoH6jrz] Exceptional Follower
+  [0xh9ISHFUFHqngK0] Execution
+  [IqTtpxZ48rApy4BN] Executioner Weapon Training
+  [qvWmW5JWpVBDyGqe] Exemplar Dedication
+  [Nkt6q2fxoiCRNKsK] Exemplar Expertise
+  [s19qwrEmJRgEsZxn] Exemplar Resiliency
+  [6aNBNGFDSWoaQALf] Exigent Aura
+  [TUIQBw9miDowhezw] Exorcist Dedication
+  [H7Ocx80td7Sx7Cqn] Expand Aura
+  [L7hs5XOCbJmh0H0e] Expand Spiral
+  [vQ4DNfpktmaqdgdM] Expanded Domain Initiate
+  [iGtqth3aSMbAx9OM] Expanded Elemental Magic
+  [UTgVD8LwSjFVMlqc] Expanded Runelord Magic
+  [gyVcJfZTmBytLsXq] Expanded Splash
+  [DjB7wElO9HkKMnzI] Expanded Swarm
+  [84n92oBsRVCxjifM] Expansive Spellstrike
+  [0Gao1ez4dGH6dIZ2] Expeditious Advance
+  [UTGVGcpgAbZONOf5] Experienced Follower
+  [Q0cTWUptV3uRIAIr] Experienced Harrower
+  [UrFeYPLjbWNYMpYA] Expert Animist Spellcasting
+  [OQAo3Us0ODGYdNNn] Expert Backstabber
+  [0RB3f3J7gOEv3fni] Expert Bard Spellcasting
+  [lx8Wt813qavwLISv] Expert Beast Gunner Spellcasting
+  [QhKLXGJPLZaX1qDp] Expert Captivator Spellcasting
+  [IZFw3Do0kBdgwZX0] Expert Cathartic Spellcasting
+  [PLTOCEAvqBS05pZu] Expert Cleric Spellcasting
+  [pKttKO84dxzRLBIC] Expert Combat Eidolon
+  [saEwTvJuiemEIfLm] Expert Druid Spellcasting
+  [eoEYZJNdmvA5GfyK] Expert Eldritch Archer Spellcasting
+  [dDFQJem5K9Jzxgda] Expert Fireworks Crafter
+  [DCjkgCbjIa4er09y] Expert Kinetic Control
+  [JmHHdGC1p53BBedu] Expert Magus Spellcasting
+  [FtO8DjjMLBtWiRhZ] Expert Oracle Spellcasting
+  [X2JzoRXHhhz5o4P4] Expert Prophet Spellcasting
+  [RJmnFuaGLXfhX3It] Expert Psychic Spellcasting
+  [bzKBUK6CH8tuLCfo] Expert Red Mantis Magic
+  [Px476getOIltCeg7] Expert Rivethun Spellcasting
+  [UrOj9TROtn8nuxPf] Expert Scroll Cache
+  [7nAoHfB7nsRwWDmF] Expert Skysage Divination
+  [llDw5DqnB4LbIUCV] Expert Snowcasting
+  [1k5PZAYth8u4Fqyr] Expert Sorcerer Spellcasting
+  [2UogDoEJ2M2tQFxn] Expert Spellcasting
+  [s6y6JzPW2K8k4m8k] Expert Summoner Spellcasting
+  [x7vMKBSrxXmfs5C2] Expert Witch Spellcasting
+  [hpCBELEKGA4ynYv4] Expert Wizard Spellcasting
+  [tFrGaa0qI2JvnHsD] Exploit Blunder
+  [FGdKV40UiS6jvBmI] Exploit Opening
+  [hr9maYUbtrNxpBPw] Exploitive Bomb
+  [nluD4gFLWePrBK5f] Explosion
+  [S9j95EYaDt6ugd7c] Explosion of Power
+  [y9lH4EqTGTHvqbNr] Explosive Arrival
+  [OEwNLolzBarx8icm] Explosive Death Drop
+  [i6eWwJ67qBIPJZoK] Explosive Entry
+  [UVsMJwHpQHjVZLTK] Explosive Leap
+  [NDbNNMouxnnwBqwm] Explosive Maneuver
+  [IK6xmiKfmotl8Hm9] Explosive Metamorphosis
+  [d7qKSoYixczsD5nL] Exsanguinate
+  [u5cPwhuCd3xTAlWl] Extend Boost
+  [asRbkgW59DZUpvAq] Extend Elixir
+  [nksxAtBmwDUmrTcS] Extend Surge
+  [D4jwLyzjEsTopn85] Extended Kinesis
+  [6YXQT1a2C03u75zW] Extract Vow of Nonviolence
+  [flRXjabqedf6GjuU] Extradimensional Stash
+  [WcY7H7mRiK2VDquV] Extravagant Parry
+  [9LvJo3K2AjKcVvTc] Exude Demonic Corruption
+  [7k8ZR72NzcTdpmz6] Exult in Violence
+  [Iqlv8dQHGweSNW7V] Exultant Blood Magic
+  [FVDozRTuCQQzD97D] Eye of Ozem
+  [vJupczSgvEfQKA2L] Eyes That See Eternity
+  [UHCWlIUcI3Sy9oaS] Eyes Unclouded
+  [EfIh3sGokwzAwYpQ] Eyes of God
+  [p2McwseYbPZrL5G3] Fabricate Truth
+  [orTWiRwIQEc9FGJQ] Fading
+  [7w8SOlLlFYOBYC5Y] Faith in the Fallen
+  [9umJBQEcV1Fax4bd] Faithful Steed
+  [45L17b1vwUuE8mMc] Faithful Stride
+  [juTBSRs2jzJzLoth] Fake It Till You Make It
+  [Stydu9VtrhQZFZxt] Fake Out
+  [DUpcEx0yMHGSU6o5] Falcon Swoop
+  [6thEFvU7aMPmLrly] False Faith
+  [bcxIg7wi8ZAhvhOD] Familiar
+  [IYt6pMqiTocTrixA] Familiar Conduit
+  [EGtuOZ3E9y0qZ1oJ] Familiar Form
+  [Hwvrive2vBIqZUcE] Familiar Mascot
+  [4zaU3GlTGMNqLFS8] Familiar Master Dedication
+  [MXWUkpPJsLPrqmJO] Familiar Ritualist
+  [YKBDNQEqYPKE8dlH] Familiar Sage Dedication
+  [Q4puGx4kBMXy45fa] Familiar's Eyes
+  [gKoNWXem1ikEqE2d] Familiar's Language
+  [BQ50m0Jb9qyoPchi] Familiar's Resolve
+  [KXPPwGmoKsMa6Ytg] Fan Dancer Dedication
+  [80CEAB05TP5ki9iW] Fane's Fourberie
+  [qI5ZyuNVME95iXhJ] Fantastic Leap
+  [BJHsCiBLdjgJo6zM] Far Lobber
+  [r6dvGxru3FWNLVE2] Far Shot
+  [VYilg64xX9XpHeJr] Far Throw
+  [PH5b61x3iJSKP3Xi] Farabellus Flip
+  [jwQERVkjtnlFp3Ec] Fast Channel
+  [3w2SktSOZdG8f6Qr] Fatal Aria
+  [qwnyuCsl5YvX0fdY] Fatal Bullet
+  [6iOLxitjqHujH1Tj] Fatal Shot
+  [iv80P6HbOpoNCoNj] Fated Duel
+  [LZsVmDfGPGjWIoSS] Faultless Defense
+  [oGu9AtUAx0SpRXy8] Favored Prey
+  [sgo7J9BVofBqwlsF] Favored Terrain
+  [a57EppvkRS1x3OFs] Fearful Symmetry
+  [1k3H7cnARIzAVCsm] Fearsome Brute
+  [PkQo8tb0Yby1pFU0] Fearsome Familiar
+  [CtC7DM1poHDwwu52] Fearsome Fangs
+  [Tln47zk8F8nswrEI] Feast
+  [SuIRAnpe0RvNrx6I] Feast Planner
+  [fxkByzNBsYOcyYp8] Feathered Flechettes
+  [F8rtjsojGLaRuU5l] Feed the Void
+  [St2pWABnDri2n1FO] Feeding Frenzy
+  [7SwpVfxSkPMPMazJ] Feeling Your Oats
+  [0Ahv8HKmJkll0wlq] Feet That Stride the Sky
+  [D71A2ZQfz9MVndqI] Felicitous Riposte
+  [7gYTO86pkFmm6zBn] Feline Dance
+  [Ij6BBPzZvOFZ3prs] Felling Shot
+  [Ad0XBuETAkMD6doj] Felling Strike
+  [Rzr6VIRaPEomi9E4] Feral Lunge
+  [oHRCNciSjIBz4xqe] Feral Mending
+  [UXuwSoU09MUB7rNV] Feral Scramble
+  [GDYy2HaaTAEWRfGQ] Feral Senses
+  [nwHYTpyreUgvxh1z] Feral Toss
+  [vEpM7qYZmBiwBiNT] Fermenting Liquors
+  [1VLIJgnTUxNlf7T8] Ferocious Charge
+  [Le30algCdKIsxmeK] Ferocious Shape
+  [P10KdjTbRcgXG0JM] Ferocity Mimicry
+  [pZUmoCqxBJfZmeqm] Festering Wounds
+  [c5SfaSn6OEHkHxII] Feverish Enzymes
+  [8rE5zLEVe4putosB] Fey Caller
+  [jSu9h6UvZtUJ7InD] Fey Life
+  [grPtqWYbdXXo7yhP] Fey Tracker
+  [XY2uS7pMKRLVNQKG] Fey's Trickery
+  [moXYfz806x6uXIW9] Field Artillery
+  [UFghSYXiBJIDV0jI] Field Propagandist Dedication
+  [9qSlXRFNLX0y07EX] Fiend Eternal
+  [DoaqSxIFx5CSgBBE] Fiend Slayer
+  [CYSH4aFmzH9PM3sm] Fiendish Form
+  [lNIHXCQ0Zc2gY5OH] Fiery Rebirth
+  [6biVVoaqqUdQmQ37] Fiery Retort
+  [8xb66hZXbVIu7HWG] Fight Choreography
+  [fwdnRUW6TVwjiAoq] Fight Through Oblivion
+  [mvNa9KfQooHYEXoA] Fighter Dedication
+  [PLz1oIEGJojVUBsW] Fighter Resiliency
+  [K9hM3AdWGbU3VE8L] Final Shot
+  [BndS11cLoHSIZc49] Final Shot Knows the Way
+  [k9B7gDit3pXbq2XF] Finessed Features
+  [PAsFP9jcVcHkBoRd] Finish Their Story!
+  [DY6pNO3GzHeKSxmQ] Finishing Follow-Through
+  [X5gNhaYNx1xu6NoH] Finishing Precision
+  [yOloZIGkulrrPYG4] Fire Lung
+  [qbH9ns3HMYBxIvEQ] Fire Resistance
+  [NagTqSLK8bAlo2nY] Firebrand Braggart Dedication
+  [MVbNnjqQOK9d8Ki3] Firework Technician Dedication
+  [j2XKVhDuhdcI15kD] First Frost
+  [HdhnAm9SNfDqxRSN] First Revelation
+  [tv0TX0DiDg2lDMOl] Fish From the Falls' Edge
+  [9mpjAbkfQD59RIpn] Fit for the Role
+  [aWGwGoodVZjcXkvE] Five Breaths, One Death
+  [8aYizNbZP8wyyj9y] Five-Breath Vanguard Dedication
+  [gq1gGsJDLQuQDrhW] Five-Gods Ram
+  [V7n3kVSl0G6a29KG] Flailtongue
+  [dyjYNaE6Nc6zpsUM] Flair Rider Stance
+  [tmGsnUkPv8SIhBgn] Flamboyant Athlete
+  [SAOtGk9k8veaX3Ww] Flamboyant Cruelty
+  [TdwC9rTGgtF4CQ25] Flamboyant Leap
+  [qbFRPTHP96Q9kGpk] Flash Your Badge
+  [v6d1N3yygUccisQL] Flash of Omnipotence
+  [N9kJPSRz1Ax9eFdD] Flash of Omnipresence
+  [VnpI3sPgwLlcCJy3] Flash of Omniscience
+  [S3NFO9meH9b08oiN] Flashforge
+  [1NS6AM2oVNKb4LhX] Flashing Shield
+  [TnYHtN9gQASqOnii] Flashy Dodge
+  [DfSe0BFocS9AuJTP] Flashy Roll
+  [SVdYJW5JsOMhAYd0] Fleet Tempo
+  [hE6fchGuHuPIeKlO] Fleeting Shadow
+  [F6VlPyZZpqV6d2CS] Flensing Slice
+  [Xdf00Kmv5C3qqrtK] Flesh Wound
+  [UqA9GdO2pGQwg9cd] Flexible Halcyon Spellcasting
+  [bmWvMfYxZbZtigDp] Flexible Ritualist
+  [CrS0iDwHmjKqvKti] Flexible Spellcaster Dedication
+  [9bgl6qYWKHzqWZj0] Flexible Studies
+  [U9zIjPHPe2PyrtlU] Flexible Transmogrification
+  [gPiYj2vgWm0CNoGW] Flickering Stories
+  [SyxXnSk2R0AM9HSn] Flickering Twirl
+  [lmo55Y5NS5iZa56o] Fling Head
+  [2eratRTKDhSYvrIZ] Fling Into Action
+  [uL6q4wtwvuP8I4po] Flinging Blow
+  [7UwXNTmPXIXps2sM] Flinging Charge
+  [d6Vb8D9yOX93mdUI] Flinging Shove
+  [RKh9lvo0PdE2Yto4] Flinging Updraft
+  [lqStZou2d2WMLJxz] Flood Stance
+  [ffLzfZIq7LoNXqWO] Floral Restoration
+  [isdTXU8bV7ZVOAuQ] Flourishing Finish
+  [yqspSW7eEQVvuYrC] Flow of War
+  [74WUIwtTHHFrw0CM] Flowing Palm Deflection
+  [wz2edbLFnDKDNWWZ] Flurry of Maneuvers
+  [hOImeMiRPIRKPPXY] Fluttering Distraction
+  [nYhkODez1r49LTXj] Fly Swat
+  [ekPCBxVAOugxpvUY] Fly on Shadowed Wings
+  [qgNc5XwjsaWET0Op] Flying Blade
+  [1SbwsBbuCkkpgeYN] Flying Flame
+  [wB1ONG2uO7RnD1iC] Flying Kick
+  [zEvU1ZlqSsXNPghw] Flying Tackle
+  [zodscjgydZRUSOLO] Focus Ally
+  [5GqjEM22n78Vmdpe] Focused Fascination
+  [t4022d8ndt8YJPSe] Focused Fire
+  [lYVAGuHU47Ixyuxy] Focused Juggler
+  [d7DQhCJKYcLxpHen] Focused Shot
+  [sG9fPQk4w9y6MmnY] Folklorist Dedication
+  [MprbkBZUouqvbKGo] Folktales Lore
+  [KlqL2QCGvcf6vbta] Follow the Threads of Fate
+  [9Q0tPGtOawPTU2TU] Follow-Up Assault
+  [m0ot9Qydb9SYWHis] Follow-Up Strike
+  [uyZ3gY7gtKCLiywR] Following Smite
+  [o8ogNJ53l1JDIJud] Font of Knowledge
+  [KVF2c1ixGkbG6Idi] Font of Life or Death
+  [SeTlSDlaFudKg86x] Food Preservation
+  [cKvGJCD8VdHOU0rq] Fool's Fleeting Plan
+  [agWNAYqgyV58jlxm] Foolproof Instructions
+  [uQExVrBNPJeS66sO] For Love, For Lightning
+  [mzpLIuRQ81DCYdKU] Force Fang
+  [jIL0dobpVmCrmSj1] Force of Nature
+  [SASOvOG2Nqs2ekdA] Forceful Push
+  [0qL4a3CarG1e0pfB] Forceful Shot
+  [UJafwv306v75Syy7] Forcible Energy
+  [pVDgiaqu1RbCOhuv] Foresee Danger
+  [PmhprI0vr3zTOkok] Foreseen Failure
+  [lKgpe2JKaeLjgnYF] Forest Passage
+  [2LjTxYTlRL7RwhOS] Forest's Heart
+  [NNeRv9Gcua1kMp4s] Forestall Curse
+  [CuVvDrBaVP9nYJlt] Foretell Harm
+  [vPA0EGXBaNzGxlxM] Forewarn
+  [ASAXLrckAyTBYi8E] Forgotten Presence
+  [RsluSLtSWq1vN8Hc] Form Control
+  [0EY2WQC3Hb6Mitgz] Form Lock
+  [l8KQgN8icNrzYIav] Form Retention
+  [UpnXrLhJZ06HTaJh] Form Up!
+  [Uwq0mhaVCWsSxlju] Fortified Elixirs
+  [7vOVPzsVuyE5a3Rp] Fortified Flesh
+  [FjuuX0vUWlYchRNM] Fortissimo Composition
+  [xdqSgSfybmBOCw5q] Fortunate Blow
+  [TzLl1YwivNqCdgIL] Fortunate Relief
+  [HNeKm6BCu795585p] Fortune's Favor
+  [ix1fhe9ttnvFLgmi] Forward Gaze Into Life
+  [iySa8O4NaTdLPKQl] Four Winds
+  [iUEYGMjvveC9sfUu] Fracture Timeflow
+  [YIzADuxb5AV1kUvK] Free from Bonds
+  [IcAEMf94XoTvtzAO] Fresh Produce
+  [V9kShXu84NlORfcg] Friendly Toss
+  [RCjMbLyRnG70R7cO] Frighten Undead
+  [Ano4tRq88V39eyPq] Frightening Appearance
+  [mAoykPgP5OALqeq3] Frightening Power
+  [Gx8MXDn2WcNARCJn] Frightful Attrition
+  [5JG0kjxukERBeayd] Frightful Aura
+  [SUNLm99CgsS5M3Eq] Frightful Condemnation
+  [xUaEpnfd1FMGNG1z] Frightful Moan
+  [gipC9eWrBDFRpNkQ] Frostbite Runes
+  [YMrcnO2l3mA71ohM] Frozen Breadth
+  [6yJxUx0W2hwHckNi] Full Automation
+  [o3J79hnr00ztcwtT] Fulminating Shot
+  [XpZkzUV9PwUHvmyq] Fulminating Synergy
+  [BcYmYMUU8HDwGthh] Fulu Familiar
+  [6y2rSSlCXUpk8DMY] Fungal Exhalation
+  [cA1IIy6UEsgETXiX] Furious Bully
+  [5gnBhockV7O32jTR] Furious Finish
+  [y61mDkTqk2k77b4x] Furious Focus
+  [7HPXQvPH3ovwtVae] Furious Grab
+  [p2I4o9Cc6UrXvjhO] Furious Sprint
+  [Oyml3OGNy468z3XI] Furious Vengeance
+  [6vHkvQv0j56nZuR3] Furnace Form
+  [kceciNwoldkzAMbq] Fuse Stance
+  [enxzAkPICXT4sSFU] Fused Staff
+  [yg1ZTjHuSiQJFO0i] Future Spell Learning
+  [DQN7YC7s7T0pL6Aa] Gadget Specialist
+  [AP3k96JtJHsDk0G4] Galvanize Spell
+  [CowQy8gXP9POjuxq] Game Hunter Dedication
+  [XRahcvEPEAEdGUn8] Gang Up
+  [bXoGskH0SYfdcEtJ] Garden Path
+  [gTg3D9Dv9L4NEVhV] Gardener's Resolve
+  [qUoAthRX9cNVHT9s] Garland Spell
+  [yg02rHaDPpGSgkrk] Gathering Moss
+  [MgLUbsvAkIA4fsZW] Gaze of Veracity
+  [HCoDbriaPwnurcNP] Gear Up
+  [HX67CcR59JO2RJXI] General's Gambit
+  [WcvscJpQhbTiefwn] Geobukseon Retaliation
+  [YRanyv890fLiyaOY] Geologic Attunement
+  [E8SDesgMD6Zbye2j] Geomancer Dedication
+  [ia3eTMsQfVyaAXlX] Get Behind Me!
+  [IaJ91ilthFr6PA9q] Get Used to Disappointment
+  [tor4lzY0wpNcJd2U] Ghost Blade
+  [52nzskpmUt9AjUf8] Ghost Dedication
+  [r1um0cn7MRIMLqcq] Ghost Eater Dedication
+  [zJXsGF61lH0WHw5v] Ghost Flight
+  [mkp6lhBbTASEmKwY] Ghost Hunter Dedication
+  [pM0g4ColXTiQ3gTa] Ghost Strike
+  [00OnDt8UEMwfoYWH] Ghost Wrangler
+  [G96zcEKvxtWLn701] Ghost-Path Epiphany
+  [NYY7zWZWZ3XlzQgs] Ghostly Condemnation
+  [Ozm0xy2lrOq6GiWU] Ghostly Grasp
+  [C3ukUk4Js10o5IBA] Ghostly Grasp (Deviant)
+  [pwM4RGwCTLiVSic0] Ghostly Resistance
+  [ABL4daQ7c65d0tEM] Ghosts in the Storm
+  [jBXsMU7ri5d8IEbw] Ghostsong
+  [EHJRMCBRL4YeBN6l] Ghoul Dedication
+  [XkYNCFdZMjZTw6nn] Giant Hunter
+  [9wd9hhtfjayeZ6zF] Giant Slayer
+  [SgXvw6rzk2lhTpXL] Giant Snare
+  [MFqFvuiYDAoADcft] Giant's Lunge
+  [W21jKAcG0GtEtBiK] Giant's Stature
+  [dzeiVab4Cogzl5XS] Gift of the Hoard
+  [IqaVsxjR2bsR4OU2] Gift of the Immortal Herb
+  [lMlfoY76xIP9GD2F] Gifted Power
+  [HxTqYtXRqFkkLfDQ] Gigantic Megafauna Companion
+  [Q21KzuubUBBkoges] Gigaton Strike
+  [lv8jRWK7bv7dR6SM] Gigavolt
+  [pGIJ6iXyg2CRzQxb] Gird Champion
+  [QfyCxRwvOZfstbj7] Glacial Prison
+  [Dm0YMEvSY0qg0jA0] Gladiator Dedication
+  [YK7PLPoLGYGBivEt] Gladiator's Roar
+  [VF5XFpzBlqUFd8Mw] Glass Skin
+  [MJW4VP7PjVAX131C] Glean Lore
+  [Bj0GvPgyPiC2kDH1] Glider Form
+  [sYOaZoPqNBnppY51] Glitter Crystals
+  [TrE7lZdKLrWzbyoZ] Glorious Banner
+  [mgbCNt7MgEVbMlJ7] Glory on High
+  [5GC2iGtVp3UAH2nm] Glutton for Flesh
+  [qUBr1YsQw3BSNy9c] Glyph Expert
+  [hXYnwpi95E77qfAu] Goading Feint
+  [pI5cG6x49ZQLchuy] Goblin Jubilee Display
+  [07TYbc4cOQi5tduT] Godbreaker
+  [102gdaYHnMFoDRL1] Godling Dedication
+  [ZuKEEP4S4b4fbgAt] Gods' Palm
+  [Mw4owPxaU6i2Dpgl] Godspeed
+  [uwp7Y4LNtPbhELjS] Golden Body
+  [HvbVV8wjJmVmkYt7] Golden Dragon's Bounty
+  [jTOxxy19o2VRJTbH] Golden League Xun Dedication
+  [MxNb97qr1yMhbjiP] Golem Grafter Dedication
+  [nRjyyDulHnP5OewA] Gorilla Pound
+  [DqD7htz8Sd1dh3BT] Gorilla Stance
+  [7jqBwXq9jVsghCva] Gossip Lore
+  [rFaUJtB46scuAidY] Graceful Poise
+  [gYcmow7HM8J3giwL] Grand Dance
+  [f4k5ripShCn5orZB] Grand Medic's Mask
+  [LHjPTV5vP3MOsPPJ] Grand Scroll Esoterica
+  [3hnmQrhv4Bru5GKR] Grand Talisman Esoterica
+  [6GUl9WG7OKvfVQo4] Grandmaster Qi Spells
+  [lJxoW6ser5naDGqf] Grasping Corpses
+  [WsEVkMFe8ZEIRKLu] Grasping Limbs
+  [qcILhNRHqIbW3xRN] Grasping Spirits Spell
+  [KWZqHwI82ae8fMML] Grave Mummification
+  [eXNkcM7gtCGC7udi] Grave Sense
+  [lszcn7eO3olp5vEt] Grave Sight
+  [7GrACprIxZuarGDs] Grave Strength
+  [RPN5wXkXpP8ky3jo] Grave Threat
+  [shDyS87L0eiabyHw] Grave's Voice
+  [zkN2FndJxGt711fj] Gravel Guts
+  [M9WIUEPY6IoRtgWN] Gravelands Herbalist
+  [ubF6nGJrnfW7ocSg] Graveshift
+  [ysXXa8K9fa383HAD] Great Bear
+  [4Ek3Kyle2DsCPQQm] Great Boaster
+  [cznEQ1W61MSaXW0u] Great Cleave
+  [hIUiDCXN82QbSIvI] Great Shield Mastery
+  [Z91dIlVcJXoicbHj] Greater Armament
+  [Km6YO7Ky2bEwhAFD] Greater Awakened Power
+  [DpRMdytpPiCypmkJ] Greater Bloodline
+  [doD3jZylVXZ0oHWO] Greater Crossblooded Evolution
+  [u2rvvAqZBugZgcYg] Greater Cruelty
+  [QHh442n2CEtJr23B] Greater Deathly Secrets
+  [Cn4w9U7uk5m1bb2S] Greater Debilitating Bomb
+  [O0QrBJfiMCTR0n0z] Greater Despair
+  [vDJRIKS27md3LudA] Greater Distracting Shot
+  [cIClNoUqtX2SGWfz] Greater Esoteric Spellcasting
+  [ygPrwqiyDr1frUHw] Greater Interpose
+  [qDfTqetM9UEpp8ty] Greater Lesson
+  [jBHDVsTVOBeoMoO4] Greater Magical Edification
+  [ErKwliHplziJY2BW] Greater Magical Scholastics
+  [8HYfYT4fHtxXP199] Greater Mental Evolution
+  [QpnZwabXOVICJL5i] Greater Merciful Elixir
+  [kZdcoaTD849QalR9] Greater Mercy
+  [O1qdoz5N3G4yvHcH] Greater Physical Evolution
+  [HSW3N9pfHhM7upRB] Greater Revelation
+  [3aolZmAj0ue8vc6q] Greater Security
+  [Mix4IwZRuCz7JS3T] Greater Snow Step
+  [hRJV7byfPUHx1b9P] Greater Spell Runes
+  [gVLICIDQMvWN5D89] Greater Spiritual Evolution
+  [HbBNuT1bqdcCU9hM] Greater Sun Blessing
+  [ND3nKsXCDBShUgYc] Greater Vital Evolution
+  [3vjOXL9ZD4ibaJL6] Green Empathy
+  [vwBD55BRDOatp4ZV] Green Tongue
+  [rPbh7sOhhL7i3j1z] Greenwatch Initiate
+  [9EmJElnNVmXQ7Rzn] Greenwatch Veteran
+  [dnm6c3nzGDHt3A76] Greenwatcher
+  [S6X3zFOCLVgRY2gd] Grief's Fury
+  [C3zKTQecexSbezhT] Grievous Blow
+  [94PGauGdzrVARMLc] Grit and Tenacity
+  [i991vEx2T7y5L6Ke] Group Taunt
+  [GmSY4YVyzgAZ4I78] Grown of Oak
+  [hRRxmIhRvg59RMqO] Growth Spell
+  [ii7aCMN4WPQo3N3l] Grudge Strike
+  [PEszRpnrcB7VPS9G] Gruesome Strike
+  [AAhRUP6Uvy8gE1jA] Guard's Fury
+  [etaixAdHNlHnLH0i] Guarded Advance
+  [Nb8MUoTpyX9u8di4] Guarded Advance (Knight Vigilante)
+  [9odEaNZQYeOnZC0e] Guarded Domain
+  [bbBUbigCqgxiIT4E] Guarded Mind
+  [fO1vRDEfl9pysfLU] Guarded Movement
+  [zNInvTqZrDdNJAS7] Guardian Dedication
+  [31ozQ8lwNtiQi2N0] Guardian Ghosts
+  [cgHpgpUeZdMXyCY4] Guardian Lion Roar
+  [2Fs30aBxpFZMTJfN] Guardian Resiliency
+  [JdCRxwgtdQkJ1Ha6] Guardian's Deflection (Fighter)
+  [YJIzE2RhGRGfbt9j] Guardian's Deflection (Swashbuckler)
+  [fJxIdcg7kWPwlULY] Guardian's Embrace
+  [vC4hrYAynasBDz16] Guardian's Intercept
+  [EVgqBU9BsEdPlRxD] Guerrilla Dedication
+  [1xzeh0vQ1WWFVO3j] Guerrilla Weaponry
+  [Ek1CoyGKxsozDsaD] Guide the Timeline
+  [DXf3HFtO4EfXBq1A] Guided Hover
+  [x7EGJYZQuxHbP50X] Guided Skill
+  [9t6Kfk8Yw8WJYY8Z] Guiding Finish
+  [1DaSVLJEdJWYOWek] Guiding Riposte
+  [3OHdjgDGn4yzMD9b] Guiding Shot
+  [LmsjuqB3rrZTqqa6] Guiding Words
+  [jwjtxZL6XpkO5lv9] Guillotine Blade
+  [FbzbZc4LGUTcz9tA] Gunpowder Gauntlet
+  [USt0jwK8XI5loG4E] Gunslinger Dedication
+  [riQ8sn3Gpbr3LdtR] Gusting Spell
+  [Csvjt2GiDhzBwhkb] Haft Beatdown
+  [pKNnFOuHBkJEvmS1] Haft Striker Stance
+  [IaV9Ao4twLNblaSq] Hail of Splinters
+  [7fU6e3HIT4NvwLYa] Halcyon Speaker Dedication
+  [LDv6RVuDXJ9nOfhj] Halcyon Spellcasting Adept
+  [HgBksiMTUibPK36M] Halcyon Spellcasting Initiate
+  [iuLLw1X5RjRcR4rH] Halcyon Spellcasting Sage
+  [lyJ3pPvZAr9nRco6] Hallowed Initiate
+  [63L2iSAxkHyq6qEt] Hallowed Necromancer Dedication
+  [CR9NcAIPTT4oWSEy] Hammer Quake
+  [UKXaMhb9qlPYw1HD] Hampering Stance
+  [s2GbcUIXG1ZBurSd] Hamstringing Strike
+  [matJDIUDvgaJqyiF] Hand of the Lich
+  [ydE2WS8DAXLvhbDf] Hands That Unweave Disaster
+  [zxaE7C1NCGqZR8aU] Haphazard Repair
+  [KuLH3nG3chToIffB] Harbinger's Armament
+  [vIoZmlIzO7gkKEWY] Harbinger's Protection
+  [REgTwIVgI3j1FQiJ] Harden Flesh
+  [cZa6br5C3Iyzqqi9] Hardwood Armor
+  [1W0a6YCyoYv8dm4e] Harming Hands
+  [21YWBdoXGmj60vdI] Harmonize
+  [UWG1USE0L2ZxEPiO] Harmonize Self
+  [ATsP9JCBnzkwVQbl] Harrow Casting
+  [JgM1DMPcceeHYhQ8] Harrow Ritualist
+  [0i4zOM1p0rFxnc5m] Harrower Dedication
+  [fCsIyglmpb7NYwiy] Harrying Strike
+  [37uOb0iaWCfTCvBZ] Harsh Judgement
+  [l5nqNPmZPG6lYFnZ] Hasted Assault
+  [iP01b6eyUm4m6KQp] Haunt Ingenuity
+  [aprpqUlRpRVXwAJv] Haunting Memories
+  [16MOW7deoOoDwE9z] Hazard Finder
+  [agfosPInBLQXNQfa] Head Stomp
+  [OYrcbyaV3v8ycksj] Head of the Night Parade
+  [iYTHfcZWAnzLgK13] Headless Haunt
+  [Q4NiHmThMtk8razS] Headshot
+  [OJxEF5FONTtEdbpP] Heal Animal
+  [FhxkU6OftQeecpQW] Heal Companion
+  [LnSMRHjMArCkE4w1] Heal Mount
+  [xXHwktc9SymSY8d6] Healing Bomb
+  [zYhcEX4JnrZ08HfV] Healing Hands
+  [cD5EsurWVYekIXkz] Healing Sanctuary
+  [85V3vdew0gykEtmu] Healing Transformation
+  [1ul2dasQBdlaMEC5] Heart of the Kaiju
+  [4fbGUm8j4zzljOo6] Heaven's Step Offense
+  [qJdbK8vgIqeHU7bu] Heaven's Thunder
+  [ndjGUomHdBdyEhwZ] Heaven-Earth Encompassing Sleeves
+  [m2Gz9y8VhGi0EpFC] Hedge Maze
+  [Uuvu1TojhHcDm7EV] Hedge Prison
+  [BBvmmULFPLlHCeIK] Heightened Captivation
+  [WlFJyOz73m67HmW2] Heightened Instincts
+  [mGGnDgk4wWpCMon8] Hell of 1,000,000 Needles
+  [J5s7NeFHYuFSdhrX] Hell's Armaments
+  [0YtidWmL4GTpONkq] Hell's Bane
+  [v22KrWg1T7F5VYgx] Hellbreaker Dedication
+  [24LBBYT1op52Pm4J] Hellbreaker's Resolve
+  [qhs0mWbaLKsdckZX] Hellknight Armiger Dedication
+  [iFEecf9o6uhJxWcG] Hellknight Order Cross-Training
+  [62hpJOuvYYSa4X7u] Hellknight Signifer Dedication
+  [qUSWPWxYF8gfhfHM] Helpful Tinkering
+  [9tXGk4h9Bw3Wcnra] Helt's Spelldance
+  [AY3XRv2j0cZvHaks] Hematocritical
+  [P07YFQCp3hT3OgJE] Herald's Strike
+  [5ELeiNtEDgXfBcwt] Herald's Weapon
+  [5uzu5u5UFSfRRBSs] Heraldic Proclamation
+  [5CRt5Dy9eLv5LpRF] Herbalist Dedication
+  [j9TEwIPFOUTZfVn3] Hero-God's Bond
+  [81jVmGF9Uo9dp2dI] Heroic Defiance
+  [KR78kinMmAZQHeoa] Heroic Recovery
+  [JbE823xBNt12IAD5] Heroic Scion Dedication
+  [4iEQ5zQSTRls3Kln] Heroic Weakness
+  [p2tFR4yBauu8t3mC] Hex Focus
+  [5H3Sk1yhalQQzUys] Hex Master
+  [rVgEkpTLfbeOdzzw] Hey! Over Here!
+  [zKh3SQLDHMVcKRLk] Hidden Hoard
+  [Kl1O0WK37KMTumv1] Hidden Paragon
+  [Chu6s3xVnpOB64GH] Hierophant's Power
+  [Ilh66megcbP7ahMN] High Alert
+  [xDTjr415ZZM8x2WW] High-Speed Regeneration
+  [1HvSkbUjqrIMXLiY] Hijack Undead
+  [RtYOsmb9R71J9ce2] Hilt Hammer
+  [RGkuVy1EmCbKjLPj] Hindquarter Kick
+  [T0LazeBYiLnUzQXC] History of Violence
+  [ug1uJSKxYmpJ1KNz] Hit and Run
+  [6LFBPpPPJjDq07fg] Hit the Dirt!
+  [xmf6oUYarFJGajtr] Holy Light
+  [MU9qS0QuBdcyLkza] Homing Beacon
+  [roItUHUbBqhHfwJr] Homing Shot
+  [WSndnu3scUYWmbki] Hook 'Em
+  [pZMBq7gn66SEEA0n] Horizon Walker Dedication
+  [dtPXuS8MiWrz5UNK] Hot Foot
+  [dutiFC41YFllm8fM] House of Imaginary Walls
+  [H6qletvAJUCC1aIa] Hulking Size
+  [6nB5ycSo4zshj22k] Hungry Blade
+  [c3b7DhnDBC7YEgRG] Hunted Shot
+  [GFtNQvpzuqtsdOTG] Hunter's Aim
+  [HVP3ZGIOlxlFy0ni] Hunter's Sanctum
+  [Nf9awfRtyjzLaeXW] Hunting Snag
+  [VTmRh5FJTxo4btKO] Hurl at the Horizon
+  [9KvsO72JJ3pfkG4U] Hurling Charge
+  [H2GlPobLyqgBYbd9] Hybrid Study Spell
+  [HnXZCpqRaj1nInjh] Hydra's Bond
+  [jGTRRCqxn1FIBxE2] Hymn of Healing
+  [mbmjj0LKVuI4Zl81] I Knew the Heroes
+  [aVzkG1UhNjQr22pE] I Meant to do That
+  [meZTsonAlueXihQU] I am the Weapon
+  [zjizIGArUSdE7hx8] I've Been Here Before
+  [0evTnx67DYsxWtg3] Ice Crafter
+  [kOqW5ZtnOiWxKl9M] Icy Apotheosis
+  [zXsJuf8RjBlJ6nJv] Igneogenesis
+  [uKeUPPqV1cNnIy0h] Ignite the Sun
+  [a5jZJPZO8RPQjqE7] Illimitable Finisher
+  [yRT94fGPaS1M9f9I] Illuminating Stories
+  [X62yfg4vky1JMnf1] Illusory Identity
+  [uvbPZR6dsQBimIUo] Imbue Mindlessness
+  [hcwSO3qeYLQtRLBa] Imbue Spell
+  [i5mNsZjIXfLAaoP8] Immediate Rebuke
+  [bwbPuv4JsilmMnPz] Immortal Bear
+  [SrTb0JpENFZ0i0mO] Immortal Lightness
+  [Nn2vUOpKJpr6ps89] Immortal Ruin
+  [QuRhGFEhvF7z0Pz9] Immortal Techniques
+  [R8MaoG7CzHZmQYtM] Immovable Object
+  [urYHB6VHhqvPMSy7] Impaling Briars
+  [Qfn7lmOeXfBtpG4O] Impaling Finisher
+  [guSjEQS3WuXJqQxf] Impaling Thrust
+  [YeyOqNFKaeuOTiJr] Impassable Wall Stance
+  [KdKkLGcUYOpI0deP] Impenetrable Fog
+  [iHGhQK8A4xsfaV8t] Imperious Aura
+  [FNW66GfWXaiBSexb] Impervious Vehicle
+  [fLrwddS607eRFfHA] Implausible Infiltration
+  [RqccUKf8DCPnsYXJ] Implausible Purchase (Investigator)
+  [zCASpQconMmtJKQN] Implausible Purchase (Rogue)
+  [mrM07U3MyElcLEx4] Implement Initiate
+  [72qOqbwShnT2Apaw] Implement's Assault
+  [AObopXQkCIsaBAID] Implement's Flight
+  [VC8qdcCxtzCmG98M] Impose Order (Psychic)
+  [07jxXvRZ8nD3JLF4] Imposing Destrier
+  [OqHfUQQorVBkx34j] Impossible Flurry
+  [L5n4PvQYhpl2WM9e] Impossible Polymath
+  [HquaVwjOLSPzcJgB] Impossible Riposte
+  [rwTbN2A2ZO7CdKoC] Impossible Snares
+  [mSqzGGttJvj4LxK9] Impossible Striker
+  [srWsvDDdz77yieY1] Impossible Technique
+  [NY2AkQscVIHEC8hQ] Impossible Volley
+  [QO8l5Dao8HnaFQE4] Impressive Landing
+  [Nxke8WzifQafSa4I] Impressive Mount
+  [GPIKvj8K2yk2eVOC] Imprison Foe
+  [nnsoFOtuHnpz2QHc] Improbable Elixirs
+  [hLMsARkiwRf4SwqZ] Improved Command Corpse
+  [A0ZQpGSB7pvIDiou] Improved Command Undead
+  [mgs7vxq6d3hQoswa] Improved Dueling Riposte
+  [8VlGHrDKjlY69jFv] Improved Elemental Blast
+  [9C6a6FXuPqWjXy8K] Improved Familiar (Familiar Master)
+  [2VKV7jLRTxWyVjGa] Improved Familiar (Witch)
+  [zK0Dr1FZDOq2DMn8] Improved Hijack Undead
+  [J9LjIYPyUmOim5r7] Improved Invigorating Elixir
+  [HPETR6zq8L6YJyi1] Improved Knockback
+  [9Eufa07qvXG41QmG] Improved Poison Weapon
+  [fEfEabn53bubYVVT] Improved Reflexive Shield
+  [mCXoiMLAbGHGsZS3] Improved Swift Banishment
+  [w2v5LZmpJy0MBxo5] Improved Twin Riposte (Fighter)
+  [Cgk4By6gEomD2bJ0] Improved Twin Riposte (Ranger)
+  [H6SL2F11nlMfqCQC] Improvise Admixture
+  [YDpSnLmnSLsItP45] Improvised Critical
+  [FSxugo3zTgRhW7Og] Improvised Pummel
+  [1RQLf09kpOO6ljmb] In Lightning, Life
+  [6FCWkhOo9NqfLKqV] In Tune
+  [E7dvSRTr9s2q8TKe] In the Horde's Grip
+  [LRSTjjBNNlD0XZX8] Incorporeal Shot
+  [DGO6kyjw2bQG7dbY] Incredible Aim
+  [aEws1NR19Lbu1Kio] Incredible Beastmaster Companion
+  [qgW8uHJXJGl3DKBS] Incredible Companion (Druid)
+  [U52NMdeSNbjSSRHE] Incredible Companion (Ranger)
+  [58LYCoLrCzG2Ll8b] Incredible Construct Companion
+  [OjGUJyeArTj5gZyG] Incredible Dragon Companion
+  [Joy1e6pdqx6fN9mH] Incredible Familiar
+  [OnlmhRfHvtwgY2Z4] Incredible Familiar (Animist)
+  [KcNXoSvULnuQjC9a] Incredible Familiar (Familiar Master)
+  [uAdnQZSkUuxcpEwz] Incredible Luck (Swashbuckler)
+  [lUjWE40fjAjHecNQ] Incredible Megafauna Companion
+  [AYBfwGImT28lUdue] Incredible Mount
+  [xhFsHEsMTAvzwJhr] Incredible Reanimated Companion
+  [2l15VfVHMw3ttgJ3] Incredible Recollection
+  [fCDC53WOOYrsyVIR] Incredible Ricochet
+  [XrvIHz2bkgdpJ8rI] Indomitable Shot
+  [ZPWYsJgSPbGkCICA] Induce Imbalance
+  [Nm4yeoJVXRy0Wyth] Inertial Barrier
+  [UxjAszOYAhUvCDt2] Inescapable Grasp
+  [jG9YwAAvNbCShumf] Inexhaustible Countermoves
+  [QkZbgdTGt8ectKGI] Inexorable
+  [zybYSfeM0PLPpAaa] Infectious Emotions
+  [of3G33qoA8oJZ0Le] Infiltrate Dream
+  [8GJOPesRzytyouAU] Infiltration Assassination
+  [HRg8cnxy0uiJ1pqE] Infiltrator's Blitz
+  [2RwRguv3J0CbzjNg] Infiltrator's Reload
+  [h5JQvV8LEooQ5hvq] Infinite Blades Celestial Arrow
+  [fklx5lSy6ZEI3sID] Infinite Expanse of Bluest Heaven
+  [LAHiW98iPJKplFyK] Infinite Possibilities
+  [DaRfJsWAivah3a07] Infused with Belkzen's Might
+  [FWQSyjjYg8h0KpHq] Initial Eidolon Ability
+  [iT39wlCEC1aWaSx7] Initiate Warden
+  [m2A7S4BjZg94WPyr] Inked Panoply
+  [QYZovCDjOhBb1u01] Innate Magical Intuition
+  [PdQAAKtCW5dS9IYj] Inner Fire (Monk)
+  [OY1Ewg0dbCp52Hl5] Inner Strength
+  [aOYnK0xe9DKFtx7d] Innocent Butterfly
+  [SIsEvELAKfjZxDwx] Inscribed with Elders' Deeds
+  [OWedlrKGsVZVkSnT] Insect Shape
+  [UIRcjHxuSedoDOj4] Inspirational Focus
+  [9pTQrhbeF348bYky] Inspired Stratagem
+  [bvOsJNeI0ewvQsFa] Inspiring Marshal Stance
+  [c2UuV5n5leFx9vlU] Inspiring Recitation
+  [AbsqV1P8OAhChcRl] Inspiring Resilience
+  [MLiEMjyZXE43wmrq] Instant Armor
+  [dC14a0DZqDBA9B8g] Instant Backup
+  [9zH7IOsmhRBEqXAV] Instant Opening
+  [mDczSj3GolIbkhGJ] Instant Return
+  [rm8NgrdZNjqpGlC1] Instigate Psychic Duel
+  [4T9HHOdTk3yVbeoO] Instinct Ability
+  [wLOt3Ejz3fLLRIqH] Instinctive Maneuvers
+  [LVTquA3DpqCJDika] Instinctive Strike
+  [buRSqam06r9jFAbB] Instinctive Support
+  [RHdY0xczRYzkIdJt] Instinctual Interception
+  [6TlBZSPr18Y8WiNk] Instructive Strike
+  [d2InKGKNEdVnPfNf] Instrument of Death
+  [i98NcWSAbWmNmBik] Instrument of Slaughter
+  [h08Vfel5iIAARWdy] Instrument of Zeal
+  [yRRM1dsY6jakEMaC] Intense Implement
+  [qOGD3K8VlQAAjsWy] Intensified Element Stance
+  [uJgATfMW3kumS6Y0] Intensify Investiture
+  [oyE933TmrbRyYqJY] Intercepting Hand
+  [aWHOcGLA7AhX4xpm] Interfering Surge
+  [VB1UK3KA5uZcxC05] Internal Dialogue
+  [wnV0H8GB0FlpdCGo] Interpose
+  [cELaMZVilk3vkrrM] Interposing Crowd
+  [uFxUj8OgX04w5MXp] Interrogate
+  [MjPqgBQU9W4kelfz] Interrupt Charge
+  [bjNeSAldeTzRcEaQ] Interweave Dispel
+  [SQM1Rrqihn1IoJJD] Intimidating Spell
+  [lkcM4V3VDAtjlR9P] Intimidating Strike
+  [QcyaUiea6fp8c17U] Into the Fray
+  [wuMa6iJyZ83LYJXH] Into the Future
+  [gL7QZsSMldjwE6te] Inured to Alchemy
+  [0bFXHrLuMKcuz9DD] Invented Vulnerability
+  [JIpjpZ8VneQomkZw] Inventor Dedication
+  [bgnf7USFkqsNh8j1] Investigate Haunting
+  [CZXhJS55rG5H6PpB] Investigator Dedication
+  [7XcQ8Ygz5cubGxdC] Investigator's Stratagem
+  [23QgyEYjoslBvkra] Invigorating Breath
+  [AhrF360kZt0QJIub] Invigorating Elixir
+  [mMboqxWsQmwUTQ6m] Invigorating Surge
+  [2zxF682cNhgLMu26] Invincible Army
+  [jtstZYC8S4YmAbIE] Inviolable
+  [BxMMITENS6tncpCk] Invisible Hand
+  [iBdvNOWazhiXeUUa] Invoke Defense
+  [2RaDe6Fi4t7S2IDF] Invoke Disaster
+  [7ZYw4SiBLBbbICNs] Invoke Movement
+  [EEtezGRTZSHayQDR] Invoke Offense
+  [tH5w8vIfFCFNVP7T] Invoke the Crimson Oath
+  [FGtiEx0yYHu16mN1] Invulnerable Rager
+  [JgfZOEOgnbKNYth4] Irezoko Tattoo
+  [MpDMv0fYQWGZcn0Z] Iridian Choirmaster Dedication
+  [8PMxl8o5YXET58Pn] Iron Lung
+  [XttSGDuAsRDTuvgS] Iron Repercussions
+  [x9cYkB8DrUBBwqJd] Ironblood Stance
+  [IqDbNiwHQH1xApo9] Ironblood Surge
+  [vtYJJCQKOffjd6L7] Ironclad Fortitude
+  [79GUhBznFfYqdwgO] Irradiate
+  [52cygjzHfSD0YhEA] Irresistible Magic
+  [hPfqQpiq6W8RPCxz] It Was Me All Along!
+  [mwBb8MlAmpbYH9T4] It's Alive!
+  [37l9SEvS7X1jHtpD] It's Not Over
+  [9L6c9sxweM4IdOse] Jagged Berms
+  [Ze9vb0wlRmWWqnXC] Jalmeri Heavenseeker Dedication
+  [CQfxxsRxf1BuUH4o] Janatimo's Lessons
+  [MROG87PQmuBTdCaB] Jelly Body
+  [Jwq5o13uZF3ooln1] Jellyfish Stance
+  [dzPwwXHW5NzYGG5h] Jester's Gambol
+  [zxP9xHpChl9y8wNW] Journey of the Sky Chariot
+  [tuhEOBeX0sVnRoWH] Jousting Mount
+  [YidYY7k2gvny9eSY] Judgement of the Monolith
+  [GCUXprGmuEl7JUdF] Juggernaut Charge
+  [jPBqvEH2jLlvDr6M] Juggernaut's Fortitude
+  [mNsNl6w3l5rXx8dL] Juggler Dedication
+  [T6Twdesb5niBhHuZ] Jumping Jenny Display
+  [YluQPhevo0LKdF1p] Just One More Thing
+  [3My19Wif5ks29tyg] Just as Planned
+  [ZfycfbXlPXZlSqw5] Just the Facts
+  [5ZoIJImgvpdhGcDR] Just the Thing!
+  [cB6K0wkiDhduAjtL] Just the Tool
+  [CZQgH17ZxoBiVXLa] Ka Stone Ritual
+  [9MbeKaIV8Xa7H4Of] Kaiju Defense Oath
+  [RwOGkOLCalt4sqz6] Kaiju Stance
+  [3zcjIjJ7ujldN3zr] Kaleidoscopic Entreaty
+  [3WUL8ExEkZDRYeBu] Keen Magical Detection
+  [Ig431EeRy3FKMmMq] Keen Recollection
+  [OzvvsyjAWWij4mmm] Keep Pace
+  [DYayudEG8sZRB3Ot] Keep Up the Good Fight
+  [xdv75qkv5TOFlHmM] Keep up the Good Fight
+  [sNth17W3rRvtqjQp] Ki Cutting Sight
+  [ySeT8hrMEPF9AsQu] Kindle Inner Flames
+  [NV9H39kbkbjhAK6X] Kinetic Activation
+  [stsCnc8hR6db1Get] Kinetic Dampening
+  [C4J8yO9g1gAZ3JKs] Kinetic Pinnacle
+  [CbfszeYw3cf99kdv] Kineticist Dedication
+  [Xiv87UvRqfLPqvin] Kitharodian Actor Dedication
+  [yFBan5ycDsdT96jN] Klingegeist
+  [h0gwBDI61MxkvVPC] Kneel Before the Rightful Heir
+  [H86VNC6cNWhBI8Ed] Knight Reclaimant Dedication
+  [1YFrl8I6ZGo7BIM9] Knight Vigilant Dedication
+  [XgUQ6Tm9LKxcZGHW] Knight in Shining Armor
+  [jZy91ekcS9ZqmdEH] Knight's Retaliation
+  [gVXefUaMzg7S1vpm] Knock Sense
+  [pVLdMOqYwul745k3] Knockback
+  [2OYJOFaEkhc8dFbl] Knockback Strike
+  [EBqnbiuVL0ULFJWX] Know It All (Eldritch Researcher)
+  [fs2zVzyXrn5yqGqd] Know Thy Doom
+  [tlqz29fgp45bjSg6] Know Your Enemy
+  [1qJCMbs3zcPMWDux] Know-It-All
+  [ZOr1FUlpJj1q6q3H] Knowledge is Power
+  [tDTZWLqV2u3PxppS] Knowledge is Power (Wizard)
+  [zSWTX520paO6Zv1i] Knowledge of Shapes
+  [iWvpq3uDZcXvBJj8] Known Weaknesses
+  [dCoX0TfsasMfwYnz] Larcenous Hand
+  [BrBDJxzIUFpmCG1V] Larger Than Life (Guardian)
+  [9O7DLcXVXpwLVXI6] Lassoing Lash
+  [T3XFrLIBzir9IqD5] Lasting Armament
+  [56BMXlQlZtg39SMV] Lasting Doubt
+  [bWYnjNa2RknMoibg] Lastwall Sentry Dedication
+  [V5Y9r31BCTaCiNzi] Lastwall Warden
+  [OFCeTaAX99YbXOu0] Lava Leap
+  [YWRdk9oGMY6WmgIC] Lead Investigator
+  [nLFP7rT0jhM11nFR] Lead by Example
+  [Aeea44xyJqYArFun] Lead the Pack
+  [TW0fUdqqB69rIbRx] Lead the Way
+  [mW9uqRmI0Wi2qYSm] Leader of All
+  [ZHPSASbvbbshq1zG] Leading Dance
+  [8YLCu791osZNFKN2] Leap and Fire
+  [U13oe5dQFLvgNkUG] Leap the Falls
+  [omhB14HQxJUZQvjj] Leaping Hedgehog Strike
+  [5dAFkOYPz8PPdFrw] Leave an Opening
+  [aMp7crNLWFfMGLGO] Legacy of Monarchs
+  [iUds1xfU9WtKGPMf] Legend of Combat
+  [Veyt4x2Kb5YcPGTv] Legendary Monster Hunter
+  [epNrbgmjZDjJe7Ry] Legendary Rider
+  [B3Fz46wzUIzrxWsA] Legendary Shot
+  [wPjNjyh60fYKrDXl] Legendary Summoner
+  [PeBz8f9h8Y4OFdws] Legs of Stone
+  [8KxcNpQhmUOj3vuV] Lepidstadt Surgeon Dedication
+  [7y1BCJLrdk9mKXlc] Leshy Familiar
+  [baz18CdB13DVMHV9] Leshy Familiar Secrets
+  [GXzTwLSXbWtQBXb6] Lesson of Bonded Eyes
+  [m9lf0M1h72tMIBKm] Lesson of Mutual Gambits
+  [8oTv8BRweFeBqtm0] Lesson of Sympathetic Vulnerability
+  [09aDtDsI47AKB0Cd] Lesson of Unified Elusion
+  [CyvXimmSlpbOlBhX] Lesson of the Broken Wing
+  [dM3hbn5ogp3oajWg] Lesson of the Circling Gale
+  [RVvi84iviUsX4Si4] Lesson of the Hurricane's Might
+  [Ry8NYQwxPagKnLKW] Lesson of the Splintered Aegis
+  [a01E0vIphNQrzBd1] Lessons of Flux
+  [nxoSp0GDiQ288BJa] Let Death be my Weapon
+  [UgmLKNTU59Z3ETFc] Let My Creature Live!
+  [Xz9jmwwJnx17PjCu] Lethal Edge
+  [XfCPAoNdF2XMnH7K] Lethal Finisher
+  [HlSwpxreIfsglTJ8] Lethargy Poisoner
+  [7OXTqBA6QgCatNwZ] Leverage Anguish
+  [6qIiczSzuOmp0yRx] Levered Swing
+  [jIMeialR9CBo1bx9] Levering Strike
+  [BQkk7qSSRTFc5jNG] Ley Line Conduit
+  [8rKzUpDxAi8tMk7I] Liberate Soul
+  [1JTEWgonWlmeCE3w] Liberating Stride
+  [NHxSvYyIBChlAasG] Liberty or Death
+  [peUBtdoG5LyVaf5g] Lich Dedication
+  [I10dkdvL6kAnqZWA] Lie Detector
+  [YYTZFBT2WZMU14om] Lifelink Surge
+  [4o9g5g12yyrfZ3Xd] Light Step
+  [jQ8JntOdBFHPw5S4] Light of Revelation
+  [Vcn3fPJU8HMEkON5] Lighter than Air
+  [DgnUXfkcufJotxN9] Lightless Sight
+  [8GG4h6DbpAEGGETG] Lightning Dash
+  [ZhiO6FDz68VCWybl] Lightning Qi
+  [7275FFz5qWQO3j0s] Lightning Rings' Intervention
+  [06wbX1YStavp4Fq4] Lightning Rings' Overcharge
+  [GabSQXUprub2eyUm] Lightning Rod
+  [4OEZrIefIuIjUDzE] Lightning Snares
+  [657SMUB2N9VZOgYp] Lightning Swap
+  [ZugnuBQu3RNcQmLv] Lightspeed Assault
+  [douVMHDuQQv8U8aq] Lingering Chill
+  [sVjATEo8eqkAosNp] Lingering Composition
+  [505CCsBRft1P53gP] Lingering Flames
+  [u6SDVWbzHnBBPNMo] Linguist Dedication
+  [4l0ewDg4gMfkU2pi] Link Focus
+  [JGfJPx6xkx11zHlW] Linked Focus
+  [zNxbsYgQgPVxdTLV] Lion Blade Dedication
+  [d81PT3w97SkyAiXQ] Lion's Fury
+  [hh0e2aeFjQOwu51T] Lion's Magic
+  [Q6EkzXkbMuuk8f7c] Lion's Might
+  [2KZG1KvQjBgcSSNA] Listener's Boon
+  [ivSf8wSIUkK8gwej] Live Ammunition
+  [keCkeRzBANPgUG8M] Live Off Borrowed Time
+  [fUvV0zsNf1Rj0eox] Live the Creed
+  [nvahDuuKRE0T8Sh9] Living Bonfire
+  [NKsNDA8rS9R5MmAX] Living Epic
+  [1eXHDDOLZATKpWjL] Living God
+  [c4ao7b2T92fiM8jR] Living Monolith Dedication
+  [MM9NcRyXWX2LFiuF] Living Rune
+  [LeQ94pmBffhCKI7B] Living Stone
+  [0ogbBzSD7fmiWp9d] Living Vessel Dedication
+  [CL43gGiErw5FUtFQ] Living for the Applause
+  [80DU0IvIzOIBGuUa] Loaner Spell
+  [XkmrLhyAoxQTLnza] Lobbed Attack
+  [SiGvSOPQmZ0nyXVO] Lock Down
+  [McnLGEZnUbtYCNDW] Lock On
+  [SjJ8BOy5sc8p2H5E] Log Roll
+  [aTI1r1RaZ1o0givR] Lonely Army
+  [BcrBeAtl1sVyGmy1] Long-Distance Taunt
+  [blOiU4LPlBjVHcgR] Look Again
+  [Jk6gZzXEABiX5A0S] Loose Cannon
+  [apz0n3Q3gWvQVChT] Lord of the Fiends
+  [BFgrPAK2v3GSKQ5e] Lore Seeker
+  [cdeVm8fTDzrP71Sw] Lorefinder
+  [lyD6eXl4wc7Pq61q] Loremaster Dedication
+  [VToVEOxiyy53AcEp] Loremaster's Etude
+  [indcWWwZ2Mg7j9eB] Lose Your Chains
+  [d8RfatiK9UOQANLz] Lost in the Crowd
+  [8lVLhQ0NhGIbQupI] Lotus Above the Wind
+  [axvGLVoAvuD9jU78] Loyal Warhorse
+  [Xb8CyW9sYS27ElcC] Lucky Escape
+  [rTkr1EqpAN6YtnAh] Lunge
+  [5tlTRfyPXkGS9Coq] Lunging Spellstrike
+  [ZghzLmYgeE19GqjP] Lunging Stance
+  [reoylyGMDPl7H6L5] Macabre Virtuoso
+  [yzBlvtPcjhRHFvp0] Maelstrom Flow
+  [ZhToff996PnTESwb] Magaambyan Attendant Dedication
+  [mqLPCNdCSNyY7gyI] Mage Hunter
+  [buUSr6Dh9md9WqJx] Mage's Field Dressing
+  [vUFvcrvszXlHvz2Y] Magic Ammunition
+  [9WMLIcHpwkQpUQfz] Magic Finder
+  [Su4nbNnR0mjgusTT] Magic Hands
+  [y8VecqdECqyH1h6o] Magic Hide
+  [AXy4A7zTYk1JAiOV] Magic Sense
+  [JfLIWyqgEVggWaBL] Magic Sense (Magus)
+  [G43fiFtxFR24CWRs] Magic Warrior Aspect
+  [5FOqVC9Q0eEKEf3w] Magic Warrior Dedication
+  [x62kd1CYJNqO2ZsS] Magic Warrior Transformation
+  [DPaZurhC9uyIWPcu] Magical Adaptation
+  [b1eGMNjBY3iqIt2S] Magical Adept
+  [chmQgMamyaZX90Tc] Magical Edification
+  [yOybxBkebeeuHWuy] Magical Knowledge
+  [aoIEVpJrQEold2Mi] Magical Master
+  [AuIE19F9rY3YvXf6] Magical Scholastics
+  [vW8dGtOD3rZVOJoq] Magical Scrounger
+  [mxO7u59ms58q7zyj] Magical Trickster
+  [WfbmFsRxbVyzMmCz] Magical Understudy
+  [YJCAiNpFbX2MIc0G] Magnetic Field
+  [IAo6UeLgWqG7KK1x] Magnetic Pinions
+  [TxKWgxor49xntDlU] Magus Dedication
+  [0yPbPVEESwB6Bdfw] Magus's Analysis
+  [SWkeel82rdttxUD3] Majestic Proclamation
+  [ZFkCMl63ogK55Otq] Major Lesson
+  [SwkIcrtHO60FkhEH] Make 'Em Sweat
+  [QDjpZKOrWIV1G8XJ] Maker of Miracles
+  [UcIyf7bTDf6RwydU] Makeshift Strike
+  [PccekOihIbRWdDky] Malleable Mental Forge
+  [hCEoINqJ75ConqqA] Mammoth Charge
+  [SVhyfYNAphQPxFjd] Mammoth Lord Dedication
+  [OljNnAAEwvD7qDOt] Mana Detonation
+  [HJBDFHIaJ3lfxcbs] Maneuvering Spell
+  [2e2Rv6SN3D2nX5M2] Manifold Conduit
+  [Dcr63tofZUome1Ze] Manifold Edge
+  [4osf0dNeZ19KBoTb] Manifold Modifications
+  [mrHrIrZQkGMfnl1j] Manipulate Realm
+  [lkLwEfc3ZhLJSkVr] Manipulative Charm
+  [4YeHOPzo3zOhZQCh] Mantis Form
+  [jZalt2bFGjK8XXcP] Many Guises (Vigilante)
+  [8VSMh11XydSm8DbP] Mark of the Sage
+  [k8c0E7YyeIQJjRzB] Marked for Rebuke
+  [MYzRfNExDYp25rro] Marshal Dedication
+  [oMwdv9ms12lT5e55] Marshall Fiendish Forces
+  [zn7arorE3VJLNYsb] Martial Artist Dedication
+  [lKeJruYQutWlNXyZ] Martial Exercise
+  [q1iP3SjAF5uceI0M] Martial Performance
+  [fFfRsvDavUsTBDF2] Martyr
+  [fGwd5g6yHzcyeCG1] Martyr's Parry
+  [GByIIkeHN3JWkZIZ] Mask Familiar
+  [ADoFKzCh5z4dXg3f] Mask of the 12th Step
+  [JIjoGVnieAhE3a5f] Mask of the 15th Step
+  [4xeDjt8eARzAGARP] Masked Casting
+  [KMVXUgFArcftg1jQ] Masquerade of Seasons Stance
+  [AFREL0ZE4F832eQG] Mass Delusion
+  [WXEOriht1LBz55R0] Master Animist Spellcasting
+  [eJNzP21lFPV3zWkm] Master Bard Spellcasting
+  [6qNRVKwbnX381jVj] Master Beast Gunner Spellcasting
+  [jI4Eoi6m0ogjXkGK] Master Captivator Spellcasting
+  [5NWZct5OvSiVvMn8] Master Cathartic Spellcasting
+  [bc6tcXSzakyCbQsS] Master Cleric Spellcasting
+  [218WeRqUqdnguRdS] Master Druid Spellcasting
+  [6kz7FPdxDrsPiNti] Master Eldritch Archer Spellcasting
+  [AJRWIcBGCIxXG0RS] Master Magus Spellcasting
+  [5csEOLLbYUWJDJoS] Master Monster Hunter
+  [ZkGhDEpqe7fzJuSr] Master Oracle Spellcasting
+  [zQazwiELy8Vhb1tS] Master Prophet Spellcasting
+  [PzbfpOQXOjpUWKkL] Master Psychic Spellcasting
+  [DAFF7zJphhDPcAws] Master Qi Spells
+  [4jl3w1ojlsnYVNZs] Master Red Mantis Magic
+  [WqAgDITfHmh1uGSm] Master Rivethun Spellcasting
+  [lIg5Gzz7W70jfbk1] Master Scroll Cache
+  [kVSZQvsz1cYjOwxL] Master Siege Engineer
+  [Ruee0G3oZG5n5Auk] Master Skysage Divination
+  [syxJQ48bxE8NY91a] Master Snowcasting
+  [phD0PbElkEeldZ2U] Master Sorcerer Spellcasting
+  [NAgaDfwUSjPAon4o] Master Spellcasting
+  [UH8pDxrq1xJq4Sid] Master Spotter
+  [t8CAK8ylu23PUxbn] Master Spotter (Investigator)
+  [rW1q7x5CMf9Rh1bi] Master Spotter (Ranger)
+  [wios5UDRwKXoUYUD] Master Summoner
+  [kPsJIz19viZy8YjO] Master Summoning Spellcasting
+  [i7ibUqJCl1GXRFEa] Master Witch Spellcasting
+  [PMckhnGYMyiwUNiL] Master Wizard Spellcasting
+  [qX9ZtfaAj6rxrVA7] Master of Many Styles
+  [178rqdgJBF9Rl0Gi] Master of the Dead
+  [EDdJFwarNIJIkP2E] Master's Counterspell
+  [AwxJcaIrutqMcUC8] Masterful Companion
+  [BBN5G6epRWXGwZHv] Masterful Warden
+  [nuBY8Ek4JBFQJzoh] Mastermind's Eye
+  [fIjEjQYRgKr8QUEL] Mated Birds in Paired Flight
+  [yozSCfdLFHVBbTxj] Mature Animal Companion (Druid)
+  [tpkJXDpSuGznfzGJ] Mature Animal Companion (Ranger)
+  [uCElsebJ45ltmZMT] Mature Beastmaster Companion
+  [adWnAp41sCCx02Ap] Mature Dragon Companion
+  [opP9j7RP7JPyt8Zj] Mature Megafauna Companion
+  [n3eOMWQd4kdR3A0l] Mature Trained Companion
+  [AimSmPyiMhJZVZRq] Mauler Dedication
+  [bO5ULM0yxTZVydtn] May Death Itself Reconsider
+  [y8l4omYxEWH7vihP] Meddling Futures
+  [MJg24e9fJd7OASvF] Medic Dedication
+  [Q9tL7cRTpPD04iPa] Meditate on This!
+  [fcFrxvqbIX6k71os] Meditative Focus
+  [laAcB3bauWQxxdAo] Medium's Awareness
+  [mMMIHLVSr8fyvVQL] Mega Bomb
+  [BEqXsP6UqARzpEFD] Megaton Strike
+  [hlX7jYoS1s6srZC2] Megavolt
+  [s97nKj9Uye1KXr7A] Meld into Eidolon
+  [kh4bTBgi3C9CjwHK] Melodious Spell
+  [4F7suRtLfcurHqFI] Memory of Nothing
+  [S36WQ8o2MvPxQp0p] Menacing Prowess
+  [pEFcWRYiWLSjxvkW] Mental Balm
+  [UtRW3hYBTFG8HQLh] Mental Buffer
+  [yantkiDNmsT5ONZX] Mental Forge
+  [7PlGRHizgieuYzDR] Mental Static
+  [2IiZFG2HJjr0Droz] Mercenary Motivation
+  [dCGg0nRvk8jUQxz8] Mercenary Reversal
+  [Mvw3ZFrdwMHedAxY] Merciful Elixir
+  [R7EaZPYtsy5H8lwn] Merciless Rend
+  [zilwynzk8lIujgZo] Mercy
+  [gOHBzx5Rqa6TZcrm] Mesmerizing Gaze
+  [URtcR1BU2OgfKHfm] Metabolize Element
+  [HbdOZ8YTtu8ykASc] Metal Carapace
+  [8KUvJuAWCoxWg5FH] Metallic Envisionment
+  [stwRJTOKUru9AmQC] Meteoric Spellstrike
+  [CkK7WwaWnrLXK9sW] Methodical Debilitations
+  [yj70CxBMXuyjqiIU] Might of the Realm
+  [YaJ1JTBMhpu1RWXV] Mighty Bear
+  [5TPKikTyN7lrCvzY] Mighty Bulwark
+  [DFY3X7Mgl9rESQuu] Mighty Dragon Shape
+  [SlXLsuxBHeUyUPII] Mighty Wings
+  [mjdLmXLCNaRgMLVw] Mimic Protections
+  [P5Zu46vfO4ptBBoj] Mind Projectiles
+  [xaSlCFYUXlu5f0zw] Mind Shards
+  [juikoiIA0Jy8PboY] Mind Smith Dedication
+  [bcExqs4CsG2Kc5Bs] Miniaturize
+  [FrlhErsjR6fEn6kX] Minor Magic
+  [u8hKEb71pI45XP1f] Minor Omen
+  [m2pHkmyGvkwqfSSN] Miracle Worker
+  [v22FQuw17Dlr1b3x] Miraculous Flight
+  [APfPNpUQlKlCAJkS] Miraculous Intervention
+  [7mGMHb7irGKZ0eQo] Miraculous Possibility
+  [kQEIPYoKTt69yXxV] Mirror Shield
+  [h7KZXNRm1gLV1yTt] Mist Escape
+  [EOYxsteDMSSZovfV] Misty Transformation
+  [jCIBYryi6Y3JwmqH] Mixed Maneuver
+  [Px1QZY0NdO9WAQQS] Mobile Finisher
+  [AyP23H3WJkEAIEKd] Mobile Magical Combat
+  [rByA8NDI6ZtNgBeT] Mobile Shot Stance
+  [mG6Qo8e8TSIiwR9l] Mobile Swarm
+  [RAymYRO2SLNNzKVk] Mobility
+  [WlgaSpTSGQQrHKlx] Mockingbird's Disarm
+  [sVEF7j9Wh1KNGPUm] Modular Dynamo
+  [pyaPfKPAN4H7hkLM] Molten Wire
+  [Ju03TtaUBaaJ0Yq7] Moment of Apotheosis
+  [vRXPsMbyuvoPvbAQ] Moment of Clarity
+  [IyWtJ1KSd6TTvfYQ] Momentary Respite
+  [QlBQEkFqiYsU2Y3x] Momentous Charge
+  [k4TsVHoGtBJNJw8a] Momentum Strike
+  [YG2RxXE9SMfwo6wP] Monastic Archer Stance
+  [YW4FdWgzTwRFneFF] Monastic Weaponry
+  [renUpSO6MJXPSXow] Monk Dedication
+  [TGFbFyv0AUi5gAGO] Monk Moves
+  [nc5G99d20PI9JKCK] Monk Resiliency
+  [bBORql3kKsSyXllk] Monk's Flurry
+  [YTTJqRKH8QZl6al2] Monster Hunter
+  [2yq3l8e2Vzz34yRV] Monster Warden
+  [54JzsYCx3uoj7Wlz] Monstrosity Shape
+  [VO2uOVrjIr7ZAjkX] Monstrous Inclinations
+  [6UeJLQ8tQP8E0kSn] Monumental Maestro
+  [Bf5rqe6tJyR6GoS3] More Real Than Real
+  [g2qwr5maymONJAVI] Morning Side Dishes
+  [fZFdoqeSQGBPDgai] Mortal Ascension
+  [XmvIQ4iJ2euOgLYb] Mortal Herald Dedication
+  [gqQK7dDrGPkQDfQQ] Mortification
+  [W2nSF326oSkAaDjw] Motionless Cutter
+  [hO4sKslTrSQMLbGx] Mountain Quake
+  [6sbuDCFHt89Uqykn] Mountain Skin
+  [ZL5UU9quCTvcWzfY] Mountain Stance
+  [n2hawNmzW7DBn1Lm] Mountain Stronghold
+  [oGOxrqT7DHI43SVk] Mounted Shield
+  [yM8ITsQuIAxPu1YT] Muckraking
+  [htOsE4hnSj2gzKdi] Mug
+  [LBfLDfLnCFn1iy5h] Multifaceted Will
+  [a898miJnjgD93ZsX] Multifarious Muse
+  [RzhnxgiAopWILCvs] Multishot Stance
+  [IUmN2WC55LxPNSBB] Mummy Dedication
+  [uBOToHKQJr5JBEsg] Mummy's Despair
+  [lFVqejlf52cdYrZy] Munitions Crafter
+  [lh3STEvbGnP7jVMr] Munitions Machinist
+  [WPGT9wBqwOFlvKbV] Munitions Master Dedication
+  [IdKfWg48qMieuzl7] Murderer's Circle
+  [8CLbJAtgSfwxk2rk] Murksight
+  [4Gl55zsGU6TkSKOJ] Musical Summons
+  [ADgFB8hjUgcXS4bF] Mutable Familiar
+  [mj1pVVFtqGLKgCQM] Mutant Innervation
+  [gQ2EvesPqLbISLQV] Mutant Physique
+  [zqGSwbm3jM2JGAy5] My Kingdom, My Blood
+  [lcsfw4H9U6KofFtG] My Reputation Precedes Me
+  [y4Cws9vZj3Bf9uqH] Mysterious Breadth
+  [Ek3nCIFRreqnSxAQ] Mysterious Repertoire
+  [eIW5p8qqvsx2MFkY] Mystery Conduit
+  [pkfa1pc72gOeyO4c] Mystical Flare
+  [53sHAxpDg9KrkcGk] Myth of Quick-Thinking
+  [n7GdtqrIaQPGaptn] Myth of Realm-Walking
+  [Lx7JtAhIn3aJ6WbP] Mythic Allies
+  [ejOTX1ukDVNorpt2] Mythic Casting
+  [y3E0V6Nmq7HElfDT] Mythic Containment
+  [ht8q3CDn94Oq7njx] Mythic Counter
+  [7GGvKGwLiUGpAxxH] Mythic Counterspell
+  [zox6jHcyZwkItalI] Mythic Heightening
+  [d605yhbRoaVgisFG] Mythic Magic
+  [Oef5B7jxmu5nFxLa] Mythic Refocus
+  [toGkX6UVPq1Z1NjB] Mythic Strike
+  [XHRD9gpm58gURMLP] Mythic Weapon Specialization
+  [l60Ua5Ugv85GnF9b] Nameless Anonymity
+  [57K9il2Jxs8PmsYL] Nantambu Chime-Ringer Dedication
+  [XusuxqmXWPYc0JYA] Narrative Conduit
+  [nLlbcEZ5w4bsgMye] Natural Conduit
+  [epBOnfEDOd4V9mQ0] Natural Swimmer
+  [p0ghAUQYzymGVpot] Nature Prowler
+  [6B7ksTtpbfp114sA] Nature's Precision
+  [NdMZvW213LYo4PhI] Necrologist Dedication
+  [PxBQ4JdaPS2KTAG7] Necromancer's Visage
+  [R337W7VveJxlEddE] Necromantic Bulwark
+  [YZEG7LsiIIhwRB91] Necromantic Deflection
+  [MnqDDUekqd40HTZc] Necromantic Resistance
+  [MkLujXEplJUt6Arv] Necromantic Resistance (Undead Slayer)
+  [PcDvw2vWTzBEIX7k] Necromantic Tenacity
+  [9gGObk9p4gnXf9co] Needle in the Gods' Eyes
+  [J8HLcsOkAcXfTxYy] Negate Damage
+  [Btu0tA6SEBS6K1hE] Never Tire
+  [xlZRdUyqjtdSYd8Q] Never!
+  [XHbdG50JIO8pEaQ4] Night Terror
+  [TjNkvawfWCqb1alg] Night's Glow
+  [KOslKkFO9N1kZY87] Night's Shine
+  [Pk6qGMlef5SMhhwE] Night's Warning
+  [PMvwXlZHHFuPGrPD] Nightwave Springing Reload
+  [dNH8OHEvx3vI9NBQ] Nimble Dodge
+  [iTdbkP07UFMOo1rI] Nimble Reprisal
+  [F6ZAceuDpiM9bUiF] Nimble Roll
+  [sKuhYCfCbXeRWivv] Nimble Shield Hand
+  [mrmPbgX3trgnkXQU] Nimble Strike
+  [lT8XlX1Ig900BblS] No Escape
+  [LgpATqbuTIfB4o6G] No Hard Feelings
+  [D3ypq5kAmLbwrgjq] No Stranger to Death
+  [XHy9inDi3oGZNd43] No! No! I Created You!
+  [quqG3jfWFdopF0G2] No!!!
+  [K0zDniOVUL4C77lk] Noble Sacrifice
+  [8bDwJieEVCjrceM7] Nocturnal Kindred
+  [k0NNa5Ko4XhDdBYB] Nocturnal Senses
+  [k5C1WNuYQ4u7nSHt] Nonlethal Takedown
+  [46mkvetP7cdi7LO0] Not So Fast!
+  [mdc30s4CuxR7HL3k] Not This Time
+  [gDvLmqxAtxY3LVaH] Nothing Personal
+  [srxzbmm6671nL0YL] Nourishing Gate
+  [IAnUKY3QI8K32yJw] Now You See Me
+  [acJkVtpX2GUvl90E] Nudge the Scales
+  [55wEtw47Zl11uqlr] Numb
+  [vsibRIwbWoG37tuC] Numbing Spice Exhalation
+  [483yvMrNZFV3fiSo] Oath of the Avenger
+  [imBsp1Tg7KMut4Lf] Oath of the Defender
+  [vUBMjoOiZiMzdc18] Oath of the Slayer
+  [mrxAX7h5ya9Z7QV9] Oatia Skysage Dedication
+  [pM57xTqy5CMYZeqD] Obscured Emergence
+  [wHwjoK3E1Ot9kkV0] Obscured Terrain
+  [3QLWe5oS9jGJ0Oq4] Observant Explorer
+  [bYyou5TjkCmzoizu] Observational Analysis
+  [Yvxr1Q2TslWiKqqi] Occult Breadth
+  [lL2fQJ2oRyBgga8Q] Occult Evolution
+  [1gtWb6lKWMw1Wp1q] Ocean's Balm
+  [cvo3DIL0BIRrDkQ6] Ode to Ouroboros
+  [5IYiVzVLwok0mT2A] Of Lions and Wyrms
+  [ciI4pld6HFRUjFB6] Officer's Education
+  [1rsWyxs5xQV2FvEV] Officer's Expertise
+  [mEY7ezGTjoVOH5Q4] Officer's Mastery
+  [YgVl3kHqhavaqcEw] Officer's Medical Training
+  [cexPKeX0kBKGd2TR] Oil Fire
+  [gQwGwW3uPeAQMAyk] Omnikinesis
+  [H1kZ8nqvHlAazM35] On Borrowed Time
+  [lFNyIFWPPXpS0qRM] On My Best Day
+  [kwYQ90zLGMSARX4O] Once and Future
+  [lCn0QYOcjXHqpYea] One Life, Two Vessels
+  [yfzpmSF9IYsMeKxo] One More Activation
+  [bCizH4ByTwbLcYA1] One for All
+  [fGBb3VsJwf7osKaL] One with the Land
+  [OxdlGZ1rndxalf6X] One with the Spirits
+  [jaAnxfXVmUQy0IKU] One-Inch Punch
+  [4caP26xpkQajkaDp] One-Millimeter Punch
+  [YDbWz3ZhH3Odk71A] One-On-One
+  [7IrZIPP5ePtzzKcI] Oneiric Influence
+  [KWXoo738KuddWMOB] Ongoing Investigation
+  [MRMW0EiuOO20pzG2] Ongoing Selfishness
+  [CAk1NNG4aO0VuHnZ] Ongoing Strategy
+  [I5swIFsr4UOAEBvv] Only My Doom May Claim Me
+  [OoEkGGDBoNOJ9XFP] Only the Worthy
+  [2mww0DmokYJXUEoA] Ooze Empathy
+  [20jNBiIIxaiOVyi0] Oozemorph Dedication
+  [lFc7HTNUCUemzSiV] Open the Blazing Eye
+  [yeSyGnYDkl2GUNmu] Opening Stance
+  [PuyvasWeofGMrhpu] Opportune Backstab
+  [3q7uo810lJJ09ghv] Opportune Opening
+  [2LdncNMDNJW5Oeyu] Opportune Throw
+  [B51a2EwAD84xVX1n] Opportune Trickster
+  [BVHDkBa4JMmmj5Sn] Opportunistic Grapple
+  [OUNj8nXTHwGcEdlh] Oracle Dedication
+  [PExiZZTSP4p7TZaW] Oracular Providence
+  [Gcliatty0MGYbTVV] Oracular Warning
+  [anVCLNgxVYb45UPc] Orator's Filibuster
+  [cbEodcnBKzx5ii3B] Orchard's Endurance
+  [9onf3uGvZRnNLPR6] Order Explorer
+  [oHdUwzUUblg3neCT] Order Magic
+  [TaoV7ArAuZjxpeQB] Order Spell
+  [AgMFfp6fdNZ1mAxn] Order Training
+  [vw0wHIqSP03XYT00] Ore Fists
+  [DUajVmPdAlf16CGP] Orichalcum Bond
+  [E5ewlRE6Mh9ZqUMu] Ostentatious Arrival
+  [KU6nyh8DyQ7NoRQj] Ostentatious Reload
+  [RxDq7SB7a97EMJbW] Ostilli Host Dedication
+  [VbGyh1LcaRSAvmKt] Ouroboric Pact
+  [EG27noJj9KzyB2i4] Out of Hand
+  [xCi23uEFef9jhtlM] Overclock Senses
+  [NBvhmNqneeok7ZOr] Overdrive Ally
+  [9CaaU5szcf3mtJXD] Overextending Feint
+  [C0ozuEhrKh9A1wMO] Overpowering Charge
+  [tIE2umG4rQOxm8D8] Oversized Throw
+  [t03Tc5I4B8RHsyqs] Overwatch Dedication
+  [eOwjwVAbl99ZTy5D] Overwhelming Blow
+  [Dwxi1q1OWB1ufFvy] Overwhelming Breath
+  [tXNfWDa6P7bCKrCt] Overwhelming Energy
+  [pmVaj53saxLE28Pl] Overwhelming Spellstrike
+  [Mq6wjHaaqBnfScYe] Pack Attack
+  [QBOhIDAIvpHUGSji] Pack Movement
+  [CGvN4xaahJegFwnX] Pack Performance
+  [ZeQP0awEkOHWmMRa] Pack Takedown
+  [W3w7iGGsdkfO1GOn] Pack of the Beast Lord
+  [U1EMvL3PbEQZXqLy] Packed with Flavor
+  [GvQ9FQ02i7GYuRRh] Pact of Draconic Fury
+  [k0h4jvjxK0fYFvOU] Pact of Eldritch Eyes
+  [0VsrXyQYdluGRfsY] Pact of Fey Glamour
+  [ByFircdZMLPOe58K] Pact of Huldra's Renewal
+  [ztxbGySxIEeWvsAT] Pact of Infernal Prowess
+  [zU0nKWJIWlKaT0gt] Pact of the Crossroads
+  [OYeBODzHgyybCBxu] Pact of the Death Hunter
+  [bSalPlHitGbYvsZM] Pact of the Fey Paths
+  [qgahXDIjevUmk5Ci] Pact of the Final Breath
+  [nZtINeZbhGvbSUAg] Pact of the Living Pact
+  [x90yRgXMhY9NCbKw] Pact of the Nightblossom
+  [gbKZk9nEXUZVywc9] Pact of the Rune Dragon
+  [uD8J9wAE3KB2w0Cf] Pactbinder Dedication
+  [BVxcuJ5TWfN1px4L] Pactbound Dedication
+  [FqrfyUtoBWJNnSi6] Pain Tolerance
+  [S5vOQ7J8DKR8sEj0] Paired Link
+  [zgljg4gVI6i1Fpb5] Paired Shots
+  [LlTIbv1py77nACkI] Palatine Detective Dedication
+  [UVgRZf3zHV8aXa5L] Palatine Enchantment
+  [OfKfYPrlxo8jdqmp] Palatine Strike
+  [qPlv8HwtoO2fAjkj] Pale Horse
+  [Oo3yRbmrgqi8dmVs] Panache Paragon
+  [PGyzFBwuTgypU8cD] Panic the Dead
+  [fMAUsLdBd5SDoHBz] Paradoxical Mystery
+  [R5hdEbfKdIVAQs24] Paragon Companion
+  [UxurtbOOvCkngsKN] Paragon Reanimated Companion
+  [hPDerDCYmag3s0dP] Paragon's Guard
+  [KgD26HpSrKyciB8f] Parallel Breakthrough
+  [8z9XkfZalQ5tUjfy] Paralyzing Slash
+  [uIL1pbp7jhYMjYLS] Parry and Riposte
+  [4PvmSnyp3URIqJUM] Parting Shot
+  [7fyWKASX6uNByJF5] Pass Through
+  [lL5MxRUFqbzS6jDm] Pass Vengeful Judgment
+  [XgMV11C8W72SX9Yg] Patch Job
+  [S450JMWfF90oOcv9] Path of Iron
+  [QnB5ArlO4wlRXQ2E] Pathfinder Agent Dedication
+  [5jsMIFF9uYekQZpU] Patron Reborn
+  [Wz0LLKjEi8GfKloV] Patron's Breadth
+  [DCItdIWcdQkaIL5g] Patron's Claim
+  [ejGRaQTZYWFSFIW0] Patron's Glamour
+  [aM36jhU3VTeUzPpr] Patron's Presence
+  [SelPslNtTfzxp7fs] Patron's Truth
+  [byLeVAcRoSWgT5DK] Patron's Whisper
+  [C3MgEkPNaIhTddbr] Peafowl Stance
+  [u2fgdFIdQDplKOS3] Peafowl Strut
+  [As8cRK5jVzf62fEd] Peculiar Anatomy
+  [aKFYL4b5Bi7qla2j] Peer Beyond
+  [kbpnrT2ey0O89kWx] Peerless Captain
+  [GsXKThvUN2Mi9eNk] Peerless Form
+  [hH2utNrlunNjpkKF] Peerless Mascot Companion
+  [W7aT1UJOVFkYdQti] Peerless Warden
+  [YlaLePtgDXGB0Fsf] Penetrating Fire
+  [tBMMKWYfzD2OMD30] Penetrating Projectile
+  [otBBb0ndASgPdAXW] Penetrating Shot
+  [J2KKsWrNR2tMqLFB] Pennant of Victory
+  [jFdCLA9X9WloBvv3] Peony's Flourish
+  [JkQjKyzfhMWLr9Gs] Perfect Clarity
+  [HBhLR980Q0cb2rxp] Perfect Debilitation
+  [MjhCcwGKyI5dpNIY] Perfect Distraction
+  [xhuXpOFOxDpJgngm] Perfect Encore
+  [BuaTJxALqxM5EZav] Perfect Finisher
+  [xAIUuSw5A85XEStY] Perfect Form Control
+  [aQjWHbjK1pk8HESM] Perfect Ki Adept
+  [ST6AhCbEDSMxXf20] Perfect Ki Exemplar
+  [xCuPob9TuSBKz6Gn] Perfect Ki Expert
+  [9v3wpgvEEiZHO0SJ] Perfect Ki Grandmaster
+  [0208T5UrkTY2ombM] Perfect Mutagen
+  [31V4Qo4Vd0ghN0IY] Perfect Pitch
+  [oYzkopbXguiwfNTx] Perfect Protection
+  [Wukrctjz2e8W4bbS] Perfect Readiness
+  [QN55ToyJIjxgPmhs] Perfect Resistance
+  [zrIrpVOvbGS6a3ux] Perfect Shot
+  [Y4gYfrxjSir2Enui] Perfect Strike
+  [8oyO7lQ1KvNMEYSR] Perfect Truths
+  [RAaUb9MPSDv1CGmF] Perfect Weaponry
+  [gOWf0HzvCz43veDb] Perfected Evaluations
+  [1ZbLYY5m2YALrrgA] Perfection's Path
+  [giupBd3dyOwdeoFl] Performance Weapon Expert
+  [SOG0yVNtiDsaNbIO] Performative Weapons Training
+  [cZED3aBrjCgO0dPC] Pernicious Poison
+  [Mvay7CiSN8snJ7DK] Perpetual Breadth
+  [eHvJqBHYqx7UjpPg] Perpetual Scout
+  [LbMPCAyUrLRHykGA] Persistent Boost
+  [L9aBLPG2veBkVow9] Persistent Creation
+  [GKP2dHkgQw1o0k8g] Persistent Mutagen
+  [csPhQeHWbUXL64p9] Person of Interest
+  [hPanopG3TbXKr52O] Pesh Skin
+  [2cygD6uy4AxJ7XCj] Petal Step
+  [JddrdXv4pfdePsGK] Petrified Skin
+  [KnaKxKP3eCUcCZC7] Petrifying Gaze Mimicry
+  [BkEOwv3SRtefczpO] Phalanx Breaker
+  [4jaCuX2JSjTSJ3wp] Phalanx Formation
+  [nY8HtHNJMqP0hz3v] Phase Bullet
+  [axGS5bBJ9vl5AePc] Phase Out
+  [4YqmeJQwnrG1Lg07] Phenom's Verve
+  [l80R1OduACbaeKtR] Phoenix's Flight
+  [8Sdw31YToKhBJ4v4] Physical Training
+  [UOxDJt8Y7SiCR4xq] Pied Piping
+  [18eGaH5rWEXpDlgk] Pierce the Eye
+  [G8iGrx1qBDwLk1HO] Piercing Critical
+  [4bKTV1UHBP3qSjzr] Piercing Doom
+  [ZTxiM8NExDmxHJDf] Pin to the Spot
+  [AiV2xFhYB90KHt2x] Pinning Fire
+  [XtIPmZ3Ihq5NJHP2] Pinpoint Poisoner
+  [i86JRWsFRpfEJnZP] Pirate Combat Training
+  [l1eCHNahsBb7rUkT] Pirate Dedication
+  [RlKGaxQWWLa7xJSc] Pirouette
+  [PFMsj4LtdAIuGn4R] Pistol Phenom Dedication
+  [A2EBy2L4acrehiAA] Pistol Twirl
+  [yOyMlFGAgLfRas8m] Pistolero's Challenge
+  [0SbHdwYumvmzwWw3] Piston Punch
+  [RnxullWsNdbU7fuH] Pivot Strike
+  [vtohCw7HNaCmcWyf] Plague Rat
+  [xEeCaJsQeDtRAVk1] Plant Banner
+  [ahyQpMVDIqhvXkQ4] Plant Empathy
+  [eww9tuiXPnZFZ3DU] Plant Evidence
+  [I9rSWQyueWHQyNxe] Plant Shape
+  [exrMKEHRyfINLJhV] Plate in Treasure
+  [KrYvJ5n06yHCipCZ] Play to the Crowd
+  [wGaxWwJhIXbMJft1] Plentiful Snares
+  [N7CM5CmHuZ1cylV9] Plot the Future
+  [IfoxFY9kzP4KG9gi] Pluck from the Sky
+  [D8XoWk1brpyW6oO2] Plum Deluge
+  [I9m5XxKzazrqDKu6] Plummeting Roll
+  [Yl2wYv24v5kw95aS] Point Blank Stance
+  [eHkMcQQ4ejRAFJAt] Poison Coat
+  [0lieFKdwgNVXep7u] Poison Resistance
+  [ALbosSUygdq4T1Yk] Poison Weapon
+  [U3YVN5oOd4mf18ry] Poisoned Sticks and Stones
+  [y7DDs03GtDnmhxFp] Poisoner Dedication
+  [pKoW1X95LjmWn5Jq] Poisoner's Twist
+  [rRbMOxX1QTHIIwAi] Portentous Spell
+  [tz0gvfTwcDq0yEfg] Portents of the Haruspex
+  [TEH73yqZBqByO624] Positioning Assault
+  [wIAiDaNztd52ltT2] Positive Luminance
+  [N0YcU8mIJnQ4C2N6] Posse
+  [zKL1lRcIbFblp2M2] Potent Poisoner
+  [4BbfHsGPRHPHfIGY] Poultice Preparation
+  [2LvdYMXTIRkTQO42] Pounce Mimicry
+  [tCKme98RHrTZ8QdS] Pouncing Transformation
+  [Ziky4XVV7syXVbUg] Powder Punch Stance
+  [dtkOVLILY8Ywl90I] Powerful Lash
+  [oIE88rIDEFNm83Mr] Powerful Shove
+  [27R8yZcY2uXH6pZN] Powerful Snares
+  [Hzzf7bi8xBMi6DCL] Powerful Sneak
+  [vu0R9VfRZ6RWTczZ] Practiced Defender
+  [0Bu48kn3Deq9gHQE] Practiced Guidance
+  [64DgI5CHP7K9kbbg] Practiced Opposition
+  [63jLdP6v8FbohoXb] Practiced Reflexes
+  [6dJokwhIMvjAHL52] Practiced Reloads
+  [AtpMrGXaMPJtDIDR] Prayer Attack
+  [2qR4QAgJVArv63Z2] Prayer-Touched Weapon
+  [MlxfNv98LZKfYl64] Precious Ammunition
+  [vxDL78Yz0dPZdAJ5] Precious Munitions
+  [wvJBIzgS298ZRp6w] Precise Debilitations
+  [qeLpqH2cMSmIrILV] Precise Finisher
+  [E1Xl8YSvhAJMlDod] Precise Hooks
+  [aFUxNGur3Hma8DKy] Predator's Pounce
+  [ZhhITE2ZMX7UZUge] Predatory Claws
+  [cErltcAC7OVnIyO1] Predictable!
+  [QSuwyX84U26OLzZI] Predictive Purchase (Investigator)
+  [Yw0qVCDu94Y5TgxQ] Predictive Purchase (Rogue)
+  [KYl1rWFOHe0e6VqJ] Premonition of Avoidance
+  [2h8a6pKhXTXwpJjP] Premonition of Clarity
+  [zzMugLCUkQQPa2qT] Preparation
+  [Tf9RmqKU148OyQbz] Prescience
+  [WYMbOaEvuAS5zCjH] Prescient Parry
+  [AUMFmt5ogVhnTe1h] Preserve the Horde
+  [vqgklLExo3HAVAm9] Preserve the Moment
+  [EeSP1SNlgAuASvkP] Preternatural Parry
+  [Xw7qG0SHepXx24vl] Prevailing Position
+  [MSqgBffcAXTg700A] Preventative Treatment
+  [pBP8KL1yPU3W1Kmh] Primadonna
+  [AbjVJIBdNjbQbVnV] Primal Aegis
+  [niKCBA11zzgGT1PU] Primal Breadth
+  [K3TasgeZLJQ84qtZ] Primal Evolution
+  [RSUmrIiFBEchdM8B] Primal Focus
+  [TopHlb1G3ZRDIWe6] Primal Guardian
+  [Cp7UttoCxTyO1pDg] Primal Howl
+  [sif4YKLU414BBNis] Primal Proportions
+  [I00uuseTfPypVgLQ] Primal Summons
+  [nWxNV9pFeBHV671W] Pristine Weapon
+  [CbCXvxKrGIRtI7jF] Profane Bargain
+  [dTPVRVzfVBlBUV2l] Projectile Snatching
+  [9oLtfp28J5DQfiIS] Prolific Prophet Spellcasting
+  [3JebYAYEYPdOf4kS] Propelling Sorcery
+  [Y1hwTaDIIBKtSCZe] Prophesied Monarch Dedication
+  [OGCb4N1RL0w6JkR8] Prophet of Kalistrade Dedication
+  [EFowS1mD93OmBxqu] Prophet's Lockbox
+  [q8c0LINVNcJrdK91] Propulsive Leap
+  [u9n11htt3dtT6CfW] Propulsive Mutation
+  [ASWqQ6RB7cfCsUo0] Protect Ally
+  [3KVFBmWPVSItUuq3] Protect the Royal Line
+  [knJlRpltciLNTZba] Protective Bond
+  [7G1gMSHyMdMGMsF9] Protective Cycle
+  [A9WrbBCCdYsmdKGv] Protective Pose
+  [nn7DiYYWinsSYrZy] Protective Spirit Mask
+  [aymNcrPx6zMt5ILp] Protective Strike
+  [8zHsIubGREIrGfAA] Prototype Companion
+  [YHeKwgJq1zkdcV0p] Proud Nail
+  [VJ3wIsfmabK02SNg] Provocator Dedication
+  [ryBj7phZqASQSEjV] Psi Burst
+  [qZsTI97BQUwoPgKF] Psi Catastrophe
+  [HkbP5zbN2meRiP7w] Psi Development
+  [uisI6b7Ua5zSHDwj] Psi Strikes
+  [OW3W2vMARiojda7e] Psychic Dedication
+  [xKKyS9nEQqolJ0SF] Psychic Duelist Dedication
+  [9oKtrUzXixj58hOg] Psychic Rapport
+  [GkPbsX5RZWyI0qFj] Psychopomp Familiar
+  [D7g9z4MuIeS4iRwN] Public Execution
+  [3cE56QOhylFdM8UD] Punishing Shove
+  [J7elM52meuLI3ZRy] Pupil's Guard
+  [hKemfam7Hvkllsgp] Purge of Moments
+  [sPCLWu1JdTFqKZVH] Purify Element
+  [k42ntHdg70ZMEKrs] Purifying Breeze
+  [VzQtyHSjq12E4Dzh] Purifying Spell
+  [BtZJJClWCpc31Ven] Push Back the Dead!
+  [gdGusdEKt5zmh3rR] Pushing Attack
+  [GxkTe4VM7u26uZGI] Pushing Wind
+  [O0YJxlWgO1BPX7w5] Putrefaction
+  [mwPOOTtELS4X7reC] Pyre Ant Sting
+  [wIRZDXOacqWfI670] Qi Center
+  [yA9tsWT9uzL2REnw] Qi Spells
+  [FMjihpGLn9eQ14Gw] Quaking Stomp
+  [xbg1scOIT7RI9Fij] Quick Bomber
+  [v1PtAazmEFhTp6fZ] Quick Change
+  [qFt6zyWVX1njJf1l] Quick Draw
+  [RlhvppSmQRqL2RUe] Quick Fix
+  [otLs7XzMXR1cZKGe] Quick Juggler
+  [E3NsAdbp7kkOvfnr] Quick Positioning
+  [SnIx3FhBuuq6AZD0] Quick Reversal
+  [pRqcm5P2ZFihSpVI] Quick Shield Block
+  [xRTlbvvBzURgC6M2] Quick Shot
+  [KW6K5Zv4J7ClWkKA] Quick Snares
+  [i7hNUqiJsB8hgIET] Quick Stow (Swordmaster)
+  [aLJsBBZzlUK3G8MW] Quick Study
+  [VeejX9bGhI9di1eL] Quick Vengeance
+  [i8MnyasCDo3j65Xd] Quicken Heartbeat
+  [gqISxjbTtZSYndZ4] Quickened Attunement
+  [l0pcURfMUGwnJgeU] Quickening Banner
+  [h5ksUZlrVGBjq6p4] Radiant Armament
+  [sEWYOllJ6rYoXK4K] Raging Athlete
+  [XseJI9XhKNtZN8pv] Raging Intimidation
+  [3GmgFUL2xzt5vhCz] Raging Stories
+  [5pGMffGKkBTZKvjw] Raging Thrower
+  [rbiMK71SvGZGRLJ1] Rain of Embers Stance
+  [879dW5QkNDS66Ue3] Rain of Razors
+  [t3BPLh4rEInYGJJW] Rain of Rust
+  [nobsCgNmsDX6aKR5] Rain-Scribe Mobility
+  [jRJqKkm6NnHcL8HO] Rain-Scribe Sustenance
+  [MpydlJhlBYYXq50r] Raise Haft
+  [7ZPm0P6vY9FlVtoy] Raise Island
+  [BuVIM4cV7qhVZ2WF] Raise Menhir
+  [koER7gKf6CnW5O0s] Raise Symbol
+  [JoxEspM0kbCop7og] Raise a Tome
+  [sahJHnojXO9eEXVE] Rallying Anthem
+  [AQfNFH7jnjdwi4FQ] Rallying Banner
+  [xsyiCcJ2YKhn6tOF] Rallying Charge (Knight Vigilant)
+  [df4cBV3qZn3qNUmP] Rallying Charge (Marshal)
+  [oVSlTmdmho8ZQo2k] Ranged Combatant
+  [MyDluIbnX2sjm3pB] Ranged Disarm
+  [R00qiDE5pBctgtyU] Ranger Dedication
+  [JKvP4pFHzwWsHu2n] Ranger Resiliency
+  [Ea6Z5cxeBCCtPD5R] Ranger's Bramble
+  [4BbywSvO2ByHxdbZ] Rapid Assessment
+  [QA4IJbtW1NoYJY9M] Rapid Hybridization
+  [18UQefmhcNq6tFav] Rapid Manifestation
+  [F7azgjrHXmvNnpIg] Rapid Reattunement
+  [DZcy4sY07w0zPsDb] Rapid Recharge
+  [OcBaEnGdDm6CuSnr] Rapid Response
+  [yR413t9x7poTHOCH] Rapid Spark
+  [IIqNyX3Hwz5mmccL] Rapid Switch
+  [u2en8XQqxX9mQxkm] Rattle the Earth
+  [mHvkBdBN4gs6CH1g] Ravel of Thorns
+  [qpoE2KhsPbF1ZDsx] Ravenous Charge
+  [uyWVFB0mHDhajYeT] Razmiran Priest Dedication
+  [Qt8sVqczbolTMZZ2] Razor's Edge
+  [QMycbf2StuPcUbzO] Reach Beyond
+  [gNxV9fd0fh10CYj4] Reach for Immortality
+  [ssrublnppwFSvVcb] Reach for the Sky
+  [GWnQMjSAIG6qcV8J] Reach for the Stars
+  [cQ2jy4Utoxmk3MkG] Reactive Charm
+  [3EtlXNK4vc44R3Gm] Reactive Dismissal
+  [LDIZtE7saDLSBduG] Reactive Distraction
+  [xBqDeQFzvuDfqhZC] Reactive Interference
+  [VVsYBmVi2E1u9E5Z] Reactive Pursuit
+  [f58Vhv4R4J6a7ie9] Reactive Resilience
+  [w8Ycgeq2zfyshtoS] Reactive Shield
+  [NMWXHGWUcZGoLDKb] Reactive Strike
+  [OqU6QXkMrZqToEEi] Reactive Striker
+  [4Q9Q41KLPYJMdV4b] Reactive Transformation
+  [HLC9g1pwluDl6vy7] Read Disaster
+  [c6LOynN7MZEabcYh] Read the Dust
+  [Gu8IAYxwNdQM603P] Read the Land
+  [bBo2mOKrMXXjAY9f] Read the Wind
+  [6VWLyjurMGi33XAT] Reading the Signs
+  [DFA3qFdvSD5uHBKI] Realm Strider
+  [5Cm2TYHzoO2DbQNM] Reanimator Dedication
+  [xmccXo6U7P0IMM3z] Reaper of Repose
+  [6qIHbbT76zIVmeEt] Rearing Display
+  [pm9PS32YNLJ2wp4o] Reason Rapidly
+  [0IVnIC6gQUdQyM8b] Rebel's Map
+  [RhQshUC35MeiNg3h] Rebellious Existence
+  [mNiJvsbyxdLBnTRs] Rebirth in Living Stone
+  [lIr2kC561L7oX290] Rebounding Assault
+  [Q0gFkEoJDmbRaaiU] Rebounding Smite
+  [5SBFayX7JqKYANwa] Rebounding Toss
+  [ttWl0hOh9cdk7Zko] Receive Prayers
+  [LQVpSsUvzBQzpm4Q] Recharging Transference
+  [LLrGafdJij7qiWZi] Reclaim Spell
+  [qmORiUubF2CVgIva] Reclaimant Plea
+  [PZb9yNbDzqd0QiVk] Recoiling Relocation
+  [Bp02C07s4RTS4vsV] Reconstruct the Scene
+  [9Qn5E7Ujye9KdxOj] Recover Spell
+  [WmSggxmf4iAe2aRD] Recycled Cogwheels
+  [UuPZ7drPBnSmI8Eo] Red Mantis Assassin Dedication
+  [aMNN3InBhiTjU6C0] Red Mantis School Spell
+  [zpeIbe0nQG52YU7a] Red-Gold Mortality
+  [AmV13b9ncALtWJFt] Redirect Elements
+  [G3NBWaItq6oLEJxx] Redirecting Draft
+  [HKNOA5WGBWGEpdmH] Redirecting Shot
+  [Qy25HbkFgoUn4Vb3] Reflect Harm
+  [k72W0qMXsX5ekJTF] Reflect Spell
+  [Yec6UwJf5FLvAbZ4] Reflecting Riposte
+  [knZUN4sYExIyRC4F] Reflective Ripple Stance
+  [irDFSzKCaF4ux3bx] Reflexive Catch
+  [nEmaHLsZEBru1Jjv] Reflexive Courage
+  [eAcMHQgfsOePtYgp] Reflexive Devotion
+  [74MnTnoqSveet8Sy] Reflexive Grapple
+  [jaekke9HomT4PZ9b] Reflexive Grip
+  [uotQ9yqetPoAWrfW] Reflexive Riposte
+  [dHUoQVzDa9Cf4QCG] Reflexive Shield
+  [LI9VtCaL5ZRk0Wo8] Reflexive Stance
+  [l1I6bmdm31MPwmWU] Regional Specialty
+  [0M7kfn0ifdwWioOQ] Regurgitate Mutagen
+  [z74e0oQxRSiviC91] Reincarnated Companion
+  [DxcjEcxTbjlOA2C0] Reinforce Eidolon
+  [LFS9M737RCt0Jq8r] Rejoice in Solstice Storm
+  [xZrTjUub7V09sXZF] Rejuvenating Touch
+  [AtidbY3lU49taaUR] Rejuvenation
+  [sqAwZeoNUFPj3Dxw] Release Me!
+  [YePPw9Oc4JlDAmYD] Release Spores
+  [9E1FLGp4CNBEwiZE] Relentless Disarm
+  [e9NcDk6ds5YebGvb] Relentless Stalker
+  [HKGO65wfxlBnobHN] Reliable Magic
+  [cT18roxM5P5MWDRT] Reliable Squire
+  [Gw8tjM91F6i3fOnR] Relinquish Control
+  [0idzh4dww7B7cbnW] Reloading Trick
+  [FwWbCQ34i2EN5or1] Remake the World
+  [H5uZqYVClk3s62ce] Remediate
+  [JMIdEsQ0vVKP29bW] Remember Their Names
+  [YhclkX1nfyUU8RtO] Remember Your Training
+  [dHJw5Yv0gY3suBZo] Reminder of the Greater Fear
+  [sk5HspGGnLW8b6bX] Remote Trigger
+  [c1QTcMtI9957gQoB] Remove Presence
+  [Q35r2ssLpGUBRksE] Rend Armor
+  [9gEVyUjYrDLUWieq] Rend Mimicry
+  [3hhCDWPm021hvicR] Renewed Vigor
+  [frRJAuuAgDg3RFii] Renewing Cycle
+  [5RbVfudZQrlHjIVh] Repeat Lesson
+  [HvPvyeXM2iMK4OYf] Repeating Hand Crossbow Training
+  [A1RcZ9mhYBZKzMUU] Repel Assault
+  [NQtIhIowH1tVywZI] Replenishing Consumption
+  [aMef2VM4mSxl0pmy] Replenishment of War
+  [vw93yCHEmxutFO8h] Repositioning Block
+  [a1TSGGsA6b5gjP3H] Reprepare Spell
+  [oENdQsSog4pPugVA] Reprisal of the Fallen
+  [IeAbL6fkRsd1hL6r] Repulse the Wicked
+  [UJcQgQpZRqXBw0Nb] Repurposed Parts
+  [wscmghwNCXvZtKsz] Rescuer's Press
+  [2VZxwS5LTi9YxikG] Reset the Past
+  [0Bm4WMi9u0EOHbkp] Resilient Mind
+  [N02sHmzuF9XQj93m] Resilient Shell
+  [tCuMXQ0yMrCNwzqW] Resilient Touch
+  [Qss6GKzSYGqKgY4b] Resolute
+  [gQKPKSS5KyK3uUfs] Resolute Defender
+  [9kY9B5WgtEleOicn] Resounding Blow
+  [dTO1ShJovbzrKUY4] Resounding Bravery
+  [mB7ENhF10qoOwQyG] Resounding Cascade
+  [lhSqWHXK1JShUabF] Resounding Finale
+  [0PcVi7eav6PMLOPl] Restorative Channel
+  [xUlRLkWnfZ7reej6] Restorative Strike
+  [nqEqvZviKYuGVxLV] Restore Omen
+  [Dr6h8WRW6xnLRfxr] Resurrectionist
+  [lleedxE6fTDSK6og] Resuscitate
+  [S3hN7qK7aiCDTrpM] Retain Absorbed Spell
+  [0EjaNZM7qeARiuEU] Retaliating Rescue
+  [y7SYHv0DWkkwjT95] Retaliatory Cleansing
+  [mFyKBHdX818sDnzO] Retch Rust
+  [HxMkvkxd8QMXcQ67] Retreating Finisher
+  [lT6yLoMfalzxGL8y] Retributive Focus
+  [OINfbwNZGnlyMqPR] Return Fire
+  [oyIswzxeih08b4rA] Return to the Pit!
+  [FgtUV7SKeq0nTivu] Return to the Sea
+  [JHcvySfCM9uYNb9N] Revealing Stab
+  [47Vapyhg9icGV6ce] Revelation's Focus
+  [ecV3Nljvs4FOBS27] Reverberate
+  [SNgOGKUHAxgFJgxW] Reverberating Spell
+  [WyGeBz9U6Hovozdl] Reverse Curse
+  [Na1qfHd6AFAXoN1A] Reverse Engineer
+  [9LwOCcutlLxd4bfS] Reversing Charge
+  [83zzG4XBiL5I3NZv] Revitalizing Finisher
+  [2rJP5TqvfazNeNmY] Revivifying Mutagen
+  [VIjI8PtkTFjeAA6a] Ricochet Feint
+  [62USpCx1ewK03wzm] Ricochet Legend
+  [qkHVva51N6H8NNGR] Ricochet Master
+  [c7mCj6wUdb47rrnw] Ricochet Shot
+  [tRHjUCl0xqG97nok] Ricochet Stance (Fighter)
+  [RsNvCSrCN7czHC0G] Ricochet Stance (Rogue)
+  [iyZC5hdOpfQhQQhn] Riddle The Sphinx
+  [P4xwr0xnh1uvK9qs] Ride the Tsunami
+  [87OyWx4AktAysKXc] Right Where You Want Them
+  [NMRBes7gGfGldOrn] Ring Their Bell
+  [OliKxFIqzky2o6vk] Ringmaster's Introduction
+  [EDZ1MwbNM9EcdTsh] Rip and Tear
+  [9MiK0Lyro5dQgHij] Rippling Spin
+  [LlA78rVpi6F85CWG] Rise, My Creature!
+  [QRqs9NIWeh0ONRSP] Rising Blood Magic
+  [0B8nLDB8gOAxvpkK] Rising Hurricane
+  [BmAk6o14CutgnIOG] Risky Reload
+  [j01dM0ZAC7KzShx0] Rites of Convocation
+  [vxHNj5PuYIdR5fEa] Rites of Liberation
+  [wa9ZGBTlFuwOjPpH] Rites of Transfiguration
+  [DUuCOQ9FiZf7vS5b] Ritual Researcher
+  [kU4K9jj9qnktoAaQ] Ritualist Dedication
+  [PVx3D9ndoytRAPca] Rivethun Adept
+  [ESSdufyTeO6h4H5W] Rivethun Devotion
+  [H8w717IWBRyg8ugO] Rivethun Emissary Dedication
+  [U3W2T3kOWPdMt3Rv] Rivethun Invoker Dedication
+  [uiX2xS6vTBRBjxdA] Rivethun Involutionist Dedication
+  [ts2A1XeuPRzaCZgA] Roadkill
+  [vwOU1t8Fd5dDEYia] Roar Mimicry
+  [F6TIEmYYJGmVhMXl] Roaring Heart
+  [iBSxOOkPYU01rJiV] Rock Rampart
+  [U9SrWgLJ8JoAKIy0] Rockslide Spell
+  [vVrh7RrvAztGwKRv] Rocky Flesh
+  [ZELjVKOohGw3ECwB] Rod of Rule
+  [bCWieNDC1CD35tin] Rogue Dedication
+  [gC3IeHyuVsX2Vtg8] Roiling Mudslide
+  [7Q7HWETkvOM9pYwV] Roll the Bones of Fate
+  [8FxKcuFtOrqsl1FH] Roll with it (Kingmaker)
+  [oQVp2UhXVBcELma5] Root to Life
+  [eceQmgvmoPplFKId] Rope Mastery
+  [ZJSkCrud1FZ7PMFk] Rotten Slurry
+  [O0POcPD2aELYTcIK] Rough Terrain Stance
+  [P0v56G9Hkt87cAKj] Rouse the Forest's Fury
+  [wUHnauB3atxO1RIo] Rubbery Skin
+  [9Slu8lSOYnDtKsIb] Ruby Resurrection
+  [OtM4pvPeIeEEdpuS] Rule of Three
+  [mz2x4HFrWT8usbEL] Runelord Dedication
+  [luKAFJAvdbAgEwV7] Runescarred Dedication
+  [ZlL18xGsa76isqkX] Runic Impression
+  [2uQbQgz1AbjzcFSp] Runic Mind Smithing
+  [NfNCSLCNmLZZyGqU] Running Kick
+  [meQJfsKVar9tm6c9] Running Reload
+  [A981119DMdqE9Pg1] Running Tackle
+  [vHKNJZPBxj66nJzZ] Rupture Stomp
+  [pQmkNJi8BVPTa2XN] Rushing Boar
+  [BQWGOK0lVmljCunm] Rushing Goat Stance
+  [7HZaOlJ43QxkDrmO] Ruthless Orator
+  [vDeG0N4kzTBDTC2b] Sabotage
+  [wbS8f7R7KqHkwOzM] Sacral Lord
+  [psr9lxsnj9aOiqlK] Sacral Monarch
+  [MOAThpfl92zO5p08] Sacred Armaments
+  [JaBDNtNYYDfTGYad] Sacred Defender
+  [cnTPUQS7zRiZMUdI] Sacred Ground
+  [bJbWM6zcOeDvCOiZ] Sacred Spells
+  [5Ar7r5HA9k73whaB] Sacred Weapon
+  [ZXkVo5iTTT8Uc8jv] Sacred Wilds Oath
+  [bYijGvCvCmJnW6aA] Sacrifice Armor
+  [ZBPRABDXeLVwxFC7] Safe Elements
+  [vKzAIJuyr9SU2JzU] Safe House
+  [tBg3FZST3nX5TfLf] Safeguard Soul
+  [6KiB0SLYB1p8Th5U] Safeguard Spell
+  [Hzq8FOtaYWpur2BL] Safety Measures
+  [ZTI12qEjht0pQuaB] Sanctified Relic
+  [qV9sAyHN90uYu4OO] Sanctified Soul
+  [xtXWw3cUnVB25XSV] Sanctify Armament
+  [40mZVDnIP5qBNhTH] Sand Snatcher
+  [HASFgAZ7spYleeaq] Sanguimancer Dedication
+  [pHBHQaqI77pYtaCU] Sanguivolent Roots
+  [TiNlehXIDEnIl95M] Sap Life
+  [UPTQ9oIpz0bTJf3M] Sapping Symbol
+  [v88bFLoJEF3YfJKb] Savage Critical
+  [F3ZBkDEWZ24NOR2j] Saving Slash
+  [fT37dtsByEIc3glC] Scales of the Dragon
+  [hYu6XxARNJYdf8Qe] Scalpel's Point
+  [tBWSxVxrojRcEzJt] Scapegoat Parallel Self
+  [RivbJYEBUyfLwPh7] Scarecrow
+  [95VqyEvnxcee8XBS] Scarred Hide
+  [j8ycCi7ghTtpRjEW] Scars of Steel
+  [L9sRaFl0tHT5AFIQ] Scatter Blast
+  [uWGpR5hfYS9znnxr] Scatter Swarm
+  [cDNxHLIgvyD7yBfM] Scattered Fire
+  [ylDAxUpT0rXxilro] Scattering Charge
+  [FvhVk79sEnSDTDtq] Scattering Shout
+  [qbNo5NLm1eXHkOMI] Scattering in Spring
+  [49TMxb8OA1Pp7AiF] Scholar's Hunch
+  [rFlBoYGI5OmfMvaO] Scholarly Defense
+  [ZB2WMbhALgQTGY3c] School Spell Redirection
+  [DSmYJvCHMvZCP0aD] Scintillating Spell
+  [R56DLSqoBG8dX4Zv] Scion of Domora Dedication
+  [XqtJVBwnxBsSo9Py] Scorching Column
+  [c1R8qAUsJmhVsq4B] Scoundrel's Surprise
+  [KNhmeUpZCSW5eHqg] Scour the Library
+  [VqVgcqmG6xmYuDbK] Scouring Rage
+  [v9HgQBsBiVmU5wAA] Scouring Spark
+  [qMa2fIP2nqrFzHrq] Scout Dedication
+  [6CE1nVGxt192AUGk] Scout's Charge
+  [jvQoupE76OeUpjZp] Scout's Pounce
+  [elbj75qsUerbM725] Scout's Speed
+  [Tpcq3Lk7qEOZ3LDP] Scout's Warning
+  [f01ieQOcJFY7Ta7m] Scrap Barricade
+  [u5DBg0LrBUKP0JsJ] Scroll Adept
+  [OqObuRB8oVSAEKFR] Scroll Esoterica
+  [sf73K6f8xlfhHS1n] Scroll Thaumaturgy
+  [uxHWqFbYD0ZvkeF8] Scroll Trickster Dedication
+  [uhfZtjbfJ8pZIWrF] Scrollmaster Dedication
+  [CaeCSWFWytWv8Fgu] Scrounger Dedication
+  [CAHJGt535l3Ai4cR] Sea Glass Guardians
+  [JCnTkz7Ad11rZKrL] Seal of the Golden Dragon
+  [obGGzuPcgO5Xiz6P] Searing Restoration
+  [f8gIyes8j3A5GEzy] Seat of Power
+  [VZczZNj3ozCj1Lzk] Second Blessing
+  [mE1MF5CvZUS1b0lq] Second Ikon
+  [g8ZMeg1YFg9WZj3I] Second Shield
+  [GBFHOgMDZlNas6DF] Second Sight
+  [COe0bYyVCyC78rzP] Second Sting
+  [XafnXTx9Bn0kN1RG] Second Thoughts
+  [4bvoePh1p3ZGgqhP] Second Wind
+  [cFQKqLf6InMDzADv] Secondary Detonation Array
+  [hZueHQeYR5bgDh5W] Secret Eater
+  [FA1s2jjZqoBy58Xx] Secrets of Shadow
+  [76MJ4dyEFim6dfoa] Secrets of Steel
+  [YAr465ZVQ4blqDzT] Security
+  [vVqOBzWTpWirPbrK] Seeker of Truths
+  [Vzbu8tclrsS2IBYU] Seize
+  [eKwy0E05FiV9Ymzf] Seize Advantage
+  [yyt2I2lGbRndXjbc] Selective Energy
+  [7aHYM9fawA3PQwtM] Self Destruct
+  [zytTsipimVTmPc5U] Selfless Parry
+  [p4OllLWJ2rV4sjxe] Semblance of Life
+  [b91gmCBK63u52VSj] Seneschal Spell
+  [HIu1miRRGvGvHevN] Seneschal Witch Dedication
+  [iyXw5PnevT2jT8kU] Sense Alignment
+  [3XFKXB3ffeIkrQYe] Sense Chaos
+  [UfgocXl8mpbgyotE] Sense Holiness
+  [bbpFExz1RXCkOhnb] Sense Ki
+  [s0xOawuTRJ5A3cpL] Sense Unholiness
+  [h85DAkAPGjRFwIuf] Sense the Strike
+  [DM9rjXZrmx2MFX7k] Sense the Unseen
+  [bj5QmGyrt7OYORjo] Senses of the Bear
+  [8foxmfC6FFT3oYpV] Sentinel Dedication
+  [RtqMWOyfNoruyoxK] Sentinel's Orbit
+  [wnrlBkwVr8BSVAZt] Sepulchral Sublimation
+  [f0fpsr8ZSNrWlfAt] Set-Up Strike
+  [3JDumHt2R62HFQFI] Seven-Colored Cosmic Bridge
+  [UgZDirfFb4CFhuWh] Seven-Part Link
+  [IevdA9OVFZE6FOVK] Sever Magic
+  [1sD5Gu8jQL09Yz2j] Sever Space
+  [f1acyuIGYVp2BpKc] Shadow Hunter
+  [C4m59yjuDmZLnTqu] Shadow Illusion
+  [tha0L3Z6608JrUwN] Shadow Magic
+  [BqcAwmNjDlKEI84X] Shadow Master
+  [F7Ao9p17ocf3JVvy] Shadow Power
+  [RLWbx2itF1jmW0OL] Shadow Reservoir
+  [N16lctDPZpvk9Khq] Shadow Sneak Attack
+  [eGgSGU1LOaRNRYR7] Shadow Spell
+  [f69C05QokaBrDFjn] Shadow Spells
+  [oDM3vxR2uI5DssuO] Shadow of Death
+  [AfTMuAln2f0Pa3Lj] Shadow's Web
+  [ncrNQcwm4gOQRAA3] Shadowcaster Dedication
+  [1AgirzUGkyDdmENy] Shadowdancer Dedication
+  [nBsd828H7AnVRV6r] Shadows Within Shadows
+  [auv1lss6LxM0q3gz] Shake it Off
+  [4AezsqaQRFtX024w] Shall not Falter, Shall not Rout
+  [X71qmyGpKN1XAoT6] Shamble
+  [PScCKDb9YujudTpa] Shambling March
+  [1fVKWWYjlVtOECku] Shape of the Cloud Dragon
+  [eR0sifECG27CC4do] Shape of the Dragon
+  [9u0uW1vZThRayXk2] Shaped Contaminant
+  [ECH7BEQQEq3pCQaS] Shard Strike
+  [adr9buwVuxgZV2B3] Share Burden
+  [jdrdkxqautAtszCX] Share Eidolon Magic
+  [vayNZR1bTzU1oUa3] Share Rage
+  [HCjPsXAYBqDhQSVW] Share Tincture
+  [a2VAaXMzlQqALJeH] Share Weakness
+  [oUcB71V1jVaM8SFx] Shared Assault
+  [pfF5UzT1MLW3KwHd] Shared Attunement
+  [wIJC00ODLq9WYc1m] Shared Avoidance
+  [ybrx1nsg5J0L8d3j] Shared Clarity
+  [ZXLbIgL3NNplgnuB] Shared Dream
+  [InGqBOX0xNk0XYHR] Shared Mind, Shared Heart
+  [U0XX0Mm2MbZcuNK2] Shared Overdrive
+  [Aqhsx5duEpBgaPB0] Shared Prey
+  [mTkbgFOHJUBl0Qwg] Shared Replenishment
+  [vFa9crHKkNkPUjFl] Shared Sight
+  [N4wCUZH2KG6FoGqh] Shared Stratagem
+  [8NQaqtHheeMUNGYr] Shared Synergy
+  [vpHn5uCd55OwGgOW] Shared Tide
+  [eSoMkHGw38ld4gj2] Shared Warding
+  [zbxqYhmn7KbqR2Sb] Shatter Defenses
+  [UA3iZTAZrugKClKE] Shatter Space
+  [Dthd23nBhnKZaMlP] Shattered Sacrament
+  [RL7faGkymMFLAqTU] Shattering Blows
+  [7r79fZBr37qBN2EF] Shattering Shot
+  [0PiyHEuxpB5zPctX] Shattering Spellstrike
+  [E4xubBMtj81kX5Bk] Shattering Strike (Monk)
+  [B7VMXObJSNVI0ZGJ] Shattering Strike (Weapon Improviser)
+  [QOnyOjncnw4tkTQp] Shattershields
+  [RzElsoBGTjKWjPgY] Sheltering Cave
+  [HP1DKj4FLwtStzYq] Sheltering Pulse
+  [RSwrDo9i0RKoAI6D] Shepherd of Desolation
+  [P9swngiLXbhMegQ8] Shield Paragon
+  [4bB3N36DmqllGJNx] Shield Salvation
+  [V6RsK1B39FTgmYMv] Shield Spell Reinforcement
+  [QpRzvfWdj6YH9TyE] Shield Wall
+  [Xik9lMAA4e5xFegM] Shield Wallop
+  [5vXc2s2siR1ihpBT] Shield Warden
+  [ixB3oIqCxKwW0VzG] Shield Warfare
+  [3SiZ4hrNi8aWjP8J] Shield Your Eyes
+  [wzJnJI6d2PaoTZIZ] Shield from Arrows
+  [ueQoFDPHUe3dqmS1] Shield from Spells
+  [w3qyriA1YnzXaas3] Shield of Faith
+  [7IDFHh2ZJLaB1y59] Shield of Grace
+  [VsTmB32x9673ONJ0] Shield of Reckoning
+  [6piAFd27zoIXvM9Q] Shield of Stone
+  [VYwWqm5LZOU7irhY] Shield the Faithful
+  [IQGx2nSNsyPGtzYt] Shielded Attrition
+  [xhqteilfGucKMGkU] Shielded Recovery
+  [tHqlcgcxHXzqLHPZ] Shielded Stride
+  [gv7PJVrnODu3qYB0] Shielded Tome
+  [CXC2aNz4ir4VFtn2] Shielding Formation
+  [qD5At83TIxznCwPg] Shielding Taunt
+  [3SGS0chf3SKosG5H] Shieldmarshal Dedication
+  [tAEGNtdlsTNoGnBW] Shift Horde
+  [q2t5qfgQHFJbbV8d] Shift Spell
+  [SA8rnheHFtjkATrJ] Shifting Terrain
+  [iAziUKdxgy4k4ypY] Shining Arms
+  [tKC06HYkt1XaWk78] Shining Glory
+  [OZmR9ZSAZyPoJuDj] Shining Runes
+  [rqUJULinzDCUgimM] Shooter's Camouflage
+  [6cQSPqXoAO6oJl0i] Shooting Stars Stance
+  [kS4wxSKrZxcOvSNK] Shore Step
+  [IeRX0tGbeOF0ev08] Shorthanded
+  [Oa41bfBRO36lf1aE] Shoulder Catastrophe
+  [HtLFPJeL0QTDLEfq] Shoulder Check
+  [z5fUX9jeqfAViOd8] Shove Down
+  [7p2tNqYHsg6u05cU] Shoving Sweep
+  [DMjfZvWD20SGuIO4] Show-Off
+  [UZpBsHE57rmS0x6S] Showstopper
+  [RonS3ZJs4poFTckH] Shrink Down
+  [KnKptBcTwN9yr4GT] Shroud of Ghosts
+  [Aww98EQXcigRhY3v] Sickening Bite
+  [j5Xjr8vZuBhCixIr] Side by Side (Druid)
+  [5YcnoTYKvEtkWiHh] Side by Side (Ranger)
+  [vp6Di3mj2zq1xsBg] Siege Celerity
+  [L4PK2he79ikr4ToV] Siege Ritualist
+  [UjYHf7rlWTFJ0v0A] Signature Spell Expansion
+  [C6BIHPqYiWM0wlvv] Signature Spell Expansion (Psychic)
+  [AiDelwfA0uVT2lN3] Signature Synergy
+  [wDo5dsSmyJqfmPgj] Signifer Armor Expertise
+  [TyjW9VGtlH0Zkm0I] Signifer's Sight
+  [BZU4aLXnlASKisr3] Silence the Profane
+  [Yk3QGpalWDn5MhBV] Silencing Strike
+  [AYByEEgPXk3QbCiF] Silent Sting
+  [bI0PWJ4c3AOcFDWN] Silk Bracelet
+  [mZcI1NKtQhteAQLn] Silver's Refrain
+  [DpmdmRNMg6LZpNB0] Simple Crystal Magic
+  [Yx3cHHhAXYDsemQE] Simultaneous Strike
+  [xblAUCASehLA9fbc] Sin Counterspell
+  [zAJY8rLvZjzOK0Mt] Sin Reservoir
+  [2oZYzQnrmKCpMH0V] Sinbladed Spell
+  [cV2CZxD6HB7HFeFv] Sing to the Steel
+  [I1xq9TDYRHNtqzGz] Sink and Swim
+  [obqFjbH0fciMH5F9] Sinking Jaws
+  [RfOnsZrmT6z2ajBN] Siphon Life
+  [XKAlLI17siAXFFyD] Siphon Magic
+  [L0f3c0DkT7FLQF9W] Siphon Power
+  [Yj0IKXM49Ver5Smc] Siphoning Touch
+  [hT0pVPqFuiEsmRb8] Six Pillars Stance
+  [cTeRwExCGhfwJbkl] Sixth Pillar Dedication
+  [sFAqKrzqXQhtrfqN] Sixth Pillar Mastery
+  [dMKx0T629hpJCN8T] Sixth Sense
+  [v4O6eDiSOkzQZHmT] Skill Mastery (Investigator)
+  [c9rhGmKft1BVT4JO] Skill Mastery (Rogue)
+  [xXHoyccK5ZG2AJKg] Skilled Partner
+  [HIyuVIh2XSDz3h2j] Skim Scroll
+  [SS8JSDB2P0SFX1KH] Sky Master Mask
+  [UjEeHamC2C8JfgJz] Sky and Heaven Stance
+  [gepQGtV8Ftr0JJ6O] Skyseeker
+  [39CqlOzlHjEhh0E4] Slam Down
+  [tDd3I3H4ISJ3Izrw] Slay
+  [5O6G488xu1p8ZHsS] Slayer's Blessing
+  [qo6oKL8mE32hSjSC] Slayer's Presence
+  [jr2LYiMvjnTNhfMM] Slayer's Strike
+  [Bm8votckjbge54bl] Sleek Reposition
+  [E1WXnYE2QwhHQxQb] Sleeper Hold
+  [JStTmD3W8R41WvPg] Sleepwalker Dedication
+  [cTQMtd2IVlvgJwAn] Slice and Swipe
+  [JxSxCTJOOayIdO4B] Slinger's Readiness
+  [rMjlDss3Km1RQ8DE] Slinger's Reflexes
+  [zdiSJlNFG7NhKHke] Slingshot Maneuver
+  [v2AScyQidSsrfm6z] Slowing Strike
+  [GjcAvxbJ6PgD2Lsi] Slurp Up
+  [C9QVzHuUznMfFQ7C] Sly Disarm
+  [AbgHCPWOKULeXrJ2] Sly Striker
+  [7ATVpDUM6pRq6HOR] Smash from the Air
+  [naghcKF1jr4dS067] Smile at Failure
+  [xgvKXeTxns0gIdAn] Smite
+  [ODnXQHvFoK7tIVpu] Smoke Bomb
+  [WDid62NmmC6NiTE6] Smoke Curtain
+  [sCkzwTBLyE8FdzWI] Smoldering Explosion
+  [2DrvFmrHzHLWS8UD] Smooth Hover
+  [mWCiu9Hl1WxajSLa] Snagging Strike
+  [GEonUnKYVyWoHh1O] Snakebird's Shadow
+  [YKPaD42aJf2C5V3B] Snap Falling Fruit
+  [zbnL5OP4zVaNFcq8] Snap Out of It! (Marshal)
+  [0UdHPOv3DX8TY9yb] Snap Shot
+  [BTE7BTAwnw2O5fz3] Snare Expert
+  [lIrPwGpJk9TldZ4c] Snare Hopping
+  [0haS0qXR9xTYKoTG] Snare Specialist
+  [4MUbwilvb9dI0X59] Snarecrafter Dedication
+  [2Nu4ZdKQM8hx8x5D] Sneak Adept
+  [bCAvo59b5RyW12iI] Sneak Attacker
+  [Wn3DWAXo2TRxrhI6] Sniper's Aim
+  [6PP57Aa5HmSr0qIZ] Sniping Duo Dedication
+  [p6j4nLPRwksjfwPW] Snow Step
+  [81pD03pQup9sPzXv] Snowcaster
+  [ds9dNclMMiDBKRtm] Snowdrift Spell
+  [2wLfchKVDSKBOIpV] Soaring Armor
+  [fyJ2slL98hnQH3On] Soaring Dynamo
+  [wNHUryoRzlfDCFAd] Soaring Shape
+  [rNPeOwFZE5Ma18JJ] Social Purview
+  [ugDZeILVpgLVhvGC] Solar Detonation
+  [WZWSaAwuDgne7Z0c] Solid Lead
+  [WoUwDqhA6i6abwen] Song of Grace and Speed
+  [0zSoSPwC4cpqRewj] Song of Marching
+  [FkN9QX1W2Iv56bkn] Song of Strength
+  [4E4121lbfWgxui4y] Song of the Fallen
+  [NfZKocqIKG2Iychg] Songbird's Call
+  [SC5oZbyvLO5CQwhl] Sonic Dash
+  [D1uVM4fif8Y0FYu1] Sonic Strafe
+  [LmdOWCDffhBiyzM3] Soothing Ballad
+  [PlD0eY5fo50Wluva] Soothing Pulse
+  [BAsKBwlbJAQ6sLhN] Soothing Vials
+  [5UQagWB13Z8xR5Z6] Sorcerer Dedication
+  [Tlqqim5TmijoPRRT] Soul Arsenal
+  [GzsPazilxYUPISm1] Soul Bleed
+  [gZrlze9HlRYEQNBG] Soul Flare
+  [moJh856BHCXtPCJm] Soul Oubliette
+  [drcZf55HVsTnnTcF] Soul Vessel Mount
+  [yWawboNWFoJMVl0g] Soul Warden Dedication
+  [B8MKXr7mMzOHhTQH] Soul Well
+  [SoocjFrWNOpchTVb] Soulforger Dedication
+  [DYc108IqRBP9N9W6] Soulsight (Bard)
+  [YGBPIpHaOgCsa2qO] Soulsight (Sorcerer)
+  [dCCVqIcYrhCp3Bzl] Sound Mirror
+  [Q9PR9achVS7aUDDt] Sour Bomb
+  [YXuhZHEUXXi9Dhqx] Sovereign's Blade
+  [TyWFsX9DliAdAVs8] Sow Spell
+  [5kua1Kf5Ca85lbzb] Space-Time Shift
+  [R4GhrpXtcRIo6Cxx] Spark of Immortality
+  [Ogso0WqodeFG27L1] Speak for the Gravelands
+  [bTNgHDqzfoqOLWu3] Speaking Sky
+  [kcWdo5zzldDTqCBP] Spear Dancer
+  [wixpmBQ5dNm3VMFk] Spear of Doom
+  [AizxNcCJIEuXDj4a] Special Sentinel Technique
+  [bki36RiEM5FR4aiT] Specialized Beastmaster Companion
+  [hdt3RHZljLrO49kq] Specialized Companion (Animal Trainer)
+  [3r5rg0BCqSh5RBNS] Specialized Companion (Druid)
+  [Fai5VMyrtOrYC5JL] Specialized Companion (Ranger)
+  [9DECwTTiVpHJc4B6] Specialized Megafauna Companion
+  [wijzB1FDUT7SC86a] Specialized Mount
+  [lffwKBOaUgWUC9KJ] Specialized Spirit Companion
+  [pCx2vSnIYIdnSKnr] Spectral Advance
+  [ZbK0WZRDjm1sfOKD] Spectral Dagger
+  [udGP9jMEOyipkA7n] Spell Acceleration
+  [dJ1ZviNMpt4ID7lc] Spell Combination
+  [XRCqj74dG27MHNxQ] Spell Gem
+  [xhiwito5kneP4sjV] Spell Mastery
+  [kRti2i47YqG4zVp7] Spell Network
+  [X9AkydrMdFwg7qIn] Spell Parry
+  [3CPKbiweBRzXAJA9] Spell Protection Array
+  [zwEaXGKqnlBTllfE] Spell Relay
+  [FItD6HmjasjbLdgS] Spell Runes
+  [DT1O80hPD7MX6oWp] Spell Shroud
+  [p1JxtebE9egaeTrC] Spell Swallow
+  [Fs88vjez9px2mmrC] Spell Swipe
+  [1re3J4hWW7raXIRB] Spell Tinker
+  [CbqaiI0TKsyDywDr] Spell Trickster Dedication
+  [cgtVYaZRVaTIW4sk] Spell-Repelling Form
+  [XfGJSMH4CifHXMtw] Spell-Woven Shot
+  [FCzfh8QHMo7QJpAM] Spellbook Prodigy
+  [XhblStN7dwnWKmrO] Spelldrinker
+  [vuApM8xHOZs4o6oS] Spellmaster Dedication
+  [dWkf6LhYBfBkeyOA] Spellmaster's Resilience
+  [lPoP5TFfq266kR6g] Spellmaster's Tenacity
+  [YdGHQjhUrNvP18AA] Spellmaster's Ward
+  [l0Qy74a7CILdE4Th] Spellshape Channel
+  [kKZ4gnT7okaWS6tB] Spellshape Mastery
+  [8T4MRIKN6t5FBeyN] Spellshield
+  [BwDIwjHasZwcd61Z] Spellshot Dedication
+  [16QBDinolgG2M66d] Spellstriker
+  [9p28s0zg4Vv4r5i2] Spike Skin
+  [gxzTEt37M0z1WY1M] Spinebreaker
+  [iMeXYpghydBEt2Q6] Spinning Release
+  [al952tuRDJJY0ENx] Spinning Stand
+  [ef57tIj30IaPnSgC] Spiral Sworn
+  [RJjQ3Jh5ErQgOfGJ] Spirit Companion
+  [8VvRnIQI2x9bmlmQ] Spirit Familiar (Animist)
+  [FCivW0HZhm7PoxrC] Spirit Familiar (Witch)
+  [WKRSBu7H9miAwUaR] Spirit Guide Form
+  [2AeGnjk4EAqFDvK8] Spirit Sheath
+  [Daap4ugeDZQWoPCx] Spirit Spells
+  [CmGe2c5fecj837P9] Spirit Walk
+  [lxfVXvlOK8id3MqA] Spirit Warrior Dedication
+  [dwILRnGUQArJvfa4] Spirit of Vigil
+  [GTKzA1rfUtQwxvgz] Spirit of the Beast
+  [ho5qkbgW4XxvkXuC] Spirit of the Blade
+  [03mVGvudDLyGEpTZ] Spirit's Absolution
+  [sIN6t7nCWdI5u1HK] Spirit's Anguish
+  [ONUvHtEccDmNEcVu] Spirit's Sacrifice
+  [gO729iC9b5ypes2K] Spirit's Wrath
+  [hjApw8AvYVuqQk2W] Spirits' Interference
+  [I6su6Z9sJTgIrhQV] Spiritual Aid
+  [7sJ7DzulbMjGWABJ] Spiritual Awakening
+  [ZH4gpcvVTAD157fn] Spiritual Expansion Spell
+  [pfBVx5xBfwKd1iVL] Spiritual Explorer
+  [CMDCWPC8m2b6HvEN] Spiritual Flurry
+  [cEu8BUS41dlPyPGW] Spiritual Guides
+  [F7zgzUn7ZLNSXhy4] Spiritual Secret
+  [HB0jvWCdim1p91q1] Spiritual Sense
+  [bTfz7ZkPQcGpJ8FZ] Spiritual Spellshape Stance
+  [9DWxzEavOeymc6Ql] Spiritual Strike
+  [AvN95M5eVLLEu2qk] Splendid Companion
+  [dGFQvkDRmyvvf4IQ] Splinter Faith
+  [KpF7RenGBXIMMGPX] Split Hex
+  [DS0XlHfi3ztb3ET7] Split Shot
+  [WAx7RABHDvVVcRI8] Split Slot
+  [F4LlHjLjubbBkWRT] Sportlebore Choke
+  [jsXDbQAAH3yMchPU] Spot Translate
+  [vOM48z8wO5Mfp9IK] Spraying Mutation
+  [emjWa77ltL5FytvA] Spring from the Shadows
+  [PEw6PEGHSfbMI9Is] Springboard
+  [WxnCYjr02usmMN1q] Sprout Fruit
+  [2xxFg9yRuCDpME3z] Spy's Countermeasures
+  [v6wYNnkoVDquzRpw] Spyglass Modification
+  [UIMZe4QDJQ9k4npN] Stab and Blast
+  [LoeoiYOpxSaEkWKv] Staff Acrobat Dedication
+  [dPmJ91qawZW2U8K3] Staff Sweep
+  [1wTXeBrYU6BVEEOn] Stage Fighting
+  [zJsu5JQGGOpyT6Xk] Stages of Fate
+  [waZzVgfyr1Vcxfqk] Staggering Blow
+  [fngPLUD4Sltho2kn] Staggering Fire
+  [tFUo2tsdreWBxMfs] Stalking Feline Mask
+  [GcpMP7vMAuewyWUJ] Stalwart Chant
+  [6pDM5AjDpoXFwzXH] Stalwart Defender Dedication
+  [lvxzgLNzmScMY0uC] Stalwart Mind
+  [UPgxAYArllEBcuGS] Stalwart Song
+  [OCvgmAFz4qgj2Scf] Stalwart Standard
+  [cQziPqmbo353bq7S] Stand Back, I'm A Doctor!
+  [OJLGFnmbT418dC18] Stand Firm
+  [Mj1KTiAwwovm7K9f] Stand Still
+  [qTxgIym89ehgW684] Stand for the Fallen
+  [esBKFd3Opiw8H9I9] Standard-Bearer's Sacrifice
+  [Zn2uUL5i3MAZ0Zwc] Standby Spell
+  [5KXJkEs39y1gaPEm] Stargazer's Eyes
+  [jK0hjx4qsRyKnpBd] Starlight Armor
+  [bLj5ufeOdVWDx8Aw] Starlit Eyes
+  [Tqarg0W2YEUfgEsn] Starlit Sentinel Dedication
+  [SVfD887ocfUFikVA] Starlit Spells
+  [qg8TlLJRgvjzW9YK] Startling Appearance (Vigilante)
+  [BmKfNH7eN7E1yQXh] Stasian Charge
+  [A0keRhzNlcB1u4gD] Stasian Smash
+  [P092yzkGN4UYYVXB] Statement Strut
+  [n4755xLnUbsKYfUM] Statue
+  [rmO7FP410nvCjFBB] Stave off Catastrophe
+  [2KBKXkRthBXpw48X] Stay Down!
+  [CmE9DKaqA4p9uYfQ] Steadfast Grip
+  [uiGsVmvRfujQQRlK] Steady Spellcasting
+  [FoJd0oiEQ9mF5KS9] Steady Spellcasting (Magus)
+  [QEOe9AhQzdqIx1ei] Steadying Stone
+  [Kb28vpCQNvA6wS1O] Steal Death
+  [0VUx8g8GJzuxvLSa] Steal Essence
+  [jsEMNIxcnfGIx7sX] Steal Magic
+  [xjwlP306nuda2z03] Steal Spell
+  [UCFGUbmDnzRGmN9I] Steal Time
+  [XoxawV3Fmn61VJcS] Steal Vitality
+  [DFtbxytrOrmkQRfm] Steal the Sky
+  [MwozkE6aj42WZ7Z1] Stealthy Companion
+  [7PjBANpMMoBxTYq3] Steam Knight
+  [eCzIiTjI4mQFYe9D] Steed Form
+  [cW88fH1HBM5AlV4M] Steed's Toppling Strike
+  [4Y7wKFogGB0LZ5ZA] Steel Yourself!
+  [0WKTvyN5nkNRed6e] Steel on Steel
+  [IEbnal1VJySrhxFR] Stella's Stab and Snag
+  [CB6UwS2g9ramyOEV] Stepping Stones
+  [fdSbB0EQVxFgLoEd] Sterling Dynamo Dedication
+  [zXKfKKOxht0b0XNL] Sticky Bomb
+  [b7isszc8C75V3okn] Sticky Poison
+  [lMIh84yjIA7f7xG8] Stir Allies
+  [TO7YGGr38shgxV6l] Stitched Familiar
+  [GuEdTz1VMEptQnOd] Stoked Flame Stance
+  [eSq9I2OPDfzhybkr] Stomp Ground
+  [CoVBrlyMToANvt2v] Stone Blood
+  [FzUe8oKad59VRDjQ] Stone Blood (Stonebound)
+  [xgg9eNF6MsJPMjyH] Stone Body
+  [sjVDquil4S6pIror] Stone Brawler Dedication
+  [llawV63qzdynbOkx] Stone Communion
+  [AGEr2Zby6Nc5g0bR] Stone Guardian
+  [Ce9z0Bc6wHkR5lDh] Stonebane
+  [jp7nDEmyRUtR5KFG] Stonebound Dedication
+  [1dfr22286eUdl0D4] Stonebound Magic
+  [CSa7v4MtbiA3FI0c] Stoney Deflection
+  [81jhTqJ4xLJvcZcr] Stoney Skin
+  [tQvWDkatsuYsNkds] Storied Companion
+  [HD3qC1lDSc4jHzii] Stories of Home
+  [UpEjRfQkCJCruAfb] Storm Born
+  [F1DVDJRARfdb1Kjz] Storm Retribution
+  [nAVLB5MLYWUu8N71] Storm Shroud
+  [hv0SwlsAtcnR7R4T] Storm Spiral
+  [fyN2LDuaFXzZTboA] Storm of Claws
+  [EBmZyzDWhFSLydlM] Storming Breath
+  [dj0aOPPcDOqmptpX] Storyteller's Mask
+  [pFKfYsxBWdUlmU6A] Strafing Breath
+  [u8YnTCS2EGoJl90W] Strain Mind
+  [WPHq7MWHlGWpTnme] Strange Script
+  [lMA3F9SGzGV79P5C] Strangle
+  [IvgLDtXmZwzbVJj1] Strategic Assessment
+  [NgUB5toKxBd8RJmm] Strategic Bypass
+  [3geVePXUZELDVQZG] Strategic Repose
+  [fJwsZM6WXwP8EStV] Strategist Stance
+  [D6bncWAOvFYX7hCE] Strident Command
+  [O3vj6p7K49gKKVWM] Strike Rivers, Seize Winds
+  [Gz9NQBjSDRQP8YTY] Striker's Scroll
+  [OiY0L3WvjwlQQ4iG] Strong Arm
+  [eHjqNXgylSuvA887] Student of Perfection Dedication
+  [WHplmUTHN8L6q1b2] Student of Water
+  [gHHnMCBi1gvG5wTL] Student of the Dueling Arts
+  [3R9l2t1ycN8iwmdU] Student of the Staff
+  [QGpcyvIezLMgmTia] Studious Capacity
+  [kYA6LkDw4AzKI156] Stumbling Feint
+  [gHkRvvdjNv6nfh9Y] Stumbling Finisher
+  [7FRYyKXDKjGoANYj] Stumbling Stance
+  [EwCDbWg8yPxDWF4a] Stunning Appearance
+  [8bMmGBO6gsMfWZk3] Stunning Blows
+  [jkBzlMB4TS1sS2Fm] Stunning Finisher
+  [lM9WNBFmOyoCJblW] Stunning Surprise
+  [pfVTsZ2asd6cnVed] Stunt Performer Stance
+  [S2YTLXTvqaXhThG6] Stymie the Gods
+  [KYmr5eXZinLPevhm] Subjugation
+  [ZXaDS4OJvsQYvhBZ] Submission Hold
+  [ZdL8pPPV0QCkBML1] Subtle Shank
+  [qQt3CMrhLkUV1wCv] Sudden Charge
+  [BkKWTt3ufaCN2ZdI] Sudden Leap
+  [CX4ISbBwndRWhP55] Summon Ensemble
+  [31Z6tFfSKWMe3OdR] Summon Mythic Power
+  [SwzPqEsLzZpNufvm] Summoner Dedication
+  [mSDKKRgK6sRMjqQo] Summoner's Call
+  [TNpoEG0cUEAuSju7] Sun Blade
+  [vqLt1qjdrflTmdsw] Sun's Fury
+  [QgfrfzQAtzgwAgtQ] Sunbird Glare
+  [RpXWOgLWQLGdx74I] Sunder Enchantment
+  [8INrcMUv5vzWMG3X] Sunder Spell
+  [9h4EmcrN4xrRydeG] Sunwrecker
+  [EoKgJXfNfHwsy2sk] Superimpose Time Duplicates
+  [GsrwoQ7DIjERXuPf] Superior Bond
+  [NIaNTFlPwi2ng1rZ] Superior Propulsion
+  [Uof5QNeGklGnks1h] Superior Sight
+  [so4v9xjBFaoJ8EQs] Supernatural Senses
+  [9yko78REsaw7i2gr] Suplex
+  [6quBFw5r7iWzln2b] Supreme Invigorating Elixir
+  [Rqj1kmrnF9M1E6pv] Supreme Psychic Center
+  [zy7lx4SWkfDxqH6m] Supreme Spellstrike
+  [qzXaFoY4411FMN57] Sure-Footed
+  [flTkVUibGyxkJWHV] Surface Tension
+  [zzjfENthtRBAjqjQ] Surgical Shock
+  [LLhVVhDPv9Z8Kd1k] Surging Blood Magic
+  [MRxQDZFNPpUKC0CL] Surging Focus
+  [YtvnnUwh4IHPz0MW] Surging Interference
+  [YV4X9u5Yuf0xvoCh] Surging Might
+  [io6eJGrw701WbmYe] Surprise Attack
+  [wqrOVv9gnqF4nlLR] Surprise Snare
+  [04RgXKFVC2A6Ryn6] Surprise Strike
+  [fHWYICk6cSePr30c] Surreptitious Spellcaster
+  [PlRAfeNof3xgJttZ] Surrounding Flames
+  [n7LTwKUSATLaQ9FD] Survivor of Desolation
+  [Sc9clbAXe97vlzxM] Suspect of Opportunity
+  [lTwi4lyVk1UXomhK] Sustaining Steel
+  [NHheDmNB7L4REmlr] Swaggering Initiative
+  [xNejAvuRXKYq2D6A] Swap Investment
+  [ossGwqEvC6ifPwgT] Swap Reflections
+  [a3YLHiWsfAFeFVYO] Swarmkeeper Dedication
+  [eAlrvPVb8qt8Lruw] Swashbuckler Dedication
+  [lZ0swL9EEUgbAuaZ] Swashbuckler's Riposte
+  [RU86cGTryRAdaEqx] Swashbuckler's Speed
+  [dY8LGT6KDcGy93GY] Sweeping Fan Block
+  [0iMPIwHTprDS148r] Sweeping Fan Redirection
+  [RBvmQJ661GpT5lkt] Sweeping Tail
+  [t3unBu3PX6AO0uIW] Swift Banishment
+  [TqODgJL1VS3eokhX] Swift Elusion
+  [tOtrtDR7ftHhPFm4] Swift Guardian
+  [Rh3KSd7BUfV12GBT] Swift Intervention
+  [VP2CWUTZ9Edg82uz] Swift Leap
+  [lzK0lwhjj5AW7iFH] Swift Paragon
+  [ZoVC0Ni7QdiWvoIx] Swift Retribution
+  [IxggfXunfldeVOsQ] Swift River
+  [c5ns35FLvvxjimuH] Swift Tracker
+  [ZvCG3exhs9ZhhKPV] Swim Through Earth
+  [JbrVcOf82oFXk3mY] Swipe
+  [efDtyZhdNjxt50PD] Swipe Souvenir
+  [RG6PAQuPho2MWdmZ] Switcheroo
+  [dWbISC0di0r4oPCi] Sword and Pistol
+  [Mocz2YVO5cuPVUXC] Sword of Sealing
+  [8M7iQfVBRuucR6hJ] Sword-Light Wave
+  [i8lCqWJDng4c3Cgp] Swordlord Exile
+  [SHpVHkPxtQggD9Cf] Swordmaster Dedication
+  [PwgiNjYvCM68ZyqS] Sympathetic Portrayal
+  [VOgAiCqC5kpIpLaf] Sympathetic Strike
+  [d00Ip4YHVmk2tecD] Sympathetic Vulnerabilities
+  [sfxLo9kz2WkCQiy4] Symphony of the Muse
+  [VJl2xHDKr0HxTUrs] Symphony of the Unfettered Heart
+  [yVC5pVZaWczYWGTa] Syncretism
+  [WAWaew53zpTFVwQM] Synergistic Spell
+  [AWd7uZBfba5mNXeT] Syu Tak-nwa's Deadly Hair
+  [3xD4LtEgpGZU0MNx] Syu Tak-nwa's Hexed Locks
+  [2pglnWX8q5p3XcqR] Syu Tak-nwa's Skillful Tresses
+  [4dQcLroKQ13QYIT3] Tactical Cadence
+  [Xdmz09kzLjIxWz9C] Tactical Debilitations
+  [MhoGCLKI5zxQ4SFD] Tactical Entry
+  [a7sCZ2ehfsLQutvO] Tactical Excellence
+  [7CbjQCIEiGRp9Q2n] Tactical Expansion
+  [2E5EPxdtbD0E2LJy] Tactical Guidance
+  [rzaoi5Roef9zO22G] Tactical Reflexes
+  [E13vR5nYbeo95nRC] Tactile Magic Feedback
+  [4bxAxvC2YYuM4Mwy] Tail Guard
+  [yPWNbTqOIKdkwaVq] Takedown Expert
+  [N43qnnWMy2H6lsrm] Tales of the Road
+  [1t5479E6bdvFs4E7] Talisman Dabbler Dedication
+  [ygCLN0brunmBYtJR] Talisman Esoterica
+  [uPikeCzrTrgzEJT8] Talismanic Sage
+  [j305O6rhKvx4sT38] Talmandor's Shout
+  [gVx6ZbeNBhxdGECB] Talon Sweep
+  [SheifYobjKqyK3Fv] Tamper
+  [PMFmVchpuOyqiWPp] Tandem Auras
+  [qmx8QwVepqI9FqiD] Tandem Movement
+  [zz7hFuycrynz3tgG] Tandem Onslaught
+  [exVjUkpAdbzJsxxg] Tandem Strike
+  [GLbl3qoWCvvjJr4S] Tangle of Battle
+  [ewbt80Yin18k6oLq] Tangled Forest Rake
+  [2tUdsoPEnW9yS8so] Tangled Forest Stance
+  [ckukkEJj4Lc3ENjr] Tap Vitality
+  [nA1yG3NJFK6pFE0a] Tap into Blood
+  [2FJwXMTJycSZY80Q] Target of Opportunity
+  [wwvz79Hwp9qx96lL] Target of Psychic Ire
+  [xqyN4Nk5mLgUm09l] Targeted Redirection
+  [DLkMoVb8qb4qxnx3] Targeting Finisher
+  [HVwmYfSLhrnCksHV] Targeting Shot
+  [drAXPlcNyrIdPm1L] Targeting Strike
+  [oKjyD46NmkKx1OvO] Tattooed Historian Dedication
+  [Um5owecqPW17dtl2] Taunting Strike
+  [rEbCScbo8DS6bRiC] Tear Tendons
+  [9XXtDeRF2egCCzcx] Tectonic Stomp
+  [mvw7TJcuwAipUqB7] Telepathic Union
+  [QufAglrest3fr1iz] Telling Blow
+  [DrZqTPcqSsmw55kb] Tempest Cloud's Speed
+  [FJdcQU6yjDVDBC4r] Tempest-Sun Redirection
+  [sTUicpQkhiFVtMK1] Tempest-Sun Shielding
+  [QShUUnBQO1X0ODJL] Tempo Duelist
+  [uMnXk55zlwx26zeW] Tempo Shift
+  [eXPJTsu80nOYgzI3] Temporal Fury
+  [UlCbjWWVEmfvaf5a] Tenacious Blood Magic
+  [LT5rw7JfemZSXUKB] Tenacious Endurance
+  [FdP21jbjHHGpHut1] Tenacious Toxins
+  [K5pXeeJLmdE8XuvM] Tense Negotiator
+  [AmKUbCrBUImXNP0Z] Terraforming Trickery
+  [phFRWFgeHdBzio2V] Terrain Form
+  [VKNxblSUxYXQYlLr] Terrain Master
+  [KOf6kmwAZaUJSDW9] Terrain Scout
+  [TNRB8IY6Wtk9BoMp] Terrain Shield
+  [Ec9Q8cvOKFgeezx6] Terrible Transformation
+  [Rbp08BSSzwpkWVjh] Terrifying Countenance
+  [HjinlKihkadhkQ4Z] Terrifying Howl
+  [Egx5NWOVhoaij7a3] Terrifying Mien
+  [rAUNZfiulXh4zcm6] Terrifying Transformation
+  [pIHjH1x0AVtiX5Tv] That's Odd
+  [gQAQRHxpFKEkNQFs] Thaumaturge Dedication
+  [rHV8GUqqt8WLgTJp] Thaumaturge's Demesne
+  [nx7UPAwAyno2rM9f] Thaumaturge's Investiture
+  [yMj9WfPctWQC7be2] Thaumaturgic Ritualist
+  [azF1RvMTwCPaJr1F] The Bigger They Are
+  [z3tH63RsLkVze82H] The Bitter Scholar's Promotion
+  [6WsUotDsr7TUVDkE] The Dead Tell Tales
+  [Fd0DriV32X3S9B2z] The Dead Walk
+  [k4QU2edqSoB23foo] The Harder They Fall
+  [qnMdgukNGmLWtSbZ] The Harder They Fall (Kingmaker)
+  [FXxVmdv9BRwkbgdU] The Immortal Attains the Summit
+  [Aa0DqivAEL0ngunw] The Shattered Mountain Weeps
+  [PYRx4lCIQXyW8tz8] The Thousand Lashes of the Weeping Willow
+  [KobkrExhlNeFaNR5] The Truth As I See It
+  [H63SJLkenhLDkVnN] The Tyrant Falls!
+  [VS28L98uFhr3j1HC] Their Master's Call
+  [XJCsa3UbQtsKcqve] Thermal Nimbus
+  [6PCNYExygF5890Fl] Thick Hide Mask
+  [LKHfdSmIg8ZNWDyc] Thlipit Contestant Dedication
+  [5gj6tZyQLfA1iQwn] Thorn in Hell's Side
+  [WjEwsu4kkexNvDcN] Thorough Research
+  [pqVG9mRKcXg5Rsjc] Thoughtform Summoning
+  [NLyldMwxUWaanlzH] Thoughtsense
+  [kYccIlNIDYFlJdSf] Thousand Visions
+  [rMPL11JRcmlutvRi] Thrash
+  [FFHNGhVapUycx3f5] Three Clear Breaths
+  [Qg5M34t95rtT0sOp] Three Pecks of Dew
+  [R40U8hF0hWyRUze8] Through Spell
+  [6tDIVv2gafdO6GV4] Through the Gate
+  [qrATFcnSEmEcD6bJ] Through the Needle's Eye
+  [nbwHIS38AgSDquNu] Throw and Catch
+  [37CUdnWwJCfOCC2H] Thunder Clap
+  [vYfRgneZnHYBzUy5] Thunderclap Spell
+  [2xwzmZVwi97hKtov] Thundering Surge
+  [rkViV16nuFbm6hPj] Thunderous Landing
+  [ibaxh77mm8ttObdk] Thwart Evil
+  [rVyEIKeBfX6EQSLs] Tidal Hands
+  [6J2ZSGNsXPKPcJGV] Tiger Slash
+  [VCjAlOvjNvFJOsG5] Tiger Stance
+  [Pay7XmMLgLtzxklN] Tight Follower
+  [6Hv4kpHj8IexNUey] Tiller's Aid
+  [Wo0HNBh6CCgPN3Co] Tiller's Drive
+  [aHlcMMNQ85VLK7QT] Timber Sentinel
+  [xM0vwRFLZgmmI4YJ] Time Dilation Cascade
+  [bTQVvkEuPj9QAiAi] Time Mage Dedication
+  [5cxkVY3mBsbYWd5K] Timeless Body
+  [TpWS2b9ISHnXVfZg] Timeless Nature
+  [cSI344GrI2K2XMae] Timelessness
+  [Ky7ZEtt4TchQNmFc] Timeline-Splitting Spell
+  [yrlwMnjLgKaWtq74] Timewracked Dedication
+  [XHOhAHv2HLdJQz2q] Tireless Guide's Mask
+  [QN7y2CQeiJ2iPioM] Titan Swing
+  [nI67dTzKYg5kKMsd] Titan's Stature
+  [cU5NdcwnMkFQNPjh] To Battle!
+  [vb8DsfARkJGWd0GT] To Me!
+  [kJ3d0aFkddkbsJ0k] To Thine Own Self
+  [1fH3M3XaUWWOJZFM] To War!
+  [HLCeP87w7qEy8PUH] To the Ends of the Earth
+  [ct4dJHBn1Dj4cx4B] Tongue of Sun and Moon
+  [MXCIjS0cnmy3CLvP] Too Much to Swallow
+  [mRHkGMLecd5aaj2R] Tools of the Trade
+  [7x1r2w7C7A4Uy7wG] Topple Foe
+  [RHEdvEFz3QKiRKlr] Topple Giants
+  [F8V4dN91JmHIOQCv] Topple The Titans
+  [s0P4JXagA3085wLW] Toppling Tentacles
+  [2hwNGs7WQnO6yv0Q] Toppling Transformation
+  [ijsMs8iv9AsHQWrv] Torrent in the Blood
+  [wxIOuPFjVBADNYDP] Torrential Backlash
+  [w1GFspPIQ9f5MbFL] Touch Focus
+  [5oifNocjSTR9PdRy] Touch of Lunacy
+  [RNBr91uB7lX9DldN] Tough Cookie
+  [aZ5JdFKA7L8NYl4o] Tower Shield Mastery
+  [ixIKF2LMmbFthI8Z] Towering Size
+  [4001krxk4fI1cTmV] Towering Transformation
+  [dtt6xTOSF8PuoStg] Tracing Sigil
+  [qq7QHfysWzBn4z36] Tragic Lament
+  [7GGxxoYNA4YrtML9] Trample (Summoner)
+  [1DIuPtx7FEm7F7WE] Trample Mimicry
+  [t6sey3cyV8n7a78l] Trampling Charge
+  [KANcYBVhzcpSat9s] Trance of Celerity
+  [WglDQlEtHnZ2eFhW] Transcendent Deflection
+  [PaUpesy5lyDLlwud] Transcribe Moment
+  [q4wFELOV4BQO4cDd] Transfusion
+  [n7a7ltuY9C4qcAiT] Transmute Weapon
+  [NPhH9XkHV0DG4WS9] Transpose
+  [oA866uVEFu1OrAX0] Trap Finder
+  [uT9RnHLgIIcm7Hhs] Trapsmith Dedication
+  [KqpXb13Scv7uzole] Tree of Duality
+  [r5vSplcFXtTS0kOB] Tremor
+  [B912Vru18B6orzcs] Trespass Teleportation
+  [lUuEX5HVxylRvFAF] Trial by Skyfire
+  [62glnJI2o0KnHULB] Triangle Shot
+  [xtRcWpprFBiXeCOB] Triangulate
+  [0HgfWQMIo2UEAlAm] Tributary Circulation
+  [1hyC4aiLMBSwM9Z1] Trick Driver Dedication
+  [ySr510TkpUO3N6Ty] Trick Shot
+  [POrE3ZgBRdBL9MsW] Trickster's Ace
+  [VT94b8incDrn91ga] Tricksterbane Oath
+  [A7uJCDT9odsuwlqW] Triggerbrand Blitz
+  [SD3RlgQMVL6aWjtW] Triggerbrand Salvo
+  [4mDk8SQyx9dRxy9y] Tripartite Omen
+  [hkdP5tsTAoqJDR8v] Triple Shot
+  [EHorYedQ8r05qAtk] Triple Threat
+  [B0T6p3kcrOfSvLqQ] Triple Time
+  [RHLfM9NlIlHTH85w] Triumphant Inspiration
+  [1Yo3FD5HKJpGbQFD] True Channel Spell
+  [2HMvAB6mIVwvwtjT] True Debilitating Bomb
+  [Xk9inG3pln4UKbs3] True Hypercognition
+  [mGzPR7M9H733j2wN] True Shapeshifter
+  [kwz8el0Z8kK0D5az] True Transmogrification
+  [YKqMuuC8j35NFh92] Tumble Behind (Rogue)
+  [fU7d5P6WrfAirgip] Tumble Behind (Swashbuckler)
+  [iSnstY2UywUdoBRZ] Tumbling Lumber
+  [Yazy4gex46FLwsph] Tumbling Opportunist
+  [jfsmtOx4QgXB19BL] Tumbling Strike
+  [laq0lLCTkszpivxm] Tunnel
+  [zxlbMEaXglMVsLpQ] Tunnel Wall
+  [0Qr7Y1IOxny0vIQf] Tunneling Claws
+  [17jjQPpnBkHRkzPE] Turn Away Misfortune
+  [3aG0gkHulBIHqqGE] Turn Back the Clock
+  [7jMAkP86uwnZCxYx] Turn the Wheel of Seasons
+  [bqBCatllklPceA34] Turn to Mist
+  [0icxuITlxUBfeomX] Turpin Rowe Lumberjack Dedication
+  [0ptK0blZehF3ABha] Tut-Tut
+  [uBr7wHtOS6KIhHnd] Twilight Speaker Dedication
+  [eXuCYDzj0UJOxNu9] Twin Distraction
+  [hYW6MsPk1UcFROFD] Twin Eidolon
+  [9XALeVNcmlIxf3tJ] Twin Feint
+  [Y8LHfkzGyOhPlUou] Twin Parry
+  [PTAdxHcTS7TjyBTg] Twin Psyche
+  [GJIAecRq1bD2r8O0] Twin Riposte
+  [aWk0JaqVaUf2Cz9a] Twin Shot Knockdown
+  [pJaJUmTrQkXW2s9G] Twin Stars
+  [Gw0wGXikhAhiGoud] Twin Takedown
+  [85xm82Z005CUNBMB] Twin Weakness
+  [xjLbabfyQzBNT4y1] Twinned Defense (Fighter)
+  [kTRGAST9J9ZxJZ4A] Twinned Defense (Swashbuckler)
+  [uT4zSkhziUQOZOD6] Twirling Strike
+  [WGGLlrhV8cKFn1v0] Twirling Throw
+  [5Jc2ySGLVi053qpz] Twist the Knife
+  [VN6Cws7BBta81AQ9] Twisting Petal Stance
+  [5mx0lL5O0WCsGsNr] Two-Element Infusion
+  [1SvBUzVH5tp0lmn5] Two-Weapon Flurry
+  [VW0Tp5rJDRjaJuSn] Two-Weapon Fusillade
+  [ny0nfGTDUE4p8TtO] Ubiquitous Gadgets
+  [85boZA8KRMu4rihN] Ubiquitous Overdrive
+  [bX2WI5k0afqPpCfm] Ubiquitous Snares
+  [LCrBGoMGat2ZXuOo] Ubiquitous Weakness
+  [w9HxCfZLsFcwXJRS] Ulfen Guard Dedication
+  [sayRIHE2V6vuxr4r] Ultimate Flexibility
+  [Rb16bcCiovwRqVgN] Ultimate Mercy
+  [QSBuAkJ5GMLcuZg9] Ultimate Polymath
+  [2sCzFjq8sKvBR3Jh] Ultimate Skirmisher
+  [4f65nrWVzTG8Njj8] Unbalancing Blow
+  [VXA50vhIRCBt4vvP] Unbalancing Finisher
+  [pmz1itHp13JtcrjW] Unbalancing Sweep
+  [nZK5oGakaSZcSOs1] Unbelievable Escape
+  [Bgnr0hw52Efr8Ew8] Unbelievable Interception
+  [QQCxSQaX8UEZHfUz] Unbelievable Luck
+  [V5Yz9cKe2Fj9LQbs] Unbelievably Believable
+  [Jv24QkykqdPB7brL] Unbreakable Bond
+  [bNUNyR3FDkgEb0gJ] Unbreaking Castle
+  [9Ht1eyBHsB1swpeE] Uncanny Bombs
+  [4Cc0gQauzUqcYdLw] Uncanny Dodge
+  [MD33E76f2olLnDZb] Uncanny Suction
+  [NzE3QK3P6U1t142f] Uncanny Vitae
+  [M6cWLywN0aWnX5Gl] Undead Master Dedication
+  [pPA2YF6Dal0PClWA] Undead Slayer Dedication
+  [49eBpqKw5Qod3XRY] Undead Spotter
+  [qJzQUD3rCcWiuofd] Underbrush Trailblazer
+  [eoDDjIGAA67Z7rQt] Underhanded Assault
+  [pgIrr8xrlCXbRAeo] Underworld Investigator
+  [1qvN6vznehBjV6ml] Undying Beast
+  [xSYkYRKlSyLzPrH1] Undying Conviction
+  [J06CgMzMDGOahXjf] Uneasy Rest
+  [q0DGOuLuJNLzgM8d] Unending Emptiness
+  [RR0p9E6GWt0CRA1q] Unending Subsistence
+  [JSkaMCO6pzKYZrZe] Unerring Shot
+  [lotpVdFhxNsNP0Ru] Unexpected Sharpshooter Dedication
+  [ZyQYP7i26DWhMNux] Unfazed Assessment
+  [2bCbfQ0KCSSYpg2q] Unfetter Eidolon
+  [M2fjNnh8yRAnGFyH] Unified Stance
+  [epfQ2PwNDLwyY31t] Unimpeded Step
+  [yYLVGhedXD7lFQMn] United Assault
+  [2s8sjTIDzMXXp1og] United Front
+  [AqVyKiIjISDBFRA0] Unkillable
+  [PycaQsgfgOQc86UX] Unleash the Blight
+  [79pGj9RC1bAt82UD] Unlimited Demesne
+  [LhqWrgeBH2sdRxND] Unlimited Ghost Flight
+  [lQpY6E5Zvc1kRnyC] Unlimited Potential
+  [JZurhROfi2JfmLfb] Unnerving Expansion
+  [V7bwuYADV8huWeF7] Unnerving Prowess
+  [ytvFkR07JlL7CZ9w] Unobstructed Shot
+  [qwp56E1xrgoi9Q2Z] Unrivaled Analysis
+  [kUb7FtYlJPNy4tYv] Unrivaled Retort
+  [39RJF47FLYr5gZ8p] Unseat
+  [2leK1eGVcIBTmx6J] Unseen Passage
+  [3ka9o7vaEXoPWKFS] Unseen Shot
+  [eGZzifQWCf5gSq2y] Unshakable Grit
+  [VqzXfdbQQ2e8Hndr] Unshakable Idealism
+  [d4B8uKyffvnkzUOw] Unshaken in Iron
+  [RtT7r61Yytpe2RlF] Unsheathing the Sword-Light
+  [tY3Zg0l14CdoKPpt] Unstable Concoction
+  [ePQXFTRQORKWP9KH] Unstable Gearshift
+  [k4u6s0S8N7fBY2fi] Unstable Patronage
+  [5zeKULjKDkiIenhu] Unstable Redundancies
+  [1rbB6bYDqjR4gVTH] Unsteadying Strike
+  [6xLDfQYA1pHzGRG2] Unstoppable Force
+  [YCqHaqn0TxdiGxiW] Unstoppable Juggernaut
+  [VaIHQzOE5ibmbtqU] Untamed Form
+  [tonJdHGheKZ16tMI] Unusual Composition
+  [xYNMWGEmpbtrtWXQ] Unwind Death
+  [kMB1fIU6SVbHUgXn] Unyielding Force
+  [eUXgY8W3fShlW7pd] Uplifting Overture
+  [ZaEK0IGhxqd1yH6Q] Uplifting Winds
+  [zZZmRwvtwQazhU0b] Upset Balance
+  [TCLDccG80M5GeqGw] Urgent Upwelling
+  [zV4vzcl7eoVewz5p] Ursine Avenger Form
+  [c3c7pVXq0Ys5a6Mr] Usurp the Lunar Reins
+  [2nSk6oOLBXCEbAhc] Vacate Vision
+  [I5hzE0XT2BsjatS3] Vampire Dedication
+  [qXWcmyHLkMlzRffC] Vantage Shot
+  [4KkzwOu2OKYLKSXQ] Variable Core
+  [km8ZBNKIlvnJexgc] Vaulting Gallop
+  [fL5lO5Odp7iJPkan] Vehicle Mechanic Dedication
+  [vD1TCRWtubijBGEP] Veil of Bugs
+  [EPqhCeCo1uOvJSTZ] Vellumis Excision
+  [Fs9ZMHZNCBo7B5Zc] Vengeful Oath
+  [6m2oJVzwufgjJi9W] Vengeful Remnant
+  [z8NUh2FayDa7Ctnp] Vengeful Spirit Deck
+  [0kkiE74cyHyxdPe6] Vengeful Strike
+  [KgyJw7fmcUWymYyb] Venipuncture
+  [SInV0npOgmsTBJVt] Venomous Touch
+  [PdQ3wVgMqvBlC2at] Venomous Weapons
+  [bdo2ubH7XAs7eG9m] Venture-Gossip Dedication
+  [qIppU9rZRmgEA5pX] Verbose Distraction
+  [orjVLLoziFTmf1mz] Verdant Metamorphosis
+  [Lbpm0OrQb4u2LVtj] Verdant Presence
+  [qPFWEyihvbWsCcUv] Verdant Weapon
+  [u2LGS5SNvnLiXpgx] Verduran Ambush
+  [i2H0iiGYRr0fhzgz] Verduran Shadow Dedication
+  [gcDnshdIZVfp9bbz] Vermillion Threads
+  [cppQZwnuoXqX8mgF] Vernai Training
+  [DSN8HoWGaf42eyxY] Versatile Blasts
+  [yZ7EcM9CLddZz8Hl] Versatile Font
+  [oZLRpBqlzFxvf33I] Versatile Mutation
+  [jBp91q4uzwd4FeSX] Versatile Performance
+  [toFhkS9QbObxg6cp] Versatile Signature
+  [6A1WTVY1PUlXy3rW] Versatile Spellstrike
+  [JezNf3xbCi8h2qKe] Vessel's Form
+  [EhKeGvsxotMarUt0] Veteran Follower
+  [IsWrDVtDsWDKTPSi] Vexing Tempest
+  [9CXQhg4YprPhqzoL] Vexing Tumble
+  [TgYs2m9scSyEJwdr] Vibration Sense
+  [zt5CWn3UrPViwaB3] Vicious Debilitations
+  [i3hALsjbjk9FdbGN] Vicious Evisceration
+  [IZupJre7o5We2VrK] Vicious Fangs
+  [NtWM5UgKBYvrTLQ4] Vicious Rend
+  [2xk4jdwcCfmasYfT] Vicious Swing
+  [KaCpXuYuho3nnDUy] Vicious Vengeance
+  [S3rPkukk46SHntai] Vigil's Palisades
+  [Jnhkl2BOhxxRCTpp] Vigil's Walls Rise Anew
+  [lIpfj1JeFFS7Zn6D] Vigilant Benediction
+  [20Yax5lEqjftKBHZ] Vigilant Mask
+  [uqIiSDbv80TbRwTQ] Vigilante Dedication
+  [4SKech3n0F38HrR5] Vigorous Anthem
+  [SOXivCy3ko3jDewI] Vigorous Victor
+  [JuEUNrvsxOYdXeYL] Viking Dedication
+  [3xiWBDSR8miAotpa] Viking Vindicator
+  [j9Rp4fOZIxizyvYy] Viking Weapon Familiarity
+  [vU86WnzVmfTde7xc] Vindicator Dedication
+  [Z9hrpFRKfLGMJXFp] Vindicator's Judgment
+  [pDkIUYQh5GGW50r3] Vindictive Thoughts
+  [fYD0SrZhMyJVQgvl] Vine Lash
+  [N8mhYbr5xBI8jydb] Violent Unleash
+  [W9Eizd4k0UKO2nT0] Virtuosic Dancer
+  [fns6SMiYrUeL6cnx] Virulent Strike
+  [XLIJXGJ1JdJJZQHG] Vision of Foresight
+  [lkl5QaDb1mlSD7SC] Visual Fidelity
+  [Tj79ePSD212EZjRM] Vitality-Manipulating Stance
+  [k2hxQ9SPOM7aFWQZ] Vivacious Afterimage
+  [2MHzEh1KUQEbhjUf] Vivacious Bravado
+  [UsEGem9s9ElaTS0d] Voice of Authority
+  [4TZNsGF9LNBxAWmS] Voice of Elements
+  [SxxL4YROFOqvOo9n] Void Siphon
+  [vKFg7HMNu4cCDD8b] Volatile Grease
+  [7zFdE4RHd9QJTWig] Volcanic Escape
+  [soHLtpMM9h3AE7PD] Voluminous Vials
+  [KFM6XeDnQoYQsIM5] Vow of Mortal Defiance
+  [wp9Pnu2qe7GkZgHS] Wailing Dead
+  [U2yGfKU47VZYP071] Wake of Devastation
+  [iAtdHXY6wqL7QRBb] Wake to Strife
+  [4Bum44iMs6tQz90v] Waking Dream
+  [Dq1SZ5LfZ66XDMNc] Walk Through the Conflagration
+  [MUwIeDV0pBtqeU3p] Walk on the Wind
+  [TzBP8yiZQHNhei1V] Walk the Plank
+  [zKUtZxlQw5jWnX9z] Walk the Wilds
+  [7IsHNime3WneCan6] Wall Run
+  [9dPz3x6uLCFEB3yK] Wandering Chef Dedication
+  [BlfgmJHjDyTVGdPs] Wandering Oasis
+  [hOZP7qOMsNYOe90o] Wandering Thoughts
+  [OlGO7dCLaghUXlQb] War Mage Dedication
+  [ht9ctVLibKCaFQdc] War Rider Stance
+  [Qjn9ErWY6wuIK9z6] Ward Casting
+  [S8Hda5OtajS9gpqM] Ward Mind
+  [NIzuFBqmHURIy2oI] Ward Slumber
+  [oHra9QanDFpAZ4hh] Warden's Boon
+  [2aFtxqRPnC4OXUGC] Warden's Focus
+  [6gtm0YCaDFpyVy35] Warden's Guidance
+  [S1UHZy6SDNqI4tHh] Warden's Reload
+  [oD4JyvTJj4kwe5vb] Warden's Step
+  [J1MURfqf0kbxrKG9] Warding Light
+  [XQEoKoFtq8n3wgA3] Warning Shot
+  [eJPu2Sj7XYCM0h0R] Warp Space
+  [mUL0C7O4HSnPSXea] Warped Constriction
+  [qsvtm35vkbB4wdUr] Warped by Rage
+  [0XdK3BJBA66jBcbQ] Warpriest's Armor
+  [Mkzi1UwdU4zbV3w1] Warrior of Legend Dedication
+  [MsNPLqPsWgOO0dqh] Warshard Rune
+  [GtohZQvFVZaIQD0S] Warshard Warrior Dedication
+  [9xcvJn3lWXwbkU52] Watch This!
+  [zZCyJhsaugHB6mZW] Watch Your Back
+  [nU8W1QoA9hl3h6nR] Watch and Learn
+  [FAO6p3pFiFF0QwCc] Watcher on the Wall
+  [6gLWr3xghsHSFwxc] Water Step
+  [fX0ipO6YSSeMv9DR] Water Walker
+  [6XL3usbKH9g5FaQo] Waterfowl Stance
+  [KGxGE0yv69ND2hct] Waters of Creation
+  [mXQG0WtHHGVyJfZf] Wave Dashes Rocks
+  [fLlCodqKXyXbZR7C] Wave Spiral
+  [AYVf9MU8oo1QWbGv] Wave the Flag
+  [o98nJriWE95xgweg] Wayfinder Resonance Infiltrator
+  [UyMQ1X8KLSZvm7AT] Wayfinder Resonance Tinkerer
+  [N46mQi4Av0HDJmfS] We Are One
+  [7tyjUicN4vh5U1zU] We've Met Before
+  [41zc9MdLoTy02kim] Weakening Assault
+  [MndcBMz6I7e6SRqx] Weapon Improviser Dedication
+  [Gvx8Mdg5mxUtTD5g] Weapon Infusion
+  [JEFPufbvaCeiA0Zo] Weapon Supremacy
+  [5nzeyuvzKL4T8eLt] Weapon-Rune Shifter
+  [9aea3IysGvjKY5tT] Weaver's Web
+  [iqAN2AqnQ6UqpQX6] Weft and Warp
+  [2c9awqDem5OLK47S] Weight of Guilt
+  [2j99hqUYPciC9bFQ] Weight of Stone
+  [K0gyvvX0S2FdJZ5T] Weighty Impact
+  [iX5HEqRImhKzfPR2] Well-Versed
+  [7nnEtLdUKmDljdhm] Wellspring Control
+  [Zyb3RMGyhsKfTjEG] Wellspring Mage Dedication
+  [AfreuohzCrdqJdRt] Werecreature Dedication
+  [pkH4DPmMWcimMov7] Westyr's Wayfinder Repository
+  [TDaf3DbWymxPmHrO] What Could Have Been
+  [XlagOGG88w6D3G3Z] Wheeling Grab
+  [IaiEZaA8erufMUCr] Whirling Blade Stance
+  [iqUYhZNcixYw0xUW] Whirling Clobber
+  [EVgtfnOPDKpB0bAi] Whirling Grindstone
+  [dloGUhZYG1xUPVE4] Whirling Knockdown
+  [w0nSRBNwexM5Dh0D] Whirling Throw
+  [EqNhUXGFjk99QzCg] Whirling in the Summer Storm
+  [0eOrhBrIPbRvPhNd] Whirlpool's Pull
+  [iHUuWrvkT2uR0PnK] Whirlwind Spell
+  [wZZyasfIqwiJBQAQ] Whirlwind Stance
+  [AGydz5DKJ2KHSO4S] Whirlwind Strike
+  [XenKYUBMWZQQ7niM] Whirlwind Toss
+  [apKvJtD1Qpvt3O9f] Whisper on the Wind
+  [nwcsv54Vs4YBGFs9] Whispering Steps
+  [EWMHFtF9pAsRsJwX] Whispers of Warning
+  [55WR55op9BIdgF1B] Whispers of Weakness
+  [yTUIiE9LXBZaA7aG] Whodunnit?
+  [KNtnb9HwPnPDY2Mv] Wide Overwatch
+  [mnhsG4l53YJkJIeY] Widen the Gap
+  [fHux2F9oZGzOj3GL] Wild Dance
+  [BQkqUrlUVNFp8BEq] Wild Lights
+  [U9mK9TXbGriGeMOW] Wild Mimic Dedication
+  [sdDOkl7IZZ0o0dix] Wild Speech
+  [VN3OHDYcnLaw0nW1] Wild Strider
+  [wKx7BWdQu5sEjL9j] Wild Winds Gust
+  [CL9pFxxMXqzIyg4j] Wild Winds Initiate
+  [Pw2YVi2eJU0GapXN] Wild Witch's Armaments
+  [QRnlCBpFkzqP1rBJ] Wildspell Dedication
+  [F2i6B8adeIy4LYxk] Wiles on the Wind
+  [0eo9ESm9Rmd2ndQ6] Willing Runes
+  [Jj6sVfIX81tgvSY4] Wind Caller
+  [FWIQ3m5KZDWzDg47] Wind Jump
+  [LoK6iI2f8ziSxFaU] Wind Seeker
+  [TdA3oVj79KxOm2Kd] Wind-Tossed Spell
+  [fjk8VsNDkVv1rjiu] Windborne Shove
+  [vXH0HWMHzevA1Wox] Winding Flow
+  [HXjDDIannDMNxMIz] Wing Bounce
+  [RkaE55TeCvwmQq7E] Wing Rider
+  [wvpDbFZZ9I8aAtmg] Wing Shove
+  [YtL4Q55dAM1GzdDh] Winged Leap
+  [c3JnbVKag8I19OA1] Winged Warrior Dedication
+  [Uzz7oZit3FNO9FxO] Wings of the Dragon
+  [tVqU3Ro0WPuAbCre] Wings of the Moon
+  [xn6EaAbQlAB5ZGe6] Winter Sleet
+  [YM4ReMXafoqCEpaR] Winter's Clutch
+  [NLjxAO9Mhx3k7gpc] Winter's Embrace
+  [mprVzno2BR2VhRSJ] Winter's Kiss
+  [TsgW87kYudNr6Bfp] Wish Alchemy
+  [GnTh2t4MvjifRxBd] Wisteria-and-Peony Reunion
+  [y0vdu6DGhKKElmE6] Witch Dedication
+  [XHaxSBOaFMnBbBKt] Witch's Armaments
+  [oEjRfI4ATIFxDCzL] Witch's Bottle
+  [3vleeliKpEIo5Bh6] Witch's Broom
+  [52QyoGaysrfBOy5H] Witch's Charge
+  [4IeAAmx2vZEHmRLX] Witch's Communion
+  [Sq9muixjFptJO8Ae] Witch's Hut
+  [S3CAJt6D7r1KcRv8] Witchwood Seed
+  [hmpkzEQV6kTFxPan] Wither Away
+  [LiLnDkoFcwW1RxqZ] Withstand Death
+  [oQ6EZRFXbHWCx08C] Wizard Dedication
+  [uJpghjJtNbqKUxRd] Wolf Drag
+  [AN9jY1JVcU20Qdw6] Wolf Stance
+  [Kxckxf4G9URXNc07] Wolf in Sheep's Clothing
+  [NGv7sphkVgF3CtXK] Wonder Worker
+  [zwxRIi0qqmyWlaTd] Wooden Palisade
+  [JgidFws6bOoGQcti] Words of Unraveling
+  [kQfqJLpKOPORq7I6] Work Yourself Up
+  [9oQRX6ss2pSqMZBr] World-Breaking Footfall
+  [thNurw2OnN9jpBGV] World-Wise Vigilance
+  [xqjPVZezw1a73JAO] Worldsphere Gravity
+  [PNKJhSy3MxdGLpTP] Worm Caller Dedication
+  [dbbX170jFFMi8sac] Worm Empathy
+  [jynhIXH1zEavQA7v] Worm Form
+  [CBJ3GZZsrAXioDNM] Worm Sense
+  [mctOx1S4JnqXkjAc] Worm's Feast
+  [7vziuNGHBwN1EKnr] Wormskin
+  [zY6y802bOouMYYFV] Wortwitch
+  [biU2NqWkO91o4FMg] Wounded Party
+  [CLKlavik0540j5bl] Wounded Rage
+  [VPnkSL25EfrEpPSX] Wrapped In Smoke
+  [csjkzb5dsyZPeOtY] Wrath of the First Ghoul
+  [AYHhuLIDtIEewfRf] Wrath of the Hold
+  [5npovgLMUlvtot2J] Wrestler Dedication
+  [ABobcAdaA8p1nHRV] Writhing Runelord Weapon
+  [aajcuwKYihsinPCt] Wronged Monk's Wrath
+  [aJBnBvbwqxQRhNZF] Wukong Extension
+  [pwiUuuUtifbAkaHl] Wylderheart Dedication
+  [Fp2ITpUZMXrSg3YN] Wyldsinger
+  [Tlo7Ln13l5wvgVtZ] Xidao Sea Mine Drop
+  [4znZkQYxrSg7RMxb] You Can't Hide From Us
+  [2q8vzxnlYYWcUGJd] You Can't Keep Us Down
+  [R5oeNpNCOXU4OtIT] You Can't Kill an Idea
+  [pog3LJUEhSeGikl3] You Don't Smell Right
+  [zBS1qFyIpFuCGhWW] You Failed to Account For... This!
+  [gjec0ts3wkFbjvHN] You're Next
+  [13bMIkqXpKt9pxAm] You're an Embarrassment!
+  [eaw645inkbHNylgC] Zealous Inevitability
+  [WRiJn6eLO76Gnuc3] Zealous Rush
+  [UyyrFtPWOo0qvXOv] Zephyr Guard Dedication
+  [ZR5Buon23cDQ1ryB] Zombie Dedication
+  [5uhKRkYDzLP7v3XY] Zombie Horde
+  [VjQfJKeDc46cWtgk] Zoophonic Communication
+  [bVPsAMxvUsSPHC1D] Zoophonic Composition
+Feat/Feature (Class Feature)
+  [GI5IAl4dkly4At8e] Ability Boosts
+  [tVxAFMBen8D516BQ] Abundant Vials
+  [5cthRUkRqRtduVvN] Adamantine Strikes
+  [l3X6D8uMlt2y6vGS] Adept Benefit (Amulet)
+  [4xDghsFgGldaNj9Y] Adept Benefit (Bell)
+  [T6p6lZnGupq3CX6A] Adept Benefit (Chalice)
+  [QK5ojonup9AQBg4O] Adept Benefit (Lantern)
+  [AEibGHmDzLiqGR0F] Adept Benefit (Mirror)
+  [EkNT2EhbClDQJUAG] Adept Benefit (Regalia)
+  [mzKV3lHPni85EMFM] Adept Benefit (Shield)
+  [gR8ODlO6au0laXo4] Adept Benefit (Tome)
+  [pax1pnWW5XFYO0Eg] Adept Benefit (Wand)
+  [XcuyDpn8L4HltRjW] Adept Benefit (Weapon)
+  [Pe0zmIqyTBc2Td0I] Advanced Alchemy
+  [3JLW5vPshsJf3nCY] Advanced Deed
+  [U7CBdITws4Sg3e5C] Advanced Design
+  [P1GbGEePC8zDi8K4] Advanced Rangefinder
+  [X9oHc6wtyJB7gFzK] Advanced Vials
+  [5FnyPYPaRbJthT3I] Advanced Vials (Bomber)
+  [6d8JFjFuvH27dpiw] Advanced Vials (Chirurgeon)
+  [wYOdTCWQQ6ec8I6b] Advanced Vials (Mutagenist)
+  [fOWKDtenCzLRWCgu] Advanced Vials (Toxicologist)
+  [7Zw83ysONrNhJMr8] Aerodynamic Construction
+  [xmZ7oeTDcQVXegUP] Agile Mind
+  [X11Y3T1IzmtNqGMV] Air Gate
+  [Eood6pNPaJxuSgD1] Alchemical Alacrity
+  [3e1PlMXmlSwKoc6d] Alchemical Expertise
+  [eG7FBDjCdEFzW9V9] Alchemical Mastery
+  [ln2Y1a4SxlU9sizX] Alchemical Sciences Methodology
+  [4ocPy4O0OCLY0XCM] Alchemical Weapon Expertise
+  [basYH3RUrT7omPQk] Alchemical Weapon Mastery
+  [bv3Qel8v9tpoFbw4] Alchemist Armor Expertise (Level 13)
+  [FiVYuIPTBzPzNP4E] Alchemist Armor Mastery (Level 19)
+  [w3aS3tsvH2Ub6XMn] Alchemy
+  [D8CSi8c9XiRpVc5M] Alertness
+  [hWzk8C4Kujel050h] All-Consuming Hunger
+  [9CC5Ek0Mq768Lhgx] Aloof Firmament
+  [PoclGJ7BCEyIuqJe] Amulet
+  [UV1HlClbWCNcaKBZ] Anathema (Cleric)
+  [nfBn8QB6HVdzpTFV] Anathema (Druid)
+  [qvRlih3u7vK3FYUR] Ancestors
+  [hippAZGFRtFd26dd] Angel Eidolon
+  [IwkAP2FBiU63aUgb] Anger Phantom Eidolon
+  [0FtzFbUrN56KA67z] Animal Instinct
+  [POBvoXifa9HaejAg] Animal Order
+  [h825m7hd9qDO3369] Animist & Apparition Spellcasting
+  [P3rO6yeGY7YbccRG] Animistic Practice
+  [ySkTxnoNuDluk6Cb] Antimagic Plating
+  [O04RZa20X6fcbLAy] Anvil's Hardness
+  [AHMjKkIx21AoMc9W] Apparition Attunement
+  [au0lwQ1nAcNQwcGh] Arcane Bond
+  [09iL38CZZEa0q0Mt] Arcane Cascade
+  [7nbKDBGvwSx9T27G] Arcane School
+  [wXaz41gwqNtTn6tf] Arcane Spellcasting (Magus)
+  [M89l9FOnjHe63wD7] Arcane Thesis
+  [ZjwJHmjPrSs6VDez] Archwizard's Spellcraft
+  [fpwtpm8pdwO1I6MO] Armor Innovation
+  [QTCIahokREpnAYDi] Armor of Fury
+  [g3HTg0z3doXZZzAV] Ashes
+  [syEkISIi0F9946zo] Assured Evasion
+  [ZcoOMwEY8FX7UzMo] Attack Refiner
+  [HC99e4WoM36W3lrL] Automated Impediments
+  [ONKUKCdsbGwhVoUb] Avenger
+  [VVMMJdIWL7fAsQf3] Baba Yaga
+  [N1hWQx0IuKWjZ2dn] Bands of Imprisonment
+  [4lp8oG9A3zuqhPBS] Bard Weapon Expertise
+  [LfgeEJgJdA8WAKV8] Barrow's Edge
+  [gjOGOR30Czpnx3tM] Battle
+  [49CkgA3kj7Im6gZ5] Battle Creed
+  [gdSmSTaGDxf4g2d8] Battle Hardened
+  [5HoEwzLDJGTCZtFa] Battledancer
+  [KQ87ZZVAT4q00Dyr] Battlefield Intuition
+  [TIvzBALymvb56L79] Battlefield Surveyor
+  [xeD5nNnQAlaowGwR] Beast Eidolon
+  [DK1LCE5pd0YCY11c] Bell
+  [Uz2Izzi5A8N6Dxjn] Blast Dodger
+  [EtltLdiy9kNfHU0c] Blessed Armament
+  [QQP0mu0cyWIwNUh9] Blessed Shield
+  [Z6E1O8X7CFcyczB1] Blessed Swiftness
+  [ERwuazupczhUSZ73] Blessing of the Devoted
+  [1PHDn7WJFtR3NgTr] Blight
+  [pLr6Kxa7XdkVMAub] Blight Soul Deviant Classification
+  [2goYo6VNbwC6aKF1] Bloodline
+  [feCnVrPPlKhl701x] Bloodline Paragon
+  [H6ziAPvCipTPG8SH] Bloodline Spells
+  [3qqvnC2U8W26yae7] Bloodline: Aberrant
+  [TFihgf3jDhmKd0fa] Bloodline: Aesir
+  [vhW3glAaEfq2DKrw] Bloodline: Angelic
+  [w5koctOVrEcpxTIq] Bloodline: Demonic
+  [o39zQMIdERWtmBSB] Bloodline: Diabolic
+  [ZHabYxSgYK0XbjhM] Bloodline: Draconic
+  [RXRnJcG4XSabZ35a] Bloodline: Elemental
+  [eW3cfCH7Wpx2vik2] Bloodline: Fey
+  [tYOMBiH3HbViNWwn] Bloodline: Genie
+  [O0uXZRWMNliDbkxU] Bloodline: Hag
+  [b6hyZTs1rVGHDexz] Bloodline: Harrow
+  [ZEtJJ5UOlV5oTWWp] Bloodline: Imperial
+  [5Wxjghw7lHuCxjZz] Bloodline: Nymph
+  [TWR1wbPJuCLnGdFZ] Bloodline: Phoenix
+  [PpzH9tJULk5ksX9w] Bloodline: Psychopomp
+  [uoQOm41BVdSo6pAS] Bloodline: Shadow
+  [7WBZ2kkhZ7JorWu2] Bloodline: Undead
+  [dKTb959aCQIzSIXj] Bloodline: Wyrmblessed
+  [qwvO0B9t7LgQCVbV] Bloodrager
+  [O3r84Uv6HytaSIbX] Blunt Shot
+  [7JbiaZ8bxODM5mzS] Bomber
+  [IaxmCkdsPlA52spu] Bones
+  [cIj344sA3BlfqoJU] Born of the Bones of the Earth
+  [KBhwFjdptrKyN5EM] Braggart
+  [GJKJafDGuX4BeAeN] Bravery
+  [78HIjRbGoONMpF31] Breakthrough Innovation
+  [EEUTd0jAyfwTLzjk] Brutality
+  [Csggpxb5Mp4lPUwh] Burnished Armor Expertise
+  [2x6Nlt4vGhkNtwOj] Burnished Armor Mastery
+  [hxjdHBJHaB47mBUT] Camouflage Pigmentation
+  [4fmks2barqWlLtik] Cascade Bearers
+  [aSOgbQWMwStTTmap] Catharsis Emotion
+  [D4k8wuq1ncHFCBZz] Cause
+  [1vgFGSnn0DIBmK7j] Chalice
+  [VgmfNKtQLgBaNi5r] Champion Expertise
+  [z5G0o04uV65zyxDB] Champion Mastery
+  [0x76o5OxgEmvqIDp] Champion's Aura
+  [sXVX4ARUuo8Egrz5] Champion's Reaction
+  [PjuFdRe1moLd1VhP] Chemical Hardiness
+  [eNZnx4LISDNftbx2] Chirurgeon
+  [v2JQB6j3VIKWqPpQ] Choir Politic
+  [VSbNezLoWtWRDok7] Churning Mind
+  [k9MeSdp2DbGd1hFz] Clarity of Focus
+  [AvNbdGSOTWNRgcxs] Cleric Spellcasting
+  [ZZzLMOUAtBVgV1DF] Cloistered Cleric
+  [CxvLFkrV5LlADQkx] Cobyslarni
+  [8g6HzARbhfcgilP8] Combat Flexibility
+  [8NtRuNYGiU2iTwgL] Commander's Banner
+  [fbMy0ltflHJjxFPD] Commanding Will
+  [j0klWHkH3AxUAgok] Complete Reconfiguration
+  [qIOKqT93h6CX6V4k] Complex Simplicity
+  [s0VbbQJNlSgPocui] Composition Spells
+  [HBTLwREPKK3H4xVD] Confident Evasion
+  [pyo0vmxUFIFX2GNl] Confident Finisher
+  [FkbFgmoVz5lHhSMo] Conflux Spells
+  [0fv6NVMZZ0peGL9e] Conscious Mind
+  [rwPx9D4PjZhinmmH] Construct Eidolon
+  [o70O2FysDd7BS9e0] Construct Innovation
+  [13QpCrR8a8XULbJa] Continuous Flair
+  [RI2EMRBBPNSoTJXu] Cosmos
+  [csrF8UOWPl1rr6st] Crafter in the Vault
+  [IiYUhFGqq2Nw0b5Y] Cultivation Order
+  [vXnMKFIxqLuCDW9q] Curse of Ancestral Meddling
+  [2VclK5CWR1Vz1vqL] Curse of Creeping Ashes
+  [RI2UHuUZd3TC1OE8] Curse of Engulfing Flames
+  [LIV2gH3ZUFlu0zu4] Curse of Inclement Headwinds
+  [5QVUaQGT1FSkFOYP] Curse of Inevitable Rot
+  [zO7dvBgLuhdGfP5t] Curse of Outpouring Life
+  [XQjR07LkDedC7tkc] Curse of Torrential Knowledge
+  [X6GQ4ngqpjP8SpCq] Curse of Turbulent Moments
+  [8ODGE24gqEdzWljj] Curse of the Living Death
+  [zLYqrQdheciiW2nm] Curse of the Mortal Warrior
+  [d03gBFLK4XJlDNNh] Curse of the Sky's Call
+  [EyRHVD4h2eZYIsk5] Custodian of Groves and Gardens
+  [vrKfwncFKxapUYRp] Dancer in the Seasons
+  [KcK3d8zw0bCEoaEG] Deadly Strike
+  [faIuxgeMG60cEa9J] Deathless Servant
+  [9SruVg2lZpNaYLOB] Debilitating Strike
+  [znxs0soGlusvRP39] Decay Instinct
+  [malYpr0CYL4fDGhr] Deductive Improvisation
+  [gU7epgcPSm0TD1UK] Defensive Robes
+  [2CtYJJjesShbkyOv] Deific Mastery
+  [FeBsYn2mHfMVDZvw] Deific Weapon
+  [ehL7mnkqxN5wIkgu] Deity (Champion)
+  [DutW12WMFPHBoLTH] Deity (Cleric)
+  [f2JzGk76CPjA2mcV] Demon Eidolon
+  [svGLZdD4PF7miAKA] Dense Plating
+  [PNpmVmD21zViDtGC] Deny Advantage
+  [8YIA0jh64Ecz0TG6] Desecration
+  [ZhYJhcOeZlh96wFh] Desynchronized Motions
+  [VLiT503OLOM3vaDx] Devastator
+  [lgo65ldX7WkXC8Ir] Devise a Stratagem
+  [XEaO0VrYNaQepXow] Devotion Phantom Eidolon
+  [Q1VfQZp49hkhY0HY] Devotion Spells
+  [T9wA833bzZVlB3Lo] Devourer of Decay
+  [cF7GqQQvQbnUVf5o] Disciplined Mind
+  [iwAzV1IlQ2pMHQoB] Divine Access
+  [0mJTp4LdEHBLInoe] Divine Defense
+  [gblTFUOgolqFS9v4] Divine Font
+  [e2MJdkZQorNwhbGn] Divine Premonition
+  [GtxSH6TudkQoKToW] Divine Spark and Ikons
+  [nFZW9LZ6lV39dhBf] Divine Weapon Mastery
+  [xygfZopqXBJ6dKBA] Divine Will
+  [tyrBwBTzo5t9Zho7] Doctrine
+  [uuHRYE8Oljk1ORxJ] Dogged Will
+  [yQY2griL1Sykw25V] Dominion Epithet
+  [76cwNLJEm4Yetnee] Double Brew
+  [W1FkMHYVDg3yTU5r] Double Debilitation
+  [DvuPpIaM4BkHLX4y] Double Reflow
+  [VmPIJomEdmgGrCMS] Double Spellstrike
+  [R41sy7weOd0JhOiW] Dragon Deviant Classification
+  [JttI3raKFGG4C8up] Dragon Eidolon
+  [VDot7CDcXElxmkkz] Dragon Instinct
+  [A5nOG2HuM8ZhMJ5p] Drilled Reactions
+  [b8pnRxGuNzG0buuh] Druid Spellcasting
+  [Ra32tlqBxHzT6fzN] Druid Weapon Expertise
+  [8STJEFVJISujgpMR] Druidic Order
+  [O9wpXEKtKYJOMIlK] Dynamic Weighting
+  [puHtHGCjsJLWCP1u] Earned Resilience
+  [dEm00L1XFXFCH2wS] Earth Gate
+  [UbOFa3BBHO8HwLJR] Echo of Lost Moments
+  [qOEpe596B0UjhcG0] Eidolon
+  [2CZPYoyWih6zYTcb] Eidolon Defensive Expertise
+  [0WvI8KM5m0SaZ3MH] Eidolon Defensive Mastery
+  [skQBrwRwJW2K6ACj] Eidolon Symbiosis
+  [nCE9DzkugRefREqT] Eidolon Transcendence
+  [pda6iUaU9waXId5Q] Eidolon Unarmed Expertise
+  [NIzHfVcVMhDmvA49] Eidolon Unarmed Mastery
+  [oCnyGRvkfjTsZXcX] Eidolon Weapon Specialization
+  [D8qtAo2w4jsqjBrM] Eldritch Trickster
+  [sZEQCWsq8MxAmEHp] Elemental Eidolon
+  [0jSS6pgNXsC8k4o7] Elemental Instinct
+  [pUkUC8HHom2DmYzz] Elemental Magic
+  [5rFzX6JK6CXLFxUP] Elemental School
+  [JhczMKRuy53BxqBi] Emerald Boughs
+  [PNihL10QAB1sYSRn] Emotional Acceptance
+  [g3mNzNphtVxyR9Xr] Empiricism Methodology
+  [6RAHnACKReBW68Sa] Encroaching Presence
+  [8PjTI21Mif26XWY7] Energetic Meltdown
+  [vUt71oX9QNLAUmZn] Energy Barrier
+  [KmFz27FVNXYWwgIc] Enhanced Damage
+  [T3742fu7oIM3W6Gz] Enhanced Resistance
+  [4ripp6EfdVpS0d60] Enigma
+  [Z1au5zxYcjZvdQpd] Entangling Form
+  [Fh5Khtx5bgGpBeOu] Envy
+  [cvQmPkJtybMcHinK] Esoteric Lore
+  [ypfT3iybew6ZSIUl] Eternal Confidence
+  [MV6XIuAgN9uSA0Da] Evasion
+  [oa3TJpPnvL98EUHh] Evasive Reflexes
+  [IPcdQAwJk0aZe5mg] Evolution Feat
+  [uptzvOLrZ3fctrl2] Exalted Reaction
+  [KxpaxUSuBC7hr4F7] Exemplary Finisher
+  [89zWKD2CN7nRu2xp] Experimental Spellshaping
+  [YMKxN56w617BYwu4] Expert Overdrive
+  [SgY4tejqWzTpEjfi] Expert Protections
+  [VgZIutWjFl8oZQFi] Expert Strikes
+  [ZvsiPWL9mVZk5Tz1] Expert Tactician
+  [pEm1RTNuzzQVKkR0] Explode
+  [uwLNfBprqZw2osTb] Exploit Vulnerability
+  [ZqNKqBJWagU1fg4A] Explosion Dodger
+  [YQs4G9YK3VskY2F6] Extensible Weapon
+  [jyCEC3eC4B6YaGoy] Extract Element
+  [wOl7EeF7S6i753Ef] Extrasensory Perception
+  [F4brPlp1tHGUqyuI] Extreme Curse
+  [Em5gwwyVHql9cSW2] Eye-Catching Spot
+  [mFqMSQoNl0NMDklv] Faith's Flamekeeper
+  [yksPhweBZYVCsE1A] Familiar (Witch)
+  [Jgid6Ja6Y879COlN] Fencer
+  [xrJ4nGGgejUPf16q] Fetching Bangles
+  [J2Oi9MxW2e2gjrKC] Fey Eidolon
+  [IxxPEahbqXwIXum7] Field Discovery
+  [8QAFgy9U8PxEa7Dw] Field Discovery (Bomber)
+  [qC0Iz6SlG2i9gv6g] Field Discovery (Chirurgeon)
+  [V4Jt7eDnJBLv5bDj] Field Discovery (Mutagenist)
+  [6zo2PJGYoig7nFpR] Field Discovery (Toxicologist)
+  [Zb7DuGbFoLEp0H1K] Fifth Doctrine
+  [n9W8MjjRgPpUTvWf] Fifth Doctrine (Cloistered Cleric)
+  [kmimy4VOaoEOgOiQ] Fifth Doctrine (Warpriest)
+  [bAaI7h937Nr3g93U] Fighter Expertise
+  [gApJtAdNb9ST4Ms9] Fighter Weapon Mastery
+  [11Prk28b1Ux9eBLR] Final Creed
+  [urBGOPrUwBmkixAo] Final Doctrine
+  [DgGefatQ4v6xT6f9] Final Doctrine (Cloistered Cleric)
+  [N1ugDqZlslxbp3Uy] Final Doctrine (Warpriest)
+  [DPxpBIxPidJfn0Xv] Final Gate
+  [PfeDtJBJdUun0THS] Fire Gate
+  [Qejo7FUWQtPTpgWH] First Doctrine
+  [aiwxBj5MjnafCMyn] First Doctrine (Cloistered Cleric)
+  [xxkszluN9icAiTO4] First Doctrine (Warpriest)
+  [VSQJtzQE6ikKdsnP] First Implement and Esoterica
+  [NdeFvIXdHwKYLiUj] Flame Order
+  [GTSvbFb36InvuH0w] Flames
+  [Upf1LXtWNJ6eB5sm] Flexible Spell Preparation
+  [rHfZWy3hzhV71F0Q] Flicker Deviant Classification
+  [6v4Rj7wWfOH1882r] Flurry
+  [NLHHHiAcdnZ5ohc2] Flurry of Blows
+  [T25ZLQWn6O4KchLo] Focus Spells
+  [O3IX7rTxXWWvDVM3] Forensic Medicine Methodology
+  [XPPG7nN9pxt0sjMg] Formula Book
+  [Hw6Ji7Fgx0XkVkac] Fortress of Will
+  [avLo2Jl3mNWssp0W] Fourth Apparition
+  [o8nHreMyiLi64rZz] Fourth Doctrine
+  [vxOf4LXZcqUG3P7a] Fourth Doctrine (Cloistered Cleric)
+  [px3gVYp7zlEQIpcl] Fourth Doctrine (Warpriest)
+  [o8QHrhc9MsWIoKUv] Fourth Gate's Threshold
+  [ZYAn8X0IjA6i38qU] Fungal Rot
+  [fctFBBqWwwwdbgdx] Furious Footfalls
+  [k7M9jedvt31AJ5ZR] Fury Instinct
+  [jx70hPakuTgB3lM5] Gate Junction
+  [vEiENk0IzuzRQesp] Gate's Threshold
+  [0UKDEtZ7ffTEsqCK] Gathered Lore
+  [hfn5w8ZuI22vfimn] Gaze Sharp as Steel
+  [JuKD6k7nDwfO0Ckv] Giant Instinct
+  [o8Q7wWx2oKvKMi1s] Gleaming Blade
+  [hzATJ1FV3lTPgeG9] Gluttony
+  [VDz0zSZOmdzRxy65] Godly Expertise
+  [JWDfzYub3JfuEtth] Graceful Legend
+  [95LI24ZSx0d4qfKX] Graceful Mastery
+  [h1NGH4TVeBljftni] Grandeur
+  [eEh5QHawYBmbRjow] Greater Creed
+  [yc9RuXXxmZ9YidH6] Greater Deed
+  [XFcCeBYqeXgfiA84] Greater Dogged Will
+  [B5SyM7qHrU0gTGR0] Greater Eidolon Specialization
+  [MEwvBnT2VsO5lQ6I] Greater Field Discovery
+  [RGs4uR3CAvgbtBAA] Greater Field Discovery (Bomber)
+  [JJcaVijwRt9dsnac] Greater Field Discovery (Chirurgeon)
+  [1BKdOJ0HNL6Eg3xw] Greater Field Discovery (Mutagenist)
+  [tnqyQrhrZeDtDvcO] Greater Field Discovery (Toxicologist)
+  [TuL0UfqH14MtqYVh] Greater Juggernaut
+  [i3qjbhL7uukg9I80] Greater Kinetic Durability
+  [Kj59CmXnMJDKXKWx] Greater Mysterious Resolve
+  [rpLPCkTXCZlQ51SR] Greater Natural Reflexes
+  [mRobjNNsABQdUUZq] Greater Performer's Heart
+  [BTpL6XvMk4jvVYYJ] Greater Rogue Reflexes
+  [AVI5SJET99zRqfpZ] Greater Spirit Striking
+  [Zb8SS1tbpbtEwqNh] Greater Unassailable Soul
+  [7JjhxMFo8DMwpGx0] Greater Weapon Specialization (Barbarian)
+  [COMhWWNBJOdaJqp7] Greed
+  [Ak646ZUtxhQdYEi9] Guardian Expertise
+  [CdDcUXv9J3aEo9HR] Guardian Mastery
+  [qbTwR81TKsv4fOHk] Guardian's Armor
+  [uSRq2tneVCknhI0P] Guardian's Techniques
+  [aKr6OE8vI2BsJzf1] Gunslinger Expertise
+  [9nRT8aq05Fy2D3i3] Gunslinger Weapon Mastery
+  [LDqVxLKrwEqSegiu] Gunslinger's Way
+  [ULOAZWZEokbJC6Rq] Gunslinging Legend
+  [B7RMnrHwQHlezlJT] Gymnast
+  [R8cfRNPdaCkd2bud] Hampering Spikes
+  [MhM6u4Stl0jV6CF2] Hands of the Wildling
+  [dsy2w4LfjMIWgy5D] Harmonic Oscillator
+  [xSgUH97WkWadielz] Healer of the World
+  [yEfHCwsbsbP6K13Q] Heavy Construction
+  [Nbg4ZllDI9uCowZL] Hefty Composition
+  [7MhzrbOyue5GQsck] Heightened Senses
+  [LzB6X9vOaq3wq1FZ] Hero's Defiance
+  [9uLh5z2uPo6LDFRY] Hex Spells
+  [gjZXHLjezR0mkMnc] Horn of Plenty
+  [tmTlnyVxo6zPqJvh] Humble Strikes
+  [0nIOGpHQNHsKSFKT] Hunt Prey
+  [mzkkj9LEWjJPBhaq] Hunter's Edge
+  [FTeIs1Z1Qeli4BIF] Hybrid Study
+  [V5qmKLmI3RL68RGb] Hyper Boosters
+  [Obm4ItMIIr0whYeO] Implement Adept
+  [QEtgbY8N2V4wTbsI] Implement Paragon
+  [PbNS8d3w3pYQYcVN] Implement's Empowerment
+  [2xVLO3JDe4gYlqv4] Impossible Alloy
+  [Gss5cYmRySgi1UxP] Impostor in Hidden Places
+  [L5D0NwFXdLiVSnk5] Improved Evasion
+  [SNZ46g3u7U6x0XJj] Improved Familiar Attunement
+  [W2rwudMNcAxs8VoX] Improved Flexibility
+  [xhCYkt3acfFd0hr2] Impulses
+  [h1hNr4jABip2ERDd] Inconspicuous Appearance
+  [Cq6NjvcKZOMySBVj] Incredible Movement
+  [82rxCGBb5qf9fwbp] Incredible Resistance
+  [BZnqKnqKVImjSIFE] Indomitable Will
+  [ZslXrvYRxHBXc1Ds] Inexorable Iron
+  [rOaLbipkComjc6qh] Infinite Invention
+  [mZwD2brwXlyR9RAR] Infinite Mind
+  [wySB9VHOW1v3TX1L] Infused Reagents
+  [EQ6DVIQHAUXUhY6Y] Iniquity
+  [BoZ3nSssFYcwuLIT] Initial Creed
+  [ALcWRnRjvuPKu4nV] Initiate Benefit (Amulet)
+  [M0UnQTqofeg1npcl] Initiate Benefit (Bell)
+  [UfUqPcPcrGgRJCO3] Initiate Benefit (Chalice)
+  [tBI15UqeQH7PLzAK] Initiate Benefit (Lantern)
+  [AehJwnLCUyASCQlu] Initiate Benefit (Mirror)
+  [3eRkOQa7h1MWmzBh] Initiate Benefit (Regalia)
+  [6IrdIGinaAutACjn] Initiate Benefit (Shield)
+  [oADE2kM43wpF7MT5] Initiate Benefit (Tome)
+  [YbRVsHfmhPXLfCTB] Initiate Benefit (Wand)
+  [MZajaYrn6c1A1XcO] Initiate Benefit (Weapon)
+  [jIAgXe2FetAKBwt7] Innovation
+  [H0iWhiyP0QqgmAKs] Instant Manifestation
+  [dU7xRpg4kFd01hwZ] Instinct
+  [tPL4lrGLCB5XbgeV] Integrated Gauntlet
+  [VdwNvQwq9sHflEwe] Intensify Vulnerability
+  [UIHUNNYZyQ3p4Vmo] Interrogation Methodology
+  [mQVC1iDyNi2tfsF8] Inventive Expertise
+  [Uu8VnpAo3XZZEKPd] Inventive Mastery
+  [0NyPgi6UACMTmAGE] Inventor Weapon Expertise
+  [mJpPaoVlNmTK47x1] Inventor Weapon Mastery
+  [PFvB79O2VFdiAeSj] Investigator Expertise
+  [wMyDcVNmA7xGK83S] Iron Will
+  [OMZs5y16jZRW9KQK] Juggernaut
+  [peEXunfbSD8WcMFk] Justice
+  [Pk3Ht0KZyFxSeL07] Keen Flair
+  [DZWQspPi4IkfXV2E] Keen Recollection
+  [1FPVkksuE2ncw9rF] Ki Spells
+  [f0BF2210l9k66cso] Kinetic Aura
+  [eTHq1Cwf1pOvsx2R] Kinetic Durability
+  [dGiMAdZEQoXQWJbn] Kinetic Expertise
+  [IDBB44egwiQ4qZNh] Kinetic Gate
+  [8ZAc21SvRO2rfPez] Kinetic Legend
+  [a6fIKxCViZwwHZLJ] Kinetic Mastery
+  [9BUk7zy1aE092XCS] Kinetic Quickness
+  [AltwHU7hCqTwpn48] Lantern
+  [3gVDqDPSz4fB5T9G] Laughing Shadow
+  [hwqaS9m2RwGe0kJk] Layered Mesh
+  [i7NKYQNGu5AaR1qb] Lead Constitution
+  [u4nlOzPj2WHkIj9l] Leaf Order
+  [WuX4ZzsE0ezQfIVS] Leech Deviant Classification
+  [o1omL2LdHvjEwh3P] Legendary Overdrive
+  [jMxFu2vsw9ZOw61O] Legendary Tactician
+  [rzuZSgunJCQqdOxv] Lesser Creed
+  [RcmqV0cuOLcnKQr0] Lesson of Bargains
+  [PLMmDXJCDdMS0V5C] Lesson of Calamity
+  [wRHeY7tCN6HFFF3a] Lesson of Death
+  [hEsmQcEryweYweis] Lesson of Decay
+  [evKUM58ymuuypRn9] Lesson of Dreams
+  [FuOHRoEU8nHOXZnk] Lesson of Elements
+  [2IhZbkx889pATIjq] Lesson of Favors
+  [HbREpzudMXPscgCj] Lesson of Life
+  [e6nZuYDbRffnJwHZ] Lesson of Memory
+  [XBgBh3xZhgGQP7lF] Lesson of Mischief
+  [KHKe3PmctOFUeh85] Lesson of Protection
+  [7Y2XDqr4gRisjiAG] Lesson of Renewal
+  [YSxymsAe2Dvq47f2] Lesson of Shadow
+  [rECRfbkVwHuG06vO] Lesson of Snow
+  [DtmKrCvsmutVLAhH] Lesson of Vengeance
+  [ZFWmfZezeJDWSMFA] Lesson of Vows
+  [JjseD5wylg4Hg9O2] Lesson of the Flock
+  [29ynmOCdtIFDzrWx] Lesson of the Frozen Queen
+  [LP6PfKqwyRJmWqOJ] Lesson of the Shark
+  [FCoMFUsth4xB4veC] Liberation
+  [o1gGG36wpn9mxeop] Life
+  [XIk9Z4cLsoJRyV0T] Life-Draining
+  [YbYrSnBL5VLGosxO] Light Mortar Innovation
+  [qVAeSFTI1dq64bB8] Ligneous Instinct
+  [wguqw300DB5XdD8W] Link Spells
+  [Zz7FPvmAaOpebHbu] Liturgist
+  [tZBb3Kh4nJcNoUFI] Lore
+  [NNVkvA9fmyFy68ag] Lurker in Devouring Dark
+  [MpZ0sdwMJ8fdZmtR] Lust
+  [YMBsi4bndRAk5CX4] Maestro
+  [NjsOpWbbzUY2Hpk3] Magnum Opus
+  [7D8duG4ARFxLLm9F] Majestic Will
+  [kpdb5TJ0F5uCTX0F] Major Creed
+  [rrzItB68Er0DzKx7] Major Curse
+  [y62b9R6RUBbkZECA] Manifold Alloy
+  [i6563IU7x4L9oRgC] Martial Weapon Mastery
+  [flEx8eY0NinF9XZU] Master Detective
+  [SXv9bJFbntDOMRIL] Master Overdrive
+  [SUUdWG0t33VKa5q4] Master Strike
+  [0iidKkzC2yy13lIf] Master Strikes
+  [wHVfwjs6LJOgDERO] Master Tactician
+  [myvcir1LEkaVxOlE] Master Tricks
+  [8LhwKWBxF2lgxEG5] Master of Mind and Spirit
+  [RVZC4wVy5B5W2OeS] Masterful Hunter
+  [JhLncIB10GSQowWL] Masterful Hunter (Flurry)
+  [vWZaLE2fEKMBw3D5] Masterful Hunter (Outwit)
+  [BJYSUbFUGcTLaPDn] Masterful Hunter (Precision)
+  [RyOkmu0W9svavuAB] Mastermind
+  [k6c2gesVQ8QuEWGm] Medium
+  [FCEp9jjxxgRJDJV3] Medium Armor Expertise
+  [esyKPSDbFQPB4lhq] Medium Armor Expertise (Inventor)
+  [cGMSYAErbUG5E8X2] Medium Armor Mastery
+  [21JjdNW0RQ2LfaH3] Metal Gate
+  [CoRfFkisEsHE1e43] Metal Strikes
+  [xndlv9T3JgYYUtf8] Metallic Reactance
+  [uhHg9BXBiHpL5ndS] Methodology
+  [88Q33X2a0iYPkbzd] Mighty Rage
+  [VCJVuqByBxnUxQoH] Military Expertise
+  [3uf31A91h3ywmlqm] Miraculous Spell
+  [N6KvTbaRsphc0Ymb] Mirror
+  [lJAQPRT2t8IABR4v] Mirrored Aegis
+  [cs9SDe93GHTHlzTz] Moderate Creed
+  [qwhfPgE2tTW0hvPe] Modular Head
+  [g9UMdKV1TxNdhpDO] Momentum Enhancer
+  [95maDg6AsCTLPAmS] Monarch of the Fey Courts
+  [lxImO5D0qWp0gXFB] Monk Expertise
+  [HhDQOylStcEVZCNg] Mortal Harvest
+  [A8rAsfXHpO8lWe2r] Mortality Reforged
+  [zy0toWeGIeQstbT4] Mosquito Witch
+  [ZrkyPG41iFicYsdX] Multisensory Mask
+  [OkxoJWrOXhM25mhi] Muscular Exoskeleton
+  [AIOBWGOS4nkfH3kW] Muses
+  [tvdb1jkjl2bRZjSp] Mutagenist
+  [cCTqkTHYnVCJKg4S] Mysterious Resolve
+  [PRJYLksQEwT39bTl] Mystery
+  [FpaycWJyvksEiRc3] Mystic Life Force
+  [D2AE8RfMlZ3D1FuV] Mystic Strikes
+  [7dMDxvzGKbqoEAdX] Natural Reflexes
+  [j2R64kwUgEJ1TudD] Nature's Edge
+  [ndSCXO9Dg57fmZIY] Noble Branch
+  [HiIvez0TqESbleB5] Obedience
+  [fEOj0eOBe34qYdAa] Occult Spellcasting
+  [RieSRew9aMGvaGhz] Of Verse Unbroken
+  [F8oXHnu9iNTcpXbJ] Offensive Boost
+  [GoMoEtTu9uP7nxkg] Omnirange Stabilizers
+  [6FasgIXUJ1X8ekRn] On the Case
+  [otELTaTnOCea7DZw] One Among the Masses
+  [Jtn7IugykXDlIoZq] Opportune Riposte
+  [7AVspOB6ITNzGFZi] Oracle Spellcasting
+  [571c1aGnvNVwfF6b] Oracular Clarity
+  [ibX2EhKkyUtbOHLj] Oracular Curse
+  [eTQZQGPMIZJHIR6J] Oracular Senses
+  [YrJj8UI0XpkHv0Ho] Order of the Chain
+  [igMHwREgpM9GsvLs] Order of the Gate
+  [UTRDN1TAieBMjwP1] Order of the Godclaw
+  [ub9gwFXnMuKvhnPL] Order of the Nail
+  [zGxO2cETUsXuvqRu] Order of the Pyre
+  [lVdfcITy5bkywW5f] Order of the Rack
+  [t01K3DB2qHnbt1q3] Order of the Scourge
+  [jHE4fPwU0sSIAjMo] Otherworldly Protection
+  [NBHyoTrI8q62uDsU] Outwit
+  [oP5zM5Yu41xcx3iu] Overdrive
+  [pSXlZggdCCbkQqNr] Pacification Tools
+  [ppGGpc3Iv2NpAhys] Palatine Detective
+  [LzYi0OuOoypNb6jd] Panache
+  [RdOzBNPKLTMUWrJs] Paradox of Opposites
+  [BdIlZ73jdXg7kQ5G] Paragon Benefit (Amulet)
+  [Mu6lZ0H7hmsgKDKH] Paragon Benefit (Bell)
+  [rW3xdQPTNptQIcL5] Paragon Benefit (Chalice)
+  [k9d3rDhYnHwLI8XF] Paragon Benefit (Lantern)
+  [jyfTDSYuzXaNuJ2r] Paragon Benefit (Mirror)
+  [zOMYv2nl2gGICErA] Paragon Benefit (Regalia)
+  [Swy3rjQsdO0wu2kU] Paragon Benefit (Shield)
+  [IGv5wS17AAi0U87W] Paragon Benefit (Tome)
+  [jVW6185zu3VlWHot] Paragon Benefit (Wand)
+  [mrSBs3kfw6POoZtG] Paragon Benefit (Weapon)
+  [1K6m6AVmn3r8XZ9d] Path to Perfection
+  [KPtF29AaeX2sJW0K] Patron
+  [nocYmxbi4rqCC2qS] Patron Theme
+  [cDnFXfl3i5Z2l7JP] Patron's Gift
+  [JH6um0St37UrjLNG] Peerless Inventor
+  [1I85hvg8k1aVrj5c] Peerless under Heaven
+  [Wy6vSjm588txUFFv] Pelt of the Beast
+  [nLwPMPLRne1HnL00] Perception Legend
+  [Q172fARBaNDR8Gqx] Perfect Fortification
+  [KmTfg7Sg5va4yU00] Perfected Form
+  [HlRYDdBh8oydCWgj] Perfected Mind
+  [nPwYSuMLkJWMB4CH] Performer's Heart
+  [ZqwHAoIZrI1dGoqK] Perpetual Infusions
+  [DFQDtT1Van4fFEHi] Perpetual Infusions (Bomber)
+  [fzvIe6FwwCuIdnjX] Perpetual Infusions (Chirurgeon)
+  [Dug1oaVYejLmYEFt] Perpetual Infusions (Mutagenist)
+  [LlZ5R50z9j8jysZL] Perpetual Infusions (Toxicologist)
+  [11nGqrSJOoGRlDjO] Perpetual Perfection
+  [xO90iBD8XNGyaCkz] Perpetual Perfection (Bomber)
+  [YByJ9O7oe8wxfbqs] Perpetual Perfection (Chirurgeon)
+  [CGetAmSbv06fW7GT] Perpetual Perfection (Mutagenist)
+  [3R19zS7gERhEX87F] Perpetual Perfection (Toxicologist)
+  [MGn2wezOr3VAdO3U] Perpetual Potency
+  [8rEVg03QJ71ic3PP] Perpetual Potency (Bomber)
+  [VS5vkqUQu4n7E28Y] Perpetual Potency (Chirurgeon)
+  [mZFqRLYOQEqKA8ri] Perpetual Potency (Mutagenist)
+  [JOdbVu14phvdjhaY] Perpetual Potency (Toxicologist)
+  [MtHLCQGD6OW98WC2] Personal Barrier
+  [5Xj38QeMKcFdrzqH] Phlogistonic Regulator
+  [8jELNQUBMAXUj3zR] Physical Protections
+  [lfwdsx5uJTNw6rF3] Plant Eidolon
+  [YL3yActlXBpXrSBl] Plunderer of the Hive's Riches
+  [y0jGimYdMGDJWrEq] Polymath
+  [7JK2a1D3VeWDcObo] Powerful Alchemy
+  [SB8UJ8rZmvbcBweJ] Powerful Fist
+  [Qrhw4SILfT8YNQgB] Precise Discipline
+  [RQH6vigvhmiYKKjg] Precise Strike
+  [u6cBjqz2fiRBadBt] Precision
+  [Ftz5jVa9X6aXybkC] Precognitive Reflexes
+  [tIpJHInpblTed5ZK] Premonition Reflexes
+  [GI09dKNZVCPdSGZC] Pride
+  [nzgb43mQmLgaqDoQ] Primal Hierophant
+  [j5TZw3xoIo6Lz0Re] Prodigious Will
+  [1tyNn9sduyexXLfL] Psi Cantrips and Amps
+  [iXwqJyBsjJNrKJae] Psychic Spellcasting
+  [kLschzVZFoe3U63C] Psychic Weapon Expertise
+  [a58MGVX2L589sC9g] Psychic Weapon Specialization
+  [v7DxQ3QRa1WyTLTd] Psychopomp Eidolon
+  [sPtl05wwTpqFI0lL] Quick Alchemy
+  [04lXNnt73rF3RNc4] Quick-Tempered
+  [WZUCvxqbigXos1L9] Rage
+  [ie6xDX9GMEcA2Iuq] Raging Resistance
+  [Oa0ENh8Zh7BftViG] Rain-Scribes
+  [5likl5SAxQPrQ3KF] Ranger Expertise
+  [QhoW8ivPvYmWzyEZ] Ranger Weapon Expertise
+  [XKhg55V7WmpLrvqL] Rascal
+  [fOulT6iKVqIK4jJX] Razor Prongs
+  [qgEIQPhtEV6d1zB2] Reaction Time
+  [hmShTfPOcTaKgbf4] Reactive Strike
+  [J46wcNqKXvtokBD1] Reconfigure
+  [srcPBNjhq7FBSmi3] Red Mantis Magic School
+  [UyuwFp0jQqYL2AdF] Redemption
+  [SIkSIln5G1J73PrM] Reflow Elements
+  [DhdLzrcMvB93Rjmt] Regalia
+  [5cjr4uwygBp6vihP] Reinforced Ego
+  [3XK573A7GH1rrLgO] Relentless Reaction
+  [cU2ofQLj7pg6wTSi] Research Field
+  [0TjNGzs0FuD7JBf4] Resolute Faith
+  [ViXWZMvWWYkVj0cQ] Restless as the Tide
+  [X3nPGnqh6rkRJ75i] Resurgent Maelstrom
+  [NXUOtO9NytHQurlg] Revelation Spells
+  [9PYHXFMmbHyp4aTL] Reveler in Lost Glee
+  [qMtyQGUllPdgpzUo] Revitalizing Rage
+  [tXbadIT3LzwuSR19] Revolutionary Innovation
+  [lgv4VIoj5TLhm9u0] Ripple in the Deep
+  [f3Dh32EU4VsHu01b] Rogue Expertise
+  [fMHYzXEUMoWskKMF] Rogue Resilience
+  [uGuCGQvUmioFV2Bd] Rogue's Racket
+  [Mlane2mQ7gCFQrfw] Root Epithet
+  [ptBLVvRqn1fA3A4l] Rope Shot
+  [3KPZ7svIO6kmmEKH] Ruffian
+  [rYfmpMBy7wd1VHeO] Rune Capacity
+  [HYTaibaCGE85rhbZ] Runelord
+  [AkIJrmsX3kjHqQ0b] Sacred Body
+  [uTBiXs4zWkmRG7qF] Savvy Reflexes
+  [9mYcuun58wYNL1Ci] Scar of the Survivor
+  [wObrT6PytPdS5aUi] School of Ars Grammatica
+  [E4GZDMn4DYk6qSEV] School of Battle Magic
+  [YZ2XPmx1WHyWtM0g] School of Civic Wizardry
+  [XXnGHBxNZvRsdkKM] School of Gates
+  [jtAqb5rnhQblZuM8] School of Kalistrade
+  [dPAwM9IdabdH68mW] School of Magical Technologies
+  [L5FiuXsfW6Sa31gO] School of Mentalism
+  [ZBFICTkzUjE4BDGJ] School of Protean Form
+  [KGkWSv9rARpwWzXW] School of Rooted Wisdom
+  [aYWPtW5T4Lx07Occ] School of Thassilonian Rune Magic
+  [xYYhJtGhFSWNifcO] School of Unified Magical Theory
+  [ZpFCZnVzIfZLfNii] School of the Boundary
+  [n2LRzksKVSzOuzqN] School of the Reclamation
+  [ZvfxtUMtfIOLYHyg] Scoundrel
+  [ZEUxZ4Ta1kDPHiq5] Second Adept
+  [OnfrrwCfDFCFw0tc] Second Doctrine
+  [sa7BWfnyCswAvBVa] Second Doctrine (Cloistered Cleric)
+  [D34mPo29r1J3DPaX] Second Doctrine (Warpriest)
+  [N5Gnf73TvuO6Reoj] Second Gate's Threshold
+  [Z8WpDAdAXyefLB7Q] Second Implement
+  [y6qnbUc8y0815QNE] Second Path to Perfection
+  [phwQ2MrDZ13D2HxC] Second Skin
+  [NRQOorKeZ310FXuk] Seer
+  [ZCfPjOn6JJ8Zrgvg] Segmented Frame
+  [DFDonF73QRMkEPu7] Seneschal
+  [ktgzHtKoeUZ5H8KA] Shadow Sheath
+  [haYJQRVJ8RaA74nt] Shaman
+  [dZNAXTQovlWVvAyX] Shared Reflexes
+  [eZPfHVz14j42jCnS] Shared Resolve
+  [QiMlJ33kNEoyh1M0] Shared Vigilance
+  [aFVxfp7uQ0ac87GN] Shepherd of Errant Winds
+  [84GDSAXaMKMTg2IT] Shield
+  [eZNCckLzbH3GyncH] Shield Block
+  [RkofVX55ciXZyfAA] Shootist's Edge
+  [9c57R18pfgfqlBCD] Silence in Snow
+  [itTk4dBouzz89vs9] Simple Weapon Expertise
+  [dmK1wya8GBi9MmCB] Skillful Lessons
+  [GyvVXuL0fDaNsa93] Skin Hard as Horn
+  [iecFmUwSrytQNwoE] Skybearer's Belt
+  [vXbk7Nm1TOTTUNvF] Slinger's Precision
+  [cz9fwc6KSkqxD3Nn] Sloth
+  [j1JE61quDxdge4mg] Sneak Attack
+  [gmnx7e1g08bppbqt] Sorcerer Spellcasting
+  [yBvGqA6Edp6ImaR3] Sorcerous Potency
+  [8AdMvVrcx40iaMwT] Sovereignty Epithet
+  [maGzhKLmgubAdUlN] Sparkling Targe
+  [2XlUg9JXtwnSbWOY] Speaker in Sibilance
+  [sTWY6PLqr1X7icgZ] Speed Boosters
+  [OAcxS625AXSGrQIC] Spell Blending
+  [6FsusoMYxxjyIkVh] Spell Repertoire (Bard)
+  [cFe6vFb3gSDyNeS9] Spell Repertoire (Oracle)
+  [1mMdsSIVsyyqNr2t] Spell Repertoire (Psychic)
+  [lURKSJZAGKVD6cH9] Spell Repertoire (Sorcerer)
+  [Ju2Tp5s5iBB76tQO] Spell Repertoire (Summoner)
+  [QzWXMCSGNfvvpYgF] Spell Substitution
+  [KVj5ofUwu3VJSrVw] Spellstrike
+  [ghIsqhEsJTvjJiNl] Spinner of Threads
+  [TQqv9Q5mB4PW6LH9] Spirit Instinct
+  [cAuV9xgPTwZ26Nj0] Spirit Striking
+  [X0k3njLOLX0322Po] Spore Order
+  [Klb35AwlkNrq1gpB] Staff Nexus
+  [ImJ09rEZW5WtS26L] Stalker in Darkened Boughs
+  [r2ZPRAw9c3VGZi8A] Starless Shadow
+  [Pew7duAozEeAemif] Starlit Span
+  [LC8i3ZJjhhKEHSLI] Starshot
+  [ILGq8LQBnwsAz2jK] Steward of Stone and Fire
+  [fKTewWlYgFuhl4KA] Stone Order
+  [acqqlYmti8D9QJi0] Storm Order
+  [huDGjojm3hnuA1E8] Strained Metabolism
+  [2Fe4YZCvAr9Yf6w7] Strategic Strike
+  [Wpdeh6EkcAKA60oH] Stubborn
+  [6HCI2iHyBZAr7a4P] Studious Spells
+  [TALz3cU06Hb14Key] Stylish Combatant
+  [pthjQIK9pDxnbER6] Stylish Tricks
+  [79ZetrRF6S01P4Vf] Subconscious Mind
+  [X3TtVdNhrydeQ3SX] Subtle Dampeners
+  [gWcN75VNpSZ4FqNb] Summoner Spellcasting
+  [SCYSjUbMmw8JD9P9] Superstition Instinct
+  [1MHXjNczVZfVvDP6] Supreme Incarnation
+  [w6rMqmGzhUahdnA7] Surprise Attack
+  [RyHp6642poxvehjy] Swarm Eidolon
+  [U74JoAcLHTOsZG6q] Swashbuckler Expertise
+  [beW1OqibVQ3fBvRw] Swashbuckler's Style
+  [bBGb1LcffXEqar0p] Swift Prey
+  [2IysodKQuf62jmd7] Tactics
+  [WxkZMlETXo165XnC] Tangle Line
+  [e6PhXRpuyZkVoCQb] Taunt
+  [zovmBa6cipFsg8GA] Teacher of Heroes
+  [2ImD2TB0RVic1VUc] Tempered Reflexes
+  [W9cF7wZztLDb1WGY] Tempest
+  [bYooavyooaCqdhYJ] Tempest-Sun Mages
+  [SRS8102DGTzJ4NmC] Tensile Absorption
+  [yvdSUIRU5uLr5eF2] Thaumaturgic Expertise
+  [VywXtJCa0Y9fdGVH] Thaumaturgic Mastery
+  [pa3Q4L7YwYGksuQK] The Brave
+  [HkN5OePNW60bce77] The Cunning
+  [Mu89z7bsdXfZTUwb] The Deft
+  [1rlBo3LcwIuPDCvz] The Distant Grasp
+  [rvpTsj9epRuNH3uB] The Infinite Eye
+  [FdLx4VODZEYLGOK9] The Inscribed One
+  [HRtspa4zHLD5cw8v] The Last Ruler
+  [t74H8o9zHFx43Bdg] The Mournful
+  [5tSR0WzMPFn5s3Xs] The Oscillating Wave
+  [GF9uIGA947DiC2dR] The Proud
+  [orqLdCTvno0mx2j8] The Radiant
+  [9OwWgOP8ZWxTAqbg] The Resentment
+  [rdWWlqvxXgfWDaSO] The Silent Whisper
+  [8dAm3ULUqaK4N5a7] The Tangible Dream
+  [FaSY47siV1x6CAQp] The Unbound Step
+  [ydI39ViUy22nBRn6] The Unseen Broker
+  [wAh2riuFRzz0edPl] Thief
+  [hNBYP7FbvIBoS9CV] Thief of Moonlight
+  [bRAjde9LlavcOUuM] Third Apparition
+  [gxNxfN9OBlQ1icus] Third Doctrine
+  [s8WEmc4GGZSHSC7q] Third Doctrine (Cloistered Cleric)
+  [Zp81uTBItG1xlH4O] Third Doctrine (Warpriest)
+  [GfQ5MngIn74OYhQL] Third Gate's Threshold
+  [zxZzjN2T53wnH4vU] Third Implement
+  [haoTkr2U5k7kaAKN] Third Path to Perfection
+  [6dtTNqL4SdPFKOrh] Thousand-League Sandals
+  [EslxR2sbDK9XJaAl] Time
+  [jpS7wcMnBXK1rS4J] Titan's Breaker
+  [MyN1cQgE0HsLF20e] Tome
+  [U9t3cmF4eXFiF7oI] Tough To Kill
+  [P9quO9XZi3OWFe1k] Toxicologist
+  [PeZi7E9lI4vz8EGY] Trackless Journey
+  [rNsdp5wDGQT5SZgf] Trespasser In Death's Realm
+  [HPYo5j8GgQIVoOOr] Troll Deviant Classification
+  [QsnIuPG2O8VzRW4d] True Creed
+  [q1Y12Pg2gQg2FJPR] Twin Juggernauts
+  [6YJ8KFl7THkVy6Gm] Twisting Tree
+  [ScUPQN2FDfr9shQj] Unassailable Soul
+  [2mVEzA3OtfLMBNRm] Unbreakable Expertise
+  [QqgWFjBWbiK2fS1A] Unbreakable Legend
+  [tgh1l7cWQtdpkJvC] Unbreakable Mastery
+  [wDSb9LGZhTa0FZB5] Undead Eidolon
+  [Jm8L7uSM01pJxSiW] Unfailing Bow
+  [y0WQzzshwGIymZsr] Unfurling Brocade
+  [RlwE99yKnhq8FUuy] Unimpeded Journey
+  [HwUps0waR29bwlTI] Unleash Psyche
+  [9ItMYxEkvxqBHrV1] Unlimited Esoterica
+  [P34Jx6i4GJGoqTtG] Unlimited Signature Spells
+  [v0EjtiwdeMj8ykI0] Untamed Order
+  [4nFnYNPMXIaI7KiY] Unyielding Resolve
+  [ivtpFSNKYZGvApBe] Uzunjati
+  [M3q0KIyuMvSgUZH7] Vanguard of Roaring Waters
+  [RI8NqxswR9Am2ZzX] Verdant Core Deviant Classification
+  [0H2LxtiZTJ275pSD] Versatile Legend
+  [PBQh0amk1FlomV0r] Versatile Vials
+  [pHUi7KCh1DH5pxMe] Victor's Wreath
+  [QOOwC3S41CKGkxlN] Vindicator
+  [8BOFeRE7ZfJ02N0O] Vivacious Speed
+  [d5BFFHXFJYKs5LXr] Voice of Nature
+  [Kf9lSN6pVS2Hy4KI] Walls of Will
+  [pDxdE8S8QJV2PGiB] Wand
+  [EMErBnhrgUHEKAsZ] Wandering Reverie
+  [vky5bQfK7SG3uOMA] War Magic
+  [w3HysrCgDs5uFXKX] Warden Spells
+  [gc6OMDRxTpSfsVtk] Warden's Endurance
+  [WXATTZWhe3QpyrYR] Warfare Expertise
+  [0Aocw3igLwna9cjp] Warpriest
+  [N03BtRvjX9TeHRa4] Warrior
+  [HssOCNIpcsmoeQ8T] Warrior of Legend
+  [MvunDFH8Karxee0t] Water Gate
+  [FuUXyv2yBs7zRgqT] Wave Order
+  [a3pSIKkDVTvvNSRO] Way of the Drifter
+  [qRLRrHf0kzaJ7xt0] Way of the Pistolero
+  [QWXvksGJhOjXbBqi] Way of the Sniper
+  [OmgtSDV1FubDUqWR] Way of the Spellshot
+  [YryaWAGcHeaRnXzS] Way of the Triggerbrand
+  [vB0yVFxJVZwalt2g] Way of the Vanguard
+  [YiDkrwaxiF7Gao7y] Weapon
+  [F5BHEav90oOJ2LwN] Weapon Expertise (Swashbuckler)
+  [bok3P78CMchFibxC] Weapon Innovation
+  [F5VenhIQMDkeGvmV] Weapon Legend
+  [v8UNEJR5IDKi8yqa] Weapon Tricks
+  [mRvyq7G0rqRP1EAr] Wellspring Magic
+  [4zE3seVFtLPNw9EQ] Whisper of Wings
+  [pgqhlWAJ18FXaHeO] Whose Cry is Thunder
+  [yqaRnXFjRnFWsWvY] Wild Willpower
+  [e0VhUyjz1clW3sC4] Wilding Steward
+  [RiAGlnnp4S21BAG3] Wildsong
+  [NhcF2CbXA8R1UCg4] Will Expertise
+  [FuVO8ksHI1B5ozVI] Will of the Pupil
+  [4lGhbEjlEoGP4scl] Wit
+  [SOan0fqyFTrkqJLV] Witch Lessons
+  [zT6QiTMxxj8JYoN9] Witch Spellcasting
+  [k9P2mXRjyy5X24rH] Witness to Ancient Battles
+  [S6WW4Yyg4XonXGHD] Wizard Spellcasting
+  [GBsC2cARoFiqMi9V] Wizard Weapon Expertise
+  [8X8db58vKx21L0Dr] Wood Gate
+  [8Jjy7VsQAJJqCeyE] Wraith Deviant Classification
+  [wtPywk3wqEg3iYOP] Wrath
+  [jHOlcSnGyjCnwoPP] Zoophonia
+Feat/Feature (Deity Curse)
+  [OaUt41v2OrQkHpM4] Abadar - Major Curse
+  [NeAA1BHGGkRAmBDe] Abadar - Minor Curse
+  [n5p8QfZdptRZp0ii] Abadar - Moderate Curse
+  [GJdHcY56q2c3kSiA] Achaekek - Major Curse
+  [1QtjogbV1MsJp7x5] Achaekek - Minor Curse
+  [wXAVESzPURB1iBWW] Achaekek - Moderate Curse
+  [zu2yJaXxOus4tNqd] Alseta - Major Curse
+  [G4Y4qWEbFJXLdI2G] Alseta - Minor Curse
+  [BdV4uubwrn0KgD8H] Alseta - Moderate Curse
+  [J0aztZRSjNjJzwGy] Arazni - Major Curse
+  [pUtQOAKeXslaD5g3] Arazni - Minor Curse
+  [1abspMhs13VKLklY] Arazni - Moderate Curse
+  [yoXU4CqZtzgKXdlB] Asmodeus - Major Curse
+  [dLudHCFcj4p7KG3j] Asmodeus - Minor Curse
+  [y9DNpX7krUiOq0YI] Asmodeus - Moderate Curse
+  [1J5gmMhFP0Ul9o64] Besmara - Major Curse
+  [DYEN06j9VVTOXqFK] Besmara - Minor Curse
+  [0JDLq5rMOjUskRTG] Besmara - Moderate Curse
+  [4gVIjPeKV6ss1atA] Brigh - Major Curse
+  [yBoHo1dcZpKygfJE] Brigh - Minor Curse
+  [iT6MnLgzuVetCzm7] Brigh - Moderate Curse
+  [fV940VM5RCsNwUvA] Calistria - Major Curse
+  [wIjqVRP0Hm2bIfyc] Calistria - Minor Curse
+  [nqOoUH4r8NEi1i2g] Calistria - Moderate Curse
+  [AJj2o3uWKH3ARyFr] Casandalee - Major Curse
+  [8jHjxcB33N4BULE1] Casandalee - Minor Curse
+  [496UIvkjyrae8xzb] Casandalee - Moderate Curse
+  [QGUFWuz9uF49EIhy] Cayden Cailean - Major Curse
+  [fLBNXULLPalAKlYe] Cayden Cailean - Minor Curse
+  [x1QrKuvZ2TbTvLUY] Cayden Cailean - Moderate Curse
+  [9neKaRaRi9ekttts] Chaldira - Major Curse
+  [dRk4kWmtau9PLQAk] Chaldira - Minor Curse
+  [8GyJK2tNVMIuV8Wa] Chaldira - Moderate Curse
+  [z4GfG3GatAOELKyA] Desna - Major Curse
+  [Up7nUIT42zwhgZf4] Desna - Minor Curse
+  [CjRUOscsOwCmai8D] Desna - Moderate Curse
+  [C6Ercv1ugcTsbVA9] Erastil - Major Curse
+  [pwmFrNkLscXrDSPN] Erastil - Minor Curse
+  [3u3vav6qfAW6hPKE] Erastil - Moderate Curse
+  [jUitGTczLgoUK0rv] Ghlaunder - Major Curse
+  [pt4dHeoDwfj8adUE] Ghlaunder - Minor Curse
+  [y736aBzm4RKwB7RQ] Ghlaunder - Moderate Curse
+  [M78A7uQaa4Ig8pGU] Gorum - Major Curse
+  [NgwW7Wt2gO9SEwPX] Gorum - Minor Curse
+  [lR9KS3pQ4gGKNspP] Gorum - Moderate Curse
+  [kEAw5PMLdX2gHlwR] Gozreh - Major Curse
+  [XYM7v72doPR3LwgA] Gozreh - Minor Curse
+  [AohWtOzgk2Qr9ADl] Gozreh - Moderate Curse
+  [NV1w0rwc7Tkhhkac] Grandmother Spider - Major Curse
+  [qbo52AnXV8KDXLnL] Grandmother Spider - Minor Curse
+  [YXjcQMRNqJbosjan] Grandmother Spider - Moderate Curse
+  [0kOGxG08y4bGgLto] Groetus - Major Curse
+  [RLdclcC8zoNAVony] Groetus - Minor Curse
+  [lwkqTPPWeJ6olxa3] Groetus - Moderate Curse
+  [YHeCTSaw1sOnXhre] Gruhastha - Major Curse
+  [nz77SkH0xWbcw5SY] Gruhastha - Minor Curse
+  [sL6WZ4EIHcIuEwVW] Gruhastha - Moderate Curse
+  [sUi427H7MJnbiMxh] Hei Feng - Major Curse
+  [CboMubDaWRkG94Ff] Hei Feng - Minor Curse
+  [MZWAF1mNNUJOzeWW] Hei Feng - Moderate Curse
+  [zWshZRICuzP7DfFV] Iomedae - Major Curse
+  [IOaepssdwTanFooc] Iomedae - Minor Curse
+  [rA7ZM6WGnJNrWTmo] Iomedae - Moderate Curse
+  [XV9hL75EXA9tIusv] Kazutal - Major Curse
+  [vJd6Ikya7B6XH4lb] Kazutal - Minor Curse
+  [MaaMu5jrfCP8w8SW] Kazutal - Moderate Curse
+  [QuNXNPHvh4DBmyZH] Kurgess - Major Curse
+  [Ul5jjHfvvfB14a3z] Kurgess - Minor Curse
+  [ffflmrfFtpFrnVqC] Kurgess - Moderate Curse
+  [py9v5HfCIzCoyC0C] Lamashtu - Major Curse
+  [5x0wEbgxYmXonBuN] Lamashtu - Minor Curse
+  [gDBa72Y2jokr8Zzg] Lamashtu - Moderate Curse
+  [Gv05Y1IXI4RWK6YO] Milani - Major Curse
+  [zMuLnoGROhRhqbDp] Milani - Minor Curse
+  [oqM1fFyHNigCNBsf] Milani - Moderate Curse
+  [4sZ9tpmPj4LIgPvU] Nethys - Major Curse
+  [KjPTFfxMAqCngQFB] Nethys - Minor Curse
+  [CmHQGVyNZ7aOmMcd] Nethys - Moderate Curse
+  [DjVTszddTHSo9fkZ] Nivi Rhombodazzle - Major Curse
+  [3hZjK8dKmjWUyotV] Nivi Rhombodazzle - Minor Curse
+  [8GElMYCPjhK5uHAj] Nivi Rhombodazzle - Moderate Curse
+  [YeWT4MjQ8vDmSThs] Nocticula - Major Curse
+  [B69aBTRn2BwSo23z] Nocticula - Minor Curse
+  [6Cpm04jBSzSwe2oC] Nocticula - Moderate Curse
+  [wREsKC8CTifEyj6v] Norgorber - Major Curse
+  [XFd7rnb9cchNw0WN] Norgorber - Minor Curse
+  [0PMqydlsIjj8GNnl] Norgorber - Moderate Curse
+  [DnlAmlrrKv3jwaOq] Pharasma - Major Curse
+  [ParIWsb6B4fdhrHF] Pharasma - Minor Curse
+  [1hdWNyedYvuZgtPr] Pharasma - Moderate Curse
+  [PoHos7qriDzQN7Gw] Rovagug - Major Curse
+  [1nALC8yWtjBDEaOC] Rovagug - Minor Curse
+  [d198p8UBPK3VcKi9] Rovagug - Moderate Curse
+  [DuGA57MDiwEKp7Y1] Sarenrae - Major Curse
+  [VZodqtMF3qrMl8a7] Sarenrae - Minor Curse
+  [V7FYIgphCCkYsEXF] Sarenrae - Moderate Curse
+  [ILtU0TAUZcOcwkkG] Shelyn - Major Curse
+  [jhixjUJZlCetNRjH] Shelyn - Minor Curse
+  [vU5leGDNAZSfPgTz] Shelyn - Moderate Curse
+  [wZWklm7jLry2rTOk] Shizuru - Major Curse
+  [LfiMah3iJnnjPi29] Shizuru - Minor Curse
+  [BKZRjVVt7hkvEpk3] Shizuru - Moderate Curse
+  [AySifuRSqWzDkCDt] Sivanah - Major Curse
+  [hoXFKbMHeUabjW3s] Sivanah - Minor Curse
+  [6CLe2ZOkLSi27S2Z] Sivanah - Moderate Curse
+  [c2wwILmpgyXIjlfe] Torag - Major Curse
+  [845vvISfgkk6sei0] Torag - Minor Curse
+  [AfuH02H6ib4KYS6C] Torag - Moderate Curse
+  [FRmpIgwDHeewpFkL] Tsukiyo - Major Curse
+  [6Iz9b01O5t31ZioP] Tsukiyo - Minor Curse
+  [P9ujY9f0o779TeEn] Tsukiyo - Moderate Curse
+  [eVRjDKt0N0qSmpCn] Urgathoa - Major Curse
+  [XfMZ83VA7dtF7fL5] Urgathoa - Minor Curse
+  [9EMaYf6odFEyjdSr] Urgathoa - Moderate Curse
+  [SaiJX9KBN3lC0RUy] Zon-Kuthon - Major Curse
+  [lI7bDExxA2zQq1sP] Zon-Kuthon - Minor Curse
+  [aOVXhHVkLw9dLCdR] Zon-Kuthon - Moderate Curse
+Feat/Feature (Deityboon)
+  [m33aOQij1BDcArN9] Abadar - Major Boon
+  [fXEeTSVINdWaKHhw] Abadar - Minor Boon
+  [DfXlr5qqbcjJN3gh] Abadar - Moderate Boon
+  [eFwCopyvVam6GiCT] Achaekek - Major Boon
+  [bvBzvLDKM5sAJm9s] Achaekek - Minor Boon
+  [xwhPzOXxX1fON3j4] Achaekek - Moderate Boon
+  [auoQ66gY4r7Tk3lc] Alseta - Major Boon
+  [ctcZm0WGiBKVWVYd] Alseta - Minor Boon
+  [pf2pAvNcz1Qcbowg] Alseta - Moderate Boon
+  [r9hOxyTwN0DsrTPU] Arazni - Major Boon
+  [LMK1RXvxxD0JP0L4] Arazni - Minor Boon
+  [HXRLOkyO8F374X8R] Arazni - Moderate Boon
+  [sy5UyOvxitqX244D] Asmodeus - Major Boon
+  [fV0t8xagcbqwvTpQ] Asmodeus - Minor Boon
+  [aV1I9VmMQBaFU9M9] Asmodeus - Moderate Boon
+  [unfh0BOx2PEhxWGB] Besmara - Major Boon
+  [9nCMvbz3e71AgsoW] Besmara - Minor Boon
+  [jDVTrMaswJRJRTuf] Besmara - Moderate Boon
+  [XQg4eq4yIyEO7z3M] Brigh - Major Boon
+  [gy4ThzGHW3plFZ2a] Brigh - Minor Boon
+  [pEtqyTx6Oa0OqNKl] Brigh - Moderate Boon
+  [FeCcooyIb1JDQhd7] Calistria - Major Boon
+  [yWASKzumwmv4TgSe] Calistria - Minor Boon
+  [Ks1HaYEuSRybaq8U] Calistria - Moderate Boon
+  [2i4AQ2tHph54SzRD] Casandalee - Major Boon
+  [Ca8ZQssvIgH6WEwZ] Casandalee - Minor Boon
+  [uM9dzDmXfnpYCCrc] Casandalee - Moderate Boon
+  [ZPlvqkjEv9a7J76T] Cayden Cailean - Major Boon
+  [La6t4fVId26PkmYk] Cayden Cailean - Minor Boon
+  [fsKVskUhWwMgvUaT] Cayden Cailean - Moderate Boon
+  [1WPIDGaeRd76EXm1] Chaldira - Major Boon
+  [NZFTnX1xzI40q8Qr] Chaldira - Minor Boon
+  [6HcZezAVWArSonu0] Chaldira - Moderate Boon
+  [DVILYNQVB2hx9Chl] Chilling Paralysis
+  [VMpc8QWEZxSH8Mr4] Curiosity
+  [fsxCcyWpag5iuWOU] Delusion
+  [pHXGTgjwWY3OBRF2] Dematerialize
+  [mcVlGufQ8rQRe61Y] Desna - Major Boon
+  [LOlv11WEGUQWYKna] Desna - Minor Boon
+  [4m2dQ2fvVWxtokVe] Desna - Moderate Boon
+  [ekiKKfsBDFEeVmun] Duty
+  [nFrCY6tT2B8uxaO3] Erastil - Major Boon
+  [hrTl9kfSNrOQeNze] Erastil - Minor Boon
+  [CL8lLQJWd4N89QIm] Erastil - Moderate Boon
+  [0HChyDaXdpXN11q4] Flickering Figure
+  [SnIvcCNASDzgevQK] Flight
+  [SvR7Ez1lfnN4You5] Geb's Blessing
+  [d2mkwn858zIqhLS7] Ghlaunder - Major Boon
+  [0hE3yCBhmReWtZGA] Ghlaunder - Minor Boon
+  [innbfBPD1VsBIVDn] Ghlaunder - Moderate Boon
+  [8G0USrxM7d4B4EVI] Gorum - Major Boon
+  [HrV31rAkNjV4KfCU] Gorum - Minor Boon
+  [kstqMWge32n0Lfdz] Gorum - Moderate Boon
+  [vfQ7TsScMBTNiznn] Gozreh - Major Boon
+  [uVZrqxtOOutr4Ss9] Gozreh - Minor Boon
+  [AvjRCVzLmxapFOLV] Gozreh - Moderate Boon
+  [dFWAMWqnioz6RZxc] Grandmother Spider - Major Boon
+  [7HOxIB1abpVRUjY9] Grandmother Spider - Minor Boon
+  [rN9uF0XUMm4LPFOk] Grandmother Spider - Moderate Boon
+  [WWyPOtmJc6lDLfgL] Groetus - Major Boon
+  [COLF56taxqleYkcZ] Groetus - Minor Boon
+  [9jFdhTtL8zElWdRC] Groetus - Moderate Boon
+  [3yYlHV7GBrafsDwE] Grudge
+  [9jxwttnEfxrOaCsY] Gruhastha - Major Boon
+  [wpOtcMUdymzpbtC4] Gruhastha - Minor Boon
+  [YYc9SJ6t3gOMWYDi] Gruhastha - Moderate Boon
+  [02FtcdSA8tjFNmvD] Hei Feng - Major Boon
+  [AOBhF0grlwKJSuxi] Hei Feng - Minor Boon
+  [McPpckNcC9hoc39a] Hei Feng - Moderate Boon
+  [dHcGihuimtCf1NOs] Iomedae - Major Boon
+  [dTJP2Hg4ZJu4Ck2y] Iomedae - Minor Boon
+  [qTmjEC528YnvPgXE] Iomedae - Moderate Boon
+  [kCCrjskDIbG0e74O] Irori - Major Boon
+  [wEqPbkQMuqlL2TPn] Irori - Major Curse
+  [fV0Xa1Bd3BoWACgT] Irori - Minor Boon
+  [DSfHCm8PDL5hLzZ0] Irori - Minor Curse
+  [xrczhivVmi7MrEfz] Irori - Moderate Boon
+  [qhVfbZCxZJS8NmB3] Irori - Moderate Curse
+  [T2csDhA9WsNiwpd5] Kazutal - Major Boon
+  [ubXii3t9Jf9YHcCk] Kazutal - Minor Boon
+  [LwXdmLWOBUIV1By0] Kazutal - Moderate Boon
+  [to4pGXcJqF1VpqBt] Kurgess - Major Boon
+  [9yABJNudAI1IvifR] Kurgess - Minor Boon
+  [XujNRFYY4w1NgArr] Kurgess - Moderate Boon
+  [XFiI9qC4MNX4WUdh] Lamashtu - Major Boon
+  [6f8zTNIs5XXzkhkR] Lamashtu - Minor Boon
+  [tFnPBYcAZ0X3GbI5] Lamashtu - Moderate Boon
+  [w4t0ElpqNQRFCaPJ] Love
+  [LOJVm2Tt4K2XdVLs] Milani - Major Boon
+  [7Ky13a2fl5KUuaMd] Milani - Minor Boon
+  [OV7cKDx5b50sz875] Milani - Moderate Boon
+  [8ZNtiMxoJIP1DJ9Q] Nethys - Major Boon
+  [jVeuBZsa4iFg0wC6] Nethys - Minor Boon
+  [HdPVL76QiDhsLCA9] Nethys - Moderate Boon
+  [MLmgyIZRJX1hfaPR] Nivi Rhombodazzle - Major Boon
+  [8Be5VeyjWRZUdxde] Nivi Rhombodazzle - Minor Boon
+  [A8HRlQB7reEHp50k] Nivi Rhombodazzle - Moderate Boon
+  [r4VjA1Wje3mtK2M4] Nocticula - Major Boon
+  [0bM6m3Gx8Th3NxXp] Nocticula - Minor Boon
+  [8x308UNvYYDuIHXH] Nocticula - Moderate Boon
+  [lOIu9jYDAR2rDe4p] Norgorber - Major Boon
+  [2EKgNifq3ozzKYfI] Norgorber - Minor Boon
+  [hUSknn3LYmT7eKzT] Norgorber - Moderate Boon
+  [g6iKvH7Y3InQtZ8K] Obsession
+  [w1nzN61S6NfkDH7Y] Passion
+  [mHsp4jGurcemml59] Persona Trait
+  [U7ZJfuPLQPyoaj4M] Pharasma - Major Boon
+  [0vmwZrIhm5rWHkYh] Pharasma - Minor Boon
+  [xrSgGobm5QtTcABQ] Pharasma - Moderate Boon
+  [KtqDsKBuOmCkbDcR] Resist Death
+  [eckkKdNGlaPlAgOW] Resonant Reflection: Reflection of Life
+  [MXATTT52FQc8MTZv] Resonant Reflection: Reflection of Light
+  [mL13OZS2t1eMRlly] Resonant Reflection: Reflection of Stone
+  [fOz4CDZmc6CSKAUm] Resonant Reflection: Reflection of Storm
+  [7Rpu9g6GBxg3jmoG] Resonant Reflection: Reflection of Water
+  [KbQXDTBi5MKtHbpU] River's Reflection
+  [cFz09CWKzff2cC73] Rovagug - Major Boon
+  [4FkVB4uQK4eHZJ6Z] Rovagug - Minor Boon
+  [a1OZtMQSzjYOm0P3] Rovagug - Moderate Boon
+  [sjLNgLFyDvTt6VVV] Sap Life
+  [dL6r0VfFIWlAazDW] Sarenrae - Major Boon
+  [e9bdt8UH7ZvpRrLz] Sarenrae - Minor Boon
+  [S1qGyGG25YImRhmS] Sarenrae - Moderate Boon
+  [l7n8n4fAoRLIn95W] Shelyn - Major Boon
+  [tilqIbJZLqeknTYo] Shelyn - Minor Boon
+  [zoJjzir97Ie7tbp0] Shelyn - Moderate Boon
+  [GKyH7IQHrmmCnuop] Shizuru - Major Boon
+  [KuNcNP42LxehKnaV] Shizuru - Minor Boon
+  [10F2EKASFp9bjsjF] Shizuru - Moderate Boon
+  [WVlWzn918RNExxpe] Sivanah - Major Boon
+  [DJxDsRXhqXvABYzK] Sivanah - Minor Boon
+  [AodAErjWnvGZaL4M] Sivanah - Moderate Boon
+  [YdG3UwVBia5AyLjO] Spite
+  [AdNAeWhnq5Is3AZb] Torag - Major Boon
+  [e7Y4jKHQ3ptbSuxc] Torag - Minor Boon
+  [30Xdyvplx7MfX1nA] Torag - Moderate Boon
+  [Xlu60yqtTXutwG2G] Tsukiyo - Major Boon
+  [d84VbnhyQ77abLKF] Tsukiyo - Minor Boon
+  [Hvz04dGqmV8x25bw] Tsukiyo - Moderate Boon
+  [UnQ8oHYc0dBJHZv9] Undying Flesh
+  [dZU3HdI2oO8LFjGq] Urgathoa - Major Boon
+  [jfWeNqYj3rn9EysM] Urgathoa - Minor Boon
+  [N29LCwYfRWHtEqrS] Urgathoa - Moderate Boon
+  [eibN2Uf0dsHCU5rE] Zon-Kuthon - Major Boon
+  [wlBiDpWvjKiw9k2z] Zon-Kuthon - Minor Boon
+  [QVEkEdxCnoGxMo9l] Zon-Kuthon - Moderate Boon
+Feat/Feature (General Feat)
+  [muMOxZyduEFv8UT6] A Home in Every Port
+  [HCEKLGrnvu8RbfzM] Additional Circus Trick
+  [ihN8gkHSdPG9Trte] Adopted Ancestry
+  [m7KjpkAAh9PptJsY] Ancestral Paragon
+  [BStw1cANwx5baL6d] Armor Proficiency
+  [CxTtzIPni048jK3U] Axuma's Awakening
+  [tVQPg1p1pCm5puNc] Axuma's Vigor
+  [QRL79whClQDHljoi] Bloodsense
+  [aJUXbe9HJVvv0Mxa] Breath Control
+  [i4yRvVwvXbGZDsD1] Canny Acumen
+  [5ZsmRm7HvFAw2XDZ] Caravan Leader
+  [I0BhPWqYf1bbzEYg] Diehard
+  [z1Z22gTp7J1VRLSR] Different Worlds
+  [GdZLxDtFXaQI3Fop] Expeditious Search
+  [N8Xz5fuW6o7GW124] Fast Recovery
+  [c9fHUSI5lRdXu1Ic] Feather Step
+  [Ux73dmoF8KnavyUD] Fleet
+  [Wb3FHiDuY6Nuc0N0] Hireling Manager
+  [xT593tHyPkumPuzz] Improvised Repair
+  [2kwXTUjYYhoAGySr] Incredible Initiative
+  [4vu6P3cYoOOeUbLK] Incredible Investiture
+  [aFoVHsuInMOkTZoQ] Incredible Scout
+  [fD9xjrnPfJ8aQxYA] Keen Follower
+  [gfMP2aMs3YGONVeB] Numb to Death
+  [6yPrvbSDaa8glLjn] Pet
+  [38uOVS8fLZxraUrg] Pick up the Pace
+  [lHFz4MmebvPqTb0A] Prescient Consumable
+  [Rq5wkA8DtsmbzoGV] Ride
+  [yTLGclKtWVFZLKIz] Robust Health
+  [2KVllUXqgWq7jCmX] Sanguine Tenacity
+  [jM72TjJ965jocBV8] Shield Block
+  [wPHZhgKzNw4VcCFt] Skitter
+  [jFmdevE4nKevovzo] Steel Your Resolve
+  [fOIUmDGa9gkeCHA0] Supertaster
+  [9QQnv7nFpsNCGE89] Thorough Search
+  [AmP0qu7c5dlBSath] Toughness
+  [uudiUylT09WnHN7e] True Perception
+  [9jGaBxLUtevZYcZO] Untrained Improvisation
+  [x9wxQ61HNkAVbDHr] Weapon Proficiency
+Feat/Feature (Mythic Calling)
+  [1FCu53hOTJrCF2iW] Acrobat's Calling
+  [ADm8BpMlmoYUCyZy] Artisan's Calling
+  [LoTFGTJCAGJFUFYs] Bookkeeper's Calling
+  [wQ4VqAhhCbT5OC9k] Caretaker's Calling
+  [sJzi16AkcZrfa7oo] Demagogue's Calling
+  [Gsltv71YQJc55XSS] Doomsayer's Calling
+  [HnUzQqmAphx9nXDt] Dreamer's Calling
+  [Ix1AfiscT2x8wGAT] Echoes of the Scrolls
+  [gOdhbDkHgiRbR7DS] Echoes of the Spells
+  [gtLL1QoTepIo6qu4] Echoes of the Swords
+  [Lc7PS4JDnO6SWmiS] Guardian's Calling
+  [qRWnLtYNjz9z8Xe5] Handler's Calling
+  [xuotWgnajtwcN7X7] Hunter's Calling
+  [5M7ybjAyttZHAdtT] Runelord's Calling
+  [BJQt9j4HAwic5AST] Saga's Calling
+  [LigU977wR6qt5Vx8] Sage's Calling
+  [CPUunLbsBjRgfS10] Thespian's Calling
+  [R1Ierj67voEOc6xu] Thief's Calling
+Feat/Feature (Pfsboon)
+  [XoamInggkxLh6Zo0] Academic Conference
+  [BEaLe5M23Q7LKTLL] Adamant Wayfinder
+  [XBf4Uz3n0AwSmpXx] Adversary Lore
+  [DWcmLzzT1eYk76c7] AoA #146: Mwangi Summoner
+  [Nadcb08xcTAoPBEX] AoA #147: Boon A - Heroic Membership
+  [WV4J7NMgKXNlXonW] AoA #147: Boon B - Expanded Summoning
+  [VLjkX7HpDqKaidNd] AoA #148: Boon A - Crystal Clear
+  [CjW54WSPDcykzqj9] AoA #148: Boon B - Expanded Summoning
+  [8cMFcCa3h9XfWNkZ] AoA #149: Boon A - Advanced Training
+  [3K8yzfU2t9chVv6h] AoA #149: Boon B - Katapesh Companion
+  [wcOnL9nFDfCkNVMZ] AoA #149: Boon C - Expanded Summoning
+  [grkmoNwwHOROKER7] AoA #150: Boon A - Legacy of Ashes
+  [We3sJV72xtdPeMjp] AoA #150: Boon B - Paragon of Promise
+  [rdY0vyXfrIlkQgqd] Beginnings and Endings
+  [xUrt3LrfLHc1DS3l] Bequeathal (Rare)
+  [LocOjnBuS89OVLic] Bequeathal (Uncommon)
+  [AULqdNRDuCIl6nUc] Bequeathal (Unique)
+  [GRiNBy8yv4sWp1ua] Bequethal
+  [SI37oVZxjwXew3E4] Bring Them Back Alive
+  [XOwkaOX5bcK8pOtq] Career Change
+  [bMp6W5kPNyqBoOxm] Charitable Adventure
+  [vYSA5M9fgBdYiGLT] Combat Mentor
+  [5tWlPSGW5AEk10GJ] Consummate Dabbler
+  [gdkQ04RgMJZ0QxbZ] Crafter's Workshop
+  [oOB1uKvoBMGj7ykZ] Curse Breaker
+  [0zhQQK3gvu75ac1Q] Eager Protege
+  [jzJ575vAsw2MaRgo] Envoy's Alliance Champion
+  [l8WNWPFUdxcqEG6e] Envoy's Alliance Champion, Improved
+  [fRFTGKMXsLiFqLWu] Envoy's Alliance Gear
+  [SujEcE3H5n9kx1PI] Esoteric Wayfinder
+  [0OcuvvUnAv7dZYRU] Evolving Destiny
+  [ocS6B3AV1n7yHFd5] Exemplary Recruiter
+  [UWZfORgk1yVNV0RF] Exotic Edge
+  [1VWMLe12ZFqF9jah] Expert Hireling
+  [2QzXBsURLO7xECxO] FoP - Fiery Companion
+  [4lLhGgG30TMu8tIx] FoP - Noala's Lessons
+  [8fbBYNkFQgU3IQV0] Grand Archive Champion
+  [Tmqa8Q9zaYr0uj6F] Grand Archive Champion, Improved
+  [JNFxGm16sQBhh2fo] Grand Archive Gear
+  [4O3qxD3I4LUjl2Vq] Harmonic Wayfinder
+  [3AAzRnmJILWaaZWk] Heroic Aegis
+  [hghR0f5IetZBvyDR] Heroic Defiance
+  [Wz2F0qk4rxZeH311] Heroic Hustle
+  [0QRG6TAVwCWL2Zr8] Heroic Inspiration
+  [En3RdoXDAtyXdNKq] Heroic Intervention
+  [wkgBg5UD3bChfl4b] Heroic Recall
+  [UNlaVxb0pDov3efw] Heroic Resurgence
+  [sBXsfT0uYltF8TFE] Hireling
+  [rddlbymeG9KbQYQM] Hireling Translator
+  [KXO4CUklzuJ0tZnw] Home Region
+  [ph7CO8ong1sZmrNc] Horizon Hunters Champion
+  [Sc9gT40T28tFhSzq] Horizon Hunters Champion, Improved
+  [GMcaN2g09IQcamxc] Horizon Hunters Gear
+  [JGBC3npfrYNFmIMB] Iceferry Lodge Gear
+  [9TDhUd6rXEzojR4c] Inherited Wayfinder
+  [Sh46AoeCVyyfO4mT] Lantern Lodge Gear
+  [hy1gMMpRmujuw8i4] Leader By Example
+  [Mu5GQ9ZEz3geAYxK] Leshy Companion
+  [95R55tdobViU7ZWe] Magical Mentor
+  [ca869lJo8E51WcW4] Master Hireling
+  [Vmg31SsMjjimghzP] Menace Under Otari
+  [MN3MlIx7djj7WDNY] Meticulous Appraisal
+  [bcsusUErwGQYHj6d] Multicultural Training
+  [KdR3mLBcs7OzNsiE] Natural Skill
+  [0FwLrQb5EeQDAUNW] Naturalist
+  [a2ZAheGPFB3WrblT] Nexus House Gear
+  [XkNW2dq5hwWOViYg] Off-Hours Study
+  [7uj8i2ckfC3zEjsg] Open Road Lodge Gear
+  [yA4XwJFMiam3Gacc] Pathfinder Condition Removal
+  [0ZsykfABRrw2p8R5] Pathfinder Society (second edition) Replay
+  [AXPlFBeJcON3yNWG] Penitent Pathfinder
+  [awcOD618fuXZN3rh] Practiced Medic
+  [WGjcz2mkgGB1qCWw] Preserve
+  [mrlQrZd0yBwOj2lk] Professional Hireling
+  [aG5cua0K2SlurXxw] Promotional Accessory
+  [cjjRFoOE1GtjEA3F] Promotional Service Award
+  [SDDbh7KmDn5HUbst] Promotional Vestments
+  [PXtBhRVHM28angjV] Protective Mentor
+  [M8cJ8qOwWj7XN6h1] Radiant Oath Champion
+  [qaSlz43CHPiCoIOC] Radiant Oath Champion, Improved
+  [J6lNh2fUQ6jYTRak] Radiant Wayfinder
+  [rFgWvC1UADsavY5J] Resist Corruption
+  [M2lGGGaPIOimeA31] Resurrection Plan
+  [DkqU67wxvbDu0Qrs] Rugged Mentor
+  [U6QqFDstHNjEeOUS] Rugged Wayfinder
+  [YVpNrVBLRrHjaR4C] S1-00 - Nexian Researcher
+  [P1sdPHrbAfqrEAM3] S1-01 - Engraved Wayfinder
+  [ig06ikA6rnNP1JUb] S1-01 - Society Connections
+  [632pDmCtbQxBlE3d] S1-02 - Cryptid Scholar
+  [1welewgoB0z86Nms] S1-03 - Team Player
+  [6oTXrz56Evik64Fy] S1-04 - A Thorny Situation
+  [XybjaZJlmBFFztwJ] S1-04 - Touched by the Storm
+  [GIdtqEFKKgwPmDBq] S1-05 - Experienced Mountaineer
+  [WVOP420jZ4jSTYI8] S1-06 - Traveler of the Spirit Road
+  [0izXWwYqRGQq74mG] S1-07 - Blast from the Past
+  [T7gyK9LV14wI7Xdy] S1-07 - To Seal and Protect
+  [lJ1lNwGxV0IrsN2z] S1-08 - River Kingdoms Politician
+  [ZtLTqT4G5q8SLJCT] S1-09 - Ally of the Iruxi
+  [wdjRk8JaZGP1mjqD] S1-09 - Iruxi Bane
+  [giyLRNefaC3IsFay] S1-10 - Tarnbreaker Champions
+  [ePZOmPbGXzrEaXXs] S1-11 - Devil's Keep
+  [fTndDUqUDSVXM0Qm] S1-11 - Diggen the Liar
+  [XOVDOCsvNBX5LS8j] S1-12 - Valais's Assurance
+  [xVMouu7E7Xy7AGER] S1-13 - Convention Hero
+  [JznxnYTs38GYpW1p] S1-14 - Big Game Hunter
+  [hxp0fDMrB7BT3y3T] S1-15 - Finadar Leshy
+  [DcMAGJWq2G5kGRWn] S1-16 - Blood Offering
+  [taUqYoHuWH9uEbsn] S1-17 - Fey Influence
+  [Y69ZRmuoj0XK9AZm] S1-18 - Light in the Dark
+  [tX2vxY8RSdcBayEu] S1-18 - Narsen's Web
+  [p8TKPInhya6oab1w] S1-19 - Iolite Trainee Hobgoblin
+  [YVOyEfO8tTx4jj2q] S1-20 - Waters of Warlock's Barrow
+  [ZZvIzyH6SwyVkEYm] S1-21 - Maze Walker
+  [iRLU5DTWY16HIqcc] S1-22 - Doom Averted
+  [0CqkYRFUlb0tB9li] S1-23 - Seasoned Diplomat
+  [PbEqXHWiyzii4g8T] S1-25 - Grand Finale
+  [WYHPJyza1BJgtFq4] S1-Q01 - Sand Slide
+  [6gVFdrqhs0mihRao] S1-Q02 - One-Who-Waits
+  [y8sk7Q4uAtacYdR2] S1-Q02 - Student of the Unforgiving Fire
+  [NR19RYJLveHrFYvf] S1-Q03 - Legacy of the Gorget
+  [prHShOQxNpLXwlss] S1-Q04 - Fane's Friend
+  [RGSw5tAc4ALp97Qe] S1-Q04 - Stella's Associate
+  [MLn6UbZsU4PphXLE] S1-Q06 - Secrets of the Jistkan Alchemists
+  [DD1mlAEaXdM1pBze] S1-Q07 - Amateur Adjuster
+  [yNTePhAPVMguqUVA] S1-Q08 - Numerian Archaeologist
+  [RJYIefY9Skx8CAgw] S1-Q09 - Wayfinder Connections
+  [MuhZZkLR8y9eEndN] S1-Q10 - Sewer Dragon Recruit
+  [B7fDgC6tcv41lcP7] S1-Q11 - Amateur Genealogist
+  [RLzWznPsb2VpbxTy] S1-Q12 - Fruit Basket
+  [G7fN5K1TfmNhTb2w] S2-00 - Spark of Life (levels 1-2)
+  [ybrynsFe4a0jJcgz] S2-00 - Spark of Life (levels 3-6)
+  [6XUhCWU0h0qbgL5Z] S2-00 - Spark of Life (levels 7-8)
+  [CKyGNdBL8Qt4ysKt] S2-03 - Fluent in Cyclops
+  [rJfATB750MbndGeP] S2-08 - Baba Yaga's Tutelage
+  [Fy7gw5WhPD8Gzxeb] Second Chance
+  [opaFl76Nbz1dITLz] Secondary Initiation
+  [3lHqim7ttvoMmVXW] Sellback Plan
+  [J1hUP5SI4MJvlK36] Skillful Mentor
+  [KZrXvKlAVcpLgGF8] Society Recruiter
+  [JXoy329UKcfigoqk] Steady Hand
+  [M1flDLvjKBH9QPcx] Storied Talent
+  [K21KQsrR3RMcJ1du] Swift Traveler
+  [FKFbajAqZfZPEM1S] Treasure Bundle Insurance
+  [CW73M2apBaQh6wLm] Unparalleled Scholarship
+  [Gmzby7whs5O0wuYC] Untarnished Reputation
+  [G0hv2CI7TKcUcSVs] Vault Delver
+  [1FWpmtZHOLRvEIdp] Verdant Wheel Champion
+  [cyrntY2zgDyzxQGO] Verdant Wheel Champion, Improved
+  [6frkVrsCgTgFhMjl] Vigilant Seal Champion
+  [CLRt3iFqWlMwCNVl] Vigilant Seal Champion, Improved
+  [xmvanQdHy8olyshz] Vigilant Seal Gear
+  [GvPWLAjLYT1dKBTL] Ward Against Fiends
+  [SxUBWlQj6BT5g4Rw] Wayfinder
+  [lkURHShWYkx6JQb1] Woodsedge Lodge Gear
+  [HxAjewfLHEW3b5tT] World Traveler
+  [CPcMqEd4H5yIVl3i] World Traveller
+  [9w8TdCsGEpttXYuy] Worldly Mentor
+Feat/Feature (Skill Feat)
+  [f0faBEUPtspdutKx] Acrobatic Performer
+  [SC95hfEEHQs7E9cG] Acupuncturist
+  [BocFD2KV0qgUC76x] Additional Lore
+  [17FAYfreumeKbSGr] Advanced First Aid
+  [pKnX7MGZayqZui0Z] Aerobatics Mastery
+  [is3Oz9wt11lNq62K] Alchemical Crafting
+  [gnH9SpdNQegDqIar] All of the Animal
+  [knrawm4bMbDL9XS3] Ambush Tactics
+  [TZASOwBqVveGjw77] Analyze Idiolect
+  [Lc4dJZivRwU3QEmT] Armor Assist
+  [lB9MVGCJr7aJQuIH] Armored Stealth
+  [gEj8aJmCThMzAjKY] Ashen Veil
+  [W6Gl9ePmItfDHji0] Assurance
+  [XmF4q4rzKWg55vG4] Assured Identification
+  [zdjPTg6vRwg8r2Lm] Aura Sight
+  [nTHhkHfAItjrO9d9] Aurochs-Headed
+  [H3I2X0f7v4EzwxuN] Automatic Knowledge
+  [nJ3EBRat9yUgeWwv] Automatic Writing
+  [7F3sTNRoNsQgD8tX] Backup Disguise
+  [ePObIpaJDgDb9CQj] Battle Cry
+  [qvLcZGsV0HP2O0CG] Battle Planner
+  [nBlzWZnmYuFHrMyV] Battle Prayer
+  [iUCz2engECjvbSeB] Beautiful Knifework
+  [WqTqHPDbargixuej] Biographical Eye
+  [9o2VSlMQVPB4LN09] Bizarre Magic
+  [UHyoXbp8O6idQ6ee] Bless Tonic
+  [dz1rHYk3n9pUFfgm] Bless Toxin
+  [SmePERlF5BZl6cTo] Blessed Medicine
+  [0GF2j54roPFIDmXf] Bon Mot
+  [pLjvgeqwHrYdg411] Bonded Animal
+  [zGrUu3dUtqHrqGuo] Break Curse
+  [NT1U4UF1WqIkR5tA] Cadre
+  [MSyU208twPGKU16W] Calm and Centered
+  [lzCObPONWqrcmt30] Canopy Predator
+  [LQw0yIMDUJJkq1nD] Cat Fall
+  [SZ8J3NbtiizFaNzz] Change of Face
+  [lQs2i9L09MQiZSPC] Charlatan
+  [B6HbYsLBWb1RR6Fx] Charming Liar
+  [RlFZ648UR0Q0YECL] Chromotherapy
+  [TXXrkkFfNSWgHrn5] Chronocognizance
+  [TVFfTP9fHRidwBlW] Cloud Jump
+  [09PurtIanNUPfNRq] Combat Climber
+  [MMaUL7r99DY7nvds] Comforting Presence
+  [TMwqXqqggiblvEGZ] Commitment to Equality
+  [lUXVmSFJbaPos5pY] Communal Crafting
+  [B9cQLRHtXoLlF0iR] Concealing Legerdemain
+  [fvYwsHM9O1twQa5N] Consult the Spirits
+  [c85a69mB1urW2Se2] Continual Recovery
+  [BujTSrQI7o0dZolY] Contract Negotiator
+  [K3Pgj5z9OpLFzxgt] Cooperative Crafting
+  [JtjnFsOToBLnSRO9] Courtly Graces
+  [v62QzTwHOT3t86cL] Craft Anything
+  [xLD9EmkEmT8hgwv7] Craft Facsimile
+  [voYr7ygVcWmlg1f4] Crafter's Appraisal
+  [LDUWw2TeEEH0KA6M] Criminal Connections
+  [6O8MoMheHs5hNHX1] Crystal Healing
+  [YXyoBZFpOj3WRX3l] Cushion Landing
+  [1MZ4WNoNoJ4jj5Z0] Cutting Flattery
+  [nV29YjbLgRfEPXMR] Dashing Pickup
+  [68Kc4UyhnP4l8mxq] Dead Reckoning
+  [r7cgrrHh75R8UEqN] Deceptive Worship
+  [DqPZCCbWzfMMGFI8] Devil You Know
+  [WxL8NMW9JQ5igu0C] Diabolic Certitude
+  [5eNKs6738aykAhK2] Dirty Trick
+  [uF0ATN2Zw1Q67ew2] Discreet Inquiry
+  [jzflcD1XnBp2bSZI] Distracting Flattery
+  [4UXyMtXLaOxuH6Js] Distracting Performance
+  [hkSuxXOc9qBleJbd] Disturbing Knowledge
+  [yoeMOIgH8Snw1JCQ] Diverse Recognition
+  [dYMxP8SsHrwOze8v] Divine Guidance
+  [qibU5SZPFHMNnpAP] Doublespeak
+  [1Bt7uCW2WI4sM84P] Dubious Knowledge
+  [Y2Tb87cd2P3WAa5j] Dueling Acumen
+  [smYXWVI9WXmqpiCs] Eclipsed Vitality
+  [ucmJ2Z5VXUtCiE3q] Efficient Controls
+  [MWjbG8L5JWg888kJ] Efficient Explorer
+  [EZrxp0XxYh9rjghB] Embed Aeon Stone
+  [EZ24QwnFteLCrgLg] Emerald Boughs Accustomation
+  [9AZjpeeS824VsYv8] Emergency Medical Assistance
+  [dUnT3HWMFD3d2eBJ] Encouraging Words
+  [qaiwbAb1PaKrZ2O0] Energy Fortification
+  [p17VlHs0I4Yc4m34] Engine Bay
+  [6vwLzzrFfeiR9pm0] Entourage
+  [u6tLp3zTBweq7CxO] Environmental Guide
+  [YgbcLfAEdi4xxvX5] Evangelize
+  [QvBIYW6aAqoiyim3] Exhort the Faithful
+  [sMm0UfYxEPpq2Yzd] Experienced Professional
+  [t3btih0O5RUwWynt] Experienced Smuggler
+  [urQZwmzg2kS53vd5] Experienced Tracker
+  [TkCy7jZUjhD8IypE] Expert Disassembly
+  [gArdEleFCvUHtdGk] Express Rider
+  [0N8TtGSk5enoLBZ8] Eye for Numbers
+  [OtV7esAwza1U6Kwr] Eye of the Arclords
+  [IyJyZ1VQxS58Nk6V] Eyes of the City
+  [e6s2nIvlTycuzlR9] Fabricated Connections
+  [0UzxiSrTfVs0jvBa] Familiar Foe
+  [5f8gQxVdioUcgsTD] Familiar Oddities
+  [mwZzcwYVcTvxbXDl] Fancy Moves
+  [9SdFlVQW4vM8ggh8] Fane's Escape
+  [7LB00jkh6JaJr3vS] Fascinating Performance
+  [9OVRsU45zCOvRQ9q] Fear of God
+  [ZiSmhTsnQMLqsmyw] Final Rest
+  [Z7M3ImHWqUyGu6cN] Fleeing Diversion
+  [Rgx0AJoX6k6HcC7Q] Fluttering Misdirection
+  [IJQJBnD5CjKvFYEx] Foil Senses
+  [FbGPETHJR9VKxf9i] Folk Dowsing
+  [8qebBeOJsyRIchcu] Forager
+  [uwJQUFLymAWtJu1a] Forced Entry
+  [Ws9JlysHcFoz6WAQ] Forensic Acumen
+  [cmuvvPJvt2R16vGe] Fresh Ingredients
+  [7Hx0i4VchvwrIOV5] Gear Gnash
+  [cc8O47KFsODReoBe] Glad-Hand
+  [WeQGWvlWdeLeOlCN] Glean Contents
+  [u96anl3ACNhBqnbT] Go with the Flow
+  [tnzZvaJ97t0N9g6y] Godless Healing
+  [63sSYk5yqiAyZGb9] Graceful Leaper
+  [9OaF7Lkrtvusg5AA] Graft Technician
+  [gUqvezs2zzoTXFAI] Group Coercion
+  [KpFetnUqTiweypZk] Group Impression
+  [AHchBBO8lXCCuVxT] Grudging Compliment
+  [bmtf49jRKBCfdC5W] Half-Truths
+  [C0Tcelg3BAPhML6J] Hefty Hauler
+  [K3Au5071pfvNwGob] Hidden Magic
+  [cQptGH6RUYZmS41Q] Hideous Ululation
+  [4RjDxgvNXNl5GG9d] Hobnobber
+  [1WfvvjjObPKeZyid] Holistic Care
+  [tjnL4wsriZugnHLn] Ilverani Purist
+  [PiUe3tpv7UVtnfvS] Impeccable Crafting
+  [xqAdXRd2gSQcqp5E] Impressive Performance
+  [3HChkcD1IRqv4DbA] Improvise Tool
+  [RcQv16RK80R6c4id] Improvised Crafting
+  [ZC9C6rxPJKrw6Ktx] In Plain Sight
+  [YRjv9cxUAkeOiNAM] Inflame Crowd
+  [f5JOSyW1tKMpz6hU] Influence Nature
+  [sMCpihnBEpx18GBD] Inoculation
+  [rhVL28qFl760qJQe] Insistent Command
+  [xQMz6eDgX75WX2ce] Intimidating Glare
+  [XFJiGllNZp8Xebda] Intimidating Prowess
+  [AYb8PmGJ37HwIMwj] Juggle
+  [gBSPbQRXdagZTUwY] Kip Up
+  [9lyFxaoZjF1ZjVN9] Know the Beat
+  [kIXFNPFBStOKunq4] Kreighton's Cognitive Crossover
+  [6vnbC90UQ3I57RrQ] Lasting Coercion
+  [vjQ3VUpYlTAAIx3b] Lead Climber
+  [Zf4yiLDdxHPovEQI] Legendary Codebreaker
+  [Vk7BzAb3D9r226sI] Legendary Guide
+  [TBg1eRh0lLUV4ewp] Legendary Leader
+  [n0S0tJiOJPQk0Rne] Legendary Linguist
+  [Kk4AMZtpQnLEgN0b] Legendary Medic
+  [A0TNeMNvyY8QpmLz] Legendary Negotiation
+  [n0urrOL8YlnVBVRQ] Legendary Sneak
+  [Ta61ObC8Lk7BxTFO] Legendary Survivalist
+  [VRCBTEyrcBf7auGz] Legendary Tattoo Artist
+  [IZbjUaZI5zHTd1Vp] Legendary Thief
+  [HEBXaS656MZTiWFu] Lengthy Diversion
+  [iCv8KTZ5PcF4GqeV] Leverage Connections
+  [Dvz54d6aPhjsmUux] Lie to Me
+  [xWY5omyIcILNR7y1] Magical Crafting
+  [v7Bt6hjmzYnLFLeG] Magical Shorthand
+  [aMI39DZhWgNgJTAn] Malleable Movement
+  [e3YE4uKIyDc2uNXl] Master Merchant
+  [HBosqD4ijMVTflCt] Master of Apprentice
+  [TNV1cs1VFqdj4D2M] Masterful Obfuscation
+  [6GO3dtFJnsNnSwWz] Medical Researcher
+  [AnTBWhLiIA1c7jkg] Megafauna Veterinarian
+  [rAbfuZ1mc3lUYH41] Minion Guise
+  [kajI2r9RmtW5xYL7] Monster Crafting
+  [wlbfINUTHDPqbV7v] Morphic Manipulation
+  [mEk2POFNU1Q0TQg2] Mortal Healing
+  [4k80lxXishAcELDg] Mounting Leap
+  [P9HCz0uR6xPHuw72] Multilingual
+  [B4nuabUvA1rk7Hej] Multilingual Cipher
+  [C5CweUNPP7HlRfBM] Muscle Mimicry
+  [5ttqjN59TWIMImc3] Myth Hunter
+  [7WBIXGqZbAKbqEU6] Named Artillery
+  [WC4xLBGmBsdOdHWu] Natural Medicine
+  [5I97q0FfAeXcUQhs] Nimble Crawl
+  [6ON8DjFXSMITZleX] No Cause for Alarm
+  [hDGosy2ZTwnyctEP] Oddity Identification
+  [d86XC1EmGQ7erkul] Operatic Adventurer
+  [5qXw5Gl9TxbPMZLB] Orthographic Mastery
+  [xOMwuKCf02aFzyp3] Paragon Battle Medicine
+  [wqhxZwB1TR8fvpHP] Party Crasher
+  [EmIV9haKFrBRB43E] Pei Zing Adept
+  [nxq9hFyIPR2jRi6G] Performer's Treatment
+  [Wsrw68pklQyaScMX] Phonetic Training
+  [jDdOqFmZLwE4dblQ] Pickpocket
+  [BqceQIKE0lwIS98s] Pilgrim's Token
+  [Yj4mpROEjdCjQzMd] Planar Survival
+  [uiEoY3uGSEOCaftX] Play to the Crowd (Dandy)
+  [HJYQlmGTdtyGWr6a] Powerful Leap
+  [Peyf3L7c9esRTsgR] Predict Weather
+  [w6ILZ88apsQmBaVK] Predispose Settlement
+  [NMbOfl885pn0Yzu9] Prepare Elemental Medicine
+  [JEzjyNbpsh05iymG] Prepare Papers
+  [xuZFUOkkjHg9mrcI] Preternatural Polish
+  [UkMG3wMvrw8X0I98] Propeller Attachment
+  [P04Hw8E6WAWARKHP] Quick Climb
+  [ThoOsKjn5xCuZUqM] Quick Contacts
+  [e4KB4pSkx2lDBNw3] Quick Disguise
+  [IlOQuCQIhjJpig3S] Quick Identification
+  [ZBhvJ9O8MvBFAlhq] Quick Jump
+  [G9l2g7sDpPVbZJza] Quick Mount
+  [2rSyTfPgAmNAo01r] Quick Recognition
+  [ASy9AKEIRxPYUi5o] Quick Repair
+  [bcEI0iIFhZXqjoaR] Quick Setup
+  [g0fyway0FkdSo7ZE] Quick Spring
+  [3G8xUlgCjRmRJNfP] Quick Squeeze
+  [bFoh3267kNLk68cU] Quick Swim
+  [7GmXKrkzmInkFyEr] Quick Unlock
+  [pekKtubQTkG9m1xK] Quiet Allies
+  [IMSpOZZ6goXadYHd] Rally Support
+  [x9xA8P2Vlz98He7C] Rapid Affixture
+  [FJK7JTLSgugRIlvS] Rapid Mantel
+  [d8AjCqU30z7IOpos] Ravening's Desperation
+  [yUuU9xyotrpwpTyC] Read Lips
+  [p5Bmj3d0uAGnrzIn] Read Psychometric Resonance
+  [Crd3qMecF9FYHjuH] Read Shibboleths
+  [MjQyTcV8Jiv1Jtln] Recognize Spell
+  [5vRXZcGAbqKRoaqL] Recognize Threat
+  [QoPooHpBjPh1sjRD] Recollect Studies
+  [dAckQkpg1qyTz8od] Resourceful Ritualist
+  [XZcd1wFHy111klu2] Reveal Machinations
+  [5s8FqK4YZTVOvP0v] Reveal True Name
+  [f0s3WwaJN5f2UTYY] Reverse Engineering
+  [bkZgWFSFV4cAf5Ot] Risky Surgery
+  [3ZerjLH8ls3JT6cD] Robust Recovery
+  [bJ4tF95Byy7wCS65] Rolling Landing
+  [22P7IFyhrF7Fbw8B] Root Magic
+  [wpqKltAoJjRQgWow] Rope Runner
+  [m7AOg13xEJRHyoTt] Rugged Survivalist
+  [gHBdjbEnIK8clK8u] Sacred Defense
+  [P9dVBWB8nYZt4AFA] Sanctify Water
+  [hAsaNx1dd3xvvAsE] Say That Again!
+  [mZttsiWl1ql5NvrH] Scare to Death
+  [g3zmkEVJJIjE32fY] Scholastic Identification
+  [lEgYzFHransLkSvI] Schooled in Secrets
+  [wbjTkaKRygpaZS0r] Secret Speech
+  [R7BO8br4BjCmpjit] Settlement Scholastics
+  [N7IsnLDFt73r7x56] Shadow Mark
+  [aAoFc10cOpxGypOY] Sign Language
+  [niQY3XR2VWp3GWDx] Signature Crafting
+  [Jk9XEMfMXoPT0ua2] Skeptic's Defense
+  [P6icK2DbRoZ3H6kc] Skill Training
+  [5YlHrBCZJmb6Q4Lz] Slippery Prey
+  [RiuZT3H4QZIIEQXJ] Slippery Secrets
+  [n3vpCWPjXAInRTyR] Snap Out of It! (Pathfinder Agent)
+  [DMetdzt1VJL2Y62i] Snare Crafting
+  [NADqgn78Rvl7TUG8] Sociable Vow
+  [0Rr1uS9pmYa5j9f9] Solo Dancer
+  [sLEawQueTV1wGn0B] Sow Rumor
+  [YBge8sTgeY5jncX2] Speech of the Mammoth Lords
+  [8NnIrUijGD2Chl55] Speedrun Strats
+  [7t2VGjVhYNU3MsEm] Spirit Speaker
+  [CnqMJR8e9jqJR7MM] Steady Balance
+  [uxwHHjWs3ehqtG4b] Steel Skin
+  [TZDQM59QbGDLheEM] Stifle Flames
+  [X2jGFfLU5qI5XVot] Streetwise
+  [x7EMZNMavris2aHY] Student of the Canon
+  [oXoQ9wwOmDe0hwbU] Subjective Truth
+  [hVZbnsDuXihggylt] Subtle Theft
+  [HRVCODLOrhjRDtGb] Sure Foot
+  [Imvu2RV2ggjJ2HZt] Swift Sneak
+  [RR6p9r8l1trcByl2] Talent Envy
+  [dZDmWXzZfIoBJ53Q] Tame Animal
+  [z0HX5L7bOOrKi0dD] Tattoo Artist
+  [zzd2KYAqY1Ez6aBD] Temperature Adjustment
+  [PhnFz0ijBPaXpHot] Terrain Ghost
+  [beyw5bdA5hkQbmaG] Terrain Stalker
+  [dc8X2Mbtwq6kGp7F] Terrified Retreat
+  [iDimfGmQHacwxeh2] Terrifying Resistance
+  [CR23F2O59fc70RXM] Text Decoder
+  [KP5VugClDb7I8enS] That Was a Close One, Huh?
+  [Jivt1iaqKfT6EcwV] That's Not Natural!
+  [0Dy8RlFqrzCVOTl4] Thorough Reports
+  [KxaYlC50zzHysJj8] Titan Wrestler
+  [oFcn7SDOH6W2QhJl] Too Angry to Die
+  [nowEaHgIyij7im8F] Train Animal
+  [rfnEcjxIFqwlJwJT] Treat Condition
+  [NUHosufuAhQCnF7N] Triumphant Boast
+  [5XwTj6DBX2a2q97E] Tumbling Teamwork
+  [80AC6Q1m0eQiE7Et] Tumbling Theft
+  [vWtPxwND60EpxBAU] Tweak Appearances
+  [B2sX3irC8DEH7JyY] Twirl Through
+  [gydOsP9VsdRw3Wg1] Underground Network
+  [iOY6YfGBaOvMNAor] Underwater Marauder
+  [XvX1EyxWbbBF32NV] Unmistakable Lore
+  [2Tla5D1vpGioh42x] Unravel Mysteries
+  [rLwzwcrLh1qaN4pk] Unusual Treatment
+  [UCen3Tq6BJlNI7rx] Uzunjati Recollection
+  [my4uFR8cnDC4mJE2] Uzunjati Storytelling
+  [tP9Hs6hHkeeCJctS] Vanish Into the Land
+  [X4T7pO25YgW5lHWJ] Vasodilation
+  [CwGMDf0akn0VbNPb] Vicious Critique
+  [WQtt44keeBP8t25P] Voice Cold as Death
+  [X8iSUF1m0eezmrjs] Wall Jump
+  [8c61nOIr5AM3KxZi] Ward Medic
+  [RLBYJiGMVkaGL5w9] Wary Disarmament
+  [MTO0spetPKyIa4sT] Water Sprint
+  [xduV7Kyoi5OWvMEK] We're on the List
+  [70SaR6jce34yuTnQ] What's That up Your Sleeve
+  [BV5jpSifVJsTwoO7] Wilderness Spotter
+Heritage
+  [6egx1zhQx2s6BEa1] Abyssal Merfolk
+  [7gGcpQMqnZhBDZLI] Adaptive Anadi
+  [N36ZR4lh9eCazDaN] Aiuvarin
+  [CMf0qluB0LXWReew] Ancient Ash
+  [Nd9hdX8rdYyRozw8] Ancient Elf
+  [zPhArF36ZVgLeVUU] Ancient Scale Azarketi
+  [yL6944LrPo2HNdEJ] Ancient-Blooded Dwarf
+  [udMXXjFirjARYr4p] Ant Kholo
+  [kRDsVbhdBVeSlpBa] Anvil Dwarf
+  [1dYDucCIaZpCJqBc] Arctic Elf
+  [jAX7yavR4lNKwDK8] Ardande
+  [VgL18yU7pysdoZZG] Artisan Android
+  [L6FwEsrOK3Xno7qM] Ascetic Tanuki
+  [CnCFZfuKzAYqy61e] Athamasi
+  [8Gsa8KFsHizEwSHU] Badlands Orc
+  [OIW3UYrdaWLwUZCh] Bakuwa Lizardfolk
+  [ClshvrjvBTMm3INX] Bandaagee Vanara
+  [nXQxlmjH24Eb8h2Q] Battle-Ready Orc
+  [d7NC4C19AgkspQQg] Battle-Trained Human (BB)
+  [GAn2cdhBE9Bqa85s] Beastkin
+  [HFHSh2RWuxa4GhhQ] Benthic Azarketi
+  [z4cvqtpkkAYoFpHa] Bloodhound Shoony
+  [buGlGWcCrdNxfCr4] Born of Animal
+  [Iaq8C3bbC9EzZhBJ] Born of Celestial
+  [RXn2y7QVHVB0XHr8] Born of Elements
+  [kHvlHDq5hs2JDG0Y] Born of Item
+  [y87jU1yU8Plz4Yhq] Born of Vegetation
+  [BDBzVaZx3GfZXs5b] Breaker Surki
+  [wHO5luJMODbDLXNi] Bright Fetchling
+  [1FmcZqnmDm8H0DRB] Budding Speaker Centaur
+  [2cii5ZkBsJ4DYdd2] Cactus Leshy
+  [DNynADD4xhwTAiE5] Carcharodon Merfolk
+  [PQuJEYI0UFl8W7fH] Cataphract Fleshwarp
+  [JW45oQRHaqthjmIx] Cave Kholo
+  [5A1wMPdzN1OWE4cY] Caveclimber Kobold
+  [NfIAGatB1KIzt8G7] Cavern Elf
+  [35k2aujXYvqUCSS1] Cavernstalker Kobold
+  [IFg2tqmAFFnU8UNU] Celestial Envoy Kitsune
+  [XeXWsvcWU3Zaj5WC] Chameleon Gnome
+  [EKY9v7SF1hVsUdbH] Changeling
+  [32oX6hHUY6K8N70Q] Charhide Goblin
+  [CpjsxaXYjlkCI5nc] Chrysanthemum Leshy
+  [bLhIBwqdjTiVJ5qm] Clawed Catfolk
+  [OoUqJJB77VfWbWRM] Cliffscale Lizardfolk
+  [13vilUcBjqMV2gxP] Climbing Animal
+  [sEnMG5zbnXdJvVPz] Cloudleaper Lizardfolk
+  [mZqaKQkvadBbNubM] Compact Skeleton
+  [4BczMv4EnLcgrEJE] Coral Athamaru
+  [hqh4zKHYBtDE26g8] Courageous Tanuki
+  [iY2CCqoMc2bRdoas] Created Fleshwarp
+  [NWbdAN5gDse0ad7C] Dark Fields Kitsune
+  [VTtXwBxrfRUXSL38] Death Warden Dwarf
+  [k4AU5tjtngDOIqrB] Deep Fetchling
+  [wn4EbYk1QN3tyFhh] Deep Orc
+  [7p9HtLzWBHc18JDW] Deep Rat
+  [qeFCDRSgFRR2ElWK] Deny Lady Nanbyo's Charity
+  [AWLcCe69nzxZzWQc] Deny the Firstborn Pursuit
+  [YoDvQ5fvpbgcoG3V] Deny the Traitor's Rebirth
+  [kiKxnKd7Dfegk9dM] Desert Elf
+  [twayjFuXbsvyHUwy] Desert Rat
+  [UaD5VDoFlILEmbyz] Dhampir
+  [TXBsQbzDg1AjJnop] Dijiang
+  [OtqOC3ElpF444qMe] Discarded Fleshwarp
+  [0B0M6CUnVDkeznRv] Dog Kholo
+  [2hLDilS6qbjHxgVS] Dogtooth Tengu
+  [gf2CfXocpIQgRsCY] Dokkaebi Goblin
+  [cbbXIV4QBred4lM5] Dragonblood
+  [P8BP1un5BTrwXoBy] Dragonscaled Kobold
+  [zcO93E8gAW1tDYKk] Draxie
+  [tLd8Qg82AwEbbmgX] Dromaar
+  [ZZKZkeSP5TuT62IA] Duskwalker
+  [Wk4HyaZtC1j221i1] Earthly Wilds Kitsune
+  [MeMAAtUlZmFgKSMF] Elemental Heart Dwarf
+  [dbj1cbkYeAAdkDSM] Elementheart Kobold
+  [ikNJZRxUjcRLisO6] Elfbane Hobgoblin
+  [ywNXVLZtwrAStyh1] Elusive Vishkanya
+  [0Anj61DzUimJ1uMS] Elytron Surki
+  [mBH1L01kYmB8EL56] Empty Sky Kitsune
+  [VqgrYMaAwnNjT9Mn] Enchanting Lily
+  [uAo0wK1JL9kePcZb] Even-Tempered Tanuki
+  [6JKdAZGa8odFzleS] Farsight Goloma
+  [Y1cG8cw4qoHR145y] Fey Dragonet
+  [D3hTAqgwSank8OyO] Fey-Touched Gnome
+  [isJhIPhT4MsjJvoq] Fishseeker Shoony
+  [z16zRyLCeTXan0Ae] Fleetwind Centaur
+  [TDc9MXLXkgEFoKdD] Flexible Catfolk
+  [QZv2taQQAdeR8Vmg] Flying Animal
+  [RZHr0olieS6YdYE9] Fodder Skeleton
+  [5CqsBKCZuGON53Hk] Forge Dwarf
+  [erZPj5701KiVAqoi] Forge-Blessed Dwarf
+  [KJ2dSDXP9d5hJHzd] Frightful Goloma
+  [6rIIsZg3tOyIU3g3] Frilled Lizardfolk
+  [kHT9dFJt5yTjeYoB] Frozen Wind Kitsune
+  [L6zfGzLMDLHbZ7VV] Fruit Leshy
+  [6gK4A6dtN4LCpCXS] Full Moon Sarangay
+  [87h0jepQuzIbN7jN] Fungus Leshy
+  [lBSO9RuEUv2P4rnp] Gandharva
+  [bHgGh3vtXL7fkhIy] Ghost Bull Minotaur
+  [Je15UGsLWYaaGJSW] Ghost Poppet
+  [jP9ORt0jgY5VHyD3] Glacier Cavern Minotaur
+  [wNnsjird4OQe0s6p] Gourd Leshy
+  [VvEAFoxuddYNBmNc] Grave Orc
+  [SqEcb1c3yeoJMxm0] Great Kholo
+  [gfXSF1TafBAmZo2u] Grig
+  [Eq42wZ5OTweJLnLU] Gutsy Halfling
+  [ImdAt4Ma9GfaNuZW] Half Moon Sarangay
+  [qKn9k3TQt0gsOLn7] Hardshell Surki
+  [NK88lPzi3SDAT8w5] Healer Samsaran
+  [G61eBHmsQaPM4Xge] Heavenscribe Kobold
+  [Mj7uHxxVkRUlOFwJ] Hillock Halfling
+  [MTTU2t7x6TjvUDnE] Hold-Scarred Orc
+  [EG0zqAipDIMGBAKz] Homing Drake
+  [tf3edMCyS15GhFPx] Hooded Nagaji
+  [yEQSw61sNRvgPy4T] Hopeful Athamaru
+  [8oqAuez98yqAgteo] House Drake
+  [9FlpW1nSczH8f85v] Hungerseed
+  [2kMltxs2rmxRSxfV] Hunter Automaton
+  [1lv7RMp7t5iqeUFT] Hunting Catfolk
+  [Mmezbef0c1fbJaVV] Impersonator Android
+  [cnbwtbDmlD0KoLqY] Insightful Goloma
+  [7ZDCShtRg5QZggrU] Inured Azarketi
+  [gyoN45SVfRZwHMkk] Irongut Goblin
+  [XQp3uReCgoXS8hCJ] Ironhoof Centaur
+  [G9Gwfi8ZIva52uGp] Jinxed Halfling
+  [g4FRxyuHndZu4KTo] Jinxed Tengu
+  [HpqQ5VQ0w4HqYgVC] Jungle Catfolk
+  [1w4npGmPzgdZw3Na] Kaleidoscopic Athamaru
+  [5WkhF3JYISElgMLL] Kanchil
+  [BhbwjTFw2V67XF35] Keen-Venom Vishkanya
+  [m4kFMTu2sOSWgnAU] Keeper Jotunborn
+  [8Uw1E3L2Mgo6PxwB] Kijimuna Gnome
+  [MQx7miBXUmOHycqJ] Laborer Android
+  [Kq3k1Z6IWGVsLrmg] Lahkgyan Vanara
+  [Wyw1tkO0e199Wm8o] Lantern Surki
+  [dQqurQys37aJYb26] Leaf Leshy
+  [Csezts78L4FMaskB] Lethoci
+  [wxQwFQGsg6yDiMmN] Leungli
+  [3F5ffk7cmnrBhPcT] Liminal Catfolk
+  [PwxbD5VSJ0Yroqvp] Liminal Fetchling
+  [23MEmXuyw75jiGKq] Littlehorn Minotaur
+  [fROPRHGyUn4PgcER] Longsnout Rat
+  [Fgysc0A1pFQE8PMA] Lorekeeper Shisk
+  [ievKYUc53q0mroGp] Lotus Leshy
+  [LU4i3qXtyzeTGWZQ] Luminous Sprite
+  [J0eAmntxXywr9sGt] Mage Automaton
+  [e6ykfotynKPzR2PT] Makari Lizardfolk
+  [TYvzNoL5ldmB5F76] Melixie
+  [SPcTcZgUMy5J4kzs] Mightyfall Kobold
+  [7wdeVadvchdM0aPK] Mistbreath Azarketi
+  [wB8xiQB4RDbzOOvR] Monstrous Skeleton
+  [3aKeX3q9hRdxgP1J] Mottle-Coat Centaur
+  [IZqIVO1IOK3fAp30] Mountaineer Samsaran
+  [ptpK6H1rM4Bu3ry4] Mountainkeeper Tengu
+  [MtH5bq0MhaMQbJEL] Murkeyed Azarketi
+  [CCwTBSNTw0caN1jd] Mutated Fleshwarp
+  [Svk2CHwvurK1QQhD] Naari
+  [pJ395g22dKNoufIK] Nascent
+  [1oLMOmLpurfWTTff] Nephilim
+  [H2mbY3aypl6ikaSR] New Moon Sarangay
+  [9mS8EGLlGUOzSAzP] Nightglider Strix
+  [hOPOyyt7qZXYYCOU] Nine Lives Catfolk
+  [idGDjqi1q3Ft8bAZ] Nomadic Halfling
+  [h2VKMYAlUIFAAXVG] Nyktera
+  [85tRKGZUTFa6pKpG] Oathkeeper Dwarf
+  [Lp7ywxabmm88Gei6] Observant Halfling
+  [PbXqlzRdQbKLQx1R] Old-Blood Vishkanya
+  [DR6okTFLHi3MYbzK] Oracular Samsaran
+  [ITgkqfnAOJCbcIys] Oread
+  [mnhpCk9dIwMuFegM] Paddler Shoony
+  [SienSObWb4deLQig] Palace Echoes Kitsune
+  [G5U7zxwxDmERm3EY] Peachchild Leshy
+  [Rz0hZM6CFvX5LnXg] Pearl Dragonet
+  [OOkgTzDU4mBvV98Z] Pelagic Merfolk
+  [KaokXdiE3ewXprdL] Pine Leshy
+  [KbG2BZ3Sbr3xU1sW] Pixie
+  [KDs97OkCmEYTLUp9] Plane-Hopper Jotunborn
+  [bmA9JK06rnOKpNLr] Poisonhide Tripkee
+  [daaXga11ov9YQVNq] Polychromatic Anadi
+  [BjuZKA7lzFSjKbif] Polyglot Android
+  [2GmWdSNbH4yx9pzY] Ponygait Centaur
+  [MUujYQYWg6PNVaaN] Predator Strix
+  [vrU3lmDO7FYzmuQc] Prismatic Vishkanya
+  [vDEfNzjLpGJU54cz] Quillcoat Shisk
+  [CkrTRdLfDDDUOCqP] Quilled Athamaru
+  [By1y7HCfVPgX2GmI] Ragdyan Vanara
+  [dwKCwwtWetvPmJks] Rainfall Orc
+  [a6F2WjYU8D0suT8T] Razortooth Goblin
+  [Q5NrFWKDMCoVn9qR] Reef Merfolk
+  [gKLTlzAVapXTQ86V] Reflection
+  [VAo6NnrCEAAOUSkc] Resolute Fetchling
+  [aPqNdvtKHv4amLcO] Respite of Cloudless Paths
+  [WczVM4KQq7xybsPZ] Respite of Loam and Leaf
+  [q7b4yu3Nty0jZLOi] Respite of a Thousand Roofs
+  [GpnHIonrLN8TFZci] Rite of Invocation
+  [faLb2rczsrxAuOTt] Rite of Knowing
+  [EoWwvDdoMqN5x0c9] Rite of Light
+  [yVtcyAbLmWCIHHZi] Rite of Passage
+  [q2omqJ9t0skGTYki] Rite of Reinforcement
+  [GlejQr3rBh3sn8sL] River Azarketi
+  [87Eej7uEvTxXeli7] Riverside Tripkee
+  [HAo0S8ysFipf6S2B] Roaming Minotaur
+  [VSyOvtgJ1ZNpIVgC] Rock Dwarf
+  [CZx9HMmoOwcpkLY8] Root Leshy
+  [bsXA1l5mxNnmBh5M] Running Animal
+  [CzOHITB2ihLGqMuJ] Runtboss Hobgoblin
+  [iOREr80Q0SsvPP8B] Sacred Nagaji
+  [NUUWs7jFwsIPmx3p] Sage Jotunborn
+  [4BiGekRGfBRC7DoI] Sailfish Merfolk
+  [MoeWxhJEtteD3v9z] Sanctuary Samsaran
+  [6xxXtgj3fcCi53lt] Sandstrider Lizardfolk
+  [ohOJHeFenX97sBHf] Scalekeeper Vishkanya
+  [j0R1SyJP8k4G2Hkn] Scavenger Strix
+  [hTl3uc6y1kTuo9ac] Seaweed Leshy
+  [jEtVesbqYcWGbBYk] Seer Elf
+  [tXC5Gwn9D5x0ouJh] Sensate Gnome
+  [eFsD7W6hnK33jlDQ] Sewer Rat
+  [tarfuEXmi0E0Enfy] Shadow Rat
+  [GvtOzLp4kIuYfx1R] Shadow of the Courtier
+  [yxZtNE87im9yZFXk] Shadow of the Hermit
+  [5apoJtHGL0lIz1cz] Shadow of the Sailor
+  [VHln8G1GNaSzNNHq] Shadow of the Smith
+  [fcsYmaIfMR9iXv06] Shadow of the Wanderer
+  [uxtcKTkD62SmrUoh] Shapewrought Fleshwarp
+  [NWsZ0cIeghyzk9bU] Sharp-Eared Catfolk
+  [j1nzBc9Pui7vsJ9o] Sharpshooter Automaton
+  [idJ2lSKEmmwqG5eT] Shifting Skeleton
+  [Cmj0pI0GPHl7kBUB] Shimmertongue Nagaji
+  [RxNBBMFZwPA3Vlg3] Shoreline Strix
+  [rQJBtQ9uKUzK9ktK] Shortshanks Hobgoblin
+  [rKV11HWREwjjMIum] Skyborn Tengu
+  [mPVEc7hFZQhv0gqJ] Slabsoul Minotaur
+  [n2eJEjA8pnOMiuCm] Smokeworker Hobgoblin
+  [2kSzKDtwbcILZTIe] Snaptongue Tripkee
+  [cwOUw7kofcAiY01I] Snaring Anadi
+  [gQyPU441J3rGt8mD] Snow Goblin
+  [7lFPhRMAFXQsXUP2] Snow Rat
+  [fWT7Mo2vFC10H4Wq] Songbird Strix
+  [VRyX00OuPGsJSurM] Spellhorn Kobold
+  [0TFf82gcfxXG9A54] Spellkeeper Shisk
+  [WxcbLvufI6JBpLt0] Spindly Anadi
+  [9Iu1gFEuvVz9zaYU] Spined Azarketi
+  [tYrb9KOv1etjE5wK] Stalker Minotaur
+  [5gqcEsJ4gkE6W5jj] Steadfast Tanuki
+  [BFOsMnWfXL1oaWkY] Steelskin Hobgoblin
+  [rFdVYKtHsZzRCsSd] Stickytoe Tripkee
+  [lDT5h3f5GXRj42Ir] Stonestep Shisk
+  [7vHLPleFpSqKAjWG] Stormtossed Tengu
+  [raDHBXYpc2MvWWgh] Stoutheart Centaur
+  [bKr34Uvxc2XClr9q] Strong Oak
+  [UV2sABrTC5teOXTE] Strong-Blooded Dwarf
+  [KcozzlkFAqShDEzo] Stronggut Shisk
+  [WaCn0mcivFv1omNK] Strongjaw Kobold
+  [7kHg780SAsu2FNfP] Stuffed Poppet
+  [P8Rl3dUsq8AzXLHC] Sturdy Skeleton
+  [RKz7Z5pefXKiv9JE] Suli
+  [hzW7VoRDYsKJB8ku] Surgewise Fleshwarp
+  [B89BCo6LtI3SJq54] Sweetbreath Kholo
+  [nlhVoQDfLKYM3j1l] Swimming Animal
+  [G8jfMayPv4vZvAVr] Sylph
+  [S1062No0sYH35AhN] Tactile Azarketi
+  [8wGUh9RsMUamOKjh] Tailed Goblin
+  [qM566kCXljkOpocA] Taloned Tengu
+  [Ga7UEU186pjq7LBD] Talos
+  [n2DKA0OQQcfvZRly] Technological Fleshwarp
+  [qbWaybAX1LK7kUyY] Thalassic Azarketi
+  [MhXHEh7utEfxBwmc] Thickcoat Shoony
+  [2QLKvmCimT9ai0Bi] Thickskin Tripkee
+  [6KhxY5ArGFhLF7r1] Thorned Rose
+  [Qr1foFh24dkTqe1s] Tidepool Dragonet
+  [LlUEmCDOLSZaGOyI] Titan Nagaji
+  [EHDYVhJcZ9uPUjfZ] Toy Poppet
+  [EEvA4uj8h3zDiAfP] Treedweller Goblin
+  [AVZJI5wP2X5o0LL3] Trogloshi
+  [cKgxEWnRVazFPi3M] Tsukumogami Poppet
+  [U882U2NUUGL6u3rL] Tunnel Rat
+  [ZW8GX14n3ZGievK1] Tunnelflood Kobold
+  [cCy8vsZENlwiAyZ6] Twilight Halfling
+  [d0bNxgGqvaCkFlhN] Umbral Gnome
+  [ULj56ZoW7dWdnBvu] Unbreakable Goblin
+  [Gmk7oNITvMVBy78Z] Undine
+  [VYfpTUuXJM3iBOz0] Unseen Lizardfolk
+  [OBxrlZKg0IC5n238] Venom-Resistant Vishkanya
+  [kTlJqhC7ZSE8P8lu] Venomous Anadi
+  [2jsWmnKtidCTpaQV] Venomshield Nagaji
+  [m9rrlchS10xHFA2G] Venomtail Kobold
+  [x5S4MNQ0aqUmgHcC] Vicious Goloma
+  [sGzhnQpgWErX1bmx] Vigilant Goloma
+  [evXJISqyhl3fHE9u] Vine Leshy
+  [JtrZ2TcPXP1uIcmd] Virtuous Tanuki
+  [ViKRoVgog172r163] Vivacious Gnome
+  [nUCRd8tmz3C6LM0T] Wajaghand Vanara
+  [MNeg7vI854rB6fmz] Waning Moon Sarangay
+  [0Iv6LfT3UEt8taj5] Warden Human (BB)
+  [K124fCpU03SJvmeP] Warmarch Hobgoblin
+  [0vaeOoECfVD5EGbq] Warrenbred Hobgoblin
+  [RuQSx0QsirIKxwKY] Warrior Android
+  [y24ykEUfpIu5Gp6D] Warrior Automaton
+  [t9HOJelfwDo3RBii] Warrior Jotunborn
+  [WEzgrxBRFBGdj8Hx] Wavediver Tengu
+  [BHiOV3ETYSv6k7kF] Waxing Moon Sarangay
+  [K0NerdkFnce9KeHw] Weaver Jotunborn
+  [etkuQkjkNLPLnjkA] Wellspring Gnome
+  [dJeiekfqGQ8dkwsO] Wetlander Lizardfolk
+  [cDElVLonQvUK3vVk] Whipfang Nagaji
+  [1wVDYY9Wue0G5R9Q] Whisper Elf
+  [e4FaENGKRD3fxZeJ] Wilderness Samsaran
+  [xtRIYizCjLg9qe1Z] Wildwood Halfling
+  [Cv7BOjuziOQ0PO9r] Windup Poppet
+  [xaTTN5anLEBzWCzv] Windweb Tripkee
+  [6dMd4JG0ndrObEUj] Winter Catfolk
+  [hwRWx3hWx8ahBdz0] Winter Kholo
+  [pZ1u2ScWrBXSaAqQ] Winter Orc
+  [KO33MNyY9VqNQmbZ] Wintertouched Human
+  [w5801ArZQCU8IXnU] Wishborn Poppet
+  [kHHcvJBJNiPJTuna] Wisp Fetchling
+  [kXp8qRh5AgtD4Izi] Witch Kholo
+  [nW1gi13E62Feto2w] Woodland Elf
+  [TQFE10VFvh9wb8zb] Woodstalker Lizardfolk
+  [FLWUYM2XxYwnIDQf] Xyloshi
+Kit
+  [2req0jGaxz8hScdB] Adventurer's Pack
+  [YQLWR9cCXQY5xaaG] Cartographer's Kit
+Shield
+  [TPiF3YBADh10JDPV] Amaranthine Pavise
+  [PuEe7jnw2dTL3POp] Arctic Worm Chitin Shield
+  [9ZGkQo739t9utj37] Arrow-Catching Shield
+  [2uQbXmE06SbudRFp] Bivouac Targe
+  [2m6ug3NJo0YHZvsj] Bloodroot Shield
+  [dMaWOT9su0Aw5NCc] Broadleaf Shield
+  [6bC6RAZddiv8Io6w] Broadleaf Shield (Greater)
+  [yPeNtJVMJmJupcM2] Broadleaf Shield (Major)
+  [wkmn8UQ0nUeVtz5J] Broadleaf Shield (True)
+  [1k3AsSW7lpU0kEpY] Buckler
+  [MK3Fq0BV2uTspvXn] Burr Shield
+  [9WcvCnh6SbIw5Cfw] Caster's Targe
+  [S5CMsB7AyYC8iSa0] Clockwork Shield
+  [ayST5rFSIKy2ynYk] Clockwork Shield (Greater)
+  [VioxW97SUADl3zTt] Cursebreak Bulwark
+  [lV1BKms3SxTvsn3N] Dart Shield
+  [oLibqACz1SwR8uhh] Dragon Shield
+  [Q8BscHUFiM1a86PO] Dragonslayer's Shield
+  [rh4T08EsddrwfHcs] Duelist's Beacon
+  [j66vP9yPSDe5by2k] Energized Shield (Greater)
+  [u2rlekTlwFOUkxLN] Energized Shield (Lesser)
+  [EpWa6SEocKadswN7] Energized Shield (Major)
+  [c3rgT6PKYery9QH8] Energized Shield (Moderate)
+  [eZximo6owpLhQPZ7] Evil-Reflecting Shield
+  [slQRh4FVDzP8h1wj] Exploding Shield
+  [Q3cmIfjVVNWzyR2f] Fiendsbane Shield
+  [ydNocKN6afzIyVh6] Floating Shield
+  [uAs0hUUgROrndceD] Floating Shield (Greater)
+  [DIzZr0K20eCbNzQo] Force Shield
+  [NoTUhKkiTY5BQU5T] Forge Warden
+  [tugYMolpupNz05cE] Fortress Shield
+  [2RrKSkj27NDREOKQ] Gauntlet Buckler
+  [IxuDS3POB6EH8TVN] Glamorous Buckler
+  [hY6Qn7HwKxYaGk2S] Guardian Shield
+  [3RUL5Oief3hdyUNU] Harnessed Shield
+  [7GEV9zi2bz1iSdaW] Heavy Rondache
+  [WDmuP3H7jNqobraf] Helmsman's Recourse
+  [19T3MHwhB6Wk4AjV] Helmsman's Recourse (Greater)
+  [kSjfrC31qFi2qovr] Helmsman's Recourse (Major)
+  [L3qye4mR9I0fU1M3] Hide Shield
+  [ODpis1NRtTWohcqS] Highhelm War Shield (Greater)
+  [fQcPx1CmWwPpnkyI] Highhelm War Shield (Lesser)
+  [Lwso6G0uaVawoRMK] Highhelm War Shield (Moderate)
+  [nmDa7ghkhoh2Nlsg] Hippopotamus Klar
+  [Hkjqt1Y98payfa37] Imposing Shield
+  [SUbYk6B1iPoGyyjh] Indestructible Shield
+  [QJNyQlmPNzIrnuLf] Jawbreaker Shield
+  [jiC2ufyGZmmxiEAm] Kizidhar's Shield
+  [Li0kDAfCuw7DAiSM] Klar
+  [f6antZJS94JyijFl] Kraken's Guard
+  [smKlMa76B6vBPNqG] Limestone Shield
+  [eMDt5vCQztp7cC6B] Lion's Shield
+  [kHLvz8icxAW9EAIj] Lodestone Shield
+  [BPZPA9Y8kPewVYoW] Magnetic Shield
+  [HWQEGY2X0QXj2zfN] Martyr's Shield
+  [stlTN5eb1qRJMHgB] Martyr's Shield (Hellbreakers)
+  [w1AuKvQ3ikJSMQNu] Medic's Shield
+  [nzQKwdUxzmmwWtzT] Medusa's Scream
+  [TyW1XOWYMM2xHGaI] Medusa's Scream (Greater)
+  [XnD9zqlwRFFK1ltc] Meteor Shield
+  [i8UuRf5yLztt43TN] Mycoweave Shield (Greater)
+  [AXewacUHP6rs980k] Mycoweave Shield (Lesser)
+  [Ruul32xBBYYVwFHC] Mycoweave Shield (Major)
+  [EKXRigmEZgqmFA62] Nethysian Bulwark
+  [ScU1DrBKn0ONHnq4] Pillow Shield
+  [63k6WWZstoY33LsH] Rampart Shield
+  [hcoBRMF0zIA986Of] Razor Disc
+  [La9qYc5NHsg423Jb] Reflecting Shield
+  [aPD0z9dBsHqgiCW0] Reforging Shield
+  [kZYyXUX8dVXnAIVp] Salvo Shield
+  [kFe3JyiO27YBboJy] Sanguine Klar
+  [vkPNIDJPt2RHpS6T] Sanguine Klar (Greater)
+  [QR7rqHMuU72NA47A] Sapling Shield (Greater)
+  [nS4ev4BZn9OUPYgt] Sapling Shield (Lesser)
+  [Qm9mmqMNKBaMn5so] Sapling Shield (Major)
+  [w0SXrrYSH1EL088n] Sapling Shield (Minor)
+  [3yeRZNUF4qZzCzHp] Sapling Shield (Moderate)
+  [VJiKPxewJNLhimEi] Sapling Shield (True)
+  [XkIfwSTy0PQL3RPJ] Scale of Igroon
+  [SwcWlWyN1IZPDnZ5] Shield of Snakes
+  [PlYr5AhYwHIztMw2] Shield of the Unified Legion
+  [M8QYa10fHOyViC5V] Shining Shield
+  [idcfnKHZvJTSCdWK] Siege Shield
+  [SJaFNXiHGILhwEMk] Silkspinner's Shield
+  [OqDAx4HJ39ojVtvg] Spellguard Shield
+  [WDh4fb9N86mNLfDV] Spined Shield
+  [EBcZ7ftWs8lVW7Fj] Staff-Storing Shield
+  [aBAU0sTkFLuTxO3X] Staff-Storing Shield (Greater)
+  [nhCHLI5SnJXF3fQE] Staff-Storing Shield (Major)
+  [xAOVPVH6cX3iVFlk] Staff-Storing Shield (True)
+  [puPx1rmbhjNM2lcz] Starfall Shield
+  [Yr9yCuJiAlFh3QEB] Steel Shield
+  [rrnWORxT2Ch4pUFb] Sturdy Shield (Greater)
+  [nDZX25OwoN0Imrq6] Sturdy Shield (Lesser)
+  [BWQzaHbGVqlBuMww] Sturdy Shield (Major)
+  [f9ygr5Cjrmop8LWV] Sturdy Shield (Minor)
+  [pNQJ9PTOEHxEZCgp] Sturdy Shield (Moderate)
+  [7Z8XXGiUiyyisKOD] Sturdy Shield (Supreme)
+  [RwR9FgjXRowrADqS] Sun Slayer
+  [lbAZmrRnV7OZvuol] Swordstealer Shield
+  [ZuqvNXDyhedwJM7y] Testudo Shield
+  [GmjKkSdqU9rapwSq] Testudo Shield (Greater)
+  [4MVVw0ExHFqLvKXL] Tiger Shield
+  [ltundBNFAnP7bgPr] Tower Shield
+  [uVmE0wsLw9tMv7hB] Turnabout Shield
+  [wAeG3XWvDZz5eP50] Vambrace of Gorum
+  [HJ0GNBKtHpdCMnfW] Vanguard's Shield
+  [4ZqyWVsjxpISfj48] War Mage's Buckler
+  [TxQvgyLziolSVfqY] Warding Escutcheon
+  [K5IWk98rsEMyJ1Xb] Warding Escutcheon (Greater)
+  [ezVp13Uw8cWW08Da] Wooden Shield
+  [EwZS3HoywMMJwnBZ] Worldscale Shield
+  [Fr75q2wqO9AFG53z] Wovenwood Shield (Greater)
+  [LZAwOTKk3dKwsGDd] Wovenwood Shield (Lesser)
+  [e9Xiei2wduOEGI5r] Wovenwood Shield (Major)
+  [7jolv0cuttvjI1JD] Wovenwood Shield (Minor)
+  [nRLMg1NB2OSmzSqX] Wovenwood Shield (Moderate)
+  [qXzP7yH72fxAChNU] Wovenwood Shield (True)
+Spell
+  [w7BHU5rk5JKuIRCe] 500 Toads
+  [Fu8Ml47ZfXpSYe7E] Aberrant Form
+  [qhJfRnkCRrMI4G1O] Aberrant Whispers
+  [vJuaxTd6q11OjGqA] Abyssal Plague
+  [rqoWAxQv4RWbwyAr] Accelerated Decomposition
+  [LbPLNWlLCxKCo5gF] Access Lore
+  [IT1aaqDBAISlHDUV] Achaekek's Clutch
+  [f8hRqLJaxBVhF1u0] Acid Arrow
+  [9h9YCncqah6VNsKf] Acid Grip
+  [gISYsBFby1TiXfBt] Acid Splash
+  [ZW8ovbu1etdfMre3] Acid Storm
+  [rnNGALRtsjspFTws] Acidic Burst
+  [GUnw9YXaW3YyaCAU] Adapt Self
+  [GoKkejPj5yWJPIPK] Adaptive Ablation
+  [uToa7ksKAzmEpkKC] Admonishing Ray
+  [XEhzFKNTSARsofav] Advanced Scurvy
+  [NzXpEzcZAjuDTZjK] Aerial Form
+  [cOjlzWerBwbPWVkX] Agile Feet
+  [r8g7oSumKOHDqJsd] Agitate
+  [nplNt08TvokZUxtR] Agonizing Despair
+  [W69zswpj0Trdy5rj] Air Bubble
+  [b5sGjGlBf58f8jn0] Air Walk
+  [fprqWKUc0jnMIyGU] Airburst
+  [6XscENSWyYRHqK0A] Airlift
+  [4WAib3GichxLjp5p] Alarm
+  [93SjFTGJUTTmAt6j] Albatross Curse
+  [gtWxTfMbIN5RHQw6] All is One, One is All
+  [wJi0lq4yA5Mlj0MY] All-Encompassing Hunger
+  [IQchIYUwbsVTa9Mc] Allegro
+  [X3fWP6YCSzcdtg93] Allfood
+  [h8zxY9hTeHtWsBVW] Alter Reality
+  [me5E8UvbBrHe3dZh] Amity Cycle
+  [7tR29sQt35NfIWqN] Anathematic Reprisal
+  [J5KrjQKCg2PrF1vz] Ancestral Defense
+  [xEjGEBvTfDJECSki] Ancestral Form
+  [dtOUkMC57izf93z5] Ancestral Memories
+  [d2pi7laQkzlr3wrS] Ancestral Touch
+  [Z4X5whSqSvgiiJ05] Ancestral Winds
+  [OJ91rm1FkJSlf3nk] Ancient Dust
+  [E3zIZ4pjlOuWeGRz] Angel Form
+  [w3uGXDVEdbLFZVO0] Angelic Halo
+  [joEruBVz31Uxczzq] Angelic Messenger
+  [kRsmUlSWhi6PJvZ7] Angelic Wings
+  [X0t0gr7S7CeCt2Q5] Anima Invocation (Modified)
+  [Aap7nGpC7neTWm78] Animal Allies
+  [vGEgI8e7AW6FQ3tP] Animal Feature
+  [yhz9fF69uwRhnHix] Animal Messenger
+  [1HfusQ8NDWutGvMx] Animal Vision
+  [rVANhQgB8Uqi9PTl] Animate Rope
+  [WqPhJNzLa8vSjrH6] Animated Assault
+  [fWU7Qjp1JiX9g6eg] Animus Mine
+  [L1JnU3RepQiWxysc] Annunciation of the Outer Gate
+  [y3jlOfgsQH1JjkJE] Anointed Ground
+  [X9dkmh23lFwMjrYd] Ant Haul
+  [EUMjrJJwSgsqNidi] Anticipate Peril
+  [LmtwcpYmrJfhGIZY] Antimagic Artifice
+  [My7FvAoLYgGDDBzy] Antimagic Field
+  [5JGSo1tgDEehqbWm] Antlion Trap
+  [qqQYrXaRJXr7uc4i] Apex Companion
+  [ZeftDoh0nFAXBAWY] Appearance of Wealth
+  [EqdSKqr8Qj5TUhMR] Approximate
+  [6wLY5LnehCo3tHlr] Aqueous Blast
+  [oUDNCArkQTdhllxD] Aqueous Orb
+  [h47yv6j6x1pUtzlr] Arcane Countermeasure
+  [KY2xyMavZHAoG69D] Arcane Explosion
+  [dL3A7H4LlRH26Imo] Arcane Weaving
+  [C2GYCH3TtUFqPfdX] Arctic Rift
+  [pSNLufPPsReKQtJR] Armor of Bones
+  [EPTmSiURVp2ldkVB] Armor of Thorn and Claw
+  [aHu20NHj7YIqxr80] Arms of Nature
+  [WfImUYSXyW3YdyY9] Army of Shadows
+  [LX4pCagYLpc9hEji] Aromatic Lure
+  [7PnjDM52lb4LEqHR] Arrow Salvo
+  [eb4FXf62NYArTqek] Artistic Flourish
+  [23cv1p49NFd0Onng] Ash Cloud
+  [2B0C22OuX9YrIJ5y] Ash Form
+  [QqMlN9VSHfD2v4Qv] Ash-Strewn Ending
+  [NtzNCW32UlPdY2xS] Ashen Wind
+  [NeyyAPwa639WjYGG] Asmodean Wager
+  [wrm1zIiLyFD1Is6h] Aspirational State
+  [KG7amdeXWc7MjGXe] Asterism
+  [BI4iwu3nApyIG0zY] Astral Labyrinth
+  [4Cntq9odgW6xMpAs] Astral Projection
+  [nUSi2B7RhIKjaiXQ] Astral Rain
+  [UGJzJRJDoonfWqqI] Athletic Rush
+  [B4p4cD9Q71mHTpOP] Attacked from Within
+  [pSepsfCrrAKuwA0N] Augmented Body
+  [41TZEjhO6D1nWw2X] Augury
+  [VUMtDHr8CRwwr3Mj] Aura of the Unremarkable
+  [ckUOoqOM7Kg7VqxB] Avatar
+  [T7N0LrYOLk3SwrFW] Avenging Wildwood
+  [6P2fzrYkaiiptxlY] Awaken Curse
+  [ZMvplR106Jxl7B15] Awaken Entropy
+  [9lz67JCNCLDfIEy3] Awaken Object
+  [AkF4yFcSCdhoULyZ] Awaken Portal
+  [s0SerOrkkUd7SAH9] Bacchanalia
+  [q9QGc0PJMFWxFOCz] Band of Heroes
+  [N9KjnGyVMKgqKcCw] Bandit's Doom
+  [7ZinJNzxq0XF0oMx] Bane
+  [nKR6Xt5cPGDumX66] Banishing Touch
+  [bay4AfSu2iIozNNW] Banishment
+  [dQ7LrD2HxJoCzi2M] Barbed Spear
+  [bRW61IbjaFea0wcv] Bathe in Blood
+  [2jWVNdVlbJq84dfT] Battlefield Persistence
+  [5WM3WjshXgrkVCg6] Beastmaster Trance
+  [BcqJqxIKYE0aoDiS] Bee-Man's Summons
+  [q5qmNn144ZJGxnvJ] Befitting Attire
+  [pBevG6bSQOiyflev] Befuddle
+  [dKWc83KKiXoIJkhp] Beheading Buzz Saw
+  [3mQkAjexj6hhAnkR] Behold the Weave
+  [qxJE2iSJwPFLZrcK] Belittling Boast
+  [HGSCofGACf1TVH55] Benediction
+  [wZ1rsLrWfYtMZfgv] Beseech Arcanotheign
+  [7GZVTtzN7H4Jujc1] Beseech the Sphinx
+  [VuPDHoVEPLbMfCJC] Bestial Curse
+  [HHCgEEkeeShVQf8d] Bilocation
+  [GUeRTriJkMlMlVrk] Bind Undead
+  [lrFKkzgz80B5vTBb] Binding Muzzle
+  [Fr2CGvWcgSyLcUi7] Bit of Luck
+  [yafsV0ni7rFgqJBj] Biting Words
+  [2w4OpAGihn1JSHFD] Black Tentacles
+  [y5pzaNfb17CM1slC] Blackfinger's Blades
+  [peCF6VArm8urfwxZ] Blade Barrier
+  [m34WOIGZCEg1h76G] Blanket of Stars
+  [bZ8BibvvYOKAbYjn] Blast of the Bellows
+  [YuCBhE9tGgN8G2zU] Blastback
+  [ywHwnXihTnXbm9Xq] Blazing Armory
+  [NacrNSvfODxpZena] Blazing Blade
+  [ZxHC7V7HtjUsB8zH] Blazing Bolt
+  [KEkPxx7Sm6Xf4W3s] Blazing Dive
+  [OYOCWWefZPEfp8Nl] Blazing Fissure
+  [XSujb7EsSwKl19Uu] Bless
+  [jj5d830iUi2ZlQfs] Blessed Boundary
+  [1b55SgYTV65JvmQd] Blessing of Defiance
+  [7yWXx3qC4eFNHhxD] Blight
+  [EgkypvUZIZkx1UlQ] Blightburn Blast
+  [pfFxj4NI5KwO119I] Blind Eye
+  [Q56HLIHVKY6bC5W3] Blinding Beauty
+  [3ygqSJYWZM1UV76Z] Blinding Bottle
+  [7uL4XhHpxZpgNJPh] Blinding Foam
+  [NhGXgmI3AjkkwnPk] Blinding Fury
+  [VosLNn2M8S7JH67D] Blindness
+  [TDaMnCtZ72uyYrz8] Blink Charge
+  [59NR1hA2jPSgg2sW] Blister
+  [3qx1axryNbl97ker] Blister Bomb
+  [hoR6w8BqX2F35Tdx] Blistering Invective
+  [crf7EL1JtBYwvAEg] Blood Duplicate
+  [ES6FkwXXqYr4ujQH] Blood Feast
+  [TaaMEYdZXQXF0Sks] Blood Vendetta
+  [dFejDNEmVj3CwYLL] Blood Ward
+  [CXpOlv2ZZq2jVbRX] Blood in the Water
+  [94eJHyFPNM1Z3TZp] Blood-Feasting Breath
+  [VXUrO8TwRqBpNzdU] Bloodspray Curse
+  [LEMfFL551YB120RN] Blunt the Final Blade
+  [3JG1t3T4mWn6vTke] Blur
+  [fBoiPXmcIO50OFFR] Boil Blood
+  [aYn7Xgrz4vIMNeIc] Bonding Meal
+  [V4IpjSlefultlOuY] Bone Flense
+  [S708JF3E0kuhuRzG] Bone Spray
+  [zdNUbHqqZzjA07oM] Boneshaker
+  [11pQoPJpSH2jp7h6] Bonewall Bulwark
+  [zPVJI8Jltt3ERkaU] Boomerang Shot
+  [HStu2Yhw3iQER9tY] Boost Eidolon
+  [IN46qySRdMdpcd0y] Boots on the Ground
+  [VUwpDY4Z91s9QCg0] Bottle the Storm
+  [F9mA2Bg27QKniIdv] Bottomless Stomach
+  [B0Ng2VlhEJMuUXUH] Bound in Death
+  [SnBc7Gl5VormWzS1] Bountiful Oasis
+  [txxm6Rj6jNxcFSQ9] Bounty of the Sky
+  [NeoRkU7C4BIz8fUM] Bracing Tendrils
+  [k2QrUk7jWMAWozMh] Brain Drain
+  [SspI4ijjR7N7r4Cc] Bralani Referendum
+  [mAdxOQUA2cHgKViU] Bramble Bush
+  [Y8cSjhU33oUqccxJ] Brand the Impenitent
+  [PGVhjDbzC4lf6aXF] Breadcrumbs
+  [Wt94cw03L77sbud7] Breath of Drought
+  [Hnc7eGi7vyZenAIm] Breath of Life
+  [y6rAdMK6EFlV6U0t] Breathe Fire
+  [VUUWjeapcyLZabVA] Bridge of Vines
+  [eidmNlfl2DUVIclc] Brine Dragon Bile
+  [8lZhUreL1bRk1v4Z] Briny Bolt
+  [xGFAGlonNySXrunq] Buffeting Winds
+  [W02bHXylIpoXbO4e] Bullhorn
+  [ILoXUDP84ru1hYLg] Buoyant Bubbles
+  [UkXTcJAeTOF2inPy] Burglar's Blind
+  [kWDt0JcKPgX6MvdD] Burning Blossoms
+  [bgX4Zfhavahu8lyN] Burrow Ward
+  [vGMbpV7GWIFPNUaZ] Bursting Bloom
+  [wneYzMFUWreyqWHD] Butterfly Bender
+  [BItahht2hEHvR9Bt] Buzzing Bites
+  [U7415tttUO8JLvpf] Buzzing Servants
+  [YVK3JUkPVzHIeGXQ] Cackle
+  [i6GUJCWdNu2278oA] Call Fluxwraith
+  [S1Msrwi990FE7uMO] Call The Blood
+  [BH3sUerzMb2bWnv1] Call of the Grave
+  [REBo9wSxDDx7Qdcc] Call the Ten
+  [dqaCLzINHBiKjh4J] Call to Arms
+  [b515AZlB0sridKSq] Calm
+  [Hycyiw9xVzoIY4Dy] Camel Spit
+  [3JQPqtE7fkscP3f6] Canopy Crawler
+  [qlxM7Ik3uUeUIOcv] Canticle of Everlasting Grief
+  [jXcsCpko8qNrWZ4x] Capital Dividend
+  [jJphHQlENHFlSElH] Captivating Adoration
+  [24JgGrYx7ixgP4kn] Carrion Mire
+  [LvezN4a3kYf1OHMg] Carryall
+  [rtisvvvhkpZPdgXc] Cascade Countermeasure
+  [OdqM06M0wDUqZWiR] Cast into Time
+  [mriIWoSDtJTJIBjX] Caster's Imposition
+  [wLIvH0AT1u7oa64N] Cataclysm
+  [FyOgUkq71LNC143w] Catch Your Name
+  [thAHF1zxNplLCJPO] Caustic Blast
+  [sBSalosrt7C4IXas] Cauterize Wounds
+  [KEagmnwgsSbGmkme] Cave Fangs
+  [vZSWzkw0uF4iFWSM] Celestial Accord
+  [9WlTR9JlEcjRmGiD] Celestial Brand
+  [guHLRnTL1OBUYh0V] Censure Falsehoods
+  [TDNlDWbYb58Y55Da] Chain Lightning
+  [xPrbxyOEwy9QaPVn] Chameleon Coat
+  [USM530HlzZ1RMd99] Champion's Sacrifice
+  [CVvkveEH7lonSTZd] Channel Arrogance
+  [g1eY1vN44mgluE33] Charged Javelin
+  [UirEIHILQgip87qv] Charitable Urge
+  [vLA0q0WOK2YPuJs6] Charm
+  [KMFRKzNCq7hVNH7H] Charming Push
+  [ut9IhJ9jSZSHDUop] Charming Touch
+  [JkyUu62rLxcNT4K9] Chastising Retort
+  [sRfSBHWHdbIa0aGc] Chilling Darkness
+  [8TQiFzGf4feoHeH0] Chilling Spray
+  [4y2DMq9DV5HvmnxC] Chroma Leach
+  [NBSBFHxBm88qxQUy] Chromatic Armor
+  [FgRpddPORsRFwNoX] Chromatic Image
+  [Hb8GdAhP0zBCv3zU] Chromatic Ray
+  [forsqeofEszBNtLq] Chromatic Wall
+  [hvV6IruyW4MAr0Ub] Chrysopoetic Curse
+  [crF4g9jRN1y84MSD] Chthonian Wrath
+  [mOUwbIN1SUp8FyPR] Cinder Gaze
+  [bVvGpSOg2WaTUItS] Cinder Swarm
+  [mpGCMTldMVa0pWYs] Circle of Protection
+  [9WMEO6JEcAulgUv3] City of Sin
+  [7dBxguCNWCoPYxIi] Clad In Metal
+  [5OcZ3HBkrRFhSWCz] Claim Curse
+  [GzN9bG6cKZ96YC6l] Claim Undead
+  [HXhWYJviWalN5tQ2] Clairaudience
+  [zvKWclOZ7A53DObE] Clairvoyance
+  [yNTfght6fu9WYKmx] Claws of the Otter
+  [7OFKYR1VY6EXDuiR] Clawsong
+  [SUKaxVZW2TlM8lu0] Cleanse Affliction
+  [ElpqHitq4FqwLURV] Cleanse Air
+  [qXTB7Ec9yYh5JPPV] Cleanse Cuisine
+  [tf4PMMMzR5xxJDun] Cleansing Flames
+  [EfFMLVbmkBWmzoLF] Clear Mind
+  [MraZBLJ4Be3ogmWL] Clinging Ice
+  [uJXs4M6IeixfPBLc] Clinging Shadows Stance
+  [TCk2MDwf5L5OYjFC] Cloak of Colors
+  [ba1RyDpwq6tfW8VM] Cloak of Light
+  [SE0fbgBj7atuukdv] Cloak of Shadow
+  [zEAblSSbfu1246JL] Clockwork Devotion
+  [pZr1xrCpaSu6qrXU] Clone
+  [A0sMo1L0271yLeDA] Clone Companion
+  [s7kVnr0EdljCamuR] Cloud Current
+  [D5ZAWGqxml5xOiZb] Cloud Dragon's Cloak
+  [XhgMx9WC6NfXd9RP] Clouded Focus
+  [S7ylpCJyq0CYkux9] Clownish Curse
+  [RcZbmSZf2bFYQtTj] Coiling Dance
+  [c3XygMbzrZMgV1y3] Collective Transposition
+  [Z3kJty995FkrsZRb] Combustion
+  [aIHY2DArKFweIrpf] Command
+  [4DaHIgtMBTyxebY3] Commanding Lash
+  [zIAvj7V6BTuQMAIi] Commune with Corazal
+  [oND3oFBjxrhyVvyG] Community Repair
+  [6RNymgUvS87lmQOj] Community Restoration
+  [53Kw9WQtvrEtABEu] Compel True Name
+  [NOB92Wpn7jXvtyVW] Competitive Edge
+  [ehd9PtifLMwjk4ep] Concealment's Curtain
+  [TSyFZNAbqfkRrcq0] Concordant Choir
+  [fkUCvynklBGb4LaI] Conductive Weapon
+  [3puDanGfpEt6jK5k] Cone of Cold
+  [CI7F5qdwp6YngyFt] Confetti Cloud
+  [VGK9s6LCMMS027zP] Confront Selves
+  [uEyfLoFQsRKBRIcB] Confusing Colors
+  [I7oklLZy4aTHIdc3] Confusing Cry
+  [LiGbewa9pO0yjbsY] Confusion
+  [eob29LrDMH2IoeAj] Conjured Clockwork
+  [FQd6Jc3CU6wiS2U7] Conjured Conveyance
+  [ion3VOiLan6ga3QC] Conquering Soldiers
+  [DgNOpb8H9MTAu9KL] Consecrate Flesh
+  [Pp88ueeq4AlkaL6g] Construct Mindscape
+  [HMTloW1hvRFJ5Z2D] Consuming Darkness
+  [9vDmTCHyAWdWWPIs] Contact Friends
+  [Dby1eQ7y5dXBWlyc] Contagious Idea
+  [qJQADktwD0x8kLAy] Containment
+  [WG91Z5TiR6oO5FOw] Contingency
+  [oahqARSgOGDRybBQ] Control Sand
+  [zfn5RqAdF63neqpP] Control Water
+  [XkDCzMIyc0YOjw05] Control Weather
+  [h7RtKSKGViNtD5o4] Coral Eruption
+  [ZIk1EYbG6l4JuUkO] Coral Scourge
+  [ADwX87fWrpB8cQ5Q] Cordyceps Command
+  [vQuwLqtFFYt0K15N] Cornucopia
+  [WRmh1aKEo0dI0NJs] Corpse Communion
+  [9aFg4EuOBVz0i3Lb] Corrosive Body
+  [BlfOg9Ceymgjstjm] Corrosive Muck
+  [IHUs4qn27RrdFQ5Y] Cosmic Form
+  [WILXkjU5Yq3yw10r] Counter Performance
+  [ykyKclKTCMp2SFXa] Countless Eyes
+  [IAjvwqgiDr3qGYxY] Courageous Anthem
+  [mwPfoYfVGSMAaUec] Cozy Cabin
+  [T4QKmtYPeCgYxVGe] Crashing Wave
+  [ZwwIUavMbEwcZz35] Create Demiplane
+  [Mt6ZzkVX8Q4xigFq] Create Food
+  [6nPc5CPRUbSSRDP1] Create Mycoguardian
+  [NCUXsaj2yFxOVhrK] Create Skinstitch
+  [WzLKjSw6hsBhuklC] Create Water
+  [TUj8eugNqAvB1vVR] Creation
+  [xTpp8dHZsNMDm75B] Creative Splash
+  [C8HWMMuB5tMhqJ5W] Crescent Scepter
+  [ExQk8AwDphmckEmZ] Crimson Breath
+  [3x6eUCm17n6ROzUa] Crisis of Faith
+  [zVfTMpkXJDRESkl5] Croak Voice
+  [h2DLv8TQV0Z83tQp] Crown of Prophets
+  [xFY9RtDE4DQKlWNR] Crusade
+  [AiWtiVmyasyL42J8] Crushing Ground
+  [0H1ozccQGGFLUwFI] Cry of Destruction
+  [10siFBMF4pIDhVmf] Cup of Dust
+  [CGB3a9gJU5S8gjKk] Curse of Calamity
+  [nQS4vPm5zprqkzFZ] Curse of Death
+  [B3eLlbaPxOYHcs1o] Curse of Lost Time
+  [9uSBfK8EUVBrcNYx] Curse of Recoil
+  [1VOjUKd1pacI67RZ] Curse of the Spirit Orchestra
+  [dN8QBNuTiaBHCKUe] Cursed Metamorphosis
+  [mMyMOxYzMxADdO5M] Cutting Eye
+  [1hLxZznnA2kvXlIt] Cutting Insult
+  [m2i7N8tnqar3gZDZ] Cycle of Retribution
+  [IDkEuq5jLEDhJ31C] Cyclone Rondo
+  [aSDfGcUOUVGU5m1g] Daemon Form
+  [Vpohy4XH1DaH95hT] Daemonic Pact
+  [9BGEf9Sv5rgNBCk0] Dance of Darkness
+  [ViqzVEprQVzCXZ9f] Dancing Blade
+  [smiVuoFMSgY2FTOO] Dancing Fountain
+  [8Hw3P6eurX1MYm7L] Dancing Shield
+  [oiUhJbJ3YCKF62Fu] Darkened Eyes
+  [BhJtCTLbngvZm8EA] Darkened Forest Form
+  [2WNFbvToMsEGxmeK] Darkened Sight
+  [sFwoKj0TsacsmoWj] Darklight
+  [4GE2ZdODgIQtg51c] Darkness
+  [pZTqGY1MLRjgKasV] Darkvision
+  [11P3KgDTMIeQIJD7] Dawnflower's Light
+  [Llx0xKvtu8S4z6TI] Day's Weight
+  [dARE6VfJ3Uoq5M53] Daydreamer's Curse
+  [4gBIw4IDrSfFHik4] Daze
+  [zul5cBTfr7NXHBZf] Dazzling Flash
+  [fZPCv2VHuM2yPbC8] Deafness
+  [dLdRqT6UxTKlsPgp] Death Knell
+  [YvXKGlHOt7mdW2jZ] Death Ward
+  [HG4afO9EOGEU9bZN] Death's Call
+  [ik0bjmAJse9PSECL] Deathless March
+  [VmqdVWCb8zAUCW8S] Debilitating Dichotomy
+  [AzTFMy9E9HQcLNRg] Debilitating Terror
+  [FrKPwgFxWIGMGgs4] Deceiver's Cloak
+  [C2DwamKrW6QHoDQg] Deep Breath
+  [Irlpzl1YBSJ6xF5e] Deep Sight
+  [oK8P3l5VvNKKDkZe] Defended by Spirits
+  [f9m9DayyGy3meqUX] Dehydrate
+  [x9RIFhquazom4p02] Deity's Strike
+  [ziHDISWkFSwz3pmn] Delay Affliction
+  [3wmX7htzOXiHLdAn] Delay Consequence
+  [8fEfjvC01gNclDKJ] Deluge
+  [J8pL8yTshga8QOk8] Delusional Pride
+  [dKbv80rlAWVpz83C] Demon Form
+  [tsKnoBuBbKMXkiz5] Demonic Pact
+  [M0jQlpQYUr0pp2Sv] Desiccate
+  [92JNBuY5pfFmywOd] Desperate Repair
+  [dQGn0eAyvYMDdj0h] Destroy Mindscape
+  [7d4DUTDIlzDa8OvX] Destructive Aura
+  [QnTtGCAvdWRU4spv] Detect Alignment
+  [kREpsv78anJpIiq2] Detect Creator
+  [gpzpAAAJ1Lza2JVl] Detect Magic
+  [vJZ83ehQiM906lea] Detect Metal
+  [QqxwHeYEVylkYjsO] Detect Poison
+  [AnWCohzPgK4L9GVl] Detect Scrying
+  [kUSShxXzY1sPtJA0] Detonate Magic
+  [dR53f0p15EW7D0xC] Devil Form
+  [PgLvO8UNHSj5f61m] Devour Life
+  [wTldMJx0vyBAehrI] Devouring Dark Form
+  [EAuUxxnDV4v3KDAC] Devouring Void
+  [Vctwx1ewa8HUOA94] Diabolic Edict
+  [30BBep9U4BDV0EgQ] Diabolic Pact
+  [AWxS2lr86qNNQVDT] Diadem of Divine Radiance
+  [wjJW9hWY5CkkMvY5] Diamond Dust
+  [6UafOE1ZUbHamsZJ] Dim the Light
+  [5p9Y4ACrtRM4gTpN] Dimensional Assault
+  [MFPvs0ARxtThYPFq] Dimensional Excision
+  [zjG6NncHyAKqSF7m] Dimensional Steps
+  [KhM8MhoUgoUjBMIz] Dinosaur Form
+  [FA55Fxf8MBXhje95] Dinosaur Fort
+  [1xLVcA8Y1onw7toT] Dirge of Doom
+  [FCfd1zUrqPaLEtau] Dirge of Remembrance
+  [uNsliWpl8Q1JdFcM] Discern Lies
+  [UmXhuKrYZR3W16mQ] Discern Secrets
+  [t1e3U2eluRsp2izf] Discomfiting Whispers
+  [PRrZ7anETWPm90YY] Disguise Magic
+  [r7ihOgKv19eJQnik] Disintegrate
+  [ihbRf964JDXztcy3] Disjunction
+  [jW2asKFchuoxniSH] Dismantle
+  [9HpwDN4MYQJnW0LG] Dispel Magic
+  [JOdOpbPDl7nqvJUm] Dispelling Globe
+  [L8pzCOi7Jzx5ALs9] Disperse into Air
+  [jSJz4vx0fXPHa3d6] Disruptive Transfer
+  [WOM9alxiTdp0HEVD] Distortion Lens
+  [JHntYF0SbaWKq7wR] Distracting Chatter
+  [z8bHh8KVttslQIU9] Distracting Decoy
+  [D8cWhrzcsd43OlIX] Div Pact
+  [1xM9muPRa8hiyJtI] Dive and Breach
+  [8OWA91bgm5r6QPaH] Dividing Trench
+  [it4wx2mDIJDlZGqS] Divine Armageddon
+  [nsQvjNyg4Whw2mek] Divine Aura
+  [sX2o0HH4RjJDAZ8C] Divine Decree
+  [BBiO9ZdwyEJ581ES] Divine Dragon's Watch
+  [A16eFTRh82xIjMu8] Divine Immolation
+  [KtTGLbLG9nqMbUYL] Divine Inspiration
+  [xKHq2Eisapixvj6q] Divine Keystone
+  [qwZBXN6zBoB9BHXE] Divine Lance
+  [NkeLctXo9FLGnDhi] Divine Plagues
+  [hiVL8qsnTJtpouw0] Divine Vessel
+  [hVU9msO9yGkxKZ3J] Divine Wrath
+  [oFwmdb6LlRrh9AUT] Diviner's Sight
+  [T5Mt4jXFuh14uREv] Divinity Leech
+  [UKsIOWmMx4hSpafl] Dizzying Colors
+  [OsOhx3TGIZ7AhD0P] Dominate
+  [PIdXUPtE6ZGpFpXV] Domora's Defense
+  [iMmexY6ZosLS4I5R] Door to Beyond
+  [K4LXpaBWrGy6jIER] Downpour
+  [S6Kkk15MWGqzC00a] Draconic Barrage
+  [JcobNl4iE9HmMYtE] Dragon Breath
+  [eAOClJ1KRSPik8SX] Dragon Turret
+  [HWJODX2zPg5cg34F] Dragon Wings
+  [cqdmSmQnM0q6wbWG] Drain Life
+  [Jte2jlX59a1yQPp8] Drain Planar Connection
+  [jsWthW1Qy6tg3SwD] Draw Ire
+  [lXsFKdaOz9t9w11U] Draw Moisture
+  [n7OgbKme4hNwxVwQ] Draw the Lightning
+  [1QMjWGq1DPOQr4VL] Dread Ambience
+  [XULNb8ItUsfupxqH] Dread Secret
+  [rwCh2qTYPA44KEoK] Dream Council
+  [yM3KTTSAIHhyuP14] Dream Message
+  [PztLrElcZfLwRnEq] Dreamer's Call
+  [y0Vy7iNL3ET8K00C] Dreaming Potential
+  [scTRIrTfXquVYHGw] Drop Dead
+  [MLdMUOdwSKegOGlo] Dull Ambition
+  [73rToy0v5Ra9NvL6] Duplicate Foe
+  [K1wmI4qPmRhFczmy] Dust Storm
+  [caehfpQz7yp9yNzz] Dutiful Challenge
+  [rerNA6YZsdxuJYt3] Déjà Vu
+  [AUZPwEorddewm0x1] Eagle's Cry
+  [XOs8C2eZJAO3go0N] Earth and Sky
+  [PrlR2sLWeiuTcPF2] Earth's Bile
+  [gPvtmKMRpg9I9D7H] Earthbind
+  [x7SPrsRxGb2Vy2nu] Earthquake
+  [ffz6wlSMzhaDpjg6] Earthworks
+  [FWuLUKIbkJZjBiuA] Eat Fire
+  [LpMeT0CW1OEKdaQL] Echo Jump
+  [vtCCVe869shMCJMj] Echoing Weapon
+  [0jadeyQIItIuRgeH] Eclipse Burst
+  [PgDFDvX64eswapSS] Ectoplasmic Expulsion
+  [QE9f3OxvvBThymD4] Ectoplasmic Interstice
+  [kuZnUNrhXHRYQ2eM] Eidolon's Wrath
+  [rVhHaWqUsVUO4GuY] Eject Soul
+  [kBhaPuzLUSwS6vVf] Electric Arc
+  [57ulIxg3Of2wCbEh] Electrified Crystal Ward
+  [vQMAdnIwnV9prPiG] Element Embodied
+  [9TauMFkIsmvKJNzZ] Elemental Absorption
+  [NyxQAazFBdBAqZGX] Elemental Annihilation Wave
+  [f9uqHnNBMU0774SF] Elemental Betrayal
+  [Qlp8G3knwLGhAxQ0] Elemental Blast
+  [fg5ZlSVXzGHNJfbO] Elemental Breath
+  [Cpj05laa7ogqGwS3] Elemental Confluence
+  [fHawnhOHwzr4Mwr7] Elemental Counter
+  [1K6AYGisvo9gqdhs] Elemental Form
+  [e36Z2t6tLdW3RUzZ] Elemental Gift
+  [B8aCUMCHCIMUCEVK] Elemental Motion
+  [wfqBbQ2RXj4VjKUZ] Elemental Sense
+  [rOwOLlfVgLMg1FND] Elemental Sentinel
+  [5NReCnDFFuThEAHB] Elemental Servitor
+  [WkqamCF8r4O5Gh0n] Elemental Sheath
+  [vfHr1N8Rf2bBpdgn] Elemental Tempest
+  [0JUOgbbFCapp3HlW] Elemental Toss
+  [kMffb6SvhCBMMI4k] Elemental Zone
+  [zjYQyuBNT5VjV4mz] Elephant Form
+  [oPVyu2a0K3aTVIR8] Elysian Whimsy
+  [eIQ86FOXK34HiNLs] Embed Message
+  [HBxsMKXzZM0HviEE] Embodied Font
+  [X4On99Nti8gjWywG] Embodiment of Battle
+  [mau1Olq58ECF0ZPi] Embrace Nothingness
+  [ilGsyGLGjjIPHbyP] Embrace the Pit
+  [obVA6duK5fGbfFUY] Empathic Link
+  [XnpRRUVAVoY6z88H] Empower Ley Line
+  [0cF9HvHzzWSbCFBP] Empty Inside
+  [CQWTyDxiVSW4uRn7] Empty Pack
+  [BNkgZi1bcQcVmBHp] Encroaching Woods
+  [4c1c6eNzU1PFGkAy] Endure
+  [eG1fBodYwolaXK98] Enduring Might
+  [LoBjvguamA12iyW0] Energy Absorption
+  [m2xFMNyQiUKQDRaj] Energy Aegis
+  [eexkxcqnkXazsGfK] Enervation
+  [J7Y7tl0bbdz7TcCc] Enfeeble
+  [ddqmGnShyoRBKFkZ] Engrave Memory
+  [a5uwCgOe7ayHPtHe] Enhance Senses
+  [rdTEF1hfAWbN58NE] Enhance Victuals
+  [wzctak6BxOW8xvFV] Enlarge
+  [8rj45fKzCFcB0fxs] Enlarge Companion
+  [11haL5O9KMpY5Fv7] Entangle Fate
+  [J6vNvrUT3b1hx2iA] Entangling Flora
+  [IihxWhRfpsBgQ5jS] Enthrall
+  [Vw2CNwlRRKABsuZi] Entrancing Eyes
+  [Yph1UqZU8vMc9bJG] Entreat Spirit
+  [Do0pe0gn8OFdCOnN] Entreat Thunderbird
+  [Vg4K3dTDswNQf4Bx] Entreat the Many
+  [X4T5RlQBrdpmA35n] Entropic Wheel
+  [VDK5cQ94BszDrMiJ] Entwined Roots
+  [gWmLT5SkA0qH2mNE] Envenom Companion
+  [5esP2GVzvxWsMgaX] Environmental Endurance
+  [HisaZTk67YAxLGBq] Ephemeral Hazards
+  [QpjHqxwTGdILLvjD] Ephemeral Tracking
+  [Z2oSFY2fT8zLkK4P] Equal Footing
+  [J5MNC4xq3CHH31qT] Eradicate Undeath
+  [Tw9e2rPaNdxcM1Rp] Erase Trail
+  [1aXX52MnVbBvT9S7] Establish Nexus
+  [XlQBVvlDWGrGlApl] Establish Ward
+  [D2nPKbIS67m9199U] Ethereal Jaunt
+  [gasOL6a0WhOhUsgL] Etheric Shards
+  [mTpPZIJ2sdgusPP1] Euphoric Renewal
+  [f45JpY7Ph2cAJGW2] Evil Eye
+  [lV8FkHZtzZu7Cy6j] Evolution Surge
+  [znMvKqcRDilIVMwA] Exchange Image
+  [GurWFDj4IjKv73kL] Excise Lexicon
+  [Z9OrRXKgAPv6Hn5l] Execute
+  [aXoh6OQAL57lgh0a] Expeditious Excavation
+  [v89KwyaBd6g5rWVS] Exploding Earth
+  [ZvB9sV7NLdpDeoTw] Explosive Barrage
+  [LyqqvufOUIh8U25d] Extend Blood Magic
+  [CR8OKDbeFJoZbOCu] Extend Boost
+  [GxxnhRIaoGKtu1iO] Extend Spell
+  [hdzyDrRdHSse88XM] Extract Brain
+  [CLThxp8Qf43IQ3Sb] Extract Poison
+  [DLFupJuCfzyLCQcO] Eyes of the Dead
+  [6s0UW4bujggma9TC] Fabricated Truth
+  [yH13KXUK2x093NUv] Face in the Crowd
+  [IkS3lDGUpIOMug7v] Faerie Dust
+  [HRb2doyaLtaoCfi3] Faerie Fire
+  [LjLSvAqnR03EnITX] Fallen Soldier's Lament
+  [vm9O7ne48NM72yrJ] Falling Sky
+  [jrBa9deU2ULFWvSl] Falling Stars
+  [2RhZkHNv8ajq0yLq] Fallow Field
+  [5z1700cfG8Ybm0e6] False Nature
+  [RCbLd7dfquHnuvrZ] False Vision
+  [8ViwItUgwT4lOvvb] False Vitality
+  [udZEKwUryIsobjBG] Falsify Heat
+  [CHZQJg7O7991Vl4m] Familiar Form
+  [9GkOWDFDEMuV3hJr] Familiar's Face
+  [nA0XlPsnMNrQMpio] Fantastic Facade
+  [ErCsWsqXe8ccRjgO] Far Sight
+  [O6BIfXsbiisKfLTe] Far-Flung Fetch
+  [W0YqtSVwfFImGgdK] Fashionista
+  [lyJDBD9OFW11vLyT] Fatal Aria
+  [e4vxRJ4sjUXMEIGP] Fate's Travels
+  [Di9gL6KIZ9eFgbs1] Fated Confrontation
+  [X3RUan7TVqo6UpUG] Fated Healing
+  [ReUoodsqUYSTwSgE] Fateful Condemnation
+  [i7u6gAdNcyIyyo3h] Favorable Review
+  [4koZzrnMXhhosn0D] Fear
+  [vctIUOOgSmxAF0KG] Fear the Sun
+  [0qA4MfMkFklOz2Lk] Fearful Feast
+  [siU9xRlqWXeKT0mH] Feast of Ashes
+  [bS3DW0MptpnZl5Zr] Feast of Supplication
+  [RvBlSIJmxiqfCpR9] Feet to Fins
+  [Ru9v8U9IRk3LtWx8] Feral Shades
+  [89Hj5QuqvcwVXcqj] Ferrous Form
+  [GzlVI3qYdCtUigLz] Fey Abeyance
+  [mBojKJatf9PTYC38] Fey Disappearance
+  [Qu4IThrk1wpONwjT] Fey Form
+  [DdXKfIjDtORUtUvY] Fey Glamour
+  [x5rGOmhDRDVQPrnW] Field of Life
+  [MLYTWHfewOpI3Cz7] Field of Razors
+  [XS7Wyh5YC0NWeWyB] Fiery Body
+  [0zU8CPejjQFnhZFI] Figment
+  [GgrrcKQgJH2Eykq1] Filter Air
+  [bIz6QnUIxu5Z7vEH] Final Fate of the Locust Host
+  [x0rWq0wS06dns4G2] Final Sacrifice
+  [oJKZi8OQgmVXHOc0] Fire Ray
+  [kuoYff1csM5eAcAP] Fire Seeds
+  [YrzBLPLd3r9m6t1p] Fire Shield
+  [nnYxDWU3Vzg9WenB] Fire's Pathway
+  [sxQZ6yqTn0czJxVd] Fireball
+  [QLTgY1AqFvX82vq2] Fireproof
+  [1OiPVy1wuoXi6LR5] Firework Blast
+  [y7Tusv3CieZktkkV] Flame Barrier
+  [p6ebe2PliRkGbmiV] Flame Dancer
+  [E3X2RbzWHCdz7gsk] Flame Strike
+  [Gn5deIoobHpd3SiR] Flame Vortex
+  [3q9tBMWsWQKlXPPJ] Flame Wisp
+  [ZClfmMoKG3E926Uq] Flames of Ego
+  [bynT1UKaDqr8dLNM] Flaming Fusillade
+  [6AqH5SGchbdhOJxA] Flammable Fumes
+  [YgbYvkLvnWJ4WfEA] Flashy Disappearance
+  [aEM2cttJ2eYcLssW] Fleet Step
+  [WV2aMNN9DO5ZBjSv] Flense
+  [zR67Rt3UMHKC5evy] Flicker
+  [2ZdHjnpEQJuqOYSG] Floating Flame
+  [b6AQvzs8EotmlK56] Flourishing Flora
+  [zCLyETFoPqCQXLVy] Flowing Strike
+  [K8vvrOgW4bGakXxm] Flurry of Claws
+  [A2JfEKe6BZcTG1S8] Fly
+  [28kgh0JzBO6pt38C] Focusing Hum
+  [yD819yTgbBFcCh5M] Fold Metal
+  [yY1H5zhO5dHmD8lz] Font of Serenity
+  [QGfVFyQhoalZbE9s] Footholds and Foothills
+  [mtxMpGWpwwWSbySj] For Love, For Lightning
+  [qdfV4y8B6mbg4Fnm] Foraging Friends
+  [lpoWfblSMLcJfxsZ] Forbidden Thought
+  [RA7VKcen3p56rVyZ] Forbidding Ward
+  [gKKqvLohtrSJj3BM] Force Barrage
+  [Hu38hoAUSYeFpkVa] Force Bolt
+  [9mPEoOPN0AMuixIv] Force Fang
+  [BQMEaeJiEFC1nepg] Forced Mercy
+  [k43PIYwuQqjeJ3S3] Forced Quiet
+  [rMGkk23qWvxTmgA8] Forceful Hand
+  [s4HTepjhQWV1yfBs] Foresee the Path
+  [qsNeG9KZpODSACMq] Foresight
+  [oKC36WjFD1jgqUN5] Forest of Gates
+  [FTR8m4qrhYzTRyrD] Forge
+  [u0AtDZs6BhBPtjEs] Forgotten Lines
+  [FKtPRWcs4zhwn9N1] Form of the Sandpoint Devil
+  [tWzxuJdbXqvskdIo] Fortify Summoning
+  [yRf59eFtZ50cGlem] Fortifying Brew
+  [kF0rs9mCPvJGfAZE] Fortissimo Composition
+  [6nTBr5XNuKOuPM5m] Foul Miasma
+  [4ddJSjC9Zz5DX0oG] Freedom
+  [1dsahW4g1ggXtypx] Freeze Time
+  [9AZEObUdLI2fwmPl] Freezing Rain
+  [fxRaWoeOGyi6THYH] Frenzied Revelry
+  [TjrZGl8z2INgf3vi] Friendfetch
+  [cCFDnmFB1EGeQUeA] Friendly Push
+  [vFkz0gVBUT2gGnm1] Frigid Flurry
+  [cnRltZAjU9aCklqz] Frog Tongue
+  [R5r4vtmlvOA8hDiF] Frost Pillar
+  [WFSazGLCUuPsBv1p] Frost's Touch
+  [IxhGEKl63R4QBvkj] Frostbite
+  [nOVSmPZsCm1C1sI3] Frozen Fog
+  [5KmyO4YSGEAUdgAS] Funeral Flames
+  [H481wmQUtEUhxHzi] Fungal Exhalation
+  [oNUyCqbpGWHifS02] Fungal Hyphae
+  [3VxVbZqIRvpKkg3O] Fungal Infestation
+  [dDiOnjcsBFbAvP6t] Gale Blast
+  [nEXkk85BQu1cREa4] Garden of Death
+  [w4M6Vqvq8k6MOFvj] Garden of Healing
+  [jQgX7zChqjFrU7Q1] Garden of the Green Man's Growth
+  [kvZCQz4NoMAfjvif] Gasping Marsh
+  [U13bC0tNgrlHoeTK] Gate
+  [nzbnTqHgNKiGZkrZ] Gathering Call
+  [Q690d3mw3TUrKX7E] Geas
+  [5KobTMrZeZxuXMgl] Gecko Grip
+  [OyiKIbWllLZC6sGz] Genie's Veil
+  [C0D2eqzTAhiKm4j9] Gentle Breeze
+  [TTwOKGqmZeKSyNMH] Gentle Landing
+  [i88Vi47PDDoP6gQv] Geyser
+  [atlgGNI1E1Ox3O3a] Ghost Sound
+  [rthC6dGm3nNrt1xN] Ghostly Carrier
+  [JqHAxsMUZ4Mr5bTr] Ghostly Shift
+  [WVc30DGbM7TRLLul] Ghostly Tragedy
+  [vhe9DduqaivMs8FV] Ghostly Transcription
+  [AMEu5zzLN7uCX645] Ghostly Weapon
+  [JhRuR7Jj3ViShpq7] Ghoulish Cravings
+  [x2Gf3lt64eoMocMd] Gift of the Anemos
+  [pLEhF3f7KRxFo0vp] Girzanje's March
+  [ZyREiMaul0VhDYh3] Glacial Heart
+  [UK349cSOljQVYpcu] Glamorize
+  [3qz32XdiugYhsr32] Glass Form
+  [dgMauNKWeRIu8pMN] Glass Sand
+  [cgfl9Qr46bKaA59e] Glass Shield
+  [ftZ750SD2iIJKIy3] Glimmer of Charm
+  [cNnHV97gPqxJ3Rrr] Glimpse Weakness
+  [ZjbVgIIqMstmdkqP] Glimpse the Truth
+  [m1vKX4xxWQJXfupu] Glowing Trail
+  [SdXFiQ4Py8761sNO] Glutton's Jaws
+  [91ZbBll8M7IXQ4yw] Gluttonous Growth
+  [yrsgOdj5oqp7lEQY] Gnaw at the Moon
+  [zJQnkKEKbJqGB3iB] Goblin Pox
+  [MPxbKoR54gkYkqLO] Gouging Claw
+  [rwWtpZpkNYvypknx] Grasp of the Deep
+  [Wpgt5TYcTHLDei6J] Grasping Earth
+  [2YIr0S2Gt14PMMQp] Grasping Grave
+  [cQgPIohUja0DUiRL] Grasping Vine
+  [Xrz6wPXDBUr27izR] Grave Impressions
+  [F1fQC9SarAkjNxpP] Gravitational Pull
+  [IWUe32Y5k2QFd7YQ] Gravity Weapon
+  [06pzGkKTyPE3tHR8] Gravity Well
+  [rTvNWcKNpOnGklGF] Gray Shadow
+  [Wu0xFpewMKRK3HG8] Grease
+  [k34hDOfIIMAxNL4a] Grim Tendrils
+  [d9sBzPOXX3KT8uTu] Grisly Growths
+  [s8gTmnNMg4H4bHEF] Gritty Wheeze
+  [3ipOKanMLnJrPwbr] Guardian's Aegis
+  [izcxFQFwf3woCnFs] Guidance
+  [R569jdqpNry8m0TJ] Guided Introspection
+  [L10q1ng6U3sega9S] Guiding Star
+  [g8QqHpv2CWDwmIm1] Gust of Wind
+  [3KiM09e8DN9AdTPA] Hag's Fruit
+  [UJmKPm1FC6pf6txP] Halcyon Infusion
+  [IERHT6v4o5ISvuJG] Halcyon Mists
+  [4bFxUA59xeq6Snhw] Hallowed Ground
+  [U58aQWJ47VrI36yP] Hallucination
+  [NQk8Cabhhw7jXkg0] Halt Death
+  [bSDTWUIvgXkBaEv8] Hand of the Apprentice
+  [wdA52JJnsuQWeyqz] Harm
+  [qJZZdYBdNaWRJFER] Harmonize Self
+  [ofAQyLtLEGnOIs3N] Harrowing
+  [o6YCGx4lycsYpww4] Haste
+  [3MzuRDc7ccylpW2e] Hasted Assault
+  [b5BQbwmuBhgPXTyi] Haunting Hymn
+  [rfZpqmj0AIIdkVIs] Heal
+  [Zmh4ynfnCtwKeAYl] Heal Animal
+  [KIV2LqzS5KtqOItV] Heal Companion
+  [rhJyqB9g3ziImQgM] Healer's Blessing
+  [m5QS8q5M6K0euKcT] Healing Plaster
+  [CzjQtkRuRlzRvwzg] Healing Well
+  [PVXqMko4yGgw90uo] Heart's Desire
+  [1B8BLEQBQn9aEMoY] Heart's Hook
+  [dZV8nZUKRhGIr6g9] Heartbond
+  [v4KzRPol5XQOOmk0] Heat Metal
+  [73gohsek77nLGPWC] Heatvision
+  [yWySiasyPZcRoe4d] Heaving Earth
+  [z0ffligcrkVtKZd6] Hedge Prison
+  [EX6gTy8s4wNyhOnl] Heinous Future
+  [9LHr9SuDLTicdbXs] Hellfire Plume
+  [0OFFXFdnMmFVlt8W] Helpful Reload
+  [3SJEBgXHolrSAFqD] Helpful Steps
+  [kcYCWMd1NVCJ5Zbu] Helpful Wood Spirits
+  [uGXWkR2h8q9MRzEM] Hero's Defiance
+  [4j0FQ1mkidBAXuQV] Heroic Feat
+  [KqvqNAfGIE5a9wSv] Heroism
+  [C2w3YfBKjIRS07DP] Hidden Mind
+  [3TuGuGZqyOBmWp7N] Hidebound
+  [wSK0wtn8iHShYT9y] Hippocampus Retreat
+  [k6f5nvSv0XIhbiHj] Hollow Heart
+  [wykbu2KW9tMBRySr] Hologram Cage
+  [DZ9bzXYqMjAK9TzC] Holy Cascade
+  [BINaRykHRLGn4Qfm] Holy Host
+  [DyiD239dNS7RIxZE] Holy Light
+  [JIphJbkWHndtFk72] Home Among Mulberry Leaves
+  [JyxTmqjYYn63V5LY] Honeyed Words
+  [y5amezSt82FYu9HG] Horde of Underlings
+  [8Uzc9WKqRr755S5d] Horizon Thunder Sphere
+  [aZg3amDcrXz3cLCz] Horrific Visage
+  [LrRyNA2bo5UwBxud] Horrifying Blood Loss
+  [PEfSofHm73IT3Khc] House of Imaginary Walls
+  [xxWhyl81w3ckslAU] Howling Blizzard
+  [2qGqa33E4GPUCbMV] Humanoid Form
+  [0EzLXIpPPH0LOKqt] Hungry Depths
+  [GfrKNJ9pNeATiKCc] Hunter's Luck
+  [tj86Rnq3QuQnDtG3] Hunter's Vision
+  [pRKaEXnjGJXbPHPC] Hurtling Stone
+  [jfVCuOpzC6mUrf6f] Hydraulic Push
+  [Y3G6Y6EDgCY0s3fq] Hydraulic Torrent
+  [gSUQlTDYoLDGAsCP] Hymn of Healing
+  [ZYoC630tNGutgbE0] Hypercognition
+  [TvZiwZRianfTSbEg] Hypnopompic Terrors
+  [K2WpC3FFoHrqX9Q5] Hypnotize
+  [P7AToTm0ulueRk63] Ibex's Harvest
+  [kHyjQbibRGPNCixx] Ice Storm
+  [M6HsK7W6JMkJXeog] Ideal Mimicry
+  [Dj44lViYKvOJ8a53] Ignite Ambition
+  [3GXU3ugrwLv0P7AH] Ignite Fireworks
+  [6DfLZBl8wKIV03Iq] Ignition
+  [6ZIKB0151LUR19Rw] Ill Omen
+  [qCkxBOLMCCXEjBWo] Illuminate
+  [f8SBoXiXQjlCKqly] Illusory Creature
+  [i35dpZFI7jZcRoBo] Illusory Disguise
+  [2oH5IufzdESuYxat] Illusory Object
+  [kLyyJayja75K9rXX] Illusory Shroud
+  [PERUlvKPtF7dMzN4] Imaginary Lockbox
+  [sUr5KCpeE6AXfvPp] Imaginary Weapon
+  [HkjeegDsA5Wq0hR2] Imitate Fauna
+  [oryfsRK27jAUnziw] Imp Sting
+  [oGV6YdpZLIG4G4gH] Impaling Briars
+  [oXeEbcUdgJGWHGEJ] Impaling Spike
+  [VJW3IzDpAFio7uls] Impart Empathy
+  [8VzbumNyMEdSzZSz] Impeccable Flow
+  [rfFZKfeCSweFv7P3] Impending Doom
+  [sUvTGELaggrBSgGm] Implement of Destruction
+  [4WS7HrFjwNvTn8T2] Implosion
+  [WJOQryAODgYmrL6g] Imprint Message
+  [2CNqkt2s2IYkVnv6] Imprisonment
+  [DcUGLLyaa9tHH1kN] Incarnate Ancestry
+  [OTd17oXwJH9qb1cS] Incendiary Ashes
+  [AspA30tzKCHFWRf0] Incendiary Aura
+  [I2fwPslQth0DTPQD] Incendiary Fog
+  [UG0SmRYSdbrx2rTA] Indestructibility
+  [xh6hPMDx2n4OaBU7] Indolent Haze
+  [fMnjP4hpNRV9EfVM] Inevitable Destination
+  [8THDHP0UC7SgOYYF] Inevitable Disaster
+  [gMbrNFKz9NP3TR4s] Inexhaustible Cynicism
+  [SE3MddYAUyPKABuF] Infectious Comedy
+  [oYBIs8MICYkFwtXD] Infectious Ennui
+  [VACvA5VRbddjt5s9] Infectious Enthusiasm
+  [mUz3wqbMQ5JQ06M5] Infectious Melody
+  [U5dw9SiuVcLmdHoi] Infiltrator's Tunnel
+  [PesUKf0lIt5zRofj] Information Overload
+  [2iQKhCQBijhj5Rf3] Infuse Vitality
+  [MiTFNcqCI9f34A2V] Inkshot
+  [eSEmqOBuywoJ6tYd] Inner Radiance Torrent
+  [ZL8NTvB22NeEWhVG] Inner Upheaval
+  [YQWq1DZuLRk32M3h] Inscrutable Mask
+  [XI6Lzd2B5pernkPd] Insect Form
+  [Einy9RNTGVq1kY3j] Inside Ropes
+  [uiv8FKuxE8HOWTxW] Instant Armor
+  [vuehhQN8gPSpqcEK] Instant Minefield
+  [xyRjD52YZl3DBsiy] Instant Parade
+  [ET2BYfeNaHqfZIWs] Instant Pottery
+  [sGenGMmE1ntkXCtN] Interdisciplinary Incantation
+  [RbORUmnwlB8b3mNf] Internal Insurrection
+  [5bTt2CvYHPvaR7QQ] Interplanar Teleport
+  [HokKyQl5g655xx9U] Interposing Earth
+  [L37RTc7K79OUpZ7X] Interstellar Void
+  [5pwK2FZX6QwgtfqX] Inveigle
+  [XXqE1eY3w3z6xJCB] Invisibility
+  [Nun72GTmb31YqSKh] Invisibility Cloak
+  [a8xXWCQhIR7o6IvP] Invisibility Curtain
+  [nX85Brzax9f650aK] Invisible Item
+  [hghGRzOSzEl4UXdS] Invoke Spirits
+  [09C2wvWZLCxwjINk] Invoke True Name
+  [AsKLseOo8hwv5Jha] Invoke the Crimson Oath
+  [82gDiXTKsCmdIF6Q] Invoke the Harrow
+  [IhwREVWG0OzzrbWA] Iron Gut
+  [mer4V7vWdTs1oLbG] Isolation
+  [AXpqBdbQ66RWyZYk] It is Written
+  [4ZGte0i9YbLh4dRi] Item Facade
+  [JEMSVySuS4jvTepQ] Jassim's Allegiance
+  [kvm68hVtmADiIvN4] Jealous Hex
+  [8bdt1TvNKzsCu9Ct] Join Pasts
+  [Q7QQ91vQtyi1Ux36] Jump
+  [KFpBT6FPfSFhxQ27] Juvenile Companion
+  [nxnGKgcVii5KTwtM] Kaiju Ward
+  [SXmEI4kVWVSagK4H] Keen Smell
+  [yo1eB5Xz21AYfWCI] Kgalaserke's Axes
+  [jrlCEw9rqBi4qU6g] Ki Cutting Sight
+  [sPHcuLIKj9SDaDAD] Kinetic Ram
+  [vM8oBYaEPgEXBimM] King's Castle
+  [6Ot4N22t5tPD51BO] Knock
+  [L6kr9AUZ8iwuxIip] Know Location
+  [l6zjNysNedpJcmDT] Know the Enemy
+  [tXa5vOu5giBNCjdR] Know the Way
+  [WRRbNyGam4ytTRgr] Labyrinthine Prison
+  [T90ij2uu6ZaBaSXV] Lament
+  [sbTxe4CGP4tn6y51] Lashing Rope
+  [8rAcQOvm0nFrqAUt] Lashunta's Life Bubble
+  [INEAWirvb8c1eAFD] Last Night's Vigil
+  [tlSE7Ly8vi1Dgddv] Laughing Fit
+  [zNN9212H2FGfM7VS] Lay on Hands
+  [2tHYKoVc5YhSewDO] Leaden Steps
+  [QVMjPfXlpnmeuWKS] Leng Sting
+  [USKnG2ZSzVs4xn85] Let Not the Fallen Rest
+  [fI20AVwOzJMHXRdo] Levitate
+  [0Dcd4iEXqCrkm4Jn] Liberating Command
+  [fAlzXtQAASaJx0mY] Life Boost
+  [HIY4XUJZKmFLAJTn] Life Connection
+  [2gQYrCPwBmwau26O] Life Link
+  [vvbS69EHZuUTq0dr] Life Pact
+  [zvvHOQV78WKUB33l] Life Siphon
+  [CgekONDD5jIxL8oM] Life's Flowing River
+  [2TVc8NabmGpc092W] Life's Fresh Bloom
+  [FHfrCABOmGVaEpPx] Life-Draining Roots
+  [9kOI14Jep97TzGO7] Life-Giving Form
+  [lOZhcvtej10TqlQm] Lifelink Surge
+  [HES5jvGiNZZnJycK] Lifewood Cage
+  [6GjJtLJnwC18Y0aZ] Lift Nature's Caul
+  [WBmvzNDfpwka3qT4] Light
+  [ou56ShiFH7GWF8hX] Light of Revelation
+  [9AAkVUCwF6WVNNY2] Lightning Bolt
+  [JyT346VmGtRLsDnV] Lightning Storm
+  [2hMy9ROM2dOZB8Jq] Lignify
+  [OM5NeD7a1CYNqy8S] Liminal Doorway
+  [irTdhxTixU9u9YUm] Lingering Composition
+  [ZMY58Yk5hnyfeE3q] Linnorm Sting
+  [Vbj8bTQ1nwrOBbYF] Live Wire
+  [cBUuG1yJHGeKffpg] Localized Quake
+  [LQzlKbYjZSMFQawP] Locate
+  [qFO9HgplrShoaAPY] Lock Item
+  [mLAYvbafVKfBgEhz] Loose Time's Arrow
+  [5Pc55FGGqVpIAJ62] Loremaster's Etude
+  [iohRnd4gUCmJlh54] Lose the Path
+  [OuZY7VYeylub5K7l] Lotus Walk
+  [flKde7BHrZnRheMl] Love's Sacrifice
+  [7OwZHalOdRCRnFmZ] Lucky Break
+  [MkHshwYy2UOeEHRR] Lucky Month
+  [rDDYGY2ekZ1yVv7q] Lucky Number
+  [1H3T9UwxW44Y0YaS] Luminous Stardust Healing
+  [fRUxp4G9kG816XAt] Lure Dream
+  [Lr737SofpsFtLpEo] Luring Wail
+  [tFKJCPvOQZxKq6ON] Mad Monkeys
+  [u2uSeH6YSbK1ajTy] Magic Hide
+  [f9duI5d8xNYqxI8d] Magic Mailbox
+  [115Xp9E38CJENhNS] Magic Passage
+  [9u6X9ykhzG11NK1n] Magic Stone
+  [b6UnLNikoq2Std1f] Magic Warrior Aspect
+  [tp4K7mYDL5MRHvJc] Magic Warrior Transformation
+  [u4FGIUQgruLjml7J] Magic's Vessel
+  [2ZPqcM9wNoVnpwkK] Magical Fetters
+  [Tx8OqkBFA2QlaldW] Magnetic Acceleration
+  [7dKtMehJ6YrXwJLR] Magnetic Attraction
+  [AsRd1gNRSkHDq2Jx] Magnetic Dominion
+  [24U1b9K4Lj94cgaj] Magnetic Repulsion
+  [AdZ2rWJStZ5unxzq] Malediction
+  [vhMCd15ZwNJn0zen] Malicious Shadow
+  [qzsQmpiQodHBBWYI] Malignant Sustenance
+  [IqBfoUaWDennHYoZ] Manifest Will
+  [AuIiqc7jjiy1GZ75] Manifestation
+  [O1ZLfeOJpHbG9G6B] Manifestation of Spirits
+  [MT8usUfwudDVUm5H] Manifold Lives
+  [bKDsmKVosexwJ80i] Mantis Form
+  [Tl1QAqre7H0sQEXt] Mantis's Grasp
+  [vF52ktg0wUIAlf57] Mantle of Heaven's Slopes
+  [CcXtbTxtdV9MKQfu] Mantle of the Frozen Heart
+  [j2kfNBFpLa0JjVr8] Mantle of the Magma Heart
+  [UcS6Tw9OuOAEDfzg] Mantle of the Melting Heart
+  [3526YUgCvB5ZsKuX] Mantle of the Unwavering Heart
+  [z2mfh3oPnfYqXflY] Mariner's Curse
+  [Oy6qBhzayCnqOiEO] Mark of Blood
+  [M9TiCE1vlG1j2faM] Martyr's Intervention
+  [WPKJOhEihhcIm2uQ] Marvelous Mount
+  [O6VQC1Bs4aSYDa6R] Mask of Terror
+  [10VcmSYNBrvBphu1] Massacre
+  [qOeBQyC1z7OScHvP] Maze of Locked Doors
+  [wTYxxYJWN348oV15] Medusa's Wrath
+  [6TudR1rDkxWMj1cv] Menacing Lament
+  [dINQzhqGmIsqGMUY] Mending
+  [PEGECeEtEmXEzwBT] Mental Map
+  [ma3sndEAZdz0Cy2H] Mercurial Stride
+  [vLzFcIaSXs7YTIqJ] Message
+  [Z7N5IxJCwrAdIgSg] Message Rune
+  [pswdik31kuHEvdno] Metamorphosis
+  [U0hL0LLaprcnAyzC] Migration
+  [2a8wiTxvBhcMbMU5] Mimic Spell
+  [xlRv8vCTHh1NeMpw] Mimic Undead
+  [29JyWqqZ0thCFr1C] Mind Games
+  [9BnhadUO8FMLmeZ3] Mind Probe
+  [KHnhPHL4x1AQHfbC] Mind Reading
+  [RWwiFnjxoJXn7H6D] Mind Swap
+  [fPlFRu4dp09qJs3K] Mind of Menace
+  [D442XMADp01qJ7Cs] Mindlink
+  [8MAHUK6jphbME4BR] Mindscape Door
+  [VJgSQBYwXGDbMmiW] Mindscape Shift
+  [YfJTXyVGzLhM6V8U] Miracle
+  [HBJPsonQnWcC3qdX] Mirage
+  [NIop4eI2i7cKFGad] Mirecloak
+  [j8vIoIEWElvpwkcI] Mirror Image
+  [CmZCq4htcZ6W0TKk] Mirror Malefactors
+  [A7w3YQBrFNH8KYsB] Mirror's Misfortune
+  [WPXzPl7YbMEIGWfi] Mislead
+  [oCdcZ8EqoC1K0Drq] Missed Cue
+  [9XHmC2JgTUIQ1CCm] Mist
+  [zu40ATlcCjtfWBnj] Misty Memory
+  [4MOew29Z1oCX8O28] Moment of Renewal
+  [ggtZTxeyEnDYbt6f] Momentary Recovery
+  [YtesyvfAIwXOqISq] Moon Frenzy
+  [SuBtUJiU6DbSJYIw] Moonbeam
+  [Shiuhdb2nO6Qgk3k] Moonburst
+  [In2A7GCyxxaqZdPI] Moonlight Bridge
+  [mtlyAyf30JnIvxVn] Moonlight Ray
+  [D6BcAoWFxHYTKwVZ] Morass of Ages
+  [dNpIc5k1aCI3bHIg] Mosquito Blight
+  [xabHqik5SoyDc5Db] Moth's Supper
+  [qVXraYXlTjissCaG] Mother's Blessing
+  [2BV2yYPfVJ5zirZt] Mountain Resilience
+  [e9tVGZhYW37CtbHA] Movanic Glimmer
+  [yAiSNmz39qXOIlco] Mud Pit
+  [kCgkreCT6g0dipMd] Murderous Vine
+  [4EmLum6EdvXxbxCj] Murmuration
+  [xCfOskoogDf9LBlD] Mushroom Patch
+  [mnhuvqTIELcpJOFX] Musical Accompaniment
+  [3ZxaIw1FOOocJboH] Musical Shift
+  [BWvGBx51RevizICD] Mutilate
+  [V4jrHiaMh4XuANOP] Mycological Malady
+  [aAbfKn8maGjJjk2W] Mystic Armor
+  [2SYq0ZTsOtJEigFx] Mystic Beacon
+  [jOWQ5wPd4xvSkjI5] Mystic Carriage
+  [ZXwxs5tRjEGrjAJT] Nature Incarnate
+  [vSSKyUdrHu86E5Gk] Nature's Bounty
+  [Tc5NLaMu71vrGTJQ] Nature's Enmity
+  [F1qxaqsEItmBura2] Nature's Pathway
+  [YtBZq49N4Um1cwm7] Nature's Reprisal
+  [JUJYVbtNNFdvyrBS] Necromancer's Generosity
+  [29p7NMY2OTpaINzt] Necrotic Radiation
+  [6lO6uMQxbqmYho0e] Necrotize
+  [iYRDFxeVpJ5KIjmr] Needle Darts
+  [aEitTTb9PnOyidRf] Needle of Vengeance
+  [0fKHBh5goe2eiFYL] Negate Aroma
+  [BA143r8fCqmSjdRf] Nettleskin
+  [5BbU1V6wGSGbrmRD] Never Mind
+  [Uqj344bezBq3ESdq] Nightmare
+  [wzLkNU3AAqOSKFPR] Noise Blast
+  [0aoRcxRyIPHfbifk] Nothing Up My Sleeve
+  [3A3ueS9Q0s3U8KXE] Noxious Metals
+  [1meVElIu1CEVYWkv] Noxious Vapors
+  [G0T1xv1FoZ23Jxvt] Nudge Fate
+  [QjdvYC1QkpMaemoX] Nudge the Odds
+  [KRcccPeNZOZ5Nweh] Nullify
+  [SAmyaiVKTDrUNjot] Nymph's Grace
+  [pHrVvoTKygXeczVG] Nymph's Token
+  [YWrfKetOqDwVFut7] Oaken Resilience
+  [cokeXkDHUAo4zHsw] Oathkeeper's Insignia
+  [RztmhJrLLQWoGVdB] Object Memory
+  [5LYi9Efs6cko4GGL] Object Reading
+  [QIjc7Zyej0P3b9v5] Oblivious Expulsion
+  [6WZgtQ2Iw9CTbv2c] Ocean's Roar
+  [HvBpSeUDg0KcK2Hg] Ocular Overload
+  [DgCS456mXKw97vNy] Ode to Ouroboros
+  [bOf5WuLh6ZJloi7F] Oil-Slicked Walls
+  [l4bHFR9UW2XiY3kH] Omnidirectional Scan
+  [dileJ0Yxqg76LMvu] One with Plants
+  [vh1RpbWfqdNC4L3P] One with Stone
+  [TbYqDhlNRiWHe146] One with the Land
+  [87zLUuTMmZ9zc7gH] Oneiric Mire
+  [0gdZrT9lwO17EIxc] Ooze Form
+  [PvkEzzCaDT07DcJb] Open the Wall of Ghosts
+  [qO4xOJ0kAvhVGDpX] Orb of Twisting Fate
+  [CPNlhDQP3aDmLzB3] Ordained Purpose
+  [bH9cH9aDByY91l1d] Organsight
+  [Cbwhd4m7qrRoRjot] Osseous Cage
+  [KSAEhNfZyXMO7Z7V] Outcast's Curse
+  [PcmFpaHPCReNp1BD] Over the Coals
+  [eCniO6INHNfc9Svr] Overflowing Sorrow
+  [ro0omoBKiJiMuDRa] Overselling Flourish
+  [mFHQ2u4LWiejqKQG] Overstuff
+  [LJHrndGJRmLdxgXD] Overwhelming Memory
+  [fkDeKktdmbeplYRY] Overwhelming Presence
+  [u3G7KX1qpFJlSeWm] Owb Pact
+  [eW7DqGEvU50CDHqc] Pack Attack
+  [cGGEi67G1RStR9cD] Pack Breaker
+  [YNAthsgsJjQIXbc8] Pact Broker
+  [HreHc5elibW9hVK8] Pain of Ages
+  [qTzvVnAMWL05VitC] Painful Vibrations
+  [oLylenH2jlP5UbRT] Painted Scout
+  [DCQHaLrYXMI37dvW] Paralyze
+  [Mkbq9xlAUxHUHyR2] Paranoia
+  [7CUgqHunmHfW2lC5] Parch
+  [9sofMbyYL80shsHH] Part the Mists to Paradise
+  [s3LISC5Z55urpBgU] Path of Least Resistance
+  [aq1yonHeYpbaj3XI] Patron's Puppet
+  [mS3p6BR3LcG1WmHs] Pave Ground
+  [onjZCEHs3JJJRTD0] Peaceful Bubble
+  [QZ7OHptO1xnwaruq] Penumbral Disguise
+  [zdb8cjOIDVKYMWdr] Penumbral Shroud
+  [QlivnxstGjlzaluf] Perceive the Threads of Fate
+  [iG1USiSRXMjCDGAr] Percussive Impact
+  [GQopUYTuhmtb7WMG] Perfect Strike
+  [8ifpNZkaxrbs3dBJ] Perfected Body
+  [cDFAQN7Z3es07WSA] Perfected Mind
+  [kExRMPVI07iIFCaa] Perfection of Essence
+  [PtX16vbWzDehj8qc] Pernicious Poltergeist
+  [ovx7O2FHvkjXhMcA] Perseis's Precautions
+  [qCmihBL0G0G5ExPF] Persistent Servant
+  [g4MAIQodRDVfNp1B] Personal Blizzard
+  [K2bTUhucPyhXlzjw] Personal Ocean
+  [kJKSLfCgqxmN2FY8] Personal Rain Cloud
+  [N91EI7H1p7YXKX0o] Personal Runewell
+  [gfPjmG6Fe6D3MFjl] Pest Form
+  [fRqHDOWmgcUTeT03] Pest Swarm
+  [F1nlmqOIucch3Cmt] Pet Cache
+  [D31YX7zvRBvenTAz] Petal Storm
+  [znv4ECL7ZtuiagtA] Petrify
+  [MJx7DmjsWYzDZ3a4] Phantasmagoria
+  [0XP2XOxT9VSiXFDr] Phantasmal Calamity
+  [uuoPmbjEtqzWZs0v] Phantasmal Custodians
+  [tlcrVRqW1MSKJ5IC] Phantasmal Killer
+  [IKb9EOfsrhScO3GO] Phantasmal Protagonist
+  [L0GoJpHxSD0wRY5k] Phantasmal Treasure
+  [WfINystwLv9ohYpS] Phantom Crowd
+  [7idCEYHnPpVNL9vX] Phantom Orchestra
+  [R8bqnYiThB6MYTxD] Phantom Pain
+  [Pwq6T7xpfAJXV5aj] Phantom Prison
+  [oOFilBgsXTVIbJpN] Phantom Ship
+  [5gophZ4AOKW4VW27] Phase Bolt
+  [rMOI8JFJ0nT2mrCF] Phase Familiar
+  [lJdAvY1sJyEmNDc6] Phoenix Ward
+  [1lmzILdCFENln8Cy] Physical Boost
+  [Um0aaJotqMKGmAlR] Pied Piping
+  [eIPIZp2FUbFcLNdj] Pillar of Water
+  [qr0HOiiuqj5LKlDt] Pillars of Sand
+  [CeSh8QcVnqP5OlLj] Pinpoint
+  [NjN6md0KpdelWpu7] Plague Shot
+  [vPWMEyVTreMOoFnm] Planar Palace
+  [XZE4BawIlTf88Yl9] Planar Seal
+  [ksLCg62cLOojw3gN] Planar Tether
+  [zCcfPS4y5SrZzU2x] Plant Form
+  [ZhJ8d9Uk4lwIx86b] Plant Growth
+  [TjWHgXqPv5jywMti] Pocket Library
+  [BKIet436snMNcnez] Polar Ray
+  [2uEuYmlyx1R7zQeH] Pollen Pods
+  [uhEjKSFdEhXzszh6] Poltergeist's Fury
+  [Z60JRD78wT3afOEJ] Portrait of Spite
+  [CuRat8IXBUu9C3Yw] Portrait of the Artist
+  [9iJaD4S7ptUeq5vO] Positive Attunement
+  [wU6hNzK8Yfqdmc8m] Possession
+  [Yk3t4ekEiFIoEz9c] Power Word Blind
+  [m3lcOFm400lQCUps] Power Word Kill
+  [7PJSqUeKxTqOVrPk] Power Word Stun
+  [otdzpPYzWMJt76Rh] Power of the Beasts
+  [v4QHuVOhFD1JMAqu] Powerful Inhalation
+  [HOj2YsTpkoMpYJH9] Practice Makes Perfect
+  [v14zLiiSc4sl9RrK] Precious Gleam
+  [APTMURAW1N0Wpk4w] Precious Metals
+  [e4c73RBCQAZdYxau] Pressure Zone
+  [Qw3fnUlaUbnn7ipC] Prestidigitation
+  [TPN3Z6VGau6Od9rG] Primal Chorus
+  [pmP8HhXvvEKP3LqU] Primal Herd
+  [MLNeD5sAunV0E23j] Primal Phenomenon
+  [kwlKUxEuT8T15YW6] Primal Summons
+  [4nEY2BcV85wavKLO] Prismatic Armor
+  [AlCFTjSBaCHuRHBv] Prismatic Shield
+  [PngDCmU0MXZkbu0v] Prismatic Sphere
+  [d6o52BnjViNz7Gub] Prismatic Spray
+  [iL6TujgTCtRRa0Y0] Prismatic Wall
+  [4cEDhvchskRvxSw6] Procyal Philosophy
+  [0873MWM0qKDDv81O] Project Image
+  [coKiMMBLESkaLNVa] Proliferating Eyes
+  [n2CM3NeRuq5RSY19] Prophet's Luck
+  [jlOAXuIOM3YxZKmn] Propulsive Breeze
+  [AfOpnnwdZwHi2Tnc] Protect Companion
+  [gMODOGamz88rgHuf] Protection
+  [lY9fOk1qBDDhBT8s] Protective Wards
+  [K9gI08enGtmih5X1] Protector Tree
+  [rQYob0QMJ0I1U2sU] Protector's Sacrifice
+  [DH9Y3RQGWO0GzXGU] Protector's Sphere
+  [pt3gEnzA159uHcJC] Prying Survey
+  [D7ZEhTNIDWDLC2J4] Puff of Poison
+  [ivKnEtI1z4UqEKIA] Pulse of Civilization
+  [E80SrXuBdZViPGiH] Pulverizing Cascade
+  [EiE1A8TCeJGVzzV2] Pulverizing Wake
+  [Rn2LkoSq1XhLsODV] Pummeling Rubble
+  [wi405lBjPcbF1DeR] Punishing Winds
+  [CBPcGH1FFDG9vf4Z] Purging Toxins
+  [66xBcxqzYcpbItBU] Purify Soul Path
+  [ZVdKM0HkgpWykrqf] Purify Tanglebriar
+  [9Ga1AOQdHKYXUY4O] Purifying Icicle
+  [3ySPK8qwNcuESwa0] Purifying Veil
+  [ayRXv0wQH00TTNZe] Purple Worm Sting
+  [myC2EIrsjmB8xosi] Pushing Gust
+  [CxpFy4HJHf4ACbxF] Putrefy Food and Drink
+  [xnh2NBOGs4hcH9B3] Pyrefowl Rebuke
+  [TUbXnR4RAuYzRx1u] Pyrotechnics
+  [oo7YcRC2gcez81PV] Qi Blast
+  [YDMOqndvYFu3OjA6] Qi Form
+  [ps0nmhclT6aIXgd8] Qi Rush
+  [Oj1PJBMQD9vuwCv7] Quandary
+  [02J0rDTk37KN2sjt] Quench
+  [F23T5tHPo3WsFiHW] Quick Sort
+  [lETZeqBPoj2htGVk] Quicken Time
+  [5LGDygjRxURUOKGR] Radiant Beam
+  [v3vFzGazNSFEDdRB] Radiant Field
+  [nXoc5YbcynmhZcQs] Radiant Globe
+  [yfCykJ6cs0uUL79b] Radiant Heart of Devotion
+  [nuE9qsY2HfPFEgAo] Raga of Remembrance
+  [0AZOIMRvZtePuGOw] Rainbow Fumarole
+  [hYK4ByCVN1ALc5gR] Rainbow's End
+  [fr1AGcQo7WuvLvUi] Raise Runelord
+  [98gJvb8Xtn8OLIY7] Rally Point
+  [bH0kPuf7UKxRvi2P] Rallying Anthem
+  [Hp2wmnRS6TUGZlZ2] Rallying Banner
+  [Pmhlv3fzPTuIhTrT] Ranage's Circle
+  [KktHf7zIAWOr499h] Ranger's Bramble
+  [ksJFGSGlNpUhwcsp] Ransack the Night
+  [fTK6ysisGhy3hRvz] Rapid Adaptation
+  [6sNjsNPipZvQ3BGe] Rapid Retreat
+  [VDWIZuLOJqwBthHc] Ravening Maw
+  [g1dDUKsIrdlpdqy9] Ravenous Darkness
+  [ER1LOEgCLtmEKd05] Ravenous Portal
+  [u3pdkfmy0AWICdoM] Ravenous Reanimation
+  [nPxYYID5JARKouSV] Ray of Corruption
+  [gYjPm7YwGtEa1oxh] Ray of Frost
+  [OhD2Z6rIGGD5ocZA] Read Aura
+  [Vvxgn7saUPW2bJhb] Read Fate
+  [pkcOby5prOausy1k] Read Omens
+  [lg73SvJZno1ypPAj] Read the Air
+  [dxOF7d5kAWusLKWF] Reaper's Lantern
+  [5p8naLYjFcG13OkU] Rebounding Barrier
+  [4nHYSMHito1GUXlm] Rebuke Death
+  [onvFdBWAsQp0CsAy] Recall Legacy
+  [bqx1tJeOZq1Ufhcc] Recall Past Life
+  [lsR3RLEdBG4rcSzd] Reclined Apport
+  [ifXNOhtmU4fKL68v] Redact
+  [bZMwSGc9t5K7uxZV] Redistribute Potential
+  [7Ahssy0KDLzcQ2Ex] Reed Whistle
+  [ghIoycTH6gxxAw3w] Reflected Beauty
+  [Mv5L4201uk8hnAtD] Reflective Scales
+  [FQZaQXiKtHdVjSc5] Regale the Lost Ones
+  [2Vkd1IxylPceUAAF] Regenerate
+  [gIVaSCrLhhBzGHQY] Reincarnate
+  [TYbCj4dgXDOZou9k] Reinforce Eidolon
+  [2LsiiZZIZEKD23VQ] Reinforced Rations
+  [lZx8jZfKrMEtyGY0] Rejuvenating Flames
+  [dMKP4fkWx8V2cqAy] Remake
+  [nrW6lGV4xDMqLS3P] Remember the Lost
+  [pZBovpzdBNLQQQmE] Repel Metal
+  [TLqMFgCewxuricJw] Repelling Pulse
+  [srEKUvym9kDVbEhD] Replicate
+  [yrZA4k2VAqEP8xx7] Repulsion
+  [Fr58LDSrbndgld9n] Resist Energy
+  [KPDHmmjJiw7PhTYF] Resplendent Mansion
+  [MTNlvZ0A9xY5sOg1] Rest Eternal
+  [SnaLVgxZ9ryUFmUr] Restoration
+  [pCvJ4yoZJxDtgUMI] Restorative Moment
+  [ljo9CEmnCMZXqfOQ] Restore Ground
+  [buhP7vfetUxQJlIJ] Restyle
+  [D4Rxud1DBr52Dmdo] Retreat Among the Rains
+  [SSsUC7rZo0CwayPn] Retributive Pain
+  [rsZ5c0AUyywe5yoK] Retrocognition
+  [ru3YdXajUREbKQDV] Return Beacon
+  [v8VnSMzaSYwkq6c7] Return To Essence
+  [9gMQPCaFM27PEIh4] Return the Favor
+  [0qaqksrGGDj74HXE] Revealing Light
+  [Eed8QBWBtpufl1iP] Revel in Retribution
+  [37ESlJzUvVbOudOT] Reverse Gravity
+  [HpIJTVqgXorH9X0L] Revival
+  [5tpk4Q2QI3FVhm99] Rewinding Step
+  [FhOaQDTSnsY7tiam] Rewrite Memory
+  [BAu5AgqoO556clyK] Rewrite Possibility
+  [Ey4pKybxyPAxq0ew] Rigid Form
+  [Popa5umI3H33levx] Rime Slick
+  [aewxsale5xWEPKLk] Ring of Truth
+  [1bw6XJMOERcbC5Iq] Rip the Spirit
+  [zTN6zuruDUKOea6h] Rising Surf
+  [KwDyrUIlnOrpdxYi] Rite of Cleansing Flame
+  [w00PBRjENqJa7Vxu] Rite of Repatriation
+  [fLiowSDQXo3vCQDh] Rite of the Red Star
+  [h7h0wMxu4WOpveQ3] Ritual Obstruction
+  [ew4ToaTU3o8ahKio] River Carving Mountains
+  [FSu6ZKxr3xdS75wq] Roar of the Dragon
+  [czO0wbT1i320gcu9] Roaring Applause
+  [BX5UIAUarWG43Fg2] Root Reading
+  [GzdgM0m7wXKuFSho] Rope Trick
+  [gBJtUhewnihlqxm7] Rose's Thorns
+  [0JWyMwVnLxX9CDYQ] Rouse Skeletons
+  [zhDIiQlJmrd4UDNC] Rousing Splash
+  [FFBYPZEmAQoll09t] Rubble Step
+  [o0l57UfBm9ScEUMW] Rune Trap
+  [4LSf04FFvDgMyDk6] Rune of Observation
+  [EE7Q5BHIrfWNCPtT] Runic Body
+  [oOaEfsdVpgTXRhrY] Runic Impression
+  [TFitdEOpQC4SzKQQ] Runic Weapon
+  [yy2K51kK3a60rRIe] Rust Cloud
+  [0fYE64odlKqISzft] Rusting Grasp
+  [rVRyA7UQog633nTe] Sacred Beasts
+  [MMCQsh12TPaDdPbV] Sacred Form
+  [GabRQPc9qD86jDGI] Sacred Nimbus
+  [IFuEzfmmWyNwVbhY] Safe Passage
+  [OsrtOeG0TvDNnEFH] Safeguard Secret
+  [APDrC83QljsyHenB] Sage's Curse
+  [8xRzLhwGL7Dgy3EZ] Sanctuary
+  [KjC2ya8HD5AENeHI] Sand Form
+  [5zeSxzDxMSr0wgSF] Sanguine Mist
+  [xn0V2HDrmDWNzPEt] Savor the Sting
+  [I2IgZu4Rd2dz0J6v] Sawtooth Terrain
+  [zA0jNIBRgLsyTpbm] Scatter Scree
+  [8E97SA9KAWCNdXfO] Schadenfreude
+  [dXIRotMLsABDQQSB] Scholarly Recollection
+  [9W2Qv0wXLg6tQg3y] Scintillating Safeguard
+  [5QD75UbyB5EiG3yz] Scorching Blast
+  [9bOqFkewRz7Z3HZ5] Scouring Pulse
+  [HGmBY8KjgLV97nUp] Scouring Sand
+  [Ek5XI0aEdZhBgm21] Scouting Eye
+  [XcMObj2p9nIBp53b] Scramble Body
+  [VNv96dJPi0WXKSFN] Scrounger's Glee
+  [r784cIz17eWujtQj] Scrying
+  [k1apwY0ROoMKlvLt] Scrying Ripples
+  [HHGUBGle4OjoxvNR] Sculpt Sound
+  [cf7Jkm39uEjUFtHt] Sea Surge
+  [tSosbMsftXcRaQgT] Sea of Thought
+  [gfKhtVsXF3HKSdmY] Seal Fate
+  [q5vbYgLztQ04FQZg] Seashell of Stolen Sound
+  [BoA00y45uDlmou07] Secret Chest
+  [VVAZPCvd4d90qVA1] Secret Page
+  [a9og2ZYfr8kAeltU] Secure Siege Weapons
+  [jwK43yKsHTkJQvQ9] See the Unseen
+  [opXqASAY37ltENB8] Seed of Mercy
+  [DOBs5ALM1titPYxe] Seize Identity
+  [GYmXvS9NJ7QwfWGg] Seize Soul
+  [R9xqCBblkS5KE4y7] Sending
+  [3mINzPzup2m9qzFU] Sepulchral Mask
+  [YKexU7BkwNq4ESCc] Serrate
+  [hvKtmoHwekDZ5iOH] Shadow Army
+  [IqJ9URobmJ9L9UBG] Shadow Blast
+  [h5UqEdeqK8iTcU0J] Shadow Double
+  [EOWh6VVcSjB3WPjX] Shadow Illusion
+  [5ttAVJbWg2GVKmrN] Shadow Jump
+  [8cuqRFB3mWBOgy61] Shadow Projectile
+  [VTb0yI6P1bLkzuRr] Shadow Raid
+  [tcwT97RWKxsJiefG] Shadow Siphon
+  [aq76wpgsVEENDyau] Shadow Spy
+  [4Gl3WSUqYjVVIsOg] Shadow Zombie
+  [n8eEXXAtguoErW0y] Shadow's Web
+  [9j35xXKVVtHCh1Pe] Shaken Confidence
+  [rnFAHvKpcsU4BJD4] Shall not Falter, Shall not Rout
+  [Z82DvtSXafPmh4KV] Shambling Horror
+  [McnPlLFvKtQVXNcG] Shape Stone
+  [CXICME10TkEJxz0P] Shape Wood
+  [cJq5NarY0eOZN74A] Share Burden
+  [d7Lwx6KAs47MtF0q] Share Life
+  [nXmC2Xx9WmS5NsAo] Share Lore
+  [TRlI5zAbNW2hDiH9] Share Vision
+  [I0j56TNRmGcTyoqJ] Shared Invisibility
+  [skvgOWNTitLehL0b] Shared Nightmare
+  [1xbFBQDRs0hT5xZ9] Shatter
+  [BqJAOPimCq5uCcEJ] Shatter Mind
+  [0uRpypf1Hi7ahvTl] Shattering Gem
+  [gxK5XW4WAXOgY1mN] Sheltering Wings
+  [SzKkzq3Rr6vKIxbp] Shepherd of Souls
+  [TVKNbcgTee19PXZR] Shield
+  [4k99nOJudmeNnBTF] Shielded Arm
+  [6QEWTuCKRQQTyoeS] Shielding Formation
+  [53NqGTJOf4LcjVyD] Shielding Strike
+  [ZL97DcoJ8us6EwAF] Shields of the Spirit
+  [lONs4r14LEBZRLLw] Shift Blame
+  [SDkIFrrO1PsE02Kd] Shifting Form
+  [HcIAQZjNXHemoXSU] Shifting Sand
+  [s3abwDbTV43pGFFW] Shillelagh
+  [yuhhRjqBzFgkKYrq] Shining Starlight Attack
+  [Y3qZrvZrqPuGJ2hk] Shock and Awe
+  [M5dp7ILSCKID9fDK] Shock to the System
+  [r3NeUnsgt9mS03Sn] Shocking Grasp
+  [dgCH2E0gMLMUgyFl] Shockwave
+  [nVfP43Xbs6I1PO8v] Shooting Star
+  [jLc8tHSNeXm0RvMQ] Show the Path
+  [ThE5zPYKF4weiljj] Show the Way
+  [PjhUmyKnq6K5uDby] Shrink
+  [kWh8sJH7yawidMyW] Shrink Item
+  [Az3PmWnlWSb5ELX9] Shrink the Span
+  [Q1OWufw6dUiY8yEI] Shroud of Flame
+  [cE7PRAX8Up7fmYef] Shroud of Night
+  [VVigI4uNdWr1XZgG] Shroud of the Mantis
+  [wdb4XIZw1xmki5nr] Siege Weapon's Blessing
+  [AUctDF2fqPZN2w4W] Sigil
+  [SxRVCc1Q2MtVuPMo] Sign of Conviction
+  [ZrRhweQ7KQ0wKN3m] Signal Skyrocket
+  [gIdDLrbswTV3OBJy] Silence
+  [xM35hJacTM1BSXUl] Silver's Refrain
+  [y1dcR5unn2UwlUR9] Skeleton Army
+  [2C0ftvzTwYgzb3Qt] Sky Laughs at Waves
+  [sYd3hqv2ZQqa0PSc] Sky Signs
+  [1Yoipc5jNcMehtEW] Slashing Gust
+  [o4lRVTwSxnOOn5vl] Sleep
+  [bTFWSpHEvXq8IK37] Sleepless Season
+  [avEutOjF2ox947fp] Sliding Blocks
+  [hWtB81P2KGzGHKAJ] Slime Spit
+  [xFp4EwVcYwSG336t] Slither
+  [X3dYByf3YmkcdwG0] Slough Skin
+  [WsUwpfmhKrKwoIe3] Slow
+  [wLWMswY7aBHEFTRb] Snake Fangs
+  [dDt8VFuLuhznT19v] Snare Hopping
+  [W6QlRwQLPoBSw6PZ] Snowball
+  [TLmkJ8ga8s057HBp] Soft Landing
+  [piMJO6aYeDJbrhEo] Solid Fog
+  [Yv3AFIO55FONQYMH] Sonata Span
+  [LTUaK3smfm5eDiFK] Song of Marching
+  [HYXyMFsH0K80etBI] Song of Silver
+  [Xxdwkt0EEDgP1LGc] Song of Strength
+  [IGXGs9PlqUCvODcH] Song of the Fallen
+  [CzMCiFbgLj1irnP4] Songbird's Call
+  [szIyEsvihc5e1w8n] Soothe
+  [0JigNJDRwevZOyjI] Soothing Ballad
+  [5XUn9NADr05IyiVw] Soothing Blossoms
+  [RGBZrVRIEDb2G48h] Soothing Mist
+  [fH08MI4KP0KH2EQ9] Soothing Spring
+  [YGRpHU5yxw73mls8] Soothing Words
+  [D6T17BdazhNy3KPm] Soul Siphon
+  [wYSLTNvmxbe78l2c] Soulshelter Vessel
+  [Et8RSCLx8w7uOLvo] Sound Body
+  [KAWQ5x2j4tUJ91ry] Sparkleskin
+  [BBvV7qoXGdw09q1C] Speak with Animals
+  [qvwIwJ9QBihy8R0t] Speak with Plants
+  [YIMampGpij4Y30yE] Speak with Stones
+  [Zvg0FWzClGbzucFd] Speaking Sky
+  [VNAOHrWhNYX3jKdy] Spectral Advance
+  [tgIhRUFtgDSELpJE] Spell Immunity
+  [9igi8LcrNQKwljK7] Spell Riposte
+  [OOELvfkTedBMlWtq] Spell Turning
+  [VrhCpCIQB8PFax77] Spellmaster's Ward
+  [XIgvCPaSy5WXStVD] Spellsurge
+  [8Umt1AzYfFbC4fui] Spellwrack
+  [DYdvMZ8G2LiSLVWw] Spider Sting
+  [3xD8DYrr8YDVYGg7] Spike Stones
+  [KAapTzGKJMbMQCL1] Spinning Staff
+  [KPGGkyBFbKse7KpK] Spiral of Horrors
+  [PHVHBbdHeQRfjLmE] Spirit Blast
+  [yHujiDQPdtXW797e] Spirit Link
+  [yp4w9SG4RuqRM8KD] Spirit Object
+  [3ehSrqTAm7IPqbIZ] Spirit Sense
+  [Ht35SDf9PDStJfoC] Spirit Song
+  [pQ3NIzZXeIIcU81C] Spirit Veil
+  [MFtXn7t5vApQXqlq] Spirit Ward
+  [wgAsL86ji5hulh7x] Spirit of the Beast
+  [Jli9WBjQZ2MmKJ8y] Spiritual Anamnesis
+  [WPu3UE3kTXSLqO40] Spiritual Armament
+  [GjmMFEJcDd6MDG2P] Spiritual Attunement
+  [MS60WhVifb45qORJ] Spiritual Epidemic
+  [jQdm301h6e8hIY4U] Spiritual Guardian
+  [tBC1QmB33KWIuBFX] Spiritual Renewal
+  [Y1YysjZ40ft0aLFN] Spiritual Torrent
+  [6o75SEEYjdaMDkoG] Spiritual Transport
+  [Fq9yCbqI2RDt6Orw] Spiritual Weapon
+  [Bc6QqTmFV4q7G7L0] Splinter Volley
+  [Y9w4TYnb8cXU4UKY] Split Shadow
+  [lXxP1ziyf4ozkpmv] Split the Tongue
+  [eSL5hVT9gXrnRLtd] Spout
+  [rsYeiz2V2KeEfjpr] Sprawling Tunnels
+  [mlNYROcFrUF8nFgk] Spray of Stars
+  [LFcGNGLMkGlsnEKQ] Spy's Mark
+  [SnjhtQYexDtNDdEg] Stabilize
+  [3E1p58MNQMO4GAxt] Stagnate Time
+  [cOwSsSXRsBaXUvlr] Stasis
+  [29AyhknPKiDBcy8s] Statuette
+  [HTou8cG05yuSkesj] Status
+  [0chL1b4OFIZxpN3v] Steal Shadow
+  [5LrQIlimsPXK2xAG] Steal Voice
+  [zoY0fQYTF1NzezTg] Steal the Sky
+  [wQDrc0LDWaBA5Xa8] Steel Fortifications
+  [Vseo7VIy8mzINUES] Sticky Fire
+  [bAxjHBi37CVwInfU] Stifling Stillness
+  [jyYBuGRfpkZz2kxs] Sting of the Sea
+  [GKpEcy9WId6NJvtx] Stinking Cloud
+  [GeUbPvwdZ4B4l0up] Stoke the Heart
+  [ECApRjIIxD0JogOa] Stone Lance
+  [Pr1ruNTbzGn3H9w5] Stone to Flesh
+  [UVLiBXLLAoWhUU4R] Stonesense
+  [FZMVLL7HvasjiM6D] Store Time
+  [XYhU3Wi94n1RKxTa] Storm Lord
+  [r4HLQcYwB62bTayl] Storm of Vengeance
+  [Ifc2b6bNVdjKV7Si] Stormburst
+  [gSFg9zKwgcNZLMEs] Stormwind Flight
+  [m4Mc5XbdML92BKOE] Strange Geometry
+  [aMvjaIuPIWN7pbc3] Strength of Mind
+  [qjUcAMgcSLIamjEq] String of Fate
+  [X8PSYw6WC2ePYSXd] Stumbling Curse
+  [CQb8HtQ1BPeZmu9h] Stupefy
+  [GP3wewkQXEPrLxYj] Subconscious Suggestion
+  [Cd6Crl4wpQaMSYrF] Subjugate Undead
+  [XFtO4BBI22Uox2QP] Sudden Blight
+  [zK0e9d9DSnxC4eAD] Sudden Bolt
+  [h5cMTygLpjY3IEF0] Sudden Recollection
+  [P9bqJsF3WkxGAJKJ] Sudden Shift
+  [2DFtBRLyYMPrimp7] Sudden Transposition
+  [qGWORxQ0aSsH2taf] Suffocate
+  [qwlh6aDgi86U3Q7H] Suggestion
+  [aVqsE5OedOwdHQvF] Summerland Spell
+  [n8ckecJpatSBEp7M] Summon Anarch
+  [tgJTm276cikEL8vU] Summon Ancient Fleshforged
+  [4YnON9JHYqtLzccu] Summon Animal
+  [JAaETUBg0xlttpCH] Summon Archmage
+  [ba12fO37w7O37gim] Summon Axiom
+  [lKcsmeOrgHtK4xQa] Summon Construct
+  [kIRWUBxocERjIBni] Summon Deific Herald
+  [2EIUqc8TCTQimggQ] Summon Draconic Legion
+  [kghwmH3tQjMIhdH1] Summon Dragon
+  [lpT6LotUaQPfinjj] Summon Elemental
+  [kVNo3ga0lwLKPrem] Summon Elemental Herald
+  [i1TvBID5QLyXrUCa] Summon Entity
+  [hs7h8f4Z1ZNdUt3s] Summon Fey
+  [29ytKctjg7qSW2ff] Summon Fiend
+  [e9UJoVYUd5kJWUpi] Summon Giant
+  [3r897dYO8oYvuyn5] Summon Healing Servitor
+  [4ONjK2hoMBmuAAyk] Summon Irii
+  [WRP8TDf36hqHyGv1] Summon Kaiju
+  [B0FZLkoHsiRgw7gv] Summon Lesser Servitor
+  [ZbEHglw5tkJ3grQZ] Summon Monitor
+  [Ywe64VHwcBOAWBtq] Summon Oliphaunt of Jandelay
+  [jSRAyd57kd4WZ4yE] Summon Plant or Fungus
+  [XWqxMJpCT95A0dZs] Summon Stampede
+  [9WGeBwIIbbUuWKq0] Summon Undead
+  [l2YoqVPoFE7jpTLe] Summon Warden of the Wild
+  [cwXiKPkZrIupjwlQ] Summoner's Precaution
+  [vb2dFNtbofJ7A9BW] Summoner's Visage
+  [pMTltbI3S3UIuFaR] Sun Blade
+  [LrFUj76CHDBV0vHW] Sun's Fury
+  [a3aQxCpoj1q1NQxC] Sunburst
+  [6TKGaQm4PfEMkeRd] Supreme Connection
+  [BCuHKrDeJ4eq53M6] Sure Footing
+  [Gb7SeieEvd0pL2Eh] Sure Strike
+  [k0qJfSZH5xUEggwU] Suspended Retribution
+  [4Sg6ZngswhphxiBD] Swallow Light
+  [iQD8OhhkwhvD8Blw] Swamp of Sloth
+  [lbrWMnS2pecKaSVB] Swampcall
+  [Pd2M1XY8EXrSfWgJ] Swarm Form
+  [LVwmAH5NGvTuuQSU] Swarming Wasp Stings
+  [5wjl0ZwEvvUh7sor] Swarmsense
+  [AYN0UihkU8Fa8yC6] Swear Oath
+  [BRtKFk0PKfWIlCAB] Sweet Dream
+  [wAJ8mXPYbyAg0qWX] Sweetest Solstice
+  [ZAX0OOcKtYMQlquR] Symphony of the Unfettered Heart
+  [BilnTGuXrof9Dt9D] Synaptic Pulse
+  [DgcSiOCR1uDXGaEA] Synchronize
+  [EeEgzWYcAY7ZQkS6] Synchronize Steps
+  [OAt2ZEns1gIOCgrn] Synesthesia
+  [KcLVELhCUcKXxiKE] Tailwind
+  [WUNZizIe6rnVHGcr] Take Root
+  [bfdiKEZQLVvslcDi] Take Your Places
+  [ZeHeNQ5BNq6m5F1j] Take its Course
+  [FM3SmEW8N1FCRjqt] Talking Corpse
+  [s7ILzY2xh1tc9U1v] Tame
+  [uZK2BYzPnxUBnDjr] Tangle Vine
+  [BokwLLK7OjK6ggHs] Tanglecurse
+  [JbAcSLu62TU1OgNF] Tangling Creepers
+  [32NpJbPblay77K6v] Tattoo Whispers
+  [avT46uIH3xYJPSv4] Teeth to Terror
+  [uc4I1diSSX6XYzb3] Telekinetic Bombardment
+  [pwzdSlJgYqN7bs2w] Telekinetic Hand
+  [tpLTLbJUrYcMWGld] Telekinetic Haul
+  [mrDi3v933gsmnw25] Telekinetic Maneuver
+  [60sgbuMWN0268dB7] Telekinetic Projectile
+  [yyz029C9eqfY38PT] Telekinetic Rend
+  [gfVXAW95YWRz0pJC] Telepathic Bond
+  [ItZgGznUBhgWBwFG] Telepathic Demand
+  [HqTI6wRrck1YXp3F] Telepathy
+  [69L70wKfGDY66Mk9] Teleport
+  [5ZW1w9f4gWlSIuWA] Teleportation Circle
+  [70BjbNRVc4OTLAgN] Tempest Cloak
+  [zhqnMOVPzVvWSUbC] Tempest Form
+  [ho1jSoYKrHUNnM90] Tempest Surge
+  [EzB9i7R6aBRAtJCh] Tempest Touch
+  [JLdbyGKhjwAAoRLs] Tempest of Shades
+  [UbHK19RYbxRXWgWX] Temporal Distortion
+  [1bXLp8cyIKFjZtVx] Temporal Twin
+  [kLxJx7BECVgHh2vb] Temporal Ward
+  [YWuyjhWbdoTiA1pw] Temporary Glyph
+  [TPI9fRCAYsDqpAe4] Temporary Tool
+  [GqvKSxzN7A7kuFk4] Tempt Fate
+  [i8PBZsnoCrK7IWph] Tentacular Limbs
+  [yUM5OYeMY8971b2S] Terminate Bloodline
+  [rtA3HRGoy7PQTOhq] Terrain Transposition
+  [Z1MoMTcgFQiCI90t] Tesseract Tunnel
+  [MVrxZarUTnJxAUN8] Tether
+  [EdRYr7HmLm9wr71X] The Four Hunters
+  [8NK5HtDxM3Qktu8H] The Parrot's Whisper
+  [V05lB4VsSMiMMsZJ] The Queen's Rainbow
+  [5xf9wK9xyAeGFPw7] The Unseeing Blade Master
+  [3DB3F2hIx2dMbX8n] The World's a Stage
+  [l194BTf9cAFlSQ96] Thermal Remedy
+  [dhpXpzt7TCm8TbHM] Thermal Stasis
+  [X56VdA98VedAfGTU] Thicket of Knives
+  [uGi6t3cypb93mgyV] Thief of Fortune
+  [qTr2oCgIXl703Whb] Thoughtful Gift
+  [s0i3S4fg2XDQX4a7] Threatening Mimicry
+  [MNiT0dHol5fEcKlz] Threefold Aspect
+  [3DY4vbXj0BYSWA7z] Threefold Limb
+  [LFSwMtQVP05EzlZe] Thunderburst
+  [mMgLHTLHjjGa206q] Thundering Dominance
+  [r82rqcm0MmGaBFkM] Thunderous Strike
+  [zDJS8E66UI0himqV] Thunderstrike
+  [iAnpxrLaBU4V6Sej] Tidal Surge
+  [9I8mp7RkjeXbkYfx] Timber
+  [G56DJkxlUjFv0C4Z] Time Beacon
+  [qJGW6BbIcU6sfA1d] Time Jump
+  [0Rl3W7kiq9xVZRcr] Time Pocket
+  [BvNbDwFYaidKJG9j] Time Sense
+  [LbqunTurwXB3u9Vp] Time Skip
+  [OhgfPzB5gymZ0IZM] Timely Tutor
+  [gzvRDpM6EvcfYHeu] Tireless Worker
+  [a0MfDnUa33oWM74s] Tomorrow's Dawn
+  [1NLMPmyCB2MBoCuR] Tortoise and the Hare
+  [zHSp4PzoOE72DV4o] Torturous Trauma
+  [Ovvflf5aFbmBxqq8] Touch of Death
+  [MmQiEc7aM9PDLO2J] Touch of Obedience
+  [GYI4xloAgkm6tTrT] Touch of Undeath
+  [oXCwHBeDja4e0Mx0] Touch of the Moon
+  [jFmWSIpJGGebim6y] Touch of the Void
+  [MlpbeZ61Euhl0d60] Toxic Cloud
+  [4U2ZV1v38D0y2CRl] Trade Death for Life
+  [rSpGzCyYrTMiWQoG] Trade Items
+  [YZnLggKDHkMY4cnw] Transcribe Conflict
+  [NxOYiKCqcuAHVRCj] Transcribe Moment
+  [vTQvfYu2llKQedmY] Translate
+  [VlNcjmYyu95vOUe8] Translocate
+  [8Lk9K3tRnV68MQPW] Transmigrate
+  [LzfrBDxxPTiuN7uL] Transmute Rock And Mud
+  [dk3XIx0ExDRMcN5z] Travel by Turtle
+  [LrhTFHUtSS9ahogL] Traveler's Transit
+  [rzcXUF5YmJYxgxEa] Traveling Workshop
+  [u5FAOOXuqK7fLqKW] Tree of Seasons
+  [uMADQaASgYNsSDDM] Tremor Signs
+  [EAYViUegegttJF1u] Tremorsense
+  [2wT21v3NjLXdmE5W] Trickster's Feathers
+  [cuKVbWWNzJj1GDpZ] Trickster's Mirrors
+  [ZhLYJlOZzUB1OKoe] Trickster's Twin
+  [A7NXFVgENRVtYoe3] Trim the Blight
+  [c8R2fpk88fBwJ1ie] Triple Time
+  [AlbpWWN87yGegoAF] True Target
+  [uqlxMQQeSGWEVjki] Truesight
+  [SwUiVavHKMWG7t5K] Truespeech
+  [eCwsj7wGQK1uBwiH] Turbulent Tide
+  [DnVTBGCsai6zqMwL] Ulcerous Canker
+  [EDwakYQTS1t6XHD4] Umbral Extraction
+  [juzb53CW6Uzz5pFY] Umbral Graft
+  [rxvS7EMJ7qmexAyA] Umbral Journey
+  [uopaLE01meX11Mbw] Umbral Mindtheft
+  [XhfsRLfQjN3ed1zI] Unbearable Cacophony
+  [floDCUOSzT0F6r77] Unblinking Flame Aura
+  [KADeCawMG6WAzYHa] Unblinking Flame Emblem
+  [aFd00WT266VYPqOG] Unblinking Flame Ignition
+  [VBNevVovTCpn04vL] Unblinking Flame Revelation
+  [ytboJsyZEbE1MLeV] Unbreaking Wave Advance
+  [YtJXpiu4ijkB6nP2] Unbreaking Wave Barrier
+  [axYqY70kYu2lN20R] Unbreaking Wave Containment
+  [ZQk2cGBCkATO25w0] Unbreaking Wave Vapor
+  [19V9aVrn8OAHsn4Q] Unbroken Panoply
+  [Jvyy6oVIQsD34MHB] Uncontrollable Dance
+  [FedTjedva2rYk33r] Undeath's Blessing
+  [YiIOsc8T6E2iDxgh] Undermine Reality
+  [z39jFoNJrobyn3MQ] Undertaker
+  [OOMQ8Z6EIrGt5NJ6] Unexpected Transposition
+  [KR8WgdazifDBjDkW] Unexpected Windfall
+  [FmNDwqMEjeTEGPrY] Unfathomable Song
+  [hW9pgce6vTme61g1] Unfetter Eidolon
+  [TYydobaLN4U7Ol3M] Unfettered Mark
+  [aqRYNoSvxsVfqglH] Unfettered Movement
+  [bVtkBJvGLP69qVGI] Unfettered Pack
+  [Ww4cPZ3QHTSpaM1m] Unfolding Wind Blitz
+  [ALuvl9GYawnsZZCx] Unfolding Wind Buffet
+  [XjNROFtWnwovhCsq] Unfolding Wind Crash
+  [tvO6Kmc2pQve9DC5] Unfolding Wind Rush
+  [HEuvZAjD1q0J8Y5i] Unholy Army
+  [gwOYh5zMVZB0HNcT] Unimpeded Stride
+  [tYLBjOTvBVn9JtRb] Unity
+  [EFLXGyIz2HZVSmll] Unravel Knowledge
+  [PaHxcqXihXkkXPsB] Unraveling Blast
+  [y2cQYLr5mljDSu1G] Unrelenting Observation
+  [TT9owkeMBXJxcERB] Unseasonable Squall
+  [bK7EZFCxZgDcko6D] Unseen Heralds
+  [iAmHJbFN3lOoOkNG] Unsettling Knowledge
+  [hq57j7Nif1zuQ2Ab] Unspeakable Shadow
+  [8RWfKConLYFZpQ9X] Untamed Form
+  [0xR9vrt6uDFl0Umo] Untamed Shift
+  [8eOMAIvT7S1CJSit] Untwisting Iron Augmentation
+  [FPnkOYyWIaOzkmqn] Untwisting Iron Buffer
+  [9DtuMEyHhtHFRp5a] Untwisting Iron Pillar
+  [9o5aG5025ZczjkPb] Untwisting Iron Roots
+  [ddKBoCjmSyPSHcws] Unusual Anatomy
+  [QozxgBbcmktLKdBs] Updraft
+  [xxhS66k68u5iIOHC] Upheaval
+  [f0Z5mqGA6Yu79B8x] Uplifting Overture
+  [XGB77j7m0SLky8U1] Utter Destruction
+  [kk7JKox6MdGAWmCH] Vacuum
+  [nRsBM1zkhMmV3VST] Valiant Anthem
+  [fd31tAHSSGXyOxW6] Vampiric Exsanguination
+  [N1Z1oLPdBxaSgrEE] Vampiric Feast
+  [07xYlmGX32XtHGEt] Vampiric Maiden
+  [zlnXpME1T2uvn8Lr] Vanishing Tracks
+  [V8wXOsoejQhe6CyG] Vapor Form
+  [DcmWrD0V5PWQQyDm] Variable Gravity
+  [a0AMgATvQGwDR5dR] Vector Screen
+  [Q25JQAgnJSGgFDKZ] Veil of Confidence
+  [NNoKWiWKqJkdD2ln] Veil of Dreams
+  [EoKBlgf6Smt8opaU] Veil of Privacy
+  [lQbfgAu9uVJQC7x4] Veil of Spirits
+  [8uVMoiYDzhzWJEZ2] Vengeful Glare
+  [yV7Ouzaoe7DHLESI] Ventriloquism
+  [EDABphKEPUBiMmQC] Verdant Sprout
+  [Juk3cD5385Ftybct] Verminous Lure
+  [RQjSQVZRG497cJhX] Vibrant Pattern
+  [nnSipUPNd3sm5vYL] Vibrant Thorns
+  [tPtTKe0X1dDwoDmQ] Vibrant Vibrato
+  [z9pIChNg9PmPmn31] Vicious Howl
+  [h6VoHgPC0JCTVzgP] Vicious Jealousy
+  [t4hGPdh6vAEgBFgZ] Victory Cry
+  [VMABZdZyplCKTAAP] Vindicator's Judgment
+  [LegaamqrflbArbWN] Vindicator's Mark
+  [jqb52wy7A0Eqwuzx] Vision of Beauty
+  [Jmxru8zMdYMRuO5n] Vision of Death
+  [NhNKzq1DvFxkvTEc] Vision of Weakness
+  [jBGAYmR0BkkbpJvG] Visions of Danger
+  [ikSb3LRGnrwXJBVX] Vital Beacon
+  [8XuNn0h0rHE24m3B] Vital Luminance
+  [KkimKrhDxEJVm6TH] Vital Singularity
+  [kcelf6IHl3L9VXXg] Vitality Lash
+  [g2V4ID0pl1ZGAxZj] Vitrifying Blast
+  [d18m4AAaxJQqUEh2] Voice on the Breeze
+  [NjK0kWRC6FYsPwXC] Void Harvest
+  [mAMEt4FFbdqoRnkN] Void Warp
+  [O7ZEqWjwdKyo2CUv] Volcanic Eruption
+  [cB17yFc9456Pyfec] Vomit Swarm
+  [drmvQJETA3WZzXyw] Voracious Gestalt
+  [FEsuyf203wTNE2et] Wails of the Damned
+  [OmhnoYOzFhrp6rXv] Waking Dream
+  [DU5daB09xwfE1y38] Waking Nightmare
+  [eONVFSbBiqaDLGey] Wall Of Mirrors
+  [IarZrgCeaiUqOuRu] Wall of Fire
+  [ZLLY6ThJXCCrO0rL] Wall of Flesh
+  [7Iela4GgVeO3LfAo] Wall of Force
+  [R5FHRv7VqyRnxg2t] Wall of Ice
+  [CB5TlGv5ZghtMifi] Wall of Metal
+  [HWrNMQENi9WSGbnF] Wall of Radiance
+  [DeF63UTmr7rchF60] Wall of Shadow
+  [MMIPT6jfwHfLPkm5] Wall of Shrubs
+  [kOa055FIrO9Smnya] Wall of Stone
+  [KsWhliKfUs3IpW3c] Wall of Thorns
+  [ZJOQBqkNErZu1QAa] Wall of Virtue
+  [LNOwaJAkCfsgTKgV] Wall of Water
+  [it4ZsAi6XgvGcodc] Wall of Wind
+  [ppA1StEigPLKEQqR] Wanderer's Guide
+  [Er9XNUlL0wB0PM36] Ward Domain
+  [CIjj9CU5ekeq1oLT] Warding Aggression
+  [D4kArD91fFiREvC6] Warning Stripes
+  [8kJbiBEjMWG4VUjs] Warp Mind
+  [sX2g6WFSQPNW9jzx] Warp Step
+  [fXdADBwxmBsU9xPk] Warped Terrain
+  [UtINSoEJ0u630ia4] Warping Pull
+  [kIwA7kwp5E0AC3yM] Warrior's Regret
+  [lmHmKGs1N3yNAvln] Wash Your Luck
+  [MZGkMsPBztFN0pUO] Water Breathing
+  [Seaah9amXg70RKw2] Water Walk
+  [RS1nrqEjEi1ZlC53] Waterproof
+  [zaZieDHguhahmM2z] Waters of Prediction
+  [GaRQlC9Yw1BGKHfN] Wave of Despair
+  [eyKkLp8V55ydA64J] Weaken Earth
+  [8M03UxGXjYyDFAoy] Weapon Storm
+  [W37iBXLsY2trJ1rS] Weapon Surge
+  [RpGB961b8FjXbGHi] Weapon Trance
+  [ZqmP9gijBmK7y8Xy] Weapon of Judgment
+  [TRpUjBNPQz3Eshaq] Weaponize Secret
+  [idcBYnj4DUHL0IJt] Weave Wood
+  [9s5tqqXNzcoKamWx] Web
+  [XQSPJHOf3TyfqvgS] Web of Eyes
+  [HqZ1VWIcXXZXWm3K] Web of Influence
+  [qDjeG6dxT4aEEC6J] Weird
+  [Wi2HcreCfujKiCvW] Whirling Flames
+  [k9x6bXXpIgAXMDsx] Whirling Scarves
+  [0fjz8qc9NfkmWmJZ] Whirlpool
+  [8hKW4mWQyLnkHVta] Whirlwind
+  [1RxPW9I70Nd7wokz] Whispering Quiet
+  [FwW2asotQE8dH1WP] Whispers of the Void
+  [BBw5oGFvoQc3gg52] Wild Allegiance
+  [5y3RlXMDPovOmrhp] Wild Feast
+  [SkarN4VlNxSJSJNw] Wild Winds Stance
+  [jks2h5pMsm8pCi8e] Wildfire
+  [GdN5YQE47gd79k7X] Wilding Word
+  [kRxlkPPe6Gr7Du59] Wind Jump
+  [i06YFOtfGfpUvcD7] Wind Whispers
+  [9ZwpT9RDwCxhYQXd] Wings of the Valkyrie
+  [EGTTGI1pkmsVPqHp] Winning Streak
+  [DeNz6eAUlE0IE9U3] Winter Bolt
+  [oYxxcgszpT242sEi] Winter's Breath
+  [4cv1cuBHjYmVfBGI] Wisdom of the Winds
+  [B3tbO85GBpzQ3u8l] Wish-Twisted Form
+  [7tp97g0UCJ9wOrd5] Withering Grasp
+  [Up4zLmZDgciUDpIv] Wood Walk
+  [aUMmmtPmBdCdVDed] Wooden Double
+  [IHjiWCouSacC5b3g] Wooden Fists
+  [2jB9eyX7YekwoCvA] Word of Freedom
+  [BazbvgNmK46XjrVc] Word of Revision
+  [aF7RiG7c8GzSQLYt] Word of Truth
+  [mSM659xN2VIAHiF3] Wordsmith
+  [bODHqeXoEc8GVU6a] World in Shadow
+  [H4oF5szC7aogqtvw] Worm's Repast
+  [yLJROsQtyrPIKcDx] Wrathful Storm
+  [8TBgEzjZxPaOJOm1] Wronged Monk's Wrath
+  [IoHxAkK0uGqrgtWl] Wyvern Sting
+  [6gEKZaGdH842RF3J] Ymeri's Mark
+  [x2LALaHXO7644GQA] You're Mine
+  [I8CPe9Pp7GABqOyB] Zeal for Battle
+  [GYD0XZ4t3tQq6shc] Zealous Conviction
+  [Yrek2Yd4k3DPC2zV] Zenith Star
+  [FL1OxeOUDzsJYfY4] Zephyr Slip
+  [P1iqzEIidRagUs7W] Zero Gravity
+Treasure
+  [7SPJO9xr89N8E23s] Agate
+  [nIlx1IQhYJfQtpVF] Alabaster
+  [hnzNKdD5hjQc1NUx] Alabaster and obsidian game set
+  [r7QGx0YFZCR0W5iu] Alabaster idol
+  [qFkhYAeCxYci8jgk] Amber
+  [epTuWsVDuPzUXMk9] Amethyst
+  [JYxnuXg9MV6y1gpQ] Amphora with lavish scenes
+  [7Uk6LMmzsCxuhhA6] Ancient dragon skull etched with mystic sigils
+  [dBQQZUXaMhCAFkpY] Aquamarine
+  [RNnVb83lRRUXg8hG] Azurite
+  [D8gzHTvP0uFxjwyA] Bloodstone
+  [uAQKNkgub7KNOHoR] Brass anklet
+  [l6Eifu4DScg0OBxb] Brass scepter with amethyst head
+  [rOMPvaCeLqNvT6rJ] Brass statuette of a bull
+  [I3KlOUruQ2CZdcJ6] Bronze bowl with wave imagery
+  [lvrvCGrmnMmE4TxU] Bronze brazier with Asmodean artwork
+  [ja5rYjVRwwUXWtOd] Bronze chalice with bloodstones
+  [P2MIJxEQiIWJmV8n] Carnelian
+  [xzmYwmvj61br2bRp] Carved wooden game set
+  [VHJM3jYtpzMqZ1wc] Ceremonial dagger with onyx hilt
+  [F4YgvB74p8kwif1t] Ceremonial shortsword with spinels
+  [MK6nnMZNWHmChAXZ] Chandelier crafted from dreams
+  [uMxXncL2bQI04GZ9] Chrysoberyl
+  [qgKOCdtdybxwmiEv] Chrysoberyl symbol of an evil eye
+  [FW1AEh214U1mMWh7] Chrysoprase
+  [WEnrPya5A8CKi91A] Citrine
+  [noLtrW7wFfRFxSUt] Colorful pastoral tapestry
+  [Ab8yDhtYDJnFrjI4] Colorful velvet half mask
+  [lzJ8AVhRcbFul5fh] Copper Pieces
+  [PNnmcBhEwZmAKsq9] Copper and spinel puzzle box
+  [xXo7KXnhp1TfvxRc] Copper statuette of a salamander
+  [u7YrZzA2yem780cP] Coral
+  [EKgLX0TCyFik3gPS] Coral idol of an elemental lord
+  [ugOCvoAZnVyEuIiN] Crystal dinner set, fine silverware
+  [svhZ61CaSgatn5by] Crystallized dragon heart
+  [ZQXCEq8IyGf3WnEj] Diamond ring with platinum band
+  [7OuVXvNRbNoKzDSy] Diamond, large
+  [z3PT7OgX34TQKAwH] Diamond, small
+  [SmN0vRjkPaSaAJZt] Divine art piece created by Shelyn
+  [PTkTPYtxrPwgCzeq] Duskwood violin by a legend
+  [L8IzHSz2jYGFpp4N] Elegant cloth doll
+  [hMIG86aqKcVYJGsg] Emerald
+  [0zVMeeklYZ7hcgXw] Emerald, brilliant green
+  [Mm3xgz27Q94wZhti] Engraved copper ring
+  [rgPjAtKt6J1AZ1Pj] Enormous chryselephantine sculpture by a legend
+  [6wCA8h0jpMnqPbib] Enormous tapestry of a major battle
+  [cSBupUqjsHJwivbp] Etched copper ewer
+  [LEfLVcrbhZPmyUyI] Famous portrait by a master
+  [x46wlAbSDKFEumvg] Fine gold spyglass
+  [NuX85j3bYLYVcINr] Garnet
+  [0b6BUtoFD4DotZHR] Gilded ceremonial armor
+  [K44zDGRTSecRjEv0] Gilded scepter with sapphire
+  [B6B7tBWJSqOBz5zz] Gold Pieces
+  [e6arpbDxMlmogfee] Gold and aquamarine diadem
+  [P7jMpOYmusKse1Yu] Gold and garnet ring
+  [x7rEpjFkUNTqmt1t] Gold and opal bracelet
+  [ony7u60cfBMtLG8F] Gold chalice with black pearls
+  [2MPfYdRWfUNnt5JK] Gold dragon statuette
+  [tcP4ZKGZr5i4586v] Gold mask of a high priest
+  [5ix9inqdHLksqeoR] Gold necklace with peridots
+  [9FsyNDq3VOsFumhz] Gold rapier with amethysts
+  [H8BXvZ1DUg3uJ53K] Gold urn with scenes of judgment
+  [JP7G2gOS3OuMNzeE] Hand mirror with decorated frame
+  [02sF1QlxEx6H6zEP] Hematite
+  [l8dFZIYYngDOIYHb] Illuminated manuscript
+  [G5WuYX1ghrZcJ1J1] Illustrated book
+  [K7KzNh3YsXBrDlyj] Inscribed crocodile skull
+  [NLcnptEjjiY9teq7] Intricate silver and gold music box
+  [YZsZ6stG0i9GBCZw] Iron and rock crystal brazier
+  [YeMi3otmwQ34W2we] Iron cauldron with gargoyle faces
+  [2PXwkWD3ymM7s0Ul] Ivory
+  [LyQQvO7COYAvFRNw] Jade
+  [j4DU62QY4lJ4WEPQ] Jasper
+  [CRTNNgrmssD6bQqQ] Jet
+  [DWzoqVeEamX118Qk] Jet and white gold game set
+  [BlqDXtRZcevCYRNz] Jeweled dawnsilver crown
+  [yrVJKmpBS0mqFuO1] Jeweled gold puzzle box
+  [hEBNs4mYaVWz3UsX] Jeweled orrery of the planes
+  [zRsMLEqh2t2hqSw4] Jewel‑encrusted gold altar
+  [DE4880DRtsRqax1N] Lapis lazuli
+  [rjHqUOFqUeyTQyin] Lapis lazuli pendant
+  [dloHmPtGDr8zSwJu] Leather flagon with Caydenite symbol
+  [zdiHlKtd4Fy1aIPC] Life‑size sculpture by an expert
+  [PzWETSKeVKisKCyl] Living flame shaped into a phoenix
+  [OzxNhgRFEgdTybFl] Major Painting by a Legend
+  [Ds8GJEQyRYamRIiB] Malachite
+  [TTuRgoLxVR2c6NEx] Marble altar
+  [vKdjLDfL75SfFGuL] Moonstone
+  [Mp6StcWjlKCpD8Jx] Moonstone and onyx game set
+  [oH7dJGkgAB0Y2Mad] Obsidian
+  [3l30rcsNpDM7moKu] Onyx
+  [ilnc82SKDYHcoEMH] Opal
+  [Oru7cHMGULLXRLV3] Original manuscript from a world‑famous author
+  [GgwlIaNPJVsyRwzz] Parade armor with flourishes
+  [hhJfZgLhPaPh5V7e] Pearl, black
+  [RLFxTy0TjMkN6rM2] Pearl, irregular freshwater
+  [7iVFlnr2ZbBdtOx8] Pearl, saltwater
+  [oZYu6GMIIoOYW2Nh] Peridot
+  [q72jL8PRcjw3DVoF] Phasing ether silk tapestry
+  [dzsJfE1JIWUMCiK4] Plain brass censer
+  [JuNPeK5Qm1w6wpb4] Platinum Pieces
+  [HMdfNM7ibp1XtcVT] Platinum dragon statuette
+  [LzHxy9YPEaCueLB9] Platinum image of a fey noble with a bit of orichalcum
+  [nBY7ueX18tcSiica] Platinum‑framed monocle
+  [z84EQt8kcPf0RXwx] Porcelain doll with amber eyes
+  [JECXvZ0bKTDr79mo] Porcelain vase inlaid with gold
+  [laXnb43oznxeSLT9] Previously lost volume from a legendary author
+  [YFokzLQ0HK74Vf6n] Pyrite
+  [iz7Mv2xGwqyicNiA] Quality painting by an unknown
+  [aGJJwRpFRMgneROG] Quality sculpture by an unknown
+  [PGlNIOpo8yedgTFR] Quartz, milky, rose, or smoky
+  [qnK4cIHZ2irCV4BL] Quartz, rock crystal
+  [Ujaoyu3WE6V7Y8Vg] Rhodochrosite
+  [3UOS4sien8IQbPNV] Ruby, large
+  [WuW89GD0TG7RYTLF] Ruby, small
+  [aqhEATP0vu4kx15I] Saint's bone with lost scriptures
+  [yTYPPB7WrhanBPbu] Sapphire
+  [mixyMNYUClKfqURh] Sard
+  [AgsZScsqv3puTmZx] Sardonyx
+  [8P87jwOAC3zMuzoF] Scrimshaw whale bone
+  [RKX4vLWyczPwfsKS] Set of decorated ceramic plates
+  [rVfFUBb0r423IPg8] Set of decorated porcelain plates
+  [69IWSryF5BWkwWXY] Set of six ivory dice
+  [6vb56WClb06JrpuJ] Shell
+  [fUENXLX3tzi33CcB] Silk ceremonial armor
+  [vJLb8wwipdwFQDH3] Silk fan decorated with turquoise
+  [8RH0e9UqXIxAPJJG] Silk mask decorated with citrines
+  [5Ew82vBF9YfaiY9f] Silver Pieces
+  [tMMYXdHps9QakCVn] Silver and jade censer
+  [Gi4vx84LhppOQAxr] Silver coronet with peridots
+  [FI8PLxBFmHF6o0pH] Silver flagon inscribed with fields
+  [5dibOpDYOhJY6Ssn] Silver mirror with gilded frame
+  [5EYlhm8ZbR6dLUHF] Silver statuette of a raven
+  [bgswgiXV12HW0aEz] Simple painting
+  [2T33bWTWXj1v2J03] Simple sculpture
+  [CNLt74pUxM0GGjyl] Simple silver circlet
+  [yv7OfuEaXTm6YCAc] Small cold iron cauldron with onyx
+  [rIhvmrRVr51VgfKa] Solidified Moment of Time
+  [hJc0dOcHJ2nkJcik] Spinel, deep blue
+  [wBoGy4DfKHAvqAko] Spinel, red or green
+  [LJxNB3Yy2sTJaUbd] Splendid lyre of world‑famous lyrist
+  [2Rb9MOLENbZ7yyRL] Star sapphire
+  [FwYqacDEAmXk5jB5] Star sapphire necklace
+  [HIxtCuH5YXNqit0W] Tankard owned by Cayden Cailean
+  [5CqtgygdvqecMoRU] Thought Lens of Astral Essence
+  [DFNmzduKX6NSuPrT] Tiger's‑eye
+  [oyGXxUmS6QcthfRc] Topaz
+  [m26FikfAdZouHzhq] Tourmaline
+  [eUXQTjezsuJ6EB4u] Towering sculpture by a master
+  [8aPckmJTsyUfBndP] Turquoise
+  [nzT4kWzAdLMcESWl] Virtuoso silver flute
+  [s6wRFNG5lVEkGGdJ] Wide landscape by an expert
+  [p3mg6gK5KhpS7plo] Zircon
+Weapon
+  [tRmoj42jniQOdjYS] Accursed Staff
+  [eIGcGgQDBihvJsEo] Accursed Staff (Greater)
+  [jHCPejseO01ki3lO] Accursed Staff (Major)
+  [jC8GmH0Un6vDxdMj] Acid Flask (Greater)
+  [M1k5QQc1qQLxzyCK] Acid Flask (Lesser)
+  [GttLYMT2welSpwCd] Acid Flask (Major)
+  [SgtqZxt26BdjUmEB] Acid Flask (Moderate)
+  [17Oza88ts0ASngdw] Acrobat's Staff
+  [8V4mgecGASsQ7fjl] Adze
+  [c4PSK2Q7ikF8jgrm] Aerekostes
+  [5XImTvAN58GhnNIE] Aether Marbles (Greater)
+  [JMu3VUwhQu1SLSFd] Aether Marbles (Lesser)
+  [67pe75mLVekaVqZH] Aether Marbles (Moderate)
+  [SzUynRs4HVtnpnel] Air Repeater
+  [YnPYSKCQBLIOtm0J] Aklys
+  [loueS11Tfa9WD320] Alchemical Crossbow
+  [JAOzIeqKr5hULumB] Alchemical Gauntlet
+  [n5yTlTs63o53n3k6] Alchemist's Fire (Greater)
+  [yd3kEK21YknZLlcT] Alchemist's Fire (Lesser)
+  [cLZrOihPht5M7eTw] Alchemist's Fire (Major)
+  [gWr4q4HiyGhETA8H] Alchemist's Fire (Moderate)
+  [iSceAVMkVv1uKK7t] Aldori Dueling Sword
+  [QyzNxesxaSdPo3Pd] Alghollthu Lash
+  [TIq0xuvRpIdPglsA] Alghollthu Whip
+  [FSIDKg5gYiXlr39j] Alicorn Lance
+  [Pu16joZ15pPJS4Bn] Alicorn Trigger
+  [yY0OkkshPrsoRkAh] Amphisbaena Handwraps
+  [kSLHMQjKL77CtvBx] Anchor Spear
+  [WcuknnE3xYfSdbhm] Animal Staff
+  [bT9azgpc96DNbitA] Animal Staff (Greater)
+  [Oo7IpJQDSTmzUyzG] Animal Staff (Major)
+  [mKEhLq7Ha4lvupMP] Animate Dreamer
+  [nymtBfivudt7t75q] Ankhrav Duster
+  [ZuyzSxmg4QdnZqLy] Ankylostar
+  [MlKNR5Q784mgmU0C] Apotheosis Knife
+  [K3qNqWRvBhnlwE3Q] Arbalest
+  [6qqsyhVHPo8LQH8Z] Arboreal Staff
+  [4kyf3ScoJ4TvhPG3] Arboreal's Revenge
+  [ChTaE7jhvCjcS6jI] Arquebus
+  [DP03AwxQxCOAxch0] Asp Coil
+  [Ka49l6JYNi41tgVi] Atlatl
+  [CPZC4rAHGkQqPLJ9] Atmospheric Staff
+  [SKKVjloic8hQbYo7] Atmospheric Staff (Greater)
+  [HarOsJI1p5oHt2Vd] Atmospheric Staff (Lesser)
+  [YMz8ZKeOmSU9VuKp] Atmospheric Staff (Major)
+  [Nqy9whrqYrChgkHh] Atrophy Bomb (Greater)
+  [Ey9g17eK5KxeuOIR] Atrophy Bomb (Lesser)
+  [HuVDfEm6U7Quq9Y4] Atrophy Bomb (Major)
+  [Jgi6iWyH9ihgXC7w] Atrophy Bomb (Moderate)
+  [YPo7jLMxob6E2p8b] Auspicious Scepter
+  [oUaeLZLK7WfolqBb] Axe Musket
+  [tPwYYwxNqdGQp2nW] Axe of the Dwarven Lords
+  [KoyxJDibsKJh24am] Azarim
+  [2dHdOVBySillcOGM] Backpack Ballista
+  [68bqnb84kst3hFjP] Backpack Catapult
+  [UogGzQfXDc32E1p7] Barricade Buster
+  [6KWYmeRMxsQfWhhJ] Bastard Sword
+  [zB0Q86QD0A10CeFH] Batsbreath Cane
+  [War0uyLBx1jA0Ge7] Battle Axe
+  [79krBL334Kp1RMNB] Battle Lute
+  [7mXZyzL5v3K6Buu2] Battle Saddle
+  [jm5gQnfvVeUiVfdW] Bayonet
+  [HoxkzrS7jhqmWpla] Beast Staff
+  [zzLGE9zmSu3yMEOq] Beast Staff (Greater)
+  [PeRLqNTbzaiITNuO] Beast Staff (Major)
+  [VTFTlP8xmPKKV4S6] Bec de Corbin
+  [H23XWSdTgBV1UhBq] Belimarius's Invidious Halberd
+  [VDyPNtcxDbVGQ613] Belkzen Deadsmasher
+  [lJOygeHETz6S8cEz] Belkzen Deadsmasher (Greater)
+  [UGqhitKOWCsqs9UQ] Bellicose Dagger
+  [GG7XnMngd9MnxhHb] Big Boom Gun
+  [OUOSAKU1tSipWtty] Bioluminescence Bomb
+  [NS2j5bYEoHeESlyN] Black King
+  [8eGV6fXbmt2v74uB] Black Powder Knuckle Dusters
+  [jkwhiuaoSsJAgkgi] Black Scorpion Stingmace
+  [o9IErbpmItz9NZT3] Blackaxe
+  [6RkxhrJqBpFQlRBD] Blade of Fallen Stars
+  [AUJfvrouapAeC4Mg] Blade of Four Energies
+  [AWUzApS5PPwt3TCI] Blade of Four Energies (Greater)
+  [tD4ZNDutHoCGIFQn] Blade of the Black Sovereign
+  [APZJC0A469gBozf1] Blade of the Rabbit Prince
+  [0lCXehyFlXdYxDfA] Bladed Diabolo
+  [PJboj72eI9JXjtbn] Bladed Gauntlet
+  [IEA7M6GGv4rnGLdW] Bladed Hoop
+  [iCdvNfzvsTZ0s5vg] Bladed Scarf
+  [geSDZ68zolr0dNrD] Bladesweeper
+  [qLhb5ZvIDOmbwvc9] Blast Lance
+  [RijrZ8lnaYrGTeMV] Blast Lance (Greater)
+  [dsMkvuLgpOOGLWDy] Blasting Stone (Greater)
+  [Xnqglykl3Cif8rN9] Blasting Stone (Lesser)
+  [IuGydh0En8LbfnWo] Blasting Stone (Major)
+  [JOaELkzLWTywhn5Z] Blasting Stone (Moderate)
+  [UFAIquTmQcgqSl7s] Blessed Reformer
+  [LhMXIGelSrFPYild] Blight Bomb (Greater)
+  [j8ajvNqyyQGBpBch] Blight Bomb (Lesser)
+  [sJjuv1991SZ7DWWD] Blight Bomb (Major)
+  [158vwM1andv8DbRI] Blight Bomb (Moderate)
+  [kIExO59KkiXZUmto] Blightburn Bomb
+  [ZrXw7hAH8dQOGAYL] Blightburn Bomb (Greater)
+  [tWoW1BeFrWm35hmV] Blink Blade
+  [kuHr6dEOxN0WAnUP] Blood Bomb (Greater)
+  [wdJ0AFtkJVycVRjX] Blood Bomb (Lesser)
+  [3SZAUzXG6MWYWoXZ] Blood Bomb (Major)
+  [ODXNXvcLQGBw6kXj] Blood Bomb (Moderate)
+  [uXug1JhufAQr8HOC] Blood-Drinker
+  [V9e6G1ZolN7Ncg7g] Blood-Drinker Blade
+  [vtPf23T4O6fPIF4P] Blood-Drinker Blade (Greater)
+  [yCD9PupW7P0frwMM] Bloodgorger Scythe
+  [f9SdiktChZHHBj8k] Bloodknuckles
+  [tNue4PqJe85ZEE5v] Bloodletting Kukri
+  [jEYl5VuFa2JslZbY] Bloody Fang
+  [FPwsiGqMCNPLHmjX] Blowgun
+  [csXSDzgZASX4RWr4] Blunderbuss
+  [hMYdSFmMWzidzHih] Bo Staff
+  [gTTJuNgwTcNmkDx2] Boarding Axe
+  [sF9uOLAjQiSmt9i3] Boarding Pike
+  [7irlzyZA50KqTwce] Boastful Hunter
+  [YUzPv0i8d8p2J9yx] Bola
+  [y5bkwzClxfs6gpDn] Boomerang
+  [tU4PKaoo1XuPkKg1] Boreal Staff
+  [PAZQrWMLfYTpDoal] Boreal Staff (Greater)
+  [rYBX6v9JqpxAiQvn] Boreal Staff (Major)
+  [r2iTRbt1zpkAqHj2] Bottled Lightning (Greater)
+  [AFR01HVd7DcZvkpP] Bottled Lightning (Lesser)
+  [rpbbfkexLhtadBDV] Bottled Lightning (Major)
+  [97QyNEOAyYLdGaYc] Bottled Lightning (Moderate)
+  [AH0u9DDvs4napvdh] Bottled Sunlight (Greater)
+  [iGT4UeQq3YFcNpEb] Bottled Sunlight (Lesser)
+  [xoucExiZTvCbjWMB] Bottled Sunlight (Major)
+  [wIQjJGLZOKCY1es9] Bottled Sunlight (Moderate)
+  [DGehMCf2XViTvBDu] Boughshatter
+  [sjOkiftTv4KbR2c0] Boulder Seed
+  [OHwsumgfO1oyH7KL] Boulder Seed (Greater)
+  [RdJg2iIQx8lJyPWe] Bounty's Light
+  [K9ndlHU5JRHj0ivP] Bow Staff
+  [fqOcjvpOdIIAx0k5] Bow of Sun Slaying
+  [h7RtjyqHouB3pGgr] Branch of the Great Sugi
+  [ymyPCjfyXCNyDcnn] Breaching Pike
+  [9jn87Bnp2kGnDFPQ] Breath Blaster
+  [4UHTZGZosYcP28lD] Breath Blaster (Greater)
+  [WnzQy5naKy9Gj4pY] Breath Blaster (Major)
+  [FXY5YezrQ13dubnd] Briar
+  [kCN0QxUbJrvidysF] Brilliant Rapier
+  [bzhJNnkIXdVRbjAA] Broadspear
+  [LxqA4VC4np2RLkQb] Butchering Axe
+  [JuR0cug2xq4sWxHR] Butterfly Sword
+  [7WRzbBTOCsJx5f7L] Buugeng
+  [aBfyzL0WBFMBAbuI] Buzzsaw Axe
+  [mXlVJIxv6EpzwTJs] Buzzsaw Axe (Greater)
+  [D2CnWGQ84bSjh5bz] Buzzsaw Axe (Major)
+  [YqhEmz8dmf02b99u] Calamity
+  [UnTUQ9w8yswupr9m] Cane Pistol
+  [h2UebueRKfVLwKOa] Cane of the Maelstrom
+  [IBxtmyiVjWVqFawh] Capturing Spetum
+  [FlZUF29msGVibG5k] Caress of the Great Serpent
+  [0liiZqvhcM69tKl9] Carver-cutter
+  [MNx8UznusoyRy06k] Carver-cutter (Greater)
+  [O5PgCWNhFtTFL7S5] Carver-cutter (Major)
+  [ePmUVkh4NgM4eGdR] Carver-cutter (True)
+  [y5ibQXac9BbzrYoT] Castrovel's Beacon
+  [2KNAip9W6IoBrfIU] Caterwaul Sling
+  [DlvJ0PgEGTGfEgUi] Catoblepas Maul
+  [0oU6xeU1fV66O47y] Cavalry Commander's Lance
+  [LMKw9PCVGeZy7knY] Cayden's Tankard
+  [TKvAPv3jgv4l143r] Celestial Peachwood Sword
+  [S1ALL8osqV1pOtf3] Celestial Staff
+  [JlakyeGJjNbryq6v] Chain Sword
+  [0wwEdvm0u9LswjQO] Chain of Command
+  [zmgF0sh9YicCngev] Chainbreaker
+  [hgyktS6n2t5MztjW] Chainbreaker (Greater)
+  [EtfVzTsCYULkEzFk] Chakram
+  [rhHGULVS5tumszGP] Chakri
+  [0GEXLXh8M5Ce6oYT] Chakri (Lost Omens)
+  [OIs6WPuCRh2UJTOe] Chalice of Justice
+  [yHtlXoXKPis7eTR0] Chaplain's Cudgel
+  [rsqPU9IRM6tk2eHc] Chatterer of Follies
+  [OaZG6jQcDQ5uCRqZ] Chimera Flail
+  [XBn3aapPC0x7X13W] Chronomancer Staff
+  [Dti9PZZoty6We8OV] Cinderclaw Gauntlet
+  [kJJvKm80KwWXPukV] Clan Dagger
+  [BtncTx8EfxTsHqQI] Clan Pistol
+  [fvvfZxfGV9i3urkd] Claw Blade
+  [Q2oyGb8l2hU7jYAi] Clear Cutter's Axe
+  [BJuqdqbflAcuCJkt] Clockwork Macuahuitl
+  [c58wczIzH2gzeXQL] Club
+  [LLYD2GEhzhdxoCAx] Coat Pistol
+  [JYtqvOyF11GUsQTB] Coldstar Pistols
+  [d11vAXNTniXKWXIx] Combat Fishing Pole
+  [3T3ayvgw9HDn05Mz] Combat Grapnel
+  [5qW06ylMkJ0wToDd] Combat Lure
+  [6TC4FywUTzVAK97v] Composer Staff
+  [KSHZBPFxPD6uCZXM] Composer Staff (Greater)
+  [pBPVm5JjKfKX8gaX] Composer Staff (Major)
+  [dUC8Fsa6FZtVikS3] Composite Longbow
+  [e4NwsnPnpQKbDZ9F] Composite Shortbow
+  [PFmBfQ4xENK3jX4M] Conflagration Club
+  [oYsyrS2hNqnAR4uy] Constricting Meteor
+  [KXoJIPHbdz746Rec] Cooperative Blade
+  [mSOYAQb8iq1N1S1I] Corset Knife
+  [KaYvuSNXZaOammij] Crescent Cross
+  [TD44V3u77AMbOnTo] Crimson Bluff
+  [k5P9YZO4ARlE4By3] Crimson Brand
+  [sAhQdzMThRXu4556] Crimson Thorn
+  [62nnVQvGhoVLLl2K] Crossbow
+  [v8C4hkqMNeUk60Db] Cruuk
+  [ivaL0xt33k6QNwQK] Crystal Shards (Greater)
+  [V2knI4GpdJYLupjg] Crystal Shards (Major)
+  [V4wgOWYmHlbSZsVG] Crystal Shards (Moderate)
+  [XnlYH66ZA7RR3QgR] Cythbikian Staff
+  [rQWaJhI5Bko5x14Z] Dagger
+  [BPQRgrJwr5GuT00g] Dagger Pistol
+  [1S3RgLWa1DBitB9V] Dagger of Eternal Sleep
+  [RN3m5Hb5LPbdZGoO] Daikyu
+  [fX63Af9Bf2XVarJu] Dancer's Spear
+  [5v2mhiBbYQDhlsw5] Dandpatta
+  [Tt4Qw64fwrxhr5gT] Dart
+  [wpvfykcSSbg27DgU] Dart Umbrella
+  [qRqGIxcadjjxcij3] Dawnsilver Tree
+  [xBp6xT689GGCYr35] Dazzling Shortbow
+  [VYmdcWj6VmUrTxJI] Deathseeker
+  [jE5H6jmDJEzxGvSP] Deepdread Claw
+  [zXUmfJEBQ7Pfovve] Deflecting Branch
+  [tcHzNhjP6BesejWT] Defoliation Bomb (Greater)
+  [M1P2Tn4e9L92Wadw] Defoliation Bomb (Lesser)
+  [Ey3AowmoC3Fo0OJ9] Defoliation Bomb (Major)
+  [bPWqAnZAoDPko7sw] Defoliation Bomb (Moderate)
+  [TO8UvbBy1NfVbrdB] Devil's Trident
+  [kP51e5Ul3Q1fusSg] Dezullon Fountain
+  [6rWcLbV82KYwaHo1] Dog-Bone Knife
+  [olwngGXM3hpgoLEP] Dogslicer
+  [Po1oeTDUaSUxeZxG] Donchak
+  [J2YjO6JfbeJCPOaT] Doomsweeper
+  [rePjr9KceepKIDuB] Double-Barreled Musket
+  [MvzR9nTnvKTeNjvQ] Double-Barreled Pistol
+  [DjF9liKIgV16YzMJ] Draddeth's Edge
+  [BzVwQ0Go1GFp9R0U] Dragon Handwraps
+  [4gWvfeDGTSAf9LAQ] Dragon Mouth Pistol
+  [l3IOo6AiQj7pxPhB] Dragon's Crest
+  [QwRTK0x9L04xKyU5] Dragon's Tongue
+  [sq33MLggeM8D7Zz3] Dragon's Tongue (Greater)
+  [fukrqsWzFeRbiLbi] Dragon's Tongue (Major)
+  [ergvi4pLRMndtiQj] Dragonfire Halfbow
+  [tEI1WOo4ZRJ5cI0K] Dragonprism Staff
+  [inyiBwK0zNootR6G] Dragonprism Staff (Greater)
+  [ZsmASTxnrtZX9JDH] Dragonscale Bo Staff
+  [4jZqYIyouoK7xe8u] Dragonscale Staff
+  [SQrkh42q3EYgygx8] Dragontooth Club
+  [Blo642O1qsgsvYEB] Dragontooth Leiomano
+  [FU9tZ3neEPM8szay] Drake Rifle (Acid)
+  [5TOdQaW1XEjDhTP0] Drake Rifle (Cold)
+  [h1G2xCiMrHd7uFko] Drake Rifle (Electricity)
+  [Gfu13B6b9eDdHCtV] Drake Rifle (Fire)
+  [ywUMtG1viqbnDFYT] Drake Rifle (Poison)
+  [0nVHDnehORCQlqP5] Drazmorg's Staff of All-Sight
+  [kpJmjm843vaMZjIu] Dread Ampoule (Greater)
+  [ds0OdA989ZZw9km1] Dread Ampoule (Lesser)
+  [MCHYtxP8E7njLC3s] Dread Ampoule (Major)
+  [IvFEJqp2MUew65nQ] Dread Ampoule (Moderate)
+  [9QugctA7ZTeCIsx2] Dreamcrusher
+  [K5PVPhK5EVM2Fxgg] Duchy Defender
+  [ogv5nwwrc3sU8DnP] Dueling Pistol
+  [d3Xv6QDWkpeg7VZn] Dueling Spear
+  [mE2MpteGPmGeYbOL] Durian Bomb (Greater)
+  [RIhdmH0yMzht7OD5] Durian Bomb (Lesser)
+  [9crpQ6bymgYcKGjq] Durian Bomb (Major)
+  [B9BYJQt5Jlwv2cxv] Durian Bomb (Moderate)
+  [xZFT5JdEvDi7q467] Dwarven Daisy (Lesser)
+  [Do4rJuA1nhr2TTiF] Dwarven Daisy (Moderate)
+  [aYzWoFt5uYY31zEQ] Dwarven Dorn-Dergar
+  [jcIabnkJgjwzK6Og] Dwarven Scattergun
+  [XK4DM8wOtcuOsji6] Dwarven Thrower
+  [MYnh7w7EL3AcQT41] Dwarven War Axe
+  [fcWvG7jAZDLMRBWn] Earthbreaker
+  [FCA7CE4mK85SVLz3] Eclipse
+  [kxrlIT6mcZ4OEAjQ] Elven Branched Spear
+  [mgrabKkyLmvxgLBK] Elven Curve Blade
+  [XOXUFjBGO6azymyb] Erraticannon
+  [cFHUt5tTA7jVPtRh] Explosive Dogslicer
+  [RN6rEc8eSkruNLPW] Exquisite Sword Cane
+  [R2mDnYVqewmx3dV0] Exquisite Sword Cane Sheath
+  [xHdbwPOUgLPUtqLj] Falcata
+  [XGtIUZ4ZNKuFx1uL] Falchion
+  [wYruARP1YLfTQBsc] Fangwire
+  [FuS6F91Rhd4m3T6d] Fauchard
+  [CIglJOSgO3HsBqUP] Faultline Hammer
+  [yUgOLSyb4pGGxfCR] Feng Huo Lun
+  [ZwJXdOdnE8TcSHK1] Fiend's Hunger
+  [ICreMLiKizKZkype] Fiendbreaker
+  [wu50pzerLWnVrHG8] Fiendbreaker (Heroic)
+  [Kx6FQS5GyVB6jlrW] Fighter's Fork
+  [76AqNZB5xuFWxgJI] Fighting Fan
+  [edlvRl3zCceS7MSo] Fighting Oar
+  [17MQKaMIHQAJNtuu] Fighting Stick
+  [CVTgOpNuRE7hsnc1] Filcher's Fork
+  [nz1v5aetUZVLBlvg] Final Rest
+  [od3HCoOa3pnDmQB9] Final Stand
+  [WUA40bb01pSWv88I] Fire Lance
+  [rfP9e1fnwjnIQSJK] Fire Poi
+  [t5FbyZtRL4qV0V7k] Flail
+  [QKhVKfaum7DyF53w] Flashblade
+  [uPtU3QGn9UdskxFh] Flashblade (Greater)
+  [GWwbrnWBymUQn4JI] Flashblade (Major)
+  [dfheZ5lK0thQUTVT] Flaying Knife
+  [PTTB9orSB4RelXF3] Fleshrender
+  [EPhsyiO4jYl0jWoC] Flingflenser
+  [hqMtsTwmOShdAdQW] Flintlock Musket
+  [N3nNqO5Nw2DIFhrv] Flintlock Pistol
+  [B71BgdfFApkYmAjc] Fluid Form Staff
+  [bQynfb23iexSu8zU] Fluid Form Staff (Greater)
+  [smrNvKVL976JNEab] Fluid Form Staff (Major)
+  [ucz1WdBA0Ma34OsS] Flying Talon
+  [kbKAFqsEDWy5mN1y] Flyssa
+  [PlXEjK5nqIxEYXQa] Forked Bipod
+  [05L6c6B8XuU8imfM] Four-Tiger Blade
+  [3oexArva2aEm69WV] Four-Ways Dogslicer
+  [B4sqJnFnucXloCOu] Freedom's Flame
+  [87IvbaQnkUOBgdD0] Frost Brand
+  [8YijFaakOFWjddJO] Frost Fair Yanyuedao
+  [intVPcEzbE9o4NQd] Frost Vial (Greater)
+  [EpxmUtLpCkE8R6KJ] Frost Vial (Lesser)
+  [4DJQID8GIlxQ7b9C] Frost Vial (Major)
+  [nVvH1ZcM7OwIVIs8] Frost Vial (Moderate)
+  [ssDxSpQTYORoeCFA] Frying Pan
+  [KQRrAVdcRqtd0Lq2] Fulminating Spear
+  [ja4phrX3anThH7hx] Fulmination Fang
+  [IoJ0WpfUPWGuaqBG] Gada
+  [NApB2Fl7i8wzp7RX] Gaff
+  [0E9ADJkQUVsz7A4G] Gakgung
+  [IKuvON8e4o7ARe4p] Gambler's Staff
+  [Ix2vicchE79d6Cl3] Gauntlet
+  [LcIfvbMPnOGYXVge] Gauntlet Bow
+  [1AHntZrWzp5e31SX] Gearblade
+  [Tej7JTxvq1K0qGYn] General's Word
+  [VSxLv1JRSo10waL0] Ghast Stiletto
+  [28osNZINXLWzqzUL] Ghost Charge (Greater)
+  [LNd5u19GqC51ngby] Ghost Charge (Lesser)
+  [i7bJcib5TUJKOd4Z] Ghost Charge (Major)
+  [Wf94e8YNhZdIvWc9] Ghost Charge (Moderate)
+  [xxSpHT2vnCFxTr0q] Ghosthand's Comet
+  [VOmOhm3Rc3VUkIu0] Ghoul Stiletto
+  [5IXLQVFWf2PEUHOJ] Giant Squid Lash
+  [FbquJr6FuXL3K373] Gill Hook
+  [wGT3VAQ8NXleUsx3] Gladius
+  [vlnzTSsRmWeSkt9O] Glaive
+  [J5It6yq3ZkN059zP] Glaive of the Artist
+  [7haFJ3s6G6K1TQFj] Gloaming Arc
+  [HWVORFebjWAPQ2NI] Gloaming Shard
+  [w5ZX1R3dPvuLcuRx] Gloom Blade
+  [5Qkz4RVJr2Kx3RL6] Glue Bomb (Greater)
+  [T6Appwwl6nUl56Xj] Glue Bomb (Lesser)
+  [BxJNWWvpxacDIsdt] Glue Bomb (Major)
+  [evBPzM1VsuYcoenn] Glue Bomb (Moderate)
+  [2z4GSaKaVX22kzPU] Gluttonous Spear
+  [caWhNJ2ahCzZjr55] Gnome Amalgam Musket
+  [oSQET5hKn9q4xlrl] Gnome Flickmace
+  [1U7Laa7Yt7i3G77L] Gnome Hooked Hammer
+  [aYFelpLdqrvZMx2Q] Godsbreath Bow
+  [dIUmjoLjlcrKgXbH] Golden Blade of Mzali
+  [SAtG9jrqey2y8EGb] Goo Grenade (Greater)
+  [t2A5PzInAqmErLzK] Goo Grenade (Lesser)
+  [W0RWd2E0jkF2ZXhf] Goo Grenade (Major)
+  [wi97vRj8IXx3wLmZ] Goo Grenade (Moderate)
+  [DFZj7RCrk6rk9fhf] Granny's Hedge Trimmer
+  [wWXnr3xw5TzDL1M7] Grasp of Droskar
+  [GQHPI84ilXlglr27] Gravedigger's Call
+  [IePXTa0jDjDqXxYl] Gray Prince
+  [8COlYvHe6hKCXY8x] Greataxe
+  [kdGqnqbrwPzQfTsm] Greatclub
+  [3Zv5hSXXtlaDatUv] Greatpick
+  [UX71GkWBL9g41VwM] Greatsword
+  [xmOGKAuCNYO4tJkM] Griffon Cane
+  [Us5dVXQHJzNjY0X8] Grisly Scythe
+  [ER9gH5A7elGPdHag] Grounding Spike
+  [ssS1yEAZwZun8yFw] Growth Gun
+  [UQ0h9IVtHla8gWT7] Guardian Staff
+  [jIX2T21YvEsRaaqp] Guardian Staff (Greater)
+  [REvrniIEqBykkWyI] Guardian Staff (Major)
+  [atB2ewbcBMWvhjNT] Guiding Star
+  [TT0pJz9odKApfq6D] Guisarme
+  [10J0WjnfgRvriLXc] Gun Sword
+  [u5VXHAmxYqp0H54F] Gut-Ripper
+  [zakdImp4CqahnFfc] Habu's Cudgel
+  [dgWxsYm0DWHb27h6] Halberd
+  [DV4qelKHrviM0O5i] Halfling Sling Staff
+  [zHJEzmoybIfX1LaV] Hammer Gun
+  [MccX4AlmqYDjAN2J] Hand Adze
+  [4LJEpZ2HkCu9BvHI] Hand Cannon
+  [XyA6PKV46aNlLXOd] Hand Crossbow
+  [FNDq4NFSN0g2HKWO] Handwraps of Mighty Blows
+  [qtlkftQXfO4wuCVu] Hardened Harrow Deck
+  [NhKIUGMcxVusTJ6y] Harmona Gun
+  [oTQKyZ8Vd2RPzaWK] Harpoon
+  [LGgvev6AV0So8tP9] Hatchet
+  [bcZB7xmlQy8UWqe1] Heartripper Blade
+  [srCxiFF44RcuRMHD] Heavenly Rolling Flames
+  [giO4LwIKGzJZoaxa] Heavy Crossbow
+  [QbEkoFL1EYNGsOom] Hell Staff
+  [ggjnWvQpl7EzXi6Q] Hell's Judgment
+  [HKcfpawD4CesJtFy] Hex Blaster
+  [z9T4c1hXwOotsMCp] Holy Water
+  [a5DlDpB3RuSIvLIC] Hongali Hornbow
+  [O3XAH3VkOx9a0FyD] Hook Sword
+  [YnwEttFE1bJacLDh] Horsechopper
+  [VvJo7xIJANfoqRKr] Horselord's Longbow
+  [4cOXKB8NcL6JzGeI] Howler Pistol
+  [RZkttcpkv4qLs1Lk] Hundred-Moth Caress
+  [4DnjM0PNivT2dlf9] Hunter's Anthem
+  [RapaDb10oJZOjujo] Hunter's Bow
+  [2jtZPnHF1M8vKWry] Hunter's Dawn
+  [nWUx4zEGOE8Uot1g] Hydra Head Club
+  [DA3hZ45tpmBuPkKZ] Hydra Spear
+  [iaZOReFQgGsKok3Q] Hydrocannon
+  [O7pgJB6M5UqUZ9Qq] Hyldarf's Fang
+  [NARrXbTyQ2X6hA7e] Icicle
+  [5SVttGODx1TkyhTU] Immolation Clan Pistol
+  [AYdpUABAZeZnSA7s] Infiltrator's Accessory
+  [zbwV685YkIVxPNWE] Inflammation Flask (Greater)
+  [IGwM0rPKZt7vZ7zq] Inflammation Flask (Lesser)
+  [AOGJdyn5J0nB9ThV] Inflammation Flask (Major)
+  [A3uCOubAKyCSRPRv] Inflammation Flask (Moderate)
+  [UCK8zXKb0Gi6uyum] Injection Spear
+  [dYydONniFSGwAdL1] Iris of the Sky
+  [JNt7GmLCCVz5BiEI] Javelin
+  [BdNRM9VTxs5BYq0C] Jax
+  [NEZfXSasFdLdQFBi] Jezail
+  [KzvbL114c72EhWhd] Jian of Life's Duality
+  [vVVorEuulaPUDHM0] Jistkan Colossus Crusher
+  [b7Qqj2Pzj6SwihwD] Jistkan War Crossbow
+  [WxczDmQ5qOaD5IxB] Jiu Huan Dao
+  [mpu2fvjDVe771RbU] Jorngarl's Harm
+  [RhfhVSfiH23v4U7k] Juggling Club
+  [QhUTsTnbehv1ft9u] Junk Bomb (Greater)
+  [WJMHv8xXowLNP2Di] Junk Bomb (Lesser)
+  [K291ECjrRssmH93Q] Junk Bomb (Major)
+  [1MuIK1TnzdKuqZJO] Junk Bomb (Moderate)
+  [urcBTs4AgSq8u5FJ] Kaldemash's Lament
+  [6v4aedCiIAoSJfiL] Kalis
+  [zSAoyzcf3nSeZCiF] Kama
+  [8XwE8hsWBFoIdoDC] Karambit
+  [Y1dkRsRd1Z7Jf2y6] Katana
+  [Fg3GkCDkszj5WtgQ] Katar
+  [OrzHZJzDpTCgGT4i] Kestros
+  [KgKSX95uVSg8iBBA] Khakkhara
+  [YLb6XnT7OxAVGL5m] Khopesh
+  [TgP5Rwzrampv1sDU] Kinetic Club
+  [Hz9ivObyYZryi8uW] Kithrender
+  [EmTK4nPOORXtb58X] Knight Captain's Lance
+  [dgXjUcaoQDAY6ZpO] Knuckle Duster
+  [Vz7nITDWjrXmyoJn] Kortos Diamond
+  [ADvVuMwIWDZZF9cv] Kris
+  [TDrO7Xdyn7juFy3c] Kukri
+  [D6E4VaKVG05G26Rm] Kusarigama
+  [C7ca35oypTp2xJbj] Lady's Knife
+  [174fUKNwSgbKwroU] Lady's Spiral
+  [TG8DO0YsLiguZJW3] Lamentation of the Faithless
+  [OPMzQdM9rZznMGhW] Lance
+  [mVjHOSH8ydCmqRQ7] Lance of Sun's Radiance
+  [cSGWhw4Wn6Z98tVK] Lancer
+  [zXvYaLxfov2jrV06] Last Hope
+  [27CO2NIr5yMgA6sa] Leiomano
+  [lkENLG26X4ah6Eun] Leydroth Spellbreaker
+  [8LEKZdpipKp3jYfx] Liar's Gun
+  [bh1Jr4YqfXQe7r9I] Librarian Staff
+  [QFvB2qgpWdeEa4fT] Librarian Staff (Greater)
+  [1gi4mdZYNgPrzWHc] Life's Last Breath
+  [2NDH3AX5Ewu4MLT6] Lifebloom
+  [FibwLZ12EIEwLGhw] Light Hammer
+  [x1TOpwH755Ami5bC] Light Mace
+  [RbM4HvPyrZ4YJxRc] Light Pick
+  [Ak3oHoPDJoMR14yg] Lion Scythe
+  [zdTVlzR2OW17gLW6] Lion's Call
+  [ZbZMaY8B8dinYhHK] Lionfish Spear
+  [R4nk2W7rTvMDqyUR] Lionfish Spear (Greater)
+  [RgVOC3rpptrwENbu] Little Love
+  [kFZpTT1jI6UMfV9I] Liuyedao
+  [DBQ68Evl8PdLAVmt] Lodestone Bomb
+  [APJ0NWJ4DYUXNpNm] Lodestone Bomb (Greater)
+  [Hc4qCwyO9i0Avlzt] Long Air Repeater
+  [mXBOqphNfUCK7L8c] Long Hammer
+  [MVAWttmT0QDa7LsV] Longbow
+  [aXuJh4i8HqSu6NYV] Longspear
+  [LJdbVTOZog39EEbi] Longsword
+  [pIYlenaADKnxdp11] Luck Blade
+  [C3vAFRWoeGbMQTAH] Luck Blade (Wishing)
+  [QNRa5r2I00YtEoIV] Lumber Lord's Axe
+  [fcRTJBvy1RqXr3ow] Lyrakien Staff
+  [uepeQsiOEIqTyNsx] Lyrakien Staff (Greater)
+  [uX8urrzOQM5wdoTD] Lyrakien Staff (Major)
+  [9iDqOLNFKxiTcFKE] Mace
+  [m3QMdlNxFyDFrkQX] Mace Multipistol
+  [O7IZBvVoe7W2XnBa] Machete
+  [BjSx9EkQNnuHZbvg] Macuahuitl
+  [lSnYM1j5C4A9a3Mn] Mageslayer
+  [6dizJBq0Dqevbf3L] Magnetic Bola
+  [iWcw1sFLAzByVLBP] Main-Gauche
+  [MeA0g9xvWCbGxf2g] Mambele
+  [tYnFIqjvxT9bWaoR] Mammoth Bow
+  [4ADeEQGQJR0ju2Nd] Man-Feller
+  [WCWdJmR5tYO7Aulb] Mattock of the Titans
+  [mlrmkpOlwpnGkw4I] Maul
+  [MiiaZeNMGGSefjVH] Maul-spade
+  [xwiZBOjispKVZzGA] Mentalist's Staff
+  [0RCC0fOg1Lp7f79I] Mentalist's Staff (Greater)
+  [DTIBj6Yhy73G5P6j] Mentalist's Staff (Major)
+  [xu3azdMCIa53Oe1f] Meteor Hammer
+  [NzVp3RKhBkAPbe3g] Metronomic Hammer
+  [oW9neeVcpHjEvjcN] Mikazuki
+  [O5da0gpQqR9MwGLF] Mindlance
+  [UmteC2OgKGJBkMDz] Mindrender Baton
+  [jVDSXbfq0ukHeSkK] Monarch
+  [cKbiv1dUMViikKOS] Monkey's Fist
+  [JosogwNGybTSrH03] Morning Glow
+  [5fu6dCtqhdBnHNqh] Morningstar
+  [IuL8O6sR8st1mevo] Mountebank's Passage
+  [9j3sqH9sG5mUe6rI] Mud Bomb (Greater)
+  [HtBqmBFYuxJp2QiZ] Mud Bomb (Lesser)
+  [Djp91D21I6QW6dlw] Mud Bomb (Major)
+  [0U4qXSxfZDMIJDtA] Mud Bomb (Moderate)
+  [mfYwthsSMkDS8djw] Musket Staff of Force
+  [lsTTJ9GlHOu5o3bt] Musket Staff of Void
+  [NufKswitJjxDCX8f] Naginata
+  [YZ8WY378H1WFaD6s] Nail Bomb (Greater)
+  [2zDOPJy5goJjRREN] Nail Bomb (Lesser)
+  [qmFVrqzvkGU9g5lt] Nail Bomb (Major)
+  [19njoGhqVm3UYsn1] Nail Bomb (Moderate)
+  [u41wQz3bgu6J1XKo] Necrotic Bomb (Greater)
+  [8JnOYyTdatqRnAV4] Necrotic Bomb (Lesser)
+  [RC8EmoFiMITFUopr] Necrotic Bomb (Major)
+  [moBSgma1rtJqh7Rp] Necrotic Bomb (Moderate)
+  [WFumHA7dT5s3jCRT] Nexian Sealing Blade
+  [cnfsOL7Pes47WPpR] Nexian Sealing Blade (Greater)
+  [yMbMbPW2WfjOIrmJ] Nightmare Cudgel
+  [ASjNBiQfQfWppPJc] Nightmare's Lament
+  [80G0z7iFUCjHeYGf] Nightstick
+  [KtarUneAx0hibGtW] Nodachi
+  [4nte7LbGGPwViu1U] North Wind's Night Verse
+  [LA8wwpQBi6tylE6z] Nunchaku
+  [vdoxsa5FbkViZ67K] Nyctessa's Staff
+  [bheWnrBqMphBRUmn] Oathbow
+  [39bdYkGlqjFR0AOL] Obsidian Edge
+  [XVxnCBQEW5idfAPw] Obsidian Edge (Greater)
+  [KRQDhu2XVmOlaVRu] Obsidian Edge (Major)
+  [8W8NvYlRM2lQPJf0] Obsidian Edge (True)
+  [Oiq3QgLrM4i3W5Hg] Ogre Hook
+  [YjaXxg9uQ02IbwLi] Orb Shard
+  [sAjzLXgA2LnIwpBM] Orc Knuckle Dagger
+  [J6H5UbLVsSXShoTs] Orc Necksplitter
+  [IbHZE47vul6Mohz6] Orc Skewermaul
+  [N7cH1SS57NNaOtf5] Ouroboros Flail
+  [sLuU3V5Hv9bYrl2a] Ouroboros Flail (Greater)
+  [j9Z8TrUDHhdArJgi] Ouroboros Flail (Major)
+  [tbc3dqTyibuGoCA6] Ovinrbaane
+  [q1mt1F9q1XmJWAKY] Pact-Bound Pistol
+  [G58Tx1lQqa8n6m5c] Palstave
+  [DFtbWoL6yBnDbtB3] Panabas
+  [ONHFPXNNw9BkNAKm] Pantograph Gauntlet
+  [tk4cfktEnMrp4K6m] Pepperbox
+  [TvEnLYsYjijBe1Cg] Pernicious Spore Bomb (Greater)
+  [841G24r5ITFYk5zQ] Pernicious Spore Bomb (Lesser)
+  [4Thv3O2smZ8AHNjP] Pernicious Spore Bomb (Major)
+  [cbgJbCMU330TVmmO] Pernicious Spore Bomb (Moderate)
+  [ZVhSxudgfnSO4AMd] Peshpine Grenade (Greater)
+  [c124j3cpv8rl5MLp] Peshpine Grenade (Lesser)
+  [b1gx7ZhuFJAyJOo8] Peshpine Grenade (Major)
+  [AvGZqDfalwwbYFvA] Peshpine Grenade (Moderate)
+  [ChLxhFpo4WSAKgLh] Petrification Cannon
+  [EvBQcbkiYUusdFKY] Phalanx Piercer
+  [lSwITRpBSdodhc1c] Phoenix Fighting Fan
+  [6I4YJAQUbTAqbpsI] Pick
+  [4lO2uNA70HqTuSAD] Piercing Wind
+  [O6he0J7l1uQgsama] Piereta
+  [LBSRvTsvrFofbB2c] Piranha Kiss
+  [MSzFbb4Jswvrqjru] Pirate Staff
+  [3VgBCJFhEvvbF4gI] Pistol Wand
+  [3SjF539wVL6NK9qq] Pistol of Wonder
+  [A6Bavci9ngWPln4l] Piston Gauntlets
+  [PnFfW5u24xZV6mOH] Poi
+  [SeZfwtBYwmxKrphR] Poisoner's Staff
+  [xr99pbmKLO2eDMk5] Poisoner's Staff (Greater)
+  [YMwlSFUoIEPIyctl] Poisoner's Staff (Major)
+  [hK5xPjOFd2hb81mi] Poisonous Dagger
+  [n4p8VFMKYACf200W] Polarizing Mace
+  [vRCH0cQJMllWvpfU] Polytool
+  [FHZHhetgkhVvGiwv] Preordained Spear
+  [DheIz1WCPXwUhxQD] Pressure Bomb (Greater)
+  [HYxnpGzoDL70FrVs] Pressure Bomb (Lesser)
+  [Otd9pV58s2LFK1gW] Pressure Bomb (Major)
+  [da6nSPRUwGicvx3c] Pressure Bomb (Moderate)
+  [XQ57G0xuxu3nSzcD] Probing Cane
+  [D9vU4fADTYSaZpM9] Protector's Final Gift
+  [rntI1KvlK0pplLFj] Purgatory Emissary's Staff
+  [fLqRH3XpvDZEMxOO] Radiant Lance
+  [phfqMz2811LT8hfD] Radiant Victory
+  [UfurZQK6H6SgOjqe] Ranseur
+  [tH5GirEy7YB3ZgCk] Rapier
+  [LDHGjtQHRM8bA8ZZ] Rapier Pistol
+  [rvxphQJrycwqejMW] Rat-Catcher Trident
+  [Il75ytwHrdwAAOwe] Reaper's Crescent
+  [DePdZBHfTorg74Ah] Reaper's Grasp
+  [6HOQwVUQNplJsrhq] Reaper's Lancet
+  [HofVPZ0eimPVK9jb] Reaper's Sigh
+  [YgsDUh6shTham38Q] Reaper's Toll
+  [GKBCShgNVVhDiNCb] Redeemer's Pistol
+  [CS3mKu9koUfRiHJo] Redpitch Bomb (Greater)
+  [HtcjYkGS8vuC0e7T] Redpitch Bomb (Lesser)
+  [riHdB9PBAXZUMsWC] Redpitch Bomb (Major)
+  [qWRigVOjyLvSW6UA] Redpitch Bomb (Moderate)
+  [tHIb3ynOHj7dGiCH] Reinforced Stock
+  [pKiuN3wnAxlJCBuK] Reinforced Wheels
+  [8ncDuZSIZAHl7PW8] Repeating Crossbow
+  [zcrIuILnp6oh4dr9] Repeating Hand Crossbow
+  [bP608Wb1l9ZY1zwb] Repeating Heavy Crossbow
+  [CHYfP0gm2AiBfk7b] Retribution
+  [q6ZvspNDkzJSP6dg] Retribution Axe
+  [lGALlZL2Gs2duyp5] Returning Starknife
+  [hmtzclfmm1FTExNp] Revenant Blade
+  [k8V3wTG1gMU5ksUr] Rhoka Sword
+  [VJbZuJFTooFckp26] Ridill
+  [sFeUlzkJ8GgcFRES] Righteous Fury
+  [py3PPoO2zMUjOzOI] Rime Foil
+  [tpKD2TZEzAToow1O] Ringmaster's Staff
+  [wWBi79jkzYGWD6uC] Ringmaster's Staff (Greater)
+  [U266pQUnWwKYImhD] Rod of Razors
+  [djSCel13i1p8JeXv] Rope Dart
+  [T5ojw0tuXiAajhZx] Rotary Bow
+  [nz8Cx3SiRWANdlJE] Rowan Rifle
+  [rnoP6uPxauJiSGPK] Rustbringer
+  [Fye3IZN9FVDYm4KJ] Rustbringer (Greater)
+  [u2u6dkr01AB34tyA] Sai
+  [jbSgs5Tq0bkmHUab] Sansetsukon
+  [TLQErnOpM9Luy7rL] Sap
+  [wkzxLpSe7LN6c5Ld] Sawtooth Saber
+  [QT1H3f9u44IZ3TmT] Scalding Gauntlets
+  [lenQyWTYsMrcC3Vg] Scalding Gauntlets (Greater)
+  [f0R9al9iggvAQ59p] Scalding Gauntlets (Major)
+  [trs1C4DEkETh9bio] Scalding Gauntlets (True)
+  [VOYQpn4yISYo5Ttq] Scarlet Queen
+  [grmaV4GdoGD7sKbn] Scimitar
+  [yIY0voZkwMoff5b3] Scizore
+  [1eiaTQo9SKiybP8G] Scizore of the Crab
+  [UXjKXqsfWYiayeMD] Scorpion Whip
+  [I5DJUbAFGMwa6qCz] Scourge
+  [PsBTAUV7ExEsKpVx] Screaming Pinion
+  [PVdl7StKFu6QPTVl] Screech Shooter
+  [1lZNaqqGOrza9BsG] Screech Shooter (Greater)
+  [v9smWWOsWFwhCZoB] Screech Shooter (Major)
+  [WS78LUHzlpeONMRo] Scrollstaff
+  [H74vYwHJ8XT4qOPI] Scythe
+  [G3a60Ug3YNCMyMVR] Searing Blade
+  [pvxRcuBexbFawjCg] Searing Blade (Greater)
+  [4Di2VTnJaU4JFQGa] Sensei's Parasol
+  [emGyagWNmjvtjiGK] Serithtial
+  [ZvIEJCY60fHqzl6r] Serpent Dagger
+  [Pzqgbtp3iVpW0pLY] Shadefield Knife
+  [VwNmUeRHomup8VoI] Shadow's Heart
+  [ehvsr3D5tgdyUF4E] Shadowpiercer
+  [bL0FbIMucp28oocF] Shard of Self-Destruction
+  [73JDNoUQPmUqjz97] Shattered Plan
+  [sBtfUPTLuyRPYI7g] Shatterstone
+  [CJesyj3lklJVujh0] Shatterstone (Greater)
+  [jkYn89XREERA3V2e] Shauth Blade
+  [WiPcevdeD4YoTLRa] Shauth Lash
+  [IF6qUrR3i030v0dH] Shears
+  [dfum7DpOEkwxwTsT] Shield Boss
+  [fz8XDaJ7n0zeOH1f] Shield Bow
+  [HaquLIE0SFc85vWY] Shield Pistol
+  [nSO0Z662LkkLfa2u] Shield Spikes
+  [hIgqLgH3YcLZBeoT] Shortbow
+  [7tKkkF8eZ4iCLJtp] Shortsword
+  [0yiz254UI7DUFXWN] Shuan Ji
+  [MBd6Fr0jk4XpUc4l] Shuln Fang Katar
+  [fjkwYZ0hRmBztwBG] Shuriken
+  [ynnBwzkzsR6B73iO] Sickle
+  [ye7cYmornhgnnOlu] Sickle-saber
+  [YBXcse5TSHyv9rvX] Silver Orb (Greater)
+  [CcQDscF79qs9HfJg] Silver Orb (Lesser)
+  [kG26J0AfQAVe9FYs] Silver Orb (Powder)
+  [ECqOpC2J3dc6kNjM] Silverscrap Bomb (Greater)
+  [QvfHp3lgIQqqiCQF] Silverscrap Bomb (Lesser)
+  [WCA8vovbzZuoHzu9] Silverscrap Bomb (Moderate)
+  [oE3fHS3CUs15bZ4r] Silversoul Bomb
+  [mfc9IT94CPnKKBG8] Silversoul Bomb (Greater)
+  [R7I0KwKM3PNZn0zJ] Silversoul Bomb (Major)
+  [ctmmhe5ZOYx57gTt] Sinew-Song
+  [tVcI2ypPhfhchwMp] Singing Shortbow
+  [ul4LuDff24Kz9n7e] Singing Shortbow (Greater)
+  [OKAR7GIyJac8dmsi] Singing Sword
+  [CtUPO3qFZ2Y6lozq] Skeletal Claw
+  [7WwKI53IcXVIHbkh] Skunk Bomb (Greater)
+  [3Sij5RwC6Z1ZVuFp] Skunk Bomb (Lesser)
+  [Dv1bozSbR39McpWd] Skunk Bomb (Major)
+  [m091zbWD9EoH6kWC] Skunk Bomb (Moderate)
+  [ANvbi1zKF1So8bON] Sky Hammer
+  [jBn5TdnxOvzf6a1F] Sky-Piercing Bow
+  [SatFUtE2UaPvC394] Skyrider Sword
+  [y49tnkAWZqJRMkba] Skyrider Sword (Greater)
+  [mQyhSg9M3VdGEUrN] Skysunder
+  [gO5dOlPBk57bg2x5] Slide Pistol
+  [USzeQdvsXz6P5L2k] Slime Whip
+  [UCH4myuFnokGv0vF] Sling
+  [onFxlajKyWpHZcXt] Smoking Sword
+  [G2BURoV8luj39suH] Snowcaster's Staff
+  [rmGfBLRTfOqhwhHW] Socialite Staff
+  [mf5eeIdKjfSZ0K3p] Solar Shellflower
+  [qgpufYE8gHRWUPiQ] Songbird's Brush
+  [B0R1MtLnQvBwnOne] Sonic Tuning Mace
+  [ak3DfubhIWT3UiCf] Sonic Tuning Mace (Greater)
+  [yYVbgyLGfhRJaNEY] Sorshen's Sinuous Guisarme
+  [uVcePmysXUFhOebP] Soul Chain
+  [wtyyxv0ffoMAGV8I] Soulcutter
+  [xczDHCiBANMuC87u] Soulcutter (Heroic)
+  [8S81RvynBS09rIOF] South Wind's Scorch Song
+  [f1UCVpGYLHa089SE] Spark Dancer
+  [5BU4hJ1oXMLtSkuA] Sparkblade
+  [tOhoGvmCMw4JpWcS] Spear
+  [kg6tEjEBFGeilmLO] Spear of the Destroyer's Flame
+  [ts5z3xR9j48Cic5H] Spectral Dagger
+  [LKIs3LJqrKNP2yrx] Spellcutter
+  [X95j0ZdqjXJkGmfZ] Spellender
+  [v6LpzpIA0BmKvEtK] Spellguard Blade
+  [lBITo8JcWfGxKmYT] Spellsap Grenade
+  [ry4In8lT0xB8Dc17] Spellsap Grenade (Greater)
+  [Cb0h1Y2OSrbYXJQ2] Spellstriker Staff
+  [Y2L8NM50BvRfUaat] Spellstriker Staff (Greater)
+  [AFkybwwQzAArjrF4] Spellstriker Staff (Major)
+  [70H54rIRjO9fJkdt] Spider Gun
+  [ET88qMrIBXBCWI5J] Spider Gun (Greater)
+  [LGbyZ4z6SLRC1cuB] Spider Gun (Major)
+  [r0eGBESoYYiFbhEm] Spider Satchel (Greater)
+  [NDIHtSxYUoQwtP2z] Spider Satchel (Lesser)
+  [pEuFCloUo1SdfORL] Spider Satchel (Major)
+  [hOuFviZYTOjN1hxM] Spider Satchel (Moderate)
+  [3qn56dTO5TYJHjbF] Spike Launcher
+  [zi9ovfoRp2fMhfpO] Spiked Chain
+  [YFfG2fMyaIAXkmtr] Spiked Gauntlet
+  [2WOpgJyaFE2gNW7H] Spiral Athame
+  [TQ3kT9pUFQNkH2dG] Spiral Rapier
+  [SNF8g7u8JYzqvsU1] Spirit Fan
+  [0z3x5UzMlZLcDOUv] Spirit Thresher
+  [2UX3tlC5vKeQjG7t] Spiritsight Crossbow
+  [CH2t4lYE6IbE3F3Q] Splintering Spear
+  [K07yZnXG1DQwFjX7] Splintering Spear (Greater)
+  [iQM5xKCkfpfdPrzL] Splintering Spear (Major)
+  [oHVCB96LOYobSQ0I] Splithead Bow
+  [MMYL2rfbYNWT0Rs1] Spoon Gun
+  [tE2IarA29mYsgrxj] Spore Sap
+  [bTwZNckINJgiT8Ef] Spore Shephard's Staff
+  [UEIwFJMx3wYt0Blp] Spore Shephard's Staff (Greater)
+  [7XEVXfgeabmO7fMd] Spore Shephard's Staff (Major)
+  [XguFCTUBh1yqJXd1] Spraysling
+  [eoSl6Rbop1EX5DwP] Spy Staff
+  [4nEdlX9GOlXGyfpl] Spy Staff (Greater)
+  [tzzvevwmwwKQaHK0] Spy Staff (Major)
+  [FVjTuBCIefAgloUU] Staff
+  [8TEundYBdonchDj1] Staff of Air
+  [9GUSQFJZarLs5tQC] Staff of Air (Greater)
+  [2wUR0XVYONWrBVa8] Staff of Air (Major)
+  [0mCj6HZcwFzVxVyM] Staff of Arcane Might
+  [L7FuscHIuzQ7FjnB] Staff of Arcane Might (Greater)
+  [w2AxS7q8bjh77pp2] Staff of Arcane Might (Major)
+  [wUFQ8cqkwn2xTCma] Staff of Control
+  [d5dnhOf5RHFFnsiB] Staff of Control (Greater)
+  [ndF4yxyM5ci1DcrO] Staff of Control (Major)
+  [pX3rpVDBLqClcL9M] Staff of Earth
+  [jaM12dWpIozRiIhk] Staff of Earth (Greater)
+  [a8YCTjKnXySKpU5C] Staff of Earth (Major)
+  [0Vw44XmzVS4knsa8] Staff of Elemental Power
+  [nvSZioRW4J1sMtO7] Staff of Elemental Power (Greater)
+  [9UfuJHNdyBBNfCsO] Staff of Elemental Power (Major)
+  [HMjn8Ln1Wp1Ld2S3] Staff of Final Rest
+  [xec2kwqFjxHjFwLa] Staff of Final Rest (Greater)
+  [SSZojuAMC9Npvfm3] Staff of Final Rest (Major)
+  [opfpl1JmKgrfds9P] Staff of Fire
+  [KcjaeMgrsBGgwUWL] Staff of Fire (Greater)
+  [qx4Cq99vng6GhzEh] Staff of Fire (Major)
+  [3OkOKxCee9WruGU5] Staff of Healing
+  [XSwEE8wjHr6UXzpw] Staff of Healing (Greater)
+  [FTVap8IjoKgCexH7] Staff of Healing (Major)
+  [WbcQqXrUytXkCMK3] Staff of Healing (True)
+  [8No84rsBOCVCkXJK] Staff of Illumination
+  [WA5eoFFuAsyx7A2t] Staff of Impossible Visions
+  [KxSyomQx7rpwqemP] Staff of Impossible Visions (Greater)
+  [oT4pyqLKpJVXDb46] Staff of Impossible Visions (Major)
+  [1glQQ63AeQOfQNvc] Staff of Impossible Visions (True)
+  [iNC3uS24FSc40AQ4] Staff of Metal
+  [qvl1OmV5F60ZOdcC] Staff of Metal (Greater)
+  [8FKxOiKAoQqPiqPA] Staff of Metal (Major)
+  [jwa10xel66Wc7U3p] Staff of Nature's Cunning
+  [xt4sb8vz8VRlJoKm] Staff of Nature's Cunning (Greater)
+  [1yZRZeVAVxrb5HM2] Staff of Nature's Cunning (Major)
+  [aPbDAb6cJKPvCHk2] Staff of Nature's Vengeance
+  [gca5Pgt9Pg8G23VA] Staff of Nature's Vengeance (Greater)
+  [hnx3dOQrYLBtsu3V] Staff of Nature's Vengeance (Major)
+  [HVgolLqbXUeRHXVN] Staff of Phantasms
+  [Svq02kCaFadVPOSq] Staff of Phantasms (Greater)
+  [7RBY90RmMtZjvnGW] Staff of Phantasms (Major)
+  [6m9niDjhA6tBfp5x] Staff of Power
+  [4O00N0HoPz5ywNyz] Staff of Protection
+  [XE8AxkahYPVzeLCW] Staff of Protection (Greater)
+  [TLLZIFIPbhW8kjyL] Staff of Protection (Major)
+  [XeTmuhuNnhGf7c4t] Staff of Providence
+  [T1L6XbgMqJLDv2Pi] Staff of Providence (Greater)
+  [U8vVCE2ePjyca666] Staff of Providence (Major)
+  [pIagOwW8EFBaKW3k] Staff of Providence (True)
+  [dh4FEXlA0FxTfnpY] Staff of Sieges
+  [v0IrX97Pf96jPvxP] Staff of Summoning
+  [GeAz02cQMU4X9nYp] Staff of Summoning (Greater)
+  [027hHaJojFz1qJBG] Staff of Summoning (Major)
+  [insH5VazP8WTkQgu] Staff of Sun Wukong
+  [frCSW1zLFYiYpjdR] Staff of Water
+  [DwNELc8YIKTb2uj1] Staff of Water (Greater)
+  [QMqPGk7oL4kESGc3] Staff of Water (Major)
+  [ED3By5mICaJeiQYo] Staff of the Black Desert
+  [Ri09KBg9DG0aapLw] Staff of the Black Desert (Greater)
+  [1uWytZ76MwVQYIO9] Staff of the Dead
+  [Ab5EjJyoRSec5YrW] Staff of the Dead (Greater)
+  [E30OrRp0StKLQwbQ] Staff of the Dead (Major)
+  [0yp4hAgJKt9Al2lz] Staff of the Desert Winds
+  [uqbvXACABUJG0ifJ] Staff of the Desert Winds (Greater)
+  [FkT0UkXdNEmKRhRx] Staff of the Desert Winds (Major)
+  [IEmYcavVfSy58aYx] Staff of the Desert Winds (True)
+  [214J8KhXn2H19DeC] Staff of the Dreamlands
+  [eHs1vJMXGLIPues8] Staff of the Dreamlands (Greater)
+  [NWMHPsVBIaNZ5X2W] Staff of the Dreamlands (Major)
+  [nI9shR1EG3P09I8r] Staff of the Magi
+  [8RQDeP3MtVLELlAn] Staff of the Ruling Beast
+  [0S8lZFSEP7ZlLFqA] Staff of the Tempest
+  [8Ia2jOo23XoArpJm] Staff of the Tempest (Greater)
+  [RDoxgjEFsherGA5x] Staff of the Tempest (Major)
+  [uhsVSBF4f3D5oym0] Staff of the Unblinking Eye
+  [jUL4ZdztH8VODBuv] Staff of the Unblinking Eye (Greater)
+  [APjEozp9ibSFV7zM] Staff of the Unblinking Eye (Major)
+  [W1XG0qStVh8fmeJ6] Star Grenade (Greater)
+  [RsCLCgCgGAn67ry5] Star Grenade (Lesser)
+  [PkqzU1Ap3O3IicUv] Star Grenade (Major)
+  [KFTkiLXWENatK9XY] Star Grenade (Moderate)
+  [mkFrHOwWJaHF0aGp] Stargazer
+  [Mv2I6M70bagbaBPn] Starknife
+  [jCthkWVsGBfTxSAT] Steelscour (Greater)
+  [1l23ulONSlgc9kFx] Steelscour (Lesser)
+  [eYT7T5I0LwnM9doD] Steelscour (Major)
+  [biHvCGfajSjUDGBS] Steelscour (Moderate)
+  [cVUhP1qWxe9USvVp] Sticky Algae Bomb (Greater)
+  [S1TrEDE8JNkchMca] Sticky Algae Bomb (Lesser)
+  [AAoAQCBwAITvHJSu] Sticky Algae Bomb (Major)
+  [h6O5uto0Ry1WDjXn] Sticky Algae Bomb (Moderate)
+  [Hh3F4DEP6aVulwQN] Stiletto Pen
+  [ud3pqCquYA5UecaS] Stoneraiser Javelin
+  [Za5Mnae009cDCwuN] Storm Flash
+  [i9mxfSIBTTOwsSlx] Storm Flash (Greater)
+  [EuTZxxwdVeN6Xg3A] Storm Hammer
+  [WdxabLnY4c5epMql] Storm Herald
+  [udm5X6TXm5vdIo4h] Sukgung
+  [2GngLv6m3uHObFGZ] Sulfur Bomb (Greater)
+  [ndVATyJ2c8Ka3HKm] Sulfur Bomb (Lesser)
+  [yPndyLkx3Nj2GMiz] Sulfur Bomb (Major)
+  [2pfEtA97lpG93kG2] Sulfur Bomb (Moderate)
+  [zWp7Kcn7mhKyGFxW] Sun Sling
+  [sfKzk4bzplyT4zax] Sunken Pistol
+  [yyZ3iD8IXMIrrWL1] Switchscythe
+  [VitLIpdIAmKlGb7i] Sword Cane
+  [5IUyrJItXkMASgmq] Tallow Bomb (Greater)
+  [OOqno1OwqJQBEtXe] Tallow Bomb (Lesser)
+  [l29fzEJ6SSIP2wJn] Tallow Bomb (Major)
+  [4pVGwkVi6izoUuLC] Tallow Bomb (Moderate)
+  [6Wj3janUyfxe17d0] Talonstrike Blade
+  [zxzJzXkM2CtODNQv] Talonstrike Blade (Greater)
+  [GuWKXErLL5R43sIy] Talwar
+  [kedgBVNDRAdmseRe] Tamchal Chakram
+  [wbJPWXKzQBKYZ74s] Taw Launcher
+  [vsJ0zvYZzduP7rtD] Tekko-Kagi
+  [596xrLHt1Sx0p7Pm] Temperbrand
+  [NIsxR5zXtVa3PuyU] Temple Sword
+  [3W0PWkDuAZFEGQtx] Tenderizer Grenade (Greater)
+  [KMfbKiCHmzenEEhQ] Tenderizer Grenade (Lesser)
+  [bo0HMGgyrp6v5Dn0] Tenderizer Grenade (Major)
+  [V9ZhiUJhemaUDYzq] Tenderizer Grenade (Moderate)
+  [6qJkA6fnHHiF4CEV] Tengu Gale Blade
+  [1IicJ7ESDNhGUqDE] Tentacle Cannon
+  [U8P9aRhjFpptHJCd] Tentacle Cannon (Greater)
+  [rKCiDIoozZTkyE4j] Tentacle Cannon (Major)
+  [FjeKuljhpaIiDTI7] Tetsubo
+  [BXaVkD10z45VCXvl] Thorn Brush
+  [2P9jItR1sV20OqmD] Thorn Whip
+  [Brs4linGy3GAod5y] Three-Section Naginata
+  [6mgB6Wv8X65pFMRL] Three-peaked Tree
+  [PIzBQehx975vMsvZ] Throwing Knife
+  [uM0OlCC1Sh6OLdNn] Throwing Knife (Extinction Curse)
+  [pnA6uENYDDduWmAn] Thunder Sling
+  [enBDzoapUkvk4WVu] Thundercrasher
+  [EcrZYy4PgbpiKyhE] Thundering Fury Dadao
+  [3NQj5gtHIYFYlAch] Thundermace
+  [oKq9ClcnLQZi1EPF] Tidal Crossbow
+  [YCGMVbqlWT8f1F6v] Tidal Fishhook
+  [uGu3NWhpPowH0zkR] Tiger Fork
+  [EtIXWXnfYdV5AGzy] Tiger's Claw
+  [8MD6Fwjjgb9cMXQb] Timeflaying Blade
+  [bCPxjuqVusM7Qlpk] Tonfa
+  [Kmrkm1sHKkGXiJlr] Torag's Silver Anvil
+  [WuzK2R5ra5SZdbij] Tri-bladed Katar
+  [zO6Fvq7ghEXpJgJR] Tricky Pick
+  [FJrsDoaIXksVjld9] Trident
+  [RytXxlJJ7dib8seN] Triggerbrand
+  [r9vNDYH7CswAjoo0] Trollhound Pick
+  [PNs3SqMhJ3rTxpSI] Trueshape Bomb
+  [wtRDteH3D3ME4FU9] Trueshape Bomb (Greater)
+  [yq5BoByEscKRZsto] Twigjack Sack (Greater)
+  [tm5l8uXtQQGMTvgY] Twigjack Sack (Lesser)
+  [8h5UFFk5EodKZh19] Twigjack Sack (Major)
+  [Ix5w4UNElK0ncBm2] Twigjack Sack (Moderate)
+  [pjUACbrAXNIy9O7S] Twining Staff
+  [2iKqXkRAq8qwlFlT] Twisting Gale
+  [99ffrZOWek8ePE4n] Ugly Cute's Gift
+  [AXz1edC2ZhqNLaeZ] Ulfen Shieldbreaker
+  [qQJguPUWpYY8z6BD] Umbrella Injector
+  [6aubQ21gRc5EMnbT] Undead Scourge
+  [EGhUorZhB7nV73Ev] Unholy Water
+  [Sarxo8kSrJs2qJEw] Urumi
+  [GFwfZrBGjCZTDcuw] Vampire-Fang Morningstar
+  [297RUMeetOWyciDe] Vampiric Scythe
+  [8pFegnc8KTHsvQZ0] Vashu's Ninth Life
+  [xeCh83loMuW7Aeqj] Venom Lash
+  [sQFQlglhORQsxBKS] Verdant Staff
+  [ylRk8NvpK2kA8bjw] Verdant Staff (Greater)
+  [ljT5pe8D7rudJqus] Versatile Vial
+  [0MPBjp2lOYVCsgeg] Vexing Vapor (Greater)
+  [Bb3cvysXG8rCM5FM] Vexing Vapor (Lesser)
+  [RXpM5Kbuf3BYfK6f] Vexing Vapor (Major)
+  [Z9TThSU2KtCX9gfD] Vexing Vapor (Moderate)
+  [JLoMkMq727XeMmlR] Vine Whip
+  [ZiaAFSG9zQY0CXdL] Vine of Roses
+  [nSAA77N0cnSkljmE] Viper Rapier
+  [sY3UJ34xJ4MA0FMK] Visap
+  [YOpopjoWgU7bkmwh] Wakizashi
+  [mVxA9E2ernBL6fM6] War Flail
+  [vpdZp46v9PoUt8z2] War Gavel
+  [DhaxHGxXL4Om7bqp] War Javelin
+  [zXbZn5HJf81tquPm] War Lance
+  [nOFcCidD5AwVZWTv] War Razor
+  [rXt4629QSg7KDTgJ] Warhammer
+  [itn6l0yJGRw7EFwu] Water Bomb (Greater)
+  [BG04L9GjWerSgWX3] Water Bomb (Lesser)
+  [EjJUCXG4Yr3T6DTM] Water Bomb (Major)
+  [hZ0s1gz0Cr0LGOLG] Water Bomb (Moderate)
+  [GntaZfIfKj5MRyA5] Wheel Blades
+  [okEnjp0JgUzbVauY] Wheel Spikes
+  [f1gwoTkf3Nn0v3PN] Whip
+  [QAEVaSQ3SCT8AuBX] Whip Claw
+  [DXidUrzzkwWIMNMD] Whip of Compliance
+  [XiL6CSyO43vjXxEf] Whip-Tongue Sling
+  [vnT33Z3V101FOUuV] Whipstaff
+  [rft8qacTooqfsUIo] Whisperer of Souls
+  [WrNHmsU8ZaBY3V9S] Whispering Staff
+  [hvMIJKY1mKXDmg1V] Windlass Bola
+  [3tspCIcL3mjcCBD2] Wintershot
+  [xEVWp9oaeF0yPseK] Wintershot (Heroic)
+  [puQ90OZgQpVhxLRe] Wish Blade
+  [1Uvz5xJpE5UvOFjJ] Wish Knife
+  [wHfhyAqJgKP9v3Dv] Wordreaper
+  [7L10GdJdL1hYcJZm] Worldringer
+  [NvukdOaemuC6kMLL] Worldringer (Greater)
+  [fZxI5GkBFfAUUf1z] Wrecker
+  [tsvqlHxWfLwLQorQ] Wrist Launcher
+  [gWSmUEKln103LVvB] Wyrm Drinker
+  [5MuAq1wFhy5NE0U0] Zealot Staff
+  [EZho49nI8ZMXD3oD] Zhuazhi Bang
+  [JtCO2nielwAg1x9m] Zombie Staff
+  [5B8sBxQ7IeKVI6TO] Zombie Staff (Greater)
+  [kJzp8I0rAmcucHuw] Zombie Staff (Major)
+  [LdOXiIVgRWpnOtcd] Zulfikar

--- a/build/exports/sf2e-anachronism.txt
+++ b/build/exports/sf2e-anachronism.txt
@@ -1,0 +1,2196 @@
+Ability
+  [LzYrjPl7doQ3iFS6] (Digital Ghost) Malware Infection
+  [y8pub4i3nwD4W2DO] (Digital Ghost) Virtual Arms
+  [MiwWwUdUbDDegnmp] (Environmental Adaptation) Temperature Adaptation
+  [haNcj3zWgoEO0yJw] (Environmental Adaptation) Terrain Adaptation
+  [lxBCyMonaQbG6w9k] (Hardlight) Tethered
+  [95jrq981CcDFIvtF] (Infiltrator Robot) Integrated Infiltration Gear
+  [zphTNvioP3r5s6bj] (Infiltrator Robot) Reactive Camouflage
+  [7fLyMprZpSJGJqZI] (Magical) Magical Resilience
+  [ZiIpvgdaCHotJoQk] (Nanite) Compression
+  [xkK4raHhkfCL9QsD] (Nanite) Nanite Surge
+  [iWxqdLRqPmCYcZLC] (Necrovite) Clear Mind
+  [YxUr6jj3CcUPhXjg] (Necrovite) Decompose
+  [oIynmyvjwwKhFfhX] (Necrovite) Entropic Touch
+  [PMCc1mZ5CcbAmX09] (Necrovite) Fatiguing Presence
+  [7kK3TyvjapWoT9Gh] (Necrovite) Keeper of the Old Ways
+  [9sNHGcLezhc40dl3] (Necrovite) Rejuvenation
+  [W3TL4VMrsQecTNFw] (Necrovite) Scramble Psyche
+  [3MOowYVsgnr9LXeN] (Necrovite) Smother the Light
+  [dIXB1WuUt3eMMBgR] (Necrovite) Undying Vigor
+  [6NHVOXLu63GE6xMy] (Nymph Queen) Astronomical Ties
+  [QiAapIRnqLS3V0Og] (Nymph Queen) Broadcast Allure
+  [qWWSkPDn3Vn32a7V] (Nymph Queen) Celestial Step
+  [ml0jNHgKdoyLK9Or] (Nymph Queen) Fan Mail
+  [M8geNMUAaFjyXj0m] (Rendworm Host) Rendworm Eruption
+  [6xz4bIGGVKRkkcSS] (Rendworm Host) Self-Destructive Frenzy
+  [5aeXp6TnJK5nduhk] (Robotic War Machine) Attack Pattern Alpha
+  [xtu4lOuOOhl0jxVk] (Robotic War Machine) Attack Pattern Beta
+  [KqD4g1SpxQgrJREE] (Robotic War Machine) Attack Pattern Delta
+  [KeU0lo8tUJMrWGPI] (Robotic War Machine) Attack Pattern Gamma
+  [Ni7Febqv9Dm1EgK9] (Robotic War Machine) BVR Engagement
+  [oiINnJTBt7FTZiHf] (Robotic War Machine) Ballistic Defense Matrix
+  [1pQkINbQ9AFEAhT3] (Robotic War Machine) Notch Position
+  [eBk94uigTDYQTQZ8] (Security Robot) Exigency
+  [76cqWtU2IoPellWa] (Security Robot) Fire Suppressor
+  [pkUBiAnmjno87Aqp] (Security Robot) Nanite Surge
+  [igummwLlUerkERdy] (Warped) Not Really There
+  [UGljOefqASKG1VfU] (Warped) Unsettling
+  [Yn4jLPVWVE1vtAaF] Access Infosphere
+  [iIESt0oV0vobl41N] Adaptive Locomotion
+  [sLikawnrJJzHMYeC] Aim
+  [PKu1HhCbmhuwm82o] Analyze Environment
+  [oc0ZKnk5zD0GXqZi] Area Fire
+  [3xDhpvORBmK6AtcI] Attune
+  [6ctkxUnVwqooSvgg] Auto-Fire
+  [00RryKnz4fXq455m] Beginner's Luck
+  [8mIyIlniGH2SMO6B] Coordinated Ambush!
+  [VQH9rEQuNb06NQ4b] Cosmic Blast
+  [rlhZC1VPq3XixagS] Dance Partner!
+  [SdPRiTobzR8adtXq] Deny Failure
+  [4oIErnhDm0qCCpxs] Digital Assessment!
+  [fQJ8xyZH3Dch5xtN] Eccentric Orbit
+  [0vqXr3SYakIa19k3] Focus Senses
+  [7dq6bpYvLArJ5odx] Forge Credentials
+  [cmCtfURzpbzkxWsy] Get 'Em!
+  [JXQaCPCd10sE0Gaa] Ghost Tap
+  [RF8xNJ8QsMwogerB] Hack
+  [8zWFGKRXg1SxIwFH] Holo-Roger
+  [eqmLD72i3cG8ybAn] Hover
+  [Iy3IsWEfMLGiVAPv] Implant Augmentation
+  [WFFYDg0sgjaXCeq6] Improvised Mastery
+  [d4vJxq49lUb7fGXq] Install Upgrade
+  [1lkfbLoteDlzoqxb] Into Position!
+  [E7HvICcH9CRAVzGc] Isolated Spell Matrix
+  [oRdDgSC3RVpNgisd] Keep on Keeping On!
+  [P95mzZ3VV40cXbx5] Light Speed
+  [K2wMNyK4JGwgrjVL] Line Up the Shot
+  [n2QwzNZLrpVnM58K] Livestream
+  [lNcZ7j1T2YmMwXF7] Living Shield
+  [NEYVJWYtgl0rRSwg] Manifest Energy Wings
+  [mbRH3JIu44z8nxXj] Nanite Form Strike
+  [hsUKPqTdAvWwsqH2] Navigate
+  [XSMTalRsPwQ0beIE] Network Spell
+  [ygvLiQmneqp1pjWb] New Plan
+  [q7UDeO9Ko1EbPRWm] Nimbus Surge
+  [rePdFswJLQfoeDSp] No Breath
+  [QQSO7DzeNKCWf9XW] Once More with Feeling
+  [wWtBcshahm11stMY] Operate Device
+  [TBLHu4RhvhPrKid6] Oppressive Presence
+  [m4IGOcYt8TBpYD8T] Overwhelming Strike
+  [ZVzoIaWpXs62QVcu] Piercing Spikes
+  [Z8GMkB50OfXBX67a] Plate Deflection
+  [LXqcXRayK58inaKo] Plot Course
+  [6fsMvO0jXtK8gYkH] Puff Up
+  [FF5KgZHj345s2moq] Push Off
+  [30Nw5q4vWKCQIBIZ] Quantum Pulse
+  [uvtdqSfKD6oXNA29] Re-Forge Solar Weapon
+  [eBxEPfTafaJaK4Kf] Reactive Step
+  [RNilk6Evoi0xNbWX] Ready Arms!
+  [nAJeT29ZJvqeg98h] Rebellious Defiance
+  [ydUK0TjHlK8VKgbs] Recharge
+  [mrcKklMzhRG4WcbH] Redirect Current
+  [9P2ZptR0PrYyiJFl] Redirect Energy
+  [qbyer2woEdGXZzoR] Sabotage
+  [HnuFb8wzkKD0dRPN] Search Infosphere
+  [wI0g2nRfu2d0YFAd] Shielding Arrogance
+  [lIZ9DhrkzM3AEQmX] Shimmering Dazzle
+  [MZ65QZDqa9ignWXm] Silver Tongue
+  [kF6CV5Jo4gfz4gVs] Soul Shield
+  [gZr207z8Q7AuH2RT] Steel Yourselves!
+  [7KMyRISNqp7JTzMn] Stunt
+  [oW81CfM9ebxXnrw3] Switch Hands
+  [VIv5Gt3yndrk0qgb] Targeted Immunization
+  [gNUrQ8jimAvAA0xg] Telekinetic Lift
+  [r1bUsyDwcwuN3MUG] Telekinetic Sprint
+  [UeMHbnnaXDa3sGfG] Transfer Vitality
+  [u9NU2bULHg3S5FaP] Umbral Stride
+  [j1FsKMy7CTtrp3Fu] Unbound Mind
+  [ZoMpqQgDdlT13Jp0] Warp Reality
+Ammunition
+  [eMNjuin4r6DivIsI] Battery (Advanced)
+  [0jSc8zqUPnAByMf9] Battery (Commercial)
+  [6Ac3Vkyp7V0xxRnr] Battery (Elite)
+  [fWrcguxFWeIVsuvl] Battery (Superior)
+  [5PS5ESGpnQfJNOdg] Battery (Tactical)
+  [oOFi3NRGW1w1O3PD] Chem Tank (Advanced)
+  [49Qja6ALTUaQuVIb] Chem Tank (Commercial)
+  [TGmKOBG0V73uensD] Chem Tank (Elite)
+  [LMBwav4NYaXPDvxF] Chem Tank (Superior)
+  [XPwiBjnQgSyb6uZ4] Chem Tank (Tactical)
+  [g00dmHOWZiRVk3yU] Iovan Ammunition
+  [ijUVS3a2PODx9u9H] Pow! Ammunition
+  [JSS89QXZggfF3OHJ] Projectile Ammo
+Ancestry
+  [3Wox3ai1kgji07FE] Astrazoan
+  [3iuWdarohpDFhlxX] Barathu
+  [KFNOUfQWPUBW5zSC] Contemplative
+  [jNE2Zq46a9kQj7bi] Dragonkin
+  [XKW1SziWusHoaCRd] Elebrian
+  [HFVQhUxBt6UTtuny] Ikeshti
+  [23MA5Ee7ExUfzrqk] Kalo
+  [H6dkr1GtoQhuQqJm] Kasatha
+  [AjSZKAwWEw0AfAJR] Khizar
+  [ZDExBZqdqYUtv5dg] Lashunta
+  [75TqHknsQuinDLjn] Pahtra
+  [i1fnTVBTRYSqFY2c] Sarcesian
+  [FjBJNHdiWAvu1lV7] Shirren
+  [CURlEp5fEl0WJq9L] Shobhad
+  [0qcXAQo7iZkZXNO9] Skittermander
+  [06FBb4UDg64S5AYI] Vesk
+  [mBsOLC7cRc7nkzV2] Vlaka
+  [P6PcVnCkh4XMdefw] Ysoki
+Armor
+  [ehsCl5WJTANTlzBy] Abadarcorp Travel Suit
+  [E9MKSSJCOk9ceLKc] Aegis Series
+  [aNoSZiPBfxVJYvap] Carbon Skin
+  [YkwoE8FiD0UJXDkl] Defiance Series
+  [IKHNA2PcSB3zIMlp] Defrex Hide
+  [FySX3VPYY1YkdBZg] Estex Suit
+  [dnv1OFVU6BpyfAWi] Flight Suit
+  [plBUD8dy3M3gGiHK] Freebooter Armor
+  [pcPU3BjbNclch4lS] Hardlight Series
+  [wnJTyjfupLw4Cy7G] Hidden Soldier Armor
+  [g51GJbedie9jebNg] Kyokor Plating
+  [CtWyIgI76ku9Fn8x] Microcord Armor
+  [JmxOtIEBwUuYWmmA] Petrified Bark
+  [BANdFbfuD16lPHs4] Second Skin
+  [eU5n2fP7DvnFyqov] Shotalashu Armor
+  [ElDjApS0gmItATq4] Skyfire Armor
+  [cDRxtKbxzHQ7t5sb] Tempweave
+  [xQYaULcqM8yE194M] Thinplate
+  [JOz3bGC8AGOPuAZl] Vesk Scales
+  [7eVxrzhOlRCw4cvL] Veskarium Imperial Plate
+Background
+  [nlNvfX6dt0Hk5uwo] Absalom Local
+  [C31476Mc8HXz5m9L] Acolyte (Grave World)
+  [W5lpy7i9eqpz5nG5] Acquistive
+  [TXUm6Y7akSgfQq1L] Akashic Recorder
+  [aIWJ3q8C3laoCMRK] Akitonian Explorer
+  [72Wu4YfmejYNaagv] Alien Hunter
+  [nS1azun1ePntzbYJ] Ancient Elebrian
+  [36cNp7LY8RmbFPRV] Anomaly Hunter
+  [VESZkgOa4uuKzyIl] Antediluvian Seeker
+  [xUrb3P4loB1PqyjY] Arena Veteran
+  [lHO7wont21ITsU0B] Athlete
+  [4QBZjtQ3lqUA89pH] Bartender
+  [4Yxr3P6cUCxTyOEE] Bouncer
+  [kFLyIvFFZAa6A4xK] Brutaris Player
+  [UKjMyBzulOShPUma] Busker
+  [mbHpGR4qWdTvZI3u] Chatty
+  [1psXSzBXfF9ixxN8] Chevalier
+  [zHI8JeJlv1wllU05] City Slicker
+  [z4ksxU9VIivyxUZP] Clansworn
+  [rxFc5d1lN2wHO6m2] Cleaner
+  [td4CIy0PhCaajtDA] Cloud Chemist
+  [nFOwTBLZmripsnj4] Code Carrier
+  [4MxBX1j7R00Rj8Lw] Comedian
+  [MAGiShfLHQ6q2Xml] Consultant
+  [ML8vXoxCP0hEi4dr] Corporate Agent
+  [W6VzGBcZQtCUuptV] Crystal Prospector
+  [MY8ZnGBRtfjRRH83] Crèche Born
+  [J8sC6fEmnP9ClAoK] Cyberborn
+  [7L6Z84rvU48W2mPI] Daegox Convict
+  [akU1lb4aIGYsvDdZ] Dataphile
+  [D3DnWgm8QXU9b47T] Defector
+  [GaMBVGpI5HLv2fsJ] Diplomat
+  [DHYbcVvo9jh2Ojzo] Disciple
+  [lye1QD6LAwmWvjwt] Doctor
+  [fJLv5UVXJKRWU22V] Dream Prophet
+  [TKxufQybzgBAtVrs] Dreamer Disciple
+  [1tWQuMj6l5FdTOvl] Electrician
+  [nyqLruVq5fyZAzwF] Eoxian Local
+  [YJ2k8RMNA8Il4WEB] Escaped Experiment
+  [WpFZhdswYEA1jqGG] Escort
+  [IuGFxWybmHAJ3oxF] Exo-Guardian
+  [oRys6HIxqrpVORT4] Fashionista
+  [XQHfPb1mkSzffUas] Final Survivor
+  [4xyPaBDI3fpcDCM7] First Ones Scholar
+  [Fee1WwTVrIuaIVMb] Fixer
+  [UIGKDskFIQV4L6mf] Forum Aspirant
+  [8M8ocSvx6hKMg19k] Gene Splicer
+  [iqfiyARvjjP4vPcp] Ghosted
+  [KeTuBS1LUAb0USEg] Grave Medic
+  [jDikmB6aZChiW2Va] Green Activist
+  [fQPesPjg4kIjw8dW] Grifter
+  [9QjJzNIma16vB9CX] Guidance's Favored
+  [Ing0ZwqLvVvNh6t4] Gun for Hire
+  [yuZhTCsX8zYgUjn6] Hacker
+  [FyPulY1eEMJ76mdg] Hacktivist
+  [dgrdnhtgFNn1IHgT] Hellforged Squire
+  [NZdZ09mi3GfwWSbx] Hitchhiker
+  [GzRAw46at8ab7Man] Hustler
+  [CAKJcnuvQIMBxxSy] Icon
+  [yc1DKdjYeHi6Xnoe] Joro Clone
+  [49R1MbdsFdtx1tCE] Lodge Administrator
+  [a3egX6gDtlW4vRYK] Lorespire Archivist
+  [pmlpHiqUOlZxX3qI] Lost Aucturnite
+  [Gclx24q3LXwB1IDb] Magic Officer
+  [ZUg6TYBwLnJmPw2e] Magic Scholar
+  [qeUf6JINKUrCMxgh] Magitech Specialist
+  [FVBvHl7UVkFyVwgi] Manifold Recruiter
+  [a0R3L7P9JnB4PssO] Masked
+  [xHRLGLF04QDmVbdr] Outlaw
+  [Wb1caT6wInSCW3AM] Party Crasher
+  [JIFO1ucSlspDIKZB] Phisher
+  [kahsYeyhX7eXdlQ8] Pickpocket
+  [ZbsQ7OVyHTRTg7rD] Planetary Preservationist
+  [CGQrWL2bV5PK2RUM] Quantum Clone
+  [LpHSR7OmHhzyZyO0] Rebel
+  [5SNQkE3fOqJeDJNL] Recluse
+  [Cclf3GeZGsxzxWDA] Recruit
+  [xqAkHXzSTBSXvUmK] Robot Adversary
+  [5IqlrsaBsXbhHlRT] Runetouched
+  [fjiv3a2DBc9ILdLa] Sacrifice
+  [P35HciGIiFyd7BMr] Salvager
+  [c4h6gddun6XdmqIZ] Saw the Afterlight
+  [YvhLzn1CU12Zzm4n] Scalawag
+  [gTCcODsEffkBV0LQ] Scaletouched
+  [hYjjqAE9Yx7LGQeR] Scam Mage
+  [OBp4du7UmN7bFSSb] Scientist
+  [xrnataVvswQRI0Uw] Shimmerstone Savior
+  [PQrVuUxSORum5C5s] Shipwrecked
+  [M5yXdlH3A8e8ooA8] Shrouded
+  [RWZju0fvHnNwwIvE] Skyrigger
+  [15kkyHDQ3rDU6Kkr] Smuggler
+  [FoaPf3HV54iLn874] Socialite
+  [tWyb6ii74p8TpjLJ] Society Scout
+  [l17KkutNfkldxALX] Space Pirate
+  [AhxV0vt0tsPQ9ULx] Space Trooper
+  [SmeEPOtPsZjorO3T] Space Trucker
+  [9s3c14nfvvkk8Jbe] Spacefarer
+  [CdIygfqF5KSSvKkj] Starfinder Trapsmith
+  [oishnwqNSfJX2gJz] Starship Dweller
+  [SPlIl9oFe2korucB] Stowaway
+  [JEARvianRcXQtTv5] Street Psychic
+  [aKQYhqB8FssW55Pi] Street Rat
+  [XIKZGJI3V0BZ9g7d] Street Vendor
+  [nMv0r7KVvNbEf652] Taxi Driver
+  [nUGvZ0Qz4907pzVd] Tech Delver
+  [qeBz5Gs7LU8szmAK] Tech Jaded
+  [rBQfRoJoXp5VuwyR] Tech Priest
+  [g1OCotaYBH2A0tAJ] Tech Support
+  [rKxGXU9gqy8ChGBv] Tech Troll
+  [lGIqMNaI4h7fjjiD] Technophile
+  [wE9FNBorVHtua3xD] Timelost
+  [vTxnVneNSrJ9ZCPn] Tourist
+  [PN8RcVDasZfYqINE] Trooper
+  [j7bueCNoGVrcvBLB] Unleashed
+  [iIMSVj69F0JYsQ2r] Vidgamer
+  [5ebdjaDVJSIskU9P] War-Hardened Hero
+  [QNLyqefno1BWBqfe] Wayfinder
+  [Qy0bDQgSAarGvPEx] Wheel Winner
+  [SwiBon194zlN4yz5] Xenobiologist
+  [Ghct2BCZB7F5JcL0] Xenoseeker
+Class
+  [wu88dOKl86DTo427] Envoy
+  [FYCUzPaaCU4G66Wz] Mystic
+  [cUWBC21I0XbzP44A] Operative
+  [zAI2ugYWzbUnmaez] Solarian
+  [sGupLSC7oqsN18sI] Soldier
+  [QhD0tldbCGmGYeoQ] Witchwarper
+Consumable
+  [dvvYuzx0QUORXMl1] Bone Serum
+  [6so0q5TRrPqs4KUb] Cairn Form Spell Amp (Commercial)
+  [R8d8zi0vsNf8vbSJ] Cairn Form Spell Amp (Tactical)
+  [JgVv4m4sh9faVSDD] Celebrity Serum
+  [4G2EmBJ1B0a6lzqx] Cellular Stimulant Spell Amp
+  [Yuws1too4LhO7Cu9] Commando Serum
+  [lxsq1n60AUXKrwsd] Congealer Incense (Advanced)
+  [5fpWv1rl1TwORrmP] Congealer Incense (Commercial)
+  [fdnaS0ivMWDwa6fE] Congealer Incense (Tactical)
+  [ZmPUZnE30kgYMZb4] Crystallized Shockshard (Advanced)
+  [q0qabDaBo7MPOBy3] Crystallized Shockshard (Commercial)
+  [NrP9WazrcBuJfjxR] Crystallized Shockshard (Elite)
+  [fAWMLqyaCsFm0Oxg] Crystallized Shockshard (Paragon)
+  [OLJP9rwS0TWHDz9v] Crystallized Shockshard (Superior)
+  [Jjwqidw5MhFBeYk8] Crystallized Shockshard (Tactical)
+  [nQEIjZYijX5fxPVA] Crystallized Shockshard (Ultimate)
+  [w1WaRSchtEsQbhim] Dizzying Anesthetic
+  [OTfHjwzsIOy64CLL] Dreamlink Serum
+  [JSPjvrjCVWvmrDol] Feline Senses Spell Amp
+  [GRbM0QdnPCAW4OHl] Fly Spell Amp
+  [vSVP3ewo2sAJ6lXo] Glow Up Spell Amp (Advanced)
+  [HTVWcutHX9THYB99] Glow Up Spell Amp (Commercial)
+  [zuDBJVIut3VcAvKD] Glow Up Spell Amp (Tactical)
+  [TEYH3HhM9vs5hmky] Haste Spell Amp
+  [sOnw25eL6RJuc5rE] Hypopen (Advanced)
+  [ckRc9E6AmJRalfV4] Hypopen (Commercial)
+  [gRZxPwfmz3O0bgOt] Hypopen (Elite)
+  [kJmAAmnck30kNx2X] Hypopen (Superior)
+  [LD6JfxuvszVgQWVd] Hypopen (Tactical)
+  [6JzH3VDHqv2rZJer] Hypopen (Ultimate)
+  [u82tssnDgj4f9UCS] Infiltrator Serum
+  [2lTv6zUJBAtgcxs2] Invisibility Spell Amp
+  [GXq5CGCuz4xd2Hps] Jump Spell Amp
+  [HxHlEHM9F9AH36sI] Machine Mind Serum (Advanced)
+  [SPGtFVOnoOSFNk89] Machine Mind Serum (Commercial)
+  [ksKJlrHEUFwZxVCj] Machine Mind Serum (Tactical)
+  [9Ty5YbJIv8wNXEVr] Marrow Paste (Advanced)
+  [YhiW4zUtd0WcYeSD] Marrow Paste (Commercial)
+  [oVIp7s2QLj99b7qJ] Marrow Paste (Superior)
+  [VhjdSGik7eZXUFQQ] Marrow Paste (Tactical)
+  [55nSLw1aQ0K0rK2L] Medpatch (Advanced)
+  [B0FiYMxy7iDiHh48] Medpatch (Commercial)
+  [KFjPEG7kw733splu] Medpatch (Elite)
+  [6VDHl7xkSp8Sc8yy] Medpatch (Superior)
+  [HWHdAQArhRauTpm6] Medpatch (Tactical)
+  [dJyYifMFfgbIwT3c] Medpatch (Ultimate)
+  [aEDrntQhg5xuE20A] Resist Energy Spell Amp (Advanced)
+  [UXEZCHFWwvNS43ug] Resist Energy Spell Amp (Commercial)
+  [7ujCSefy4ELtHfT3] Resist Energy Spell Amp (Tactical)
+  [xBlfbu0fUmV6ucqR] Sharpshooter Serum (Commercial)
+  [vcCeNRokXv5HSlRf] Sharpshooter Serum (Tactical)
+  [5IayDQk6oasOBPOM] Shimmerstone Serum
+  [iRaxjZFzrdCHETt2] Shrink Spell Amp
+  [ulNSlan9Q5j1ozPI] Spell Gem (10th-Rank Spell)
+  [R6LuVXimv1Hh8ehE] Spell Gem (1st-Rank Spell)
+  [p5DYjh3sCSjzrBBg] Spell Gem (2nd-Rank Spell)
+  [Nwl7YydQ0r8cAhw7] Spell Gem (3rd-Rank Spell)
+  [88IBM9viOjJ0kJbm] Spell Gem (4th-Rank Spell)
+  [BVCQFla90m2JDepV] Spell Gem (5th-Rank Spell)
+  [9PAmdF8UqVQKXWPA] Spell Gem (6th-Rank Spell)
+  [JgvLQeWK45OxFrx0] Spell Gem (7th-Rank Spell)
+  [Vt6VVUXFf1boNs3P] Spell Gem (8th-Rank Spell)
+  [8nNTrkf4ZCqkApNT] Spell Gem (9th-Rank Spell)
+  [sFKOrJVfupoXyNtO] Sprayflesh
+Container
+  [TirRAlOEF2h2CWUs] Container (Designer)
+  [XRk3UWHAQ5WVkZGu] Container (Ordinary)
+  [4lriWcmTDwklOTqO] Null Space Chamber (Advanced)
+  [EAMHdtJLqWUO0ZU0] Null Space Chamber (Commercial)
+  [klJ5cYUmVrHHVBaH] Null Space Chamber (Superior)
+  [ASYV7hnQ7PzICUzp] Null Space Chamber (Tactical)
+Deity
+  [MPol496nDguPTmCU] Battle Saints
+  [fjisjygyebkfu9pN] Damoritosh
+  [N1eCNDynvJFIl154] Eloritu
+  [fyVrRIME5ruQ61S9] Hylax
+  [VIrT7AMlWHNOlgPs] Ibra
+  [o9dgag7sAiFUnN9I] Lambatuin
+  [8KdiTOuKttm4njGx] Meyel
+  [5uQoTXSUuoJv1VMt] Oras
+  [CYUkMkhXSnZPLLhr] Talavet
+  [ZiHWMKZk7bgwG8yC] The Cycle
+  [frkwaiKRQnE8s5QQ] The Newborn
+  [OSQPUVZrtxJUisPa] Triune
+  [hrqNoz1QiA6z9LMV] Weydan
+  [YiV6Wd2OxCOxy00A] Yaraesa
+  [P8SXe1RC7PTR2384] Zon-Shelyn
+Effect
+  [bbdg6JeElvGWb20A] Effect: According to My Calculations
+  [qbnXMOmVMMKphIgg] Effect: Adaptive Defense
+  [1KLuThhsYQMPO5Qj] Effect: Adaptive Locomotion
+  [xZ5XMY55S42aGyjg] Effect: Aeon Stone (Uplifting)
+  [7o4KWymf4Yy2n2Qx] Effect: Aim
+  [F2VaEGedUJJ5aPqF] Effect: Aim (Reduce Cover)
+  [5da0ZOocaoySCSJ2] Effect: Anchoring Impacts
+  [mmT4wCspLVjiGnND] Effect: Apocalypse Smite
+  [c3Y1xZ6IIxbsnPk1] Effect: Armament of the Archons
+  [68zoB7dwKUcmEO1R] Effect: Artificial Immortalizer
+  [yAV9fgqOQUuxFEsX] Effect: Assess Target
+  [Gt6n0nYxHlPSmWVH] Effect: Assistive Shove
+  [K1v7z7TWE52mpDV3] Effect: Atavistic Rage
+  [yDgrjb3OuB51axy7] Effect: Atmospheric Flight
+  [qA3xFKVmtZCXSgsg] Effect: Attuned Wards
+  [e2z2ZdHOdc3BrVf8] Effect: Attunement Aura (Graviton-Attuned)
+  [uVKf8emUoSGeRZQt] Effect: Attunement Aura (Photon-Attuned)
+  [qj97oOs2Z2qk9w00] Effect: Blood Renewal
+  [b09qH19WK3FQi2QF] Effect: Bolstered by Battle
+  [ZWOPndNX0EIhYCG9] Effect: Bolstering Aura
+  [9Sq4P1Pxr1owEv6R] Effect: Bond Boost
+  [WNCJ8ZgkqU7LhJNk] Effect: Bond Spell
+  [Crg77XKCHxittH5a] Effect: Bone Serum
+  [CIO1HR8vbx61qpXw] Effect: Bone Shards
+  [NEgZy4YHA1TGlF6T] Effect: Bring it On!
+  [X5oMEjGHa8WsCiqW] Effect: Buffering Zone (Failure)
+  [KiCwXxBqYjxS0u2Q] Effect: Bullet Fever
+  [dCDZQr7EBfCALmT2] Effect: Celebrity Serum
+  [22BLEySiAaQwoO6f] Effect: Cellular Regeneration
+  [ck4ogo5HX97e5UuM] Effect: Colony Mind
+  [uf3Fb7Fm7dSzc7Os] Effect: Commando Serum
+  [YI60jVAgutn1YrI7] Effect: Confounding Disquisition (Failure)
+  [xYipnklm52BcgwSD] Effect: Cooperative
+  [x9nA4lIcHmE7x8Tt] Effect: Coordinated Fire
+  [0kdfFVZuHoHTG5c0] Effect: Covering Fire
+  [sEPdCQ7J3hF6mjHi] Effect: Deadlift
+  [6gduthFziKA5pU53] Effect: Defensive Formation
+  [2Iuhg4udP9eQF3oM] Effect: Digital Assessment!
+  [liRaJmKk1vWWuJ8W] Effect: Divine Farewell
+  [mpoTONLPMyb14mO9] Effect: Dramatic Reading (Critical Success)
+  [IPIYAY9bTGetPw12] Effect: Dramatic Reading (Success)
+  [MZzCPh8IHQwe4xP3] Effect: Drop Tail
+  [SjauZALDFxxkSNbl] Effect: Dual Aim
+  [ZQM4vfHEKgxvNJik] Effect: Effortless Influencer
+  [xQvyfiOh05xK2A5A] Effect: Electric Kalo
+  [xoUfhVC7gCK716ut] Effect: Elemental Harmony
+  [f92GBWr5lfx4tKot] Effect: Elemental Perfect Harmony
+  [t5ZPkSBVnNF4Rm04] Effect: Encouraging Hope (Allies)
+  [jbyNkh8q1TWg8APb] Effect: Encouraging Hope (Enemies)
+  [g1J6DOxBQkacvbyE] Effect: Energy Consumption
+  [U7ZWScb2rLlZYxpF] Effect: Energy Infusion
+  [Pdm2JmwnKc6yB1y5] Effect: Enter Rivener State
+  [52tyG1y50LmTqCA9] Effect: Explorer's Canteen
+  [IaICLG7zwOV4OKgM] Effect: Face in the Crowd
+  [YbBoPkBHnyyy3xLd] Effect: Focus Senses
+  [Bw1u0YIbG0ZV1CIR] Effect: Follicle Germination
+  [7CtHz1DQcMXLafOS] Effect: Force Field
+  [ey2zSEnprAGgvrij] Effect: Get 'Em!
+  [dAcHJiPDtqxxrR4Z] Effect: Get in There!
+  [b3bGLDuzs0lKS1Oq] Effect: Gorge
+  [73I9yj9XlxcBLXfa] Effect: Got 'Em
+  [1uk1rvqSP0S2HfVG] Effect: Gremlin's Gift
+  [LdbqPPiSg5gn5Kqp] Effect: Gremlin's Inverted Gift
+  [B4JhFkbk5WHmWcOZ] Effect: Hang In There!
+  [WUHSeAxZXX3Fin3S] Effect: Harmonic Convergence
+  [cnmur02H1qW03Gwi] Effect: Heroic Last Stand
+  [9Zp0f8bUTq4iZNBT] Effect: Hidden Agenda
+  [9wWPl1LVWgqiZ2Wz] Effect: Holo-Roger
+  [SS3He5Oh41NZjmf7] Effect: Homing Mote
+  [NqP5f6IChp8XNCrJ] Effect: Hypopen (Quickened or Fast Healing)
+  [lRXqkQTrtVRqqDWH] Effect: Improvised Mastery
+  [DqJVydBDD48StDVh] Effect: Infernal Armaments
+  [ZLGe31v4jLANtk91] Effect: Infiltrator Enhanced Exploit
+  [zXZoUqxzXFisGqmw] Effect: Infiltrator Serum
+  [5IVLUdHeIGnHADjZ] Effect: Input Overload Aura
+  [fzsAxccVTPTMlpih] Effect: Inscrutable
+  [2UI9dt0QM2VEvpJV] Effect: Interstellar Raft
+  [B0ZDwyk4qOr7hp4e] Effect: Intimidating Taunt
+  [K0hYQZcHLRa3GdfK] Effect: Into Position! (Lead by Example)
+  [0kP4P73w0PykYkPY] Effect: Jetpack
+  [piyxWlJUtjJIKdW4] Effect: Keep on Keeping On!
+  [x4fR05693ijNBCii] Effect: Kindle Blaze
+  [UEnGE804ZFRJmQYN] Effect: Lead the Charge
+  [81igjVgKBDXMomwb] Effect: Manifest Energy Wings
+  [4DiN5KNJSrBkV1BA] Effect: Meandering Mind
+  [kxaRFiXRKMNpasnu] Effect: Meditative Analysis
+  [VKSOvJQMwUby4fba] Effect: Medpatch
+  [gKDw3GcOiOYMMK1k] Effect: Mental Interference
+  [Uwb0PSFXd4QGG9Q1] Effect: Mobile Aim
+  [B8kDmWVlRX1uJb1o] Effect: Mobile Aim (Ephemeral)
+  [Gl74rxqPUxtOgj8E] Effect: Morale Boost
+  [aw4sF8U2odkls99H] Effect: Nanite Form
+  [g5T2YGRn0nSGKYyy] Effect: Natural Thruster
+  [bynA4hR6QPQbiyJY] Effect: Nimbus Ward
+  [8uHTQ6ha3CT79fS6] Effect: Not in the Face
+  [y6VGOjPa8TtVVvYR] Effect: Phase Shift
+  [O4Ck3SKtbPWN3WKU] Effect: Photosynthetic Regeneration
+  [7tSTaSqLPYwPzbMx] Effect: Plant Rumor
+  [5lbVIAgzYywMJ3t2] Effect: Rallied by the Beasts
+  [p2GrXbOJbv0OT4Zr] Effect: Rally the Troops
+  [6lT9d0YrRkdWOJ7u] Effect: Rally the Troops
+  [NNBc9roYRnFmB3dF] Effect: Rebellious Defiance
+  [yYafOxeNKG7n3WQn] Effect: Redirect Energy
+  [k2Sal2fpeoUsGZAv] Effect: Relentless Endurance
+  [ItKEn1ikbsZROaBL] Effect: Restorative Shapeshifting
+  [ayrgURELCK5rhnna] Effect: Revert
+  [h1bYCRQFvDl0gPkG] Effect: Sandstorm Veil
+  [cA7lJArsiFL45GFa] Effect: Sandstorm Vortex
+  [GpzaKY9WlDFAhgcg] Effect: Scoring
+  [hcH7IdEjC2wUVfaK] Effect: Scrapper's Ingenuity
+  [E5oRUzuYh5rLlPzu] Effect: Search High and Low!
+  [QsTiJFodHt7RsfYh] Effect: Seep In
+  [Asd7LTVUZDrqZN6A] Effect: Self-Destructive Frenzy
+  [mprZBMDC5a4U2STA] Effect: Sharpshooter
+  [UB0yKVxoS0EBXyCO] Effect: Sharpshooter Serum
+  [DL7GOlVLthV6HJpb] Effect: Sharpshooter Serum (Reduce Cover)
+  [Ll3uZdiSqaszP3fn] Effect: Shattering Impact
+  [T9vJgdL1zidgsPJi] Effect: Shed Skin
+  [af3dMl0TEkqOp2K9] Effect: Shielding Arrogance
+  [sNFHjpv27IFPVI9k] Effect: Shoot to Kill
+  [bx5WXjFyU9nu4UyE] Effect: Siphon Poison
+  [RBWwGxsrxPBKi3X7] Effect: Size Up
+  [N2sUfIzHp08G5fUA] Effect: Size of the Ancients
+  [TMarUs51Jg7v3g3f] Effect: Skillful Encouragement
+  [q5W7fV1wXvqBFxt8] Effect: Solar Shield
+  [UlFxEP3YrbseKA62] Effect: Solar Weapon
+  [gABm4VTVRcfbv5sG] Effect: Solar Weapon (Twin Weapons)
+  [pZabAZDrrIENU803] Effect: Spellsurge Ammo
+  [ncmWr1EPq7nGErQf] Effect: Spin Doctor
+  [kJR7VvSqPzhA6lR2] Effect: Star Brand
+  [4J30S9nhyfaCX1Cm] Effect: Starship Possession
+  [RhmWzzEbiykniDHQ] Effect: Steel Yourselves!
+  [XmdJvu33YRjQbLsz] Effect: Sway the Heart, Stoke the Spirit
+  [ppKeWbPcSaVqD1Cj] Effect: Tactical Strike
+  [n33jAVZDDWQ7ifvl] Effect: Tactical Tutelage
+  [fa4T1oR8S0lF5888] Effect: Take 'Em Alive
+  [nvB1852vEPVqjxhR] Effect: Tangible Object (Anchoring Effect)
+  [8HDUnGy6hfvj6p37] Effect: Telekinetic Sprint
+  [gFELDtZR5N3jx7fl] Effect: Telekinetic Titan
+  [V2RD3qNBmkrzXb4K] Effect: Telepredict
+  [Ojy9y4WYGjQJjUwj] Effect: Unbound Mind
+  [jtlZPjobJNXLol7S] Effect: Undead Slayer
+  [HB8lDFxU86aAl50M] Effect: Unstoppable Directives
+  [NhV64Budza1tG6ah] Effect: Vent Gas
+  [8eqdNadBEcXMvjng] Effect: Watch Out
+  [MVoUvf0bzUUSUkiR] Effect: Willful Defiance
+  [A8NpjGmBeDx3taOP] Effect: You'll Have to Go Through Me!
+  [6A2QDy8wRGCVQsSd] Glitching
+  [h1i8c47U0IOrMrHJ] Spell Effect: Akashic Download
+  [7r6mw8H87SUaj9Tq] Spell Effect: Analyze Target
+  [VacLbml5QIO0jqlO] Spell Effect: Anthem
+  [v724q5Xi7KPPnLQ3] Spell Effect: Cairn Form
+  [16Li37zRYKClxqsv] Spell Effect: Carcinization
+  [q47pDFylqDY1VYEk] Spell Effect: Commune with Tech
+  [4BwlNXei3xMKygMv] Spell Effect: Elemental Barrier
+  [oGUuRPGJHouppf8V] Spell Effect: Enhance Body
+  [yopd0S7smKU5eB07] Spell Effect: Enhance Weapon
+  [1Ut6QrRtIZzjmqZW] Spell Effect: Feline Senses
+  [R9R0Nf8YX5ahx5FH] Spell Effect: Feline Senses (6th-Rank)
+  [4cFhz9knnHUHj3wi] Spell Effect: Genetic Regeneration
+  [hOp5ybOzyJlECU6B] Spell Effect: Glow Up
+  [NmhqKZyMgQSHbyHj] Spell Effect: Motivating Ringtone
+  [Mjzoqg7MpTst3koD] Spell Effect: Promession
+  [bfimY3Rbx3lrsFAJ] Spell Effect: Quantum Analysis
+  [Yl3Wb0cN6Mvx2EWf] Spell Effect: Quantum Analysis (Cover Suppression)
+  [J5f9SpgmiFOPKU8Q] Spell Effect: Quantum Analysis (Fortune)
+  [pWm0NCsxjxTUCJ7y] Spell Effect: Shifting Surge
+  [80ciNFwm19EKBONT] Spell Effect: Shuffle Repeat
+  [kT8REROKKaXF2QK1] Spell Effect: Skyfire Wings (3rd-Rank)
+  [IHIQ7PcirTwjJQev] Spell Effect: Skyfire Wings (5th-Rank)
+  [9DZ8819QPDnxcnFw] Spell Effect: Skyfire Wings (7th-Rank)
+  [sElqtOTF8X0LUcnZ] Spell Effect: Skyfire Wings (9th-Rank)
+  [4P2rPLVKjSpUbOWI] Spell Effect: Subjective Reality
+  [zzOekbiIKePQDQKy] Spell Effect: Supercharge Weapon
+  [NcPiz5TOhnel5ZoX] Spell Effect: Tech Intuition
+  [NP75qOKsF43zLaiZ] Spell Effect: Vague Idea
+  [ikNI8DM5DRa1k4G3] Spell Effect: Void Seed
+  [NWNXwJhNpNvNdyLd] Spell Effect: Void Vessel
+  [bFy8NADnVR95YKyx] Spell Effect: Warp Time
+  [LXi2h0q58zg9EFCN] Spell Effect: Wild Bond
+  [enA7BxAjBb7ns1iF] Suppressed
+  [z1ucw4CLwLqHoAp3] Untethered
+Equipment
+  [JdBYoPRqFhVWoJFi] +1 Weapon Potency Crystal
+  [AYZ8VGXirdelFqBb] +2 Weapon Potency Crystal
+  [U746WCfdSOJs0qwd] +3 Weapon Potency Crystal
+  [GKnDEM8RWyo3UhKu] Active Camouflage (Advanced)
+  [7Qj7zNHqp5KW9omz] Active Camouflage (Commercial)
+  [PwEKIutKVOwGmk4o] Active Camouflage (Tactical)
+  [T4JV6YG5OwIPh5UL] Adaptive Energy Shielding
+  [uxHoe7QTTXreGBky] Aeon Stone (Guiding)
+  [7pABFja0fmeeSJGo] Aeon Stone (Life-Giving)
+  [lLXSHmNwWUuSiACi] Aeon Stone (Navigating)
+  [JTgJTAunHqnLjwLs] Aeon Stone (Projecting)
+  [kFfYq4ONuKMgISRi] Aeon Stone (Uplifting)
+  [yAXP5QTRFBf8mvqR] Akashic Lens (Advanced)
+  [coLUuQfleC56qdhe] Akashic Lens (Commercial)
+  [DSDFCIDP7qPcDadq] Akashic Lens (Tactical)
+  [AILwbnjXnT1BVYYd] Animated Intelligence (Advanced)
+  [diAapfk5dEZlghqV] Animated Intelligence (Commercial)
+  [qbmzVsnSWfneGlI9] Animated Intelligence (Tactical)
+  [d2Z53s2y4CUJi7sK] Antigrav Harness (Advanced)
+  [KbVBdUXq1kOcC2vI] Antigrav Harness (Commercial)
+  [voeYTU9JcpjmOufS] Antigrav Harness (Tactical)
+  [84ae9kFPqWmqUZDC] Archaic Text
+  [0J8PMTLDGIIP1KGE] Artificial Immortalizer
+  [1kYUux9KdGkPggB4] Auto-CPR Unit
+  [AdUYBa6CvmgDSN0v] Autodreamer
+  [XrEbh1PXWWVp6O7K] Autograppler (Commercial)
+  [nYzvVgdK4iS4r2Mk] Autograppler (Tactical)
+  [GBtIO5fqFGD9Dzk1] Autorecognition Lens
+  [FLODmOj4yK7eJn0a] Basic Environmental Protection
+  [wn4wjYcoVxAm0lWy] Bipod (Advanced)
+  [xgeRYUg32Jex5GSY] Bipod (Commercial)
+  [20MrfbsA9c1LN2Is] Bipod (Tactical)
+  [zdIIbAt8D0CMwzEL] Bone Speaker Bobblehead
+  [zzNRlflg2JlybDzq] Cable Line (50 Feet, Commercial)
+  [8Fk7Zhf7xdrrzun3] Cable Line (50 Feet, Tactical)
+  [NAa1537jLii1129F] Camping Kit
+  [vsNJcwknK2irmIjC] Cardiac Accelerator
+  [btcbYUK4UqgQ699i] Chemalyzer
+  [KFHRIjcpbV8YYtCd] Climbing Kit (Commercial)
+  [xG9CN7dm8Tx7ih83] Climbing Kit (Tactical)
+  [4sj4PcFSP7dAqaIp] Cloaking Device (Commercial)
+  [efmRJxyFS6KUTeMr] Cloaking Device (Tactical)
+  [qUak1gMC2VQGANSR] Cloaking Skin (Advanced)
+  [XrMKojmO5brKtWGR] Cloaking Skin (Commercial)
+  [4Yj6UtcTQAp2OyU4] Cloaking Skin (Tactical)
+  [AupC6W7aSI3Sszg7] Cognition Accelerator
+  [fClhrG92Zi4k14Hq] Comm Unit
+  [dov79V3iw5rJyxCR] Consecrated Keycaps
+  [X3nrJlRfyuuHKOtb] Cosmic Connector
+  [FtXDw1QyZz3CJoKX] Cycling Crystal
+  [xKa81R2YkJwdgLPb] Darkvision Capacitors (Commercial)
+  [lOnsIupW1Ocve3kB] Darkvision Capacitors (Tactical)
+  [7psnMwQ95uO5apQz] Darkvision Visor
+  [FDR6syV9prX8EDF6] Data Chip
+  [bMgxTWp5PGp30uQ8] Datajack (Advanced)
+  [3TQ2WCBNaFwEUDHo] Datajack (Commercial)
+  [PrU4x8lXoSclhUEF] Datajack (Tactical)
+  [HxaKRfVbL1ZyGcu1] Datapad
+  [RfKBzZcysjL6f4Vq] Dermal Plating (Advanced)
+  [j66fZJrm1nECG3UM] Dermal Plating (Commercial)
+  [OesDcmqYJV7OGJ1F] Dermal Plating (Elite)
+  [UlKke1R62YMFXrdG] Dermal Plating (Paragon)
+  [120680FW1mXo1vgt] Dermal Plating (Superior)
+  [WezCJAnWTRUTLDi7] Dermal Plating (Tactical)
+  [AlRslI3YH2h1B4xY] Dermal Plating (Ultimate)
+  [54kRtg5Dies13GLc] Diva's Microphone (Advanced)
+  [kljB8eEkjUKfcmY2] Diva's Microphone (Commercial)
+  [RfYKYFGsjUemREqF] Diva's Microphone (Tactical)
+  [lfWvZTop2cPqufWU] Dragon Gland (Advanced)
+  [ejsPnjUVXf2TJgeD] Dragon Gland (Commercial)
+  [T3QeQ51KwNyJdkLb] Dragon Gland (Elite)
+  [W64JcFdOg4XjucFP] Dragon Gland (Superior)
+  [4PgeysPXkt6G5xua] Dragon Gland (Tactical)
+  [RMrZyCh0sdhEF8Mp] Dragon Gland (Ultimate)
+  [p9INuxluZEUJvoAv] Dragonsight Flashlight
+  [cw9u2izfwLqWZYBb] Duo-Enhancers
+  [PlcS8xrnX8NyWxj9] Electroencephalon
+  [5GeONzHSxmn3uvtw] Emergency Beacon
+  [F3xHu12Jmk8GgPGI] Energy Shielding (Advanced)
+  [fQxWOthZx2HZUEzZ] Energy Shielding (Commercial)
+  [on8hik5UAQRzJTjN] Energy Shielding (Tactical)
+  [JGbmqiZS3kurgKFu] Entropic Destabilizer (Commercial)
+  [DObTb7yBvPPvl8nq] Entropic Destabilizer (Tactical)
+  [WGdcokSMynEyF332] Explorer's Canteen
+  [OsURCZfOTbeU5wqq] Explosive Defense Unit
+  [QuUyXSB0yTCM3bcR] Fear Projector (Commercial)
+  [5esAuSMPfXOGd0P2] Fear Projector (Tactical)
+  [pEob2HYKeFtToeeC] Field Scientist's Toolkit (Commercial)
+  [7aGluzZ4bjfXbygG] Field Scientist's Toolkit (Tactical)
+  [aac5hRRU0wbqSHki] Filtered Rebreather (Advanced)
+  [0kD0MZgiK0SYS6e6] Filtered Rebreather (Commercial)
+  [hFU8q6aCS6bq89oW] Filtered Rebreather (Elite)
+  [41drAN0CXPX7whb9] Filtered Rebreather (Superior)
+  [rvHo4g2VFgGdUESn] Filtered Rebreather (Tactical)
+  [8CgzoVKwSX9TiAaM] Fire Extinguisher (Advanced)
+  [QTc6Z2G5G3PORbcB] Fire Extinguisher (Commercial)
+  [3pptlSCHkO6d1NeU] Fire Extinguisher (Tactical)
+  [3gQ8AI0DUEJE7s9t] Fireburst Chamber
+  [h4oJih49e0kZcsWG] Flaming Module (Commercial)
+  [nVHtapEShNIu1f4V] Flaming Module (Tactical)
+  [cjOdJfGUs5IDw8Pi] Flashlight (Commercial)
+  [9gKyKIMhT4AnUwr5] Flashlight (Tactical)
+  [NN0cdTkaj69R2B2u] Force Field (Advanced)
+  [ZdItrVii0l2yuSMJ] Force Field (Commercial)
+  [YZjmnoJD64oLMQ7q] Force Field (Elite)
+  [24LGHALXm2vl3oqq] Force Field (Paragon)
+  [2637b5l0hxitACkR] Force Field (Superior)
+  [6ZW9IcSwd4WCFuf6] Force Field (Tactical)
+  [6hunzJ4gwfNT58vl] Force Field (Ultimate)
+  [CcN2GgKeeau0IUJk] Frost Module (Commercial)
+  [OpSc2QLvJECTWRov] Frost Module (Tactical)
+  [TgJMTB1ub5Eh4xJO] Ghost Killer
+  [zyrPSFBAwL58wCUB] Gill Sheath
+  [5ar8OM7cYywnfTjD] Glamer Projector
+  [raxz4fpTfjM0L1Qj] Glarecaster
+  [KZhgAm5kmlv5KWIQ] Gluon Crystal (Advanced)
+  [icgDHyiDNUspNcR7] Gluon Crystal (Commercial)
+  [LgJrTVo1rReh9H5m] Gluon Crystal (Superior)
+  [sZcqNfSvls2rI8xU] Gluon Crystal (Tactical)
+  [uj6raatkNE6E9nFA] Graviton Crystal (Commercial)
+  [0KN1ZsFpc7ks9eB7] Graviton Crystal (Tactical)
+  [QGV4NiKDCHYOK5Dj] Great Absalom Relay Medal
+  [dk4qkf4BF7wCPV4u] Hacking Toolkit (Advanced)
+  [qqjDcCW118ySAlAS] Hacking Toolkit (Commercial)
+  [5o7wOnkxEsyBwBNj] Hacking Toolkit (Tactical)
+  [xTbGz4uDeCWwMyVA] Hideaway Limb (Commercial)
+  [ib7UwlCqzgOlC4wK] Hideaway Limb (Tactical)
+  [Jvp0x2Sc82WVpExT] Holoskin (Commercial)
+  [YhkomhtKBK3i9C7Q] Holoskin (Tactical)
+  [S12VloOQmRvzHN4D] Holospark
+  [he1AD9ck10fLSvWn] Holy Module (Commercial)
+  [XJEqTuohpEGkHQAt] Holy Module (Tactical)
+  [x6gjdASwtFcMmGWf] Homespun Hat
+  [iNMomdgMWzzZ7cPt] Hygiene Kit
+  [ZYEtDkPBD5Lm6Unj] Hypernerves
+  [F0SYGfqJatyyxl79] Infiltrator's Toolkit (Commercial Picks)
+  [coJUVZGcuVg3FoYh] Infiltrator's Toolkit (Commercial)
+  [hsk3weQS9I7LyGkn] Infiltrator's Toolkit (Tactical Picks)
+  [ao5MC3I1b4Gx9LNC] Infiltrator's Toolkit (Tactical)
+  [9lRzR6X1xEuBOy6A] Infinity Deck
+  [CIZ3Walj6DmiaJGq] Jetpack (Commercial)
+  [DnuTMCJFBDj9nNRx] Jetpack (Tactical)
+  [rcoxWcmLV9G7HKG0] Jump Jets
+  [vB760MwE0ZUJv3Rq] Laser Eye
+  [CiGu0DmW03OiYkLY] Load Lifter (Advanced)
+  [qyqiI7slF9PEHSI3] Load Lifter (Commercial)
+  [sEFRqPaYmIvc3H0Q] Load Lifter (Tactical)
+  [kjoqoG7H7ceZycez] Lock (Advanced)
+  [6gVlmHbuFtwaPCjs] Lock (Commercial)
+  [EjjBj2kwhHxVisqR] Lock (Elite)
+  [NE6LenCQSFEAhWwX] Lock (Tactical)
+  [tMVTprjg28EEYqz9] Loudener (Commercial)
+  [OyqLJ1zQy8PpnSHR] Loudener (Tactical)
+  [7CMMrOsOmHPKffsB] Magboots
+  [keOgvGTouQardZ5f] Maker's App
+  [wCso2FANtxU43Who] Maker's Toolkit (Commercial)
+  [pMvFn7PTtcpIANTe] Maker's Toolkit (Tactical)
+  [1034KqIGsMWJuEb3] Maneuvering Unit (Advanced)
+  [JkAPHaa3tRidHD2M] Maneuvering Unit (Commercial)
+  [uyBTaJIspxwF4598] Maneuvering Unit (Superior)
+  [VS8uXQqDqsc6hp8k] Maneuvering Unit (Tactical)
+  [s1vB3HdXjMigYAnY] Medkit (Commercial)
+  [SGkOHFyBbzWdBk8D] Medkit (Tactical)
+  [XUv5DLh6QUCOs7JT] Microgoggles
+  [z6gMut93BGlGbvz1] Microphone
+  [F76S117Yl85MCqp0] Mobility Enhancer (Commercial)
+  [rBIx7Ll5RFo4ZQsQ] Mobility Enhancer (Tactical)
+  [VYtnxv13EtkyggD4] Moodskin
+  [AMO15E9lrNJ93fJI] Muscle Invigorator
+  [oRuWi8EhgBiS3cbh] Musical Instrument (Handheld, Commercial)
+  [TwnyjvE7ZX35lCrj] Musical Instrument (Handheld, Tactical)
+  [pm5cjJotmQRlJ0pZ] Musical Instrument (Heavy, Commercial)
+  [suvVsy5oA4WjgetD] Musical Instrument (Heavy, Tactical)
+  [SoB2prFShd0z31Cp] Nano-Optics Node
+  [vvoIYWfv7OGgeEqR] Necrolung (Advanced)
+  [CBFbt7Xg5YP856ld] Necrolung (Commercial)
+  [KTx6t0YaoPy8VCuj] Necrolung (Superior)
+  [iPJkp8LnQVKybqqm] Necrolung (Tactical)
+  [smtr0wluu4BChOoR] Pain Journal (Commercial)
+  [a0Kh8y8UHHyRVcz4] Pain Journal (Tactical)
+  [xLxqq8NKbZsFt7EC] Parallel Accord
+  [HRpZtAdpSg12N9n0] Photon Crystal (Commercial)
+  [WZgjjY3FrWG7p8B7] Photon Crystal (Tactical)
+  [IjmO1DY00eygOvCO] Photosynthetic Skin
+  [9huJDWkgN0zK5jNw] Portable Amp
+  [JU2rhUAAl824OYAH] Presence Intensifier
+  [ly2Jpx5f5SlF0WRS] Programmer's Plushie (Advanced)
+  [z9B1rE6L3ICLyKsG] Programmer's Plushie (Commercial)
+  [REFyZv56sXT408L6] Programmer's Plushie (Tactical)
+  [vJvy0qPz2Mcd7yXl] Prosthetic Limb
+  [aXZPaqzYOrY9fVjh] Psychoactive Eyes (Commercial)
+  [oBmL3AYC9mPIxci0] Psychoactive Eyes (Tactical)
+  [ZzdJKzOrz6i5WuAp] Quasar Crystal
+  [2GvHO9VAUNqY4hUX] Quicklock
+  [gZmmlNszibwt5y0f] Radiation Buffer (Advanced)
+  [p8WHKcuKovu9Q4pR] Radiation Buffer (Commercial)
+  [xvYdM79er23ljP6T] Radiation Buffer (Superior)
+  [lLBKptoIh0mj2KV4] Radiation Buffer (Tactical)
+  [fWsawZJ5YGIyHWpa] Radiation Sweeper
+  [k1fLpwMmXM5RKdGI] Reality Distorter
+  [BzX1RzuIyckt52k6] Regenerative Rune Splice
+  [vLGDUFrg4yGzpTQX] Repair Toolkit (Commercial)
+  [aDsdYMPpVc8hOnM5] Repair Toolkit (Tactical)
+  [PJaarOSEHTLje8sT] Retinal Reflectors
+  [dUeJNZWPHaTDf3qT] Retrieval Boosters
+  [MCRSSwFdemDLmLYv] Reusable Grenade Shell
+  [q8FqlWg5u1Qvih0r] Shielding Skin (Advanced)
+  [OxabxPb3yC7AcKSw] Shielding Skin (Commercial)
+  [jKsuo5rytI4rvr8q] Shielding Skin (Tactical)
+  [0Hdg9aWMIYVGjvj0] Shock Module (Commercial)
+  [nl4tBzrHddJgpgbs] Shock Module (Tactical)
+  [SGdVaPZmhell8gsV] Shredskin (Advanced)
+  [wS5fBC7TRbDM4q3q] Shredskin (Commercial)
+  [VYC16EQv9hqltURV] Shredskin (Tactical)
+  [HUlH5jza7pcI71qM] Shrouding Sphere
+  [nPmeqjZ8b0mjqSfs] Silencer (Commercial)
+  [G64VfK5H5zUM1tB0] Silencer (Tactical)
+  [9u9HHjFJuCQeYhSq] Skull of Yore
+  [ZHqx7LT3eIYnA1T8] Slough-Do (Commercial)
+  [ifIGbGiqjGRpzwDO] Slough-Do (Tactical)
+  [dJgKsigmKDBjWz7u] Smuggler's Grip (Commercial)
+  [fUbHquBm5ImybSTz] Smuggler's Grip (Tactical)
+  [ZTTC6SoRggi3HIoq] Sniper's Scope (Advanced)
+  [10lYyQDoJXUojKm2] Sniper's Scope (Commercial)
+  [ClyvL5OGaqYbZ6jQ] Sniper's Scope (Superior)
+  [kx5czsbsN9ryr1z2] Sniper's Scope (Tactical)
+  [VIGFz39NLcNarYl9] Speed Suspension (Advanced)
+  [HZPVRQWgGreue272] Speed Suspension (Commercial)
+  [q5vKWIwkpKECVPN1] Speed Suspension (Tactical)
+  [U48mM3lcrBTh25d9] Spell Chip (1st-Rank Spell)
+  [88WZweNBd4j2X2hd] Spell Chip (2nd-Rank Spell)
+  [Wn8GEmCG24QIM1wt] Spell Chip (3rd-Rank Spell)
+  [5O3DUTQoUA3rcF6v] Spell Chip (4th-Rank Spell)
+  [nyTMtaCsBvXeK4JP] Spell Chip (5th-Rank Spell)
+  [PinBkpx2xRvmUiiM] Spell Chip (6th-Rank Spell)
+  [TBtiV7FLBpI2HtCC] Spell Chip (7th-Rank Spell)
+  [cUks0bsnFkfxeojU] Spell Chip (8th-Rank Spell)
+  [sB9xK4xLUCyXUDzm] Spell Chip (9th-Rank Spell)
+  [nZVTCMNdBmbNBQmb] Striking Crystal (Advanced)
+  [AmF4ApGgYVhwU04Z] Striking Crystal (Commercial)
+  [hLQlFY3NpdZ67uWE] Striking Crystal (Tactical)
+  [0X44YvSjbR2ER0gk] Sunshades (Commercial)
+  [CJwfbmQO91Q9v3kg] Sunshades (Tactical)
+  [rOtCdylPWiIiswbP] Telebond Band
+  [Dmwb9DcWLf9y8JmC] Telepathy Node
+  [P4807u23Ixo6Puat] Thermal Capacitor (Advanced)
+  [92Q2vr8vxJgldLKQ] Thermal Capacitor (Commercial)
+  [Xuz9uyRo2hE2CNvh] Thermal Capacitor (Superior)
+  [6oHrw4XN1IULr9fv] Thermal Capacitor (Tactical)
+  [fY3howNXvpWRYW4j] Truesight Sight (Commercial)
+  [jYBxzNbdEanJ89rA] Truesight Sight (Tactical)
+  [h8YVrmdfqepbhS2T] Ultralight Wings (Advanced)
+  [5Zgnk1EEYEaddjSY] Ultralight Wings (Commercial)
+  [OCqs5ZRBmqsGmKfr] Ultralight Wings (Superior)
+  [hCGBEZKmTi6oLGBI] Ultralight Wings (Tactical)
+  [fZ0YzlGLRk1FUrLp] Undermounted Grenade Launcher (Advanced)
+  [UbgiYNUHFy0pycfS] Undermounted Grenade Launcher (Commercial)
+  [3sTFk0Qxt656QpuU] Undermounted Grenade Launcher (Superior)
+  [GmdWyq6QB9n1DHxi] Undermounted Grenade Launcher (Tactical)
+  [0PuufwwJdcFcUPjt] Uniclamp
+  [nflzpHfTNsAovvhH] Venom Spur
+  [QCzqkk6x05wG7qWV] Vocal Modulator
+  [6Y9wXEATPg8EezD7] Voice Amplifier
+  [8oT6jfnuyUWVU5Nc] Wildwise Graft
+Feat/Feature (Ancestry Feat)
+  [JyzcpbqsVVbSpgvm] A Life For a Life
+  [JYPbUPZAV5PQTxAT] Aberrant Shape
+  [goYtDvggPIibuDKX] Accelerated Step
+  [F6y2aWiufZPRoi8c] Adaptable Intellect
+  [aHLTHh3VjElAMQC7] Adaptable Limbs
+  [MsH43TvmVSf7ewKj] Adapted Augmentations
+  [oVElzviiQAzmox6f] Adopted Talents
+  [AHTk5YkcV3lzm094] Advanced Atmospheric Flight
+  [pyvN8ImE7TqR5Enp] Aerial Dash
+  [9GgDasvLuOeSGdjl] Aerial Master
+  [EPeo604ByeeAx3AL] All Hands on Deck
+  [Sm0y2cAEP8UXgp1Z] Allsix
+  [mQaqQIEtauUiqdDs] Alluring Pheromones
+  [TidCHs7Yd7h4aOiV] Ambidextrous Shifter
+  [wADHwJTSe9ZIar9j] Amplify Radiance
+  [W5WkZTNWAh0cvxrz] Ancestral Knowledge
+  [nrBRVbQ8LvGO3HEm] Ancestral Physiology
+  [jGoacSlRk8afEqkj] Ancestral Weapon Familiarity
+  [3pjfIw16GKmEYF9K] Animal Skins
+  [zIJ7D33DM0hyAi6k] Arcane Adept
+  [gvMJqU4wNt8zp0MW] Arcane Recall
+  [FwNss6LroM7KZSUB] Arctic Bite
+  [hQHCzRzRPEHdLgMq] Armor Ace
+  [ZoiHVp984Kuanr5m] Ascending Necrovite
+  [DMRniZMlnZAnoXk0] Aspiring Necrovite
+  [TD9g4O6m7jngmFag] Assistive Shove
+  [wZyBTTRM2BjC93gg] Atmospheric Flight
+  [vgHQELxr8Wn2QukL] Augmented Adaptation
+  [a9nZ0ILhLENEXnp9] Avid Traveler
+  [KMDfLxScL59k8eJR] Baleful Gaze
+  [9Mao1aasa9tWVIpb] Baleful Presence
+  [NESPbaZ58wcZ027U] Barathu Lore
+  [YSi48yghu0wmkSrr] Basic Insectile Flight
+  [o7tBL0FGr9ptMPGe] Battle Saint
+  [sFwTLTMKDBTXKnTL] Battleblessed
+  [y4ezCine7hGv24wv] Bioluminescence
+  [CTZgRrfVvHnCSIcF] Biting Corpsefolk
+  [ZX7RgHviBOn9PyOh] Blazing Corona
+  [DWgfKsZGmidpyfDq] Blood Feast
+  [zvpABbaLyqtOmXi0] Blood Sense
+  [yDEcPHO2JXCFEZbm] Bloomguard
+  [yFRVsyX9yR6Pgwzz] Body Art
+  [HKmLMpA5esbUsxTB] Bolstered By Battle
+  [vn6EDm2nvAkITmtX] Bondbearer
+  [QoDqOiFCq0OkZ7ne] Bonded Transposition
+  [6EULnMpte8cl2EET] Bone Shards
+  [rD50FL4Z0mqSMpN9] Borai Lore
+  [Fg4M65FsO7ZSxCE2] Born to Fly
+  [TlZnjM85BmkiAqAQ] Bottomless Pockets
+  [rC3ZB1F8ngBY7TN3] Boundless Brachiator
+  [dapMcPgR17HUFJfT] Boundless Energy
+  [mJkdbGat3b6d8a1r] Brainsplain
+  [AytE84e6pU6Achc3] Breach
+  [FgA7uXPGGYavF9RH] Brood-Minder
+  [OFM2dbsMPtz7Rs7J] Broodless
+  [s7QK7Q63k9SxG106] Brutal Anatomy
+  [tWpWkc42MbAS16BP] Brutal Blows
+  [fRNNdUOhLQO1to7i] Buoy
+  [oVRv2ny1ginYsU6R] Calm Before the Storm
+  [PF5sBTrvGTyGALfG] Camouvisage
+  [DfiqsFzUQppwlkL3] Canny Survivor
+  [oqNJM8SOsmYlRaRZ] Carrion Feeder
+  [Ks7uSfEUcE4v18wk] Cautious Trespasser
+  [E6o233SXkv9qzBcz] Cellular Acceleration
+  [guAB6iY0mq3aIiPu] Cellular Adaptation
+  [SiVWK0ksapz0Y8UU] Cellular Regeneration
+  [sobAVW9cH4VGaRkn] Center Thoughts
+  [RouLFLNSEAGDYHs5] Centered Mind
+  [E9L7E372G4Wz3lk7] Cerebral Circumvention
+  [Yz49JzHw8pEFSUBK] Chattermander
+  [yGVUJszXrL6sicX7] Check it Out!
+  [0tdgb99mUuTw4FlL] Child of the Red Planet
+  [GVrTUenThtL7mvDj] Cleanse Spirit
+  [RjRIRJDAGMUazLvW] Clinging Bite
+  [CLNIJlz8GaCWzNn4] Coagulation
+  [mK26QgHQvD7JSDQP] Combine
+  [dyWMWnlBEqPkNnIF] Command Tactics
+  [EIBDGfiD5siW0dUU] Commanding Pheromones
+  [StCU4LUfFW6owYzf] Communalism
+  [iac0qVH4SDzCXOyc] Compact Predator
+  [xSWncnZFZw7bgufW] Competitive Spirit
+  [wXZUPAcTlIn5uNxa] Confident Actualization
+  [t8UJEwp6jK1GmCUk] Congregant's Acumen
+  [S0XPUjurbuyOnjTc] Consistent Communalism
+  [8ftl9i9rmorxoBow] Consume Flesh
+  [zh2EP8Pr0i5lI0Bg] Contemplative Lore
+  [VbRwIBl7eu7DAUF7] Contortive Compression
+  [YaS0LQv3YCfiBRgR] Convergent Evolution
+  [LHtaCR4gS4kozJyP] Cooperative
+  [5vEB3hwojjKZ2Vrm] Coronal Flare
+  [4eP7LvqWj3fI71Mu] Corpsefolk Lore
+  [7t8Wzb4PAD7YTD0k] Corrosive Venting
+  [FPJ3B9vFsNR3UaI2] Cosmic Caster
+  [Xyf3tjm3nEliqaaf] Cosmic Traveler
+  [tF0sAUpEiZqyCfHw] Creative Combat
+  [hEP34bAM7g2sNRpy] Crew Member
+  [iKl4RHQPi9eXLDpG] Crushing Fists
+  [JvDANwjccI4rL65G] Current Rider
+  [AnV5YDStfunTnPyK] Cyclone
+  [CmK6MOwZ9KFX2TZU] Damoritosh's Claw
+  [KFOXOovEhtvDZVXV] Darkvision Adaptation
+  [a4BhF5fJFjJmUlUT] Data Jockey
+  [dWDC5L6mSBqfUbgH] Dauntless
+  [VjSIPDj5PiMAPPNX] Dazzling Diversion
+  [TuY90W5JlyUgdYtJ] Dazzling Glare
+  [7aa1KDTvXriZjP6T] Dead Nerves
+  [mXqAbWyB7bqizkZn] Death Eternal
+  [jUj1iwCiFOrivhAc] Death's Advance
+  [TDphpBKl58Yj0iMV] Death's Indifference
+  [aTIbdcnMlwzg1XcR] Death-Touched Caster
+  [zI2wWFyyxroZ3mzZ] Deathless Study
+  [zZdeosoQTxKpmOZB] Deathly Constitution
+  [yK7aB7d2QDZyzWgX] Deep Diplomat
+  [NT3qcFKixhuZuF6C] Deepspeaker
+  [xF4Vse5IwmWveqxI] Defensive Formation
+  [CcOKDqU8RtKqrW5R] Defiant Liberation
+  [ndiCrnBVL7qD115a] Dermal Spikes
+  [fXQxrEuO2ER8fUgW] Determined Optimist
+  [ZaRcUkykzxCEPqtn] Digestive Outburst
+  [ewtBlMMwV7F7YPPB] Digestive Spray
+  [00ZSZtCvFuJzXgNn] Disciple of the Cycle
+  [jZEoRmky1wkk6evN] Dishonored Contrarian
+  [U10WCzCTQNpYzJ8O] Distant Telepath
+  [61txGmMLr22B93cU] Double Draw
+  [PrG3NWw7X8TTJput] Draconic Lethality
+  [BTjoKBpVtN2KXlFT] Draconic Senses
+  [39buScKHd66Z1Rho] Dragon's Tenacity
+  [PzfAk0BBtRviHW7E] Dragonkin Breath
+  [QCDFm9TfJEuKWcT1] Dragonkin Lore
+  [SX1BCOMptzYyaHqQ] Dragonkin Weapon Familiarity
+  [EvO3CAUHcPLENizp] Dramatic Blocking
+  [QYQmAFvXirWpHeC3] Dramatic Reading
+  [eM9cctmBcIjjUQ1q] Drift Blink
+  [qZK8Jbg59oIpUS7W] Drift Hop
+  [GUDyvtiwWuVYuTZN] Drift Strike
+  [kvCXhmAdYFR2BTq4] Drift-Touched
+  [8jmGw4nCmoq7pLWV] Drop Tail
+  [QwTsuEY0PZz0rdcL] Dual Bond
+  [nQoNAj6noiCy2Hy0] Eager Assistant
+  [q61FKwfib0A9Pxg6] Eager Combatant
+  [MrSdr4BSIcCm4cLa] Elebrian Cantrip
+  [PTdSkzlYel3lU8UA] Elebrian Lore
+  [XXdcwmXbu1OzaPyG] Elebrian Magic
+  [6pbJgG8uJaNSdVj5] Electrical Shielding
+  [feom9It7PqL7RxMR] Electromagnetic Whiskers
+  [sAsVs0vxzdMccKKd] Embrace the Magic
+  [Y6qEr3Kz5Hh61tCY] Emotional Defiance
+  [alFHSgEGbUhGng4y] Emotional Maestro
+  [LH5dRKAG6GDPhFwO] Empowered Scales
+  [0Qy2ByMZ86bR4Taq] Encode Presence
+  [IIMNM0nvYCnsk1sD] Encore
+  [AX1aZd5VzkcalLsr] Encyclopedic Recall
+  [DsS3TFeyVQiqhr3c] Enduring Echolocation
+  [3RqBU4dfoegOPzqw] Energy Consumption
+  [hvWJRc0dGF3ivrb6] Energy Deflection
+  [WNcP7KjKS65Rz46m] Energy Infusion
+  [lmowZWTzJaZfM3bb] Energy Shielding
+  [DrRxVVXQMTib4ni1] Enhanced Echolocation
+  [5mpJwD7j8InP3yCQ] Enlightened Rivener
+  [kxXC7sNk5GCDqKeZ] Enter Rivener State
+  [Lvq45hwOzhNEqDRM] Esoteric Education
+  [MbNWJIlVicCoiNiS] Etheric
+  [240LEtG9bNlQNBMI] Exceptional Reach
+  [uDjmNIypyI1lNQRC] Expanded Solar Reserves
+  [5ndv6xVcgJ96UTtf] Expansive Verse
+  [wXfVye3TSCMaHTHm] Explosive Surprise
+  [vc2fiI68PUxqn5Gs] Fantastic Ferocity
+  [yAXSsQoGuFglxOtx] Far-Reaching Mind
+  [cBMpUhDdPcRHrYgl] Fearless
+  [TFxVT6iiDxLx6sOa] Fearsome
+  [45NlyrR5JUuSp6HI] Ferocious Recovery
+  [y07qgtt6osIDIjR1] Filtering Tentacles
+  [OhEATZzWsLaRd9mb] Fissile Budding
+  [bOuoMaJcdk0unLFf] Fixation
+  [yldWiA3mhg4NAs4W] Flashing Fit
+  [fMz3XrLqxB06A0J1] Flatten Body
+  [ExYhwMcLJYudEvMa] Flip the Script
+  [H2Mjq4vkfxaZtEMV] Floating Balance
+  [jkPKKWlxEQPPf2Y2] Floating Flight
+  [hyl5HlC7YNxTmUPT] Fluid Anatomy
+  [stVN1RNLbP2kmNFx] Focus Pheromones
+  [cvkSzyFsiwGyXdou] Follow Their Lead
+  [AyyRBi2imbURHzxK] Four-Armed Climber
+  [bMFzbLqAEobIWlFL] Frequent Drifter
+  [CLVaFbrMGteLyUu6] Friendly Face
+  [CGuDSVaPHNJdEc7a] Frightening Display
+  [upAhgOzTQCTYEIHM] From Hope
+  [Sg3W3VCNbnpPgpvx] Furious Flap
+  [MzN641BnPdMmdPAj] Galaxy Brain
+  [EGuboukc6LrUd4vT] Gelid Bite
+  [4t81Su8o58GUoYtJ] Gifted Mentor
+  [Td4pZXAeuCLQEElT] Gliding Wings
+  [HiyKcS69XV98pQ2S] Glimpse of the Bloom
+  [AhpkwOnIdbZYHa8O] Glimpse the Pattern
+  [IYhooDxEG5NqFSom] Gorge
+  [tCO8xnFwEQeWWr83] Grandmother's Favorite
+  [hr2ugNVF1cvGQXkB] Grandmother's Lore
+  [gO0zaaX5fxh3IFDo] Grasping Tendrils
+  [tE1t3fwt4ukbfZ8f] Guilt Trip
+  [eRktm0QkDNNwPUEh] Hardy Transplant
+  [vjJuvP5nxrASzMzv] Harmonic Sensitivity
+  [sH0N77Uby1LcJGkj] Harmonic Shielding
+  [U720v15o8nhNwibY] Harness Cosmic Forces
+  [NyrWOc6otZLbbgsY] Headstrong
+  [nGzImHzzDBPlGQvY] Heart of Planets Lost
+  [ZiyExMCbCKHwgbzh] Heightened Paranoia
+  [13cofwVwk4XvwNSO] Heightened Thoughtsense
+  [OmKZ0EQLqd1ktdJR] Helping Hand
+  [CBuBWa9a7FgDp3x0] Hero's Edge
+  [4fUYVzqPQTfz1cNd] Hero's Perseverance
+  [a9ER2amvCuQEJODm] Heroic Last Stand
+  [PgMLakZc1aGbr9xW] Historian
+  [hvKYNmAHs0Ybgb5c] History Buff
+  [ESCBAfxDe7eHSsMI] Homeguard
+  [p2buOu0jpzCHq7Yi] Hug Master
+  [MLLODiQmze45bUIg] Hulking Corpsefolk
+  [SJATkfqF5IeTwBRd] Hurl Ally
+  [s1g2Ni6mgSQXM0H9] Hush
+  [pfTGKcKoRpiCFnnA] Hyper
+  [DDFbyNAIiKOuKTHi] I'm the Real One!
+  [MjTcpII4r52vMSrI] Icy Spelunker
+  [AzwvJEYMSLOyx2Hn] Ikeshti Lore
+  [WuSl6BGTt02jRxe6] Implacable Grappler
+  [BVfib221WePDbxfz] Impressive Lungs
+  [65j34j0yT6VaGfYT] Improv Workshop
+  [D9VmYez4TIczPdFy] Improved Conductivity
+  [qQTFMTWuhIA7kGKL] Improved Elebrian Magic
+  [t9Y0rtU5McaJUt8f] Improved Undead Senses
+  [0JLeRrEoDJcDw2Wj] Infodump
+  [ho5ZAFIrMa8Gh8u6] Inner Peace
+  [fqqmEkCgSH9R0XM3] Inner Wellspring
+  [C9i9QgKcytScNld7] Intensified Psychic Shock
+  [1MK6OXaZe9wJj6Oz] Internal Chemistry
+  [VHNHXuYDkZ7MkSnR] Intuitive Talent
+  [EfDkXkKyFZZTaLui] Just Like Rehearsal
+  [y0i2dBbVjtbYWm3U] Just the Thing...
+  [xNhWhFxh1u8U8uQz] Kalo Lore
+  [zSFfvQMPvZvgy8fP] Kasatha Lore
+  [amYdnH5YgyywTWWC] Kasatha Weapon Elegance
+  [j6Qnu67ZNnmfadkG] Kasathan Weapon Familiarity
+  [r3q6u0kOINoHMurf] Khizar Lore
+  [dp3jTnxAb98E2BCk] Kindle Blaze
+  [5IUQ1vBOaIeSOgiB] Large Reach
+  [GnhT3k213Z6iBeFG] Lashunta Lore
+  [BpeLt0TB3NiYJfSl] Leading Role
+  [RFEpLG8MwHY1Paom] Learning Experience
+  [0DiJqneDdSKZh6z3] Legend Weaver
+  [HQDXlIihi9qR7o4d] Linguistic Master
+  [MeBVpW5EIOzoEHCh] Linguistic Prodigy
+  [sdwyBgOJSAxHtbbp] Linnorm Bite
+  [yvgbvOU6r5opYlex] Living Battery
+  [WlcnVVvLPGt6uhQO] Long Whiskered
+  [eQfyOv5RKKYd2AKz] Long-Legged
+  [XMDrSEgzLGSzFz9P] Longrifle Reload
+  [YhZ1s6iEqQh2o2RW] Loping Vines
+  [G2f5Sm4Uc0UAUMDc] Lucky Improviser
+  [qITHNzTMrTnnwTaY] Luminous Wings
+  [Xo4bUJdBAsoM4DcF] Machine Saboteur
+  [cq0l8iIeN7FrvGKa] Magical Guardian
+  [kpQcCjZbCAKnQ5qW] Magical Savior
+  [zNsHuFBbMYHwP38n] Manifold Evolution
+  [nsiVrUSD16HzMGru] Manifold Masters
+  [d6QkZhtt7nJRHsyY] Mantarider
+  [Bzf7PzuQDYPaqUPt] Masked
+  [aK6zdP2tK4Y4BuXK] Masks Under Masks
+  [ak2RO5zLvrjdUchi] Massive Fists
+  [gZ7zghmY31rM2ez1] Masterful Imitation
+  [P06SIkM0OQ9sINSx] Mediator
+  [BWQQXCdv9qOy5DPp] Melodic Adaptation
+  [PLnos5N0yF3fADjD] Memories of Ashok
+  [bw1u57AB9M5wA4eS] Memory Matrix
+  [E6QDGBpiuFMtyTcJ] Memory Recovery
+  [uwbdY8k9sAZDXAu3] Memory Shield
+  [eRn7kFIHTMCl5y6g] Menacing Growl
+  [ym2RbWBf9vDzKVmJ] Menacing Snarl
+  [0ezvQlxETxMsGFx4] Mental Deflection
+  [CLqjExB2xWcFU5JN] Metabolic Manipulation
+  [Z1ZGO2UWoV6IKLaO] Method Actor
+  [6JNMOkqnVoRqkX80] Meyel's Melody
+  [GPrdVyoKBpIzE8pP] Mighty Guardian
+  [CUZl01GJ70rM004v] Mindrender
+  [CE9d04nIDzkWDbQp] Molecular Modification
+  [GUnNXgK2XNS9LqVA] Monitoring Bond
+  [fypfpE2OFpHZEXNH] Moodscales
+  [HNVF2mCiODs8SFyn] Mounted Unity
+  [IdP7WH78GovkzKrd] Mournful Howl
+  [idTznaLfjJMW9HOT] Multi-Stemmed
+  [OlSfsaJSE4Lk7wkt] Nanite Form
+  [CFljdx9UR86iC1rD] Natural Camouflage
+  [CZSit6pgL1EWdhOJ] Natural Empathy
+  [GExi3NDWqhfICneX] Natural Grace
+  [Wr07U9y4HdBXlS0M] Natural Hunter
+  [ttLeQtd7BjUGHPuf] Necrogourmand
+  [shZanzwcaGEw4tqz] Necrotized
+  [ms12IdKU40IUQEyw] Nimble Tail
+  [f7CDEE0BHxBb4IJ0] Nomad's Guard
+  [UyjHGfGyMV0c6FTp] Nomad's Persistence
+  [VSsqLuESvWHKIQAJ] Novice Necrovite
+  [dtyolFw2GkOB2vYY] Objects in Motion
+  [xlTv0VBGGwjTaWCi] Off the Top of my Head
+  [CD6stS729kh94ciV] Only Slightly Dead
+  [x2H7npi8AUSnVFaD] Opening Roar
+  [ZB9gfqzJFtGccXwm] Opportunistic Hug
+  [vhbN1xKKgOQpa9SG] Overcome Shame
+  [44w1WEbY7QXSrHHo] Overwhelming Ego
+  [f8c1MXxBARqymXKF] Pahtra Lore
+  [L1xoJKmFcGtw2hRD] Partial Corpsefolk
+  [rQsfFYEapefaGHOx] Partitioned Focus
+  [ENHAVgdMoZwpWRk1] Perfectly Balanced
+  [XUK4bZhHpWacvdXo] Persistent Confidence
+  [mRJIE8SIT4TpKWPS] Persistent Protection
+  [MKLp4V5jCZBJbCEX] Persistent Tactics
+  [ywM6SzmYVXtYExQn] Photosynthetic Regeneration
+  [9yeWpYipqip44Inv] Pinpoint Thoughtsense
+  [JNgEoH4vAaNMgqVH] Plantlike
+  [rihC7g7SmIz0nlSV] Plated Deflection
+  [I3WFIdKurB9OIYZM] Powerful Exhalation
+  [iX5qnxdVaxbIQcrQ] Predatory
+  [kQZa9Vfl7qRRSJAX] Prehensile Tail
+  [M8FE9jj4lSsZSNYy] Primafloral Adaptation
+  [h2j5UDmxAtKMyZI2] Prismatic Display
+  [crgckU918G7188aJ] Prismeni Lore
+  [PbPCMls5szAKHXtr] Proleptic Parry
+  [8VCGuAPwIs43qqFP] Prop Closet
+  [HJBsluaq58vqHlIQ] Prophet
+  [dcAVCzF4dlHEaSm4] Prophet's Premonition
+  [mttO15LzR2EJ5Ma7] Protect the Pack
+  [pPBz8XjqxxODrtSA] Prototype Electroencephalon
+  [fM77YeMtMyc2NI0a] Psychic Bully
+  [Er8wuOwAZN6cEOCU] Psychic Constellation
+  [zDrH3YGI4hJuFX2b] Psychic Investigator
+  [Ow6E0zzzspTxW9be] Psychic Master
+  [BycIrcZoimRDL8aY] Psychic Mastery
+  [UixUjTzatn3W63fw] Psychic Paragon
+  [s0Z63nGoTX3RO0hl] Psychic Scholar
+  [Lsu5dRPLTlMB5xpv] Psychic Talent
+  [CJbfmjcI3CalYa3m] Pungent Astrazoan
+  [sQXuTA06jmdrA546] Quick Break
+  [yihRg0mTC0dbZ3Fw] Quick Stow
+  [vzYKSXMmdCjNxSzQ] Quickened Processor
+  [eo9bLAmEqXV6jOOu] Range Sniper
+  [XOfQpV10BtmZzNe7] Ravenous Restoration
+  [Kw65oclKUTzN1eBC] Reactive Shapeshifting
+  [1JZw1knjquhJeZQG] Red Eye
+  [88ork3wcFUECxlfo] Reflexive Hypotheses
+  [zMkTMpxjk6w1yKCZ] Reliable Grace
+  [Zwg2i0FOossMTUNm] Remix World's Rhythm
+  [kxguGXvsFrUXRVWC] Remote Access
+  [IBug8Fc4Usf9tE1N] Repeating Role
+  [jfJUaCjGmhR7mu6O] Resonant Weapon
+  [7yIxWfNZ7yEKs0Fd] Restorative Shapeshifting
+  [dMIij0rQ3Z0bErDY] Return to the River
+  [of2jEhwftctikitr] Reunite
+  [shLQcNg3CtUQmOH7] Revitalized by the Drift
+  [hPmYo6zCElcukFWV] Ride the River Between
+  [W5wOmOJ5Y242UFNT] Rip Current
+  [jPUbNI1iFDU7NpOc] Rip, Tear
+  [oRZuA2FNSAcI9hO6] Role Repertoire
+  [HWcbrUti93ukXoqo] Ruin Delver
+  [M5XIGRr2TZKSQ3bG] Sanctuary Kin
+  [AZppgbJeG7PlzJYS] Sarcesian Lore
+  [qAQfnNjONWfukQWn] Sarcesian Weapon Familiarity
+  [0gwnLMiRtFDE8BKz] Scatter Thoughts
+  [hrr9TUkQcGdSmB4L] Scramble Tech
+  [U9Cv3DBWBjTPg1eR] Scrapper's Ingenuity
+  [t15fosCmf6isG2Vg] Scrupulous Stalker
+  [POBFsfiYDrRUonvL] Secrete Numbing Saliva
+  [60vq5OZ44Ji7KRYK] Seedling Reincarnation
+  [hQ6s9YekCTexSaId] Seedpod Lure
+  [k9K2sjAw9ocFSwfx] Seedpod Surveillance
+  [FlMtCbhm4ARYYhpt] Sense Emotions
+  [ieR9nSO7oqamY1gJ] Sense Life
+  [AcMMGduwWqnJeiX5] Sensitive Antennae
+  [Logc2RRMGScxCMex] Septocular
+  [GYuW5KhcmQBrr6da] Sequester Form
+  [toXr9sOGmGM92Vu0] Shambling Corpsefolk
+  [Wb4vtGqg2Cl2FF1k] Shed Skin
+  [Mg0yYkrCsVQ6kYLY] Sheltering Limbs
+  [YK1EqEA73pazfBkb] Shifter's Eye
+  [7Th5q3QVYL2KzKEy] Shifter's Feint
+  [R6IusnBEHihQWPF6] Shifter's Orientation
+  [F3Q7TzvYQlqZF2I2] Shifter's Reach
+  [BRQNBWlobuIvWAoU] Shifter's Shove
+  [CwvroCs8PRZdbbJ9] Shifter's Squeeze
+  [SguzfGVqJ5vOySHA] Shifting Smuggler
+  [1sw9sBje5grwUtiO] Shirren Lore
+  [gD7l0iYrsdKMCmyV] Shobhad Ferocity
+  [QfMqsY8ZEHPBRAAQ] Shobhad Lore
+  [OScdfD8SyVvGqnog] Shobhad Special
+  [MKNbEWBOT91pwRob] Shobhad Spirit-Blessed
+  [Y7AL0vuOdMorOte3] Shobhad Weapon Familiarity
+  [LmCHemr9mZQlFUMw] Shroud of Shattered Spirits
+  [s4Rr5vmMCN5DC0vf] Shy
+  [Kgtj8NRoBnWCK9qw] Sigiled Scales
+  [R52hSpOvF0ljiubW] Silent Tide
+  [0AIlka5XzyM0VAd6] Siphon Solar Vitality
+  [ri5qV0g9RwwWLiBk] Size of the Ancients
+  [eVpE7gotiKAbgQkm] Skilled Bodyguard
+  [EFkWRLQwain42TFm] Skillful Encouragement
+  [o48idQ4nRxZ4K8pd] Skittermander Lore
+  [IRl8dRNpGUTlg05Z] Skulking Strike
+  [xYvSZDBbPdMkLuIf] Skyguard
+  [n85h3CaVZCiqhlBu] Slip From Sight
+  [CEG0OyTuYerUFg97] Smug Affirmation
+  [6RPZDMPUzSJQOwRD] Song of My People
+  [OPrs0Nbhdu9FKmgC] Soul Sustenance
+  [y8cOnQWb0ZjAb794] Soul-Soother
+  [xF9qa9uFi1U5UEhs] Spectra Ascendant
+  [DIy7pCjjlKyKHcGq] Spectra Transmission
+  [nPOCgeKARJGhRpoa] Spectrasoul
+  [5BSarl3Nfs9O0E7P] Speed of Thought
+  [itv3fuCoKkZU0wZc] Spirit's Protection
+  [oOeW0NOc1saY8B3D] Spirit-Blessed Protections
+  [Mec5rU0SOB28Hqq2] Spiritual Wards
+  [32W1Pnex4xbhx5Bj] Squirt Blood
+  [spIr4dKoOld003LY] Stand Aside
+  [Mt9aWD58GblCbuDL] Stubborn Corpse
+  [dTSvva2NW1kq6BT3] Student of the Unseen
+  [QImUeDyZg8KKzNdx] Stunt Double
+  [eYL5cEaLyjZvRH7N] Stunt Work
+  [hnL4m8dv53YkGDOE] Sturdy Vine
+  [tEDa3aTb0rUt0wox] Suction Cups
+  [5fcBv1Vu7C213hzw] Supernatural Soothing
+  [L9IUYeXqWVrGlgke] Supersonic Speed
+  [0U2qfko6c3XBaYm7] Surface Strider
+  [DnK9XekYYKA3NqrC] Surprising Escape
+  [WXyalVd471MVyoN6] Survivor's Instincts
+  [R9K6Wgm2jYQMyHGX] Swarm Evolution
+  [ypSQT2urAcrgaoQ1] Sway the Heart, Stoke the Spirit
+  [F3K4I4GWdty1Y5DM] Swerveshift
+  [nJDNq0cNJn0bgqKm] Synchronized Initiative
+  [j3Q78pOsFlConHDw] Synthetic Speech
+  [kwJB7fZABo1IvGi0] Tactical Bond
+  [4v1tOyYEGM1KOVRu] Tactical Bully
+  [IuIzLQr2xkwJmnVH] Tale Spinner
+  [r8O7PCk2rsVBneWy] Talented Tracker
+  [O8ozWpzId4uhICQw] Talon Transporter
+  [dfbgBVXd3B9enbvV] Tech Caster
+  [AvfH1TgQFIOkHp5n] Tech Familiarity
+  [Cj9UI2RZL6WBJ6EB] Telekinetic Titan
+  [OwKhWs0Qk0DCFHSM] Telepathic Conduit
+  [bqQ80aCjgigKSJMY] Telepredict
+  [s2ZpBKkDtbIzlbCU] Tentacle Whip
+  [r1huiuhhfdWGB9vL] Terrifying Bravado
+  [akrQJ3KbYdSQGc0m] The Science of Motion
+  [L0MUHNikE5fo2DQY] Thermal Conversion
+  [Cizv80DJNxT9OCrN] Thick Skins
+  [lPTZmZhjdHyxYpuz] Thoughtful Insight
+  [cwhtA9D80XcPfnhF] Timber!
+  [1ZL3tUfStY1rPtST] Too Stubborn to Die
+  [zSc4smZxmfgJlqWn] Touch The Sky
+  [deGy1JMa2uLfKnIb] Toxic Transference
+  [cgruXxdR2cqjVk09] Transforming Huddle
+  [QCNC3ooL3fD1y2ht] Travel-Tongue
+  [eq8KM8jS8vvqdNrh] Trek the Frigid Wastes
+  [7LT4uNsB7RqwaKvs] Triune's Chosen
+  [j1bp3PT5rfbUlyxx] Twitching Muscles
+  [6n8lPrRSBvWu9Dpa] Two Minds, One Soul
+  [iOl69a3tgFR7WrEv] Ultimate Spacefarer
+  [6TqlX6m01QSQatom] Uncanny Comprehension
+  [5snnXHrqo5NSfQ4k] Uncontrollable
+  [FKomeKpgy7NUA2Hb] Undead Scholar
+  [ZY7n1EwpR86duTIK] Undead Senses
+  [GfsYdvVDWOJWeL5t] Underfoot
+  [9jDc7rybWCK4CZok] Underwater Combatant
+  [Z1gVcykXan7GDWeh] Undying
+  [tgdUzgGuFjRxFcQY] Undying Defiance
+  [JMpRc0eGNjSUN5pK] Universal Telepath
+  [74PrrTXPLMPwHTi0] Universal Translator
+  [LEDQYYh1uYiK5qjU] Unleash Pneuma
+  [c0Jduoit1Lzo7gxF] Unleash Sota's Flame
+  [zJzo0bkZlfiTL0jD] Unliving Memories
+  [na4oi7S1tpD1loVj] Unquenchable Breath
+  [6bJ11ho9L4JomESi] Unseen Tides
+  [WUMwOGndWF6iaAKK] Unsettling Display
+  [ruiw4DcY40C58F8f] Urchin
+  [aQoNgLD8WhthMFyP] Use the Scenery
+  [e9uXXN7GOtWBGz09] Vent Gas
+  [Qf5yZFh4RAamNGVC] Versatile Outfit
+  [zSRfyW0RVBN8mgnI] Vesk Weapon Familiarity
+  [txi5BrSLw29aCdze] Vicious Breath
+  [GBO7qD31Ie0lHkTX] Vicious Takedown
+  [NzI8UeSgnxFtRQ8J] Vital Sap
+  [fzgkmQV00X7QuOXq] Vlaka Lore
+  [8xtxZYud9OULEa72] Void Blood
+  [179D1ll6jPitkdHb] Void Sight
+  [4Q2shCcRIzCtDIdO] Voidstrong
+  [6jNni17eQ3k3vwbh] Well of Vitality
+  [NUZClDNinM6oVgJN] Willful Defiance
+  [Egwaz4EJUJuAL7fJ] Work's Never Done
+  [cTBp5oAwNOSMR59x] Working Artist
+  [ogC4qn7wNOnjVswv] Wriggling Contortionist
+  [mQYO501xyMgtIQ3W] Ysoki Lore
+  [o7xxuslqMeEvsqha] Zoomies
+Feat/Feature (Ancestry Feature)
+  [STjiyuU7xqYmomSP] Atrophied
+  [KRRhNw25Ys5PO9Zf] Cold-Adapted
+  [B7iYVc6y7zKniJkX] Energy Wings
+  [jwBbIr07dlAfrow8] Four-Armed
+  [83O5vLT0CiahoOds] Genetic Adaptation
+  [N9EDgQPjWcSS6rSb] Limited Telepathy
+  [6Br8G6BBZ0xWw7Pj] Magical Sense
+  [fD4YQ2Hq7929t8p2] Partner Bond
+  [cuEGqGBU1pRhMW1D] Sensory Diversity
+  [cIrL2cSC1rCIBVDa] Six-Armed
+  [QurWzrxrUpo2ywih] Suspended Respiration
+  [HOYa3N9R5VLS1kvv] Thoughtsense
+  [n9vli6v60O21ELYs] Verdant
+  [1UDBixyOSXzgK5AJ] Versed
+  [6o7O13zkqKE1kvgQ] Wasteland Survivor
+Feat/Feature (Class Feat)
+  [aRQhgf7tLFMfsHMa] 360 No Scope
+  [MRfRe8pL4rzDrXRE] AbadarCorp Rep Dedication
+  [IJvX7FJ40i84XPuR] According to My Calculations
+  [Cst3eALyEAakkmjy] Acquire Asset
+  [y0dtKu1ZuwqMUFEf] Adaptive Defense
+  [DTTFeuW10H7QRAlE] Adaptive Talent
+  [Ea4bswXApUsR4dGW] Advanced Distortion
+  [LvhBb8noKNc2A3EG] Advanced Epiphany
+  [E6qvaboWcvQXhoFT] Advanced Gunner
+  [WOZoG1rikcQ0eCb4] Advanced Leadership
+  [BLUUkk43oBILzC8s] Advanced Mysticism
+  [U0FX5NnFLYj3eTv1] Advanced Soldier Training
+  [wAerjBkKUHYXNbmB] Advanced Stellar Attunement
+  [fq19VhHnQ8Ho8FVC] Advanced Warp
+  [dvbF2j5DKQgliV4p] Always on Alert
+  [Qbg2LpdgXJi7Sd97] Ammo Hoarder
+  [jlfPjyWEzxQ2GiDh] Anchoring Impacts
+  [miDSBlxDcJdUn9n1] Anchoring Strike
+  [ydZJRxWQSxN3Y7IN] Ascended Stability
+  [PdqQ8AXG3jPABM98] Attuned Blow
+  [eTefuy0BRvwAcqbQ] Attuned Wards
+  [qdYOLC9JVaA8tGuR] Basic Distortion
+  [ILx4TaKIN9SEtRhh] Basic Epiphany
+  [B8LtCLANsVLU85zv] Basic Gunner
+  [7oChczYtNoWFII3r] Basic Leadership
+  [aE3S7P6x9p1HRJtl] Basic Mystic Spellcasting
+  [9x7Ke7cc6BUheOUJ] Basic Mysticism
+  [jISf3f2KiAj56NJD] Basic Quantum Field
+  [DlrCIyIAXZqoHFMx] Basic Soldier Training
+  [RRjp2xNrzVQO9sDp] Basic Stellar Attunement
+  [g7xhT2A6IqTohPCU] Basic Warp Spell
+  [ZkKybSkWvM1Xbr2T] Basic Witchwarper Spellcasting
+  [sdf1sR7OjAx5Ljnw] Big Bang
+  [N8df8eJqEFiVDdmJ] Binaric Assault
+  [51dFA09erqAeMt39] Black Hole
+  [s0vrkx346PLPbP3R] Bloody Wounds
+  [LGrCVzOvUayHW1Pu] Bond Boost
+  [ANmwfBz6O24D5Zje] Bond Spell
+  [k4n019dm7hx2uBU5] Borrow Spell
+  [3mMNEAr5wgTFC9mC] Bring it On!
+  [1FeZiKaHCoKpnsMb] Broadside Charge
+  [ElhRgSo375ERugIJ] Brutal Barrage
+  [J9MbGFyEZscnEaWU] Bullet Dance
+  [9RqJNPSx5T6b2WoB] Bullet Fever
+  [O3HJRpkDbnoO9Prn] Bullet Hell
+  [1itdVNkZwFaOlZi4] Bullet Typhoon
+  [04KKDJvHThu2hLa5] Burst Fire
+  [nhrviadHL9h3xjff] Burst of Strength
+  [aQ2VW51nBxfNXaTQ] Byzantine Linguistics
+  [js2Qwj7qqY3NExtL] Careful Strike
+  [bTiv9Yd6WJR6vFys] Change of Plans
+  [aNlH5doV7DLZ037x] Cheer Up
+  [uoFMox9RchlL7Jbm] Clinging Flare
+  [6PFzTOcdoOudpPy0] Cloaking Field
+  [ZH19WJdxc48e3tS1] Cloud Storage
+  [F02phoqX8X60SnyZ] Clustered Shots
+  [Yg8YVRLLfV7kGjCM] Collateral Witness
+  [oxgaZD7FcFE9yUyG] Combat Reflexes
+  [HhjmPcqAtOZOXHaJ] Come Get Some!
+  [NYMnnMJMLw3aiciu] Complete Transposition
+  [6AMH5DfG2cSz1tY0] Concentrated Shot
+  [WR4Ziq4PIq2HFWyv] Confounding Disquisition
+  [xCeTKPGMrwK2tWKX] Constellation Vortex
+  [yasxZn3sgWv55kFC] Convert Elemental Essence
+  [Qa0YQRBJj8TNmEVX] Convert Illumination
+  [TmcPmncR1Y8sjPLz] Convert Information
+  [cA2llXc5XTOVUjgx] Convert Life Force
+  [5j38DYLlhZi2kfWK] Convert Tempo
+  [ai1n3ZCBbM5VEGPo] Coordinated Fire
+  [s3AFgP78spcJGBt0] Corona
+  [RnKrdgguZzuVb8Tv] Corporate Speak
+  [fjBHwVDDGGKJsEeD] Cosmic Alignment
+  [dgJ0Ms2ES0JO5BOk] Cosmic Infusion
+  [bSNHMpq5e4ZYOyWo] Covering Fire
+  [9RgKTogyOlvbf0LH] Covering Flare
+  [BL34yKdTM1gPrBAK] Cut 'Em Deep
+  [7r4QYITcF7LcaagL] Damoritosh's Grip
+  [iQPcSeXhRdIAVTS5] Dance!
+  [FnAzJ4DIRPJJaGv7] Danger Awareness
+  [ryCmTz9Z62qbtmQM] Danger Zone
+  [pLNk9TItSEulQWfq] Data Bond
+  [gibsdQ8jgyL8FZQc] Death Blossom
+  [sW7AbeYfKc8OH7nG] Debris Zone
+  [bDoUr1qdg0cZphbK] Defensive Gunner
+  [gqFni8l7l9fJZ43V] Defy Gravity
+  [oCR1IV0v8IXh67Ry] Destructive Dash
+  [G2BRjjJodqDDCVan] Devastating Aim
+  [z5ezBD83rgjvP7ek] Dirty Retort
+  [CMnwG6ScqfbEKr7N] Disarming Shot
+  [LH1IEKqeb5wYj1XR] Disperse!
+  [1X0VMGiCNhPPVleL] Distant Feint
+  [eYZnpU0uGSFyCRNF] Distant Flare
+  [Y2CHy6HTI11oT3dR] Diverse Schemes
+  [i98LKe4OVRfvo33P] Divine Bond
+  [zvNI1GGW7xzA677q] Don't Touch That!
+  [onFpn2IPCZEm5mBb] Don't You Die on Me
+  [l5v7SnMbgsVGCsMA] Double Tap
+  [45uuX5EppO0FgilY] Down to the Wire
+  [hE7UxbuJvB1PsB6x] Dual Aim
+  [aHslHBTkkPHQUBFX] Eclipse Strike
+  [cMbBH7RBX6Qtrym3] Effortless Influencer
+  [Cs73duFVDLIcTBZ7] Eldritch Bond
+  [3f9HwoDToOh3jvXi] Elusive Target
+  [kTmHzD83BRz8bvmg] Endlessly Adaptive
+  [Z96whXmfXXXfXp34] Enlarge Quantum Field
+  [WLXWLYl4J8IIKpZh] Enlightenment
+  [wUqOzEWcNX9ohLE2] Envoy Dedication
+  [0tF69rIc308iAbaq] Expanded Connection
+  [vlUtA0fGdDcyNA37] Expert Mystic Spellcasting
+  [GgZfDFqZsvdT9ohg] Expert Witchwarper Spellcasting
+  [nIwH5MjTHCkQe7C6] Explosive Deflection
+  [BUt7LSUaHTmjtKIx] Extend Directive
+  [wdziWIdMnc6MgurV] Extended Vitality
+  [yQysR8OZFrL4Arlf] Extreme Accuracy
+  [vO9uljpsyAyjDe5h] Fan the Hammer
+  [gnNtZKaHCLbdi0uQ] Fast Synergy
+  [cDxFPXDuZpDbJEgU] Fish in a Barrel
+  [vrYm2kc7lnwE2Hqo] Flicker Strike
+  [UF45fuzJXbl04r2b] Fog of War
+  [2iVU7Qq0f2lzsAnG] Folded Paradoxes
+  [6mQYPkXeWjvO9CcG] Follow-Up Fire
+  [QZTPMHVvZSlDrnCF] Fundamental Understanding
+  [GbG5m7R3ZjvHXq3Z] Galactic Bond
+  [WFLC2BR50XGhyHtI] Get Them!
+  [ndYnIz8DvI8RpAup] Get in There!
+  [2zE1Q9TSj5utOTJz] Go to Ground!
+  [15v6nXEIi10i0CNI] Got 'Em
+  [os6a17z3yBlbTV9Z] Grazing Shot
+  [aFThHBV8YyYerNpf] Greater Epiphany
+  [Q6iBJ7entZwxUqF5] Greater Warp
+  [OW2RzoTyDGm1tl0x] Gun Expert
+  [7v5tuehEjmQStncQ] Hammer the Nail
+  [Nh1QHQqbLXcMLRdo] Hampering Flare
+  [W80bGpWLBSCLP9QE] Hampering Shot
+  [YRy857LORIhKOgbY] Hang in There
+  [ELkCf9SO5URWXP0R] Harmonic Convergence
+  [uLZcelY6CTKJOOLU] Homing Mote
+  [G2Kxj7nNDkvWE1LC] Hurry
+  [q5Z3MubN2nioQ986] Hybrid Technique
+  [RHwcB2VGOHW0PN6k] I'll Be Back
+  [UPFUN2iKxHOHEZAD] Impeding Shot
+  [JSIlPiYbFOY1NkxV] Improvised Legend
+  [ktfCt5Vi1fLI5TUY] In Another Life
+  [WpJCB3dCycbIzG3w] Infernal Armaments
+  [3SJtpZK58WKpC2SO] Infernal Bulwark
+  [VHAkNf4SY5FIaEB3] Infinite Aim
+  [sHb5WHG22V425uIO] Infinite Magic
+  [3ObXjbScOIOuyRCk] Influence
+  [67LsozN4cJKHEWdN] Infused Spell
+  [I3SKICQDCaNuQ9QZ] Instinctive Aim
+  [8EnKNTqKEZJBoIQb] Intimidating Taunt
+  [WcDJMMPoAO2v26TN] Iomedae's Barrage
+  [eJBTtj66SdMvLoQM] Iomedae's Helm
+  [ZOuBKbHt7E3BrksL] Iomedae's Shield
+  [4Yxq6DxG3K9f41zK] Iomedae's Sword
+  [4bMox7VXPrLzKsV8] Keep Them in Your Sights
+  [DG1zn37jIWSz6uLm] Kick it Into Overdrive
+  [fyy19HaSmtKsnepl] Kill Shot
+  [99JrVhP4zKe3CAxZ] Kill Steal
+  [Z0lKny0VVq0zf3UY] Knight of Golarion Dedication
+  [bUQPddjc1Y7CpLBh] Leader's Confidence
+  [AE5ScIq8t4waaVXU] Life Bond
+  [TbHoIKZdGtHaS9Ct] Light 'Em Up
+  [gtYPdUsrTehjcbxZ] Line 'em Up
+  [J1XVWYiR17es8m0m] Load-Bearing Hero
+  [JYF9KC95ItpwkCwn] Look Alive
+  [gzVKE7AgtPtmNHYe] Master Mystic Spellcasting
+  [864e9sSCKDcz7YDD] Master Plan
+  [UKN0Vm7kR7J2SsWj] Master Spy
+  [2xEv22i8cPgGrmBb] Master Witchwarper Spellcasting
+  [U0g9zLZAat8RMJvx] Meandering Mind
+  [d8ekF23HTScyOrbr] Meditative Analysis
+  [ulDDuZsHQsqHKEmj] Menacing Laughter
+  [pOQv4G8pLP6SWbmr] Mental Interference
+  [KYdtXJXPBbLMRUB6] Mindward Shield
+  [0jw2LbYkT7WkfYi4] Mission Briefing
+  [rWDM8q30Fay713In] Mobile Aim
+  [Uz6dTsSRif8UYWLN] Momentum
+  [e8SJU9NmM35Z6huK] Multiverse Magic
+  [LTkzlr9KZrVpbg09] Mutable Manifestation
+  [BK1xOBi8FSrt5Lfg] Muzzle Flash
+  [7kCWmCSwlKQqQkLh] Mystic Dedication
+  [4fnH8jSNVKHLj7MM] Network Attunement
+  [etCe8dSuMyv1uS1O] Network Shield
+  [BG4JNxkFYzGD2rJs] New Epiphany
+  [aqjGTsGT2aPUxC92] Nimbus Block
+  [hAOjYvcgTbWQffbT] Nimbus Ward
+  [OlIuxKxrKAeDklfN] Not in the Face
+  [9BiW7yzDpWkj7hnv] Offensive Defense
+  [Wavi0q21NJNXkA6F] Opening Volley
+  [V0Qm2R3YUmS9fKrE] Operative Dedication
+  [Dd2326p0pqJaAwxi] Operative Exploit
+  [0qw5IWck23QimHc6] Operative Resiliency
+  [GPFYj9TF7UzQWois] Opportune Retort
+  [U6ZzAyFSTI3WuanL] Otherworldly Spell
+  [fa0mijOTL37Nj3bk] Overkill
+  [OYLDlfwTOJef049H] Overwatch
+  [oxTOc7LL2FvpZaWy] Overwhelming Assault
+  [coyJHvbNqAci90Zg] Overwhelming Shot
+  [L9sq9ROk0QFil5wl] Pardon Me
+  [WBrg7BsHa8ylkigL] Parkour
+  [gSnImgOmBlHIahrH] Peek
+  [qARRA5ro0HhvT6vs] Perfectly-Attuned
+  [fr0GiGA5O9lkR7re] Persistent Quantum Field
+  [Ts9l3J6pH1GPsL2W] Pin Down
+  [gT70L4yEjpklDkxZ] Pirate's Parry
+  [SEqvBdZITnGXTIhS] Planetary Bond
+  [kPndV25wPdTvTriq] Planetary Reincarnation
+  [OHZnPdwQe1GKwhMi] Plasma Ejection
+  [yf6ank3QcOwUZQ5A] Practiced Escape
+  [81REBETJHky5GRrB] Predict Outcome
+  [M4WSRMcWSg95S0fP] Predictive Positioning
+  [vjNtbPCT4SatU894] Press-Gang the Soul
+  [aezc7s7aGw8wJgAV] Primary Target
+  [HIHxmK5e02Mf2rE7] Propulsive Shield
+  [staCd7NUtYoa6Fnk] Punishing Salvo
+  [fwIazuCZJxGREspo] Punitive Strike
+  [z0RLX3kWgdaILzmr] Quantum Aura
+  [PZPSwGS5mR1B66dA] Quantum Breadth
+  [oRX1j8w0hMSivJjJ] Quantum Entanglement
+  [vIDD8TD5EIOjRISq] Quantum Negation
+  [CVCT9Nay7nfEFAuj] Quantum Recycle
+  [MVT7iJNv6L3y2eL9] Quantum Research
+  [myRqOBWiyTlnPM92] Quick Swap
+  [OjoM1PJ5RlXg2LtD] Quip
+  [gdAHbyEjIQMf2ARy] Radiant Bond
+  [IEPUsAbgkkdSAFFz] Radiant Zone
+  [7eSdek1tvNhQ61dU] Ready For Trouble
+  [4041QDrSgYeFDt2g] Ready Reload
+  [L8IpPIJUOFVDhSoY] Ready to Roll
+  [Ih5wL2VqcCkO38OJ] Realized Epiphany
+  [3ahX6ykhR0eUbvGX] Really Get Em!
+  [5bI24fWYB9uK7MuR] Relentless Aim
+  [o2Tknvim2UP2W6Yk] Relentless Endurance
+  [yoQdsiWMihueF5L0] Rocket Jump
+  [nLQqltDF93pHHjLg] Run Hot
+  [8ToT45Je3wD1ZJVH] Run, Cowards!
+  [vINNCMp04vI26mej] Running Shot
+  [cI7HyW33qezimXWG] Sales Pitch
+  [nnnx5sO11sG3M200] Saw it Coming
+  [JSuwtcZgbz3fkyVX] Scattering Fire
+  [rhEfisGERMwwn0qz] Scope Sight
+  [0lq5ZSFzkbvSspZN] Scrub Psyche
+  [GYk8nKT8abT5S5NO] Search High and Low!
+  [oXWgo98rXjrxILa0] Secondary Directive
+  [kxyys4AseS9UgFYf] Sense Abnormalities
+  [YRAFkSogKx3WhxPc] Share Quantum Aura
+  [KNAHp7MLPMso8K3d] Sharpshooter
+  [4XYoe783SsKoVCsA] Shattering Impact
+  [dLcXl7VrHp34vwxb] Shell Shower
+  [dk5yvNJacVCxVYOd] Shot on the Run
+  [fSqUeSAFhvBfq4sE] Shoving Shot
+  [kTXp7QPeIlNfl5CN] Singularity
+  [mHcZdkio6UmPGXpD] Situational Awareness
+  [iHzfiebxLxN3ogpH] Size Up
+  [enYJDAwYFLhrqDrP] Smooth Diversions
+  [mwzOiGNsDVhuylfC] Solar Barrage
+  [1udHBHV6m2JFFtd1] Solar Flare
+  [ZqDLcOYIGlAB5qzN] Solar Manifestation Expert
+  [pUjY86BZzj5pFbDa] Solar Nimbus
+  [rU32khCvtNY7Pb1r] Solar Rampart
+  [hKkUTNTjRztyRSJr] Solar Shield
+  [Ee3rEmM1ZSuGxohf] Solar Weapon Customization
+  [wv5mub14JX8lHXFC] Solar Wind
+  [1hp73yUEZoKWaV27] Solarian Dedication
+  [VXUhOC7xHqoJXy21] Solarian's Resiliency
+  [5U1q1pLm3eBIHCXl] Soldier Dedication
+  [7usqQckH1Mx2FzqC] Soldier's Resiliency
+  [RhiQWWUdbwoUqBOD] Soldier's Toughness
+  [RWmxZ5irZu25bytb] Soldier's Training
+  [MZAza87U33qs68Ky] Soothing Anchor
+  [rgDcqcd7whBvFU0X] Soul Furnace
+  [8aGoy6Jaw4pDFZyN] Space Pirate Dedication
+  [uc5siPW4LQ5eXviI] Specialized Operative
+  [nygEe8US6gwSPJ9t] Spellsurge Ammo
+  [pFr1JyMlyiVVsNDV] Spot Healing
+  [2lZzp2B03JhLQmhd] Spread the Love
+  [Mktaz78MaDtR4pxx] Sprint
+  [3HmrwfbkjMHn6jw0] Star Brand
+  [kWOLT8dsYXWwmk2l] Starfinder Field Agent Dedication
+  [725sU5S9ZXXpkO1P] Starfinder Provisions
+  [jks2kk95Mt47rW6r] Statistical Anomaly
+  [7nogykxuNzdaRfnf] Stellar Rush
+  [r5FD2LZ9kWOhDPby] Stellar Shield Collapse
+  [W75pq86D7sYW6Myx] Stop Them in Their Tracks
+  [71DtcZirJ9bbKMTY] Supernova
+  [ITyH6Le70UdKBXea] Suppressing Fire
+  [RbZCiRjHjF8g081P] Swap Upgrades
+  [D7txRQIC586uOZMd] Swift Reposition
+  [7z2jStHaxZbk1mhH] Switch Target
+  [uQQ9v2KdOaKi67dY] Syncretic Epiphany
+  [c0TkeJ8LytJ5A6A1] Tactical Advance
+  [YhnO1igW6Ds2n4C7] Tactical Swap
+  [86YwN8XwJdk2kTgQ] Take 'Em Alive!
+  [QpHJD3PSRSxq7Vu5] Terror-Forming
+  [v1WEgt6b1ZWczZvp] That'll Show 'Em
+  [u83c2XAxja0lLTfN] Toppling Shot
+  [6tu2lS0CgxiDMHVO] Transcended Existence
+  [zAeC7qKVJdfjcC0P] Tripartite Mind
+  [nH8j68JCBvrQX8tp] True Leader
+  [QvOGVk20XzN3xDSQ] Twin Draw
+  [V0OlaVWSTWUh1qvm] Twin Guard
+  [HPmI5ITOpwvbWQCQ] Twin Shooter
+  [Mett2INmoUZxE0CR] Twin Weapons
+  [rTebGqlQpa420YQy] Twisted Dark Zone
+  [xalt79rSmmtHjbQW] Unhindered Advance
+  [sKZJDPCrCehAC3Sq] Unleash Hell!
+  [2Ye5H37ZP0AYpxHT] Unstable Flare
+  [Byflan3ypJEPDwby] Unstoppable Directives
+  [9OSyLqbvtNU028ae] Vector Reflector
+  [BuTSr1Lo8vRxZ2cb] Veteran Trap Finder
+  [kK5JtGm6PQh7DT7Q] Vitality Network
+  [z49Npry4YAYHnG1V] Vitality Web
+  [PRKr7ugCsMdaDrdK] Warp Wounds
+  [G3n7BdG56o6qnF1h] Waste Not
+  [60BRmtuNHT6mpJOH] Watch Out
+  [3M56DryKBFBpODrX] Weakening Shot
+  [xND8wnEdnGSq84kn] Whirling Swipe
+  [B2BaUMz72Q2Z5CSe] Widen Area
+  [IPkqRIWf8riO0krc] Wild Bond
+  [P8nPDOlSIiKnkQAy] Witchwarper Dedication
+  [afWWdc7Fc7p93fQg] Wormhole
+  [i5OwninARF668ud8] Xenoarchaeologist Dedication
+  [3Jc7lz6O0M7aObtE] Xenodruid Bond
+  [UTA9Fk6V6tPFkMdj] Xenodruid Dedication
+  [IKubKJb9vqFi0hFE] You Can Do It
+  [M8kAxAXWRRWMRTzT] You'll Have to Go Through Me!
+  [MsCW9UEjyWS73vz9] Zone Overlap
+Feat/Feature (Class Feature)
+  [ajzZpzc8uMtgU6N8] Action Hero
+  [9nO9EkhE1TiS0Yh6] Adaptive Talent
+  [fM1vlupLq9Zlyt7C] Akashic
+  [42tQJXhySw9QKcn6] Analyst
+  [aBe79UixtYqZKwtv] Anchor
+  [hFIB6wlYGK93zl4g] Anomaly
+  [T78VQC8oaD1Odz1k] Armor Storm
+  [VDEYb7aAwAjBp8Av] Bombard
+  [5mOTKBsn8OsEvFaA] Close Quarters
+  [68j2yQ0lamRuR6oF] Connection
+  [ENxkQJEIkz35yuMT] Core Memories
+  [mn0U5WmxlYuRrsGT] Critical Aim
+  [AurhNoZmNNhHktx6] Elemental
+  [f9dNcZi9kzbaGl8M] Envoy Directives
+  [ZXDU1AYQakFVEovf] Envoy Expertise
+  [FSAqTE67445EvyX8] Erudite Warrior
+  [wz7AMXiqMxMdULHs] Fearsome Bulwark
+  [idjill6Zh7b3SLqE] Focal Point
+  [fkRGEE9raPLD8NpN] Focused
+  [u2dy5FMDv30UH8HC] From the Front
+  [KEoTccJlfKzMk19l] From the Shadows
+  [SfHIy6u6IYYCgK3w] Galaxy Renowned
+  [1E12XmyqzIK1jXrY] Gap Influenced
+  [1bgDbGzALewzo7cy] Ghost
+  [aDCKR3sl5dzTFa3S] Gravitas
+  [trdD4tm2VZrHQYni] Group Chat
+  [jaGIV3t7G07F0qda] Guns Blazing
+  [XV8C2ASALC65G5MH] Healing
+  [M9TRPDyDZI4dDFCJ] Hidden Agenda
+  [sqSpxpY0831nV1wc] Improvised Mastery
+  [RIUhD5eldHzBsFIe] In the Spotlight
+  [bzZxqUzt5sjcbyZa] Incredible Senses
+  [u4hB3FGFJwGtjrZB] Infiltrator
+  [GTmdHGLcuc11Bizi] Infosphere Director
+  [DlE8xw6WF1t7ICny] Initial Epiphany
+  [8bE9icPZbaqFDGlC] Inscrutable
+  [QslkWkHbHQEvWFCL] Isolated Spell Matrix
+  [9g0pgy75Gd1hcrM8] Leader's Confidence
+  [Fni0F4rfaG08nO1Y] Leadership Style
+  [e5vmlTZ2zbYak1Yp] Legendary Gunner
+  [Ng1FaH8JnQWwuA6g] Legendary Improvisation
+  [lCzX29XTGKHvMiBe] Legendary Soldier
+  [zqUdEySBPebaErKZ] Master Gunner
+  [kvyqzqiWsIrBZt6h] Mystic Bond
+  [HTPor4UvcZ2CBLGh] Mystic Spellcasting
+  [tvuvMnV3laXgKlXM] On the Move
+  [E8Nx7wgn1nxqiUcN] Operative Expertise
+  [8OobrKN53cceDHmI] Operative Resilience
+  [ZAiCSJ8Vg4vgJODt] Operative's Edge
+  [oUyCwa9Usbv0RXpA] Operative's Specialization
+  [TJ6x3cwFzlZmpglX] Paradox
+  [99RXzaPifPIiZXv6] Perfect Harmony
+  [cxBVbSITniNRwfMi] Precog
+  [oFwbBK5c2yk1FD0c] Primary Target
+  [OTac5ufg6zuerW2U] Quantum Defenses
+  [iDZVHCu8Iwl8OCPg] Quantum Field
+  [NgXjtkNTKUcaGk6s] Quantum Thesis
+  [5eGnpfSduO6QeFcZ] Quantum Will
+  [ckV4AMjqPv3a8i1J] Reflex Mastery
+  [2vTSmlYIttoIEwjh] Resilient Soul
+  [jV9LIUswOPkVRC49] Rhythm
+  [r8lFIZb9U84x2PbQ] Savvy Improviser
+  [kvmpnKMVw4wwGk8c] Shadow
+  [YWgkncF2cFzvqXKy] Sharpshooter
+  [aNjblp6lHFILQY3e] Silver Tongue
+  [HSKJ1VkPdlMkcqzc] Skirmisher
+  [OCWsQQ95P7ecp7Rn] Sniper
+  [uUzVTZ7XohXlavB6] Solar Manifestations
+  [Pi0J21KfcqPi5z8N] Solar Weapon Expertise
+  [IzvRwi14ni4jgwZn] Solarian Expertise
+  [i4BxqSCrc7jj0Qzg] Solarian Mastery
+  [cC0kO5gP0FKFtdiF] Solarian Weapon Mastery
+  [EDPwZPU83FuSZ89r] Soldier Expertise
+  [SDFjJXIoIdOSPMSc] Soldier Fighting Style
+  [bqqCQKroiW9dGPzb] Soldier Weapon Expert
+  [ohkzxDNZqST1avRc] Soldier Weapon Mastery
+  [iOGvwhx11XetNT9p] Soldier's Resolution
+  [N6fZPvGFrS8LZgnE] Specialized Skill Set
+  [kZ7qB7yZMRCdMad3] Stellar Attunement
+  [NU0g3Cmq8BSXneVA] Stellar Paragon
+  [LZ5m0ykyzJbUr6bb] Stellar Partition
+  [Cait1ugGIGFlZrPD] Stellar Resilience
+  [1HTIyZc7ZTqiGzMt] Stellar Senses
+  [EpxKCi6G0KnWQhHP] Striker
+  [cJ8j2FKJxmL8HZG2] Suppressing Fire
+  [GBIcDtot2q7pQt5d] Tactical Barrage
+  [92UyrMU8lS21iZSO] Tactician
+  [Z1sThY5XgXiXQBIy] Tangible Object
+  [6cFaxZ4aAhuUbnwi] Through Desperate Times
+  [ZwyuKa2N7QJdPUzN] Tough as Nails
+  [cI27Sd5IacN9OeDe] Transcendence
+  [0XdFDw5UmkUgaNNG] Unshakable Juggernaut
+  [5fAXLfqq1dEbFiTj] Urban Operator
+  [hNnIAyBxfQ2Howp2] Vitality Network
+  [8E1y9iptQCmZDBHJ] Walking Armory
+  [2BkdnQRLTNf16bb0] Warped Infinities
+  [R478sqSSEwGEzfML] Wise to the Game
+  [h5toU3dCzHeSj50h] Witchwarper Spellcasting
+Feat/Feature (General Feat)
+  [sEb6KmjQVdWNTqiu] Augmented Body
+  [9S5mBcJujWOYCE6j] Barricade
+Feat/Feature (Pfsboon)
+  [gEqeu6VeRgLv9VSb] Expanded Summoning - Pathfinder Monster Core
+  [ebOjHK6h0FRGa7Ly] Legacy Admittance: Dwarf
+  [WUY98tLIf8lkE3Zl] Legacy Admittance: Elf
+  [tEp37YsTS6rnOYQq] Legacy Admittance: Gnome
+  [oTmQbomCrg4Pex0I] Legacy Admittance: Goblin
+  [f2u3oYoRB7fpvGIV] Legacy Admittance: Halfling
+  [QBBcVSa6TlYCBg7g] Legacy Admittance: Leshy
+  [aQT82H8YZcCRxebG] Mnemonic Editor
+  [NyJweIysfjINA60g] Revival Protocol
+  [Ir7hAz0wFpcmxFCD] Secondary Initiation
+  [xhPIyGraTCvjqIfW] Starfinder Condition Removal
+Feat/Feature (Skill Feat)
+  [xQQgbsRjFWp7dZhU] Akashic Sync
+  [MoFlThCPOrJj5t5u] Akashic Transcendence
+  [49lDxXmZZ0eJFI78] Blend In
+  [abcKcLvAGE5AKig4] Combat Hack
+  [JFPGW8OiYNYtOYOL] Crowd Control
+  [lqdeHNRyaa2EfXXG] Crowd Surfing
+  [Wc26O3XFKxWfxY5N] Deadlift
+  [s5q9GB5PHCUHCIbt] Deific Obedience
+  [Bi0wdUuHsLxvSqrJ] Digital Ambassador
+  [0ZNErs9RICfOw1Nf] Digital Diversion
+  [tNhDIAP90tt3XOPW] Dive for Cover
+  [nbwTRNqbVwy7io1d] Do You Know Who I Work For?
+  [VxmkzyDr4ShmJnNZ] Electrical Engineer
+  [N68CjcvYmLF35KrD] Face in the Crowd
+  [XeL6uygxW4u2vMkF] Favored Disguise
+  [Q6vXNDmTwDom59GV] Feign Death
+  [CkYOYzeZUKWeeJVw] Fly Anything
+  [RdCEfz6Mn8IP1RDM] Fool the Camera
+  [GBGvxPo6rnlEXFMg] Hologram Skeptic
+  [zdycsO9Z0wHBZ17k] Intimidating Shot
+  [wlYpPyBKa0rT52Oa] It's Who You Know
+  [dTuDmdfeax9B6kIk] Just Kidding
+  [EfRt0g6vfKt2GFpi] Kiss it Better
+  [01qv8QiKM7S6hHt7] Legendary Troll
+  [eR73a0yWba7clUyC] Management Material
+  [k25vcbGtu5bsPF4h] Maximize Profits
+  [7AvbXCgDkP9GDkbN] Percussive Maintenance
+  [tqInOh5OiStqiCVg] Phishing Expertise
+  [ifQiKhl0Gt2CM7i9] Phreaker
+  [6ErQf23Gm9km8YSz] Plant Rumor
+  [luE3KQ8tAiYxipLq] Predator's Eye
+  [kcLeXu7Ikjh81o5h] Quick Install
+  [NY2R5hNgdkSRPkTV] Religious Talisman
+  [VRLHQPDkjy0gbxBY] Serum Crafting
+  [VPFiluVQoj8F2Ho0] Stunt Maneuver
+  [mX0Xl6wY1WmhyuVO] Tech Crafting
+  [YtbPw4FSa86QAdRq] Urban Survivalist
+  [oVSrZDRpHZUoiXIy] Without a Trace
+Heritage
+  [56iLg8E5YvvI6xk9] Akitonian Kasatha
+  [QFNqrRQncrkMniMA] Akitonian Nomad Shobhad
+  [BHG0mfWnbHhKluxO] Akitonian Ysoki
+  [9tHpz23J3FSz0K2E] Aquazoan
+  [yp5O0Z97KtL0vlsZ] Artificial Scion Android
+  [LWYCoYVa9JiN5Cs6] Assimilated Astrazoan
+  [g8HDK1liSwjtUQNi] Asteroid Hopper Sarcesian
+  [v1FRU6XUr7QZsG6d] Bloom-Born Kalo
+  [ENIlxRfjGN218iKJ] Borai
+  [lHF7WmacNWdiRNNd] Briskwander Vesk
+  [GDVA8GmJg1slzKgv] Cloned Astrazoan
+  [j35JtiwUwUgulBuz] Compact Sarcesian
+  [mLffetxNUmSHhGk1] Construct Copycat
+  [iCOQI4pXzO98wnE1] Corpsefolk
+  [RPecy7rjuK40IJkx] Courtier Shirren
+  [DkMIxqmsFTrebsmd] Crèche-Raised Sarcesian
+  [ymuI4UO22iMmobRh] Damaya Lashunta
+  [MOuOhoGwjHkGoOrc] Deadwood
+  [Ey2iWNKXd8rzHP2J] Deep Kalo
+  [7p9HtLzWBHc18JDW] Deep Ysoki
+  [jbSgKLxeANdgrfvD] Defiant Shirren
+  [Lc03oetnQ5sNRNYT] Desert Ikeshti
+  [TZTa5BJoOyv5O0fS] Dreamer Barathu
+  [1eYRZT4aOJXrTAQF] Early Stage Barathu
+  [ZAOKze0PTYPPbUua] Electric Kalo
+  [2EBZRLWaeSJULFZb] Empathic Vlaka
+  [A3XpAjUgnGyxXoDI] Entertainer Elebrian
+  [46QpOfnvTpkFd9ST] Everwhelp Skittermander
+  [UjSJHYe9RRXbGHl2] Exiled Elebrian
+  [ezPp5n1TQKjhkZsy] Experimental Ikeshti
+  [952YwmIOYQPJTLRB] Flameheart Dragonkin
+  [JWt2ARxLCZ6ru8H2] Gadraveech Skittermander
+  [IMdFH4T27NC1GQCE] Glacierborn Shobhad
+  [QZ67FjD8QxI0Ab35] Golarion Survivor Human
+  [NXVULEwhf37gVKGf] Heartbroken Dragonkin
+  [KgekeGih8FTo36Sc] Hunter-Stalker Pahtra
+  [xFescMtvHlMJSpTs] Imperious Contemplative
+  [vlLSIOKqJHXRaCIt] Inflorescent
+  [Nkll4kC0WQW67wE8] Inured Ikeshti
+  [LCC7RhgpBkhyHlFc] Iridescent Shirren
+  [bNR7l0I5yLA8pWbd] Irreproachable Contemplative
+  [faGqBgQEAugkZ5wH] Kasath Survivalist
+  [ESUvBfORAP5SY73a] Keen Sighted Vlaka
+  [a5znSq93Wz22iQHP] Korasha Lashunta
+  [fROPRHGyUn4PgcER] Longsnout Ysoki
+  [ZA03oUyOKDSOOGaG] Manifested Contemplative
+  [IKJwTaMRnPIio4jH] Manufacturer Barathu
+  [1YJl56kqLbHdwHVq] Mercurial Dragonkin
+  [mq92ECPMTFZXDI6E] Merged Barathu
+  [FGOV0tjruePwBpLM] Meyel's Chosen Pahtra
+  [C1E7FVWq1A9vmeeG] Mod Fanatic Android
+  [wHGhjTqNvsaAMJHM] Networked Android
+  [GhfhQjc0Id58xm8E] Nightstalker Vesk
+  [ySfpV3VZIYdmI2fT] Nomadic Vlaka
+  [kxY0MXkQzEnGcbBo] Offworld Shobhad
+  [8xJLb7SmPydkTzfG] Outworlder Kalo
+  [JuqBWWB16ekM0Tdf] Pampered Ikeshti
+  [l5WFo2QxPOYUyLTJ] Petrified
+  [4CW2vHPdjx9xDJVU] Plated Vesk
+  [Usolg3I0x7V5RT3R] Prismeni
+  [oyxtHoW8wUWnYzTO] Renewed Android
+  [huDjFa4Vt7UF0JUa] Retrograde Contemplative
+  [sVLbQ2yf5ITq4asR] Rime Walker Pahtra
+  [EXwIrrzLZQZODLOd] Sageborn Elebrian
+  [RafHOA55opMBMtiZ] Sand Roamer
+  [m9Nb3UrUoEGAxaCr] Scrabbler Skittermander
+  [KTc9RuD02CDmAvzN] Sharp-Eyed Sarcesian
+  [FDEvJXDoWPLHoEsT] Sharp-Toothed Vlaka
+  [qRHZENQf5C43t3q4] Shipborn Dragonkin
+  [P8x1XiN52lgbgzB0] Shipborn Kasatha
+  [ApPYlfqJs6pIDF4D] Shipborn Ysoki
+  [5SqvxQBmTllq2Lzu] Skitter Raised
+  [lN2YREClxT8iup5o] Sniper Shobhad
+  [llkEXzVjzZVl9lHW] Stagehand Elebrian
+  [DTDJDSro9YfgNuXi] Star Marked Vlaka
+  [JiQwHacgrrb6qUqA] Stellar Nomad Kasatha
+  [bjgKWl3GbIywvJm6] Stellar Sarcesian
+  [ShGlcqeMXp7ZK0vC] Stormrider Dragonkin
+  [Dz2ckZBbUuS5bIgQ] Survivalist Shobhad
+  [WyqKrnAAQXkJQyNm] Swarm Exile Shirren
+  [mLgNG46EWZuabvqA] Tempering
+  [Vf8NOK1Jnk0zQDqv] Thorny Ikeshti
+  [t0OfbPwWPYSr7JL5] Thoughtseeker Contemplative
+  [U882U2NUUGL6u3rL] Tunnel Ysoki
+  [2TXiMFGXAL2aO6Ar] Unbound Lashunta
+  [TwU15npTtpW9TJcv] Underground Ikeshti
+  [lTUuHE9w3mP7Q9Y2] Urban Shobhad
+  [mLPafbWvDDwKK7U4] Urbanite Human
+  [2PxNQLqeXGAZ3VBf] Venomthought Vesk
+  [Pxw4kKf2goygSYpB] Warblood Vesk
+  [fTJTN6C6aVLcbb0n] Wild Astrazoan
+  [SBRnZHvzGQCSdlWE] Wildseed
+  [o9QBHUuvGsHcGh4n] Winged Shirren
+  [CMgZu5L4MXVX7Cwl] Winter Coat Vlaka
+NPC Attack
+  [lYUyDnVB4EiMBddW] (Malevolent AI) Electric Cable
+  [1b4aCeJDd3tiKQOO] (Malevolent AI) Energy Beam
+Shield
+  [7fIZAOxTqKohRhVv] Carbon Shield
+  [T0E2WL0QBpaUSlNL] Compact Shield
+  [ZIIEmh2nAnST6vGk] Deflecting Field
+  [Myr4T1uWznTNsWhZ] Irising Shield
+  [l59yRzJzWCMgjcVi] Mobile Bulwark
+  [SYQx5Lv36L0yOrrN] Phase Shield
+  [n7My3cvLdfygf9xp] Riot Shield
+Spell
+  [kGas0LdEAR1WjLGZ] Absolute Zero
+  [RDvWFbAaXtxrhJMD] Accelerate
+  [p83iYWlcJRqe0PxL] Adaptive Camouflage
+  [h7IhypLwItepwhou] Adhere
+  [z0Spgrf92nmaqjCW] Akashic Assistant
+  [VynaowCerc7B4yvI] Akashic Download
+  [mAu69GVbFKYzQM5a] Akashic Fount
+  [f98vwzcdxafum8ln] Akashic Revival
+  [vL7w8EtvZHlgRKlo] Alternate Outcome
+  [NkvRoN33RbDg3fl9] Analyze Target
+  [smCC1LNhMb7Z1lrU] Anthem
+  [UnWaP06SVi3jRN0M] Atomic Blast
+  [FIM54CSlkvBwwzdA] Awaken Computer
+  [Fa1f7VtZitQYrArX] Battle Sonata
+  [HAaRcHfN4g83eSEC] Cairn Form
+  [J3zMwmhIVgI2yzxm] Call Cosmos
+  [n5a3t5Qnx5AU8auy] Carcinization
+  [GB1RVtoFPwyH1B9G] Caustic Conversion
+  [QiW8VNdBf0SFUq69] Cellular Stimulant
+  [JIAIyvj4PV84tnFk] Chill Gaze
+  [g58dbrP7FadZhh6j] Chrono Push
+  [rluzzX2ml4yFWnYw] Cloying Shadows
+  [dyDIRdq3QmP2QzBR] Commune with Tech
+  [7WtiWJRYZhT6a9Ey] Control Machine
+  [nbIGKNr7eyiTqKwS] Corrosive Haze
+  [ASOR3qVrjqStL4Ph] Cozy Crashpad
+  [CjVOXjuvvTJqC7AD] Data Drain
+  [J9IWyHhvdtMVBjqg] Deadly Vitality
+  [zdzeVZlKHkMAt2Rf] Death Sentence
+  [yXD9uU8w8uFD2OBQ] Delete
+  [qOLMHvkAGsVYLhtn] Detect Thoughts
+  [rBh2PjtbDGAjbcu6] Discharge
+  [VIKDSgBRR3Wd1mQx] Doom Scroll
+  [ZrFj6ktotd0pBnqO] Dream of Home
+  [Y8Y0LS6sh4pkxPsq] Eldritch Bond
+  [FEaM1B4WuiqFO7Uk] Eldritch Lance
+  [jyrxfWeeCsrkhNit] Eldritch Wrath
+  [Cbj7tDkb2ZTp10Cg] Electrotether
+  [5apI8Yamauo02VYR] Elemental Barrier
+  [DZOjyZBZUrzkw5q2] Elemental Nova
+  [d5dmu4HZ3YyrwcaF] Elemental Weapon
+  [GmeI009NbLbR6sR5] Enhance Body
+  [ahXTkKpQtOTAQOFm] Enhance Weapon
+  [kR5A0h2a9hY41wav] Entropy Strike
+  [0pl80qKToraH4dvO] Event Horizon
+  [qAbHuohnFmiXx9sd] Explosion of Rot
+  [1lv6Zmp2eWRIPn1n] Feline Senses
+  [ogEFxmaTBlXcpdoS] Forge Drift Beacon
+  [TAbOBvFU8dLzKiWw] Forget
+  [s6J1Q0e28Gb42epQ] Genetic Regeneration
+  [c3pohoiOH2qIhDDp] Ghost Killer Weapon
+  [V1cojmrEOWkJ1yPF] Glow Up
+  [gLOelTMvex2OgBqV] Gravity Field
+  [eHiWtMiXoI1d48A7] Holographic Memory
+  [g9QLswd5uqDdcCjv] Howl
+  [ZBeKxBcUOsXrfMRo] Implant Data
+  [d7Mj4nUQe8wg1mV7] Infusion
+  [ZofLZ5Zs8NN5yDPJ] Inject Nanobots
+  [sNUvbMoMeLTnYJm8] Injury Echo
+  [mnoTqz0gjRmuc4oR] Instant Virus
+  [MfsxPjshwZJZuNpN] Irradiate
+  [ShwUELLERVMtdjwE] Life Seal
+  [j6KI3dFuaYJmMSZh] Liquid Siphon
+  [ijlB3l9IBnpppfK0] Logic Bomb
+  [bBQ83xDvjQS3W1CG] Measure
+  [uBo6g5aW087cLSJR] Mind Skewer
+  [5ZZca1GGJs44OxC8] Motivating Ringtone
+  [jon2tSGg7fSTqtk9] New Game
+  [wOjoJjl2ndZKTuFJ] Overheat
+  [5cMDrC3jX1yrxOzh] Overload Systems
+  [XoYUZP9OYdDMz4I0] Parallel Forms
+  [0mNmVi9CLXor3McX] Personal Gravity
+  [Y3egStSTzL8k86qc] Phantasmal Fleet
+  [ITzIb93GBvyX8UbJ] Pocket Vacuum
+  [xS4bqHnbodCwjpqI] Promession
+  [v8JA4sG2tsVP2gOM] Quantum Analysis
+  [d1weVZHIiCXhTlqg] Quantum Negation
+  [YAa1StmuYC2QQ043] Reality Wipe
+  [5y70IWhVV6bVjC9N] Recharge Weapon
+  [Ii8adgcCejAovsNv] Remix
+  [t0oFlhMhNOHbb6rG] Reorient
+  [sXnWQOcGG2ELcxXb] Ricochet
+  [BHWG0rQPTgBF5Ye1] Rocket Dash
+  [ZhQWnQ0500AAtjDb] Root of all Pain
+  [nf8q0zvJDnnkzANe] Scan Environment
+  [3VucgRc8FRPGy9NI] Seek the Stars
+  [L6Gww2b2YVM3q0ZQ] Selective Invisibility
+  [pgjlPNfXCpEYyLVu] Shadow Prison
+  [uh9Br4yrKvJA6zq0] Shadow Snap
+  [EhN3GjdjXChMdiFk] Share Pain
+  [7P4eBdqWcgQJAFCa] Shifting Surge
+  [AlYzxLKWZujnzsjJ] Shuffle Repeat
+  [tVTJS07cKDA5rNgc] Sift the Sphere
+  [aPZMapuunaNpxubp] Singularity Seed
+  [v2S6tlilNbA4uGdM] Skim Data
+  [VmtQlZqeraTv0Eer] Skyfire Wings
+  [a02hsymtiVRQvh3i] Slice Reality
+  [QpP30fcEl4NGjHwo] Sonic Scream
+  [HPHr5aoLMH4eVwaw] Soul Surge
+  [Nf6GqoHkNbfWJDQT] Speak with Computers
+  [jgN33YSYXB8iIHTw] Stumble
+  [CptKtBneM7od45nc] Subjective Reality
+  [KlJEDmAOk1ztdNFf] Summon Robot
+  [SbBqa1HStMrV47fb] Supercharge Weapon
+  [A09nTb61ceLF27vX] Tech Intuition
+  [OudLZtxmg6gI1UEL] Telekinetic Strangulation
+  [64DDZxOrmr4ddqs2] Telekinetic Tantrum
+  [H0WECXb2wvTHT9yk] Temporal Bullets
+  [HzFdtjvRCFpb0NrS] Time Loop
+  [GdlG9a4o0ax0F2HT] Time's Edge
+  [XhypWjpV3NP76ahy] Twisted Vision
+  [8FT564z5zMQVZNih] Vague Idea
+  [hk2mTLH9DIvNqDuS] Verdant Code
+  [wRNRWwCEbmSxbHDl] Vibe Check
+  [MTulATAiOZfZNQ9d] Vital Rebirth
+  [zzi7LUKxKNWr5GsG] Vitality Nova
+  [6HMiN0oQzeoYR3it] Vitality Web
+  [x21WInzhprQHMyKT] Void Scour
+  [FIW0VpGULprL2u8J] Void Seed
+  [sTpdXXaaKhoGOIxh] Void Vessel
+  [qkehzRdn7JeGrR6E] Void Whispers
+  [dRP4Imw3RJNQqEgc] Wall of Plasma
+  [fRT0T9sbd8zWc1q9] Wall of Steel
+  [tZQpEnaFqwmU4AMZ] Warp Presence
+  [KOkGLXwOBAIlczzk] Warp Probability
+  [TN2pHF9l3k4ZJ7di] Warp Terrain
+  [1gkdgFwKfAoQx163] Warp Time
+  [9w90nlUdV5HBRWFm] Warp World
+  [kTzbLqmqPcZwOa5F] Wave of Warning
+  [7Ib3qxIC0bFD3ued] Weight of Ages
+  [ssOpTABjuHAqNTPu] Wild Bond
+  [Sqo1uzSmebVWpqoT] Wisp Ally
+  [DPP4TW5FxE85XPKZ] X-Ray Vision
+Weapon
+  [25ePewNhni6x8zgX] Acid Dart Rifle
+  [OP6XoTRsDvPfYU5o] Aeon Rifle
+  [uk9u5cX31uEuFMEa] Arc Emitter
+  [M0PsUbGLkBk878YZ] Arc Pistol
+  [TAgaAiDMPGnF87Vv] Arc Rifle
+  [iQqOE805CjAUyTt3] Artillery Laser
+  [4X0L8oORH8ty2tH4] Assassin Rifle
+  [utPFW3Cg5iPOUMPO] Aucturnite Chakram
+  [dxkmvJZOblZ8oImW] Autotarget Rifle
+  [D4KuxPi9gqFkvZ3h] Baton
+  [PIdM8V0m8nLEI73e] Battle Ribbon
+  [7KrNTRa5WpVdv2Vw] Battleglove
+  [r2EzMZWgtMaJth6A] Blockthrower
+  [w0ajYoUHRxs0mdHM] Bone Scepter
+  [6goqwLZUy4eUro6T] Boom Pistol
+  [qRg7totm2jOAWd4c] Breaching Gun
+  [4pnd1mGCNrsQckXi] Card Slinger
+  [V7epvZwIrMLMYI97] Coil Rifle
+  [gwVhd31nGDXo5HAa] Crossbolter
+  [G8dJYbYBmxHZhV8q] Cryopike
+  [pV3VmchqUUirCkEa] Degradation Grenade (Advanced)
+  [WOvRpqLDNOatDgcO] Degradation Grenade (Commercial)
+  [rIcsfhrhP23RUYzx] Degradation Grenade (Elite)
+  [rAjQodk6M3JHhWaF] Degradation Grenade (Paragon)
+  [XFolhh9K0gccBe8i] Degradation Grenade (Superior)
+  [7S1nh9Dftkt68DtS] Degradation Grenade (Tactical)
+  [Q65y4LVV2DAf8Hef] Degradation Grenade (Ultimate)
+  [SiYdlPu9zfqZrBdR] Disintegration Lash
+  [QWWg91KgMFSqK6lv] Doshko
+  [a2e5svVQ20WrzRTK] Dueling Sword
+  [nW1ZJKG81d9I3mAA] Electromag Grenade (Advanced)
+  [zZfvCl6hcRMAiJQB] Electromag Grenade (Commercial)
+  [TTWzhSdn1RlBVJ2D] Electromag Grenade (Elite)
+  [aVuRjQz18Sjv1ipB] Electromag Grenade (Paragon)
+  [oBIUI95iuUisM7fZ] Electromag Grenade (Superior)
+  [PQU82RsdMS1g7YTV] Electromag Grenade (Tactical)
+  [s2uqSzSvkRFXb3Ag] Electromag Grenade (Ultimate)
+  [7BZM2I0fasujPIEa] Fangblade
+  [3yWQhmBrAXnBhYaF] Flamethrower
+  [yJYorlEvJLSxc3VS] Flash Grenade (Advanced)
+  [yZ1PddTL7huZhECC] Flash Grenade (Commercial)
+  [zQlnRRTdC4pdwCvi] Flash Grenade (Elite)
+  [KtThxo7Jv7eYAiwR] Flash Grenade (Paragon)
+  [z4hYYCFlMRypJ6Wd] Flash Grenade (Superior)
+  [0fZ9jBVvpljgAZC8] Flash Grenade (Tactical)
+  [p4S4iBqbVkpvWP6Z] Flash Grenade (Ultimate)
+  [NvchdxN8P3W2rLJo] Force Needle
+  [omxqK2E84pGaMj6x] Frag Grenade (Advanced)
+  [SzGr78zdpnnrorre] Frag Grenade (Commercial)
+  [KaUapB2WwBE6wnzd] Frag Grenade (Elite)
+  [weV9f340wsszD1rD] Frag Grenade (Paragon)
+  [8ThQnRVi44idLq8T] Frag Grenade (Superior)
+  [BmJARyq7RrMXQezF] Frag Grenade (Tactical)
+  [LaDOwzjCIAskfql0] Frag Grenade (Ultimate)
+  [rgprAOXrCIFtwfpr] Grenade Launcher (Commercial)
+  [qqFSu3Ed6zirmoXn] Grenade Launcher (Superior)
+  [Gvd406aqaxjBcnFI] Grenade Launcher (Tactical)
+  [P4SuZ6SumQ0YV9JN] Grenade Launcher (Ultimate)
+  [awjAsQFUBIFFx7R1] Grindblade
+  [dEk5qaPw43AoKhxv] Gyrojet Pistol
+  [pwN8Bh8amBjBPka4] Hardlight Handwraps (Advanced)
+  [b12tnjobe9IrphII] Hardlight Handwraps (Commercial)
+  [Q2wVgoS7y1JlciTV] Hardlight Handwraps (Elite)
+  [xIyau4fBsCcoLB9x] Hardlight Handwraps (Paragon)
+  [MeV8qRq6cMlSBC2E] Hardlight Handwraps (Superior)
+  [xJBRvJHRz7KHAlpj] Hardlight Handwraps (Tactical)
+  [Vp7O4NTBJ5OZwGMG] Hardlight Handwraps (Ultimate)
+  [h53QPQt1GlzPwdaY] Incendiary Grenade (Advanced)
+  [EgAVqAYCrSJzxF1j] Incendiary Grenade (Commercial)
+  [R8dEureCA93msBsa] Incendiary Grenade (Elite)
+  [ZIm4WMr5CYblEBHF] Incendiary Grenade (Paragon)
+  [fvKj2J4p6MwXeupx] Incendiary Grenade (Superior)
+  [TrS4puy7wfjbDJIA] Incendiary Grenade (Tactical)
+  [xFmyDUWtH9PDJ8ww] Incendiary Grenade (Ultimate)
+  [dSBaVgdksA6zDfWZ] Ivory Chompers
+  [V0LgOSOvkNvs2i0x] Knife
+  [qIgcUV22LaDCzmb2] Laser Pistol
+  [0TSUahGsoVnDZ6kv] Laser Rifle
+  [EnufuFPBa1U2pPDn] Machine Gun
+  [bHHFXS2nmfOQFQyu] Magnetar Rifle
+  [MU6FApzuFhTccPaT] Maratan Headache (Advanced)
+  [RlU8twwDgwwqwZ5J] Maratan Headache (Commercial)
+  [kUfQvnJzmB1GO1Lh] Maratan Headache (Elite)
+  [lNtur8hLaimtVXJj] Maratan Headache (Paragon)
+  [u45uqFNOb3paG9Za] Maratan Headache (Superior)
+  [axc1Ov6XUYc4cdwV] Maratan Headache (Tactical)
+  [h6HfP8BorXGIluiw] Maratan Headache (Ultimate)
+  [VkepQ6oX9SYeQrTt] Nano-edge Rapier
+  [wbXXoYRwqZDKPTFr] Neural Lash
+  [eUZcCSon8XlQzOqR] Painglaive
+  [eBWGwv3rryQkHfh4] Phase Cutlass
+  [WTG6BeN4WJfbA3lO] Plasma Cannon
+  [OQJQqJlUYR9JhWjs] Plasma Caster
+  [quVFEQcSblaeKD1v] Plasma Doshko
+  [jLiackiAHgru9OY0] Plasma Sword
+  [zMq3hXhcgohjoSnp] Polyglove
+  [6g4SJgd2LUGnA0jj] Pulse Gauntlet
+  [vpjJYIgYZab0UZFa] Pulsecaster Pistol
+  [NENPU3uX5dtxdakS] Puzzleblade
+  [O5NUuLG5fECaz8dQ] Quantum Reaver
+  [nCDhToSxmf9xrpEh] Reaction Breacher
+  [KnGzQ30kkhYPxABY] Reality Ripper
+  [l4yre1br3yCOeciB] Replica Zo! Microphone
+  [hrjtJgBrmYfDPRlx] Rotating Pistol
+  [QqR5bmqrv8VzWdll] Rotolaser
+  [1cSlAefjEmcQd4h1] Scattergun
+  [tAolYCDR7VlfJZjQ] Screamer
+  [2gIo208O7zxPTL5J] Seeker Rifle
+  [K0xFwEC6Zv7ghVFa] Semi-Auto Pistol
+  [LTYzHdOOhCjtb79T] Shirren-eye Rifle
+  [sTe6qQmJ1lC1xDfC] Shock Pad
+  [ST6R4rRFf50vzSdJ] Shock Truncheon
+  [wbKiBgYY120RyoGg] Shooting Starknife
+  [OEZJFJFLL5xmfAaZ] Shuriken Drone
+  [mBwMcT367Qaigo0t] Singing Coil
+  [2BrT2UOFKWbXncAd] Singing Spear
+  [QdxskYrRPk92siaB] Skyfire Sword
+  [HlrNSzynsQuZrc2o] Smoke Grenade (Advanced)
+  [7y8IWTlnQnnjkfXe] Smoke Grenade (Commercial)
+  [kzc2sa3DulMUTx3m] Smoke Grenade (Elite)
+  [OvyHsBJVspNBZQhR] Smoke Grenade (Paragon)
+  [Lx9IS1tHIzSICJi7] Smoke Grenade (Superior)
+  [5Tc2Eaaf15LVByBJ] Smoke Grenade (Tactical)
+  [7NnacNASvkIezlZO] Smoke Grenade (Ultimate)
+  [QzG4mOFftnN2v9Wd] Sonic Rifle
+  [XOT0d4a0G5fhb674] Starfall Pistol
+  [HubVnt6gFuzaXMUK] Stellar Cannon
+  [SGy1aJYOIKeg1k4T] Streetsweeper
+  [KA4zMLBuYb3DgUe6] Tailblade
+  [jBc5pGz3AbkKTx9v] Talon
+  [lzhMTwh9Ur1Enf6D] Thermal Dynafan
+  [1wM54zozOmNCDFwu] Vertebralis Thorn
+  [nTfNpQOrzgNuWcSx] Zero Cannon
+  [Jtl2vxrTdhm1e3Er] Zero Knife
+  [O3QRrXVfhNpF0XyY] Zero Pistol


### PR DESCRIPTION
Adds export logs of all items (not actors) to the commit log. One fear of anachronism builds is that duplicates may lead to something no longer being exported, and we may need to set up redirects in some of those cases. These logs should hopefully catch that when new anachronism builds are created by checking the diffs in the git log.

A suggestion was placed to make it a duplicates log instead, but a new entry in a duplicates log may be from a new content release and not require a redirect. An export log is better at catching potential broken links.