### PR TITLE
Remove badly formatted Spear Frog (Monster Core 2) skills

### DIFF
--- a/packs/pf2e/pathfinder-monster-core-2/spear-frog.json
+++ b/packs/pf2e/pathfinder-monster-core-2/spear-frog.json
@@ -242,9 +242,6 @@
                 "base": 5,
                 "special": []
             },
-            "and swim)": {
-                "base": null
-            },
             "athletics": {
                 "base": 0,
                 "special": [
@@ -263,12 +260,6 @@
                         ]
                     }
                 ]
-            },
-            "high jump": {
-                "base": null
-            },
-            "long jump": {
-                "base": null
             }
         },
         "traits": {


### PR DESCRIPTION
Skills section contained skills clearly malformed from the special label.