### PR TITLE
Include scrolls, wands, spell gems in Anachronism

### DIFF
--- a/build/anachronism/index.ts
+++ b/build/anachronism/index.ts
@@ -4,6 +4,7 @@ import { LANGUAGES_BY_RARITY } from "@actor/creature/values.ts";
 import { ItemSourcePF2e } from "@item/base/data/index.ts";
 import { itemIsOfType } from "@item/helpers.ts";
 import { ancestryTraits, classTraits } from "@scripts/config/traits.ts";
+import { SPELL_CONSUMABLES_BY_SYSTEM } from "@scripts/config/spell-consumables.ts";
 import { objectHasKey, recursiveReplaceString, sluggify } from "@util/misc.ts";
 import fs from "fs";
 import path from "path";
@@ -48,9 +49,13 @@ console.log(`Building Modules: ${contentSystems.map((c) => `${c}-anachronism`)}`
 /** Root module file contents of anachronism. This should be moved to a file somewhere. */
 const moduleSourceContents = String.raw`
 import UUID_REDIRECTS from "./uuid-redirects.json" with { type: "json" };
+import SPELL_CONSUMABLES from "./spell-consumables.json" with { type: "json" };
 for (const [from, to] of Object.entries(UUID_REDIRECTS)) {
     CONFIG.compendium.uuidRedirects[from] = to;
 }
+Hooks.once("init", () => {
+    Object.assign(CONFIG.PF2E.spellcastingItems, SPELL_CONSUMABLES);
+});
 `;
 
 console.log("Starting build, loading compendiums for both systems");
@@ -320,6 +325,14 @@ for (const contentSystem of contentSystems) {
     await fs.promises.writeFile(
         path.join(outDir, "uuid-redirects.json"),
         JSON.stringify(uuidRedirects, null, 4),
+        "utf8",
+    );
+
+    // Expose the bundled spell consumable items via CONFIG.PF2E.spellcastingItems so users can craft from spells.
+    const spellConsumables = recursiveReplaceString(SPELL_CONSUMABLES_BY_SYSTEM[contentSystem], remapUuid);
+    await fs.promises.writeFile(
+        path.join(outDir, "spell-consumables.json"),
+        JSON.stringify(spellConsumables, null, 4),
         "utf8",
     );
 

--- a/src/module/actor/character/crafting/helpers.ts
+++ b/src/module/actor/character/crafting/helpers.ts
@@ -10,6 +10,7 @@ import { EarnIncomeDialog } from "@scripts/macros/earn-income.ts";
 import { CheckRoll } from "@system/check/index.ts";
 import { DegreeOfSuccess } from "@system/degree-of-success.ts";
 import { TextEditorPF2e } from "@system/text-editor.ts";
+import { tupleHasValue } from "@util";
 
 /** Implementation of Crafting rules on https://2e.aonprd.com/Actions.aspx?ID=43 */
 
@@ -112,7 +113,7 @@ export async function craftSpellConsumable(
     actor: ActorPF2e,
 ): Promise<void> {
     const consumableType = item.category;
-    if (!["scroll", "wand", "spell-gem"].includes(consumableType)) return;
+    if (!tupleHasValue(["scroll", "wand", "spell-gem"] as const, consumableType)) return;
     const rank = (consumableType === "wand" ? Math.ceil(item.level / 2) - 1 : Math.ceil(item.level / 2)) as OneToTen;
     const validSpells = actor.itemTypes.spell
         .filter((s) => s.baseRank <= rank && !s.isCantrip && !s.isFocusSpell && !s.isRitual)

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -12,6 +12,7 @@ import type { AbilityTrait, ActionCategory } from "@item/ability/types.ts";
 import type { EffectTrait } from "@item/abstract-effect/types.ts";
 import type { ActionType, ItemSourcePF2e } from "@item/base/data/index.ts";
 import { SpellcastingItemCreator } from "@item/consumable/apps/spellcasting-item-creator/app.ts";
+import { spellConsumableCategoriesFor } from "@item/consumable/spell-consumables.ts";
 import { isContainerCycle } from "@item/container/helpers.ts";
 import { itemIsOfType } from "@item/helpers.ts";
 import { Coins, sizeItemForActor, transferCredits } from "@item/physical/helpers.ts";
@@ -1206,6 +1207,8 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends fav1.sheets.Acto
             if (item.isRitual) {
                 return this._onDropItemCreate(item.clone().toObject());
             } else if (dropContainerType === "actorInventory" && itemSource.system.level.value > 0) {
+                // Skip if the current system has no spell-consumable category that fits this spell
+                if (Object.keys(spellConsumableCategoriesFor(item)).length === 0) return [];
                 new SpellcastingItemCreator({ actor, spell: item, mystified }).render({ force: true });
                 return [item];
             } else {

--- a/src/module/item/consumable/apps/spellcasting-item-creator/app.svelte
+++ b/src/module/item/consumable/apps/spellcasting-item-creator/app.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { CANTRIP_DECK_UUID } from "@item/consumable/spell-consumables.ts";
+    import { spellConsumableCategoriesFor } from "@item/consumable/spell-consumables.ts";
     import { localizer, objectHasKey, ordinalString } from "@util";
     import { UUIDUtils } from "@util/uuid.ts";
     import * as R from "remeda";
@@ -14,11 +14,7 @@
     const itemTypeData = $derived(
         objectHasKey(CONFIG.PF2E.spellcastingItems, type) ? CONFIG.PF2E.spellcastingItems[type] : null,
     );
-    const itemTypeOptions = $derived(
-        isCantrip
-            ? { cantripDeck5: localize("CantripDeck5") }
-            : R.mapValues(CONFIG.PF2E.spellcastingItems, (c) => _loc(c.name)),
-    );
+    const itemTypeOptions = $derived(R.mapValues(spellConsumableCategoriesFor({ isCantrip }), (c) => _loc(c.name)));
     const compendiumUuids: Record<number, string | null> | null = $derived(itemTypeData?.compendiumUuids ?? null);
     const ranks = $derived(
         Object.keys(compendiumUuids ?? {})
@@ -26,7 +22,7 @@
             .filter((r) => r >= minimumRank && !!compendiumUuids?.[r]),
     );
     const noValidRanks = $derived(!isCantrip && ranks.length === 0);
-    const resolvedItem = $derived(type === "cantripDeck5" ? CANTRIP_DECK_UUID : compendiumUuids?.[Number(rank)]);
+    const resolvedItem = $derived(itemTypeData?.cantripsOnly ? compendiumUuids?.[1] : compendiumUuids?.[Number(rank)]);
 
     async function viewItem(selection: unknown) {
         if (!UUIDUtils.isItemUUID(selection)) return;
@@ -54,7 +50,7 @@
         ></button>
     </div>
 </div>
-{#if type !== "cantripDeck5"}
+{#if !itemTypeData?.cantripsOnly}
     <div class="form-group">
         <label for={`${foundryApp.id}.rank`}>{_loc("PF2E.Item.Spell.Rank.Label")}</label>
         <div class="form-fields">

--- a/src/module/item/consumable/apps/spellcasting-item-creator/app.ts
+++ b/src/module/item/consumable/apps/spellcasting-item-creator/app.ts
@@ -1,7 +1,9 @@
 import { ActorPF2e } from "@actor";
 import { createConsumableFromSpell } from "@item/consumable/spell-consumables.ts";
 import { SpellPF2e } from "@item/spell/document.ts";
+import type { OneToTen } from "@module/data.ts";
 import { SvelteApplicationMixin, SvelteApplicationRenderContext } from "@module/sheet/mixin.svelte.ts";
+import { ErrorPF2e, objectHasKey } from "@util";
 import Root from "./app.svelte";
 import fapi = foundry.applications.api;
 
@@ -62,9 +64,15 @@ class SpellcastingItemCreator extends SvelteApplicationMixin(fapi.ApplicationV2)
         _form: HTMLFormElement,
         formData: fa.ux.FormDataExtended,
     ) {
+        const type = String(formData.object.type);
+        if (!objectHasKey(CONFIG.PF2E.spellcastingItems, type)) {
+            throw ErrorPF2e(`Invalid spell consumable type: ${type}`);
+        }
+        const rawRank = Number(formData.object.rank);
+        const rank = rawRank.between(1, 10) ? (rawRank as OneToTen) : undefined;
         const item = await createConsumableFromSpell(this.#spell, {
-            type: String(formData.object.type),
-            rank: Number(formData.object.rank),
+            type,
+            rank,
             mystified: !!formData.object.mystified,
         });
         this.#actor.inventory.add(item, { stack: true });

--- a/src/module/item/consumable/spell-consumables.ts
+++ b/src/module/item/consumable/spell-consumables.ts
@@ -5,19 +5,18 @@ import { MAGIC_TRADITIONS } from "@item/spell/values.ts";
 import { traditionSkills } from "@item/spellcasting-entry/trick.ts";
 import { DCOptions, calculateDC } from "@module/dc.ts";
 import type { OneToTen } from "@module/data.ts";
-import type { SpellRankUuids } from "@scripts/config/spell-consumables.ts";
 import { ErrorPF2e, objectHasKey, setHasElement } from "@util";
 import * as R from "remeda";
 
-const CANTRIP_DECK_UUID = "Compendium.pf2e.equipment-srd.Item.tLa4bewBhyqzi6Ow";
-
-type SpellConsumableItemType = "cantripDeck5" | keyof ConfigPF2e["PF2E"]["spellcastingItems"];
+type SpellConsumableItemType = keyof ConfigPF2e["PF2E"]["spellcastingItems"];
 
 function isSpellConsumableUUID(itemId: string): boolean {
-    return (
-        itemId === CANTRIP_DECK_UUID ||
-        Object.values(CONFIG.PF2E.spellcastingItems).some((c) => Object.values(c.compendiumUuids).includes(itemId))
-    );
+    return Object.values(CONFIG.PF2E.spellcastingItems).some((c) => Object.values(c.compendiumUuids).includes(itemId));
+}
+
+/** Spell consumable categories available for this kind of spell in the current system. */
+function spellConsumableCategoriesFor(spell: { isCantrip: boolean }): Partial<typeof CONFIG.PF2E.spellcastingItems> {
+    return R.pickBy(CONFIG.PF2E.spellcastingItems, (c) => !!c?.cantripsOnly === spell.isCantrip);
 }
 
 async function createConsumableFromSpell(
@@ -33,8 +32,7 @@ async function createConsumableFromSpell(
     },
 ): Promise<ConsumableSource> {
     const data = objectHasKey(CONFIG.PF2E.spellcastingItems, type) ? CONFIG.PF2E.spellcastingItems[type] : null;
-    const uuids: Partial<SpellRankUuids> = data?.compendiumUuids ?? {};
-    const uuid = uuids[rank] ?? (type === "cantripDeck5" ? CANTRIP_DECK_UUID : null);
+    const uuid = data?.compendiumUuids[rank] ?? null;
     const consumable = uuid ? await fromUuid<ItemPF2e>(uuid) : null;
     if (!consumable?.isOfType("consumable")) {
         throw ErrorPF2e("Failed to retrieve consumable item");
@@ -50,9 +48,8 @@ async function createConsumableFromSpell(
     }
     traits.value.sort();
 
-    const nameTemplate = type === "cantripDeck5" ? "PF2E.Item.Physical.FromSpell.CantripDeck5" : data?.nameTemplate;
-    consumableSource.name = nameTemplate
-        ? _loc(nameTemplate, { name: spell.name, level: rank })
+    consumableSource.name = data?.nameTemplate
+        ? _loc(data.nameTemplate, { name: spell.name, level: rank })
         : `${type} of ${spell.name} (Rank ${rank})`;
     const description = consumableSource.system.description.value;
 
@@ -68,8 +65,8 @@ async function createConsumableFromSpell(
         return containerElement.innerHTML;
     })();
 
-    // Cantrip deck casts at level 1
-    if (type !== "cantripDeck5") {
+    // Cantrip-only categories (e.g. cantrip deck) aren't single-spell consumables — skip embedding.
+    if (!data?.cantripsOnly) {
         consumableSource.system.spell = fu.mergeObject(
             spell._source,
             { _id: fu.randomID(), system: { location: { value: null, heightenedLevel: rank } } },
@@ -106,5 +103,10 @@ function calculateTrickMagicItemCheckDC(
     return Object.fromEntries(skills);
 }
 
-export { CANTRIP_DECK_UUID, calculateTrickMagicItemCheckDC, createConsumableFromSpell, isSpellConsumableUUID };
+export {
+    calculateTrickMagicItemCheckDC,
+    createConsumableFromSpell,
+    isSpellConsumableUUID,
+    spellConsumableCategoriesFor,
+};
 export type { SpellConsumableItemType, TrickMagicItemDifficultyData };

--- a/src/module/item/consumable/spell-consumables.ts
+++ b/src/module/item/consumable/spell-consumables.ts
@@ -4,6 +4,8 @@ import { MagicTradition } from "@item/spell/types.ts";
 import { MAGIC_TRADITIONS } from "@item/spell/values.ts";
 import { traditionSkills } from "@item/spellcasting-entry/trick.ts";
 import { DCOptions, calculateDC } from "@module/dc.ts";
+import type { OneToTen } from "@module/data.ts";
+import type { SpellRankUuids } from "@scripts/config/spell-consumables.ts";
 import { ErrorPF2e, objectHasKey, setHasElement } from "@util";
 import * as R from "remeda";
 
@@ -25,14 +27,14 @@ async function createConsumableFromSpell(
         rank = spell.baseRank,
         mystified = false,
     }: {
-        type: string;
-        rank?: number;
+        type: SpellConsumableItemType;
+        rank?: OneToTen;
         mystified?: boolean;
     },
 ): Promise<ConsumableSource> {
     const data = objectHasKey(CONFIG.PF2E.spellcastingItems, type) ? CONFIG.PF2E.spellcastingItems[type] : null;
-    const uuids: Record<number, string | null | undefined> = data?.compendiumUuids ?? [];
-    const uuid = uuids?.[rank] ?? (type === "cantripDeck5" ? CANTRIP_DECK_UUID : null);
+    const uuids: Partial<SpellRankUuids> = data?.compendiumUuids ?? {};
+    const uuid = uuids[rank] ?? (type === "cantripDeck5" ? CANTRIP_DECK_UUID : null);
     const consumable = uuid ? await fromUuid<ItemPF2e>(uuid) : null;
     if (!consumable?.isOfType("consumable")) {
         throw ErrorPF2e("Failed to retrieve consumable item");

--- a/src/module/item/spell/data.ts
+++ b/src/module/item/spell/data.ts
@@ -37,7 +37,7 @@ interface SpellSystemSource extends ItemSystemSource {
     location: {
         value: string | null;
         signature?: boolean;
-        heightenedLevel?: number;
+        heightenedLevel?: OneToTen;
 
         /** The level to heighten this spell to if it's a cantrip or focus spell */
         autoHeightenLevel?: OneToTen | null;

--- a/src/module/item/spell/document.ts
+++ b/src/module/item/spell/document.ts
@@ -514,7 +514,7 @@ class SpellPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ite
             // Set the spell as heightened if necessary (either up or down)
             const currentRank = source.system.location.heightenedLevel ?? source.system.level.value;
             if (castRank && castRank !== currentRank) {
-                source.system.location.heightenedLevel = castRank;
+                source.system.location.heightenedLevel = Math.clamp(castRank, 1, 10) as OneToTen;
             }
 
             source._id = this.id;

--- a/src/module/migration/migrations/734-spell-location-props-and-signature.ts
+++ b/src/module/migration/migrations/734-spell-location-props-and-signature.ts
@@ -48,7 +48,10 @@ export class Migration734SpellLocationPropsAndSignature extends MigrationBase {
             if (data.heightenedLevel || data.autoHeightenLevel) {
                 // These fields should only exist if there's an actor
                 if (actor) {
-                    data.location.heightenedLevel = data.heightenedLevel?.value ?? undefined;
+                    const heightenedLevel = data.heightenedLevel?.value;
+                    data.location.heightenedLevel = heightenedLevel
+                        ? (Math.clamp(heightenedLevel, 1, 10) as OneToTen)
+                        : undefined;
                     data.location.autoHeightenLevel = data.autoHeightenLevel?.value ?? undefined;
                 }
 

--- a/src/module/migration/migrations/772-v10-embedded-spell-data.ts
+++ b/src/module/migration/migrations/772-v10-embedded-spell-data.ts
@@ -1,5 +1,6 @@
 import { ItemSourcePF2e, SpellSource } from "@item/base/data/index.ts";
 import { SpellSystemSource } from "@item/spell/data.ts";
+import type { OneToTen } from "@module/data.ts";
 import { MigrationBase } from "../base.ts";
 
 /** Push back embedded spell property one object-nesting level */
@@ -13,13 +14,21 @@ export class Migration772V10EmbeddedSpellData extends MigrationBase {
                 source.system.spell = embeddedSpell.data;
                 source.system.spell.system = embeddedSpell.data.data;
                 source.system.spell.system.location.heightenedLevel =
-                    Number(embeddedSpell.data.heightenedLevel) || source.system.spell.system.level.value;
+                    (Math.clamp(
+                        Number(embeddedSpell.data.heightenedLevel) || source.system.spell.system.level.value,
+                        1,
+                        10,
+                    ) as OneToTen) || undefined;
                 embeddedSpell.data["-=data"] = null;
                 delete embeddedSpell.data.data;
             } else if (embeddedSpell.data?.system) {
                 source.system.spell = embeddedSpell.data;
                 source.system.spell.system.location.heightenedLevel =
-                    Number(embeddedSpell.data.heightenedLevel) || source.system.spell.system.level.value;
+                    (Math.clamp(
+                        Number(embeddedSpell.data.heightenedLevel) || source.system.spell.system.level.value,
+                        1,
+                        10,
+                    ) as OneToTen) || undefined;
             } else if (embeddedSpell.data === null) {
                 source.system.spell = null;
             }

--- a/src/scripts/config/index.ts
+++ b/src/scripts/config/index.ts
@@ -49,6 +49,7 @@ import {
     physicalDamageTypes,
 } from "./damage.ts";
 import { immunityTypes, resistanceTypes, weaknessTypes } from "./iwr.ts";
+import { SPELL_CONSUMABLES_BY_SYSTEM } from "./spell-consumables.ts";
 import {
     actionTraits,
     ancestryTraits,
@@ -832,60 +833,7 @@ export const PF2ECONFIG = {
         ritual: "PF2E.PreparationTypeRitual",
     },
 
-    spellcastingItems:
-        SYSTEM_ID === "pf2e"
-            ? {
-                  scroll: {
-                      name: "PF2E.Item.Consumable.Category.scroll",
-                      nameTemplate: "PF2E.Item.Physical.FromSpell.Scroll",
-                      compendiumUuids: {
-                          1: "Compendium.pf2e.equipment-srd.Item.RjuupS9xyXDLgyIr",
-                          2: "Compendium.pf2e.equipment-srd.Item.Y7UD64foDbDMV9sx",
-                          3: "Compendium.pf2e.equipment-srd.Item.ZmefGBXGJF3CFDbn",
-                          4: "Compendium.pf2e.equipment-srd.Item.QSQZJ5BC3DeHv153",
-                          5: "Compendium.pf2e.equipment-srd.Item.tjLvRWklAylFhBHQ",
-                          6: "Compendium.pf2e.equipment-srd.Item.4sGIy77COooxhQuC",
-                          7: "Compendium.pf2e.equipment-srd.Item.fomEZZ4MxVVK3uVu",
-                          8: "Compendium.pf2e.equipment-srd.Item.iPki3yuoucnj7bIt",
-                          9: "Compendium.pf2e.equipment-srd.Item.cFHomF3tty8Wi1e5",
-                          10: "Compendium.pf2e.equipment-srd.Item.o1XIHJ4MJyroAHfF",
-                      },
-                  },
-                  wand: {
-                      name: "PF2E.Item.Consumable.Category.wand",
-                      nameTemplate: "PF2E.Item.Physical.FromSpell.Wand",
-                      compendiumUuids: {
-                          1: "Compendium.pf2e.equipment-srd.Item.UJWiN0K3jqVjxvKk",
-                          2: "Compendium.pf2e.equipment-srd.Item.vJZ49cgi8szuQXAD",
-                          3: "Compendium.pf2e.equipment-srd.Item.wrDmWkGxmwzYtfiA",
-                          4: "Compendium.pf2e.equipment-srd.Item.Sn7v9SsbEDMUIwrO",
-                          5: "Compendium.pf2e.equipment-srd.Item.5BF7zMnrPYzyigCs",
-                          6: "Compendium.pf2e.equipment-srd.Item.kiXh4SUWKr166ZeM",
-                          7: "Compendium.pf2e.equipment-srd.Item.nmXPj9zuMRQBNT60",
-                          8: "Compendium.pf2e.equipment-srd.Item.Qs8RgNH6thRPv2jt",
-                          9: "Compendium.pf2e.equipment-srd.Item.Fgv722039TVM5JTc",
-                          10: null,
-                      },
-                  },
-              }
-            : {
-                  "spell-gem": {
-                      name: "PF2E.Item.Consumable.Category.spell-gem",
-                      nameTemplate: "PF2E.Item.Physical.FromSpell.spell-gem",
-                      compendiumUuids: {
-                          1: "Compendium.sf2e.equipment.Item.R6LuVXimv1Hh8ehE",
-                          2: "Compendium.sf2e.equipment.Item.p5DYjh3sCSjzrBBg",
-                          3: "Compendium.sf2e.equipment.Item.Nwl7YydQ0r8cAhw7",
-                          4: "Compendium.sf2e.equipment.Item.88IBM9viOjJ0kJbm",
-                          5: "Compendium.sf2e.equipment.Item.BVCQFla90m2JDepV",
-                          6: "Compendium.sf2e.equipment.Item.9PAmdF8UqVQKXWPA",
-                          7: "Compendium.sf2e.equipment.Item.JgvLQeWK45OxFrx0",
-                          8: "Compendium.sf2e.equipment.Item.Vt6VVUXFf1boNs3P",
-                          9: "Compendium.sf2e.equipment.Item.8nNTrkf4ZCqkApNT",
-                          10: "Compendium.sf2e.equipment.Item.ulNSlan9Q5j1ozPI",
-                      },
-                  },
-              },
+    spellcastingItems: SPELL_CONSUMABLES_BY_SYSTEM[SYSTEM_ID],
 
     attitude: {
         hostile: "PF2E.Attitudes.Hostile",

--- a/src/scripts/config/spell-consumables.ts
+++ b/src/scripts/config/spell-consumables.ts
@@ -1,0 +1,83 @@
+import type { OneToTen } from "@module/data.ts";
+
+type SpellRankUuids = Record<OneToTen, string | null>;
+
+interface SpellConsumableCategory {
+    name: string;
+    nameTemplate: string;
+    compendiumUuids: SpellRankUuids;
+}
+
+type Pf2eSpellConsumables = {
+    scroll: SpellConsumableCategory;
+    wand: SpellConsumableCategory;
+};
+type Sf2eSpellConsumables = {
+    "spell-gem": SpellConsumableCategory;
+};
+
+interface SpellConsumablesBySystem {
+    pf2e: Pf2eSpellConsumables;
+    sf2e: Sf2eSpellConsumables;
+}
+
+/** Spell consumable categories with all keys optional. The system fills its own, modules may fill the rest. */
+type SpellConsumableEntries = Partial<Pf2eSpellConsumables & Sf2eSpellConsumables>;
+
+const SPELL_CONSUMABLES_BY_SYSTEM: Record<SystemId, SpellConsumableEntries> = {
+    pf2e: {
+        scroll: {
+            name: "PF2E.Item.Consumable.Category.scroll",
+            nameTemplate: "PF2E.Item.Physical.FromSpell.Scroll",
+            compendiumUuids: {
+                1: "Compendium.pf2e.equipment-srd.Item.RjuupS9xyXDLgyIr",
+                2: "Compendium.pf2e.equipment-srd.Item.Y7UD64foDbDMV9sx",
+                3: "Compendium.pf2e.equipment-srd.Item.ZmefGBXGJF3CFDbn",
+                4: "Compendium.pf2e.equipment-srd.Item.QSQZJ5BC3DeHv153",
+                5: "Compendium.pf2e.equipment-srd.Item.tjLvRWklAylFhBHQ",
+                6: "Compendium.pf2e.equipment-srd.Item.4sGIy77COooxhQuC",
+                7: "Compendium.pf2e.equipment-srd.Item.fomEZZ4MxVVK3uVu",
+                8: "Compendium.pf2e.equipment-srd.Item.iPki3yuoucnj7bIt",
+                9: "Compendium.pf2e.equipment-srd.Item.cFHomF3tty8Wi1e5",
+                10: "Compendium.pf2e.equipment-srd.Item.o1XIHJ4MJyroAHfF",
+            },
+        },
+        wand: {
+            name: "PF2E.Item.Consumable.Category.wand",
+            nameTemplate: "PF2E.Item.Physical.FromSpell.Wand",
+            compendiumUuids: {
+                1: "Compendium.pf2e.equipment-srd.Item.UJWiN0K3jqVjxvKk",
+                2: "Compendium.pf2e.equipment-srd.Item.vJZ49cgi8szuQXAD",
+                3: "Compendium.pf2e.equipment-srd.Item.wrDmWkGxmwzYtfiA",
+                4: "Compendium.pf2e.equipment-srd.Item.Sn7v9SsbEDMUIwrO",
+                5: "Compendium.pf2e.equipment-srd.Item.5BF7zMnrPYzyigCs",
+                6: "Compendium.pf2e.equipment-srd.Item.kiXh4SUWKr166ZeM",
+                7: "Compendium.pf2e.equipment-srd.Item.nmXPj9zuMRQBNT60",
+                8: "Compendium.pf2e.equipment-srd.Item.Qs8RgNH6thRPv2jt",
+                9: "Compendium.pf2e.equipment-srd.Item.Fgv722039TVM5JTc",
+                10: null,
+            },
+        },
+    },
+    sf2e: {
+        "spell-gem": {
+            name: "PF2E.Item.Consumable.Category.spell-gem",
+            nameTemplate: "PF2E.Item.Physical.FromSpell.spell-gem",
+            compendiumUuids: {
+                1: "Compendium.sf2e.equipment.Item.R6LuVXimv1Hh8ehE",
+                2: "Compendium.sf2e.equipment.Item.p5DYjh3sCSjzrBBg",
+                3: "Compendium.sf2e.equipment.Item.Nwl7YydQ0r8cAhw7",
+                4: "Compendium.sf2e.equipment.Item.88IBM9viOjJ0kJbm",
+                5: "Compendium.sf2e.equipment.Item.BVCQFla90m2JDepV",
+                6: "Compendium.sf2e.equipment.Item.9PAmdF8UqVQKXWPA",
+                7: "Compendium.sf2e.equipment.Item.JgvLQeWK45OxFrx0",
+                8: "Compendium.sf2e.equipment.Item.Vt6VVUXFf1boNs3P",
+                9: "Compendium.sf2e.equipment.Item.8nNTrkf4ZCqkApNT",
+                10: "Compendium.sf2e.equipment.Item.ulNSlan9Q5j1ozPI",
+            },
+        },
+    },
+} as const satisfies SpellConsumablesBySystem;
+
+export { SPELL_CONSUMABLES_BY_SYSTEM };
+export type { SpellConsumableCategory, SpellConsumableEntries, SpellRankUuids };

--- a/src/scripts/config/spell-consumables.ts
+++ b/src/scripts/config/spell-consumables.ts
@@ -6,11 +6,14 @@ interface SpellConsumableCategory {
     name: string;
     nameTemplate: string;
     compendiumUuids: SpellRankUuids;
+    /** If true, only offered when the spell is a cantrip, and the spell isn't embedded into the created item. */
+    cantripsOnly?: boolean;
 }
 
 type Pf2eSpellConsumables = {
     scroll: SpellConsumableCategory;
     wand: SpellConsumableCategory;
+    cantripDeck5: SpellConsumableCategory;
 };
 type Sf2eSpellConsumables = {
     "spell-gem": SpellConsumableCategory;
@@ -57,6 +60,23 @@ const SPELL_CONSUMABLES_BY_SYSTEM: Record<SystemId, SpellConsumableEntries> = {
                 9: "Compendium.pf2e.equipment-srd.Item.Fgv722039TVM5JTc",
                 10: null,
             },
+        },
+        cantripDeck5: {
+            name: "PF2E.SpellcastingItemCreator.CantripDeck5",
+            nameTemplate: "PF2E.Item.Physical.FromSpell.CantripDeck5",
+            compendiumUuids: {
+                1: "Compendium.pf2e.equipment-srd.Item.tLa4bewBhyqzi6Ow",
+                2: null,
+                3: null,
+                4: null,
+                5: null,
+                6: null,
+                7: null,
+                8: null,
+                9: null,
+                10: null,
+            },
+            cantripsOnly: true,
         },
     },
     sf2e: {


### PR DESCRIPTION
Implements #22339 

This doesn't touch spell chips, as the equipment items are already included in Anachronism and work the same as they do in the SF2e system, i.e., they do nothing.  I saw murmurings in the discord that full spell chip implementation may be waiting on changes to how spells get embedded in items rather than just using the same flow as wands. What's the current plan there? I'd be interested in taking a look at it.