### PR TITLE
Avoid eager construction of all synthetic actors during world load

### DIFF
--- a/src/module/item/abstract-effect/document.ts
+++ b/src/module/item/abstract-effect/document.ts
@@ -30,10 +30,8 @@ abstract class AbstractEffectPF2e<TParent extends ActorPF2e | null = ActorPF2e |
         // actor, and it may be in the middle of construction presently.
         if (originUUID.startsWith("Scene.")) {
             const tokenUUID = originUUID.replace(/\.Actor\..+$/, "");
-            const tokenDoc = fromUuidSync(tokenUUID);
-            if (!(tokenDoc instanceof TokenDocumentPF2e)) return null;
-            const descriptor = Object.getOwnPropertyDescriptor(tokenDoc, "delta");
-            return descriptor?.value instanceof ActorDelta ? (descriptor.value.syntheticActor ?? null) : null;
+            const tokenDoc = fromUuidSync<TokenDocumentPF2e>(tokenUUID);
+            return tokenDoc?.hasConstructedActor ? tokenDoc.actor : null;
         }
 
         return fromUuidSync<ActorPF2e>(originUUID);

--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -35,6 +35,16 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
     /** The most recently used animation for later use when a token override is reverted. */
     #lastAnimation: TokenAnimationOptions | null = null;
 
+    /** Prevent eager construction of synthetic actors */
+    override get actor(): ActorPF2e<this | null> | null {
+        if (game.ready || this.scene?.isView || this.hasConstructedActor || this.inCombat) {
+            return super.actor as ActorPF2e<this | null> | null;
+        }
+        return Array.isArray(this._source.delta?.items) && this._source.delta.items.some((i) => i.type === "effect")
+            ? (super.actor as ActorPF2e<this | null> | null)
+            : null;
+    }
+
     /** Returns the combatant representing this token or this token's troop */
     override get combatant(): CombatantPF2e<EncounterPF2e, this> | null {
         const troop = this.flags[SYSTEM_ID].troop;
@@ -51,7 +61,7 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
 
     /** Returns if the token is in combat, though some actors have different conditions */
     override get inCombat(): boolean {
-        return this.actor?.isOfType("party")
+        return this.actorLink && this.actor?.isOfType("party")
             ? this.actor.members.every((a) => game.combat?.getCombatantsByActor(a).length)
             : super.inCombat;
     }
@@ -158,6 +168,13 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
                     b.system.terrain.difficult > highest ? b.system.terrain.difficult : highest,
                 0,
             );
+    }
+
+    /** Is this token's actor present and constructed? Synthetic actors are done so lazily. */
+    get hasConstructedActor(): boolean {
+        return this.actorLink
+            ? !!this.baseActor
+            : !!(Object.getOwnPropertyDescriptor(this, "delta")?.value && this.delta?.syntheticActor);
     }
 
     /** Check actor for effects found in `CONFIG.specialStatusEffects` */
@@ -300,7 +317,6 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
         const flags = fu.mergeObject(this.flags, { [SYSTEM_ID]: {} });
         const actor = this.actor;
         if (!actor) return;
-
         TokenDocumentPF2e.assignDefaultImage(this);
 
         // Dimensions and scale
@@ -409,7 +425,8 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
 
     protected override _inferMovementAction(): string {
         const actor = this.actor;
-        switch (actor?.type) {
+        if (!actor) return super._inferMovementAction();
+        switch (actor.type) {
             case "character":
             case "npc":
             case "familiar":
@@ -660,13 +677,13 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
     /** Toggle token hiding if this token's actor is a loot actor */
     protected override _onCreate(data: this["_source"], options: DatabaseCreateCallbackOptions, userId: string): void {
         super._onCreate(data, options, userId);
-        if (game.user.id === userId && this.actor?.isOfType("loot")) {
-            this.actor.toggleTokenHiding();
+        const actor = this.actor;
+        if (game.user.id === userId && actor?.isOfType("loot")) {
+            actor.toggleTokenHiding();
         }
 
         // Resync when troops are recently created or segments are added
         // This also informs other segments that this segment was created
-        const actor = this.actor;
         if (actor?.isOfType("npc") && this.flags[SYSTEM_ID].troop) {
             const segments = this.segments;
             if (segments?.length && !actor.otherSegments?.length) {
@@ -745,7 +762,7 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
 interface TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> extends TokenDocument<TParent> {
     flags: TokenFlagsPF2e;
     regions: Set<RegionDocumentPF2e<NonNullable<TParent>>>;
-    get actor(): ActorPF2e<this | null> | null;
+    get baseActor(): ActorPF2e<null> | null;
     get object(): TokenPF2e<this> | null;
     get sheet(): TokenConfigPF2e;
 }

--- a/src/scripts/hooks/canvas-init.ts
+++ b/src/scripts/hooks/canvas-init.ts
@@ -1,0 +1,11 @@
+/** Ensure all synthetic actors are constructed in a to-be-viewed scene. */
+export const CanvasInit = {
+    listen: (): void => {
+        Hooks.once("canvasInit", () => {
+            if (!game.ready) return;
+            for (const token of canvas.scene?.tokens ?? []) {
+                if (!token.hasConstructedActor && token.baseActor) token.reset();
+            }
+        });
+    },
+};

--- a/src/scripts/hooks/canvas-ready.ts
+++ b/src/scripts/hooks/canvas-ready.ts
@@ -17,7 +17,6 @@ export const CanvasReady = {
             game.pf2e.effectPanel.render({ force: true });
             if (!canvas.scene) return;
 
-            if (game.ready) canvas.scene.reset();
             // Accomodate hex grid play with a usable default cone angle
             CONFIG.MeasuredTemplate.defaults.angle = canvas.grid.isHexagonal ? 60 : 90;
 

--- a/src/scripts/hooks/index.ts
+++ b/src/scripts/hooks/index.ts
@@ -1,3 +1,4 @@
+import { CanvasInit } from "./canvas-init.ts";
 import { CanvasReady } from "./canvas-ready.ts";
 import { CloseWorldClockSettings } from "./close-world-clock-settings.ts";
 import { DiceSoNiceReady } from "./dice-so-nice-ready.ts";
@@ -27,6 +28,7 @@ export const HooksPF2e = {
     listen(): void {
         const listeners: { listen(): void }[] = [
             Load, // Run this first since it's not an actual hook listener
+            CanvasInit,
             CanvasReady,
             CloseWorldClockSettings,
             DiceSoNiceReady,


### PR DESCRIPTION
Tested with a fresh Kingmaker world

Before:
<img width="372" src="https://github.com/user-attachments/assets/ecf02cd2-6934-445d-9ef6-7a083a349ccc" />

After:
<img width="372" src="https://github.com/user-attachments/assets/9db88571-a4f9-43da-8b79-b03353c3b99a" />
