### PR TITLE
Brush up Vogorond

### DIFF
--- a/packs/pf2e/pathfinder-npc-core/primalist/tree-singer.json
+++ b/packs/pf2e/pathfinder-npc-core/primalist/tree-singer.json
@@ -2137,7 +2137,6 @@
                         "radius": 30,
                         "traits": [
                             "auditory",
-                            "concentrate",
                             "linguistic",
                             "plant",
                             "primal",

--- a/packs/pf2e/revenge-of-the-runelords-bestiary/book-2-crypt-of-runes/vogorond.json
+++ b/packs/pf2e/revenge-of-the-runelords-bestiary/book-2-crypt-of-runes/vogorond.json
@@ -226,7 +226,7 @@
                 "rules": [
                     {
                         "key": "RollOption",
-                        "option": "ruinous-aura",
+                        "option": "self:ruinous-aura",
                         "suboptions": [
                             {
                                 "label": "PF2E.Foot.Preformatted.10",
@@ -246,9 +246,9 @@
                     {
                         "key": "Aura",
                         "predicate": [
-                            "ruinous-aura"
+                            "self:ruinous-aura"
                         ],
-                        "radius": "@item.flags.system.rulesSelections.ruinousAura",
+                        "radius": "@item.flags.system.rulesSelections.selfruinousAura",
                         "traits": [
                             "occult"
                         ]
@@ -259,7 +259,7 @@
                             "criticalSuccess"
                         ],
                         "predicate": [
-                            "ruinous-aura"
+                            "self:ruinous-aura"
                         ],
                         "selector": "damage-received",
                         "text": "{item|description}",

--- a/packs/pf2e/revenge-of-the-runelords-bestiary/book-2-crypt-of-runes/vogorond.json
+++ b/packs/pf2e/revenge-of-the-runelords-bestiary/book-2-crypt-of-runes/vogorond.json
@@ -258,6 +258,9 @@
                         "outcome": [
                             "criticalSuccess"
                         ],
+                        "predicate": [
+                            "ruinous-aura"
+                        ],
                         "selector": "damage-received",
                         "text": "{item|description}",
                         "title": "{item|name}",

--- a/packs/pf2e/revenge-of-the-runelords-bestiary/book-2-crypt-of-runes/vogorond.json
+++ b/packs/pf2e/revenge-of-the-runelords-bestiary/book-2-crypt-of-runes/vogorond.json
@@ -225,12 +225,43 @@
                 },
                 "rules": [
                     {
-                        "effects": [],
+                        "key": "RollOption",
+                        "option": "ruinous-aura",
+                        "suboptions": [
+                            {
+                                "label": "PF2E.Foot.Preformatted.10",
+                                "value": "10"
+                            },
+                            {
+                                "label": "PF2E.Foot.Preformatted.20",
+                                "value": "20"
+                            },
+                            {
+                                "label": "PF2E.Foot.Preformatted.30",
+                                "value": "30"
+                            }
+                        ],
+                        "toggleable": true
+                    },
+                    {
                         "key": "Aura",
-                        "radius": 10,
+                        "predicate": [
+                            "ruinous-aura"
+                        ],
+                        "radius": "@item.flags.system.rulesSelections.ruinousAura",
                         "traits": [
                             "occult"
                         ]
+                    },
+                    {
+                        "key": "Note",
+                        "outcome": [
+                            "criticalSuccess"
+                        ],
+                        "selector": "damage-received",
+                        "text": "{item|description}",
+                        "title": "{item|name}",
+                        "visibility": "owner"
                     }
                 ],
                 "slug": null,
@@ -264,7 +295,15 @@
                     "remaster": false,
                     "title": ""
                 },
-                "rules": [],
+                "rules": [
+                    {
+                        "key": "Note",
+                        "selector": "initiative",
+                        "text": "{item|description}",
+                        "title": "{item|name}",
+                        "visibility": "owner"
+                    }
+                ],
                 "slug": null,
                 "traits": {
                     "value": [
@@ -288,7 +327,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p>Each enemy in the vogorond's ruinous aura takes @Damage[8d6[bludgeoning]] damage (@Check[reflex|dc:40|basic] save).</p>"
+                    "value": "<p>Each enemy in the vogorond's ruinous aura takes @Damage[8d6[bludgeoning]|options:area-damage] damage (@Check[reflex|dc:40|basic|options:area-effect] save).</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -317,7 +356,7 @@
                 },
                 "category": "offensive",
                 "description": {
-                    "value": "<p><strong>Requirements</strong> The vogorond's ruinous aura is active</p><hr /><p><strong>Effect</strong> The vogorond launches a piece of rubble up to 100 feet. Upon impact, the rubble explodes in a @Template[type:burst|distance:20]. Any creatures in the area take @Damage[15d8[bludgeoning]|options:area-damage] damage (@Check[reflex|dc:40|basic] save). The radius of the vogorond's aura then decreases by 10 feet. The vogorond can't Launch Rubble again for [[/gmr 1d4 #Recharge Launch Rubble]]{1d4 rounds}.</p>"
+                    "value": "<p><strong>Requirements</strong> The vogorond's ruinous aura is active</p><hr /><p><strong>Effect</strong> The vogorond launches a piece of rubble up to 100 feet. Upon impact, the rubble explodes in a @Template[type:burst|distance:20]. Any creatures in the area take @Damage[15d8[bludgeoning]|options:area-damage] damage (@Check[reflex|dc:40|basic|options:area-effect] save). The radius of the vogorond's aura then decreases by 10 feet. The vogorond can't Launch Rubble again for [[/gmr 1d4 #Recharge Launch Rubble]]{1d4 rounds}.</p>"
                 },
                 "publication": {
                     "license": "OGL",


### PR DESCRIPTION
The `ruinous-aura` roll option is `self`, as otherwise it isn't included in the `damage-received` Note context.

Also remove `concentrate` from Tree Singer's Verdant Aria:
```
foundry.mjs:11744 DataModelValidationError: AuraRuleElement validation errors:
  traits: 
    1: concentrate is not a valid choice
    at DataModelValidationFailure.asError (foundry.mjs:5141:12)
    at AuraRuleElement.validate (foundry.mjs:11744:34)
    at AuraRuleElement.validate (pf2e.mjs:1557:276839)
```