### PR TITLE
[WIP] Tie default window sizes to selected font size

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -85,7 +85,14 @@ interface ClientSettingsPF2e extends fh.ClientSettings {
     get(scope: "core", key: "fontSize"): number;
     get(scope: "core", key: "noCanvas"): boolean;
     get(scope: "core", key: "messageMode"): ChatMessageMode;
-    get(scope: "core", key: "uiConfig"): { colorScheme: { applications: string; interface: string }; uiScale: number };
+    get(
+        scope: "core",
+        key: "uiConfig",
+    ): {
+        colorScheme: { applications: string; interface: string };
+        uiScale: number;
+        fontScale?: number;
+    };
     get(scope: SystemId, setting: "automation.actorsDeadAtZero"): "neither" | "npcsOnly" | "pcsOnly" | "both";
     get(scope: SystemId, setting: "automation.encumbrance"): boolean;
     get(scope: SystemId, setting: "automation.flankingDetection"): boolean;

--- a/src/module/actor/army/sheet.ts
+++ b/src/module/actor/army/sheet.ts
@@ -7,7 +7,13 @@ import { CampaignFeaturePF2e, ItemPF2e, ItemProxyPF2e } from "@item";
 import type { ItemSourcePF2e } from "@item/base/data/index.ts";
 import type { DropCanvasItemData } from "@module/canvas/drop-canvas-data.ts";
 import { ChatMessagePF2e } from "@module/chat-message/document.ts";
-import { AdjustedValue, eventToRollParams, getAdjustedValue, getAdjustment } from "@module/sheet/helpers.ts";
+import {
+    AdjustedValue,
+    eventToRollParams,
+    getAdjustedValue,
+    getAdjustment,
+    scaleDimensionsToClientFont,
+} from "@module/sheet/helpers.ts";
 import { kingmakerTraits } from "@scripts/config/traits.ts";
 import { TextEditorPF2e } from "@system/text-editor.ts";
 import { ErrorPF2e, htmlClosest, htmlQuery, htmlQueryAll, objectHasKey, tupleHasValue } from "@util";
@@ -23,11 +29,12 @@ class ArmySheetPF2e extends ActorSheetPF2e<ArmyPF2e> {
 
     static override get defaultOptions(): ActorSheetOptions {
         const options = super.defaultOptions;
+        const sized = scaleDimensionsToClientFont(750, 625);
         return {
             ...options,
             classes: [...options.classes, "army"],
-            width: 750,
-            height: 625,
+            width: sized.width,
+            height: sized.height,
             template: `systems/${SYSTEM_ID}/templates/actors/army/sheet.hbs`,
             scrollY: [".sheet-body"],
         };

--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -5,6 +5,7 @@ import { MODIFIER_TYPES, createProficiencyModifier } from "@actor/modifiers.ts";
 import type { SheetClickActionHandlers } from "@actor/sheet/base.ts";
 import type { AbilityViewData, InventoryItem } from "@actor/sheet/data-types.ts";
 import { condenseSenses, createAbilityViewData } from "@actor/sheet/helpers.ts";
+import { scaleDimensionsToClientFont } from "@module/sheet/helpers.ts";
 import type { AttributeString, SaveType, SkillSlug } from "@actor/types.ts";
 import { ATTRIBUTE_ABBREVIATIONS } from "@actor/values.ts";
 import type { ActorSheetOptions } from "@client/appv1/sheets/actor-sheet.d.mts";
@@ -88,8 +89,9 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
     static override get defaultOptions(): ActorSheetOptions {
         const options = super.defaultOptions;
         options.classes = [...options.classes, "character"];
-        options.width = 750;
-        options.height = 750;
+        const sized = scaleDimensionsToClientFont(750, 750);
+        options.width = sized.width;
+        options.height = sized.height;
         options.scrollY.push(".tab[data-tab=spellcasting] > [data-panels]", ".tab.active .tab-content");
         options.dragDrop.push({ dragSelector: "ol[data-strikes] > li, ol[data-elemental-blasts] > li" });
         options.tabs = [

--- a/src/module/actor/familiar/sheet.ts
+++ b/src/module/actor/familiar/sheet.ts
@@ -5,7 +5,7 @@ import type { SheetClickActionHandlers } from "@actor/sheet/base.ts";
 import type { AbilityViewData } from "@actor/sheet/data-types.ts";
 import { createAbilityViewData } from "@actor/sheet/helpers.ts";
 import type { ActorSheetOptions } from "@client/appv1/sheets/actor-sheet.d.mts";
-import { eventToRollParams } from "@module/sheet/helpers.ts";
+import { eventToRollParams, scaleDimensionsToClientFont } from "@module/sheet/helpers.ts";
 import type { StatisticTraceData } from "@system/statistic/index.ts";
 import * as R from "remeda";
 import type { FamiliarPF2e } from "./document.ts";
@@ -19,11 +19,12 @@ export class FamiliarSheetPF2e<TActor extends FamiliarPF2e> extends CreatureShee
 
     static override get defaultOptions(): ActorSheetOptions {
         const options = super.defaultOptions;
+        const sized = scaleDimensionsToClientFont(650, 680);
         return {
             ...options,
             classes: [...options.classes, "familiar"],
-            width: 650,
-            height: 680,
+            width: sized.width,
+            height: sized.height,
             tabs: [{ navSelector: ".sheet-navigation", contentSelector: ".sheet-content", initial: "attributes" }],
             template: `systems/${SYSTEM_ID}/templates/actors/familiar/sheet.hbs`,
         };

--- a/src/module/actor/hazard/sheet.ts
+++ b/src/module/actor/hazard/sheet.ts
@@ -1,7 +1,7 @@
 import { ActorSheetPF2e, SheetClickActionHandlers } from "@actor/sheet/base.ts";
 import { SAVE_TYPES } from "@actor/values.ts";
 import type { ActorSheetOptions } from "@client/appv1/sheets/actor-sheet.d.mts";
-import { createNPCAttackTraitsAndTags } from "@module/sheet/helpers.ts";
+import { createNPCAttackTraitsAndTags, scaleDimensionsToClientFont } from "@module/sheet/helpers.ts";
 import { HTMLTagifyTagsElement } from "@system/html-elements/tagify-tags.ts";
 import { TextEditorPF2e } from "@system/text-editor.ts";
 import { htmlClosest, htmlQuery } from "@util/dom.ts";
@@ -12,12 +12,13 @@ import { HazardActionSheetData, HazardAttackSheedData, HazardSaveSheetData, Haza
 export class HazardSheetPF2e extends ActorSheetPF2e<HazardPF2e> {
     static override get defaultOptions(): ActorSheetOptions {
         const options = super.defaultOptions;
+        const sized = scaleDimensionsToClientFont(710, 680);
         return {
             ...options,
             classes: [...options.classes, "hazard"],
             scrollY: ["section.content"],
-            width: 710,
-            height: 680,
+            width: sized.width,
+            height: sized.height,
             template: `systems/${SYSTEM_ID}/templates/actors/hazard/sheet.hbs`,
         };
     }

--- a/src/module/actor/loot/sheet.ts
+++ b/src/module/actor/loot/sheet.ts
@@ -7,6 +7,7 @@ import type BaseActor from "@common/documents/actor.d.mts";
 import type { ActorSchema } from "@common/documents/actor.d.mts";
 import type { PhysicalItemPF2e } from "@item";
 import { TextEditorPF2e } from "@system/text-editor.ts";
+import { scaleDimensionsToClientFont } from "@module/sheet/helpers.ts";
 import { htmlClosest, htmlQuery } from "@util";
 import { ActorSheetPF2e } from "../sheet/base.ts";
 import { DistributeCoinsDialog } from "../sheet/popups/distribute-coins-dialog.ts";
@@ -17,12 +18,13 @@ export class LootSheetPF2e<TActor extends LootPF2e> extends ActorSheetPF2e<TActo
     static override get defaultOptions(): ActorSheetOptions {
         const options = super.defaultOptions;
 
+        const sized = scaleDimensionsToClientFont(650, 680);
         return {
             ...options,
             editable: true,
             classes: [...options.classes, "loot"],
-            width: 650,
-            height: 680,
+            width: sized.width,
+            height: sized.height,
             tabs: [{ navSelector: ".sheet-navigation", contentSelector: ".sheet-content", initial: "inventory" }],
         };
     }

--- a/src/module/actor/npc/sheet.ts
+++ b/src/module/actor/npc/sheet.ts
@@ -5,6 +5,7 @@ import { Modifier } from "@actor/modifiers.ts";
 import { NPCSkillsEditor } from "@actor/npc/skills-editor.ts";
 import { SheetClickActionHandlers } from "@actor/sheet/base.ts";
 import { createAbilityViewData } from "@actor/sheet/helpers.ts";
+import { scaleDimensionsToClientFont } from "@module/sheet/helpers.ts";
 import { RecallKnowledgePopup } from "@actor/sheet/popups/recall-knowledge-popup.ts";
 import { ATTRIBUTE_ABBREVIATIONS, SAVE_TYPES } from "@actor/values.ts";
 import type { ActorSheetOptions } from "@client/appv1/sheets/actor-sheet.d.mts";
@@ -147,10 +148,11 @@ class NPCSheetPF2e extends AbstractNPCSheet {
         const options = super.defaultOptions;
         options.scrollY.push(".inventory-list", ".tab:not(.inventory)");
 
+        const sized = scaleDimensionsToClientFont(650, 680);
         return {
             ...options,
-            width: 650,
-            height: 680,
+            width: sized.width,
+            height: sized.height,
             tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "main" }],
         };
     }
@@ -511,10 +513,11 @@ class SimpleNPCSheet extends AbstractNPCSheet {
         const options = super.defaultOptions;
         options.classes.push("simple");
 
+        const sized = scaleDimensionsToClientFont(650, 420);
         return {
             ...options,
-            width: 650,
-            height: 420,
+            width: sized.width,
+            height: sized.height,
             scrollY: [".sheet-body"],
             template: `systems/${SYSTEM_ID}/templates/actors/npc/simple-sheet.hbs`,
         };

--- a/src/module/actor/party/kingdom/sheet.ts
+++ b/src/module/actor/party/kingdom/sheet.ts
@@ -21,6 +21,7 @@ import {
     eventToRollParams,
     getAdjustedValue,
     getAdjustment,
+    scaleDimensionsToClientFont,
 } from "@module/sheet/helpers.ts";
 import type { SocketMessage } from "@scripts/socket.ts";
 import { Statistic } from "@system/statistic/index.ts";
@@ -95,11 +96,12 @@ class KingdomSheetPF2e extends ActorSheetPF2e<PartyPF2e> {
     static override get defaultOptions(): ActorSheetOptions {
         const options = super.defaultOptions;
 
+        const sized = scaleDimensionsToClientFont(750, 630);
         return {
             ...options,
             classes: [...options.classes, "kingdom"],
-            width: 750,
-            height: 630,
+            width: sized.width,
+            height: sized.height,
             template: `systems/${SYSTEM_ID}/templates/actors/party/kingdom/sheet.hbs`,
             scrollY: [...options.scrollY, ".tab.active", ".tab.active .content", ".sidebar"],
             tabs: [

--- a/src/module/actor/party/sheet.ts
+++ b/src/module/actor/party/sheet.ts
@@ -15,7 +15,12 @@ import { Bulk, Coins } from "@item/physical/index.ts";
 import { PHYSICAL_ITEM_TYPES } from "@item/physical/values.ts";
 import type { DropCanvasItemData } from "@module/canvas/drop-canvas-data.ts";
 import type { ZeroToFour } from "@module/data.ts";
-import { SheetOptions, createSheetTags, eventToRollParams } from "@module/sheet/helpers.ts";
+import {
+    SheetOptions,
+    createSheetTags,
+    eventToRollParams,
+    scaleDimensionsToClientFont,
+} from "@module/sheet/helpers.ts";
 import type { SocketMessage } from "@scripts/socket.ts";
 import type { SettingsMenuOptions } from "@system/settings/menu.ts";
 import { TextEditorPF2e } from "@system/text-editor.ts";
@@ -35,11 +40,12 @@ class PartySheetPF2e extends ActorSheetPF2e<PartyPF2e> {
     static override get defaultOptions(): ActorSheetOptions {
         const options = super.defaultOptions;
 
+        const sized = scaleDimensionsToClientFont(720, 720);
         return {
             ...options,
             classes: [...options.classes, "party"],
-            width: 720,
-            height: 720,
+            width: sized.width,
+            height: sized.height,
             template: `systems/${SYSTEM_ID}/templates/actors/party/sheet.hbs`,
             scrollY: [...options.scrollY, ".tab.active", ".tab.active .content", ".sidebar"],
             tabs: [

--- a/src/module/actor/vehicle/sheet.ts
+++ b/src/module/actor/vehicle/sheet.ts
@@ -5,7 +5,7 @@ import type { FormSelectOption } from "@client/applications/forms/fields.d.mts";
 import type { ActorSheetOptions } from "@client/appv1/sheets/actor-sheet.d.mts";
 import type { ImageFilePath } from "@common/constants.d.mts";
 import { ItemPF2e } from "@item";
-import { AdjustedValue, getActionIcon, getAdjustedValue } from "@module/sheet/helpers.ts";
+import { AdjustedValue, getActionIcon, getAdjustedValue, scaleDimensionsToClientFont } from "@module/sheet/helpers.ts";
 import { ErrorPF2e, htmlClosest, htmlQuery, htmlQueryAll } from "@util";
 import { ActorSheetPF2e } from "../sheet/base.ts";
 import type { VehicleSystemSchema } from "./data.ts";
@@ -13,11 +13,12 @@ import type { VehicleSystemSchema } from "./data.ts";
 export class VehicleSheetPF2e extends ActorSheetPF2e<VehiclePF2e> {
     static override get defaultOptions(): ActorSheetOptions {
         const options = super.defaultOptions;
+        const sized = scaleDimensionsToClientFont(670, 520);
         return {
             ...options,
             classes: [...options.classes, "vehicle"],
-            width: 670,
-            height: 520,
+            width: sized.width,
+            height: sized.height,
             tabs: [{ navSelector: ".sheet-navigation", contentSelector: ".sheet-content", initial: "details" }],
             template: `systems/${SYSTEM_ID}/templates/actors/vehicle/sheet.hbs`,
         };

--- a/src/module/sheet/helpers.ts
+++ b/src/module/sheet/helpers.ts
@@ -14,6 +14,68 @@ import { traitSlugToObject } from "@util/tags.ts";
 import * as R from "remeda";
 
 /** Prepare form options on an item or actor sheet */
+function resolveClientSettingDefault(defaultField: unknown): unknown {
+    return typeof defaultField === "function" ? defaultField() : defaultField;
+}
+
+/** When font is below default, raw linear ratio shrinks sheet windows too aggressively; exponent in (0,1) eases that. */
+const SHEET_WINDOW_FONT_SHRINK_EXPONENT = 0.58;
+
+/**
+ * Map linear font/baseline ratio to sheet dimension scale. Ratios ≥ 1 stay linear (matches large-font feel);
+ * ratios below 1 are curved so windows do not shrink as fast as the font setting.
+ */
+function sheetWindowScaleFromLinearFontRatio(linear: number): number {
+    const clamped = Math.clamp(linear, 0.5, 3);
+    const eased = clamped < 1 ? clamped ** SHEET_WINDOW_FONT_SHRINK_EXPONENT : clamped;
+    return Math.clamp(eased, 0.5, 3);
+}
+
+/**
+ * Ratio of the client's current interface font size to the core setting default (1 at defaults).
+ * Prefers `core.uiConfig.fontScale` when that setting's schema includes it; otherwise `core.fontSize`.
+ */
+function getClientInterfaceDimensionScale(): number {
+    if (!game?.settings) return 1;
+    const registrations = game.settings.settings;
+
+    const uiRegistration = registrations.get("core.uiConfig");
+    const baselineUi = uiRegistration
+        ? (resolveClientSettingDefault(uiRegistration.default) as { fontScale?: number } | null)
+        : null;
+    const uiDefinesFontScale =
+        !!baselineUi &&
+        typeof baselineUi === "object" &&
+        "fontScale" in baselineUi &&
+        typeof baselineUi.fontScale === "number";
+
+    if (uiRegistration && uiDefinesFontScale) {
+        const uiConfig = game.settings.get("core", "uiConfig") as { fontScale?: number } | null | undefined;
+        const baselineScale = baselineUi.fontScale!;
+        const currentScale = typeof uiConfig?.fontScale === "number" ? uiConfig.fontScale : baselineScale;
+        if (baselineScale > 0) {
+            return sheetWindowScaleFromLinearFontRatio(currentScale / baselineScale);
+        }
+    }
+
+    const fontSizeRegistration = registrations.get("core.fontSize");
+    if (fontSizeRegistration) {
+        const current = game.settings.get("core", "fontSize");
+        const baseline = resolveClientSettingDefault(fontSizeRegistration.default);
+        if (typeof current === "number" && typeof baseline === "number" && baseline > 0) {
+            return sheetWindowScaleFromLinearFontRatio(current / baseline);
+        }
+    }
+
+    return 1;
+}
+
+/** Scale pixel dimensions for actor sheets so layout tracks the user's Foundry font size. */
+function scaleDimensionsToClientFont(width: number, height: number): { width: number; height: number } {
+    const scale = getClientInterfaceDimensionScale();
+    return { width: Math.round(width * scale), height: Math.round(height * scale) };
+}
+
 function createSheetOptions(
     options: Record<string, string | { label: string }>,
     selections: SheetSelections = [],
@@ -379,6 +441,7 @@ export {
     getItemFromDragEvent,
     isControlDown,
     maintainFocusInRender,
+    scaleDimensionsToClientFont,
     sendItemToChat,
 };
 export type { AdjustedValue, BasePhysicalItemViewData, NPCAttackTraitOrTag, SheetOption, SheetOptions, TagifyEntry };


### PR DESCRIPTION
This is an experiment to improve user experience for people with non-default font size selected. Personally, I use font 7 (5 is the default), so each time I have to open any character or monster sheet, it's content doesn't fit into the screen and I have to re-adjust it.
Suggestions/thoughts/comments are very welcome!

Here's an example of changes in action:
<img width="1339" height="720" alt="Foundry_Virtual_Tabletop_JjylKBCCYE-ezgif com-optimize" src="https://github.com/user-attachments/assets/1a9a5ef3-4efa-483a-804c-3441f4aea769" />
