### PR TITLE
Fix Compendium Browser header controls

### DIFF
--- a/src/module/apps/compendium-browser/browser.ts
+++ b/src/module/apps/compendium-browser/browser.ts
@@ -79,16 +79,13 @@ class CompendiumBrowser extends SvelteApplicationMixin(fa.api.ApplicationV2) {
         actions: {
             addToRollTable: function (this: CompendiumBrowser) {
                 if (!this.activeTab) return;
-                this.toggleControls(false);
                 this.activeTab.addToRollTable();
             },
             createRollTable: function (this: CompendiumBrowser) {
                 if (!this.activeTab) return;
-                this.toggleControls(false);
                 this.activeTab.createRollTable();
             },
             openSettings: function (this: CompendiumBrowser) {
-                this.toggleControls(false);
                 new CompendiumBrowserSettingsApp().render({ force: true });
             },
         },


### PR DESCRIPTION
- Closes #22007 

I remember the header menu stayed open after clicking in v13 and that's why these calls were there. Looks like that was fixed at some point.