### PR TITLE
Remove inversion filter from light mode status effect hud icons

### DIFF
--- a/src/styles/ui/_token-hud.scss
+++ b/src/styles/ui/_token-hud.scss
@@ -6,6 +6,7 @@
         .effect-control {
             border: 1px solid transparent;
             position: relative;
+            filter: none;
 
             &.active {
                 border-color: var(--color-warm-2);


### PR DESCRIPTION
The filter is already disabled in dark mode by core CSS.
<br><br>
<img width="378" height="422" alt="status-effects" src="https://github.com/user-attachments/assets/359fb81d-a94c-4c0a-a53c-3620103b980c" />

