### PR TITLE
Reduce width increase of scene config

### DIFF
--- a/src/module/scene/sheet.ts
+++ b/src/module/scene/sheet.ts
@@ -10,7 +10,7 @@ import fields = foundry.data.fields;
 export class SceneConfigPF2e<TDocument extends ScenePF2e> extends fa.sheets.SceneConfig<TDocument> {
     static override DEFAULT_OPTIONS: DeepPartial<fa.api.DocumentSheetConfiguration> = {
         sheetConfig: false,
-        position: { width: 650 },
+        position: { width: 660 },
         actions: {
             openAutomationSettings: SceneConfigPF2e.#onClickOpenAutomationSettings,
             openWorldClockSettings: SceneConfigPF2e.#onClickOpenWorldClockSettings,

--- a/src/module/scene/sheet.ts
+++ b/src/module/scene/sheet.ts
@@ -10,7 +10,7 @@ import fields = foundry.data.fields;
 export class SceneConfigPF2e<TDocument extends ScenePF2e> extends fa.sheets.SceneConfig<TDocument> {
     static override DEFAULT_OPTIONS: DeepPartial<fa.api.DocumentSheetConfiguration> = {
         sheetConfig: false,
-        position: { width: 700 },
+        position: { width: 650 },
         actions: {
             openAutomationSettings: SceneConfigPF2e.#onClickOpenAutomationSettings,
             openWorldClockSettings: SceneConfigPF2e.#onClickOpenWorldClockSettings,

--- a/src/styles/scene/_sheet.scss
+++ b/src/styles/scene/_sheet.scss
@@ -1,4 +1,7 @@
 .application.scene-config {
+    .top-tabs {
+        gap: var(--spacer-8);
+    }
     label.managed-by-rbv {
         flex-wrap: nowrap;
         gap: 0.25rem;


### PR DESCRIPTION
Base width is 600, v14 support made it 700 to fit the tab. This attempts to do something a bit more middleground, since I think the wide scene config looks strange.

<img width="657" height="801" alt="image" src="https://github.com/user-attachments/assets/892474ff-95b4-4eb9-b3ef-2937b02381c3" />
