### PR TITLE
Add deployment toggle to Ultralight Wings

### DIFF
--- a/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-advanced.json
+++ b/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-advanced.json
@@ -51,7 +51,10 @@
                 "predicate": [
                     "wings-deployed",
                     {
-                        "nor": ["armor:category:heavy", "armor:category:medium"]
+                        "nor": [
+                            "armor:category:heavy",
+                            "armor:category:medium"
+                        ]
                     }
                 ],
                 "selector": "fly",
@@ -59,8 +62,13 @@
             },
             {
                 "key": "FlatModifier",
-                "predicate": ["action:maneuver-in-flight", "wings-deployed"],
-                "selector": ["acrobatics"],
+                "predicate": [
+                    "action:maneuver-in-flight",
+                    "wings-deployed"
+                ],
+                "selector": [
+                    "acrobatics"
+                ],
                 "type": "item",
                 "value": 2
             }
@@ -68,7 +76,9 @@
         "size": "med",
         "traits": {
             "rarity": "common",
-            "value": ["biotech"]
+            "value": [
+                "biotech"
+            ]
         },
         "usage": {
             "value": "implanted"

--- a/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-advanced.json
+++ b/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-advanced.json
@@ -41,7 +41,7 @@
         "rules": [
             {
                 "key": "RollOption",
-                "label": "Wings Deployed",
+                "label": "PF2E.SpecificRule.Equipment.UltralightWings.WingsDeployed",
                 "option": "wings-deployed",
                 "toggleable": true,
                 "value": false

--- a/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-advanced.json
+++ b/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-advanced.json
@@ -40,14 +40,18 @@
         "quantity": 1,
         "rules": [
             {
+                "key": "RollOption",
+                "label": "Wings Deployed",
+                "option": "wings-deployed",
+                "toggleable": true,
+                "value": false
+            },
+            {
                 "key": "BaseSpeed",
                 "predicate": [
                     "wings-deployed",
                     {
-                        "nor": [
-                            "armor:category:heavy",
-                            "armor:category:medium"
-                        ]
+                        "nor": ["armor:category:heavy", "armor:category:medium"]
                     }
                 ],
                 "selector": "fly",
@@ -55,13 +59,8 @@
             },
             {
                 "key": "FlatModifier",
-                "predicate": [
-                    "action:maneuver-in-flight",
-                    "wings-deployed"
-                ],
-                "selector": [
-                    "acrobatics"
-                ],
+                "predicate": ["action:maneuver-in-flight", "wings-deployed"],
+                "selector": ["acrobatics"],
                 "type": "item",
                 "value": 2
             }
@@ -69,9 +68,7 @@
         "size": "med",
         "traits": {
             "rarity": "common",
-            "value": [
-                "biotech"
-            ]
+            "value": ["biotech"]
         },
         "usage": {
             "value": "implanted"

--- a/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-advanced.json
+++ b/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-advanced.json
@@ -41,7 +41,7 @@
         "rules": [
             {
                 "key": "RollOption",
-                "label": "PF2E.SpecificRule.Equipment.UltralightWings.WingsDeployed",
+                "label": "SF2E.SpecificRule.Equipment.UltralightWings.WingsDeployed",
                 "option": "wings-deployed",
                 "toggleable": true,
                 "value": false

--- a/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-commercial.json
+++ b/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-commercial.json
@@ -48,7 +48,10 @@
                 "predicate": [
                     "wings-deployed",
                     {
-                        "nor": ["armor:category:heavy", "armor:category:medium"]
+                        "nor": [
+                            "armor:category:heavy",
+                            "armor:category:medium"
+                        ]
                     }
                 ],
                 "selector": "fly",
@@ -56,8 +59,13 @@
             },
             {
                 "key": "FlatModifier",
-                "predicate": ["action:maneuver-in-flight", "wings-deployed"],
-                "selector": ["acrobatics"],
+                "predicate": [
+                    "action:maneuver-in-flight",
+                    "wings-deployed"
+                ],
+                "selector": [
+                    "acrobatics"
+                ],
                 "type": "item",
                 "value": 1
             }
@@ -65,7 +73,9 @@
         "size": "med",
         "traits": {
             "rarity": "common",
-            "value": ["biotech"]
+            "value": [
+                "biotech"
+            ]
         },
         "usage": {
             "value": "implanted"

--- a/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-commercial.json
+++ b/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-commercial.json
@@ -38,7 +38,7 @@
         "rules": [
             {
                 "key": "RollOption",
-                "label": "PF2E.SpecificRule.Equipment.UltralightWings.WingsDeployed",
+                "label": "SF2E.SpecificRule.Equipment.UltralightWings.WingsDeployed",
                 "option": "wings-deployed",
                 "toggleable": true,
                 "value": false

--- a/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-commercial.json
+++ b/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-commercial.json
@@ -37,14 +37,18 @@
         "quantity": 1,
         "rules": [
             {
+                "key": "RollOption",
+                "label": "Wings Deployed",
+                "option": "wings-deployed",
+                "toggleable": true,
+                "value": false
+            },
+            {
                 "key": "BaseSpeed",
                 "predicate": [
                     "wings-deployed",
                     {
-                        "nor": [
-                            "armor:category:heavy",
-                            "armor:category:medium"
-                        ]
+                        "nor": ["armor:category:heavy", "armor:category:medium"]
                     }
                 ],
                 "selector": "fly",
@@ -52,13 +56,8 @@
             },
             {
                 "key": "FlatModifier",
-                "predicate": [
-                    "action:maneuver-in-flight",
-                    "wings-deployed"
-                ],
-                "selector": [
-                    "acrobatics"
-                ],
+                "predicate": ["action:maneuver-in-flight", "wings-deployed"],
+                "selector": ["acrobatics"],
                 "type": "item",
                 "value": 1
             }
@@ -66,9 +65,7 @@
         "size": "med",
         "traits": {
             "rarity": "common",
-            "value": [
-                "biotech"
-            ]
+            "value": ["biotech"]
         },
         "usage": {
             "value": "implanted"

--- a/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-commercial.json
+++ b/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-commercial.json
@@ -38,7 +38,7 @@
         "rules": [
             {
                 "key": "RollOption",
-                "label": "Wings Deployed",
+                "label": "PF2E.SpecificRule.Equipment.UltralightWings.WingsDeployed",
                 "option": "wings-deployed",
                 "toggleable": true,
                 "value": false

--- a/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-superior.json
+++ b/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-superior.json
@@ -51,7 +51,10 @@
                 "predicate": [
                     "wings-deployed",
                     {
-                        "nor": ["armor:category:heavy", "armor:category:medium"]
+                        "nor": [
+                            "armor:category:heavy",
+                            "armor:category:medium"
+                        ]
                     }
                 ],
                 "selector": "fly",
@@ -59,8 +62,13 @@
             },
             {
                 "key": "FlatModifier",
-                "predicate": ["action:maneuver-in-flight", "wings-deployed"],
-                "selector": ["acrobatics"],
+                "predicate": [
+                    "action:maneuver-in-flight",
+                    "wings-deployed"
+                ],
+                "selector": [
+                    "acrobatics"
+                ],
                 "type": "item",
                 "value": 2
             }
@@ -68,7 +76,9 @@
         "size": "med",
         "traits": {
             "rarity": "common",
-            "value": ["biotech"]
+            "value": [
+                "biotech"
+            ]
         },
         "usage": {
             "value": "implanted"

--- a/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-superior.json
+++ b/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-superior.json
@@ -41,7 +41,7 @@
         "rules": [
             {
                 "key": "RollOption",
-                "label": "Wings Deployed",
+                "label": "PF2E.SpecificRule.Equipment.UltralightWings.WingsDeployed",
                 "option": "wings-deployed",
                 "toggleable": true,
                 "value": false

--- a/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-superior.json
+++ b/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-superior.json
@@ -40,14 +40,18 @@
         "quantity": 1,
         "rules": [
             {
+                "key": "RollOption",
+                "label": "Wings Deployed",
+                "option": "wings-deployed",
+                "toggleable": true,
+                "value": false
+            },
+            {
                 "key": "BaseSpeed",
                 "predicate": [
                     "wings-deployed",
                     {
-                        "nor": [
-                            "armor:category:heavy",
-                            "armor:category:medium"
-                        ]
+                        "nor": ["armor:category:heavy", "armor:category:medium"]
                     }
                 ],
                 "selector": "fly",
@@ -55,13 +59,8 @@
             },
             {
                 "key": "FlatModifier",
-                "predicate": [
-                    "action:maneuver-in-flight",
-                    "wings-deployed"
-                ],
-                "selector": [
-                    "acrobatics"
-                ],
+                "predicate": ["action:maneuver-in-flight", "wings-deployed"],
+                "selector": ["acrobatics"],
                 "type": "item",
                 "value": 2
             }
@@ -69,9 +68,7 @@
         "size": "med",
         "traits": {
             "rarity": "common",
-            "value": [
-                "biotech"
-            ]
+            "value": ["biotech"]
         },
         "usage": {
             "value": "implanted"

--- a/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-superior.json
+++ b/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-superior.json
@@ -41,7 +41,7 @@
         "rules": [
             {
                 "key": "RollOption",
-                "label": "PF2E.SpecificRule.Equipment.UltralightWings.WingsDeployed",
+                "label": "SF2E.SpecificRule.Equipment.UltralightWings.WingsDeployed",
                 "option": "wings-deployed",
                 "toggleable": true,
                 "value": false

--- a/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-tactical.json
+++ b/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-tactical.json
@@ -41,7 +41,7 @@
         "rules": [
             {
                 "key": "RollOption",
-                "label": "Wings Deployed",
+                "label": "PF2E.SpecificRule.Equipment.UltralightWings.WingsDeployed",
                 "option": "wings-deployed",
                 "toggleable": true,
                 "value": false

--- a/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-tactical.json
+++ b/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-tactical.json
@@ -40,14 +40,18 @@
         "quantity": 1,
         "rules": [
             {
+                "key": "RollOption",
+                "label": "Wings Deployed",
+                "option": "wings-deployed",
+                "toggleable": true,
+                "value": false
+            },
+            {
                 "key": "BaseSpeed",
                 "predicate": [
                     "wings-deployed",
                     {
-                        "nor": [
-                            "armor:category:heavy",
-                            "armor:category:medium"
-                        ]
+                        "nor": ["armor:category:heavy", "armor:category:medium"]
                     }
                 ],
                 "selector": "fly",
@@ -55,13 +59,8 @@
             },
             {
                 "key": "FlatModifier",
-                "predicate": [
-                    "action:maneuver-in-flight",
-                    "wings-deployed"
-                ],
-                "selector": [
-                    "acrobatics"
-                ],
+                "predicate": ["action:maneuver-in-flight", "wings-deployed"],
+                "selector": ["acrobatics"],
                 "type": "item",
                 "value": 1
             }
@@ -69,9 +68,7 @@
         "size": "med",
         "traits": {
             "rarity": "common",
-            "value": [
-                "biotech"
-            ]
+            "value": ["biotech"]
         },
         "usage": {
             "value": "implanted"

--- a/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-tactical.json
+++ b/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-tactical.json
@@ -51,7 +51,10 @@
                 "predicate": [
                     "wings-deployed",
                     {
-                        "nor": ["armor:category:heavy", "armor:category:medium"]
+                        "nor": [
+                            "armor:category:heavy",
+                            "armor:category:medium"
+                        ]
                     }
                 ],
                 "selector": "fly",
@@ -59,8 +62,13 @@
             },
             {
                 "key": "FlatModifier",
-                "predicate": ["action:maneuver-in-flight", "wings-deployed"],
-                "selector": ["acrobatics"],
+                "predicate": [
+                    "action:maneuver-in-flight",
+                    "wings-deployed"
+                ],
+                "selector": [
+                    "acrobatics"
+                ],
                 "type": "item",
                 "value": 1
             }
@@ -68,7 +76,9 @@
         "size": "med",
         "traits": {
             "rarity": "common",
-            "value": ["biotech"]
+            "value": [
+                "biotech"
+            ]
         },
         "usage": {
             "value": "implanted"

--- a/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-tactical.json
+++ b/packs/sf2e/equipment/augmentations/biotech/ultralight-wings-tactical.json
@@ -41,7 +41,7 @@
         "rules": [
             {
                 "key": "RollOption",
-                "label": "PF2E.SpecificRule.Equipment.UltralightWings.WingsDeployed",
+                "label": "SF2E.SpecificRule.Equipment.UltralightWings.WingsDeployed",
                 "option": "wings-deployed",
                 "toggleable": true,
                 "value": false

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -7758,7 +7758,7 @@
                     "ClimbMetalSurfaces": "Magboots — Climb metal surfaces"
                 },
                 "UltralightWings": {
-                    "WingsDeployed": "Wings Deployed"
+                    "WingsDeployed": "Ultralight Wings — Wings Deployed"
                 },
                 "SolarianCrystals": {
                     "Gluon": {

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -7757,6 +7757,9 @@
                 "Magboots": {
                     "ClimbMetalSurfaces": "Magboots — Climb metal surfaces"
                 },
+                "UltralightWings": {
+                    "WingsDeployed": "Wings Deployed"
+                },
                 "SolarianCrystals": {
                     "Gluon": {
                         "Note": "On a critical hit, the target is @UUID[Compendium.pf2e.conditionitems.Item.i3OJZU2nk64Df3xm]{Clumsy 1} until it recovers from the persistent bleed damage.",


### PR DESCRIPTION
- add the missing `wings-deployed` roll option toggle to all Ultralight Wings variants
- allow the existing fly Speed and Maneuver in Flight bonus rules to activate correctly when the wings are deployed
- match the item behavior described in Starfinder Player Core

Fixes [#21778](https://github.com/foundryvtt/pf2e/issues/21778)
