### PR TITLE
Revert "Register Compendium for Hell's Destiny"

### DIFF
--- a/system.pf2e.json
+++ b/system.pf2e.json
@@ -333,19 +333,6 @@
             "flags": {}
         },
         {
-            "name": "hells-destiny-bestiary",
-            "label": "Hell's Destiny",
-            "path": "packs/hells-destiny-bestiary",
-            "type": "Actor",
-            "banner": "systems/pf2e/assets/compendium-banner/red.webp",
-            "system": "pf2e",
-            "ownership": {
-                "PLAYER": "LIMITED",
-                "ASSISTANT": "OWNER"
-            },
-            "flags": {}
-        },
-        {
             "name": "lost-omens-bestiary",
             "label": "Lost Omens Bestiary",
             "path": "packs/lost-omens-bestiary",
@@ -1380,7 +1367,6 @@
                         "fists-of-the-ruby-phoenix-bestiary",
                         "gatewalkers-bestiary",
                         "hellbreakers-bestiary",
-                        "hells-destiny-bestiary",
                         "outlaws-of-alkenstar-bestiary",
                         "kingmaker-bestiary",
                         "myth-speaker-bestiary",


### PR DESCRIPTION
Reverts foundryvtt/pf2e#22179

The compendium is empty and was apparently merged too early.