### PR TITLE
Fix healing calculation in Administer Ambient Magic

### DIFF
--- a/packs/pf2e/actions/archetype/ostilli-host/administer-ambient-magic.json
+++ b/packs/pf2e/actions/archetype/ostilli-host/administer-ambient-magic.json
@@ -12,7 +12,7 @@
         },
         "category": "defensive",
         "description": {
-            "value": "<p><strong>Frequency</strong> once per hour</p><hr /><p><strong>Effect</strong> Your ostilli pulses a calm lavender color as it converts stored magic into a curative balm. You regain @Damage[(2*(floor(@actor.level/4))d4)[healing]] Hit Points, and you can immediately attempt a flat check to recover from persistent bleed damage with the DC reduced to 10. This healing increases by 2d4 at 8th level and every 4 levels thereafter.</p>"
+            "value": "<p><strong>Frequency</strong> once per hour</p><hr /><p><strong>Effect</strong> Your ostilli pulses a calm lavender color as it converts stored magic into a curative balm. You regain @Damage[((2*floor(@actor.level/4))d4)[healing]] Hit Points, and you can immediately attempt a flat check to recover from persistent bleed damage with the DC reduced to 10. This healing increases by 2d4 at 8th level and every 4 levels thereafter.</p>"
         },
         "frequency": {
             "max": 1,


### PR DESCRIPTION
During gameplay, I noticed the previous calculation was listed as 2*0d4. 

This moves the `2*` into the first brackets to make it match the values listed under [AON](https://2e.aonprd.com/Feats.aspx?ID=5452)