### PR TITLE
Use check icon for trade accept button in unaccepted state

### DIFF
--- a/src/module/apps/trade-dialog/app.svelte
+++ b/src/module/apps/trade-dialog/app.svelte
@@ -144,7 +144,7 @@
                 aria-label={self.accepted ? localize("Acceptance.Rescind") : localize("Acceptance.Accept")}
                 onclick={toggleAccepted}
             >
-                <i class="fa-solid fa-{self.accepted ? 'check' : 'xmark'}"></i>
+                <i class="fa-solid fa-check"></i>
             </button>
         </header>
         <div class="flexrow search">


### PR DESCRIPTION
Fixes #21836.

The self-accept button rendered an X (`fa-xmark`) before acceptance, which players consistently misread as "cancel". Swapped to `fa-check`; the existing `.toggle-accepted` CSS dims it when unaccepted and brightens on `.accepted`, so the click target now reads as "tick to accept". Trader-side status indicator (line 213) intentionally kept as xmark/check to distinguish whether the other party has accepted.

## Test plan
- [x] Initiated trade between two PCs; self-accept shows dim check, click toggles to bright check, rescind returns to dim
- [x] Trader-side indicator unchanged
