### PR TITLE
Target system id in migration 958

### DIFF
--- a/src/module/migration/migrations/958-gnoll-grippli-remaster.ts
+++ b/src/module/migration/migrations/958-gnoll-grippli-remaster.ts
@@ -44,13 +44,13 @@ export class Migration958GnollGrippliRemaster extends MigrationBase {
 
     override async updateActor(source: ActorSourcePF2e): Promise<void> {
         source.system = this.#replaceStrings(source.system);
-        source.flags.pf2e &&= this.#replaceStrings(source.flags.pf2e);
+        source.flags[SYSTEM_ID] &&= this.#replaceStrings(source.flags[SYSTEM_ID]);
         source.system.traits?.value?.sort();
     }
 
     override async updateItem(source: ItemSourcePF2e): Promise<void> {
         source.system = this.#replaceStrings(source.system);
-        source.flags.pf2e &&= this.#replaceStrings(source.flags.pf2e);
+        source.flags[SYSTEM_ID] &&= this.#replaceStrings(source.flags[SYSTEM_ID]);
         source.system.traits?.value?.sort();
     }
 }


### PR DESCRIPTION
There is a chance that someone imported gnolls and grippli into sf2e via anachronism. So we should migrate there as well.