### PR TITLE
Add slugs to Living Weapons's Strikes

### DIFF
--- a/packs/pf2e/feats/ancestry/fleshwarp/level-1/living-weapon.json
+++ b/packs/pf2e/feats/ancestry/fleshwarp/level-1/living-weapon.json
@@ -72,6 +72,7 @@
                 "predicate": [
                     "living-weapon:claw"
                 ],
+                "slug": "claw",
                 "traits": [
                     "agile",
                     "finesse",
@@ -94,6 +95,7 @@
                 "predicate": [
                     "living-weapon:horn"
                 ],
+                "slug": "horn",
                 "traits": [
                     "versatile-s",
                     "unarmed"
@@ -116,6 +118,7 @@
                 "predicate": [
                     "living-weapon:jaws"
                 ],
+                "slug": "jaws",
                 "traits": [
                     "versatile-s",
                     "unarmed"
@@ -137,6 +140,7 @@
                 "predicate": [
                     "living-weapon:tusk"
                 ],
+                "slug": "tusk",
                 "traits": [
                     "versatile-s",
                     "unarmed"
@@ -158,6 +162,7 @@
                 "predicate": [
                     "living-weapon:tail"
                 ],
+                "slug": "tail",
                 "traits": [
                     "backswing",
                     "unarmed"


### PR DESCRIPTION
So that when their names are translated, Effect: Mutate Weapon recognizes them.