### PR TITLE
Show heightened spell data in spell collection sheet

### DIFF
--- a/src/module/item/spellcasting-entry/collection.ts
+++ b/src/module/item/spellcasting-entry/collection.ts
@@ -175,8 +175,10 @@ class SpellCollection<TActor extends ActorPF2e> extends Collection<string, Spell
                 const active = populateList
                     ? group.prepared.map((slot) => {
                           const spell = slot && this.get(slot.id ?? "");
-                          const castRank = spell?.computeCastRank(rank);
-                          return spell ? { castRank, spell, expended: slot.expended } : null;
+                          if (!spell) return null;
+                          const castRank = spell.computeCastRank(rank);
+                          const variant = (castRank ? spell.loadVariant({ castRank }) : null) ?? spell;
+                          return { castRank, spell: variant, expended: slot.expended };
                       })
                     : [];
 
@@ -199,7 +201,9 @@ class SpellCollection<TActor extends ActorPF2e> extends Collection<string, Spell
             const normal = spells.filter((spell) => !spell.isCantrip);
 
             if (cantrips.length) {
-                const active = cantrips.map((spell) => ({ spell }));
+                const active = cantrips.map((spell) => ({
+                    spell: spell.loadVariant({ castRank: spell.rank }) ?? spell,
+                }));
                 groups.push({
                     id: "cantrips",
                     maxRank: maxCantripRank,
@@ -209,7 +213,9 @@ class SpellCollection<TActor extends ActorPF2e> extends Collection<string, Spell
             }
 
             if (normal.length > 0) {
-                const active = normal.map((spell) => ({ spell }));
+                const active = normal.map((spell) => ({
+                    spell: spell.loadVariant({ castRank: spell.rank }) ?? spell,
+                }));
                 groups.push({
                     id: maxCantripRank,
                     maxRank: maxCantripRank,
@@ -230,7 +236,7 @@ class SpellCollection<TActor extends ActorPF2e> extends Collection<string, Spell
                     const uses =
                         this.entry.isSpontaneous && rank !== 0 ? { value: data.value, max: data.max } : undefined;
                     const active = spells.map((spell) => ({
-                        spell,
+                        spell: spell.loadVariant({ castRank: spell.rank }) ?? spell,
                         expended: isInnate && !spell.system.location.uses?.value,
                         uses: isInnate && !spell.atWill ? spell.system.location.uses : undefined,
                     }));
@@ -275,7 +281,8 @@ class SpellCollection<TActor extends ActorPF2e> extends Collection<string, Spell
                         existing.signature = true;
                     } else if (group.uses?.max) {
                         const castRank = group.id;
-                        group.active.push({ spell, castRank, signature: true, virtual: true });
+                        const variant = spell.loadVariant({ castRank }) ?? spell;
+                        group.active.push({ spell: variant, castRank, signature: true, virtual: true });
                     }
                 }
             }
@@ -316,7 +323,10 @@ class SpellCollection<TActor extends ActorPF2e> extends Collection<string, Spell
                     id: Number(rank) as SpellSlotGroupId,
                     label: _loc("PF2E.Item.Spell.Rank.Ordinal", { rank: ordinalString(Number(rank)) }),
                     maxRank: 10,
-                    active: spells.map((spell) => ({ spell, expended: spell.parentItem?.uses.value === 0 })),
+                    active: spells.map((spell) => ({
+                        spell: spell.loadVariant({ castRank: spell.rank }) ?? spell,
+                        expended: spell.parentItem?.uses.value === 0,
+                    })),
                 }),
             );
 


### PR DESCRIPTION
Fixes #22095.

`SpellCollection` pushed the base spell into the sheet data, so columns reading from `spell.system` (range, area, target) showed un-heightened values even though the spell description used the heightened variant via `loadVariant({ castRank })`. Most visible on the Range column for Message and Thoughtful Gift.

Load the heightened variant up front for each path that pushes spells into `SpellCollectionData` (prepared from slot rank, focus / innate / spontaneous / ritual from spell rank, signature additions from group id, ephemeral wand/scroll/staff collection). Falls back to the base spell when `loadVariant` returns null.

This is the broader of the two options described on the issue, so any other columns silently showing un-heightened values will also reflect heightening.

## Test plan
- [x] Message cantrip on L5 Ezren (auto-heightened to rank 3): Range shows 500 ft (was 120 ft)
- [x] Message cantrip on L1 Ezren (no heightening): Range shows 120 ft
- [x] Thoughtful Gift prepared in a rank 1 slot vs rank 3 slot: 120 ft vs 500 ft
- [x] Spell name, action glyph, defense, traits all still render on both characters
- [x] Spells without heightening data display unchanged
