### PR TITLE
Remove fire resistance and immunity with Curse of Engulfing Flames

### DIFF
--- a/packs/pf2e/class-features/curse-of-engulfing-flames.json
+++ b/packs/pf2e/class-features/curse-of-engulfing-flames.json
@@ -116,6 +116,29 @@
                 ],
                 "reevaluateOnUpdate": true,
                 "uuid": "Compendium.pf2e.conditionitems.Item.Persistent Damage"
+            },
+            {
+                "key": "Immunity",
+                "mode": "remove",
+                "predicate": [
+                    "self:condition:cursebound"
+                ],
+                "priority": 110,
+                "type": [
+                    "fire"
+                ]
+            },
+            {
+                "key": "Resistance",
+                "mode": "remove",
+                "predicate": [
+                    "self:condition:cursebound"
+                ],
+                "priority": 110,
+                "type": [
+                    "fire"
+                ],
+                "value": 0
             }
         ],
         "traits": {


### PR DESCRIPTION
This is part of the Spring 2026 errata, I updated the text but missed adding these rule elements.