### PR TITLE
Fix  detection of inline damage rolls

### DIFF
--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -64,7 +64,7 @@ class TextEditorPF2e extends foundry.applications.ux.TextEditor {
     ): Promise<HTMLAnchorElement | null> {
         const anchor = await super._createInlineRoll(match, rollData, options);
         const formula = anchor?.dataset.formula;
-        if (!formula || anchor.dataset.flavor) return anchor;
+        if (!formula || !("flavor" in anchor.dataset)) return anchor;
         const roll = ((): DamageRoll | null => {
             try {
                 return new DamageRoll(formula);

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -64,7 +64,7 @@ class TextEditorPF2e extends foundry.applications.ux.TextEditor {
     ): Promise<HTMLAnchorElement | null> {
         const anchor = await super._createInlineRoll(match, rollData, options);
         const formula = anchor?.dataset.formula;
-        if (!formula || !("flavor" in anchor.dataset)) return anchor;
+        if (!formula || anchor.dataset.flavor) return anchor;
         const roll = ((): DamageRoll | null => {
             try {
                 return new DamageRoll(formula);

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -64,7 +64,7 @@ class TextEditorPF2e extends foundry.applications.ux.TextEditor {
     ): Promise<HTMLAnchorElement | null> {
         const anchor = await super._createInlineRoll(match, rollData, options);
         const formula = anchor?.dataset.formula;
-        if (!formula) return anchor;
+        if (!formula || anchor.dataset.flavor) return anchor;
         const roll = ((): DamageRoll | null => {
             try {
                 return new DamageRoll(formula);

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -64,7 +64,7 @@ class TextEditorPF2e extends foundry.applications.ux.TextEditor {
     ): Promise<HTMLAnchorElement | null> {
         const anchor = await super._createInlineRoll(match, rollData, options);
         const formula = anchor?.dataset.formula;
-        if (!formula || anchor.dataset.flavor) return anchor;
+        if (!formula || !anchor.dataset.flavor) return anchor;
         const roll = ((): DamageRoll | null => {
             try {
                 return new DamageRoll(formula);

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -64,7 +64,7 @@ class TextEditorPF2e extends foundry.applications.ux.TextEditor {
     ): Promise<HTMLAnchorElement | null> {
         const anchor = await super._createInlineRoll(match, rollData, options);
         const formula = anchor?.dataset.formula;
-        const messageMode = anchor.dataset.mode ?? "public";
+        const messageMode = anchor?.dataset.mode ?? "public";
         if (!formula || !(messageMode in CONFIG.ChatMessage.modes)) return anchor;
         const roll = ((): DamageRoll | null => {
             try {

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -64,7 +64,7 @@ class TextEditorPF2e extends foundry.applications.ux.TextEditor {
     ): Promise<HTMLAnchorElement | null> {
         const anchor = await super._createInlineRoll(match, rollData, options);
         const formula = anchor?.dataset.formula;
-        if (!formula || !objectHasKey(CONFIG.ChatMessage.modes, anchor.dataset.mode)) return anchor;
+        if (!formula) return anchor;
         const roll = ((): DamageRoll | null => {
             try {
                 return new DamageRoll(formula);

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -64,7 +64,8 @@ class TextEditorPF2e extends foundry.applications.ux.TextEditor {
     ): Promise<HTMLAnchorElement | null> {
         const anchor = await super._createInlineRoll(match, rollData, options);
         const formula = anchor?.dataset.formula;
-        if (!formula || !anchor.dataset.flavor) return anchor;
+        const messageMode = anchor.dataset.mode ?? "public";
+        if (!formula || !(messageMode in CONFIG.ChatMessage.modes)) return anchor;
         const roll = ((): DamageRoll | null => {
             try {
                 return new DamageRoll(formula);


### PR DESCRIPTION
Looks like the core anchor element no longer has a `mode`. I'm not 100% sure if removing the check without replacement is safe.

Before:
<img width="768" height="134" alt="image" src="https://github.com/user-attachments/assets/69f383ec-e2b9-403b-88c2-d21cb4351aa3" />


After:
<img width="768" height="134" alt="image" src="https://github.com/user-attachments/assets/3262406d-cad0-42a2-af2d-6c2edd2b7b57" />
