### PR TITLE
Remove action cost from Improvised Pummel

### DIFF
--- a/packs/pf2e/feats/archetype/weapon-improviser/improvised-pummel.json
+++ b/packs/pf2e/feats/archetype/weapon-improviser/improvised-pummel.json
@@ -5,10 +5,10 @@
     "name": "Improvised Pummel",
     "system": {
         "actionType": {
-            "value": "action"
+            "value": "passive"
         },
         "actions": {
-            "value": 1
+            "value": null
         },
         "category": "class",
         "description": {


### PR DESCRIPTION
- Closes #22073

I checked the PDF and errata just to be sure. It appears this was an intentional change.