### PR TITLE
Update Divine Living Rune (Prey for Death) initiative statistic

### DIFF
--- a/packs/pf2e/prey-for-death-bestiary/divine-living-rune.json
+++ b/packs/pf2e/prey-for-death-bestiary/divine-living-rune.json
@@ -992,7 +992,7 @@
             }
         },
         "initiative": {
-            "statistic": "performance"
+            "statistic": "stealth"
         },
         "perception": {
             "details": "",


### PR DESCRIPTION
Changes Divine Living Rune statistic from performance to stealth to match the adventure.

I was unable to find errata for this adventure, the NPC doesn't have a performance statistic, and thematically it makes a whole lot of sense with stealth.