### PR TITLE
Change background of secret roll links in dark mode

### DIFF
--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -398,4 +398,5 @@ body.theme-dark .application:not(.themed),
 .themed.theme-dark {
     --color-text-tertiary: var(--color-light-4);
     --visibility-gm-bg: var(--color-cool-4);
+    --blind-roll: #2b122be6;
 }


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/22063

Blind Roll vs Regular Roll:
<img width="164" height="113" alt="image" src="https://github.com/user-attachments/assets/7fcd5709-b68f-4c01-b030-3d74dee5e90d" />
