### PR TITLE
Update Draconic Fury to calculate damage based on actor level

### DIFF
--- a/packs/pf2e/feats/archetype/draconic-acolyte/draconic-fury.json
+++ b/packs/pf2e/feats/archetype/draconic-acolyte/draconic-fury.json
@@ -12,7 +12,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p><strong>Requirements</strong> You are holding or wearing your draconic gift.</p><hr /><p>You briefly summon spectral claws that lash out in a flurry. All creatures in a @Template[type:cone|distance:15] take @Damage[(1 + floor(@item.level/4))d6[slashing]|options:area-damage] damage with a @Check[reflex|against:class-spell|basic|options:area-effect] save against the higher of your class DC or spell DC. A creature that critically fails the save also takes @Damage[(floor(@item.level/4))d4[persistent,bleed]] damage. If you are Channeling Draconic Essence, your spectral dragon's space can be the origin of the cone.</p>\n<p>At 8th level and every 4 levels thereafter, the initial damage increases by 1d6 and the persistent bleed damage on a critical failure increases by 1d4.</p>"
+            "value": "<p><strong>Requirements</strong> You are holding or wearing your draconic gift.</p><hr /><p>You briefly summon spectral claws that lash out in a flurry. All creatures in a @Template[type:cone|distance:15] take @Damage[(1 + floor(@actor.level/4))d6[slashing]|options:area-damage] damage with a @Check[reflex|against:class-spell|basic|options:area-effect] save against the higher of your class DC or spell DC. A creature that critically fails the save also takes @Damage[(floor(@actor.level/4))d4[persistent,bleed]] damage. If you are Channeling Draconic Essence, your spectral dragon's space can be the origin of the cone.</p>\n<p>At 8th level and every 4 levels thereafter, the initial damage increases by 1d6 and the persistent bleed damage on a critical failure increases by 1d4.</p>"
         },
         "level": {
             "value": 4


### PR DESCRIPTION
Updated the damage calculation to use actor's level instead of item's level.