### PR TITLE
Enable "otherTags" for equipment items and add a "Rune" tag

### DIFF
--- a/src/module/item/equipment/sheet.ts
+++ b/src/module/item/equipment/sheet.ts
@@ -8,11 +8,11 @@ export class EquipmentSheetPF2e extends PhysicalItemSheetPF2e<EquipmentPF2e> {
         const item = this.item;
         const sheetData = await super.getData(options);
         const category = item.system.usage.type === "installed" ? "upgrade" : null;
-
+        const otherTags = { ...CONFIG.PF2E.otherArmorTags, ...CONFIG.PF2E.otherEquipmentTags };
         return {
             ...sheetData,
             itemType: category ? _loc(`PF2E.Item.Equipment.Category.${category}`) : sheetData.itemType,
-            otherTags: createSheetTags(CONFIG.PF2E.otherArmorTags, item.system.traits.otherTags),
+            otherTags: createSheetTags(otherTags, item.system.traits.otherTags),
         };
     }
 }

--- a/src/module/item/equipment/types.ts
+++ b/src/module/item/equipment/types.ts
@@ -1,3 +1,4 @@
 type EquipmentTrait = keyof typeof CONFIG.PF2E.equipmentTraits;
+type OtherEquipmentTag = "rune";
 
-export type { EquipmentTrait };
+export type { EquipmentTrait, OtherEquipmentTag };

--- a/src/module/system/tag-selector/index.ts
+++ b/src/module/system/tag-selector/index.ts
@@ -12,6 +12,7 @@ const SELECTABLE_TAG_FIELDS = [
     "materialDamageEffects",
     "otherArmorTags",
     "otherConsumableTags",
+    "otherEquipmentTags",
     "otherWeaponTags",
     "senses",
     "skills",

--- a/src/scripts/config/index.ts
+++ b/src/scripts/config/index.ts
@@ -67,6 +67,7 @@ import {
     npcAttackTraits,
     otherArmorTags,
     otherConsumableTags,
+    otherEquipmentTags,
     otherWeaponTags,
     preciousMaterials,
     shieldTraits,
@@ -715,6 +716,7 @@ export const PF2ECONFIG = {
 
     otherArmorTags,
     otherConsumableTags,
+    otherEquipmentTags,
     otherWeaponTags,
 
     actionTraits,

--- a/src/scripts/config/traits.ts
+++ b/src/scripts/config/traits.ts
@@ -2,6 +2,7 @@ import { OtherArmorTag } from "@item/armor/types.ts";
 import { BackgroundTrait } from "@item/background/types.ts";
 import { ClassTrait } from "@item/class/types.ts";
 import { OtherConsumableTag } from "@item/consumable/types.ts";
+import { OtherEquipmentTag } from "@item/equipment/index.ts";
 import { PreciousMaterialType } from "@item/physical/types.ts";
 import { MagicTradition } from "@item/spell/types.ts";
 import { OtherWeaponTag } from "@item/weapon/types.ts";
@@ -691,6 +692,10 @@ const otherConsumableTags: Record<OtherConsumableTag, string> = {
     "alchemical-food": "PF2E.Item.Physical.OtherTag.AlchemicalFood",
     "alchemical-tool": "PF2E.Item.Physical.OtherTag.AlchemicalTool",
     herbal: "PF2E.Item.Physical.OtherTag.Herbal",
+};
+
+const otherEquipmentTags: Record<OtherEquipmentTag, string> = {
+    rune: "PF2E.Item.Equipment.OtherTag.Rune",
 };
 
 const otherWeaponTags: Record<OtherWeaponTag, string> = {
@@ -1924,6 +1929,7 @@ export {
     npcAttackTraits,
     otherArmorTags,
     otherConsumableTags,
+    otherEquipmentTags,
     otherWeaponTags,
     preciousMaterials,
     shieldTraits,

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2600,6 +2600,9 @@
             "Equipment": {
                 "Category": {
                     "upgrade": "Upgrade"
+                },
+                "OtherTag": {
+                    "Rune": "Rune"
                 }
             },
             "FIELDS": {

--- a/static/templates/items/equipment-details.hbs
+++ b/static/templates/items/equipment-details.hbs
@@ -1,1 +1,16 @@
 {{> (resolvePath "templates/items/partials/apex.hbs")}}
+
+<div class="form-group stacked">
+    <label>
+        {{localize "PF2E.Item.Physical.OtherTags.Label"}}
+        <i class="fa-solid fa-circle-info" data-tooltip="PF2E.Item.Physical.OtherTags.Hint"></i>
+        {{#if editable}}
+            <a class="tag-selector" data-tag-selector="basic" data-config-types="otherArmorTags,otherEquipmentTags" data-title="PF2E.Item.Physical.OtherTags.Label" data-property="system.traits.otherTags"><i class="fa-solid fa-edit"></i></a>
+        {{/if}}
+    </label>
+    <ul class="traits-list tags">
+        {{#each otherTags as |tag|}}
+            <li class="tag tag_alt">{{tag.label}}</li>
+        {{/each}}
+    </ul>
+</div>


### PR DESCRIPTION
If this is accepted I have a follow-up PR to add an "Other Tags" filter to the Compendium Browser.
I don't think the `otherArmorTags` are in use for equipment but I left them in just to be safe (it's just "shoddy").

- Closes #22181 