### PR TITLE
Update dawnsilver-tree and shield-pistol rounds

### DIFF
--- a/packs/pf2e/equipment/rounds-dawnsilver-tree.json
+++ b/packs/pf2e/equipment/rounds-dawnsilver-tree.json
@@ -3,7 +3,7 @@
     "img": "icons/weapons/ammunition/shot-round-lead.webp",
     "name": "Rounds (Dawnsilver Tree)",
     "system": {
-        "baseItem": "rounds",
+        "baseItem": "rounds-mithral-tree",
         "bulk": {
             "value": 0.1
         },
@@ -41,7 +41,8 @@
         "traits": {
             "rarity": "common",
             "value": [
-                "alchemical"
+                "alchemical",
+                "consumable"
             ]
         },
         "uses": {

--- a/packs/pf2e/equipment/rounds-shield-pistol.json
+++ b/packs/pf2e/equipment/rounds-shield-pistol.json
@@ -5,7 +5,7 @@
     "system": {
         "baseItem": "rounds-shield-pistol",
         "bulk": {
-            "value": 0
+            "value": 0.1
         },
         "containerId": null,
         "craftableAs": null,

--- a/packs/pf2e/equipment/rounds-shield-pistol.json
+++ b/packs/pf2e/equipment/rounds-shield-pistol.json
@@ -41,6 +41,7 @@
         "traits": {
             "rarity": "uncommon",
             "value": [
+                "alchemical",
                 "consumable"
             ]
         },


### PR DESCRIPTION
- Closes https://github.com/foundryvtt/pf2e/issues/22360
Also adds 'alchemical' to shield-pistol rounds.

P.S. Spike Launcher rounds also miss the alchemical trait, but since that's a beastgun, not sure if that's intentional