### PR TITLE
Preserve token mirror state when applying TokenImage scale override

### DIFF
--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -319,8 +319,8 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
         if (tokenOverrides.texture) {
             this.texture.src = tokenOverrides.texture.src;
             if ("scaleX" in tokenOverrides.texture) {
-                const mirrorX = this.texture.scaleX < 0 ? -1 : 1;
-                const mirrorY = this.texture.scaleY < 0 ? -1 : 1;
+                const mirrorX = Math.sign(this.texture.scaleX);
+                const mirrorY = Math.sign(this.texture.scaleY);
                 this.texture.scaleX = mirrorX * Math.abs(tokenOverrides.texture.scaleX);
                 this.texture.scaleY = mirrorY * Math.abs(tokenOverrides.texture.scaleY);
                 this.flags[SYSTEM_ID].autoscale = false;

--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -319,8 +319,10 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
         if (tokenOverrides.texture) {
             this.texture.src = tokenOverrides.texture.src;
             if ("scaleX" in tokenOverrides.texture) {
-                this.texture.scaleX = tokenOverrides.texture.scaleX;
-                this.texture.scaleY = tokenOverrides.texture.scaleY;
+                const mirrorX = this.texture.scaleX < 0 ? -1 : 1;
+                const mirrorY = this.texture.scaleY < 0 ? -1 : 1;
+                this.texture.scaleX = mirrorX * Math.abs(tokenOverrides.texture.scaleX);
+                this.texture.scaleY = mirrorY * Math.abs(tokenOverrides.texture.scaleY);
                 this.flags[SYSTEM_ID].autoscale = false;
             }
             this.texture.tint = tokenOverrides.texture.tint ?? this.texture.tint;


### PR DESCRIPTION
Fixes #22351.

The `TokenDocumentPF2e.prepareBaseData` override was blindly assigning `scaleX` / `scaleY` from a TokenImage rule element's `scale` field, overwriting any negative sign the user had set to mirror the token. Toggling Mirror Horizontally / Vertically in the token's Appearance tab appeared to do nothing on tokens with such a rule element.

Preserves the existing sign of `scaleX` / `scaleY` when applying the override, matching the pattern already used in `prepareScale` higher up in the same file (lines 254-257).

## Test plan
- [x] Created an effect with a TokenImage rule (`value: icons/svg/mystery-man.svg`, `scale: 1.5`), dropped on a blank actor (no existing token image) on the scene, confirmed the token reskinned and rescaled
- [x] Toggled Mirror Horizontally on that token via Configure Token, confirmed the mirror sticks across subsequent renders (this is the regression being fixed)
- [x] No regression on the simple path: the change is scoped inside the `if ("scaleX" in tokenOverrides.texture)` branch, so tokens without a TokenImage rule element never hit the new code