### PR TITLE
Add module tab registration API to PartySheetPF2e

### DIFF
--- a/src/module/actor/party/sheet.ts
+++ b/src/module/actor/party/sheet.ts
@@ -29,7 +29,45 @@ interface PartySheetRenderOptions extends ActorSheetRenderOptionsPF2e {
     actors?: boolean;
 }
 
+interface ModuleTab {
+    /** A unique tab identifier used as the data-tab attribute value */
+    tabId: string;
+    /** The display label rendered in the navigation link */
+    label: string;
+    /** Optional async callback that returns an HTML string for the tab content region */
+    renderCallback?: (app: PartySheetPF2e, element: HTMLElement, data: object) => Promise<string>;
+    /** Optional callback to attach event listeners after renderCallback populates innerHTML. Ignored if renderCallback is absent. */
+    activateListeners?: (app: PartySheetPF2e, element: HTMLElement) => void;
+}
+
+/** Options for registering a module tab with render callback integration */
+interface ModuleTabOptions {
+    /** Async callback that returns an HTML string for the tab content region */
+    renderCallback: (app: PartySheetPF2e, element: HTMLElement, data: object) => Promise<string>;
+    /** Optional callback to attach event listeners after renderCallback populates innerHTML */
+    activateListeners?: (app: PartySheetPF2e, element: HTMLElement) => void;
+}
+
 class PartySheetPF2e extends ActorSheetPF2e<PartyPF2e> {
+    static readonly moduleTabs: ModuleTab[] = [];
+
+    /** Register a module-provided tab on the party sheet */
+    static registerModuleTab(tabId: string, label: string, options?: ModuleTabOptions): void {
+        const builtInTabs = ["overview", "exploration", "inventory", "orphaned"];
+        if (!/^[a-z0-9-]+$/.test(tabId)) return;
+        if (builtInTabs.includes(tabId)) return;
+        if (this.moduleTabs.some((t) => t.tabId === tabId)) return;
+
+        const tab: ModuleTab = { tabId, label };
+        if (options?.renderCallback) {
+            tab.renderCallback = options.renderCallback;
+            if (options.activateListeners) {
+                tab.activateListeners = options.activateListeners;
+            }
+        }
+        this.moduleTabs.push(tab);
+    }
+
     currentSummaryView = "languages";
 
     static override get defaultOptions(): ActorSheetOptions {
@@ -125,6 +163,11 @@ class PartySheetPF2e extends ActorSheetPF2e<PartyPF2e> {
                 activities: hexplorationActivities.find((max) => max.speed >= travelSpeed)?.activities ?? 0,
             },
             orphaned: this.actor.items.filter((i) => !i.isOfType(...this.actor.allowedItemTypes)),
+            moduleTabs: PartySheetPF2e.moduleTabs.map((t) => ({
+                tabId: t.tabId,
+                label: t.label,
+                hasRenderCallback: !!t.renderCallback,
+            })),
         };
     }
 
