### PR TITLE
Fix updating physical item price

### DIFF
--- a/src/module/item/physical/sheet.ts
+++ b/src/module/item/physical/sheet.ts
@@ -210,7 +210,6 @@ class PhysicalItemSheetPF2e<TItem extends PhysicalItemPF2e> extends ItemSheetPF2
             formData["system.price.value"] = _replace(
                 Coins.fromString(String(formData["system.price.value"])).toObject(),
             );
-            delete formData["system.price.value"];
         }
 
         return super._updateObject(event, formData);


### PR DESCRIPTION
- Closes #22020 

Previously this was adding `formData["system.price.value=="]` and deleting the base value made sense in that context.