### PR TITLE
Fix styling of character language tags

### DIFF
--- a/src/styles/_tags.scss
+++ b/src/styles/_tags.scss
@@ -1,7 +1,7 @@
 // Note: tags html element is tagify, and .tags is paizo tag/traits styling. They are not mutually exclusive.
 
 // Prevent affecting upstream `.tags > .tag` introduced in V12
-.tags:not(.package-overview):not(.input-element-tags) {
+.tags:where(:not(.package-overview):not(.input-element-tags)) {
     align-items: center;
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
Reduces specificity of the base tag styles. Tags in the scene still look fine and dandy.