### PR TITLE
Fix missing Tool Rat statistics

### DIFF
--- a/packs/sf2e/alien-core-bestiary/tool-rat.json
+++ b/packs/sf2e/alien-core-bestiary/tool-rat.json
@@ -849,37 +849,37 @@
     "system": {
         "abilities": {
             "cha": {
-                "mod": 0
+                "mod": 2
             },
             "con": {
-                "mod": 0
+                "mod": 1
             },
             "dex": {
-                "mod": 0
+                "mod": 4
             },
             "int": {
-                "mod": 0
+                "mod": -2
             },
             "str": {
                 "mod": 0
             },
             "wis": {
-                "mod": 0
+                "mod": 3
             }
         },
         "attributes": {
             "ac": {
                 "details": "",
-                "value": 10
+                "value": 18
             },
             "allSaves": {
                 "value": ""
             },
             "hp": {
                 "details": "",
-                "max": 10,
+                "max": 30,
                 "temp": 0,
-                "value": 10
+                "value": 30
             },
             "speed": {
                 "otherSpeeds": [
@@ -894,8 +894,10 @@
         "details": {
             "blurb": "",
             "languages": {
-                "details": "",
-                "value": []
+                "details": "(cannot speak any language)",
+                "value": [
+                    "common"
+                ]
             },
             "level": {
                 "value": 2
@@ -913,25 +915,51 @@
         },
         "perception": {
             "details": "",
-            "mod": 0,
-            "senses": []
+            "mod": 10,
+            "senses": [
+                {
+                    "type": "low-light-vision"
+                },
+                {
+                    "acuity": "imprecise",
+                    "range": 30,
+                    "type": "scent"
+                }
+            ]
         },
         "resources": {},
         "saves": {
             "fortitude": {
                 "saveDetail": "",
-                "value": 0
+                "value": 6
             },
             "reflex": {
                 "saveDetail": "",
-                "value": 0
+                "value": 10
             },
             "will": {
                 "saveDetail": "",
-                "value": 0
+                "value": 8
             }
         },
-        "skills": {},
+        "skills": {
+            "acrobatics": {
+                "base": 8,
+                "special": []
+            },
+            "crafting": {
+                "base": 8,
+                "special": []
+            },
+            "stealth": {
+                "base": 7,
+                "special": []
+            },
+            "thievery": {
+                "base": 5,
+                "special": []
+            }
+        },
         "traits": {
             "rarity": "common",
             "size": {


### PR DESCRIPTION
Fix missing data for [Tool Rat](https://2e.aonsrd.com/creatures/111-tool-rat) creature entry.