### PR TITLE
Correct Essence Overflow's damage formula to use `@actor.level`

### DIFF
--- a/packs/pf2e/feats/archetype/draconic-acolyte/essence-overflow.json
+++ b/packs/pf2e/feats/archetype/draconic-acolyte/essence-overflow.json
@@ -12,7 +12,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p><strong>Requirements</strong> You are Channeling Draconic Essence.</p><hr /><p>Uncontainable power explodes from your spectral dragon. Your Channel Draconic Essence ends, and all creatures (except you) in a @Template[type:emanation|distance:10] from your spectral dragon take @Damage[(5+floor((@actor.level - 4)/2))d6|options:area-damage] damage with a @Check[reflex|against:class-spell|basic|options:area-effect] save against the higher of your class DC or spell DC. The damage's type matches the breath of your draconic benefactor. You then can't use Essence Overflow again for [[/gmr 1d4 #Recharge Essence Overflow]]{1d4 rounds}.</p>\n<p>At 8th level and every 2 levels thereafter, the damage increases by 1d6.</p>"
+            "value": "<p><strong>Requirements</strong> You are Channeling Draconic Essence.</p><hr /><p>Uncontainable power explodes from your spectral dragon. Your Channel Draconic Essence ends, and all creatures (except you) in a @Template[type:emanation|distance:10] from your spectral dragon take @Damage[(5+floor((@actor.level - 4)/2))d6|options:area-damage] damage with a @Check[reflex|against:class-spell|basic|options:area-effect] save against the higher of your class DC or spell DC. The damage's type matches the breath of your draconic benefactor. You then can't use Essence Overflow again for [[/r 1d4 #Recharge Essence Overflow]]{1d4 rounds}.</p>\n<p>At 8th level and every 2 levels thereafter, the damage increases by 1d6.</p>"
         },
         "level": {
             "value": 6

--- a/packs/pf2e/feats/archetype/draconic-acolyte/essence-overflow.json
+++ b/packs/pf2e/feats/archetype/draconic-acolyte/essence-overflow.json
@@ -12,7 +12,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p><strong>Requirements</strong> You are Channeling Draconic Essence.</p><hr /><p>Uncontainable power explodes from your spectral dragon. Your Channel Draconic Essence ends, and all creatures (except you) in a @Template[type:emanation|distance:10] from your spectral dragon take @Damage[(5+floor((@item.level - 4)/2))d6|options:area-damage] damage with a @Check[reflex|against:class-spell|basic|options:area-effect] save against the higher of your class DC or spell DC. The damage's type matches the breath of your draconic benefactor. You then can't use Essence Overflow again for [[/gmr 1d4 #Recharge Essence Overflow]]{1d4 rounds}.</p>\n<p>At 8th level and every 2 levels thereafter, the damage increases by 1d6.</p>"
+            "value": "<p><strong>Requirements</strong> You are Channeling Draconic Essence.</p><hr /><p>Uncontainable power explodes from your spectral dragon. Your Channel Draconic Essence ends, and all creatures (except you) in a @Template[type:emanation|distance:10] from your spectral dragon take @Damage[(5+floor((@actor.level - 4)/2))d6|options:area-damage] damage with a @Check[reflex|against:class-spell|basic|options:area-effect] save against the higher of your class DC or spell DC. The damage's type matches the breath of your draconic benefactor. You then can't use Essence Overflow again for [[/gmr 1d4 #Recharge Essence Overflow]]{1d4 rounds}.</p>\n<p>At 8th level and every 2 levels thereafter, the damage increases by 1d6.</p>"
         },
         "level": {
             "value": 6


### PR DESCRIPTION
- Closes #22269