### PR TITLE
Fix two type errors in TS 6.0 and TS Go

### DIFF
--- a/src/module/system/action-macros/crafting/craft.ts
+++ b/src/module/system/action-macros/crafting/craft.ts
@@ -9,13 +9,15 @@ import { SelectItemDialog } from "./select-item.ts";
 
 export async function craft(options: CraftActionOptions): Promise<void> {
     // resolve item
-    const item = options.item ?? (await (options.uuid ? fromUuid(options.uuid) : SelectItemDialog.getItem("craft")));
+    const item =
+        options.item ?? (await (options.uuid ? fromUuid<ItemPF2e>(options.uuid) : SelectItemDialog.getItem("craft")));
 
     // ensure item is a valid crafting target
     if (!(item instanceof ItemPF2e)) {
         console.warn("PF2e System | No item selected to craft: aborting");
         return;
-    } else if (!(item instanceof PhysicalItemPF2e)) {
+    }
+    if (!item.isOfType("physical")) {
         ui.notifications.warn(_loc("PF2E.Actions.Craft.Warning.NotPhysicalItem", { item: item.name ?? "" }));
         return;
     }

--- a/src/module/system/action-macros/crafting/repair.ts
+++ b/src/module/system/action-macros/crafting/repair.ts
@@ -8,14 +8,16 @@ import { SelectItemDialog } from "./select-item.ts";
 
 async function repair(options: RepairActionOptions): Promise<void> {
     // resolve item
-    const item = options.item ?? (await (options.uuid ? fromUuid(options.uuid) : SelectItemDialog.getItem("repair")));
+    const item =
+        options.item ?? (await (options.uuid ? fromUuid<ItemPF2e>(options.uuid) : SelectItemDialog.getItem("repair")));
 
     // ensure specified item is a valid repair target
     if (!(item instanceof ItemPF2e)) {
         console.warn("PF2e System | No item selected to repair: aborting");
         return;
-    } else if (!(item instanceof PhysicalItemPF2e)) {
-        ui.notifications.warn(_loc("PF2E.Actions.Repair.Warning.NotPhysicalItem", { item: item?.name ?? "" }));
+    }
+    if (!item.isOfType("physical")) {
+        ui.notifications.warn(_loc("PF2E.Actions.Repair.Warning.NotPhysicalItem", { item: item.name ?? "" }));
         return;
     }
 


### PR DESCRIPTION
These are the only errors I found while using the ts-go preview in VSCode. Typescript 6.0 has the same two errors.

I've added the pf2e repo as a git submodule to one of my module projects as the source of foundry and system types. Merging this would unblock me from updating the module to TS6.