### PR TITLE
Fix precision immunity crit damage miscalculation

### DIFF
--- a/src/module/system/damage/helpers.ts
+++ b/src/module/system/damage/helpers.ts
@@ -288,12 +288,17 @@ function isSystemDamageTerm(term: terms.RollTerm): term is ArithmeticExpression 
     return term instanceof ArithmeticExpression || term instanceof Grouping;
 }
 
-function deepFindTerms(term: terms.RollTerm, { flavor }: { flavor: string }): terms.RollTerm[] {
+function deepFindTerms(
+    term: terms.RollTerm,
+    { flavor, multiplier = 1 }: { flavor: string; multiplier?: number },
+): [terms.RollTerm, number][] {
+    const nestedMultiplier =
+        multiplier !== 1 ? multiplier : term instanceof ArithmeticExpression ? Number(term.options.crit) || 1 : 1;
     const childTerms =
         term instanceof Grouping ? [term.term] : term instanceof ArithmeticExpression ? term.operands : [];
     return [
-        term.flavor.split(",").includes(flavor) ? [term] : [],
-        childTerms.map((t) => deepFindTerms(t, { flavor })).flat(),
+        term.flavor.split(",").includes(flavor) ? [[term, nestedMultiplier] satisfies [terms.RollTerm, number]] : [],
+        childTerms.map((t) => deepFindTerms(t, { flavor, multiplier: nestedMultiplier })).flat(),
     ].flat();
 }
 

--- a/src/module/system/damage/roll.ts
+++ b/src/module/system/damage/roll.ts
@@ -599,15 +599,9 @@ class DamageInstance extends AbstractDamageRoll {
     }
 
     componentTotal(component: "precision" | "splash"): number {
-        if (!this._evaluated) {
-            throw ErrorPF2e("Component totals may only be accessed from an evaluated damage instance");
-        }
-
-        const terms = deepFindTerms(this.head, { flavor: component });
-        const rawTotal = terms.reduce((total, t) => total + (Number(t.total) || 0), 0);
-        const critMultiplier = Number(this.head.options.crit) || 1;
-
-        return rawTotal * critMultiplier;
+        if (!this._evaluated) throw ErrorPF2e("Component totals may only be accessed from evaluated damage instances");
+        const matches = deepFindTerms(this.head, { flavor: component });
+        return matches.reduce((total, [term, multiplier]) => total + (Number(term.total) || 0) * multiplier, 0);
     }
 
     /**

--- a/src/module/system/damage/terms.ts
+++ b/src/module/system/damage/terms.ts
@@ -13,14 +13,16 @@ class ArithmeticExpression extends terms.RollTerm<ArithmeticExpressionData> {
         super(termData);
 
         this.operator = termData.operator;
-        this.operands = termData.operands.slice(0, 2).map((datum) => {
-            if (datum instanceof terms.RollTerm) return datum;
+        this.operands = termData.operands.slice(0, 2).map((operand) => {
+            if (operand instanceof terms.RollTerm) return operand;
             const TermCls =
-                CONFIG.Dice.termTypes[datum.class ?? ""] ??
-                Object.values(CONFIG.Dice.terms).find((t) => t.name === datum.class) ??
+                CONFIG.Dice.termTypes[operand.class ?? ""] ??
+                Object.values(CONFIG.Dice.terms).find((t) => t.name === operand.class) ??
                 terms.Die;
-            return simplifyTerm(TermCls.fromData(datum));
+            return simplifyTerm(TermCls.fromData(operand));
         }) as [terms.RollTerm, terms.RollTerm];
+
+        if (this.#dataIsCriticalDoubling(termData)) this.options.crit = 2;
     }
 
     static override SERIALIZE_ATTRIBUTES = ["operator", "operands"];
@@ -147,6 +149,19 @@ class ArithmeticExpression extends terms.RollTerm<ArithmeticExpressionData> {
         return ArithmeticExpression.totalOf(this.operator, left, right)!;
     }
 
+    /** Whether the data of the child term is a critical hit doubling */
+    #dataIsCriticalDoubling(data: terms.RollTermData): data is ArithmeticExpressionData {
+        return (
+            "operator" in data &&
+            data.operator === "*" &&
+            "operands" in data &&
+            Array.isArray(data.operands) &&
+            data.operands.length === 2 &&
+            data.operands.every((o): o is Record<string, unknown> => R.isPlainObject(o)) &&
+            data.operands[0].number === 2
+        );
+    }
+
     /** Construct a string for an HTML rendering of this term */
     render(): DocumentFragment {
         const fragment = new DocumentFragment();
@@ -221,9 +236,6 @@ class Grouping extends terms.RollTerm<GroupingData> {
         } else {
             super(termData);
             this.term = childTerm;
-            if (this.#dataIsCriticalDoubling(termData.term)) {
-                this.options.crit = 2;
-            }
         }
 
         this._evaluated = termData.evaluated ?? this.term._evaluated ?? true;
@@ -297,19 +309,6 @@ class Grouping extends terms.RollTerm<GroupingData> {
 
     get maximumValue(): number {
         return DamageInstance.getValue(this.term, "maximum");
-    }
-
-    /** Whether the data of the child term is a critical hit doubling */
-    #dataIsCriticalDoubling(data: terms.RollTermData): data is ArithmeticExpressionData {
-        return (
-            "operator" in data &&
-            data.operator === "*" &&
-            "operands" in data &&
-            Array.isArray(data.operands) &&
-            data.operands.length === 2 &&
-            data.operands.every((o): o is Record<string, unknown> => R.isPlainObject(o)) &&
-            data.operands[0].number === 2
-        );
     }
 
     protected override async _evaluate(


### PR DESCRIPTION
- Closes #19318

2 changes needed for the fix:
1. Setting `.options.crit` in both Grouping and ArithmeticExpression. Previously .options.crit was only set in Grouping's child node - having formula with any damage that doesn't multiply on crit caused that flag to not be set. 
2. Check for .options.crit in deepFindTerms instead of componentTotal - before `.options.crit` was only checked on the head node, so had to account for nested ones.

Tested on:
- normal/critical damage
- with/without fatal
- with/without deadly
- against a target with crit immunity, precision immunity, both present and both absent

Please let me know if additional testing is required