### PR TITLE
Fix empty tooltips flashing when hovering over the effect panel

### DIFF
--- a/src/module/sheet/helpers.ts
+++ b/src/module/sheet/helpers.ts
@@ -217,6 +217,10 @@ function createTooltipListener(
                     const bounds = target.getBoundingClientRect();
                     const maxH = window.innerHeight - actualTooltip.offsetHeight;
                     actualTooltip.style.top = `${Math.clamp(bounds.top, pad, maxH - pad)}px`;
+
+                    // Circumvent https://github.com/foundryvtt/foundryvtt/issues/14237
+                    // by keeping the global tooltip behind the locked one
+                    if (options.locked) game.tooltip.tooltip.style.top = actualTooltip.style.top;
                 }
             }
         },


### PR DESCRIPTION
The empty tooltip flash still exists, but it is now hidden behind the real one, so users don't see it. This is a upstream quirk of how game.tooltip.activate() with locked: true