### PR TITLE
Support inline damage from Notes with Energized Spark

### DIFF
--- a/packs/pf2e/feats/class/exemplar/level-1/energized-spark.json
+++ b/packs/pf2e/feats/class/exemplar/level-1/energized-spark.json
@@ -256,7 +256,8 @@
                                     "action:strike",
                                     "damage:tag:exemplar"
                                 ]
-                            }
+                            },
+                            "exemplar-spirit-damage"
                         ]
                     }
                 ],

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -4500,7 +4500,7 @@
                         "Label": "Heaven Rains an Ending"
                     },
                     "Label": "Infinite Blades Celestial Arrow",
-                    "Note": "Whenever you successfully Strike an enemy with your weapon ikon, up to two enemies adjacent to the target take @Damage[@item.system.damage.dice@item.system.damage.die[spirit]] damage as they are struck by duplicated missiles."
+                    "Note": "Whenever you successfully Strike an enemy with your weapon ikon, up to two enemies adjacent to the target take @Damage[@item.system.damage.dice@item.system.damage.die[spirit]|options:exemplar-spirit-damage] damage as they are struck by duplicated missiles."
                 },
                 "MatedBirdsInPairedFlight": {
                     "Pair": "Two separate ikons.",


### PR DESCRIPTION
- Closes #22056

(the part of it that wasn't addressed by #22098)