### PR TITLE
Avoid coercing boost to number in trait config

### DIFF
--- a/src/module/item/base/data/system.ts
+++ b/src/module/item/base/data/system.ts
@@ -24,6 +24,7 @@ interface ActionCost {
 
 interface TraitConfig {
     area?: { type: EffectAreaShape; value: number | null };
+    boost?: string;
     capacity?: number;
     deadly?: string;
     fatal?: string;

--- a/src/module/item/helpers.ts
+++ b/src/module/item/helpers.ts
@@ -151,7 +151,9 @@ function addOrUpgradeTrait<TTrait extends ItemTrait>(
     const traitPattern = new RegExp(String.raw`${traitBase}-(\d*d?\d*)`);
     const existingTrait = value.find((t) => traitPattern.test(t));
     const existingAnnotation = existingTrait?.match(traitPattern)?.at(1);
-    const configValue = ["deadly", "fatal"].includes(traitBase) ? upgradeAnnotation : Number(upgradeAnnotation);
+    const configValue = ["boost", "deadly", "fatal"].includes(traitBase)
+        ? upgradeAnnotation
+        : Number(upgradeAnnotation);
     if (!(existingTrait && existingAnnotation)) {
         if (!value.includes(newTrait)) value.push(newTrait);
         if (config) config[traitBase] = configValue;


### PR DESCRIPTION
Fixes boost trait being NaN

Before fix:
<img width="381" height="172" alt="image" src="https://github.com/user-attachments/assets/6142942a-3a7b-4711-aad3-807cf83c571f" />
<img width="482" height="70" alt="image" src="https://github.com/user-attachments/assets/c80b2ce6-8488-4135-bb30-259b397f49aa" />

After fix:
<img width="274" height="40" alt="image" src="https://github.com/user-attachments/assets/85cc4585-727a-4844-b735-93842c8d2649" />


