### PR TITLE
Refresh token bars on Temp HP updates.

### DIFF
--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -707,6 +707,11 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
         const updates = Array.isArray(update) ? update : [update];
         this.simulateUpdate(updates[0]);
 
+        // Core's bar refresh only diffs {value, max}, so a temp-HP-only change won't trigger a redraw on its own.
+        if (this.scene.isView && updates.some((u) => u && fu.hasProperty(u, "system.attributes.hp.temp"))) {
+            this.object?.renderFlags.set({ refreshBars: true });
+        }
+
         // Follow up any actor (or descendant document thereof) modification with a size synchronization
         const actor = this.actor;
         if (!actor?.isOwner) return;


### PR DESCRIPTION
Closes #22239 

Before v14, Foundry redrew a token's bars on any actor update. v14 diffs `{value, max}` before and after the update and only redraws when one of those changed.