### PR TITLE
Address deprecation of `PointSourcePolygonConfig#wallDirectionMode`

### DIFF
--- a/src/module/canvas/perception/modes.ts
+++ b/src/module/canvas/perception/modes.ts
@@ -114,7 +114,7 @@ class HearingDetectionMode extends fc.perception.DetectionMode {
                 type: "sound",
                 mode: "any",
                 source: visionSource,
-                wallDirectionMode: foundry.canvas.geometry.PointSourcePolygon.WALL_DIRECTION_MODES.REVERSED,
+                edgeDirectionMode: CONST.EDGE_DIRECTION_MODES.REVERSED,
                 useThreshold: true,
             });
         test.loh.set(visionSource, hasLOH);

--- a/types/foundry/client/canvas/geometry/_types.d.mts
+++ b/types/foundry/client/canvas/geometry/_types.d.mts
@@ -1,3 +1,4 @@
+import { EdgeDirectionMode } from "@common/constants.mjs";
 import { PointEffectSource } from "../sources/point-effect-source.mjs";
 import { Ray } from "./_module.mjs";
 import { CollisionResult } from "./edges/collision.mjs";
@@ -23,8 +24,8 @@ export interface PointSourcePolygonConfig {
     radius?: number;
     /** The direction of facing, required if the angle is limited */
     rotation?: number;
-    /** Customize how wall direction of one-way walls is applied */
-    wallDirectionMode?: number;
+    /** Customize how edge direction of one-way edges is applied */
+    edgeDirectionMode?: EdgeDirectionMode;
     /** Compute the polygon with threshold wall constraints applied */
     useThreshold?: boolean;
     /** Display debugging visualization and logging for the polygon */
@@ -44,24 +45,27 @@ export interface PointSourcePolygonConfig {
 type EdgeType = "wall" | "darkness" | "light" | "innerBounds" | "outerBounds";
 
 /**
- * @example
- * How modes are working:
- * - 0=no     : The edges of this type are rejected and not processed (equivalent of not having an edgeType.)
- * - 1=maybe  : The edges are processed and tested for inclusion.
- * - 2=always : The edges are automatically included.
+ *   Modes:
+ *    - Never (`0`): The edges of this type are never included.
+ *    - Maybe (`1`): The edges of this type are tested for inclusion.
+ *    - Always (`2`): The edges of this type are always included.
  */
+interface ClockwiseSweepEdgeConfig {
+    mode: 0 | 1 | 2;
+    priority: number;
+}
 
 interface ClockwiseSweepPolygonConfig extends PointSourcePolygonConfig {
     /**
-     * Optional priority when it comes to ignore edges from darkness and light sources
+     * Edges with priority less than this priority are ignored
      * @default 0
      */
     priority?: number;
     /**
-     * Edge types configuration object. This is not required by most polygons and will be inferred based on the polygon
-     * type and priority.
+     * Edge types configured as `false` is equivalent to those edges never being included.
+     * Edge types configured as `true` are included conditionally depending on the type of polygon and the type of edge.
      */
-    edgeTypes?: Record<EdgeType, { priority: number; mode: 0 | 1 | 2 }>;
+    edgeTypes?: Record<EdgeType, boolean | Partial<ClockwiseSweepEdgeConfig>>;
 }
 
 interface RayIntersection {

--- a/types/foundry/client/canvas/geometry/shapes/source-polygon.d.mts
+++ b/types/foundry/client/canvas/geometry/shapes/source-polygon.d.mts
@@ -6,18 +6,9 @@ import Ray from "./ray.mjs";
 /**
  * An extension of Polygon which is used to represent the line of sight for a point source.
  */
-export default abstract class PointSourcePolygon<
-    TConfig extends PointSourcePolygonConfig = PointSourcePolygonConfig,
-> extends PIXI.Polygon {
-    /**
-     * Customize how wall direction of one-way walls is applied
-     */
-    static WALL_DIRECTION_MODES: Readonly<{
-        NORMAL: 0;
-        REVERSED: 1;
-        BOTH: 2;
-    }>;
-
+export default abstract class PointSourcePolygon<TConfig extends PointSourcePolygonConfig = PointSourcePolygonConfig>
+    extends PIXI.Polygon
+{
     /**
      * The rectangular bounds of this polygon
      */

--- a/types/foundry/common/constants.d.mts
+++ b/types/foundry/common/constants.d.mts
@@ -1258,30 +1258,83 @@ export const USER_PERMISSIONS: Readonly<{
 
 export type UserPermission = keyof typeof USER_PERMISSIONS;
 
+/**
+ * The edge properties which restrict the way interaction occurs with a specific edge
+ * @see {@link https://foundryvtt.com/article/walls/}
+ */
 export const EDGE_RESTRICTION_TYPES: readonly ["light", "darkness", "sight", "sound", "move"];
 
 export type EdgeRestrictionType = (typeof EDGE_RESTRICTION_TYPES)[number];
 
 /**
- * The allowed directions of effect that a Wall can have
- * @see https://foundryvtt.com/article/walls/
+ * The types of sensory collision which an Edge may impose
+ * @see {@link https://foundryvtt.com/article/walls/}
  */
-export const WALL_DIRECTIONS: Readonly<{
+export const EDGE_SENSE_TYPES: Readonly<{
     /**
-     * The wall collides from both directions.
+     * Senses do not collide with this edge.
+     */
+    NONE: 0;
+    /**
+     * Senses collide with this edge.
+     */
+    LIMITED: 10;
+    /**
+     * Senses collide with the second intersection, bypassing the first.
+     */
+    NORMAL: 20;
+    /**
+     * Senses bypass the edge within a certain proximity threshold.
+     */
+    PROXIMITY: 30;
+    /**
+     * Senses bypass the edge outside a certain proximity threshold.
+     */
+    DISTANCE: 40;
+}>;
+
+export type EdgeSenseType = (typeof EDGE_SENSE_TYPES)[keyof typeof EDGE_SENSE_TYPES];
+
+/**
+ * The allowed directions of effect that a Edge can have
+ * @see {@link https://foundryvtt.com/article/walls/}
+ */
+export const EDGE_DIRECTIONS: Readonly<{
+    /**
+     * The edge collides from both directions.
      */
     BOTH: 0;
     /**
-     * The wall collides only when a ray strikes its left side.
+     * The edge collides only when a ray strikes its left side.
      */
     LEFT: 1;
     /**
-     * The wall collides only when a ray strikes its right side.
+     * The edge collides only when a ray strikes its right side.
      */
     RIGHT: 2;
 }>;
 
-export type WallDirection = (typeof WALL_DIRECTIONS)[keyof typeof WALL_DIRECTIONS];
+export type EdgeDirection = (typeof EDGE_DIRECTIONS)[keyof typeof EDGE_DIRECTIONS];
+
+/**
+ * The possible direction modes.
+ */
+export const EDGE_DIRECTION_MODES: Readonly<{
+    /**
+     * The edge direction applies normally.
+     */
+    NORMAL: 0;
+    /**
+     * The edge direction applies reversed.
+     */
+    REVERSED: 1;
+    /**
+     * The edge blocks in both directions always.
+     */
+    BOTH: 2;
+}>;
+
+export type EdgeDirectionMode = (typeof EDGE_DIRECTION_MODES)[keyof typeof EDGE_DIRECTION_MODES];
 
 /**
  * The allowed door types which a Wall may contain


### PR DESCRIPTION
This was spamming deprecation warnings.