### PR TITLE
Fix antifungal salve effect duration

### DIFF
--- a/packs/pf2e/equipment-effects/effect-antifungal-salve.json
+++ b/packs/pf2e/equipment-effects/effect-antifungal-salve.json
@@ -10,7 +10,7 @@
             "expiry": "turn-start",
             "sustained": false,
             "unit": "hours",
-            "value": 24
+            "value": 6
         },
         "level": {
             "value": 1


### PR DESCRIPTION
update Effect: Antifungal Salve to use the correct 6-hour duration 

It fix: [#21769](https://github.com/foundryvtt/pf2e/issues/21769)