### PR TITLE
add sniper weapon crit specialization damage automatically

### DIFF
--- a/src/module/rules/rule-element/crit-spec.ts
+++ b/src/module/rules/rule-element/crit-spec.ts
@@ -175,6 +175,7 @@ class CritSpecRuleElement extends RuleElement<CritSpecRuleSchema> {
                 return [dice, bonus ?? []].flat();
             }
             case "pick":
+            case "sniper":
                 return weapon.baseDamage.die
                     ? [
                           new Modifier({


### PR DESCRIPTION
Fixes #22038.

The hint that made this change easy to figure out was the fact that the "pick" crit spec type has the same behaviour.

https://github.com/user-attachments/assets/740161ec-4785-4d2a-bcaf-c4d5929896ee

