### PR TITLE
Add toggleable Glitching Failure roll option

### DIFF
--- a/packs/sf2e/conditions/glitching.json
+++ b/packs/sf2e/conditions/glitching.json
@@ -32,9 +32,7 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "predicate": [
-                    "glitching-failure"
-                ],
+                "predicate": ["glitching-failure"],
                 "selector": "all",
                 "type": "item",
                 "value": "-@item.badge.value"
@@ -46,6 +44,12 @@
             {
                 "key": "RollOption",
                 "option": "self:condition:glitching:{item|badge.value}"
+            },
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Glitching.FailureToggle",
+                "option": "glitching-failure",
+                "toggleable": true
             }
         ],
         "start": {

--- a/packs/sf2e/conditions/glitching.json
+++ b/packs/sf2e/conditions/glitching.json
@@ -32,7 +32,9 @@
         "rules": [
             {
                 "key": "FlatModifier",
-                "predicate": ["glitching-failure"],
+                "predicate": [
+                    "glitching-failure"
+                ],
                 "selector": "all",
                 "type": "item",
                 "value": "-@item.badge.value"
@@ -47,7 +49,6 @@
             },
             {
                 "key": "RollOption",
-                "label": "PF2E.SpecificRule.Glitching.FailureToggle",
                 "option": "glitching-failure",
                 "toggleable": true
             }

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -4856,9 +4856,6 @@
                     "Addendum": "You can use Glitching Memory at a range of 60 feet."
                 }
             },
-            "Glitching": {
-                "FailureToggle": "Apply glitching item penalty (failed flat check)"
-            },
             "GeneralTraining": {
                 "Prompt": "Select a 1st-level general feat."
             },

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -4856,6 +4856,9 @@
                     "Addendum": "You can use Glitching Memory at a range of 60 feet."
                 }
             },
+            "Glitching": {
+                "FailureToggle": "Apply glitching item penalty (failed flat check)"
+            },
             "GeneralTraining": {
                 "Prompt": "Select a 1st-level general feat."
             },


### PR DESCRIPTION
The Glitching condition's flat-check failure penalty (-value item to all checks and DCs) was gated behind a `glitching-failure` predicate that had no way to be activated when the glitching creature was the target of a roll, only when it was the roller. The penalty therefore could not apply to AC or to defender-side DCs (e.g. Reflex DC against Trip).

This adds a toggleable `RollOption` on the condition itself so the GM can mark the failed flat check. With the toggle on, the existing `FlatModifier { selector: "all" }` propagates the item penalty to both the creature's own checks and to its AC / save DCs when targeted (same propagation pattern as the (unpredicated) Frightened condition).

Can be made automatic on condition gain if wanted/needed.

Closes #22161

## Test plan
- [x] Apply Glitching 3 to an SF2e actor
- [x] Verify the new toggle appears under the actor's Actions panel
- [x] Tick the toggle, roll a Reflex save — modifier breakdown shows `-3 item (Glitching)`
- [x] Have another actor attack the glitching creature — AC shows the `-3 item` penalty
- [x] Tick off — penalty no longer applies