### PR TITLE
Prevent troop token flags from being saved to prototype tokens

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -1841,6 +1841,12 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
         const result = await super._preUpdate(changed, options, user);
         if (result === false) return false;
 
+        // Troop token flags should only ever be actual tokens, not prototype tokens
+        // This prevents them from being copied in from the Assign Token button
+        if (changed.prototypeToken?.flags?.[SYSTEM_ID] && "troop" in changed.prototypeToken.flags[SYSTEM_ID]) {
+            delete changed.prototypeToken.flags[SYSTEM_ID].troop;
+        }
+
         const isFullReplace = !((options.diff ?? true) && (options.recursive ?? true));
         if (isFullReplace) return result;
 


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/22164 though do let me know if we should also strip it out during data prep.

In short, copying a token into the prototype token using the Assign Token button can cause placing troops from the world actors to no longer work. The troop flags are used to prevent copying a single segment from creating multiple segments, and those flags being in the prototype token causes all newly spawned tokens to believe that the troop has already been placed.