### PR TITLE
Add missing `replaceAll: true` for Talon and Claw stance effects

### DIFF
--- a/packs/pf2e/feat-effects/stance-claw-stance.json
+++ b/packs/pf2e/feat-effects/stance-claw-stance.json
@@ -22,6 +22,7 @@
         },
         "rules": [
             {
+                "baseType": "claw",
                 "category": "unarmed",
                 "damage": {
                     "base": {

--- a/packs/pf2e/feat-effects/stance-claw-stance.json
+++ b/packs/pf2e/feat-effects/stance-claw-stance.json
@@ -33,6 +33,7 @@
                 "group": "brawling",
                 "key": "Strike",
                 "label": "PF2E.SpecificRule.Feat.ClawdancerDedication.FrenziedClaw",
+                "replaceAll": true,
                 "slug": "frenzied-claw",
                 "traits": [
                     "agile",

--- a/packs/pf2e/feat-effects/stance-talon-stance.json
+++ b/packs/pf2e/feat-effects/stance-talon-stance.json
@@ -33,6 +33,7 @@
                 "group": "brawling",
                 "key": "Strike",
                 "label": "PF2E.SpecificRule.Feat.ClawdancerDedication.SpinningTalon",
+                "replaceAll": true,
                 "slug": "spinning-talon",
                 "traits": [
                     "finesse",


### PR DESCRIPTION
Just noticed that of all 'The only Strikes you can make are X' feats (excluding weapon ones) these are missing the replaceAll