### PR TITLE
Fix migrating old spell consumables

### DIFF
--- a/src/module/migration/migrations/845-empty-spell-consumables.ts
+++ b/src/module/migration/migrations/845-empty-spell-consumables.ts
@@ -9,8 +9,12 @@ export class Migration845EmptySpellConsumables extends MigrationBase {
     override async preUpdateItem(source: ItemSourcePF2e): Promise<void> {
         if (source.type === "consumable") {
             const spell: unknown = source.system.spell;
-            if (R.isPlainObject(spell) && !["_id", "name", "type", "system"].every((p) => p in spell)) {
-                source.system.spell = null;
+            if (R.isPlainObject(spell)) {
+                if (!["_id", "name", "type", "system"].every((p) => p in spell)) {
+                    source.system.spell = null;
+                } else {
+                    spell._stats ??= R.pick(source._stats, ["systemId", "systemVersion", "coreVersion"]);
+                }
             }
         }
     }


### PR DESCRIPTION
There is an error that manifests running abomination vaults since some of the wand items are old. It works fine at first, but using Troubleshooting -> Remigrate errors because embedded spells do not automatically receive a _stats if missing like real documents do. However the type is a bit awkward and made me null out a bunch of things, so if there's a cleaner way let me know.

This error is not new to v14 and exists in v13 as well.