### PR TITLE
Have darkness lights work like darkness regions with darkvision

### DIFF
--- a/src/module/canvas/group/effects.ts
+++ b/src/module/canvas/group/effects.ts
@@ -1,7 +1,26 @@
-class EffectsCanvasGroupPF2e extends fc.groups.EffectsCanvasGroup {
-    /** Is rules-based vision enabled and applicable to the scene? */
-    get rulesBasedVision(): boolean {
-        return game.pf2e.settings.rbv && canvas.ready && !!canvas.scene?.tokenVision;
+import type { AmbientLightPF2e, TokenPF2e } from "../index.ts";
+
+class EffectsCanvasGroupPF2e extends fc.groups.EffectsCanvasGroup<TokenPF2e | AmbientLightPF2e> {
+    static #colorFilter = new PIXI.ColorMatrixFilter();
+
+    /** (De)saturate darkness lights if a vision source has darkvision. */
+    override refreshLighting(): void {
+        super.refreshLighting();
+        const darknessFilters = (this.darkness.filters ??= []);
+        const colorFilter = EffectsCanvasGroupPF2e.#colorFilter;
+        const withDarkvision = this.visionSources.find(
+            (s) => "hasDarkvision" in s.object.document && s.object.document.hasDarkvision,
+        );
+        const tokenDoc = withDarkvision?.object.document;
+        if (!tokenDoc || !("actor" in tokenDoc) || withDarkvision.isBlinded) {
+            darknessFilters.findSplice((f) => f === colorFilter);
+            return;
+        }
+        const adjustment = tokenDoc.actor?.flags[SYSTEM_ID]?.colorDarkvision ? "saturate" : "desaturate";
+        colorFilter[adjustment]();
+        if (!darknessFilters.includes(colorFilter)) {
+            darknessFilters.push(colorFilter);
+        }
     }
 }
 

--- a/src/module/canvas/perception/modes.ts
+++ b/src/module/canvas/perception/modes.ts
@@ -2,27 +2,31 @@ import type { CanvasVisibilityTest } from "@client/_types.d.mts";
 import type { TokenDetectionMode } from "@client/canvas/perception/detection-mode.d.mts";
 import { TokenPF2e } from "../token/object.ts";
 
-const darkvision = new fc.perception.VisionMode({
-    id: "darkvision",
-    label: "VISION.ModeDarkvision",
-    canvas: {
-        shader: fc.rendering.shaders.ColorAdjustmentsSamplerShader,
-        uniforms: { enable: true, contrast: 0, saturation: -1, brightness: 0 },
-    },
-    lighting: {
-        levels: {
-            // from core-bundled darkvision mode: maybe restore?
-            // [VisionMode.LIGHTING_LEVELS.DIM]: VisionMode.LIGHTING_LEVELS.BRIGHT,
-        },
-        background: { visibility: fc.perception.VisionMode.LIGHTING_VISIBILITY.REQUIRED },
-    },
-    vision: {
-        darkness: { adaptive: true },
-        defaults: { attenuation: 0, contrast: 0, saturation: -1, brightness: 0 },
-    },
-});
+class DarkvisionMode extends fc.perception.VisionMode {
+    constructor() {
+        super({
+            id: "darkvision",
+            label: "VISION.ModeDarkvision",
+            canvas: {
+                shader: fc.rendering.shaders.ColorAdjustmentsSamplerShader,
+                uniforms: { contrast: 0, saturation: -1, brightness: 0 },
+            },
+            lighting: {
+                levels: {
+                    // from core-bundled darkvision mode: maybe restore?
+                    // [VisionMode.LIGHTING_LEVELS.DIM]: VisionMode.LIGHTING_LEVELS.BRIGHT,
+                },
+                background: { visibility: fc.perception.VisionMode.LIGHTING_VISIBILITY.REQUIRED },
+            },
+            vision: {
+                darkness: { adaptive: true },
+                defaults: { attenuation: 0, contrast: 0, saturation: -1, brightness: 0 },
+            },
+        });
+    }
+}
 
-class LightPerceptionMode extends fc.perception.DetectionModeLightPerception {
+class LightDetectionMode extends fc.perception.DetectionModeLightPerception {
     constructor() {
         super({
             id: "lightPerception",
@@ -34,12 +38,14 @@ class LightPerceptionMode extends fc.perception.DetectionModeLightPerception {
 
     protected override _canDetect(
         visionSource: PointVisionSourcePF2e,
-        target: fc.placeables.PlaceableObject,
+        target: object | null,
         level: fd.Level,
     ): boolean {
-        if (target instanceof fc.placeables.PlaceableObject && target.document.hidden) return false;
-        if (target instanceof TokenPF2e && target.actor?.hasCondition("hidden", "undetected", "unnoticed")) {
-            return false;
+        if (target instanceof fc.placeables.PlaceableObject) {
+            const document = target.document;
+            if (document.hidden || document.actor?.hasCondition("hidden", "undetected", "unnoticed")) {
+                return false;
+            }
         }
         return super._canDetect(visionSource, target, level);
     }
@@ -55,10 +61,12 @@ class VisionDetectionMode extends fc.perception.DetectionModeDarkvision {
         });
     }
 
-    protected override _canDetect(visionSource: PointVisionSourcePF2e, target: fc.placeables.PlaceableObject): boolean {
-        if (target instanceof fc.placeables.PlaceableObject && target.document.hidden) return false;
-        if (target instanceof TokenPF2e && target.actor?.hasCondition("hidden", "undetected", "unnoticed")) {
-            return false;
+    protected override _canDetect(visionSource: PointVisionSourcePF2e, target: object | null): boolean {
+        if (target instanceof fc.placeables.PlaceableObject) {
+            const document = target.document;
+            if (document.hidden || document.actor?.hasCondition("hidden", "undetected", "unnoticed")) {
+                return false;
+            }
         }
         return super._canDetect(visionSource, target);
     }
@@ -80,7 +88,7 @@ class HearingDetectionMode extends fc.perception.DetectionMode {
         return filter;
     }
 
-    protected override _canDetect(visionSource: PointVisionSourcePF2e, target: fc.placeables.PlaceableObject): boolean {
+    protected override _canDetect(visionSource: PointVisionSourcePF2e, target: object | null): boolean {
         // Not if the target isn't a token
         if (!(target instanceof TokenPF2e)) return false;
 
@@ -161,9 +169,9 @@ class DetectionModeTremorPF2e extends fc.perception.DetectionModeTremor {
 }
 
 function setPerceptionModes(): void {
-    CONFIG.Canvas.visionModes.darkvision = darkvision;
+    CONFIG.Canvas.visionModes.darkvision = new DarkvisionMode();
     CONFIG.Canvas.detectionModes.basicSight = new VisionDetectionMode();
-    CONFIG.Canvas.detectionModes.lightPerception = new LightPerceptionMode();
+    CONFIG.Canvas.detectionModes.lightPerception = new LightDetectionMode();
     CONFIG.Canvas.detectionModes.hearing = new HearingDetectionMode();
     CONFIG.Canvas.detectionModes.feelTremor = new DetectionModeTremorPF2e();
 }

--- a/src/module/canvas/perception/vision-source.ts
+++ b/src/module/canvas/perception/vision-source.ts
@@ -1,0 +1,8 @@
+import { TokenPF2e } from "../token/index.ts";
+
+export class PointVisionSourcePF2e extends fc.sources.PointVisionSource<TokenPF2e> {
+    protected override _initialize(data: Partial<fc.sources.VisionSourceData>): void {
+        super._initialize(data);
+        if (data.visionMode === "darkvision") this.data.priority = 1;
+    }
+}

--- a/src/scripts/hooks/load.ts
+++ b/src/scripts/hooks/load.ts
@@ -34,6 +34,7 @@ import {
     TokenLayerPF2e,
     TokenPF2e,
 } from "@module/canvas/index.ts";
+import { PointVisionSourcePF2e } from "@module/canvas/perception/vision-source.ts";
 import { TerrainDataPF2e } from "@module/canvas/token/movement/terrain-data.ts";
 import { TokenRulerPF2e } from "@module/canvas/token/ruler.ts";
 import { ChatMessagePF2e } from "@module/chat-message/index.ts";
@@ -136,6 +137,7 @@ export class Load {
         CONFIG.Canvas.layers.regions.layerClass = RegionLayerPF2e;
         CONFIG.Canvas.layers.tokens.layerClass = TokenLayerPF2e;
         CONFIG.Canvas.rulerClass = RulerPF2e;
+        CONFIG.Canvas.visionSourceClass = PointVisionSourcePF2e;
 
         CONFIG.Dice.rolls.push(CheckRoll, StrikeAttackRoll, DamageRoll, DamageInstance);
         for (const TermCls of [ArithmeticExpression, Grouping, InstancePool, IntermediateDie]) {

--- a/types/foundry/client/canvas/groups/effects.d.mts
+++ b/types/foundry/client/canvas/groups/effects.d.mts
@@ -18,7 +18,7 @@ import CanvasGroupMixin from "./canvas-group-mixin.mjs";
  * - {@link hookEvents.createEffectsCanvasGroup}
  * - {@link hookEvents.lightingRefresh}
  */
-export default class EffectsCanvasGroup extends CanvasGroupMixin(PIXI.Container) {
+export default class EffectsCanvasGroup<TObject extends AmbientLight | Token> extends CanvasGroupMixin(PIXI.Container) {
     /**
      *  Whether to currently animate light sources.
      */
@@ -32,17 +32,17 @@ export default class EffectsCanvasGroup extends CanvasGroupMixin(PIXI.Container)
     /**
      * A mapping of light sources which are active within the rendered Scene.
      */
-    lightSources: Collection<string, PointLightSource<AmbientLight | Token>>;
+    lightSources: Collection<string, PointLightSource<TObject>>;
 
     /**
      * A mapping of darkness sources which are active within the rendered Scene.
      */
-    darknessSources: Collection<string, PointDarknessSource<AmbientLight>>;
+    darknessSources: Collection<string, PointDarknessSource<TObject>>;
 
     /**
      * A Collection of vision sources which are currently active within the rendered Scene.
      */
-    visionSources: Collection<string, PointVisionSource<Token>>;
+    visionSources: Collection<string, PointVisionSource<TObject>>;
 
     /**
      *  A set of vision mask filters used in visual effects group
@@ -72,7 +72,7 @@ export default class EffectsCanvasGroup extends CanvasGroupMixin(PIXI.Container)
     /**
      * Iterator for all light and darkness sources.
      */
-    allSources(): Generator<PointDarknessSource<AmbientLight> | PointLightSource<AmbientLight | Token>, void, void>;
+    allSources(): Generator<PointDarknessSource<TObject> | PointLightSource<TObject>, void, void>;
 
     protected override _createLayers(): {
         background: CanvasBackgroundAlterationEffects;
@@ -129,10 +129,7 @@ export default class EffectsCanvasGroup extends CanvasGroupMixin(PIXI.Container)
      * order to be tested.
      * @returns Is inside light?
      */
-    testInsideLight(
-        position: ElevatedPoint,
-        options?: (source: PointLightSource<AmbientLight | Token>) => boolean,
-    ): boolean;
+    testInsideLight(position: ElevatedPoint, options?: (source: PointLightSource<TObject>) => boolean): boolean;
 
     /**
      * Test whether the point is inside darkness.
@@ -141,10 +138,7 @@ export default class EffectsCanvasGroup extends CanvasGroupMixin(PIXI.Container)
      * @param options.condition Optional condition a source must satisfy in order to be tested.
      * @returns Is inside a darkness?
      */
-    testInsideDarkness(
-        position: ElevatedPoint,
-        options?: (source: PointDarknessSource<AmbientLight>) => boolean,
-    ): boolean;
+    testInsideDarkness(position: ElevatedPoint, options?: (source: PointDarknessSource<TObject>) => boolean): boolean;
 
     /**
      * Get the darkness level at the given point.

--- a/types/foundry/client/canvas/sources/point-darkness-source.d.mts
+++ b/types/foundry/client/canvas/sources/point-darkness-source.d.mts
@@ -3,13 +3,13 @@ import { Point } from "@common/_types.mjs";
 import { LightingLevel } from "@common/constants.mjs";
 import { PointSourceMesh } from "../containers/_module.mjs";
 import { PointSourcePolygonConfig } from "../geometry/_types.mjs";
-import AmbientLight from "../placeables/light.mjs";
+import { AmbientLight, Token } from "../placeables/_module.mjs";
 import BaseLightSource from "./base-light-source.mjs";
 import { PointEffectSource } from "./point-effect-source.mjs";
 import { RenderedEffectLayerConfig } from "./rendered-effect-source.mjs";
 
 declare const PointEffectBaseLightSource: {
-    new <TObject extends AmbientLight>(...args: any): BaseLightSource<TObject> & PointEffectSource;
+    new <TObject extends AmbientLight | Token>(...args: any): BaseLightSource<TObject> & PointEffectSource;
 } & Omit<typeof BaseLightSource, "new"> &
     typeof PointEffectSource;
 
@@ -20,7 +20,9 @@ interface PointEffectBaseLightSource<TObject extends AmbientLight> extends Insta
 /**
  * A specialized subclass of the BaseLightSource which renders a source of darkness as a point-based effect.
  */
-export default class PointDarknessSource<TObject extends AmbientLight> extends PointEffectBaseLightSource<TObject> {
+export default class PointDarknessSource<
+    TObject extends AmbientLight | Token,
+> extends PointEffectBaseLightSource<TObject> {
     static override sourceType: "darkness";
 
     static override effectsCollection: "darknessSources";


### PR DESCRIPTION
No controlled token
<img width="518" src="https://github.com/user-attachments/assets/e10c07db-7964-45bb-85de-01072eefa6e7" />

Harsk controlled (before):
<img width="518" src="https://github.com/user-attachments/assets/fa4ee851-7073-494a-bc32-aca53c21dc51" />

Harsk controlled (after):
<img width="518" src="https://github.com/user-attachments/assets/fe3f40c5-bcc1-4fa4-a717-c9105753e6e3" />
