### PR TITLE
Disambiguate FeatGroup slot ids when levels repeat

### DIFF
--- a/src/module/actor/character/feats/group.ts
+++ b/src/module/actor/character/feats/group.ts
@@ -56,7 +56,7 @@ class FeatGroup<TActor extends ActorPF2e = ActorPF2e, TItem extends FeatLike = F
 
         if (data.slots) {
             this.slotted = true;
-            for (const slotData of data.slots) {
+            for (const slotData of R.unique(data.slots)) {
                 const slotObject =
                     typeof slotData === "object"
                         ? slotData


### PR DESCRIPTION
Closes #22417.

Numeric `campaignFeatSections` like `slots: [1, 1, 1]` derived the same slot id three times, so only the last survived in `this.slots` and drops fell through to bonus feats. `R.unique` on the input collapses literal duplicates to one entry.

## Test plan
- [x] Synthetic `campaignFeatSection` with `slots: [1, 1, 1]`: renders as a single slot row, drops land in it
- [x] Workbench v7.2.0 dual class + ancestral paragon (slot arrays `[1,2,4,...,20]` and `[1,3,7,...,19]`): no duplicates, behave identically to pre-PR
