### PR TITLE
Fix migration choking on embedded spells without flags

### DIFF
--- a/src/module/migration/migrations/958-gnoll-grippli-remaster.ts
+++ b/src/module/migration/migrations/958-gnoll-grippli-remaster.ts
@@ -44,7 +44,7 @@ export class Migration958GnollGrippliRemaster extends MigrationBase {
 
     override async updateActor(source: ActorSourcePF2e): Promise<void> {
         source.system = this.#replaceStrings(source.system);
-        if (source.flags) source.flags[SYSTEM_ID] &&= this.#replaceStrings(source.flags[SYSTEM_ID]);
+        source.flags[SYSTEM_ID] &&= this.#replaceStrings(source.flags[SYSTEM_ID]);
         source.system.traits?.value?.sort();
     }
 

--- a/src/module/migration/migrations/958-gnoll-grippli-remaster.ts
+++ b/src/module/migration/migrations/958-gnoll-grippli-remaster.ts
@@ -44,13 +44,13 @@ export class Migration958GnollGrippliRemaster extends MigrationBase {
 
     override async updateActor(source: ActorSourcePF2e): Promise<void> {
         source.system = this.#replaceStrings(source.system);
-        source.flags[SYSTEM_ID] &&= this.#replaceStrings(source.flags[SYSTEM_ID]);
+        if (source.flags) source.flags[SYSTEM_ID] &&= this.#replaceStrings(source.flags[SYSTEM_ID]);
         source.system.traits?.value?.sort();
     }
 
     override async updateItem(source: ItemSourcePF2e): Promise<void> {
         source.system = this.#replaceStrings(source.system);
-        source.flags[SYSTEM_ID] &&= this.#replaceStrings(source.flags[SYSTEM_ID]);
+        if (source.flags) source.flags[SYSTEM_ID] &&= this.#replaceStrings(source.flags[SYSTEM_ID]);
         source.system.traits?.value?.sort();
     }
 }

--- a/src/module/migration/runner/index.ts
+++ b/src/module/migration/runner/index.ts
@@ -152,7 +152,7 @@ export class MigrationRunner extends MigrationRunnerBase {
             } catch (error) {
                 // Output the error, since this means a migration threw it
                 if (error instanceof Error) {
-                    console.error(`Error thrown while migrating ${actor.uuid}: ${error.message}`, error);
+                    console.error(`Error thrown while migrating ${actor.uuid}: `, error);
                 }
                 return null;
             }

--- a/src/module/migration/runner/index.ts
+++ b/src/module/migration/runner/index.ts
@@ -152,7 +152,7 @@ export class MigrationRunner extends MigrationRunnerBase {
             } catch (error) {
                 // Output the error, since this means a migration threw it
                 if (error instanceof Error) {
-                    console.error(`Error thrown while migrating ${actor.uuid}: ${error.message}`);
+                    console.error(`Error thrown while migrating ${actor.uuid}: ${error.message}`, error);
                 }
                 return null;
             }


### PR DESCRIPTION
Spells inside wands and scrolls don't get defaults set, so it exploded in my game. To my credit, the previous version without SYSTEM_ID would have also exploded.