### PR TITLE
Handle some svelte warnings

### DIFF
--- a/src/module/apps/compendium-browser/components/app.svelte
+++ b/src/module/apps/compendium-browser/components/app.svelte
@@ -6,8 +6,7 @@
 
     const browser = game.pf2e.compendiumBrowser;
     const tabs = $derived(browser.tabsArray.filter((t) => t.visible));
-    const props: CompendiumBrowserContext = $props();
-    const state = props.state;
+    const { state }: CompendiumBrowserContext = $props();
 
     async function onClickNav(event: PointerEvent & { currentTarget: EventTarget }): Promise<void> {
         if (!(event.target instanceof HTMLElement)) return;

--- a/src/module/apps/compendium-browser/components/result-item.svelte
+++ b/src/module/apps/compendium-browser/components/result-item.svelte
@@ -12,7 +12,6 @@
         activeTabName: ContentTabName | "";
         entry: CompendiumBrowserIndexData;
     }
-
     const { entry, activeTabName }: ResultItemProps = $props();
 
     async function onClickButton(uuid: string, action: "buy-item" | "open-sheet" | "take-item"): Promise<void> {

--- a/src/module/apps/compendium-browser/components/result-item.svelte
+++ b/src/module/apps/compendium-browser/components/result-item.svelte
@@ -8,9 +8,12 @@
     import type { ContentTabName } from "../data.ts";
     import type { ActorPF2e } from "@actor";
 
-    const props: { activeTabName: ContentTabName | ""; entry: CompendiumBrowserIndexData } = $props();
-    const entry = props.entry;
-    const activeTabName = props.activeTabName;
+    interface ResultItemProps {
+        activeTabName: ContentTabName | "";
+        entry: CompendiumBrowserIndexData;
+    }
+
+    const { entry, activeTabName }: ResultItemProps = $props();
 
     async function onClickButton(uuid: string, action: "buy-item" | "open-sheet" | "take-item"): Promise<void> {
         switch (action) {

--- a/src/module/sheet/components/item-traits.svelte
+++ b/src/module/sheet/components/item-traits.svelte
@@ -13,7 +13,7 @@
 
 <div class="tags paizo-style">
     {#if rarity && rarity !== "common"}
-        <span class={["tag", "rarity", rarity].join(" ")}>{_loc(CONFIG.PF2E.rarityTraits[rarity])}</span>
+        <span class={`tag rarity ${rarity}`}>{_loc(CONFIG.PF2E.rarityTraits[rarity])}</span>
     {/if}
     {#each traits.filter((t) => !t.mystified) as trait (trait.value)}
         <span class="tag" data-trait={trait.value}>{trait.label}</span>

--- a/src/module/sheet/components/item-traits.svelte
+++ b/src/module/sheet/components/item-traits.svelte
@@ -9,12 +9,11 @@
     }
 
     const { rarity, traits = [], properties = [] }: ItemTraitsProps = $props();
-    const rarityLabel = rarity ? CONFIG.PF2E.rarityTraits[rarity] : null;
 </script>
 
 <div class="tags paizo-style">
-    {#if rarity && rarity !== "common" && rarityLabel}
-        <span class={["tag", "rarity", rarity].join(" ")}>{_loc(rarityLabel)}</span>
+    {#if rarity && rarity !== "common"}
+        <span class={["tag", "rarity", rarity].join(" ")}>{_loc(CONFIG.PF2E.rarityTraits[rarity])}</span>
     {/if}
     {#each traits.filter((t) => !t.mystified) as trait (trait.value)}
         <span class="tag" data-trait={trait.value}>{trait.label}</span>


### PR DESCRIPTION
This handles everything I noticed that wasn't in the trade dialog.

While $derived() would work I didn't really see a need for that in these cases.