### PR TITLE
Fix missing sanctification trait on Herald's Weapon

### DIFF
--- a/packs/pf2e/feat-effects/effect-heralds-weapon.json
+++ b/packs/pf2e/feat-effects/effect-heralds-weapon.json
@@ -55,6 +55,22 @@
                 ],
                 "property": "traits",
                 "value": "sanctified"
+            },
+            {
+                "definition": ["item:slug:{item|flags.system.rulesSelections.weapon}"],
+                "key": "AdjustStrike",
+                "mode": "add",
+                "predicate": ["sanctification:holy"],
+                "property": "traits",
+                "value": "holy"
+            },
+            {
+                "definition": ["item:slug:{item|flags.system.rulesSelections.weapon}"],
+                "key": "AdjustStrike",
+                "mode": "add",
+                "predicate": ["sanctification:unholy"],
+                "property": "traits",
+                "value": "unholy"
             }
         ],
         "start": {

--- a/packs/pf2e/feat-effects/effect-heralds-weapon.json
+++ b/packs/pf2e/feat-effects/effect-heralds-weapon.json
@@ -57,18 +57,26 @@
                 "value": "sanctified"
             },
             {
-                "definition": ["item:slug:{item|flags.system.rulesSelections.weapon}"],
+                "definition": [
+                    "item:slug:{item|flags.system.rulesSelections.weapon}"
+                ],
                 "key": "AdjustStrike",
                 "mode": "add",
-                "predicate": ["sanctification:holy"],
+                "predicate": [
+                    "sanctification:holy"
+                ],
                 "property": "traits",
                 "value": "holy"
             },
             {
-                "definition": ["item:slug:{item|flags.system.rulesSelections.weapon}"],
+                "definition": [
+                    "item:slug:{item|flags.system.rulesSelections.weapon}"
+                ],
                 "key": "AdjustStrike",
                 "mode": "add",
-                "predicate": ["sanctification:unholy"],
+                "predicate": [
+                    "sanctification:unholy"
+                ],
                 "property": "traits",
                 "value": "unholy"
             }


### PR DESCRIPTION
Add holy or unholy strike traits to [Herald's Weapon](https://2e.aonprd.com/Feats.aspx?ID=7532) based on the actor's sanctification choice 

It close #21417