### PR TITLE
Fix `TextEditor#_createInlineRoll` failing to return valid inline rolls

### DIFF
--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -64,7 +64,7 @@ class TextEditorPF2e extends foundry.applications.ux.TextEditor {
     ): Promise<HTMLAnchorElement | null> {
         const anchor = await super._createInlineRoll(match, rollData, options);
         const formula = anchor?.dataset.formula;
-        if (!formula) return null;
+        if (!formula) return anchor;
         if (anchor.dataset.tooltipText) {
             anchor.dataset.tooltip = "";
             anchor.ariaLabel = anchor.dataset.tooltipText;


### PR DESCRIPTION
Before:
<img width="447" height="119" alt="image" src="https://github.com/user-attachments/assets/cbb1d5ee-caff-4d6b-94a3-0f747547b3bf" />


After:
<img width="443" height="123" alt="image" src="https://github.com/user-attachments/assets/1ffbe671-85a4-4d64-9f62-fec69c4bd5d3" />
