### PR TITLE
Add Armor base sf2e localization overrides

### DIFF
--- a/static/lang/sf2e-overrides-en.json
+++ b/static/lang/sf2e-overrides-en.json
@@ -40,6 +40,8 @@
         "Item": {
             "Armor": {
                 "Base": {
+                    "armored-coat": "Armored Coat",
+                    "quilted-armor": "Quilted Armor",
                     "swarmsuit": "Swarmsuit"
                 }
             }

--- a/static/lang/sf2e-overrides-en.json
+++ b/static/lang/sf2e-overrides-en.json
@@ -37,6 +37,13 @@
             }
         },
         "Ethnicity": "Home World",
+        "Item": {
+            "Armor": {
+                "Base": {
+                    "swarmsuit": "Swarmsuit"
+                }
+            }
+        },
         "Nationality": "Port of Call",
         "Scene": {
             "HearingRange": {


### PR DESCRIPTION
While Armored Coat and Quilted Armor are likely similar between PF and SF, Swarmsuit is very different and requires different translation.