### PR TITLE
Display Heritages in the Features Tab

### DIFF
--- a/src/module/actor/character/feats/collection.ts
+++ b/src/module/actor/character/feats/collection.ts
@@ -247,6 +247,9 @@ class CharacterFeats<TActor extends CharacterPF2e> extends Collection<string, Fe
                 if (granter?.isOfType("feat") && granter.grants.includes(feat) && isNested) {
                     continue;
                 }
+                if (granter?.isOfType("heritage") && isNested) {
+                    continue;
+                }
             }
 
             // Find the group then assign the feat

--- a/src/module/actor/character/feats/collection.ts
+++ b/src/module/actor/character/feats/collection.ts
@@ -1,9 +1,9 @@
 import type { CharacterPF2e } from "@actor";
-import type { FeatPF2e, ItemPF2e } from "@item";
+import type { FeatPF2e, HeritagePF2e, ItemPF2e } from "@item";
 import { sluggify } from "@util";
 import * as R from "remeda";
 import { FeatGroup } from "./group.ts";
-import { FeatGroupData, FeatSlotData } from "./types.ts";
+import type { FeatGroupData, FeatSlot, FeatSlotData } from "./types.ts";
 
 class CharacterFeats<TActor extends CharacterPF2e> extends Collection<string, FeatGroup<TActor>> {
     /** Feats belonging no actual group ("bonus feats" in rules text) */
@@ -262,6 +262,58 @@ class CharacterFeats<TActor extends CharacterPF2e> extends Collection<string, Fe
         for (const group of this) {
             group.postProcess();
         }
+
+        this.#prependHeritageToAncestryFeatures();
+    }
+
+    #nestedGrantSlotsFromItemGrants(granter: ItemPF2e<TActor>): FeatSlot<FeatPF2e<TActor>>[] {
+        const rawGrants = granter.flags[SYSTEM_ID]?.itemGrants ?? {};
+        const grantsById = R.mapKeys(rawGrants, (_, g) => g.id) as Record<string, { nested?: boolean }>;
+
+        const grantFeats: FeatPF2e<TActor>[] = granter.isOfType("feat")
+            ? granter.grants.filter(
+                  (g): g is FeatPF2e<TActor> => g.isOfType("feat") && grantsById[g.id]?.nested !== false,
+              )
+            : Object.values(rawGrants)
+                  .filter((g) => R.isPlainObject(g) && (g.nested ?? null) !== false && typeof g.id === "string")
+                  .map((g) => this.actor.items.get(g.id))
+                  .filter((i): i is FeatPF2e<TActor> => !!i && i.isOfType("feat"));
+
+        return grantFeats.map(
+            (grant): FeatSlot<FeatPF2e<TActor>> => ({
+                id: grant.id,
+                label: null,
+                level: null,
+                feat: grant,
+                children: this.#nestedGrantSlotsFromItemGrants(grant),
+            }),
+        );
+    }
+
+    #prependHeritageToAncestryFeatures(): void {
+        const group = this.get("ancestryfeature");
+        if (!group) return;
+
+        const isGrantedByFeat = (heritage: HeritagePF2e<TActor>): boolean =>
+            heritage.grantedBy?.isOfType("feat") ?? false;
+
+        const primary = this.actor.heritage;
+        const others = this.actor.itemTypes.heritage
+            .filter((h) => !primary || h.id !== primary.id)
+            .filter((h) => !isGrantedByFeat(h))
+            .sort((a, b) => a.sort - b.sort);
+
+        const heritageSlots = [primary, ...others].filter(R.isTruthy).map((heritage) => {
+            const slot: FeatSlot<HeritagePF2e<TActor>> = {
+                id: heritage.id,
+                label: null,
+                level: null,
+                feat: heritage,
+                children: this.#nestedGrantSlotsFromItemGrants(heritage),
+            };
+            return slot as FeatGroup<TActor>["feats"][number];
+        });
+        group.feats.unshift(...heritageSlots);
     }
 }
 

