### PR TITLE
Remove padding from traits and paizo-style

### DIFF
--- a/src/styles/_tags.scss
+++ b/src/styles/_tags.scss
@@ -7,8 +7,8 @@
     flex-wrap: wrap;
     gap: var(--space-2);
     list-style-type: none;
-    margin-bottom: var(--space-2);
     padding-left: 0;
+    margin-bottom: var(--space-2);
 
     .tag,
     .tag option {
@@ -104,7 +104,6 @@ tags.tagify {
 .tags.paizo-style {
     border: none;
     gap: 0;
-    padding: 0.5em 0.05em;
 
     tag,
     .tag,

--- a/src/styles/actor/character/_character.scss
+++ b/src/styles/actor/character/_character.scss
@@ -97,7 +97,6 @@
             .traits {
                 grid-column: span 2;
                 margin: calc(-1 * var(--space-4)) 0 0 calc(-1 * var(--space-2));
-                padding: 0;
             }
 
             .deity.selected {

--- a/src/styles/actor/npc/_index.scss
+++ b/src/styles/actor/npc/_index.scss
@@ -15,6 +15,7 @@
         display: flex;
         flex: 1 0 auto;
         flex-direction: column;
+        gap: var(--spacer-4);
 
         .name {
             flex-wrap: nowrap;
@@ -28,7 +29,7 @@
 
             .name-value {
                 font-variant: small-caps;
-                margin-left: 0.375rem;
+                padding-left: 0.375rem;
                 margin-right: 1.125rem;
             }
 
@@ -49,6 +50,15 @@
             display: flex;
             flex-direction: row;
             justify-content: space-between;
+        }
+
+        .tags {
+            margin: 0;
+        }
+
+        .blurb {
+            height: 1.5rem;
+            padding-left: var(--spacer-4);
         }
     }
 

--- a/src/styles/mixins/_typography.scss
+++ b/src/styles/mixins/_typography.scss
@@ -112,7 +112,6 @@
     .traits {
         display: flex;
         flex-wrap: wrap;
-        padding: 0;
 
         p,
         span {

--- a/static/templates/actors/npc/partials/header.hbs
+++ b/static/templates/actors/npc/partials/header.hbs
@@ -49,6 +49,6 @@
             {{#if (eq data.traits.value.length 0)}}placeholder="{{localize "PF2E.Traits"}}"{{/if}} />
     </div>
     <div class="flexrow">
-        <input name="system.details.blurb" type="text" value="{{data.details.blurb}}" />
+        <input class="blurb" name="system.details.blurb" type="text" value="{{data.details.blurb}}" />
     </div>
 </header>


### PR DESCRIPTION
Also updates the npc sheet header.

the one in typography.scss doesn't seem to actually override anything, and its used for a very specific prosemirror element. However the one for .tags.paizo-style is causing style rot in a few places, with multiple places actually overriding it to remove padding. I could remove those overrides as well if you would like. 

Everywhere else I tested for paizo tags (character sheet first tab, item sheet, chat messages, item summaries, formula picker, compendium browser, army tags) seems to have no difference. They have explicit padding overrides, usually to 0.

### Before

<img width="727" height="139" alt="image" src="https://github.com/user-attachments/assets/1ee3f627-e167-4d3c-9c97-b57744941561" />

<img width="664" height="220" alt="image" src="https://github.com/user-attachments/assets/6bb91a01-ccba-4e49-92d8-f2ef6c582506" />

### After

<img width="720" height="139" alt="image" src="https://github.com/user-attachments/assets/4a11b11a-cfc0-4254-9068-a738f63b9856" />

<img width="665" height="277" alt="image" src="https://github.com/user-attachments/assets/d8b2b9bb-acd0-4f0f-8f41-9325af596cc5" />
