### PR TITLE
Fix stale and clobbered state in Svelte applications

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -23,7 +23,7 @@ import type {
     CompendiumBrowser,
     CompendiumBrowserSettings,
     CompendiumBrowserSources,
-} from "@module/apps/compendium-browser/browser.ts";
+} from "@module/apps/compendium-browser/browser.svelte.ts";
 import type { EffectsPanel } from "@module/apps/effects-panel.ts";
 import type {
     ActorDirectoryPF2e,

--- a/src/module/actor/character/apps/abc-picker/app.svelte
+++ b/src/module/actor/character/apps/abc-picker/app.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
     import { ErrorPF2e } from "@util";
     import type { MouseEventHandler } from "svelte/elements";
+    import type { SvelteAppProps } from "@module/sheet/mixin.svelte.ts";
     import type { ABCPickerContext } from "./app.ts";
 
-    const { actor, foundryApp, state: data }: ABCPickerContext = $props();
+    const { actor, foundryApp, getState }: ABCPickerContext & SvelteAppProps<ABCPickerContext> = $props();
+    const data = $derived(getState());
     let searchQuery = $state("");
     const filteredItems = $derived.by(() => {
         const query = searchQuery.trim();
@@ -18,10 +20,8 @@
         });
     });
 
-    const typePlural = _loc(`PF2E.Item.${data.itemType.capitalize()}.Plural`);
-    const searchPlaceholder = _loc("PF2E.Actor.Character.ABCPicker.SearchPlaceholder", {
-        items: typePlural,
-    });
+    const typePlural = $derived(_loc(`PF2E.Item.${data.itemType.capitalize()}.Plural`));
+    const searchPlaceholder = $derived(_loc("PF2E.Actor.Character.ABCPicker.SearchPlaceholder", { items: typePlural }));
 
     /** Open an item sheet to show additional details. */
     const viewItemSheet: MouseEventHandler<HTMLButtonElement> = async (event): Promise<void> => {

--- a/src/module/actor/character/apps/abc-picker/app.ts
+++ b/src/module/actor/character/apps/abc-picker/app.ts
@@ -31,10 +31,16 @@ interface ABCItemRef {
     hidden: boolean;
 }
 
+interface ABCPickerState {
+    prompt: string;
+    itemType: AhBCDType;
+    items: ABCItemRef[];
+}
+
 interface ABCPickerContext extends SvelteApplicationRenderContext {
     actor: CharacterPF2e;
     foundryApp: ABCPicker;
-    state: { prompt: string; itemType: AhBCDType; items: ABCItemRef[] };
+    state: ABCPickerState;
 }
 
 /** A `Compendium`-like application for presenting A(H)BCD options for a character */
@@ -142,4 +148,5 @@ class ABCPicker extends SvelteApplicationMixin<
     }
 }
 
-export { ABCPicker, type ABCPickerContext };
+export { ABCPicker };
+export type { ABCPickerContext, ABCPickerState };

--- a/src/module/actor/character/apps/attribute-builder/app.svelte
+++ b/src/module/actor/character/apps/attribute-builder/app.svelte
@@ -6,14 +6,11 @@
     import RemainingIndicator from "@module/apps/attribute-builder/components/remaining-indicator.svelte";
     import { tupleHasValue } from "@util";
     import * as R from "remeda";
-    import { AttributeBuilder, type AttributeBuilderState } from "./app.ts";
+    import type { SvelteAppProps } from "@module/sheet/mixin.svelte.ts";
+    import { AttributeBuilder, type AttributeBuilderContext, type AttributeBuilderState } from "./app.ts";
 
-    interface Props {
-        foundryApp: AttributeBuilder;
-        state: AttributeBuilderState;
-    }
-
-    const { foundryApp, state: data }: Props = $props();
+    const { foundryApp, getState }: AttributeBuilderContext & SvelteAppProps<AttributeBuilderContext> = $props();
+    const data = $derived(getState());
 
     const attributeList = [...ATTRIBUTE_ABBREVIATIONS] as const;
 

--- a/src/module/actor/character/apps/formula-picker/app.svelte
+++ b/src/module/actor/character/apps/formula-picker/app.svelte
@@ -1,11 +1,21 @@
 <script lang="ts">
+    import type { SvelteAppProps } from "@module/sheet/mixin.svelte.ts";
     import type { FormulaPickerContext } from "./app.ts";
     import ItemSummary from "@module/sheet/components/item-summary.svelte";
     import ItemTraits from "@module/sheet/components/item-traits.svelte";
     import HoverIconButton from "@module/sheet/components/hover-icon-button.svelte";
     import { sendItemToChat } from "@module/sheet/helpers.ts";
 
-    const { state: data, actor, ability, mode, searchEngine, onSelect, onDeselect }: FormulaPickerContext = $props();
+    const {
+        actor,
+        ability,
+        mode,
+        searchEngine,
+        onSelect,
+        onDeselect,
+        getState,
+    }: FormulaPickerContext & SvelteAppProps<FormulaPickerContext> = $props();
+    const data = $derived(getState());
     const openStates: Record<string, boolean> = $state({});
     let queryText = $state("");
 

--- a/src/module/actor/character/apps/formula-picker/app.ts
+++ b/src/module/actor/character/apps/formula-picker/app.ts
@@ -40,7 +40,7 @@ class FormulaPicker extends SvelteApplicationMixin<
 
     declare options: FormulaPickerConfiguration;
 
-    override root = Root;
+    protected root = Root;
 
     #resolve?: (value: PhysicalItemPF2e | null) => void;
 
@@ -159,19 +159,22 @@ class FormulaPicker extends SvelteApplicationMixin<
     }
 }
 
