### PR TITLE
Implement SF2e spell chips

### DIFF
--- a/packs/sf2e/equipment/magic-items/spell-chip-1st-rank-spell.json
+++ b/packs/sf2e/equipment/magic-items/spell-chip-1st-rank-spell.json
@@ -8,6 +8,7 @@
         "bulk": {
             "value": 0.1
         },
+        "category": "spell-chip",
         "containerId": null,
         "description": {
             "value": "<p><strong>Usage</strong> installed in computer or comm unit;</p><hr /><p>These chips can be installed in comm units and other computers to allow the device to cast spells. Each device can have only one spell chip. Casting a spell from a spell chip requires holding the computer or comm unit in one hand and activating it with a Cast a Spell activity using the normal number of actions for that spell. The spell must appear on your spell list. Because you're the one Casting the Spell, use your spell attack modifier and spell DC. The spell must be of your spellcasting tradition. If the spell has a locus, you must still have that locus to cast the spell from a spell chip. Spell chips can't contain cantrips or rituals. The traits for this item vary based on the spell it contains.</p>\n<p>In addition to the charge expended to Cast the Spell, the delicate components that make up the core lattice of a spell chip can be destroyed if used in quick succession. Attempting to use a spell chip more than once per day requires overclocking it. Cast the Spell again, then roll a @Check[flat|dc:10]. On a success, the spell chip is broken. On a failure, the spell chip is destroyed. If anyone tries to overclock a spell chip that's already been overclocked that day, the spell chip is automatically destroyed (even if it's been repaired) and no spell is cast.</p>\n<p><strong>Activate</strong> Cast a Spell</p>\n<p><strong>Frequency</strong> once per day, plus overclock</p>\n<p><strong>Effect</strong> You Cast the Spell at the indicated rank.</p>"
@@ -45,8 +46,13 @@
             ]
         },
         "usage": {
-            "value": "other"
+            "value": "installed-in-a-computer-or-comm-unit"
+        },
+        "uses": {
+            "autoDestroy": false,
+            "max": 1,
+            "value": 1
         }
     },
-    "type": "equipment"
+    "type": "consumable"
 }

--- a/packs/sf2e/equipment/magic-items/spell-chip-2nd-rank-spell.json
+++ b/packs/sf2e/equipment/magic-items/spell-chip-2nd-rank-spell.json
@@ -8,6 +8,7 @@
         "bulk": {
             "value": 0.1
         },
+        "category": "spell-chip",
         "containerId": null,
         "description": {
             "value": "<p><strong>Usage</strong> installed in computer or comm unit;</p><hr /><p>These chips can be installed in comm units and other computers to allow the device to cast spells. Each device can have only one spell chip. Casting a spell from a spell chip requires holding the computer or comm unit in one hand and activating it with a Cast a Spell activity using the normal number of actions for that spell. The spell must appear on your spell list. Because you're the one Casting the Spell, use your spell attack modifier and spell DC. The spell must be of your spellcasting tradition. If the spell has a locus, you must still have that locus to cast the spell from a spell chip. Spell chips can't contain cantrips or rituals. The traits for this item vary based on the spell it contains.</p>\n<p>In addition to the charge expended to Cast the Spell, the delicate components that make up the core lattice of a spell chip can be destroyed if used in quick succession. Attempting to use a spell chip more than once per day requires overclocking it. Cast the Spell again, then roll a @Check[flat|dc:10]. On a success, the spell chip is broken. On a failure, the spell chip is destroyed. If anyone tries to overclock a spell chip that's already been overclocked that day, the spell chip is automatically destroyed (even if it's been repaired) and no spell is cast.</p>\n<p><strong>Activate</strong> Cast a Spell</p>\n<p><strong>Frequency</strong> once per day, plus overclock</p>\n<p><strong>Effect</strong> You Cast the Spell at the indicated rank.</p>"
@@ -48,8 +49,13 @@
             ]
         },
         "usage": {
-            "value": "other"
+            "value": "installed-in-a-computer-or-comm-unit"
+        },
+        "uses": {
+            "autoDestroy": false,
+            "max": 1,
+            "value": 1
         }
     },
-    "type": "equipment"
+    "type": "consumable"
 }

--- a/packs/sf2e/equipment/magic-items/spell-chip-3rd-rank-spell.json
+++ b/packs/sf2e/equipment/magic-items/spell-chip-3rd-rank-spell.json
@@ -8,6 +8,7 @@
         "bulk": {
             "value": 0.1
         },
