### PR TITLE
Allow the didactic strike application to attack spells

### DIFF
--- a/packs/pf2e/feat-effects/effect-didactic-strike.json
+++ b/packs/pf2e/feat-effects/effect-didactic-strike.json
@@ -26,7 +26,7 @@
                 "diceNumber": 2,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "selector": "strike-damage"
+                "selector": ["attack-damage"]
             }
         ],
         "start": {

--- a/packs/pf2e/feat-effects/effect-didactic-strike.json
+++ b/packs/pf2e/feat-effects/effect-didactic-strike.json
@@ -26,7 +26,7 @@
                 "diceNumber": 2,
                 "dieSize": "d6",
                 "key": "DamageDice",
-                "selector": ["attack-damage"]
+                "selector": "attack-damage"
             }
         ],
         "start": {


### PR DESCRIPTION
closes https://github.com/foundryvtt/pf2e/issues/22308