### PR TITLE
Fix 2 NPCs in Outlaws with malformed resources JSON

### DIFF
--- a/packs/pf2e/outlaws-of-alkenstar-bestiary/book-1-punks-in-a-powder-keg/dewey-daystar.json
+++ b/packs/pf2e/outlaws-of-alkenstar-bestiary/book-1-punks-in-a-powder-keg/dewey-daystar.json
@@ -1375,11 +1375,8 @@
         },
         "resources": {
             "focus": {
-                "max": {
-                    "max": 1,
-                    "value": 1
-                },
-                "value": null
+                "max": 1,
+                "value": 1
             }
         },
         "saves": {

--- a/packs/pf2e/outlaws-of-alkenstar-bestiary/book-1-punks-in-a-powder-keg/follower-of-shumfallow.json
+++ b/packs/pf2e/outlaws-of-alkenstar-bestiary/book-1-punks-in-a-powder-keg/follower-of-shumfallow.json
@@ -415,11 +415,8 @@
         },
         "resources": {
             "focus": {
-                "max": {
-                    "max": 1,
-                    "value": 1
-                },
-                "value": null
+                "max": 1,
+                "value": 1
             }
         },
         "saves": {


### PR DESCRIPTION
Existing JSON had incorrectly nested blocks.

Please note that the NPCs in question do not have Focus spells (but are casters). I was unsure how to handle this, but found multiple other examples where the resources block was constructed the same way.