### PR TITLE
Fix feat delete on ABCSheet silently failing

### DIFF
--- a/src/module/item/abc/sheet.ts
+++ b/src/module/item/abc/sheet.ts
@@ -109,7 +109,7 @@ abstract class ABCSheetPF2e<TItem extends ABCItem> extends ItemSheetPF2e<TItem> 
             }
 
             htmlQuery(li, "[data-action=remove]")?.addEventListener("click", () => {
-                this.item.update({ [`system.items.index`]: _del });
+                this.item.update({ [`system.items.${index}`]: _del });
             });
         }
     }


### PR DESCRIPTION
I looked through the DataFieldOperator commits and didn't spot any other broken updates