### PR TITLE
Fix incorrect assets paths in Vite hmr mode

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -285,7 +285,7 @@ const config = Vite.defineConfig(({ command, mode }): Vite.UserConfig => {
             open: "/game",
             proxy: {
                 [`^(?!/systems/${SYSTEM_ID}/)`]: `http://localhost:${foundryPort}/`,
-                [`^/systems/${SYSTEM_ID}/lang`]: `http://localhost:${foundryPort}/`,
+                [`^/systems/${SYSTEM_ID}/(?:assets|lang)`]: `http://localhost:${foundryPort}/`,
                 "/socket.io": {
                     target: `ws://localhost:${foundryPort}`,
                     ws: true,


### PR DESCRIPTION
Some files (e.g. `systems/pf2e/assets/system-banners/03.webp`) were being replaced with a "This file is for a running vite dev server and is not copied to a build." stub.
After some digging I found out that for a normal build these assets are copied from `static/assets/system-banners/pf2e/` to `dist/pf2e/assets/system-banners/` but that doesn't happen when the files are served via HMR. Only the original paths in Vite's `publicDir` are available so the banner is served at `system/pf2e/assets/system-banners/pf2e/03.webp` instead.

Adding an explicit proxy rule for the assets ensures that they are serverd from the foundry server with the correct path.

Before:
<img width="580" height="331" alt="image" src="https://github.com/user-attachments/assets/44980cce-87fa-4b5e-bceb-508197c86d20" />

After:
<img width="580" height="331" alt="image" src="https://github.com/user-attachments/assets/5711e96b-693a-47cd-9759-4b6981ce22a3" />