@@ -475,18 +518,33 @@ class PartySheetPF2e extends ActorSheetPF2e<PartyPF2e> {
         // Eventually this should cache results to compare if re-rendering
         for (const region of htmlQueryAll(element, "[data-region]")) {
             const regionId = region.dataset.region ?? "";
+
+            // Built-in region path: look up template
             const templateName = this.regionTemplates[regionId];
-            if (!templateName) continue;
+            if (templateName) {
+                const template = `systems/${SYSTEM_ID}/templates/actors/party/regions/${templateName}`;
+                const result = await fa.handlebars.renderTemplate(template, data);
 
-            const template = `systems/${SYSTEM_ID}/templates/actors/party/regions/${templateName}`;
-            const result = await fa.handlebars.renderTemplate(template, data);
+                region.innerHTML = result;
+                if (this._state !== appv1.api.Application.RENDER_STATES.RENDERING) {
+                    this.activateListeners($(region));
+                }
 
-            region.innerHTML = result;
-            if (this._state !== appv1.api.Application.RENDER_STATES.RENDERING) {
-                this.activateListeners($(region));
+                await this.#renderRegions(region, data);
+                continue;
             }
 
-            await this.#renderRegions(region, data);
+            // Module tab region path: look up render callback
+            const moduleTab = PartySheetPF2e.moduleTabs.find((t) => t.tabId === regionId && t.renderCallback);
+            if (moduleTab) {
+                try {
+                    const result = await moduleTab.renderCallback!(this, region, data);
+                    region.innerHTML = result;
+                    moduleTab.activateListeners?.(this, region);
+                } catch (error) {
+                    console.error(`PF2e System | Module tab "${regionId}" render failed:`, error);
+                }
+            }
         }
     }
 
@@ -554,6 +612,7 @@ interface PartySheetData extends ActorSheetDataPF2e<PartyPF2e> {
     };
     /** Unsupported items on the sheet, may occur due to disabled campaign data */
     orphaned: ItemPF2e[];
+    moduleTabs: { tabId: string; label: string; hasRenderCallback: boolean }[];
 }
 
 interface SkillData {
@@ -602,4 +661,4 @@ interface LanguageSheetData {
     actors: ActorPF2e[];
 }
 
-export { PartySheetPF2e, type PartySheetRenderOptions };
+export { PartySheetPF2e, type ModuleTab, type PartySheetRenderOptions };

--- a/static/templates/actors/party/sheet.hbs
+++ b/static/templates/actors/party/sheet.hbs
@@ -35,6 +35,9 @@
         {{/unless}}
         <a data-tab="exploration">{{localize "PF2E.Actor.Party.Tabs.Exploration"}}</a>
         <a data-tab="inventory">{{localize "PF2E.Actor.Party.Tabs.Stash"}}</a>
+        {{#each moduleTabs}}
+            <a data-tab="{{this.tabId}}">{{this.label}}</a>
+        {{/each}}
         {{#if orphaned}}
             <a data-tab="orphaned">{{localize "PF2E.Actor.Party.Tabs.Orphaned"}}</a>
         {{/if}}
@@ -61,6 +64,10 @@
                 {{> (resolvePath "templates/actors/partials/total-bulk.hbs")}}
             </section>
         </div>
+
+        {{#each moduleTabs}}
+            <div class="tab" data-tab="{{this.tabId}}" {{#if this.hasRenderCallback}}data-region="{{this.tabId}}"{{/if}}></div>
+        {{/each}}
 
         {{#if orphaned}}
             <div class="tab" data-tab="orphaned">


### PR DESCRIPTION
Hello,
 I'm the developer for https://github.com/scooper4711/pfs-chronicle-generator - a module that adds an additional tab to the Party sheet to allow PFS GMs to generate chronicles for their players right from inside Foundry. It works together with a browser extension I've also written to make PFS Session reporting easier. Think "rpg chronicles lite, but from inside of Foundry".
 
 Currently, I have to do a several hacks to add a tab to the party sheet, and because of this, when players make changes, the party sheet is re-drawn and my new Society tab is de-selected and the GM is put back into the Overview tab. It's proven to be quite disruptive for the workflow. 
 
 I'm humbly submitting this patch to allow any module to register a new tab with associate callback hooks. This would work for any module, not just mine. 

**Problem statement**
Currently modules have to hook renderPartySheetPF2e, use setTimeout hacks to wait for DOM readiness, and manually inject tab elements. This API gives modules a first-class way to add tabs with proper lifecycle management.

**Solution**

Introduce a static registerModuleTab() method on PartySheetPF2e that allows modules to add custom tabs to the party sheet. Modules can optionally provide renderCallback and activateListeners functions to integrate with the sheet's region-based rendering lifecycle.

When a renderCallback is provided, the tab element receives a data-region attribute so that #renderRegions invokes the callback during both initial render and partial re-renders (e.g. when party membership changes). The sheet app instance is passed as the first argument to both callbacks, giving modules access to the actor and sheet state without relying on hook timing or DOM traversal.

Tabs registered without callbacks get an empty content div that modules can populate via the existing renderPartySheetPF2e hook.