### PR TITLE
Fix tag strikethrough when rerolling untrained improv using mythic

### DIFF
--- a/src/module/system/check/check.ts
+++ b/src/module/system/check/check.ts
@@ -590,7 +590,10 @@ class Check {
 
                   // Add mythic proficiency tag
                   if (resource?.slug === "mythic-points") {
-                      const proficiencyTag = htmlQuery(parsedFlavor, "span[data-slug=proficiency]");
+                      const previousSlug =
+                          systemFlags.modifiers?.find((m) => m.type === "proficiency" && m.enabled)?.slug ??
+                          "proficiency";
+                      const proficiencyTag = htmlQuery(parsedFlavor, `span[data-slug=${previousSlug}]`);
                       if (proficiencyTag) {
                           const mythicTag = proficiencyTag.cloneNode() as HTMLElement;
                           proficiencyTag.style.textDecorationLine = "line-through";


### PR DESCRIPTION
Fixes a visual issue mentioned here https://github.com/foundryvtt/pf2e/pull/22110. The strikethrough now applies to any proficiency type modifier, not specifically modifiers with the proficiency slug.

<img width="292" height="256" alt="image" src="https://github.com/user-attachments/assets/a929aea7-403a-4063-bad0-c24e6c795064" />
