### PR TITLE
Also fix colors of whisper and blind inline rolls in dark mode

### DIFF
--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -64,7 +64,10 @@ body,
     // Inline links and user visibility
     --visibility-gm-bg: #e8e8ef;
     --visibility-owner-bg: #ddebe1;
-    --blind-roll: #f5eaf5;
+    --color-blind-roll-background: #f5eaf5;
+    --color-blind-roll-border: #720073;
+    --color-whisper-roll-background: #e8e8ef;
+    --color-whisper-roll-border: #545469;
 
     /* Lighter / Darker */
     --primary-dark: var(--color-pf-primary-dark);
@@ -398,5 +401,6 @@ body.theme-dark .application:not(.themed),
 .themed.theme-dark {
     --color-text-tertiary: var(--color-light-4);
     --visibility-gm-bg: var(--color-cool-4);
-    --blind-roll: #2b122be6;
+    --color-blind-roll-background: #2b122be6;
+    --color-whisper-roll-background: #12122be6;
 }

--- a/src/styles/_globals.scss
+++ b/src/styles/_globals.scss
@@ -200,13 +200,13 @@ a.content-link {
 
 a.inline-roll {
     &.blindroll {
-        background-color: var(--color-blind-background, #f5eaf5);
-        border-color: var(--color-blind-border, #6b476b);
+        background-color: var(--color-blind-roll-background);
+        border-color: var(--color-blind-roll-border);
     }
     &.gmroll,
     &.selfroll {
-        background-color: var(--color-whisper-background, #e8e8ef);
-        border-color: var(--color-whisper-border, #545469);
+        background-color: var(--color-whisper-roll-background);
+        border-color: var(--color-whisper-roll-border);
     }
     &.altered {
         color: var(--color-text-dark-improved);
@@ -226,8 +226,8 @@ span[data-pf2-action] {
     cursor: pointer;
 
     &[data-secret] {
-        background: var(--blind-roll);
-        border-color: #720073;
+        background: var(--color-blind-roll-background);
+        border-color: var(--color-blind-roll-border);
     }
 
     &[data-pf2-glyph]::before {
@@ -302,8 +302,8 @@ span[data-pf2-check] {
     }
 
     &[data-pf2-traits*="secret"] {
-        background: var(--blind-roll);
-        border-color: #720073;
+        background: var(--color-blind-roll-background);
+        border-color: var(--color-blind-roll-border);
     }
 
     &[data-invalid] {


### PR DESCRIPTION
The previous colors were core colors that are now chat message scoped and don't have dark mode variants. So we have to make our own.

<img width="200" height="192" alt="image" src="https://github.com/user-attachments/assets/79a2e37b-ce70-4d9c-839e-227f7f862a6a" />
