### PR TITLE
Restore missing radio buttons in shield block dialog

### DIFF
--- a/src/styles/ui/_hover.scss
+++ b/src/styles/ui/_hover.scss
@@ -88,6 +88,7 @@
                                 justify-self: center;
                                 position: relative;
                                 top: calc(-1 * var(--space-1));
+                                appearance: auto;
                             }
                         }
                     }


### PR DESCRIPTION
Before:
<img width="442" height="303" alt="before" src="https://github.com/user-attachments/assets/e0929f24-8710-4746-9a74-0f6aab54142a" />
After:
<img width="440" height="296" alt="after" src="https://github.com/user-attachments/assets/cc426688-1a57-47ab-88cf-9195fc55ca6b" />


- Closes #22257 