+interface FormulaPickerState {
+    name: string;
+    resource: ResourceData | null;
+    prompt: string;
+    sections: FormulaSection[];
+}
+
 interface FormulaPickerContext extends SvelteApplicationRenderContext {
+    foundryApp: FormulaPicker;
     actor: ActorPF2e;
     ability: CraftingAbility;
     mode: "craft" | "prepare";
     onSelect: (uuid: ItemUUID) => void;
     onDeselect: (uuid: ItemUUID) => void;
     searchEngine: MiniSearch<Pick<PhysicalItemPF2e, "id" | "name">>;
-    state: {
-        name: string;
-        resource: ResourceData | null;
-        prompt: string;
-        sections: FormulaSection[];
-    };
+    state: FormulaPickerState;
 }
 
 interface FormulaSection {
@@ -196,4 +199,4 @@ interface FormulaViewData {
 }
 
 export { FormulaPicker };
-export type { FormulaPickerContext };
+export type { FormulaPickerContext, FormulaPickerState };

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -17,7 +17,7 @@ import { isContainerCycle } from "@item/container/helpers.ts";
 import { itemIsOfType } from "@item/helpers.ts";
 import { Coins, sizeItemForActor, transferCredits } from "@item/physical/helpers.ts";
 import { COIN_DENOMINATIONS, PHYSICAL_ITEM_TYPES } from "@item/physical/values.ts";
-import { TradeDialog } from "@module/apps/trade-dialog/app.ts";
+import { TradeDialog } from "@module/apps/trade-dialog/app.svelte.ts";
 import { DropCanvasItemData } from "@module/canvas/drop-canvas-data.ts";
 import { createUseActionMessage } from "@module/chat-message/helpers.ts";
 import {

--- a/src/module/apps/compendium-browser/browser.svelte.ts
+++ b/src/module/apps/compendium-browser/browser.svelte.ts
@@ -18,9 +18,11 @@ class CompendiumBrowser extends SvelteApplicationMixin(fa.api.ApplicationV2) {
     /** The amount of rendered result items for initial loading and per load operation */
     static RESULT_LIMIT = 100;
 
-    declare protected $state: CompendiumBrowserState;
+    protected root = App;
 
-    root = App;
+    /** Live UI state. openTab and other external callers mutate it. */
+    activeTabName: ContentTabName | "" = $state("");
+    resultList: HTMLUListElement = $state(document.createElement("ul"));
 
     activeTab: BrowserTab;
     dataTabsList = ["action", "bestiary", "campaignFeature", "equipment", "feat", "hazard", "spell"] as const;
@@ -118,12 +120,7 @@ class CompendiumBrowser extends SvelteApplicationMixin(fa.api.ApplicationV2) {
     }
 
     protected override async _prepareContext(_options: fa.ApplicationRenderOptions): Promise<CompendiumBrowserContext> {
-        return {
-            state: {
-                activeTabName: "",
-                resultList: document.createElement("ul"), // This is required to make the value bindable
-            },
-        };
+        return { foundryApp: this };
     }
 
     #setVisibleTabs(visible?: ContentTabName[]): void {
@@ -138,7 +135,7 @@ class CompendiumBrowser extends SvelteApplicationMixin(fa.api.ApplicationV2) {
 
     resetListElement(): void {
         untrack(() => (this.activeTab.resultLimit = CompendiumBrowser.RESULT_LIMIT));
-        this.$state.resultList?.scrollTo({ top: 0, behavior: "instant" });
+        this.resultList?.scrollTo({ top: 0, behavior: "instant" });
     }
 
     async openTab(tabName: TabName, options?: CompendiumBrowserOpenTabOptions): Promise<void> {
@@ -177,7 +174,7 @@ class CompendiumBrowser extends SvelteApplicationMixin(fa.api.ApplicationV2) {
         } else {
             this.#setVisibleTabs();
         }
-        this.$state.activeTabName = tabName;
+        this.activeTabName = tabName;
 
         this.bringToFront();
     }
@@ -327,19 +324,12 @@ class CompendiumBrowser extends SvelteApplicationMixin(fa.api.ApplicationV2) {
                 await tab.init(true);
             }
         }
-        this.$state.activeTabName = "";
+        this.activeTabName = "";
     }
 }
 
 interface CompendiumBrowserContext extends SvelteApplicationRenderContext {
-    state: CompendiumBrowserState;
-}
-
-interface CompendiumBrowserState {
-    /** Changing this will trigger a tab rerender. An empty string will show the landing page */
-    activeTabName: ContentTabName | "";
-    /** The result list HTML element */
-    resultList: HTMLUListElement;
+    foundryApp: CompendiumBrowser;
 }
 
 type CompendiumBrowserSettings = TabData<Record<string, PackInfo | undefined>>;
@@ -367,5 +357,4 @@ export type {
     CompendiumBrowserOpenTabOptions,
     CompendiumBrowserSettings,
     CompendiumBrowserSources,
-    CompendiumBrowserState,
 };

--- a/src/module/apps/compendium-browser/components/app.svelte
+++ b/src/module/apps/compendium-browser/components/app.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
     import { tupleHasValue } from "@util";
     import BrowserTab from "./browser-tab.svelte";
-    import type { CompendiumBrowserContext } from "../browser.ts";
     import type { MouseEventHandler } from "svelte/elements";
 
     const browser = game.pf2e.compendiumBrowser;
     const tabs = $derived(browser.tabsArray.filter((t) => t.visible));
-    const { state }: CompendiumBrowserContext = $props();
 
     async function onClickNav(event: PointerEvent & { currentTarget: EventTarget }): Promise<void> {
         if (!(event.target instanceof HTMLElement)) return;
@@ -14,7 +12,7 @@
         if (tupleHasValue(browser.dataTabsList, clickedTab)) {
             browser.activeTab = browser.tabs[clickedTab];
             await browser.activeTab.init();
-            state.activeTabName = clickedTab;
+            browser.activeTabName = clickedTab;
         }
     }
 </script>
@@ -25,7 +23,7 @@
             <button
                 type="button"
                 onclick={onClickNav as MouseEventHandler<EventTarget>}
-                class:active={state.activeTabName === tab.tabName}
+                class:active={browser.activeTabName === tab.tabName}
                 data-tab-name={tab.tabName}
             >
                 {tab.label}
@@ -33,12 +31,12 @@
         {/each}
     </nav>
 {/if}
-{#if !state.activeTabName}
+{#if !browser.activeTabName}
     <div class="browser-tab" data-tooltip-class="pf2e">
         <div class="landing-page">{_loc("PF2E.CompendiumBrowser.Hint")}</div>
     </div>
 {:else}
-    <BrowserTab bind:activeTabName={state.activeTabName} {state} />
+    <BrowserTab />
 {/if}
 
 <style lang="scss">

--- a/src/module/apps/compendium-browser/components/browser-tab.svelte
+++ b/src/module/apps/compendium-browser/components/browser-tab.svelte
@@ -1,17 +1,11 @@
 <script lang="ts">
     import Filters from "./filters.svelte";
     import ResultItem from "./result-item.svelte";
-    import { ErrorPF2e } from "@util";
-    import { CompendiumBrowser, type CompendiumBrowserState } from "../browser.ts";
-    import type { ContentTabName } from "../data.ts";
+    import { CompendiumBrowser } from "../browser.svelte.ts";
 
-    type BrowserTabProps = { activeTabName: ContentTabName; state: CompendiumBrowserState };
-
-    const { activeTabName = $bindable(), ...props }: BrowserTabProps = $props();
-    if (!activeTabName) {
-        throw ErrorPF2e(`Invalid tab name: "${activeTabName}"!`);
-    }
     const browser = game.pf2e.compendiumBrowser;
+    // Parent gates rendering on `browser.activeTabName` being non-empty, so the cast is safe.
+    const activeTabName = $derived(browser.activeTabName as Exclude<typeof browser.activeTabName, "">);
     const tab = $derived(browser.tabs[activeTabName]);
 
     function resetFilters(): void {
@@ -19,8 +13,8 @@
     }
 
     function onscroll(): void {
-        if (!activeTabName) return;
-        const resultList = props.state.resultList;
+        if (!browser.activeTabName) return;
+        const resultList = browser.resultList;
         if (resultList.scrollTop + resultList.clientHeight >= resultList.scrollHeight - 5) {
             tab.resultLimit += CompendiumBrowser.RESULT_LIMIT;
         }
@@ -28,7 +22,7 @@
 
     $effect(() => {
         if (tab.isGMOnly && !game.user.isGM) {
-            props.state.activeTabName = "";
+            browser.activeTabName = "";
             console.error("PF2e System | This browser tab is flagged as GM-only!");
         }
     });
@@ -36,7 +30,7 @@
 
 <div class="browser-tab" data-tab-name={activeTabName} data-tooltip-class="pf2e">
     <Filters bind:filter={tab.filterData} {resetFilters} />
-    <ul class="result-list" {onscroll} bind:this={props.state.resultList}>
+    <ul class="result-list" {onscroll} bind:this={browser.resultList}>
         {#each tab.results.slice(0, tab.resultLimit) as entry (entry.uuid)}
             <ResultItem {activeTabName} {entry} />
         {/each}

--- a/src/module/apps/compendium-browser/components/filters/filter-container.svelte
+++ b/src/module/apps/compendium-browser/components/filters/filter-container.svelte
@@ -13,6 +13,8 @@
         label: string;
     }
     const props: Props = $props();
+    // The prop only provides the initial value; this component controls isExpanded after that.
+    // svelte-ignore state_referenced_locally
     let isExpanded = $state(props.isExpanded);
 </script>
 

--- a/src/module/apps/compendium-browser/index.ts
+++ b/src/module/apps/compendium-browser/index.ts
@@ -1,1 +1,1 @@
-export { CompendiumBrowser } from "./browser.ts";
+export { CompendiumBrowser } from "./browser.svelte.ts";

--- a/src/module/apps/compendium-browser/loader.ts
+++ b/src/module/apps/compendium-browser/loader.ts
@@ -2,7 +2,7 @@ import type { CompendiumDocument } from "@client/documents/_module.d.mts";
 import type CompendiumCollection from "@client/documents/collections/compendium-collection.d.mts";
 import type { CompendiumIndexData } from "@client/documents/collections/compendium-collection.d.mts";
 import { localizer, sluggify } from "@util";
-import type { CompendiumBrowserSources } from "./browser.ts";
+import type { CompendiumBrowserSources } from "./browser.svelte.ts";
 
 class PackLoader {
     loadedSources: string[] = [];

--- a/src/module/apps/compendium-browser/tabs/action.ts
+++ b/src/module/apps/compendium-browser/tabs/action.ts
@@ -1,6 +1,6 @@
 import { getActionIcon } from "@module/sheet/helpers.ts";
 import * as R from "remeda";
-import { CompendiumBrowser } from "../browser.ts";
+import { CompendiumBrowser } from "../browser.svelte.ts";
 import { ContentTabName } from "../data.ts";
 import { CompendiumBrowserTab } from "./base.svelte.ts";
 import { ActionFilters, CompendiumBrowserIndexData } from "./data.ts";

--- a/src/module/apps/compendium-browser/tabs/base.svelte.ts
+++ b/src/module/apps/compendium-browser/tabs/base.svelte.ts
@@ -4,7 +4,7 @@ import { Predicate, type PredicateStatement } from "@system/predication.ts";
 import { ErrorPF2e, htmlQuery, sluggify } from "@util";
 import MiniSearch from "minisearch";
 import * as R from "remeda";
-import { CompendiumBrowser, CompendiumBrowserOpenTabOptions } from "../browser.ts";
+import { CompendiumBrowser, CompendiumBrowserOpenTabOptions } from "../browser.svelte.ts";
 import { BrowserTabs, ContentTabName } from "../data.ts";
 import type {
     BrowserFilter,

--- a/src/module/apps/compendium-browser/tabs/bestiary.ts
+++ b/src/module/apps/compendium-browser/tabs/bestiary.ts
@@ -1,4 +1,4 @@
-import { CompendiumBrowser } from "../browser.ts";
+import { CompendiumBrowser } from "../browser.svelte.ts";
 import { ContentTabName } from "../data.ts";
 import { CompendiumBrowserTab } from "./base.svelte.ts";
 import { BestiaryFilters, CompendiumBrowserIndexData } from "./data.ts";

--- a/src/module/apps/compendium-browser/tabs/campaign-feature.ts
+++ b/src/module/apps/compendium-browser/tabs/campaign-feature.ts
@@ -1,5 +1,5 @@
 import { KINGMAKER_CATEGORIES } from "@item/campaign-feature/values.ts";
-import { CompendiumBrowser } from "../browser.ts";
+import { CompendiumBrowser } from "../browser.svelte.ts";
 import { ContentTabName } from "../data.ts";
 import { CompendiumBrowserTab } from "./base.svelte.ts";
 import { CampaignFeatureFilters, CompendiumBrowserIndexData } from "./data.ts";

--- a/src/module/apps/compendium-browser/tabs/equipment.ts
+++ b/src/module/apps/compendium-browser/tabs/equipment.ts
@@ -2,7 +2,7 @@ import { Coins } from "@item/physical/helpers.ts";
 import { PHYSICAL_ITEM_TYPES } from "@item/physical/values.ts";
 import { MAGIC_TRADITIONS } from "@item/spell/values.ts";
 import * as R from "remeda";
-import { CompendiumBrowser } from "../browser.ts";
+import { CompendiumBrowser } from "../browser.svelte.ts";
 import { ContentTabName } from "../data.ts";
 import { CompendiumBrowserTab } from "./base.svelte.ts";
 import { CompendiumBrowserIndexData, EquipmentFilters, RangesInputData } from "./data.ts";

--- a/src/module/apps/compendium-browser/tabs/feat.ts
+++ b/src/module/apps/compendium-browser/tabs/feat.ts
@@ -1,5 +1,5 @@
 import * as R from "remeda";
-import { CompendiumBrowser } from "../browser.ts";
+import { CompendiumBrowser } from "../browser.svelte.ts";
 import { ContentTabName } from "../data.ts";
 import { CompendiumBrowserTab } from "./base.svelte.ts";
 import { CompendiumBrowserIndexData, FeatFilters } from "./data.ts";

--- a/src/module/apps/compendium-browser/tabs/hazard.ts
+++ b/src/module/apps/compendium-browser/tabs/hazard.ts
@@ -1,4 +1,4 @@
-import { CompendiumBrowser } from "../browser.ts";
+import { CompendiumBrowser } from "../browser.svelte.ts";
 import { ContentTabName } from "../data.ts";
 import { CompendiumBrowserTab } from "./base.svelte.ts";
 import { CompendiumBrowserIndexData, HazardFilters } from "./data.ts";

--- a/src/module/apps/compendium-browser/tabs/spell.ts
+++ b/src/module/apps/compendium-browser/tabs/spell.ts
@@ -1,7 +1,7 @@
 import { MAGIC_TRADITIONS } from "@item/spell/values.ts";
 import { getActionGlyph, ordinalString, sluggify } from "@util";
 import * as R from "remeda";
-import { CompendiumBrowser } from "../browser.ts";
+import { CompendiumBrowser } from "../browser.svelte.ts";
 import type { ContentTabName } from "../data.ts";
 import { CompendiumBrowserTab } from "./base.svelte.ts";
 import type { CompendiumBrowserIndexData, SpellFilters } from "./data.ts";

--- a/src/module/apps/pick-a-thing-prompt/app.svelte
+++ b/src/module/apps/pick-a-thing-prompt/app.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import SvelectePf2e from "@module/sheet/components/svelecte-pf2e.svelte";
+    import type { SvelteAppProps } from "@module/sheet/mixin.svelte.ts";
     import type { PickableThing, PickAThingRenderContext } from "./app.ts";
     import { UUIDUtils } from "@util/uuid.ts";
     import { ItemPF2e } from "@item";
@@ -7,7 +8,13 @@
     import { sluggify } from "@util/misc.ts";
     import * as R from "remeda";
 
-    const { state: data, updateSelection, resolve, testAllowedDrop }: PickAThingRenderContext = $props();
+    const {
+        getState,
+        updateSelection,
+        resolve,
+        testAllowedDrop,
+    }: PickAThingRenderContext & SvelteAppProps<PickAThingRenderContext> = $props();
+    const data = $derived(getState());
     const { containsItems, selectMenu, allowNoSelection, includeDropZone } = $derived(data);
     let droppedOption: PickableThing | null = $state(null);
 

--- a/src/module/apps/pick-a-thing-prompt/app.ts
+++ b/src/module/apps/pick-a-thing-prompt/app.ts
@@ -24,7 +24,7 @@ class PickAThingPrompt<TThing extends string | number | object> extends SvelteAp
         },
     };
 
-    override root = Root;
+    protected root = Root;
 
     #resolve?: (value: PickableThing<TThing> | null) => void;
 
@@ -122,21 +122,24 @@ interface PickableThing<T extends string | number | object = string | number | o
     group?: string;
 }
 
+interface PickAThingState<T extends string | number | object = string | number | object> {
+    prompt: string;
+    includeDropZone: boolean;
+    allowNoSelection: boolean;
+    selectMenu: boolean;
+    containsItems: boolean;
+    choices: PickableThing<T>[];
+}
+
 interface PickAThingRenderContext<
     T extends string | number | object = string | number | object,
 > extends SvelteApplicationRenderContext {
+    foundryApp: PickAThingPrompt<T>;
     updateSelection: (option: PickableThing<T> | null) => void;
     resolve: (option: PickableThing<T> | null) => void;
     testAllowedDrop: (option: ItemPF2e) => boolean;
-    state: {
-        prompt: string;
-        includeDropZone: boolean;
-        allowNoSelection: boolean;
-        selectMenu: boolean;
-        containsItems: boolean;
-        choices: PickableThing<T>[];
-    };
+    state: PickAThingState<T>;
 }
 
 export { PickAThingPrompt };
-export type { PickableThing, PickAThingRenderContext };
+export type { PickableThing, PickAThingRenderContext, PickAThingState };

--- a/src/module/apps/roll-inspector/app.svelte
+++ b/src/module/apps/roll-inspector/app.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
     import { DamageDicePF2e, Modifier } from "@actor/modifiers.ts";
+    import type { SvelteAppProps } from "@module/sheet/mixin.svelte.ts";
     import type { RollInspectorContext } from "./app.ts";
     import * as R from "remeda";
     import { createHTMLElement, signedInteger } from "@util";
     import { getDamageDiceOverrideLabel, getDamageDiceValueLabel } from "@system/damage/helpers.ts";
 
     const localize = game.i18n.localize.bind(game.i18n);
-    const { state: data }: RollInspectorContext = $props();
+    const { getState }: SvelteAppProps<RollInspectorContext> = $props();
+    const data = $derived(getState());
     let searchTerm = $state("");
 
     const context = $derived(data.context);

--- a/src/module/apps/roll-inspector/app.ts
+++ b/src/module/apps/roll-inspector/app.ts
@@ -19,7 +19,7 @@ class RollInspector extends SvelteApplicationMixin(fa.api.ApplicationV2) {
         },
     };
 
-    protected override root = Root;
+    protected root = Root;
 
     message: ChatMessagePF2e;
 
@@ -70,4 +70,4 @@ interface RollInspectorState {
 }
 
 export { RollInspector };
-export type { RollInspectorContext };
+export type { RollInspectorContext, RollInspectorState };

--- a/src/module/apps/sidebar/actor-directory.ts
+++ b/src/module/apps/sidebar/actor-directory.ts
@@ -9,7 +9,7 @@ import type { DropCanvasData } from "@client/helpers/hooks.d.mts";
 import type { ActorUUID } from "@common/documents/_module.d.mts";
 import { htmlClosest, htmlQueryAll } from "@util";
 import * as R from "remeda";
-import { TradeDialog, TradeRequestData } from "../trade-dialog/app.ts";
+import { TradeDialog, TradeRequestData } from "../trade-dialog/app.svelte.ts";
 
 /** Extend ActorDirectory to show more information */
 class ActorDirectoryPF2e extends fa.sidebar.tabs.ActorDirectory<ActorPF2e<null>> {

--- a/src/module/apps/trade-dialog/app.svelte
+++ b/src/module/apps/trade-dialog/app.svelte
@@ -1,35 +1,44 @@
 <script lang="ts">
     import { ErrorPF2e } from "@util";
-    import type { TradeQueryData, TradeDialogRenderContext, TradeItemData } from "./app.ts";
+    import type { SvelteAppProps } from "@module/sheet/mixin.svelte.ts";
+    import type { TradeDialogRenderContext, TradeQueryData, TradeItemData } from "./app.svelte.ts";
 
-    const { state: data, foundryApp: dialog, traderUser, searchEngine, localize }: TradeDialogRenderContext = $props();
-    const { self, trader } = data;
-    const portraitAlt = {
-        self: localize("ImgAlt.Actor", { actor: self.actor.name, user: localize("You") }),
-        trader: localize("ImgAlt.Actor", { actor: trader.actor.name, user: traderUser.name }),
-    };
+    const {
+        foundryApp: dialog,
+        traderUser,
+        searchEngine,
+        localize,
+        getState,
+    }: TradeDialogRenderContext & SvelteAppProps<TradeDialogRenderContext> = $props();
+    const data = $derived(getState());
+    const selfActor = $derived(data.selfActor);
+    const traderActor = $derived(data.traderActor);
+    const portraitAlt = $derived({
+        self: localize("ImgAlt.Actor", { actor: selfActor.name, user: localize("You") }),
+        trader: localize("ImgAlt.Actor", { actor: traderActor.name, user: traderUser.name }),
+    });
 
     // Item lists and summaries
     const listFormatter = game.i18n.getListFormatter({ style: "narrow" });
-    const selfItems = $derived(
-        self.items
+    const selfItemsVisible = $derived(
+        dialog.selfItems
             .filter((i) => i.matchScore > 0)
             .sort((a, b) => b.matchScore - a.matchScore || a.name.localeCompare(b.name, game.i18n.lang)),
     );
     const withQuantity = (i: { quantity: number; marked: number; name: string }) =>
         i.quantity > 1 ? `${i.marked}x ${i.name}` : i.name;
     const itemsToSend = $derived.by(() => {
-        const list = listFormatter.format(selfItems.filter((i) => i.marked > 0).map((i) => withQuantity(i)));
+        const list = listFormatter.format(selfItemsVisible.filter((i) => i.marked > 0).map((i) => withQuantity(i)));
         return list.length > 0 ? localize("Sending", { list }) : "";
     });
 
-    const traderItems = $derived(
-        trader.items
+    const traderItemsVisible = $derived(
+        dialog.traderItems
             .filter((i) => i.visible || i.marked)
             .sort((a, b) => Number(b.marked > 0) - Number(a.marked > 0) || a.name.localeCompare(b.name)),
     );
     const itemsToReceive = $derived.by(() => {
-        const list = listFormatter.format(traderItems.filter((i) => i.marked > 0).map((i) => withQuantity(i)));
+        const list = listFormatter.format(traderItemsVisible.filter((i) => i.marked > 0).map((i) => withQuantity(i)));
         return list.length > 0 ? localize("Receiving", { list }) : "";
     });
 
@@ -47,15 +56,15 @@
     }
 
     function toggleAccepted(): void {
-        self.accepted = !self.accepted;
+        dialog.selfAccepted = !dialog.selfAccepted;
         const marked = Object.fromEntries(
-            self.items
+            dialog.selfItems
                 .values()
                 .filter((i) => i.marked > 0)
                 .map((i) => [i.id, i.marked]),
         );
-        if (self.accepted && trader.accepted) dialog.close({ success: true });
-        sendQuery({ action: "update", marked, accepted: self.accepted });
+        if (dialog.selfAccepted && dialog.traderAccepted) dialog.close({ success: true });
+        sendQuery({ action: "update", marked, accepted: dialog.selfAccepted });
     }
 
     function search(event: Event): void {
@@ -63,7 +72,7 @@
         const searchText = event.target.value.trim();
         const results = new Map(searchEngine.search(searchText).map((r) => [r.id, r.score]));
         const fallbackScore = results.size > 0 ? 0 : 1;
-        for (const item of self.items) {
+        for (const item of dialog.selfItems) {
             item.matchScore = results.get(item.id) ?? fallbackScore;
         }
     }
@@ -78,7 +87,7 @@
         }
     }
 
-    function focusQuantityInput(event: PointerEvent & { currentTarget: HTMLSpanElement }): void {
+    function focusQuantityInput(event: PointerEvent & { currentTarget: HTMLDivElement }): void {
         const input = event.currentTarget.querySelector("input");
         input?.focus();
     }
@@ -97,7 +106,7 @@
         if (quantity !== item.marked) {
             item.marked = quantity;
             const newMarks = Object.fromEntries(
-                self.items
+                dialog.selfItems
                     .values()
                     .filter((i) => i.marked > 0)
                     .map((i) => [i.id, i.marked]),
@@ -117,7 +126,7 @@
         const multiplier = event[ctrlKey] && event.shiftKey ? 50 : event[ctrlKey] ? 10 : event.shiftKey ? 5 : 1;
         item.marked = Math.clamp(item.marked + Number(button.value) * multiplier, 0, item.quantity);
         const newMarks = Object.fromEntries(
-            self.items
+            dialog.selfItems
                 .values()
                 .filter((i) => i.marked > 0)
                 .map((i) => [i.id, i.marked]),
@@ -130,39 +139,44 @@
 <div class="content standard-form" data-tooltip-class="pf2e">
     <section class="panel self flexcol">
         <header class="flexrow">
-            <img src={self.actor.img} alt={portraitAlt.self} />
+            <img src={selfActor.img} alt={portraitAlt.self} />
             <div class="name flexcol">
-                <span class="actor">{self.actor.name}</span>
+                <span class="actor">{selfActor.name}</span>
                 <span class="user">({localize("You")})</span>
             </div>
             <button
                 type="button"
                 id="{dialog.id}-self-accepted"
                 class="toggle-accepted"
-                class:accepted={self.accepted}
+                class:accepted={dialog.selfAccepted}
                 data-tooltip
-                aria-label={self.accepted ? localize("Acceptance.Rescind") : localize("Acceptance.Accept")}
+                aria-label={dialog.selfAccepted ? localize("Acceptance.Rescind") : localize("Acceptance.Accept")}
                 onclick={toggleAccepted}
             >
-                <i class="fa-solid fa-check"></i>
+                <i class="fa-solid fa-{dialog.selfAccepted ? 'check' : 'xmark'}"></i>
             </button>
         </header>
         <div class="flexrow search">
             <input type="search" id="{dialog.id}-search" placeholder="&#xf002;" aria-label="Search" oninput={search} />
         </div>
         <ul class="flexcol scrollable">
-            {#each selfItems as item (item.id)}
+            {#each selfItemsVisible as item (item.id)}
                 <li class="flexrow" class:marked={item.marked}>
                     <img src={item.img} alt={localize("ImgAlt.Item", { item: item.name })} />
                     <span class="name">{item.name}</span>
-                    <span class="quantity flexrow" role="button" onpointerup={focusQuantityInput}>
+                    <div
+                        class="quantity flexrow"
+                        role="group"
+                        aria-label={localize("Quantity.Label", { item: item.name })}
+                        onpointerup={focusQuantityInput}
+                    >
                         <button
                             type="button"
                             id="{dialog.id}-{item.id}-decrement"
                             class="icon fa-solid fa-left"
                             value="-1"
                             tabindex="-1"
-                            disabled={item.marked === 0 || trader.accepted}
+                            disabled={item.marked === 0 || dialog.traderAccepted}
                             onclick={(e) => updateTradeQuantity(item, e)}
                             aria-label={localize("Quantity.Decrement", { item: item.name })}
                         ></button>
@@ -189,11 +203,11 @@
                             class="icon fa-solid fa-right"
                             value="1"
                             tabindex="-1"
-                            disabled={item.marked === item.quantity || trader.accepted}
+                            disabled={item.marked === item.quantity || dialog.traderAccepted}
                             onclick={(e) => updateTradeQuantity(item, e)}
                             aria-label={localize("Quantity.Increment", { item: item.name })}
                         ></button>
-                    </span>
+                    </div>
                 </li>
             {/each}
         </ul>
@@ -206,20 +220,22 @@
         <header class="flexrow">
             <div
                 class="toggle-accepted"
-                class:accepted={trader.accepted}
+                class:accepted={dialog.traderAccepted}
                 data-tooltip
-                aria-label={localize(`Acceptance.${trader.accepted ? "" : "Not"}Accepted`, { user: traderUser.name })}
+                aria-label={localize(`Acceptance.${dialog.traderAccepted ? "" : "Not"}Accepted`, {
+                    user: traderUser.name,
+                })}
             >
-                <i class="fa-solid fa-{trader.accepted ? 'check accepted' : 'xmark'}"></i>
+                <i class="fa-solid fa-{dialog.traderAccepted ? 'check accepted' : 'xmark'}"></i>
             </div>
             <div class="name flexcol">
-                <span class="actor">{trader.actor.name}</span>
+                <span class="actor">{traderActor.name}</span>
                 <span class="user">({traderUser.name})</span>
             </div>
-            <img src={trader.actor.img} alt={portraitAlt.trader} />
+            <img src={traderActor.img} alt={portraitAlt.trader} />
         </header>
         <ul class="scrollable" tabindex="-1">
-            {#each traderItems as item (item.id)}
+            {#each traderItemsVisible as item (item.id)}
                 {#if item.visible}
                     <li class="flexrow" class:marked={item.marked > 0} data-item-id={item.id}>
                         <img src={item.img} alt={localize("ImgAlt.Item", { item: item.name })} />

--- a/src/module/apps/trade-dialog/app.svelte.ts
+++ b/src/module/apps/trade-dialog/app.svelte.ts
@@ -43,7 +43,20 @@ class TradeDialog extends SvelteApplicationMixin(fa.api.ApplicationV2) {
 
     protected root = Root;
 
-    declare protected $state: TradeDialogState;
+    /** Typed $state accessor for #setGiftData. */
+    protected override get $state(): TradeDialogState {
+        return super.$state as TradeDialogState;
+    }
+
+    protected override set $state(value: TradeDialogState) {
+        super.$state = value;
+    }
+
+    /** Live trade state. Mutated by both the component and #onUpdate. */
+    selfItems: TradeItemData[] = $state([]);
+    traderItems: TradeItemData[] = $state([]);
+    selfAccepted = $state(false);
+    traderAccepted = $state(false);
 
     /** The present user's side of the trade */
     #self: {
@@ -209,7 +222,9 @@ class TradeDialog extends SvelteApplicationMixin(fa.api.ApplicationV2) {
         const context = await super._prepareContext(options);
         const self = this.#self;
         const trader = this.#trader;
-        const selfItems = this.#prepareItems(self, this.$state.self?.items ?? []);
+        // Rebuild items, preserving previously-marked counts via the live arrays.
+        this.selfItems = this.#prepareItems(self, this.selfItems);
+        this.traderItems = this.#prepareItems(trader, this.traderItems);
         const wordSegmenter =
             "Segmenter" in Intl
                 ? new Intl.Segmenter(game.i18n.lang, { granularity: "word" })
@@ -233,22 +248,14 @@ class TradeDialog extends SvelteApplicationMixin(fa.api.ApplicationV2) {
             searchOptions: { combineWith: "AND", prefix: true },
             storeFields: ["id", "name"],
         });
-        searchEngine.addAll([...selfItems]);
+        searchEngine.addAll([...this.selfItems]);
         return Object.assign(context, {
             state: {
-                self: {
-                    actor: R.pick(self.actor, ["id", "img", "name"]),
-                    items: selfItems,
-                    accepted: false,
-                },
-                trader: {
-                    actor: {
-                        id: trader.actor.id,
-                        img: trader.actor.img,
-                        name: TradeDialog.#getObfuscatedActorName(trader.actor),
-                    },
-                    items: this.#prepareItems(trader, this.$state.trader?.items ?? []),
-                    accepted: false,
+                selfActor: R.pick(self.actor, ["id", "img", "name"]),
+                traderActor: {
+                    id: trader.actor.id,
+                    img: trader.actor.img,
+                    name: TradeDialog.#getObfuscatedActorName(trader.actor),
                 },
             },
             foundryApp: this,
@@ -283,16 +290,15 @@ class TradeDialog extends SvelteApplicationMixin(fa.api.ApplicationV2) {
 
     /** Create, update and/or delete items following a successful trade. */
     async #transact(): Promise<void> {
-        const state = this.$state;
         const selfActor = this.#self.actor;
-        if (!state.trader.accepted) throw ErrorPF2e(`${this.#trader.user.name} hasn't accepted the trade`);
+        if (!this.traderAccepted) throw ErrorPF2e(`${this.#trader.user.name} hasn't accepted the trade`);
         const receivedQuantities = R.mapToObj(
-            state.trader.items.filter((i) => i.marked > 0),
+            this.traderItems.filter((i) => i.marked > 0),
             (i) => [i.id, i.marked],
         );
 
         // Deletions
-        const toDelete = state.self.items.filter((i) => i.marked === i.quantity).map((i) => i.id);
+        const toDelete = this.selfItems.filter((i) => i.marked === i.quantity).map((i) => i.id);
         await selfActor.deleteEmbeddedDocuments("Item", toDelete, { render: false });
 
         // Creations and/or quantity increases)
@@ -307,7 +313,7 @@ class TradeDialog extends SvelteApplicationMixin(fa.api.ApplicationV2) {
         await selfActor.inventory.add(toReceive, { stack: true, render: false });
 
         // Quantity deductions
-        const toUpdate = state.self.items
+        const toUpdate = this.selfItems
             .filter((i) => selfActor.inventory.has(i.id) && i.marked > 0 && i.marked < i.quantity)
             .map((i) => {
                 const quantity = Math.max(0, (selfActor.inventory.get(i.id)?.quantity ?? i.quantity) - i.marked);
@@ -319,32 +325,28 @@ class TradeDialog extends SvelteApplicationMixin(fa.api.ApplicationV2) {
         selfActor.render();
     }
 
-    /** Create a state object with gift data, to be used in lieu of data created during dialog render. */
+    /** Replace live trade data with gift-only data, used in lieu of data created during dialog render. */
     #setGiftData(): void {
         if (!this.#self.gift && !this.#trader.gift) {
             throw ErrorPF2e("Cannot perform gift transaction: nothing marked for gifting");
         }
         const traderActor = this.#trader.actor;
         this.$state = {
-            self: {
-                actor: R.pick(this.#self.actor, ["id", "img", "name"]),
-                items: [this.#self.actor.inventory.get(this.#self.initialMarked ?? "")]
-                    .filter(R.isDefined)
-                    .map((i) => this.#itemToData(i, this.#self.gift)),
-                accepted: true,
-            },
-            trader: {
-                actor: {
-                    id: traderActor.id,
-                    img: traderActor.img,
-                    name: TradeDialog.#getObfuscatedActorName(traderActor),
-                },
-                items: [traderActor.inventory.get(this.#trader.initialMarked ?? "")]
-                    .filter(R.isDefined)
-                    .map((i) => this.#itemToData(i, this.#trader.gift)),
-                accepted: true,
+            selfActor: R.pick(this.#self.actor, ["id", "img", "name"]),
+            traderActor: {
+                id: traderActor.id,
+                img: traderActor.img,
+                name: TradeDialog.#getObfuscatedActorName(traderActor),
             },
         };
+        this.selfItems = [this.#self.actor.inventory.get(this.#self.initialMarked ?? "")]
+            .filter(R.isDefined)
+            .map((i) => this.#itemToData(i, this.#self.gift));
+        this.traderItems = [traderActor.inventory.get(this.#trader.initialMarked ?? "")]
+            .filter(R.isDefined)
+            .map((i) => this.#itemToData(i, this.#trader.gift));
+        this.selfAccepted = true;
+        this.traderAccepted = true;
     }
 
     /** Create and send an appropriate notification upon successful conclusion of a trade. */
@@ -369,8 +371,8 @@ class TradeDialog extends SvelteApplicationMixin(fa.api.ApplicationV2) {
         const self = this.#self;
         const trader = this.#trader;
         if (!self.initiator || !itemsExchanged || !self.actor.combatant?.combat.started) return;
-        const receivedItems = !self.gift && this.$state.trader.items.some((i) => i.marked);
-        const mutualExchange = receivedItems && !trader.gift && this.$state.self.items.some((i) => i.marked);
+        const receivedItems = !self.gift && this.traderItems.some((i) => i.marked);
+        const mutualExchange = receivedItems && !trader.gift && this.selfItems.some((i) => i.marked);
         const annotationKey = mutualExchange ? "ExchangeItems" : "GiveItem";
         const subtitle = `PF2E.Actions.Interact.${annotationKey}.Title`;
         const flavorData = {
@@ -384,8 +386,8 @@ class TradeDialog extends SvelteApplicationMixin(fa.api.ApplicationV2) {
         const itemExchanged = mutualExchange
             ? null
             : receivedItems
-              ? trader.actor.inventory.get(this.$state.trader.items.find((i) => i.marked)?.id ?? "")
-              : self.actor.inventory.get(this.$state.self.items.find((i) => i.marked)?.id ?? "");
+              ? trader.actor.inventory.get(this.traderItems.find((i) => i.marked)?.id ?? "")
+              : self.actor.inventory.get(this.selfItems.find((i) => i.marked)?.id ?? "");
         const flavor = await fa.handlebars.renderTemplate(templates.flavor, flavorData);
         const speakerActor = receivedItems && !mutualExchange ? trader.actor : self.actor;
         const speaker = ChatMessagePF2e.getSpeaker({
@@ -413,8 +415,7 @@ class TradeDialog extends SvelteApplicationMixin(fa.api.ApplicationV2) {
     override async close(options: TradeDialogClosingOptions = {}): Promise<this> {
         if (options.success) {
             if (this.#self.gift || this.#trader.gift) this.#setGiftData();
-            const itemsExchanged =
-                this.$state.self.items.some((i) => i.marked) || this.$state.trader.items.some((i) => i.marked);
+            const itemsExchanged = this.selfItems.some((i) => i.marked) || this.traderItems.some((i) => i.marked);
             this.#notifySuccess(itemsExchanged);
             await this.#postMessage(itemsExchanged);
             this.#transact();
@@ -528,16 +529,13 @@ class TradeDialog extends SvelteApplicationMixin(fa.api.ApplicationV2) {
 
     /** Handle a trade-update query from another user. */
     async #onUpdate(data: UpdateQueryData): Promise<TradeQueryResponse> {
-        const trader = this.$state.trader;
-        if (typeof data.accepted === "boolean") trader.accepted = data.accepted;
+        if (typeof data.accepted === "boolean") this.traderAccepted = data.accepted;
         if (data.marked) {
-            for (let i = 0; i < trader.items.length; i++) {
-                const itemData = trader.items[i];
-                const itemId = itemData.id;
-                itemData.marked = data.marked[itemId] ?? 0;
+            for (const item of this.traderItems) {
+                item.marked = data.marked[item.id] ?? 0;
             }
         }
-        if (data.accepted && this.$state.self.accepted) this.close({ success: true });
+        if (data.accepted && this.selfAccepted) this.close({ success: true });
         return { ok: true };
     }
 
@@ -581,17 +579,10 @@ interface TradeRequestData extends MaybeTradeInitiationData {
     trader: { actor: TradeActor; user: UserPF2e };
 }
 
+/** Render-derived state only. Live data (items, accepted flags) lives on the app. */
 interface TradeDialogState {
-    self: {
-        actor: Pick<ActorPF2e, "id" | "name" | "img">;
-        items: TradeItemData[];
-        accepted: boolean;
-    };
-    trader: {
-        actor: Pick<ActorPF2e, "id" | "name" | "img">;
-        items: TradeItemData[];
-        accepted: boolean;
-    };
+    selfActor: Pick<ActorPF2e, "id" | "name" | "img">;
+    traderActor: Pick<ActorPF2e, "id" | "name" | "img">;
 }
 
 interface TradeDialogRenderContext extends SvelteApplicationRenderContext {
@@ -638,4 +629,11 @@ interface TradeDialogClosingOptions extends fa.ApplicationClosingOptions {
 }
 
 export { TradeDialog };
-export type { TradeDialogRenderContext, TradeItemData, TradeQueryData, TradeQueryResponse, TradeRequestData };
+export type {
+    TradeDialogRenderContext,
+    TradeDialogState,
+    TradeItemData,
+    TradeQueryData,
+    TradeQueryResponse,
+    TradeRequestData,
+};

--- a/src/module/item/consumable/apps/spellcasting-item-creator/app.svelte
+++ b/src/module/item/consumable/apps/spellcasting-item-creator/app.svelte
@@ -3,10 +3,13 @@
     import { localizer, objectHasKey, ordinalString } from "@util";
     import { UUIDUtils } from "@util/uuid.ts";
     import * as R from "remeda";
+    import type { SvelteAppProps } from "@module/sheet/mixin.svelte.ts";
     import type { CreateSpellConsumableContext } from "./app.ts";
     const localize = localizer("PF2E.SpellcastingItemCreator");
 
-    const { foundryApp, state: data }: CreateSpellConsumableContext = $props();
+    const { foundryApp, getState }: CreateSpellConsumableContext & SvelteAppProps<CreateSpellConsumableContext> =
+        $props();
+    const data = $derived(getState());
     const { name, isCantrip, minimumRank, initialMystified } = $derived(data);
     let type = $state();
     let rank = $state();

--- a/src/module/item/consumable/apps/spellcasting-item-creator/app.ts
+++ b/src/module/item/consumable/apps/spellcasting-item-creator/app.ts
@@ -26,7 +26,7 @@ class SpellcastingItemCreator extends SvelteApplicationMixin(fapi.ApplicationV2)
         },
     };
 
-    override root = Root;
+    protected root = Root;
 
     #actor: ActorPF2e;
 
@@ -87,15 +87,17 @@ interface CreateSpellConsumableConfiguration extends DeepPartial<fa.ApplicationC
     mystified?: boolean;
 }
 
+interface CreateSpellConsumableState {
+    name: string;
+    isCantrip: boolean;
+    minimumRank: number;
+    initialMystified: boolean;
+}
+
 interface CreateSpellConsumableContext extends SvelteApplicationRenderContext {
     foundryApp: SpellcastingItemCreator;
-    state: {
-        name: string;
-        isCantrip: boolean;
-        minimumRank: number;
-        initialMystified: boolean;
-    };
+    state: CreateSpellConsumableState;
 }
 
 export { SpellcastingItemCreator };
-export type { CreateSpellConsumableContext };
+export type { CreateSpellConsumableContext, CreateSpellConsumableState };

--- a/src/module/item/weapon/apps/weapon-reloader/app.svelte
+++ b/src/module/item/weapon/apps/weapon-reloader/app.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
     import ItemTraits from "@module/sheet/components/item-traits.svelte";
+    import type { SvelteAppProps } from "@module/sheet/mixin.svelte.ts";
     import type { ReloadWeaponContext } from "./app.ts";
     import ItemSummary from "@module/sheet/components/item-summary.svelte";
     import HeavyBullets from "../../../../../../static/assets/icons/heavy-bullets.svg?raw";
-    const { state: data, foundryApp }: ReloadWeaponContext = $props();
+    const { foundryApp, getState }: ReloadWeaponContext & SvelteAppProps<ReloadWeaponContext> = $props();
+    const data = $derived(getState());
     const openStates: Record<string, boolean> = $state({});
 </script>
 

--- a/src/module/item/weapon/apps/weapon-reloader/app.ts
+++ b/src/module/item/weapon/apps/weapon-reloader/app.ts
@@ -36,7 +36,7 @@ class WeaponReloader extends SvelteApplicationMixin<
 
     declare options: WeaponReloaderConfiguration;
 
-    override root = Root;
+    protected root = Root;
 
     #closeSignal = new AbortController();
 
@@ -202,13 +202,15 @@ class WeaponReloader extends SvelteApplicationMixin<
     }
 }
 
+interface ReloadWeaponState {
+    loaded: ValueAndMax;
+    weapon: BasePhysicalItemViewData;
+    compatible: AmmoChoiceViewData[];
+}
+
 interface ReloadWeaponContext extends SvelteApplicationRenderContext {
     foundryApp: WeaponReloader;
-    state: {
-        loaded: ValueAndMax;
-        weapon: BasePhysicalItemViewData;
-        compatible: AmmoChoiceViewData[];
-    };
+    state: ReloadWeaponState;
 }
 
 interface AmmoChoiceViewData extends BasePhysicalItemViewData {
@@ -218,4 +220,4 @@ interface AmmoChoiceViewData extends BasePhysicalItemViewData {
 }
 
 export { WeaponReloader };
-export type { ReloadWeaponContext };
+export type { ReloadWeaponContext, ReloadWeaponState };

--- a/src/module/sheet/mixin.svelte.ts
+++ b/src/module/sheet/mixin.svelte.ts
@@ -1,10 +1,26 @@
 import * as svelte from "svelte";
 
 interface SvelteApplicationRenderContext extends fa.ApplicationRenderContext {
-    /** State data tracked by the root component: objects herein must be plain object. */
-    state: object;
+    /**
+     * Render-derived data. The mixin replaces this wholesale on every render, so
+     * it MUST NOT be mutated from TypeScript. Anything user- or peer-mutated
+     * belongs on instance-level $state (declared in a .svelte.ts file) instead.
+     * Optional: omit entirely if all live state lives on the app instance.
+     */
+    state?: object;
     /** This application instance */
     foundryApp?: SvelteApplication;
+}
+
+/**
+ * Mixin-injected props. Combine with the context type at the call site:
+ *   const { ... }: MyContext & SvelteAppProps<MyContext> = $props();
+ * Don't inline the intersection into this type. That triggers a recursive type cycle
+ * through `foundryApp: MyApp` for every app.
+ */
+interface SvelteAppProps<TContext extends SvelteApplicationRenderContext = SvelteApplicationRenderContext> {
+    /** Returns the current state object. Call inside a $derived to track replacement. */
+    getState: () => TContext["state"];
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
@@ -21,8 +37,23 @@ function SvelteApplicationMixin<
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         protected abstract root: svelte.Component<any>;
 
-        /** State data tracked by the root component */
-        protected $state: object = $state({});
+        /**
+         * Reactive slot for the render-derived state object. $state.raw means the
+         * SLOT is reactive (reassigning it fires signals), but the value inside
+         * is treated as immutable. This enforces the contract: anyone mutating
+         * this.$state.foo = bar will see the write succeed but no reactivity
+         * fire, which is the desired behavior to push that state to a different
+         * surface (component-local $state or instance-level $state).
+         */
+        #state: object = $state.raw({});
+
+        protected get $state(): object {
+            return this.#state;
+        }
+
+        protected set $state(value: object) {
+            this.#state = value;
+        }
 
         /** The mounted root component, saved to be unmounted on application close */
         #mount: object = {};
@@ -42,9 +73,14 @@ function SvelteApplicationMixin<
             content: HTMLElement,
             options: fa.ApplicationRenderOptions,
         ): void {
-            Object.assign(this.$state, result.state);
+            // Wholesale-replace the state object. Components read it via the
+            // getState prop inside a $derived so they pick up the new value.
+            this.$state = result.state ?? {};
             if (options.isFirstRender) {
-                this.#mount = svelte.mount(this.root, { target: content, props: { ...result, state: this.$state } });
+                this.#mount = svelte.mount(this.root, {
+                    target: content,
+                    props: { ...result, getState: (): object => this.$state },
+                });
             }
         }
 
@@ -59,4 +95,5 @@ function SvelteApplicationMixin<
 
 type SvelteApplication = InstanceType<ReturnType<typeof SvelteApplicationMixin>>;
 
-export { SvelteApplicationMixin, type SvelteApplicationRenderContext };
+export { SvelteApplicationMixin };
+export type { SvelteAppProps, SvelteApplicationRenderContext };

--- a/src/module/system/action-macros/crafting/select-item.svelte
+++ b/src/module/system/action-macros/crafting/select-item.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
     import type { DropCanvasItemData } from "@module/canvas/drop-canvas-data.ts";
     import { ItemPF2e, type PhysicalItemPF2e } from "@item";
+    import type { SvelteAppProps } from "@module/sheet/mixin.svelte.ts";
     import type { SelectItemRenderContext } from "./select-item.ts";
     import { sluggify } from "@util";
 
-    const { state: data, resolve }: SelectItemRenderContext = $props();
+    const { resolve, getState }: SelectItemRenderContext & SvelteAppProps<SelectItemRenderContext> = $props();
+    const data = $derived(getState());
 
     let selection: PhysicalItemPF2e | null = $state(null);
 

--- a/src/module/system/action-macros/crafting/select-item.ts
+++ b/src/module/system/action-macros/crafting/select-item.ts
@@ -28,9 +28,7 @@ class SelectItemDialog extends SvelteApplicationMixin(fa.api.ApplicationV2) {
         },
     };
 
-    override root = Root;
-
-    declare protected $state: SelectItemState;
+    protected root = Root;
 
     override get title(): string {
         const key = sluggify(this.#action, { camel: "bactrian" });
@@ -80,4 +78,4 @@ interface SelectItemRenderContext extends SvelteApplicationRenderContext {
 }
 
 export { SelectItemDialog };
-export type { ItemAction, SelectItemRenderContext };
+export type { ItemAction, SelectItemRenderContext, SelectItemState };

--- a/src/module/user/document.ts
+++ b/src/module/user/document.ts
@@ -1,7 +1,7 @@
 import type { ActorPF2e } from "@actor";
 import type UserTargets from "@client/canvas/placeables/tokens/targets.d.mts";
 import type { DatabaseUpdateCallbackOptions } from "@common/abstract/_types.d.mts";
-import type { TradeQueryData, TradeQueryResponse } from "@module/apps/trade-dialog/app.ts";
+import type { TradeQueryData, TradeQueryResponse } from "@module/apps/trade-dialog/app.svelte.ts";
 import type { TokenPF2e } from "@module/canvas/index.ts";
 import type { ScenePF2e, TokenDocumentPF2e } from "@scene";
 import * as R from "remeda";

--- a/src/scripts/hooks/load.ts
+++ b/src/scripts/hooks/load.ts
@@ -21,7 +21,7 @@ import { KitSystemData } from "@item/kit/data.ts";
 import { MeleeSystemData } from "@item/melee/data.ts";
 import { TreasureSystemData } from "@item/treasure/data.ts";
 import { ActiveEffectPF2e } from "@module/active-effect.ts";
-import { TradeDialog } from "@module/apps/trade-dialog/app.ts";
+import { TradeDialog } from "@module/apps/trade-dialog/app.svelte.ts";
 import { DoorControlPF2e } from "@module/canvas/door-control.ts";
 import { EnvironmentCanvasGroupPF2e } from "@module/canvas/group/environment.ts";
 import {

--- a/src/scripts/set-game-pf2e.ts
+++ b/src/scripts/set-game-pf2e.ts
@@ -4,7 +4,7 @@ import { ElementalBlast } from "@actor/character/elemental-blast.ts";
 import { CheckModifier, Modifier, StatisticModifier } from "@actor/modifiers.ts";
 import { Coins, generateItemName } from "@item/physical/helpers.ts";
 import { checkPrompt } from "@module/apps/check-prompt-generator.ts";
-import { CompendiumBrowser } from "@module/apps/compendium-browser/browser.ts";
+import { CompendiumBrowser } from "@module/apps/compendium-browser/browser.svelte.ts";
 import { EffectsPanel } from "@module/apps/effects-panel.ts";
 import { WorldClock } from "@module/apps/world-clock/index.ts";
 import { StatusEffects } from "@module/canvas/status-effects.ts";


### PR DESCRIPTION
I was going through the Svelte build warnings and the `state_referenced_locally` ones led me to explore and experiment with how `SvelteApplicationMixin` hands state to its root component. Turns out the mixin has a couple of latent bugs affecting every Svelte-based app. This reworks how that state flow works.

TL;DR: `SvelteApplicationMixin` had two latent bugs: derivations reading stable references (Foundry documents) silently stopped updating on re-render, and user or peer state stored in the `state` object got clobbered every re-render. The visible result was trades that can't complete after any actor update. Fix: the `state` object is now strictly render-derived and replaced wholesale (`$state.raw` plus a `getState()` accessor); anything mutated from TypeScript moved to instance `$state` on the app (trade-dialog and compendium-browser became `.svelte.ts`). Measured performance is neutral.

### The problems

The mixin kept one `$state` object and did `Object.assign(this.$state, freshState)` each render to merge in whatever `_prepareContext` returned. Two issues with that:

**1. Reactivity that worked by accident.** `Object.assign` onto a `$state` proxy skips writes where the value is the same reference (`===`). A lot of what `_prepareContext` returns is stable references, Foundry documents like `actor.ancestry` in the Attribute Builder for instance. Those fields never actually triggered reactivity on re-render. It only looked fine because derivations also read a fresh object (`build`, again on the Attribute Builder) that did trigger, and re-reading the mutated document while re-running gave the right answer anyway. Any derivation depending solely on something like `data.ancestry.system.foo` would silently go stale, with no warning.

**2. State clobbering.** `_prepareContext` returns the whole state object, including things like `accepted: false`, on the trade dialog. On re-render, `Object.assign` writes that straight over whatever the user had set. User and peer-driven state living in the state object got wiped every render.

In trade-dialog these combined into something genuinely broken. The component captured `const { self, trader } = data` once at mount (those `state_referenced_locally` warnings). After a re-render, `$state.self` was replaced with a fresh `accepted: false` object, but the component kept reading the old one. The checkmark stayed green while `$state.self.accepted` was actually false. UI and logic silently disagree.

In practice, any actor update after the dialog opens re-renders the dialog and breaks trade completion for one or both of the actors (which one depends on a few things, who had the actor update, who has already accepted, and the order in which events occur). Either the trade completes for one player and never completes on the other, or never completes for either even after both have accepted. The item doesn't transfer in either case. If neither actor is touched after the dialog opens it works fine. The bug needs at least one re-render.

https://github.com/user-attachments/assets/2d98e924-aa35-4849-a72e-76757ef175fd

Compendium browser has a similar issue, but is dormant because it doesn't auto-re-render:

1. Open the browser, click into a tab
2. Console: `game.pf2e.compendiumBrowser.render()`
3. View snaps back to the landing page, active tab gets clobbered

### The fix

The `state` object is now treated as strictly render-derived: replaced wholesale each render instead of merged, and typed `$state.raw` so the slot is reactive but the contents aren't. Components read it through a `getState()` accessor inside a `$derived`, so they always see the current object instead of a captured-once reference.

The key consequence of `$state.raw`: mutating `this.$state.foo = bar` no longer does anything reactive. That's deliberate, it makes the wrong thing fail loudly instead of silently. Anything actually mutated has to live elsewhere now.

So there are three clear homes for state:

- The `state` object: render-derived data, rebuilt by `_prepareContext` every render and never written afterward. The mixin injects a `getState()` accessor as a prop; components read it inside a `$derived` (`const data = $derived(getState())`) so they always pick up the freshly-replaced object instead of a captured-once reference.
- Component-local `$state`: UI-only state the component owns (search text, expand toggles), declared with `$state` in the component's `<script>`. Already worked, unchanged.
- Instance `$state` on the app class: state mutated from TypeScript that must survive re-renders. For example trade-dialog updating when the other player accepts or changes their offer, or compendium-browser's `openTab()` when an actor sheet or the sidebar tells the browser to jump to a tab. Declared as `$state` fields on the app itself, which is why those files have to become `.svelte.ts`. Components read it straight off the instance through the `foundryApp` prop (`foundryApp.selfAccepted`).

8 of 10 apps only needed the `getState()` swap; they were already just consuming render-derived data. Two needed instance state:

- trade-dialog: `selfItems`, `traderItems`, `selfAccepted`, `traderAccepted` are now `$state` fields on `TradeDialog`. The other player's trade updates (`#onUpdate`) and the component both mutate the same instance; `_prepareContext` can't touch them. It also overrides the mixin's `$state` accessor with a typed one, since `#setGiftData` still assigns `this.$state` directly and the override gets that write shape-checked (an app that never touches `this.$state` from TS, like compendium-browser, doesn't need this).
- compendium-browser: `activeTabName` and `resultList` moved to instance `$state`. `openTab()` (called from actor sheets and the sidebar) and the tab nav in the component both write `activeTabName`, so it can't live in the render-replaced `state` object.

Also cleaned up the `state_referenced_locally` and a11y warnings in the touched components. Svelte build warnings drop from 8 to 0 (surpressed an intentional one in `filter-container`).

### Performance

Neutral to slightly positive. `$state.raw` skips the recursive proxying that plain `$state` does, so the render-derived state object is no longer wrapped in nested proxies; for the larger ones that's a small win on every access. Replacing the object wholesale is a single assignment instead of the old per-key `Object.assign` loop.

The one thing worth calling out: wholesale replacement invalidates every derivation reading the state each render. Before, only derivations reading a field that got a fresh reference re-ran; ones reading stable references (like `data.ancestry`) didn't, which is exactly problem 1. So "all derivations re-run now" mostly means the ones that were silently not updating finally do. The genuinely new cost is small: derivation re-runs are cheap, Svelte still diffs the DOM so a derivation that recomputes to the same result costs nothing downstream, and renders only happen when Foundry data actually changes, not on a loop.

I measured this on the attribute builder to be sure. With the builder open, 5 actor updates: render count was 5 before and after (we don't render more often); a derivation reading `data.build` re-ran 5 times before and after (no regression); a derivation reading only `data.ancestry` re-ran 0 times before and 5 times after. That 0-to-5 is the whole delta, and it's the bug being fixed: the derivation that was silently never updating now correctly does.

Most of this matters more later. The apps in this PR are small dialogs and pickers with modest state, so wholesale replacement is fine for them. Actor sheets are where it gets real: large nested state, more frequent re-renders, and `_prepareContext` already doing a lot of work. Regardless: the headline Svelte benefit, only the changed part of the sheet repainting instead of the whole thing, comes from Svelte's DOM diffing and is independent of the state model.

### Fine-grained invalidation (for later)

The model in this PR is coarse: every derivation reading the state re-runs each render. Again, that's effectively free for these apps. Actor sheets will be bigger and re-render more often, so here are the options for going fine-grained and why none are worth doing yet, as reference for when it comes up.

First, why the old code couldn't be both. Foundry documents are passed by stable reference and mutated in place. Fine-grained invalidation needs a changed field to arrive as a fresh reference and an unchanged field to keep its old one. A Foundry document gives neither guarantee: the reference is the same whether or not its contents changed, so a `===` check can't tell the two apart. That's the root of problem 1.

There are two ways to fix that properly.

Route 1: deep-equal memoization. Have `_prepareContext` (or the mixin) deep-compare each field of the new state against the previous render's, keep the old reference where equal and use a fresh one where changed. A deep `$state` with per-field assignment would then invalidate correctly and finely. The problem is it trades one cost for another: instead of re-running the derivations, you deep-compare the whole state every render. On a large sheet that comparison costs about the same as the re-derivation it's trying to avoid, so it doesn't actually help.

Route 2: hook-driven granular state. Stop rebuilding state from `_prepareContext` on every render. Keep a long-lived reactive model on the app and patch only the affected `$state` fields in response to Foundry's `updateActor` and `updateItem` hooks, which carry a precise diff of what changed. Reactivity is then driven by what actually changed: no deep-compare, no coarse invalidation, and correct because each patch targets exactly the changed paths. This is genuinely fine-grained and correct. The cost is that it's a different data-flow architecture, not a mixin change.

On stores for route 2: Svelte 5 has largely superseded them. The official guidance is that shared reactive state should be a `$state` object in a `.svelte.ts` module (what the rest of this work uses), with stores kept mainly for complex async streams. So route 2's model should be `$state`, not stores. The one store feature that stays genuinely relevant is the start/stop notifier (`writable(initial, (set) => { ...; return cleanup; })`): it registers a subscription on first use and tears it down on last, a tidy way to bridge a Foundry hook into reactivity. That's a convenience rather than a capability, since the app already manages its own lifecycle, but worth knowing if the hook side ever gets genuinely complex.

Route 2 is the one worth doing eventually and route 1 isn't, the expensive part of a big sheet isn't derivation re-runs, it's `_prepareContext` itself (Foundry data prep, already heavy and made worse by the HP-change clone). Route 1 leaves that cost fully in place. Route 2 removes it for small changes, because patching one field skips the full re-prepare. So the real future optimization isn't "make derivations re-run less," it's "stop re-preparing the whole sheet for a one-field change," and route 2 is how you get there.