### PR TITLE
Use modifier type to find proficiency modifier in mythic rerolls

### DIFF
--- a/src/module/system/check/check.ts
+++ b/src/module/system/check/check.ts
@@ -470,7 +470,7 @@ class Check {
         const unevaluatedNewRoll = ((): CheckRoll => {
             if (resource?.slug !== "mythic-points" || !actor.isOfType("character")) return oldRoll.clone();
             // Create a new CheckRoll in case of a mythic point reroll
-            const proficiencyModifier = (systemFlags.modifiers ?? []).find((m) => m.slug === "proficiency");
+            const proficiencyModifier = (systemFlags.modifiers ?? []).find((m) => m.type === "proficiency" && m.enabled);
             if (!proficiencyModifier) {
                 throw ErrorPF2e(`Failed to reroll check with a mythic point. Check is missing a proficiency modifier!`);
             }

--- a/src/module/system/check/check.ts
+++ b/src/module/system/check/check.ts
@@ -470,7 +470,9 @@ class Check {
         const unevaluatedNewRoll = ((): CheckRoll => {
             if (resource?.slug !== "mythic-points" || !actor.isOfType("character")) return oldRoll.clone();
             // Create a new CheckRoll in case of a mythic point reroll
-            const proficiencyModifier = (systemFlags.modifiers ?? []).find((m) => m.type === "proficiency" && m.enabled);
+            const proficiencyModifier = (systemFlags.modifiers ?? []).find(
+                (m) => m.type === "proficiency" && m.enabled,
+            );
             if (!proficiencyModifier) {
                 throw ErrorPF2e(`Failed to reroll check with a mythic point. Check is missing a proficiency modifier!`);
             }


### PR DESCRIPTION
To account for Untrained Improvisation and other differently-slugged modifiers. Also check that the modifier found is enabled
- Closes #22081

Worth noting that there is still a visual bug where the old modifier's tag is not strikethroughed and replaced by the Mythic tag when the modifier is something other than just a normal proficiency modifier (with the `proficiency` slug). I think this is because the code expects that particular span to have the `proficiency` slug, but that doesn't apply to non-standard proficiency modifiers, such as those from rule elements like Untrained Improvisation. I don't know how to fix that though.

<img width="291" height="476" alt="image" src="https://github.com/user-attachments/assets/003f1564-5b8e-4483-9b68-8b6f2e2d4d71" />
