### PR TITLE
Fix anachronism exclusions and fine tune logic

### DIFF
--- a/build/anachronism.ts
+++ b/build/anachronism.ts
@@ -93,13 +93,12 @@ const packPairs = allPackDirs.map((dir) => {
                 continue;
             }
 
-            // If the id matches, always consider it an overlap. Add the id though.
-            if (pf2eData._id && pf2eData._id === sf2eData._id) {
-                overlaps.add(pf2eData._id);
-                continue;
-            }
-
+            // Never treat certain types of items as overlaps
+            // Despite being in both systems, "Armored Coat" and "Courier" are not considered to be the same thing.
+            // Actual reprints (listed in duplicates) are still filtered out through other means
             const isItem = isItemSource(pf2eData) && sf2eData && isItemSource(sf2eData);
+            if (isItem && itemIsOfType(pf2eData, "background", "physical")) continue;
+
             if (isItem && itemIsOfType(pf2eData, "feat") && itemIsOfType(sf2eData, "feat")) {
                 const allTraits = [...pf2eData.system.traits.value, ...sf2eData.system.traits.value];
 
@@ -109,12 +108,14 @@ const packPairs = allPackDirs.map((dir) => {
                 // Class features and class feats for classes are also never overlaps
                 if (pf2eData.system.category === "classfeature") continue;
                 if (pf2eData.system.category === "class" && allTraits.some((t) => t in classTraits)) continue;
-            } else if (isItem && itemIsOfType(pf2eData, "background") && itemIsOfType(sf2eData, "background")) {
-                // Backgrounds often share names but aren't the same at all. Rely on id overlaps only.
-                continue;
             }
 
-            overlaps.add(pf2eData.name);
+            // Add to overlaps based on if its a name or id overlap
+            if (pf2eData.name === sf2eData.name) {
+                overlaps.add(pf2eData.name);
+            } else if (pf2eData._id && pf2eData._id === sf2eData._id) {
+                overlaps.add(pf2eData._id);
+            }
         }
     }
 
@@ -203,7 +204,7 @@ for (const contentSystem of contentSystems) {
         if (!pack) continue;
 
         const data = pack.data
-            .filter((d) => !packPair.overlaps.has(d.name))
+            .filter((d) => !!d._id && !(packPair.overlaps.has(d.name) || packPair.overlaps.has(d._id)))
             .map((entry) => {
                 entry = recursiveReplaceString(entry, (s) => {
                     s = s.replaceAll(`systems/${contentSystem}`, `systems/${targetSystem}`);
@@ -361,14 +362,19 @@ for (const contentSystem of contentSystems) {
     };
     const exportLog = R.pipe(
         packPairs.filter((p) => p.documentName === "Item"),
-        R.flatMap(({ overlaps, ...data }) =>
-            [...overlaps].map(
+        R.flatMap(({ overlaps, ...data }) => {
+            // From the pack, get all overlaps, but make sure we *actually* excluded it
+            const registeredDupes = [...overlaps].map(
                 (idOrName) =>
                     data[contentSystem]?.data.find((d) => d.name === idOrName || d._id === idOrName) ??
                     data[targetSystem]?.data.find((d) => d.name === idOrName || d._id === idOrName),
-            ),
-        ),
-        R.filter((i): i is ItemSourcePF2e => !!i && isItemSource(i)),
+            );
+            const outputPack = contentPacks.find((p) => p.id === data[contentSystem]?.id);
+            const outputtedIds = new Set(outputPack?.data.map((d) => d._id) ?? []);
+            return registeredDupes.filter(
+                (d): d is ItemSourcePF2e => !!d && isItemSource(d) && !outputtedIds.has(d._id),
+            );
+        }),
         R.groupBy((i) => (itemIsOfType(i, "feat") ? `feat-${i.system.category}` : i.type)),
         R.entries(),
         R.map(([key, value]) => {

--- a/module.pf2e-anachronism.json
+++ b/module.pf2e-anachronism.json
@@ -10,8 +10,8 @@
     "socket": true,
     "compatibility": {
         "minimum": "13.348",
-        "verified": "13.351",
-        "maximum": "13"
+        "verified": "14.360",
+        "maximum": "14"
     },
     "authors": [
         {

--- a/module.sf2e-anachronism.json
+++ b/module.sf2e-anachronism.json
@@ -2,7 +2,7 @@
     "id": "sf2e-anachronism",
     "title": "Starfinder Anachronism: Official Starfinder Content Pack for Pathfinder Second Edition",
     "description": "<p>Official Starfinder 2e content pack for Pathfinder 2e! Add SF2e character options, creatures, and items into your PF2e game!</p>",
-    "version": "0.0.1",
+    "version": "1.4.0",
     "license": "./LICENSE",
     "manifest": "https://raw.githubusercontent.com/foundryvtt/pf2e/v13-dev/module.sf2e-anachronism.json",
     "url": "https://github.com/foundryvtt/pf2e",
@@ -10,8 +10,8 @@
     "socket": true,
     "compatibility": {
         "minimum": "13.348",
-        "verified": "13.351",
-        "maximum": "13"
+        "verified": "14.360",
+        "maximum": "14"
     },
     "authors": [
         {


### PR DESCRIPTION
Some people weren't happy about export exclusion removing things like "Courier" and "Armored Coat" because the boosted stats, traits, and lore are not the same between system. After speaking with Tikael, I've decided to always export equipment and backgrounds in anachronism (unless its a full-on reprint like Necromancer's Apprentice).

This also fixes a bug where despite being in the exclusions, some things weren't actually being excluded.