### PR TITLE
Add forgotten text in black belt NPC

### DIFF
--- a/packs/pf2e/pathfinder-npc-core/martial-artist/black-belt.json
+++ b/packs/pf2e/pathfinder-npc-core/martial-artist/black-belt.json
@@ -758,7 +758,7 @@
                 "value": 12
             },
             "privateNotes": "",
-            "publicNotes": "<p>Martial artists strive to master the art of hand-to-hand fighting.</p>",
+            "publicNotes": "<p>Many martial arts schools use colored belts to differentiate skill levels. Above all is the black belt, an advanced practitioner who can counter any attack.</p><hr /><p>Martial artists strive to master the art of hand-to-hand fighting.</p>",
             "publication": {
                 "license": "ORC",
                 "remaster": true,


### PR DESCRIPTION
Update public notes to add forgotten text in the description of the black belt.