### PR TITLE
Fix inline check options for against DCs

### DIFF
--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -265,6 +265,7 @@ export class InlineRollLinks {
                             : [],
                         rollOptions: [
                             item?.isOfType("action", "feat") ? `${opposingRole}:action:slug:${item.slug}` : null,
+                            ...extraRollOptions,
                         ].filter(R.isTruthy),
                     });
                     if (defenseStat) {


### PR DESCRIPTION
Pass inline check `options` to `against` defense statistic resolution

**Testing**
- tested against a target with `Root Boots` and `Grip Ground` enabled
- confirmed `Flowing Hair` uses the same increased Fortitude DC as `Shove`

this fixes contextual inline checks #20775, but not bare chat-authored checks without actor or item context