--- a/src/module/actor/character/feats/group.ts
+++ b/src/module/actor/character/feats/group.ts
@@ -121,21 +121,36 @@ class FeatGroup<TActor extends ActorPF2e = ActorPF2e, TItem extends FeatLike = F
         return true;
     }
 
-    #getChildSlots(feat: Maybe<ItemPF2e>): FeatSlot<FeatPF2e<ActorPF2e> | HeritagePF2e<ActorPF2e>>[] {
-        if (!feat?.isOfType("feat")) return [];
-        const grantsById = R.mapKeys(feat.flags[SYSTEM_ID].itemGrants, (_, g) => g.id);
+    #getChildSlots(granter: Maybe<ItemPF2e>): FeatSlot<FeatPF2e<TActor> | HeritagePF2e<TActor>>[] {
+        if (!granter) return [];
+        const rawGrants = granter.flags[SYSTEM_ID]?.itemGrants ?? {};
+        const grantsById = R.mapKeys(rawGrants, (_, g) => g.id) as Record<string, { nested?: boolean }>;
 
-        return feat.grants
-            .filter((g) => grantsById[g.id]?.nested !== false)
-            .map((grant): FeatSlot<FeatPF2e<ActorPF2e> | HeritagePF2e<ActorPF2e>> => {
-                return {
-                    id: grant.id,
-                    label: null,
-                    level: grant.system.level?.taken ?? null,
-                    feat: grant,
-                    children: this.#getChildSlots(grant),
-                };
-            });
+        const grants: (FeatPF2e<TActor> | HeritagePF2e<TActor>)[] = [];
+        const grantIds = granter.isOfType("feat")
+            ? granter.grants.map((g) => g.id)
+            : granter.isOfType("heritage")
+              ? Object.values(rawGrants)
+                    .filter(
+                        (g) => R.isPlainObject(g) && (g.nested ?? null) !== false && typeof g.id === "string",
+                    )
+                    .map((g) => g.id)
+              : [];
+
+        for (const grantId of grantIds) {
+            if (grantsById[grantId]?.nested === false) continue;
+            const item = this.actor.items.get(grantId);
+            if (item?.isOfType("feat")) grants.push(item);
+            else if (item?.isOfType("heritage")) grants.push(item);
+        }
+
+        return grants.map((grant): FeatSlot<FeatPF2e<TActor> | HeritagePF2e<TActor>> => ({
+            id: grant.id,
+            label: null,
+            level: grant.isOfType("feat") ? (grant.system.level?.taken ?? null) : null,
+            feat: grant,
+            children: this.#getChildSlots(grant),
+        }));
     }
 
     /** Returns true if this feat is a valid type for the group */

--- a/src/module/actor/character/feats/group.ts
+++ b/src/module/actor/character/feats/group.ts
@@ -131,9 +131,7 @@ class FeatGroup<TActor extends ActorPF2e = ActorPF2e, TItem extends FeatLike = F
             ? granter.grants.map((g) => g.id)
             : granter.isOfType("heritage")
               ? Object.values(rawGrants)
-                    .filter(
-                        (g) => R.isPlainObject(g) && (g.nested ?? null) !== false && typeof g.id === "string",
-                    )
+                    .filter((g) => R.isPlainObject(g) && (g.nested ?? null) !== false && typeof g.id === "string")
                     .map((g) => g.id)
               : [];
 
@@ -144,13 +142,15 @@ class FeatGroup<TActor extends ActorPF2e = ActorPF2e, TItem extends FeatLike = F
             else if (item?.isOfType("heritage")) grants.push(item);
         }
 
-        return grants.map((grant): FeatSlot<FeatPF2e<TActor> | HeritagePF2e<TActor>> => ({
-            id: grant.id,
-            label: null,
-            level: grant.isOfType("feat") ? (grant.system.level?.taken ?? null) : null,
-            feat: grant,
-            children: this.#getChildSlots(grant),
-        }));
+        return grants.map(
+            (grant): FeatSlot<FeatPF2e<TActor> | HeritagePF2e<TActor>> => ({
+                id: grant.id,
+                label: null,
+                level: grant.isOfType("feat") ? (grant.system.level?.taken ?? null) : null,
+                feat: grant,
+                children: this.#getChildSlots(grant),
+            }),
+        );
     }
 
     /** Returns true if this feat is a valid type for the group */

