### PR TITLE
Fix icon of add/remove currency dialog

### DIFF
--- a/src/module/actor/sheet/popups/update-currency-dialog.ts
+++ b/src/module/actor/sheet/popups/update-currency-dialog.ts
@@ -16,7 +16,7 @@ class UpdateCurrencyDialog extends fa.api.HandlebarsApplicationMixin(fa.api.Appl
         id: "update-currency",
         tag: "form",
         window: {
-            icon: "fa-solid fa-currency",
+            icon: "fa-solid fa-coins",
             contentClasses: ["standard-form"],
         },
         position: {


### PR DESCRIPTION
Slipped by when I did a coins -> currency rename.