### PR TITLE
Fix tags in dark mode formula picker

### DIFF
--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -403,4 +403,5 @@ body.theme-dark .application:not(.themed),
     --visibility-gm-bg: var(--color-cool-4);
     --color-blind-roll-background: #2b122be6;
     --color-whisper-roll-background: #12122be6;
+    --tag-color: var(--color-light-4);
 }


### PR DESCRIPTION
Before

<img width="482" height="147" alt="image" src="https://github.com/user-attachments/assets/bf0aa6b8-79d8-452e-897d-479149ee574d" />

After

<img width="481" height="139" alt="image" src="https://github.com/user-attachments/assets/3891b2ac-c28f-4cf8-a880-f119d18d94c6" />