--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -71,7 +71,7 @@ import {
 } from "./data.ts";
 import type { CharacterPF2e } from "./document.ts";
 import { ElementalBlast, ElementalBlastConfig } from "./elemental-blast.ts";
-import type { FeatBrowserFilterProps, FeatGroup, FeatSlot } from "./feats/index.ts";
+import type { FeatBrowserFilterProps, FeatGroup } from "./feats/index.ts";
 import { getItemProficiencyRank } from "./helpers.ts";
 import { PCSheetTabManager } from "./tab-manager.ts";
 import { CHARACTER_SHEET_TABS } from "./values.ts";
@@ -84,28 +84,6 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
 
     /** Non-persisted tweaks to formula data */
     #formulaQuantities: Record<string, number> = {};
-
-    /** Nested feat rows for sheet UI from `flags.pf2e.itemGrants` (same rules as `FeatGroup.#getChildSlots`). */
-    #getNestedSlots(granter: ItemPF2e): FeatSlot<FeatPF2e<TActor>>[] {
-        const itemGrants = (granter.flags?.[SYSTEM_ID]?.itemGrants ?? {}) as Record<
-            string,
-            { id?: string; nested?: boolean }
-        >;
-
-        return Object.values(itemGrants)
-            .filter((g) => (g?.nested ?? null) !== false)
-            .map((g) => (typeof g?.id === "string" && g.id.length > 0 ? (this.actor.items.get(g.id) ?? null) : null))
-            .filter((i): i is FeatPF2e<TActor> => !!i && i.isOfType("feat"))
-            .map(
-                (grant): FeatSlot<FeatPF2e<TActor>> => ({
-                    id: grant.id,
-                    label: null,
-                    level: null,
-                    feat: grant,
-                    children: this.#getNestedSlots(grant),
-                }),
-            );
-    }
 
     static override get defaultOptions(): ActorSheetOptions {
         const options = super.defaultOptions;
@@ -311,23 +289,7 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
         sheetData.hasStamina = game.pf2e.settings.variants.stamina;
         sheetData.actions = this.#prepareAbilities();
 
-        const featGroups: FeatGroup[] = [...actor.feats, actor.feats.bonus];
-        const ancestryFeatures = featGroups.find((g) => g.id === "ancestryfeature");
-        // Add the heritage to the ancestry features if it is not already present
-        if (actor.heritage && ancestryFeatures) {
-            const alreadyPresent = ancestryFeatures.feats.some((f) => f.feat?.id === actor.heritage?.id);
-            if (!alreadyPresent) {
-                const heritageRow: FeatSlot<HeritagePF2e<TActor>> = {
-                    id: "heritage",
-                    label: null,
-                    level: null,
-                    feat: actor.heritage,
-                    children: this.#getNestedSlots(actor.heritage),
-                };
-                ancestryFeatures.feats.unshift(heritageRow as FeatGroup<TActor>["feats"][number]);
-            }
-        }
-        sheetData.feats = featGroups;
+        sheetData.feats = [...actor.feats, actor.feats.bonus];
 
         sheetData.crafting = await this.#prepareCrafting();
 

--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -317,13 +317,14 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
         if (actor.heritage && ancestryFeatures) {
             const alreadyPresent = ancestryFeatures.feats.some((f) => f.feat?.id === actor.heritage?.id);
             if (!alreadyPresent) {
-                ancestryFeatures.feats.unshift({
+                const heritageRow: FeatSlot<HeritagePF2e<TActor>> = {
                     id: "heritage",
                     label: null,
                     level: null,
                     feat: actor.heritage,
                     children: this.#getNestedSlots(actor.heritage),
-                } as never);
+                };
+                ancestryFeatures.feats.unshift(heritageRow as FeatGroup<TActor>["feats"][number]);
             }
         }
         sheetData.feats = featGroups;

--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -71,7 +71,7 @@ import {
 } from "./data.ts";
 import type { CharacterPF2e } from "./document.ts";
 import { ElementalBlast, ElementalBlastConfig } from "./elemental-blast.ts";
-import type { FeatBrowserFilterProps, FeatGroup } from "./feats/index.ts";
+import type { FeatBrowserFilterProps, FeatGroup, FeatSlot } from "./feats/index.ts";
 import { getItemProficiencyRank } from "./helpers.ts";
 import { PCSheetTabManager } from "./tab-manager.ts";
 import { CHARACTER_SHEET_TABS } from "./values.ts";
@@ -84,6 +84,28 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
 
     /** Non-persisted tweaks to formula data */
     #formulaQuantities: Record<string, number> = {};
+
+    /** Nested feat rows for sheet UI from `flags.pf2e.itemGrants` (same rules as `FeatGroup.#getChildSlots`). */
+    #getNestedSlots(granter: ItemPF2e): FeatSlot<FeatPF2e<TActor>>[] {
+        const itemGrants = (granter.flags?.[SYSTEM_ID]?.itemGrants ?? {}) as Record<
+            string,
+            { id?: string; nested?: boolean }
+        >;
+
+        return Object.values(itemGrants)
+            .filter((g) => (g?.nested ?? null) !== false)
+            .map((g) => (typeof g?.id === "string" && g.id.length > 0 ? (this.actor.items.get(g.id) ?? null) : null))
+            .filter((i): i is FeatPF2e<TActor> => !!i && i.isOfType("feat"))
+            .map(
+                (grant): FeatSlot<FeatPF2e<TActor>> => ({
+                    id: grant.id,
+                    label: null,
+                    level: null,
+                    feat: grant,
+                    children: this.#getNestedSlots(grant),
+                }),
+            );
+    }
 
     static override get defaultOptions(): ActorSheetOptions {
         const options = super.defaultOptions;
@@ -288,7 +310,23 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
         // Is the stamina variant rule enabled?
         sheetData.hasStamina = game.pf2e.settings.variants.stamina;
         sheetData.actions = this.#prepareAbilities();
-        sheetData.feats = [...actor.feats, actor.feats.bonus];
+
+        const featGroups: FeatGroup[] = [...actor.feats, actor.feats.bonus];
+        const ancestryFeatures = featGroups.find((g) => g.id === "ancestryfeature");
+        // Add the heritage to the ancestry features if it is not already present
+        if (actor.heritage && ancestryFeatures) {
+            const alreadyPresent = ancestryFeatures.feats.some((f) => f.feat?.id === actor.heritage?.id);
+            if (!alreadyPresent) {
+                ancestryFeatures.feats.unshift({
+                    id: "heritage",
+                    label: null,
+                    level: null,
+                    feat: actor.heritage,
+                    children: this.#getNestedSlots(actor.heritage),
+                } as never);
+            }
+        }
+        sheetData.feats = featGroups;
 
         sheetData.crafting = await this.#prepareCrafting();
 

--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -288,7 +288,6 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
         // Is the stamina variant rule enabled?
         sheetData.hasStamina = game.pf2e.settings.variants.stamina;
         sheetData.actions = this.#prepareAbilities();
-
         sheetData.feats = [...actor.feats, actor.feats.bonus];
 
         sheetData.crafting = await this.#prepareCrafting();


### PR DESCRIPTION
- Closes #22235
Supersedes https://github.com/foundryvtt/pf2e/pull/22233

Inserts the heritage in Ancestry Features list and renders it's nested feats, if any.
Some examples:
<img width="581" height="667" alt="image" src="https://github.com/user-attachments/assets/da7a0ca2-18b8-40fd-96fd-1607d6df0ca6" />
