### PR TITLE
Change Recognize Spell (PF) and Face in the Crowd (SF) localization keys

### DIFF
--- a/packs/pf2e/feats/skill/level-1/recognize-spell.json
+++ b/packs/pf2e/feats/skill/level-1/recognize-spell.json
@@ -32,7 +32,7 @@
         "rules": [
             {
                 "key": "RollOption",
-                "label": "PF2E.SpecificRule.SkillFeat.RecognizeSpell.RollOptionLabel",
+                "label": "PF2E.SpecificRule.Feat.RecognizeSpell.RollOptionLabel",
                 "option": "recognize-spell",
                 "toggleable": true
             },

--- a/packs/sf2e/feat-effects/effect-face-in-the-crowd.json
+++ b/packs/sf2e/feat-effects/effect-face-in-the-crowd.json
@@ -25,7 +25,7 @@
             {
                 "choices": [
                     {
-                        "label": "SF2E.SpecificRule.SkillFeat.FaceInTheCrowd.CrowdSize.Ten",
+                        "label": "SF2E.SpecificRule.Feat.FaceInTheCrowd.CrowdSize.Ten",
                         "predicate": [
                             {
                                 "lte": [
@@ -37,7 +37,7 @@
                         "value": 2
                     },
                     {
-                        "label": "SF2E.SpecificRule.SkillFeat.FaceInTheCrowd.CrowdSize.Five",
+                        "label": "SF2E.SpecificRule.Feat.FaceInTheCrowd.CrowdSize.Five",
                         "predicate": [
                             {
                                 "gte": [
@@ -49,13 +49,13 @@
                         "value": 2
                     },
                     {
-                        "label": "SF2E.SpecificRule.SkillFeat.FaceInTheCrowd.CrowdSize.Hundred",
+                        "label": "SF2E.SpecificRule.Feat.FaceInTheCrowd.CrowdSize.Hundred",
                         "value": 4
                     }
                 ],
                 "flag": "crowdSizeBonus",
                 "key": "ChoiceSet",
-                "prompt": "SF2E.SpecificRule.SkillFeat.FaceInTheCrowd.Prompt"
+                "prompt": "SF2E.SpecificRule.Feat.FaceInTheCrowd.Prompt"
             },
             {
                 "key": "FlatModifier",

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -4554,6 +4554,9 @@
                 "QuickSwim": {
                     "Note": "You Swim 5 feet farther on a success and 10 feet farther on a critical success, to a maximum of your Speed."
                 },
+                "RecognizeSpell": {
+                    "RollOptionLabel": "Critical success on Recognize Spell"
+                },
                 "RiskySurgery": {
                     "Note": "When you Treat Wounds, you can deal @Damage[1d8[slashing]] damage to your patient just before applying the effects of the Treat Wounds. If you do, gain a +2 circumstance bonus to your Medicine check to Treat Wounds, and if you roll a success, you get a critical success instead."
                 },
@@ -6226,11 +6229,6 @@
             "SkilledClimber": {
                 "Label": "Climbing Cavern Wall or Tree"
             },
-            "SkillFeat": {
-                "RecognizeSpell": {
-                    "RollOptionLabel": "Critical success on Recognize Spell"
-                }
-            },
             "SkillMastery": {
                 "ExpertPrompt": "Select a skill to become expert in.",
                 "MasterPrompt": "Select a skill to become master in."
@@ -7826,6 +7824,16 @@
                     }
                 }
             },
+            "Feat": {
+                "FaceInTheCrowd": {
+                    "CrowdSize": {
+                        "Five": "At least 5 creatures",
+                        "Ten": "At least 10 creatures",
+                        "Hundred": "At least 100 creatures"
+                    },
+                    "Prompt": "Select a crowd size."
+                }
+            },
             "Hellknight": {
                 "Order": {
                     "Chain": "Chain",
@@ -8045,16 +8053,6 @@
                 "WeaponFamiliarity": {
                     "AdvancedWeapons": "Advanced Shobhad Weapons",
                     "MartialWeapons": "Martial Shobhad Weapons"
-                }
-            },
-            "SkillFeat": {
-                "FaceInTheCrowd": {
-                    "CrowdSize": {
-                        "Five": "At least 5 creatures",
-                        "Ten": "At least 10 creatures",
-                        "Hundred": "At least 100 creatures"
-                    },
-                    "Prompt": "Select a crowd size."
                 }
             },
             "Skittermander": {


### PR DESCRIPTION
The keys were changed because they were the only entries in their subcategory.

Primary reason to sort keys that was so that I could just add RE localizations without bothering with order and have them sorted automatically later.
Unfortunately, this is not the complete sort, as there are cases where I felt preserving sequential order is more valuable than having keys in alphabetical.