+        "category": "spell-chip",
         "containerId": null,
         "description": {
             "value": "<p><strong>Usage</strong> installed in computer or comm unit;</p><hr /><p>These chips can be installed in comm units and other computers to allow the device to cast spells. Each device can have only one spell chip. Casting a spell from a spell chip requires holding the computer or comm unit in one hand and activating it with a Cast a Spell activity using the normal number of actions for that spell. The spell must appear on your spell list. Because you're the one Casting the Spell, use your spell attack modifier and spell DC. The spell must be of your spellcasting tradition. If the spell has a locus, you must still have that locus to cast the spell from a spell chip. Spell chips can't contain cantrips or rituals. The traits for this item vary based on the spell it contains.</p>\n<p>In addition to the charge expended to Cast the Spell, the delicate components that make up the core lattice of a spell chip can be destroyed if used in quick succession. Attempting to use a spell chip more than once per day requires overclocking it. Cast the Spell again, then roll a @Check[flat|dc:10]. On a success, the spell chip is broken. On a failure, the spell chip is destroyed. If anyone tries to overclock a spell chip that's already been overclocked that day, the spell chip is automatically destroyed (even if it's been repaired) and no spell is cast.</p>\n<p><strong>Activate</strong> Cast a Spell</p>\n<p><strong>Frequency</strong> once per day, plus overclock</p>\n<p><strong>Effect</strong> You Cast the Spell at the indicated rank.</p>"
@@ -45,8 +46,13 @@
             ]
         },
         "usage": {
-            "value": "other"
+            "value": "installed-in-a-computer-or-comm-unit"
+        },
+        "uses": {
+            "autoDestroy": false,
+            "max": 1,
+            "value": 1
         }
     },
-    "type": "equipment"
+    "type": "consumable"
 }

--- a/packs/sf2e/equipment/magic-items/spell-chip-4th-rank-spell.json
+++ b/packs/sf2e/equipment/magic-items/spell-chip-4th-rank-spell.json
@@ -8,6 +8,7 @@
         "bulk": {
             "value": 0.1
         },
+        "category": "spell-chip",
         "containerId": null,
         "description": {
             "value": "<p><strong>Usage</strong> installed in computer or comm unit;</p><hr /><p>These chips can be installed in comm units and other computers to allow the device to cast spells. Each device can have only one spell chip. Casting a spell from a spell chip requires holding the computer or comm unit in one hand and activating it with a Cast a Spell activity using the normal number of actions for that spell. The spell must appear on your spell list. Because you're the one Casting the Spell, use your spell attack modifier and spell DC. The spell must be of your spellcasting tradition. If the spell has a locus, you must still have that locus to cast the spell from a spell chip. Spell chips can't contain cantrips or rituals. The traits for this item vary based on the spell it contains.</p>\n<p>In addition to the charge expended to Cast the Spell, the delicate components that make up the core lattice of a spell chip can be destroyed if used in quick succession. Attempting to use a spell chip more than once per day requires overclocking it. Cast the Spell again, then roll a @Check[flat|dc:10]. On a success, the spell chip is broken. On a failure, the spell chip is destroyed. If anyone tries to overclock a spell chip that's already been overclocked that day, the spell chip is automatically destroyed (even if it's been repaired) and no spell is cast.</p>\n<p><strong>Activate</strong> Cast a Spell</p>\n<p><strong>Frequency</strong> once per day, plus overclock</p>\n<p><strong>Effect</strong> You Cast the Spell at the indicated rank.</p>"
@@ -48,8 +49,13 @@
             ]
         },
         "usage": {
-            "value": "other"
+            "value": "installed-in-a-computer-or-comm-unit"
+        },
+        "uses": {
+            "autoDestroy": false,
+            "max": 1,
+            "value": 1
         }
     },
-    "type": "equipment"
+    "type": "consumable"
 }

--- a/packs/sf2e/equipment/magic-items/spell-chip-5th-rank-spell.json
+++ b/packs/sf2e/equipment/magic-items/spell-chip-5th-rank-spell.json
@@ -8,6 +8,7 @@
         "bulk": {
             "value": 0.1
         },
+        "category": "spell-chip",
         "containerId": null,
         "description": {
             "value": "<p><strong>Usage</strong> installed in computer or comm unit;</p><hr /><p>These chips can be installed in comm units and other computers to allow the device to cast spells. Each device can have only one spell chip. Casting a spell from a spell chip requires holding the computer or comm unit in one hand and activating it with a Cast a Spell activity using the normal number of actions for that spell. The spell must appear on your spell list. Because you're the one Casting the Spell, use your spell attack modifier and spell DC. The spell must be of your spellcasting tradition. If the spell has a locus, you must still have that locus to cast the spell from a spell chip. Spell chips can't contain cantrips or rituals. The traits for this item vary based on the spell it contains.</p>\n<p>In addition to the charge expended to Cast the Spell, the delicate components that make up the core lattice of a spell chip can be destroyed if used in quick succession. Attempting to use a spell chip more than once per day requires overclocking it. Cast the Spell again, then roll a @Check[flat|dc:10]. On a success, the spell chip is broken. On a failure, the spell chip is destroyed. If anyone tries to overclock a spell chip that's already been overclocked that day, the spell chip is automatically destroyed (even if it's been repaired) and no spell is cast.</p>\n<p><strong>Activate</strong> Cast a Spell</p>\n<p><strong>Frequency</strong> once per day, plus overclock</p>\n<p><strong>Effect</strong> You Cast the Spell at the indicated rank.</p>"
@@ -45,8 +46,13 @@
             ]
         },
         "usage": {
-            "value": "other"
+            "value": "installed-in-a-computer-or-comm-unit"
+        },
+        "uses": {
+            "autoDestroy": false,
+            "max": 1,
+            "value": 1
         }
     },
