### PR TITLE
Add automation for Glue Bullet

### DIFF
--- a/packs/pf2e/equipment-effects/effect-glue-bullet.json
+++ b/packs/pf2e/equipment-effects/effect-glue-bullet.json
@@ -1,0 +1,67 @@
+{
+    "_id": "dBjXvsLFezo2fGRa",
+    "img": "systems/pf2e/icons/equipment/consumables/ammunition/glue-bullet.webp",
+    "name": "Effect: Glue Bullet",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.equipment-srd.Item.Glue Bullet]</p>\n<p>You take a –10-foot circumstance penalty to your Speeds. On a critical hit, you are also immobilized.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "rounds",
+            "value": 2
+        },
+        "fromSpell": false,
+        "level": {
+            "value": 4
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Guns & Gears"
+        },
+        "rules": [
+            {
+                "choices": [
+                    {
+                        "label": "PF2E.Check.Result.Degree.Attack.criticalSuccess",
+                        "value": "critical-success"
+                    },
+                    {
+                        "label": "PF2E.Check.Result.Degree.Attack.success",
+                        "value": "success"
+                    }
+                ],
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.DegreeOfSuccess",
+                "rollOption": "glue-bullet"
+            },
+            {
+                "key": "FlatModifier",
+                "selector": "all-speeds",
+                "type": "circumstance",
+                "value": -10
+            },
+            {
+                "inMemoryOnly": true,
+                "key": "GrantItem",
+                "predicate": [
+                    "glue-bullet:critical-success"
+                ],
+                "uuid": "Compendium.pf2e.conditionitems.Item.Immobilized"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/pf2e/equipment/glue-bullet.json
+++ b/packs/pf2e/equipment/glue-bullet.json
@@ -10,7 +10,7 @@
         "containerId": null,
         "craftableAs": [],
         "description": {
-            "value": "<p><strong>Ammunition</strong> round</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> (manipulate)</p><hr /><p>These cartridges are filled with sticky clear glue. When a glue bullet hits, a syrupy webbing coats the target and sticks to the ground or a nearby surface, hindering their movement. The target takes a –10-foot circumstance penalty to its Speeds for [[/r 2d4 #rounds]]{2d4 rounds}, or until it [[/act escape dc=18]]{Escapes} against a DC of 18. On a critical hit, the target is also @UUID[Compendium.pf2e.conditionitems.Item.Immobilized] until it Escapes.</p>"
+            "value": "<p><strong>Ammunition</strong> round</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">1</span> (manipulate)</p><hr /><p>These cartridges are filled with sticky clear glue. When a glue bullet hits, a syrupy webbing coats the target and sticks to the ground or a nearby surface, hindering their movement. The target takes a –10-foot circumstance penalty to its Speeds for [[/r 2d4 #rounds]]{2d4 rounds}, or until it [[/act escape show-dc=all dc=18]]{Escapes} against a DC of 18. On a critical hit, the target is also @UUID[Compendium.pf2e.conditionitems.Item.Immobilized] until it Escapes.</p>\n<p>@UUID[Compendium.pf2e.equipment-effects.Item.Effect: Glue Bullet]</p>"
         },
         "hardness": 0,
         "hp": {
@@ -35,7 +35,18 @@
             "title": "Pathfinder Guns & Gears"
         },
         "quantity": 1,
-        "rules": [],
+        "rules": [
+            {
+                "key": "Note",
+                "outcome": [
+                    "criticalSuccess",
+                    "success"
+                ],
+                "selector": "{item|id}-attack",
+                "text": "PF2E.AmmunitionNotes.GlueBullet.Text",
+                "title": "PF2E.AmmunitionNotes.GlueBullet.Title"
+            }
+        ],
         "size": "med",
         "traits": {
             "rarity": "uncommon",

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -34,6 +34,10 @@
                 "Text": "The target must succeed at a @Check[fortitude|dc:19] save or be @UUID[Compendium.pf2e.conditionitems.Item.xYTAsEpcJE1Ccni3]{Slowed 1} for 1 round by the intense cold (slowed 1 for 1 minute on a critical failure).",
                 "Title": "Freezing Ammunition"
             },
+            "GlueBullet": {
+                "Text": "On a hit, the target takes a –10-foot circumstance penalty to its Speeds for [[/r 2d4 #rounds]]{2d4 rounds}. On a critical hit, the target is also @UUID[Compendium.pf2e.conditionitems.Item.eIcWbB5o3pP6OIMe]{Immobilized}. @UUID[Compendium.pf2e.equipment-effects.Item.dBjXvsLFezo2fGRa]{Effect: Glue Bullet}.",
+                "Title": "Glue Bullet"
+            },
             "MeteorShot": {
                 "CriticalFailureText": "On a critical failure, the weapon misfires.",
                 "Greater": {


### PR DESCRIPTION
Note that since the duration can't be automated, it's set a the 2-round minimum.

Closes https://github.com/foundryvtt/pf2e/issues/21785