### PR TITLE
Fix path to cover reduction flag in Aim's ephemeral effect

### DIFF
--- a/packs/sf2e/feat-effects/effect-aim-reduce-cover.json
+++ b/packs/sf2e/feat-effects/effect-aim-reduce-cover.json
@@ -27,7 +27,7 @@
                 "mode": "subtract",
                 "selector": "ac",
                 "slug": "cover",
-                "value": "@item.origin.flags.system.operative.aimCoverReduction"
+                "value": "@item.origin.flags.system.operative.aim.coverReduction"
             },
             {
                 "key": "AdjustModifier",

--- a/packs/sf2e/feat-effects/effect-aim.json
+++ b/packs/sf2e/feat-effects/effect-aim.json
@@ -64,7 +64,6 @@
             {
                 "key": "EphemeralEffect",
                 "predicate": [
-                    "target:mark:aim",
                     "aim-cover-reduction"
                 ],
                 "selectors": "strike-attack-roll",


### PR DESCRIPTION
Also removing the `target:mark:` roll option in aim's Ephemeral Effect rule element predicate. There's a problem with Ephemeral Effects at the moment where if you want to predicate on a target having a mark you actually need to use the `self:` prefix instead (see #20594).

I'd rather wait for that to be fixed to work as expected than change `target` for `self` here. Should be fine to remove that roll option since it's a toggle anyway.