-    "type": "equipment"
+    "type": "consumable"
 }

--- a/packs/sf2e/equipment/magic-items/spell-chip-6th-rank-spell.json
+++ b/packs/sf2e/equipment/magic-items/spell-chip-6th-rank-spell.json
@@ -8,6 +8,7 @@
         "bulk": {
             "value": 0.1
         },
+        "category": "spell-chip",
         "containerId": null,
         "description": {
             "value": "<p><strong>Usage</strong> installed in computer or comm unit;</p><hr /><p>These chips can be installed in comm units and other computers to allow the device to cast spells. Each device can have only one spell chip. Casting a spell from a spell chip requires holding the computer or comm unit in one hand and activating it with a Cast a Spell activity using the normal number of actions for that spell. The spell must appear on your spell list. Because you're the one Casting the Spell, use your spell attack modifier and spell DC. The spell must be of your spellcasting tradition. If the spell has a locus, you must still have that locus to cast the spell from a spell chip. Spell chips can't contain cantrips or rituals. The traits for this item vary based on the spell it contains.</p>\n<p>In addition to the charge expended to Cast the Spell, the delicate components that make up the core lattice of a spell chip can be destroyed if used in quick succession. Attempting to use a spell chip more than once per day requires overclocking it. Cast the Spell again, then roll a @Check[flat|dc:10]. On a success, the spell chip is broken. On a failure, the spell chip is destroyed. If anyone tries to overclock a spell chip that's already been overclocked that day, the spell chip is automatically destroyed (even if it's been repaired) and no spell is cast.</p>\n<p><strong>Activate</strong> Cast a Spell</p>\n<p><strong>Frequency</strong> once per day, plus overclock</p>\n<p><strong>Effect</strong> You Cast the Spell at the indicated rank.</p>"
@@ -48,8 +49,13 @@
             ]
         },
         "usage": {
-            "value": "other"
+            "value": "installed-in-a-computer-or-comm-unit"
+        },
+        "uses": {
+            "autoDestroy": false,
+            "max": 1,
+            "value": 1
         }
     },
-    "type": "equipment"
+    "type": "consumable"
 }

--- a/packs/sf2e/equipment/magic-items/spell-chip-7th-rank-spell.json
+++ b/packs/sf2e/equipment/magic-items/spell-chip-7th-rank-spell.json
@@ -8,6 +8,7 @@
         "bulk": {
             "value": 0.1
         },
+        "category": "spell-chip",
         "containerId": null,
         "description": {
             "value": "<p><strong>Usage</strong> installed in computer or comm unit;</p><hr /><p>These chips can be installed in comm units and other computers to allow the device to cast spells. Each device can have only one spell chip. Casting a spell from a spell chip requires holding the computer or comm unit in one hand and activating it with a Cast a Spell activity using the normal number of actions for that spell. The spell must appear on your spell list. Because you're the one Casting the Spell, use your spell attack modifier and spell DC. The spell must be of your spellcasting tradition. If the spell has a locus, you must still have that locus to cast the spell from a spell chip. Spell chips can't contain cantrips or rituals. The traits for this item vary based on the spell it contains.</p>\n<p>In addition to the charge expended to Cast the Spell, the delicate components that make up the core lattice of a spell chip can be destroyed if used in quick succession. Attempting to use a spell chip more than once per day requires overclocking it. Cast the Spell again, then roll a @Check[flat|dc:10]. On a success, the spell chip is broken. On a failure, the spell chip is destroyed. If anyone tries to overclock a spell chip that's already been overclocked that day, the spell chip is automatically destroyed (even if it's been repaired) and no spell is cast.</p>\n<p><strong>Activate</strong> Cast a Spell</p>\n<p><strong>Frequency</strong> once per day, plus overclock</p>\n<p><strong>Effect</strong> You Cast the Spell at the indicated rank.</p>"
@@ -45,8 +46,13 @@
             ]
         },
         "usage": {
-            "value": "other"
+            "value": "installed-in-a-computer-or-comm-unit"
+        },
+        "uses": {
+            "autoDestroy": false,
+            "max": 1,
+            "value": 1
         }
     },
-    "type": "equipment"
+    "type": "consumable"
 }

--- a/packs/sf2e/equipment/magic-items/spell-chip-8th-rank-spell.json
+++ b/packs/sf2e/equipment/magic-items/spell-chip-8th-rank-spell.json
@@ -8,6 +8,7 @@
         "bulk": {
             "value": 0.1
         },
