### PR TITLE
Add expend tag to weapon description and strikes

### DIFF
--- a/src/module/item/weapon/document.ts
+++ b/src/module/item/weapon/document.ts
@@ -559,15 +559,19 @@ class WeaponPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
     ): Promise<RawItemChatData> {
         const traits = this.traitChatData(CONFIG.PF2E.weaponTraits);
         const chatData = await super.getChatData();
-        const rangeLabel = createActionRangeLabel(this.range);
-        const properties = [CONFIG.PF2E.weaponCategories[this.category], this.system.reload.label, rangeLabel].filter(
-            R.isTruthy,
-        );
-
+        const expendLabel =
+            typeof this.system.expend === "number" && (this.system.expend !== 1 || SYSTEM_ID === "sf2e")
+                ? _loc("PF2E.Item.Weapon.ExpendN", { n: this.system.expend })
+                : null;
         return this.processChatData(htmlOptions, {
             ...chatData,
             traits,
-            properties,
+            properties: [
+                CONFIG.PF2E.weaponCategories[this.category],
+                this.system.reload.label,
+                createActionRangeLabel(this.range),
+                expendLabel,
+            ].filter(R.isTruthy),
         });
     }
 

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3067,6 +3067,7 @@
                 "Damage": {
                     "DiceNumber": "Dice Number"
                 },
+                "ExpendN": "Expend {n}",
                 "Forceful": {
                     "Second": "Forceful 2nd Attack",
                     "Third": "Forceful 3rd+ Attack"

--- a/static/templates/actors/character/partials/strike.hbs
+++ b/static/templates/actors/character/partials/strike.hbs
@@ -143,6 +143,11 @@
             {{else if action.item.system.range}}
                 <span class="tag tag_secondary">{{localize "PF2E.Action.Range.IncrementN" n=action.item.system.range}}</span>
             {{/if}}
+            {{#if action.item.system.expend includeZero=true}}
+                {{#if (or (eq systemId "sf2e") (ne action.item.system.expend 1))}}
+                    <span class="tag tag_secondary">{{localize "PF2E.Item.Weapon.ExpendN" n=action.item.system.expend}}</span>
+                {{/if}}
+            {{/if}}
         </div>
     </div>
 </li>


### PR DESCRIPTION
No open issue but a feature gap I ran into. Shows on any value in SF2e, shows on non-one values in PF2e.

This does cause the double barrelled musket to declare expend 2 if the toggle is on.