### PR TITLE
add teleportation trait in retrieval prism

### DIFF
--- a/packs/pf2e/equipment/retrieval-prism.json
+++ b/packs/pf2e/equipment/retrieval-prism.json
@@ -11,7 +11,7 @@
         "containerId": null,
         "damage": null,
         "description": {
-            "value": "<p><strong>Usage</strong> affixed to armor</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">f</span> command</p>\n<p><strong>Requirements</strong> You have a free hand.</p>\n<hr />\n<p>This triangular prism showing swirling black patterns inside constantly moves around on your armor, no matter where you affix it. As part of the process of Affixing this Talisman, you attune it to a single item of 1 Bulk or less. When you activate this talisman, the attuned item immediately teleports into your hand.</p>\n<p>The retrieval prism can't retrieve an item that's not on your plane, including one that's in an extradimensional space like a bag of holding. If you haven't expended the talisman, you can attune it to a different item by Affixing the Talisman again.</p>"
+            "value": "<p><strong>Usage</strong> affixed to armor</p>\n<p><strong>Activate</strong> <span class=\"action-glyph\">f</span> command</p>\n<p><strong>Requirements</strong> You have a free hand.</p>\n<hr />\n<p>This triangular prism showing swirling black patterns inside constantly moves around on your armor, no matter where you affix it. As part of the process of Affixing this Talisman, you attune it to a single item of 1 Bulk or less. When you activate this talisman, the attuned item immediately teleports into your hand.</p>\n<p>The retrieval prism can't retrieve an item that's not on your plane, including one that's in an extradimensional space like a <em>bag of holding</em>. If you haven't expended the talisman, you can attune it to a different item by Affixing the Talisman again.</p>"
         },
         "hardness": 0,
         "hp": {
@@ -43,7 +43,8 @@
             "value": [
                 "consumable",
                 "magical",
-                "talisman"
+                "talisman",
+                "teleportation"
             ]
         },
         "usage": {


### PR DESCRIPTION
Updated the description of the retrieval prism to include formatting changes of bag of holding and added 'teleportation' to its traits.