+        "category": "spell-chip",
         "containerId": null,
         "description": {
             "value": "<p><strong>Usage</strong> installed in computer or comm unit;</p><hr /><p>These chips can be installed in comm units and other computers to allow the device to cast spells. Each device can have only one spell chip. Casting a spell from a spell chip requires holding the computer or comm unit in one hand and activating it with a Cast a Spell activity using the normal number of actions for that spell. The spell must appear on your spell list. Because you're the one Casting the Spell, use your spell attack modifier and spell DC. The spell must be of your spellcasting tradition. If the spell has a locus, you must still have that locus to cast the spell from a spell chip. Spell chips can't contain cantrips or rituals. The traits for this item vary based on the spell it contains.</p>\n<p>In addition to the charge expended to Cast the Spell, the delicate components that make up the core lattice of a spell chip can be destroyed if used in quick succession. Attempting to use a spell chip more than once per day requires overclocking it. Cast the Spell again, then roll a @Check[flat|dc:10]. On a success, the spell chip is broken. On a failure, the spell chip is destroyed. If anyone tries to overclock a spell chip that's already been overclocked that day, the spell chip is automatically destroyed (even if it's been repaired) and no spell is cast.</p>\n<p><strong>Activate</strong> Cast a Spell</p>\n<p><strong>Frequency</strong> once per day, plus overclock</p>\n<p><strong>Effect</strong> You Cast the Spell at the indicated rank.</p>"
@@ -48,8 +49,13 @@
             ]
         },
         "usage": {
-            "value": "other"
+            "value": "installed-in-a-computer-or-comm-unit"
+        },
+        "uses": {
+            "autoDestroy": false,
+            "max": 1,
+            "value": 1
         }
     },
-    "type": "equipment"
+    "type": "consumable"
 }

--- a/packs/sf2e/equipment/magic-items/spell-chip-9th-rank-spell.json
+++ b/packs/sf2e/equipment/magic-items/spell-chip-9th-rank-spell.json
@@ -8,6 +8,7 @@
         "bulk": {
             "value": 0.1
         },
+        "category": "spell-chip",
         "containerId": null,
         "description": {
             "value": "<p><strong>Usage</strong> installed in computer or comm unit;</p><hr /><p>These chips can be installed in comm units and other computers to allow the device to cast spells. Each device can have only one spell chip. Casting a spell from a spell chip requires holding the computer or comm unit in one hand and activating it with a Cast a Spell activity using the normal number of actions for that spell. The spell must appear on your spell list. Because you're the one Casting the Spell, use your spell attack modifier and spell DC. The spell must be of your spellcasting tradition. If the spell has a locus, you must still have that locus to cast the spell from a spell chip. Spell chips can't contain cantrips or rituals. The traits for this item vary based on the spell it contains.</p>\n<p>In addition to the charge expended to Cast the Spell, the delicate components that make up the core lattice of a spell chip can be destroyed if used in quick succession. Attempting to use a spell chip more than once per day requires overclocking it. Cast the Spell again, then roll a @Check[flat|dc:10]. On a success, the spell chip is broken. On a failure, the spell chip is destroyed. If anyone tries to overclock a spell chip that's already been overclocked that day, the spell chip is automatically destroyed (even if it's been repaired) and no spell is cast.</p>\n<p><strong>Activate</strong> Cast a Spell</p>\n<p><strong>Frequency</strong> once per day, plus overclock</p>\n<p><strong>Effect</strong> You Cast the Spell at the indicated rank.</p>"
@@ -45,8 +46,13 @@
             ]
         },
         "usage": {
-            "value": "other"
+            "value": "installed-in-a-computer-or-comm-unit"
+        },
+        "uses": {
+            "autoDestroy": false,
+            "max": 1,
+            "value": 1
         }
     },
-    "type": "equipment"
+    "type": "consumable"
 }

