### PR TITLE
Suppress volley trait penalty with Sniper operative specialization

### DIFF
--- a/packs/pf2e/menace-under-otari-bestiary/secrets-of-the-unlit-star/string-slime-bb.json
+++ b/packs/pf2e/menace-under-otari-bestiary/secrets-of-the-unlit-star/string-slime-bb.json
@@ -274,7 +274,7 @@
         "traits": {
             "rarity": "common",
             "size": {
-                "value": "lg"
+                "value": "med"
             },
             "value": [
                 "mindless",

--- a/packs/pf2e/troubles-in-grayce-bestiary/4-the-disgraced-dollmaker/trial-by-flame-trap.json
+++ b/packs/pf2e/troubles-in-grayce-bestiary/4-the-disgraced-dollmaker/trial-by-flame-trap.json
@@ -63,7 +63,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>no multiple attack penalty</p>"
+                    "value": "<p>No multiple attack penalty</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -76,6 +76,7 @@
                 },
                 "rules": [],
                 "slug": null,
+                "subjectToMAP": false,
                 "traits": {
                     "config": {},
                     "value": [

--- a/packs/pf2e/troubles-in-grayce-bestiary/4-the-disgraced-dollmaker/trial-by-poison-trap.json
+++ b/packs/pf2e/troubles-in-grayce-bestiary/4-the-disgraced-dollmaker/trial-by-poison-trap.json
@@ -62,7 +62,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>(no multiple attack penalty)</p>"
+                    "value": "<p>No multiple attack penalty</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -75,6 +75,7 @@
                 },
                 "rules": [],
                 "slug": null,
+                "subjectToMAP": false,
                 "traits": {
                     "config": {},
                     "value": [

--- a/packs/pf2e/troubles-in-grayce-bestiary/4-the-disgraced-dollmaker/wall-blades-trap.json
+++ b/packs/pf2e/troubles-in-grayce-bestiary/4-the-disgraced-dollmaker/wall-blades-trap.json
@@ -53,7 +53,7 @@
                     }
                 },
                 "description": {
-                    "value": "<p>(no multiple attack penalty)</p>"
+                    "value": "<p>No multiple attack penalty</p>"
                 },
                 "publication": {
                     "license": "OGL",
@@ -63,6 +63,7 @@
                 "range": null,
                 "rules": [],
                 "slug": null,
+                "subjectToMAP": false,
                 "traits": {
                     "config": {},
                     "value": [

--- a/packs/pf2e/troubles-in-grayce-bestiary/6-the-count-of-petals/sangrist.json
+++ b/packs/pf2e/troubles-in-grayce-bestiary/6-the-count-of-petals/sangrist.json
@@ -339,6 +339,7 @@
             },
             "value": [
                 "human",
+                "undead",
                 "unholy"
             ]
         }

--- a/packs/sf2e/class-features/operative/specializations/sniper.json
+++ b/packs/sf2e/class-features/operative/specializations/sniper.json
@@ -100,6 +100,12 @@
                 "selector": "ranged-strike-attack-roll",
                 "text": "SF2E.SpecificRule.Operative.Specialization.Sniper.EnhancedExploit.Note",
                 "title": "SF2E.SpecificRule.Operative.EnhancedExploit.Label"
+            },
+            {
+                "key": "AdjustModifier",
+                "selector": "sniper-group-attack-roll",
+                "slug": "volley",
+                "suppress": true
             }
         ],
         "subfeatures": {


### PR DESCRIPTION
- Closes #22101
There are pf2e fixes here too, but they shouldn't be credited, so I'll omit the label.