### PR TITLE
Remove erroneous buttons from flexible spellcasting

### DIFF
--- a/static/templates/actors/partials/spell-collection.hbs
+++ b/static/templates/actors/partials/spell-collection.hbs
@@ -182,29 +182,30 @@
 
                             <div class="item-controls">
                                 {{#if @root.editable}}
-                                    {{#if entry.isPrepared}}
-                                        {{#unless (eq group.id "cantrips")}}
-                                            <a
-                                                data-action="toggle-slot-expended"
-                                                data-tooltip="{{#if slot.expended}}PF2E.RestoreSpellTitle{{else}}PF2E.ExpendSpellTitle{{/if}}"
-                                            ><i class="fa-solid fa-fw fa-{{#if slot.expended}}plus{{else}}minus{{/if}}-square"></i></a>
-                                        {{/unless}}
+                                    {{#if (and entry.isSpontaneous (ne group.id "cantrips"))}}
                                         <a
-                                            data-action="unprepare-spell"
-                                            data-tooltip="PF2E.UnprepareItemTitle"
-                                        ><i class="fa-solid fa-fw fa-trash"></i></a>
-                                    {{else if (ne entry.category "items")}}
-                                        {{#if (and entry.isSpontaneous (ne group.id "cantrips"))}}
-                                            <a
-                                                data-action="toggle-signature-spell"
-                                                data-tooltip="PF2E.ToggleSignatureSpellTitle"
-                                            ><i class="fa-{{#if slot.signature}}solid{{else}}regular{{/if}} fa-fw fa-star"></i></a>
-                                        {{/if}}
-                                        {{#unless slot.virtual}}
-                                            <a data-action="edit-item" data-tooltip="PF2E.EditItemTitle"><i class="fa-solid fa-fw fa-edit"></i></a>
-                                            <a data-action="delete-item" data-tooltip="PF2E.DeleteItemTitle"><i class="fa-solid fa-fw fa-trash"></i></a>
-                                        {{/unless}}
+                                            data-action="toggle-signature-spell"
+                                            data-tooltip="PF2E.ToggleSignatureSpellTitle"
+                                        ><i class="fa-{{#if slot.signature}}solid{{else}}regular{{/if}} fa-fw fa-star" inert></i></a>
                                     {{/if}}
+
+                                    {{#unless slot.virtual}}
+                                        {{#if entry.isPrepared}}
+                                            {{#unless (eq group.id "cantrips")}}
+                                                <a
+                                                    data-action="toggle-slot-expended"
+                                                    data-tooltip="{{#if slot.expended}}PF2E.RestoreSpellTitle{{else}}PF2E.ExpendSpellTitle{{/if}}"
+                                                ><i class="fa-solid fa-fw fa-{{#if slot.expended}}plus{{else}}minus{{/if}}-square" inert></i></a>
+                                            {{/unless}}
+                                            <a
+                                                data-action="unprepare-spell"
+                                                data-tooltip="PF2E.UnprepareItemTitle"
+                                            ><i class="fa-solid fa-fw fa-trash"></i></a>
+                                        {{else if (ne entry.category "items")}}
+                                            <a data-action="edit-item" data-tooltip="PF2E.EditItemTitle"><i class="fa-solid fa-fw fa-edit" inert></i></a>
+                                            <a data-action="delete-item" data-tooltip="PF2E.DeleteItemTitle"><i class="fa-solid fa-fw fa-trash" inert></i></a>
+                                        {{/if}}
+                                    {{/unless}}
                                 {{/if}}
                             </div>
                             <div class="item-summary" hidden></div>


### PR DESCRIPTION
- Closes https://github.com/foundryvtt/pf2e/issues/21762. Disable whitespace while reviewing.

This hides these buttons to the right of cast that were showing for flexible spellcasters. 
<img width="109" height="80" alt="image" src="https://github.com/user-attachments/assets/4597c18a-3560-4686-b707-f31970273f11" />

"virtual" slots are basically fake spell rows and come into play for signature spells and prepared flexible spells. The virtual check was on for spontaneous, but for prepared.

I don't want to conver the anchor tags to buttons until appv2, but I added inert in the meantime.