--- a/src/module/actor/character/crafting/helpers.ts
+++ b/src/module/actor/character/crafting/helpers.ts
@@ -114,7 +114,7 @@ export async function craftSpellConsumable(
     actor: ActorPF2e,
 ): Promise<void> {
     const consumableType = item.category;
-    if (!["scroll", "wand", "spell-gem"].includes(consumableType)) return;
+    if (!["scroll", "wand", "spell-chip", "spell-gem"].includes(consumableType)) return;
     const rank = (consumableType === "wand" ? Math.ceil(item.level / 2) - 1 : Math.ceil(item.level / 2)) as OneToTen;
     const validSpells = actor.itemTypes.spell
         .filter((s) => s.baseRank <= rank && !s.isCantrip && !s.isFocusSpell && !s.isRitual)

--- a/src/module/actor/creature/document.ts
+++ b/src/module/actor/creature/document.ts
@@ -283,9 +283,20 @@ abstract class CreaturePF2e<
         super.prepareData();
 
         // Add spell collections from spell consumables if a matching spellcasting ability is found
-        const spellConsumables = this.itemTypes.consumable.filter(
-            (c) => ["scroll", "wand", "spell-gem"].includes(c.category) && c.isIdentified && !c.isStowed,
-        );
+        // If the item is a Scroll, Wand or Spell Gem, get the item directly from the inventory
+        // If the item is a Spell Chip, only consider it if it's attached.
+        const spellConsumables = this.items
+            .filter((i) => i.isOfType("physical"))
+            .flatMap((i) =>
+                i.isOfType("consumable") ? [i] : [...i.subitems.contents].filter((i) => i.isOfType("consumable")),
+            )
+            .filter(
+                (c) =>
+                    c.isIdentified &&
+                    !c.isStowed &&
+                    (["scroll", "wand", "spell-gem"].includes(c.category) ||
+                        (c.category === "spell-chip" && c.parentItem)),
+            );
         for (const consumable of spellConsumables) {
             const spell = consumable.embeddedSpell;
             if (!spell?.id) continue;

--- a/src/module/actor/creature/sheet.ts
+++ b/src/module/actor/creature/sheet.ts
@@ -152,9 +152,14 @@ abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends ActorSheet
         };
 
         handlers["draw-item"] = (event) => {
-            const itemId = htmlClosest(event.target, "[data-item-id")?.dataset.itemId;
-            const item = actor.inventory.get(itemId, { strict: true });
-            return actor.changeCarryType(item, { carryType: "held", handsHeld: 1 });
+            const itemId = htmlClosest(event.target, "[data-item-id]")?.dataset.itemId;
+            const item = actor.inventory.contents
+                .flatMap((i) => [i, ...i.subitems.contents])
+                .find((i) => i.id === itemId);
+            if (!item) {
+                throw new Error(`Item [${itemId}] does not exist in on actor ${actor.name} [${actor.id}]`);
+            }
+            return actor.changeCarryType(item.parentItem ?? item, { carryType: "held", handsHeld: 1 });
         };
 
         handlers["recovery-check"] = (event) => actor.rollRecovery(event);

--- a/src/module/actor/creature/sheet.ts
+++ b/src/module/actor/creature/sheet.ts
@@ -160,8 +160,14 @@ abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends ActorSheet
         handlers["recovery-check"] = (event) => actor.rollRecovery(event);
 
         handlers["consume-item"] = (event) => {
-            const itemId = htmlClosest(event.target, "[data-item-id]")?.dataset.itemId;
-            const item = actor.inventory.get(itemId, { strict: true });
+            const element = htmlClosest(event.target, "[data-item-id],[data-subitem-id]");
+            const itemId = element?.dataset?.itemId ?? element?.dataset?.subitemId;
+            const item = actor.inventory.contents
+                .flatMap((i) => [i, ...i.subitems.contents])
+                .find((i) => i.id === itemId);
+            if (!item) {
+                throw new Error(`Item [${itemId}] does not exist in on actor ${actor.name} [${actor.id}]`);
+            }
             return item.isOfType("consumable") && item.consume();
         };
 

--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -383,7 +383,7 @@ class ItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
             if (
                 currentSource.type === "consumable" &&
                 currentSource.system.spell?.system?.traits &&
-                tupleHasValue(["scroll", "spell-gem", "wand"], currentSource.system.category) &&
+                tupleHasValue(["scroll", "spell-chip", "spell-gem", "wand"], currentSource.system.category) &&
                 latestSource.type === "consumable" &&
                 !latestSource.system.spell
             ) {

--- a/src/module/item/consumable/document.ts
+++ b/src/module/item/consumable/document.ts
@@ -80,7 +80,9 @@ class ConsumablePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extend
             ? [game.i18n.localize(CONFIG.PF2E.consumableCategories[this.category]), true]
             : [
                   this.generateUnidentifiedName({ typeOnly: true }),
-                  !["other", "scroll", "spell-gem", "talisman", "toolkit", "wand"].includes(this.category),
+                  !["other", "scroll", "spell-chip", "spell-gem", "talisman", "toolkit", "wand"].includes(
+                      this.category,
+                  ),
               ];
 
         const usesLabel = game.i18n.localize("PF2E.Item.Consumable.Uses.Label");
@@ -92,7 +94,13 @@ class ConsumablePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extend
             properties:
                 this.isIdentified && this.uses.max > 1 ? [`${this.uses.value}/${this.uses.max} ${usesLabel}`] : [],
             category,
-            isUsable: isUsableItemType && !fromFormula && this.parent && this.parent.items.get(this.id),
+            isUsable:
+                isUsableItemType &&
+                !fromFormula &&
+                this.parent &&
+                this.parent.items.some(
+                    (i) => i.id === this.id || (i.isOfType("physical") && i.subitems.some((s) => s.id === this.id)),
+                ),
         });
     }
 
@@ -131,7 +139,7 @@ class ConsumablePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extend
         if (!actor) return;
         const uses = this.uses;
 
