### PR TITLE
Revert updates to anachronism versions

### DIFF
--- a/module.pf2e-anachronism.json
+++ b/module.pf2e-anachronism.json
@@ -2,16 +2,16 @@
     "id": "pf2e-anachronism",
     "title": "Pathfinder Anachronism: Official Pathfinder Content Pack for Starfinder Second Edition",
     "description": "<p>Official Pathfinder 2e content pack for Starfinder 2e! Add PF2e character options, creatures, and items into your SF2e game!</p>",
-    "version": "2.1.0",
+    "version": "2.0.2",
     "license": "./LICENSE",
     "manifest": "https://raw.githubusercontent.com/foundryvtt/pf2e/v14-dev/module.pf2e-anachronism.json",
-    "download": "https://github.com/foundryvtt/pf2e/releases/download/pf2e-anachronism-2.1.0/module.zip",
+    "download": "https://github.com/foundryvtt/pf2e/releases/download/pf2e-anachronism-2.0.2/module.zip",
     "url": "https://github.com/foundryvtt/pf2e",
     "bugs": "https://github.com/foundryvtt/pf2e/issues",
     "socket": true,
     "compatibility": {
-        "minimum": "14.360",
-        "verified": "14.361",
+        "minimum": "13.348",
+        "verified": "14.360",
         "maximum": "14"
     },
     "relationships": {
@@ -21,7 +21,7 @@
                 "type": "system",
                 "manifest": "https://raw.githubusercontent.com/foundryvtt/pf2e/v14-dev/system.sf2e.json",
                 "compatibility": {
-                    "minimum": "1.1.1"
+                    "minimum": "0.0.11"
                 }
             }
         ]

--- a/module.sf2e-anachronism.json
+++ b/module.sf2e-anachronism.json
@@ -2,16 +2,16 @@
     "id": "sf2e-anachronism",
     "title": "Starfinder Anachronism: Official Starfinder Content Pack for Pathfinder Second Edition",
     "description": "<p>Official Starfinder 2e content pack for Pathfinder 2e! Add SF2e character options, creatures, and items into your PF2e game!</p>",
-    "version": "2.1.0",
+    "version": "2.0.0",
     "license": "./LICENSE",
     "manifest": "https://raw.githubusercontent.com/foundryvtt/pf2e/v14-dev/module.sf2e-anachronism.json",
-    "download": "https://github.com/foundryvtt/pf2e/releases/download/sf2e-anachronism-2.1.0/module.zip",
+    "download": "https://github.com/foundryvtt/pf2e/releases/download/sf2e-anachronism-2.0.0/module.zip",
     "url": "https://github.com/foundryvtt/pf2e",
     "bugs": "https://github.com/foundryvtt/pf2e/issues",
     "socket": true,
     "compatibility": {
-        "minimum": "14.360",
-        "verified": "14.361",
+        "minimum": "13.348",
+        "verified": "14.360",
         "maximum": "14"
     },
     "relationships": {
@@ -21,7 +21,7 @@
                 "type": "system",
                 "manifest": "https://raw.githubusercontent.com/foundryvtt/pf2e/v14-dev/system.pf2e.json",
                 "compatibility": {
-                    "minimum": "8.1.1"
+                    "minimum": "7.12.2"
                 }
             }
         ]


### PR DESCRIPTION
Closes https://github.com/foundryvtt/pf2e/issues/22262

This occured because I was originally gonna do an anachronism update and then I realized that the dragon migration blocks us from doing so until the next system release. But I forgot that updates point to the repo files.