### PR TITLE
Restore missing reroll icons in chat context menu

### DIFF
--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -189,7 +189,7 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
         const headerResource = this.actor.getResource(resources.mythicPoints.max > 0 ? "mythic-points" : "hero-points");
         sheetData.headerResource = {
             ...headerResource,
-            icon: headerResource?.slug === "mythic-points" ? "fa-circle-m" : "fa-hospital-symbol",
+            icon: headerResource?.slug === "mythic-points" ? "fa-circle-m" : "fa-circle-h",
         };
 
         // Indicate whether the PC has all attribute boosts allocated

--- a/src/module/apps/sidebar/chat-log.ts
+++ b/src/module/apps/sidebar/chat-log.ts
@@ -541,7 +541,7 @@ class ChatLogPF2e extends fa.sidebar.tabs.ChatLog {
             },
             {
                 label: "PF2E.RerollMenu.HeroPoint",
-                icon: "fa-solid hospital-symbol",
+                icon: "fa-solid fa-circle-h",
                 visible: canHeroPointReroll,
                 onClick: (_e: PointerEvent, li: HTMLElement): void => {
                     const message = game.messages.get(li.dataset.messageId, { strict: true });
@@ -577,7 +577,7 @@ class ChatLogPF2e extends fa.sidebar.tabs.ChatLog {
             },
             {
                 label: "PF2E.RerollMenu.KeepHigher",
-                icon: "fa-solid dice-six",
+                icon: "fa-solid fa-dice-six",
                 visible: canReroll,
                 onClick: (_e: PointerEvent, li: HTMLElement): void => {
                     const message = game.messages.get(li.dataset.messageId, { strict: true });

--- a/src/module/system/check/check.ts
+++ b/src/module/system/check/check.ts
@@ -560,9 +560,9 @@ class Check {
 
         const rerollIcon = fontAwesomeIcon(
             resource?.slug === "hero-points"
-                ? "hospital-symbol"
+                ? "fa-circle-h"
                 : resource?.slug === "mythic-points"
-                  ? "circle-m"
+                  ? "fa-circle-m"
                   : "dice",
         );
         rerollIcon.classList.add("reroll-indicator");


### PR DESCRIPTION
`fa-hospital-symbol` is deprecated and is identical to `fa-circle-h`.

<img width="323" height="399" alt="image" src="https://github.com/user-attachments/assets/d5314690-78e4-4de3-8670-c34611e35cca" />
  
 
- Closes #22288 