-        if (["scroll", "spell-gem", "wand"].includes(this.category) && this.system.spell) {
+        if (["scroll", "spell-chip", "spell-gem", "wand"].includes(this.category) && this.system.spell) {
             if (actor.spellcasting?.canCastConsumable(this)) {
                 this.castEmbeddedSpell();
             } else if (actor.itemTypes.feat.some((feat) => feat.slug === "trick-magic-item")) {

--- a/src/module/item/consumable/sheet.ts
+++ b/src/module/item/consumable/sheet.ts
@@ -19,7 +19,8 @@ class ConsumableSheetPF2e extends PhysicalItemSheetPF2e<ConsumablePF2e> {
             !!item.system.damage &&
             ["vitality", "void", "untyped"].includes(item.system.damage.type);
         const embeddedSpell = item.actor ? item.embeddedSpell : null;
-        const shouldHaveSpell = !!embeddedSpell || ["scroll", "spell-gem", "wand"].includes(item.system.category);
+        const shouldHaveSpell =
+            !!embeddedSpell || ["scroll", "spell-chip", "spell-gem", "wand"].includes(item.system.category);
 
         return {
             ...sheetData,

--- a/src/module/item/consumable/values.ts
+++ b/src/module/item/consumable/values.ts
@@ -10,6 +10,7 @@ const CONSUMABLE_CATEGORIES = new Set([
     "poison",
     "potion",
     "scroll",
+    "spell-chip",
     "spell-gem",
     "snare",
     "talisman",

--- a/src/module/item/equipment/document.ts
+++ b/src/module/item/equipment/document.ts
@@ -15,6 +15,14 @@ class EquipmentPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends
         return this.system.usage.type === "installed";
     }
 
+    override acceptsSubitem(candidate: PhysicalItemPF2e): boolean {
+        const usage = candidate.system.usage;
+        if (this.slug === "comm-unit" && usage.type === "installed" && usage.where.includes("comm-unit")) {
+            return true;
+        }
+        return super.acceptsSubitem(candidate);
+    }
+
     override async getChatData(
         this: EquipmentPF2e<ActorPF2e>,
         htmlOptions: EnrichmentOptionsPF2e = {},

--- a/src/module/item/physical/document.ts
+++ b/src/module/item/physical/document.ts
@@ -115,7 +115,7 @@ abstract class PhysicalItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | n
 
     /** Whether the item has an attached (or affixed, applied, etc.) usage */
     get isAttachable(): boolean {
-        return false;
+        return ["attached", "installed"].includes(this.system.usage.type);
     }
 
     get price(): Price {

--- a/src/module/item/physical/document.ts
+++ b/src/module/item/physical/document.ts
@@ -37,7 +37,7 @@ import { COIN_DENOMINATIONS } from "./values.ts";
 
 abstract class PhysicalItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends ItemPF2e<TParent> {
     /** The item in which this item is embedded */
-    parentItem: PhysicalItemPF2e | null;
+    parentItem: PhysicalItemPF2e<TParent> | null;
 
     /**
      * The cached container of this item, if in a container, or null

--- a/src/scripts/config/index.ts
+++ b/src/scripts/config/index.ts
@@ -881,6 +881,22 @@ export const PF2ECONFIG = {
                           10: "Compendium.sf2e.equipment.Item.ulNSlan9Q5j1ozPI",
                       },
                   },
+                  "spell-chip": {
+                      name: "PF2E.Item.Consumable.Category.spell-chip",
+                      nameTemplate: "PF2E.Item.Physical.FromSpell.spell-chip",
+                      compendiumUuids: {
+                          1: "Compendium.sf2e.equipment.Item.U48mM3lcrBTh25d9",
+                          2: "Compendium.sf2e.equipment.Item.88WZweNBd4j2X2hd",
+                          3: "Compendium.sf2e.equipment.Item.Wn8GEmCG24QIM1wt",
+                          4: "Compendium.sf2e.equipment.Item.5O3DUTQoUA3rcF6v",
+                          5: "Compendium.sf2e.equipment.Item.nyTMtaCsBvXeK4JP",
+                          6: "Compendium.sf2e.equipment.Item.PinBkpx2xRvmUiiM",
+                          7: "Compendium.sf2e.equipment.Item.TBtiV7FLBpI2HtCC",
+                          8: "Compendium.sf2e.equipment.Item.cUks0bsnFkfxeojU",
+                          9: "Compendium.sf2e.equipment.Item.sB9xK4xLUCyXUDzm",
+                          10: null,
+                      },
+                  },
               },
 
     attitude: {

--- a/src/scripts/config/index.ts
+++ b/src/scripts/config/index.ts
@@ -865,25 +865,9 @@ export const PF2ECONFIG = {
                   },
               }
             : {
-                  "spell-gem": {
-                      name: "PF2E.Item.Consumable.Category.spell-gem",
-                      nameTemplate: "PF2E.Item.Physical.FromSpell.spell-gem",
-                      compendiumUuids: {
-                          1: "Compendium.sf2e.equipment.Item.R6LuVXimv1Hh8ehE",
-                          2: "Compendium.sf2e.equipment.Item.p5DYjh3sCSjzrBBg",
-                          3: "Compendium.sf2e.equipment.Item.Nwl7YydQ0r8cAhw7",
-                          4: "Compendium.sf2e.equipment.Item.88IBM9viOjJ0kJbm",
-                          5: "Compendium.sf2e.equipment.Item.BVCQFla90m2JDepV",
-                          6: "Compendium.sf2e.equipment.Item.9PAmdF8UqVQKXWPA",
-                          7: "Compendium.sf2e.equipment.Item.JgvLQeWK45OxFrx0",
-                          8: "Compendium.sf2e.equipment.Item.Vt6VVUXFf1boNs3P",
-                          9: "Compendium.sf2e.equipment.Item.8nNTrkf4ZCqkApNT",
-                          10: "Compendium.sf2e.equipment.Item.ulNSlan9Q5j1ozPI",
-                      },
-                  },
                   "spell-chip": {
                       name: "PF2E.Item.Consumable.Category.spell-chip",
-                      nameTemplate: "PF2E.Item.Physical.FromSpell.spell-chip",
+                      nameTemplate: "PF2E.Item.Physical.FromSpell.SpellChip",
                       compendiumUuids: {
                           1: "Compendium.sf2e.equipment.Item.U48mM3lcrBTh25d9",
                           2: "Compendium.sf2e.equipment.Item.88WZweNBd4j2X2hd",
@@ -895,6 +879,22 @@ export const PF2ECONFIG = {
                           8: "Compendium.sf2e.equipment.Item.cUks0bsnFkfxeojU",
                           9: "Compendium.sf2e.equipment.Item.sB9xK4xLUCyXUDzm",
                           10: null,
+                      },
+                  },
+                  "spell-gem": {
+                      name: "PF2E.Item.Consumable.Category.spell-gem",
+                      nameTemplate: "PF2E.Item.Physical.FromSpell.SpellGem",
+                      compendiumUuids: {
+                          1: "Compendium.sf2e.equipment.Item.R6LuVXimv1Hh8ehE",
+                          2: "Compendium.sf2e.equipment.Item.p5DYjh3sCSjzrBBg",
+                          3: "Compendium.sf2e.equipment.Item.Nwl7YydQ0r8cAhw7",
+                          4: "Compendium.sf2e.equipment.Item.88IBM9viOjJ0kJbm",
+                          5: "Compendium.sf2e.equipment.Item.BVCQFla90m2JDepV",
+                          6: "Compendium.sf2e.equipment.Item.9PAmdF8UqVQKXWPA",
+                          7: "Compendium.sf2e.equipment.Item.JgvLQeWK45OxFrx0",
+                          8: "Compendium.sf2e.equipment.Item.Vt6VVUXFf1boNs3P",
+                          9: "Compendium.sf2e.equipment.Item.8nNTrkf4ZCqkApNT",
+                          10: "Compendium.sf2e.equipment.Item.ulNSlan9Q5j1ozPI",
                       },
                   },
               },

--- a/src/scripts/config/usage.ts
+++ b/src/scripts/config/usage.ts
@@ -110,6 +110,7 @@ const USAGES = {
     "held-in-one-or-two-hands": "PF2E.TraitHeldOneTwoHands",
     "held-in-two-hands": "PF2E.TraitHeldTwoHands",
     implanted: "PF2E.TraitImplanted",
+    "installed-in-a-computer-or-comm-unit": "PF2E.TraitInstalledInAComputerOrCommUnit",
     "installed-in-a-datapad": "PF2E.TraitInstalledInADatapad",
     "mounted-on-a-tripod-or-bracket": "PF2E.TraitMountedOnATripodOrBracket",
     other: "PF2E.TraitOther",

--- a/src/scripts/macros/rest-for-the-night.ts
+++ b/src/scripts/macros/rest-for-the-night.ts
@@ -1,5 +1,6 @@
 import { CharacterPF2e } from "@actor";
 import { CharacterAttributesSource, CharacterResourcesSource } from "@actor/character/data.ts";
+import { PhysicalItemPF2e } from "@item";
 import type { ItemSourcePF2e } from "@item/base/data/index.ts";
 import { ChatMessageSourcePF2e } from "@module/chat-message/data.ts";
 import { ChatMessagePF2e } from "@module/chat-message/index.ts";
@@ -44,6 +45,7 @@ export async function restForTheNight(options: RestForTheNightOptions): Promise<
         };
         const itemCreates: PreCreate<ItemSourcePF2e>[] = [];
         const itemUpdates: EmbeddedDocumentUpdateData[] = [];
+        const subitemsUpdates: { item: PhysicalItemPF2e; update: { [key: string]: unknown } }[] = [];
         // A list of messages informing the user of updates made due to rest
         const statements: string[] = [];
 
@@ -99,6 +101,25 @@ export async function restForTheNight(options: RestForTheNightOptions): Promise<
         itemUpdates.push(...wands.map((wand) => ({ _id: wand.id, "system.uses.value": wand.uses.max })));
         const wandRecharged = itemUpdates.length > 0;
 
+        // Restore spell chips charges
+        const chips = actor.items
+            .filter((i) => i.isOfType("physical"))
+            .flatMap((i) =>
+                i.isOfType("consumable") ? [i] : [...i.subitems.contents].filter((s) => s.isOfType("consumable")),
+            )
+            .filter((s) => s.category === "spell-chip" && s.uses.value < s.uses.max);
+        for (const chip of chips) {
+            if (chip.parentItem)
+                subitemsUpdates.push({
+                    item: chip,
+                    update: { "system.uses.value": chip.uses.max },
+                });
+            else {
+                itemUpdates.push({ _id: chip.id, "system.uses.value": chip.uses.max });
+            }
+        }
+        const chipsRecharged = chips.length > 0;
+
         // Restore reagents
         const resources = actor.system.resources;
         const reagents = resources.crafting.infusedReagents;
@@ -152,6 +173,11 @@ export async function restForTheNight(options: RestForTheNightOptions): Promise<
             await actor.updateEmbeddedDocuments("Item", itemUpdates, { render: false });
         }
 
+        // Spell chips are subitems and can't be updated in bulk
+        for (const { item, update } of subitemsUpdates) {
+            await item.update(update);
+        }
+
         if (recharges.affected.frequencies) {
             statements.push(localize("Message.Frequencies"));
         }
@@ -184,6 +210,11 @@ export async function restForTheNight(options: RestForTheNightOptions): Promise<
         // Wand recharge
         if (wandRecharged) {
             statements.push(localize("Message.WandsCharges"));
+        }
+
+        // Chips recharge
+        if (chipsRecharged) {
+            statements.push(localize("Message.ChipsCharges"));
         }
 
         // Conditions removed

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -80,6 +80,7 @@
                     "CraftingSlots": "Crafting slots restored.",
                     "ConditionReduced": "{condition} reduced by 1.",
                     "ConditionRemoved": "No longer {condition}.",
+                    "ChipsCharges": "Spell Chips recharged.",
                     "FocusPoints": "Focus points restored.",
                     "Frequencies": "Action frequencies refreshed.",
                     "HitPoints": "{hitPoints} hit points restored.",
@@ -2144,6 +2145,7 @@
                     "fulu": "Fulu",
                     "gadget": "Gadget",
                     "spell-gem": "Spell Gem",
+                    "spell-chip": "Spell Chip",
                     "mutagen": "Mutagen",
                     "oil": "Oil",
                     "other": "Other",
@@ -2734,6 +2736,7 @@
                     "CantripDeck5": "Cantrip Deck of {name} (5-pack)",
                     "Scroll": "Scroll of {name} (Rank {level})",
                     "spell-gem": "Spell Gem of {name} (Rank {level})",
+                    "spell-chip": "Spell Chip of {name} (Rank {level})",
                     "Wand": "Wand of {name} (Rank {level})"
                 },
                 "GeneratedName": {
@@ -5335,6 +5338,7 @@
         "TraitInstalledInArmor": "Installed in Armor",
         "TraitInstalledInArmorWithTheEnergyShieldingUpgrade": "Installed in Armor with the Energy Shielding upgrade",
         "TraitInstalledInArmorWithTheExposedTrait": "Installed in Armor with the Exposed trait",
+        "TraitInstalledInAComputerOrCommUnit": "Installed in a computer or comm unit",
         "TraitInstalledInADatapad": "Installed in a datapad",
         "TraitInstalledInAGrenadeLauncherOrTwoHandedWeaponWithAnUndermoundedGrenadeLauncher": "Installed in a Grenade Launcher or Two-Handed Weapon with an Undermounded Grenade Launcher",
         "TraitInstalledInAWeaponSight": "Installed in a Weapon Sight",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2735,8 +2735,8 @@
                 "FromSpell": {
                     "CantripDeck5": "Cantrip Deck of {name} (5-pack)",
                     "Scroll": "Scroll of {name} (Rank {level})",
-                    "spell-gem": "Spell Gem of {name} (Rank {level})",
-                    "spell-chip": "Spell Chip of {name} (Rank {level})",
+                    "SpellChip": "Spell Chip of {name} (Rank {level})",
+                    "SpellGem": "Spell Gem of {name} (Rank {level})",
                     "Wand": "Wand of {name} (Rank {level})"
                 },
                 "GeneratedName": {

--- a/static/templates/actors/partials/item-line.hbs
+++ b/static/templates/actors/partials/item-line.hbs
@@ -20,7 +20,7 @@
                 {{#if itemSize}}<span class="size">({{itemSize}})</span>{{/if}}
                 {{#if item.isTemporary}}<i class="fa-solid fa-stopwatch" data-tooltip="PF2E.TemporaryItemToolTip"></i>{{/if}}
             </h4>
-            {{#if (and item.uses.max (or (gt item.uses.max 1) (eq item.category "wand")))}}
+            {{#if (and item.uses.max (or (gt item.uses.max 1) (or (eq item.category "wand") (eq item.category "spell-chip"))))}}
                 <span class="uses">({{item.uses.value}}/{{item.uses.max}})</span>
             {{/if}}
         </div>


### PR DESCRIPTION
I've based the implementation on spell wands, but since the spell chip has to be installed into a comm unit, the changes went significantly beyond just configuration.

1) Added a new consumable subtype "spell-chip" and changed spell chips to consumable type
2) Added a new install type and **additional logic for physical items that allow them to be attachable if their usage includes installed or attached**.
3) Made Comm Unit (by slug) accept items that are installable in it.
4) Because subitems inherit their usage from parent items, when the Comm Unit is held in hand, the spell can be used.
5) Made interface tweaks - show SC charges. Made "Use" button appear on subitems. When the chip is drawn from the activations tab, it will draw the parent item instead.
6) Made chips recharge on rest.

<img width="676" height="459" alt="image" src="https://github.com/user-attachments/assets/43acb3a5-eafd-40af-8abc-e8021565b226" />


A helper function to iterate over subitems would be useful. Using flatmaps feel really ugly.
And another one to obtain subitems by id.

Relevant issue https://github.com/foundryvtt/pf2e/issues/21771

Note for the future - enable these items with anachronism.