### PR TITLE
Add some missing compendium sources for physical items

### DIFF
--- a/packs/pf2e/agents-of-edgewatch-bestiary/book-4-assault-on-hunting-lodge-seven/priest-of-blackfingers.json
+++ b/packs/pf2e/agents-of-edgewatch-bestiary/book-4-assault-on-hunting-lodge-seven/priest-of-blackfingers.json
@@ -2381,6 +2381,9 @@
         },
         {
             "_id": "6MyLDqoNMe9zPlqG",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.w2ENw2VMPcsbif8g"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/arrows.webp",
             "name": "Arrows",
             "sort": 3100000,

--- a/packs/pf2e/agents-of-edgewatch-bestiary/book-4-assault-on-hunting-lodge-seven/sleepless-sun-veteran.json
+++ b/packs/pf2e/agents-of-edgewatch-bestiary/book-4-assault-on-hunting-lodge-seven/sleepless-sun-veteran.json
@@ -450,6 +450,9 @@
         },
         {
             "_id": "gWZgyCMj5PWxyDXw",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.w2ENw2VMPcsbif8g"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/arrows.webp",
             "name": "Arrows",
             "sort": 700000,

--- a/packs/pf2e/agents-of-edgewatch-bestiary/book-5-belly-of-the-black-whale/black-whale-guard-f3.json
+++ b/packs/pf2e/agents-of-edgewatch-bestiary/book-5-belly-of-the-black-whale/black-whale-guard-f3.json
@@ -399,6 +399,9 @@
         },
         {
             "_id": "5AFX1CIhHBVEB1c7",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.w2ENw2VMPcsbif8g"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/arrows.webp",
             "name": "Arrows",
             "sort": 600000,

--- a/packs/pf2e/agents-of-edgewatch-bestiary/book-5-belly-of-the-black-whale/black-whale-guard.json
+++ b/packs/pf2e/agents-of-edgewatch-bestiary/book-5-belly-of-the-black-whale/black-whale-guard.json
@@ -399,6 +399,9 @@
         },
         {
             "_id": "5AFX1CIhHBVEB1c7",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.w2ENw2VMPcsbif8g"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/arrows.webp",
             "name": "Arrows",
             "sort": 600000,

--- a/packs/pf2e/agents-of-edgewatch-bestiary/book-5-belly-of-the-black-whale/calennia.json
+++ b/packs/pf2e/agents-of-edgewatch-bestiary/book-5-belly-of-the-black-whale/calennia.json
@@ -254,6 +254,9 @@
         },
         {
             "_id": "qLX5FtpUy7WWTkVi",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.AITVZmakiu3RgfKo"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/bolts.webp",
             "name": "Bolts",
             "sort": 400000,

--- a/packs/pf2e/agents-of-edgewatch-bestiary/book-5-belly-of-the-black-whale/garrote-master-assassin.json
+++ b/packs/pf2e/agents-of-edgewatch-bestiary/book-5-belly-of-the-black-whale/garrote-master-assassin.json
@@ -304,6 +304,9 @@
         },
         {
             "_id": "86ydWzLv6y0ptlJi",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.AITVZmakiu3RgfKo"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/bolts.webp",
             "name": "Bolts",
             "sort": 500000,

--- a/packs/pf2e/agents-of-edgewatch-bestiary/book-5-belly-of-the-black-whale/grimwold.json
+++ b/packs/pf2e/agents-of-edgewatch-bestiary/book-5-belly-of-the-black-whale/grimwold.json
@@ -362,6 +362,9 @@
         },
         {
             "_id": "0G3XbmSt8ppIAeV2",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.AITVZmakiu3RgfKo"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/bolts.webp",
             "name": "Bolts",
             "sort": 600000,

--- a/packs/pf2e/agents-of-edgewatch-bestiary/book-5-belly-of-the-black-whale/starwatch-commando.json
+++ b/packs/pf2e/agents-of-edgewatch-bestiary/book-5-belly-of-the-black-whale/starwatch-commando.json
@@ -400,6 +400,9 @@
         },
         {
             "_id": "aUT5HG083JzDakWn",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.AITVZmakiu3RgfKo"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/bolts.webp",
             "name": "Bolts",
             "sort": 600000,

--- a/packs/pf2e/agents-of-edgewatch-bestiary/book-5-belly-of-the-black-whale/zealborn.json
+++ b/packs/pf2e/agents-of-edgewatch-bestiary/book-5-belly-of-the-black-whale/zealborn.json
@@ -817,6 +817,9 @@
         },
         {
             "_id": "8Amt0GlpUWuROReN",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.MKSeXwUm56c15MZa"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/sling-bullets.webp",
             "name": "Sling Bullets",
             "sort": 1300000,

--- a/packs/pf2e/hellbreakers-bestiary/adjutant-hellknight-armiger.json
+++ b/packs/pf2e/hellbreakers-bestiary/adjutant-hellknight-armiger.json
@@ -252,6 +252,9 @@
         },
         {
             "_id": "C1JOnzu8AzgGKmJ5",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.AITVZmakiu3RgfKo"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/bolts.webp",
             "name": "Bolts",
             "sort": 400000,

--- a/packs/pf2e/hellbreakers-bestiary/brakknap.json
+++ b/packs/pf2e/hellbreakers-bestiary/brakknap.json
@@ -1349,6 +1349,9 @@
         },
         {
             "_id": "pkKtCXG0wUmPVdK8",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.AITVZmakiu3RgfKo"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/bolts.webp",
             "name": "Bolts",
             "sort": 1800000,

--- a/packs/pf2e/hellbreakers-bestiary/captain-lamperia-bane.json
+++ b/packs/pf2e/hellbreakers-bestiary/captain-lamperia-bane.json
@@ -404,6 +404,9 @@
         },
         {
             "_id": "fjB3EpWvUf4zMABE",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.AITVZmakiu3RgfKo"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/bolts.webp",
             "name": "Bolts",
             "sort": 600000,

--- a/packs/pf2e/hellbreakers-bestiary/chelaxian-loyalist-leader.json
+++ b/packs/pf2e/hellbreakers-bestiary/chelaxian-loyalist-leader.json
@@ -251,6 +251,9 @@
         },
         {
             "_id": "HwswVGZAAmJpqDCe",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.AITVZmakiu3RgfKo"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/bolts.webp",
             "name": "Bolts",
             "sort": 400000,

--- a/packs/pf2e/hellbreakers-bestiary/chelaxian-loyalist.json
+++ b/packs/pf2e/hellbreakers-bestiary/chelaxian-loyalist.json
@@ -253,6 +253,9 @@
         },
         {
             "_id": "0ApG2tnLDuB8VQsO",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.AITVZmakiu3RgfKo"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/bolts.webp",
             "name": "Bolts",
             "sort": 400000,

--- a/packs/pf2e/hellbreakers-bestiary/chelaxian-recruit.json
+++ b/packs/pf2e/hellbreakers-bestiary/chelaxian-recruit.json
@@ -257,6 +257,9 @@
         },
         {
             "_id": "nO8FsvHlp3AktlAn",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.w2ENw2VMPcsbif8g"
+            },
             "img": "icons/weapons/ammunition/arrows-broadhead-white.webp",
             "name": "Arrows",
             "sort": 400000,

--- a/packs/pf2e/hellbreakers-bestiary/drunken-isgeri-slayer.json
+++ b/packs/pf2e/hellbreakers-bestiary/drunken-isgeri-slayer.json
@@ -344,6 +344,9 @@
         },
         {
             "_id": "yR6Y3pvsPjhZuuWM",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.w2ENw2VMPcsbif8g"
+            },
             "img": "icons/weapons/ammunition/arrows-broadhead-white.webp",
             "name": "Arrows",
             "sort": 500000,

--- a/packs/pf2e/hellbreakers-bestiary/false-hellbreaker.json
+++ b/packs/pf2e/hellbreakers-bestiary/false-hellbreaker.json
@@ -402,6 +402,9 @@
         },
         {
             "_id": "IHyqTYfxD95yGZQe",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.AITVZmakiu3RgfKo"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/bolts.webp",
             "name": "Bolts",
             "sort": 600000,

--- a/packs/pf2e/hellbreakers-bestiary/hecatinia.json
+++ b/packs/pf2e/hellbreakers-bestiary/hecatinia.json
@@ -463,6 +463,9 @@
         },
         {
             "_id": "bZFu2ofUZ4PYyiKR",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.AITVZmakiu3RgfKo"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/bolts.webp",
             "name": "Bolts",
             "sort": 700000,

--- a/packs/pf2e/hellbreakers-bestiary/hestlebeth.json
+++ b/packs/pf2e/hellbreakers-bestiary/hestlebeth.json
@@ -419,6 +419,9 @@
         },
         {
             "_id": "XKwspfwpq1KxRoi4",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.AITVZmakiu3RgfKo"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/bolts.webp",
             "name": "Bolts",
             "sort": 700000,

--- a/packs/pf2e/hellbreakers-bestiary/novice-hellknight-armiger.json
+++ b/packs/pf2e/hellbreakers-bestiary/novice-hellknight-armiger.json
@@ -312,6 +312,9 @@
         },
         {
             "_id": "3JGeC8Sl3BKtGZea",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.AITVZmakiu3RgfKo"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/bolts.webp",
             "name": "Bolts",
             "sort": 500000,

--- a/packs/pf2e/hellbreakers-bestiary/skirmancer-mage.json
+++ b/packs/pf2e/hellbreakers-bestiary/skirmancer-mage.json
@@ -1269,6 +1269,9 @@
         },
         {
             "_id": "p0H8IKhG7uytJ78X",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.w2ENw2VMPcsbif8g"
+            },
             "img": "icons/weapons/ammunition/arrows-broadhead-white.webp",
             "name": "Arrows",
             "sort": 1700000,

--- a/packs/pf2e/hellbreakers-bestiary/viro-ahala.json
+++ b/packs/pf2e/hellbreakers-bestiary/viro-ahala.json
@@ -327,6 +327,9 @@
         },
         {
             "_id": "zhw722WZMjQtZmhR",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.AITVZmakiu3RgfKo"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/bolts.webp",
             "name": "Bolts",
             "sort": 500000,

--- a/packs/pf2e/menace-under-otari-bestiary/secrets-of-the-unlit-star/bugbear-prowler-bb.json
+++ b/packs/pf2e/menace-under-otari-bestiary/secrets-of-the-unlit-star/bugbear-prowler-bb.json
@@ -5,6 +5,9 @@
     "items": [
         {
             "_id": "m3dItgmBHHteBg7H",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.JNt7GmLCCVz5BiEI"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/javelin.webp",
             "name": "Javelin",
             "sort": 100000,
@@ -91,6 +94,9 @@
         },
         {
             "_id": "5SNjwi1IsfLEtwth",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.LJdbVTOZog39EEbi"
+            },
             "img": "icons/weapons/swords/sword-guard-blue.webp",
             "name": "Longsword",
             "sort": 200000,
@@ -177,6 +183,9 @@
         },
         {
             "_id": "vWi5PtF7CdjklUl5",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.4tIVTg9wj56RrveA"
+            },
             "img": "icons/equipment/chest/breastplate-banded-simple-leather-brown.webp",
             "name": "Leather Armor",
             "sort": 300000,

--- a/packs/pf2e/menace-under-otari-bestiary/secrets-of-the-unlit-star/bugbear-tormentor-bb.json
+++ b/packs/pf2e/menace-under-otari-bestiary/secrets-of-the-unlit-star/bugbear-tormentor-bb.json
@@ -5,6 +5,9 @@
     "items": [
         {
             "_id": "FQmSBDqEIB0OxIyT",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.rQWaJhI5Bko5x14Z"
+            },
             "img": "icons/weapons/daggers/dagger-straight-blue.webp",
             "name": "Dagger",
             "sort": 100000,
@@ -94,6 +97,9 @@
         },
         {
             "_id": "CuiT7YhWr0yDFYpj",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.ynnBwzkzsR6B73iO"
+            },
             "img": "icons/tools/hand/sickle-steel-grey.webp",
             "name": "Sickle",
             "sort": 200000,
@@ -181,6 +187,9 @@
         },
         {
             "_id": "sQ5yKFoSrnURIhgY",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.MPcM4Wt6KmWE2kGL"
+            },
             "img": "systems/pf2e/icons/equipment/armor/chainshirt.webp",
             "name": "Chain Shirt",
             "sort": 300000,

--- a/packs/pf2e/menace-under-otari-bestiary/secrets-of-the-unlit-star/goblin-commando-bb.json
+++ b/packs/pf2e/menace-under-otari-bestiary/secrets-of-the-unlit-star/goblin-commando-bb.json
@@ -5,6 +5,9 @@
     "items": [
         {
             "_id": "zImKMHKstCvHpRga",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.UX71GkWBL9g41VwM"
+            },
             "img": "icons/weapons/swords/greatsword-crossguard-silver.webp",
             "name": "Greatsword",
             "sort": 100000,
@@ -90,6 +93,9 @@
         },
         {
             "_id": "I8UtqLMDpYWaJaAR",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.hIgqLgH3YcLZBeoT"
+            },
             "img": "icons/weapons/bows/shortbow-leather.webp",
             "name": "Shortbow",
             "sort": 200000,
@@ -179,6 +185,9 @@
         },
         {
             "_id": "RkUs2hSR3E4NfNx9",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.4tIVTg9wj56RrveA"
+            },
             "img": "icons/equipment/chest/breastplate-banded-simple-leather-brown.webp",
             "name": "Leather Armor",
             "sort": 300000,
@@ -245,6 +254,9 @@
         },
         {
             "_id": "994orUBaHZsd3j73",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.w2ENw2VMPcsbif8g"
+            },
             "img": "icons/weapons/ammunition/arrows-broadhead-white.webp",
             "name": "Arrows",
             "sort": 400000,

--- a/packs/pf2e/menace-under-otari-bestiary/secrets-of-the-unlit-star/goblin-igniter-bb.json
+++ b/packs/pf2e/menace-under-otari-bestiary/secrets-of-the-unlit-star/goblin-igniter-bb.json
@@ -375,6 +375,9 @@
         },
         {
             "_id": "53rujRVubQFgkgmy",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.8Jdw4yAzWYylGePS"
+            },
             "img": "icons/sundries/lights/torch-brown.webp",
             "name": "Torch",
             "sort": 600000,

--- a/packs/pf2e/menace-under-otari-bestiary/secrets-of-the-unlit-star/hobgoblin-archer-bb.json
+++ b/packs/pf2e/menace-under-otari-bestiary/secrets-of-the-unlit-star/hobgoblin-archer-bb.json
@@ -5,6 +5,9 @@
     "items": [
         {
             "_id": "heNxIFcC3Ye9NDMA",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.62nnVQvGhoVLLl2K"
+            },
             "img": "icons/weapons/crossbows/crossbow-simple-brown.webp",
             "name": "Crossbow",
             "sort": 100000,
@@ -92,6 +95,9 @@
         },
         {
             "_id": "UsSLxXRW7qgACHGU",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.7tKkkF8eZ4iCLJtp"
+            },
             "img": "icons/weapons/swords/sword-guard-purple.webp",
             "name": "Shortsword",
             "sort": 200000,
@@ -179,6 +185,9 @@
         },
         {
             "_id": "UWZN9sI8zfuBOL7z",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.YMQr577asquZIP65"
+            },
             "img": "icons/equipment/chest/breastplate-metal-scaled-grey.webp",
             "name": "Scale Mail",
             "sort": 300000,
@@ -245,6 +254,9 @@
         },
         {
             "_id": "Hc46a75PnZYUic1U",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.AITVZmakiu3RgfKo"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/bolts.webp",
             "name": "Bolts",
             "sort": 400000,

--- a/packs/pf2e/menace-under-otari-bestiary/secrets-of-the-unlit-star/umbral-gnome-rockwarden-bb.json
+++ b/packs/pf2e/menace-under-otari-bestiary/secrets-of-the-unlit-star/umbral-gnome-rockwarden-bb.json
@@ -1114,6 +1114,9 @@
         },
         {
             "_id": "L5C6Y3z4fmhWtRcR",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.UCH4myuFnokGv0vF"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/sling.webp",
             "name": "Sling",
             "sort": 1500000,
@@ -1201,6 +1204,9 @@
         },
         {
             "_id": "62keOl5lUzoW452l",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.H74vYwHJ8XT4qOPI"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/scythe.webp",
             "name": "Scythe",
             "sort": 1600000,
@@ -1287,6 +1293,9 @@
         },
         {
             "_id": "fr9SXyrQKxYmHIx6",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.AnwzlOs0njF9Jqnr"
+            },
             "img": "icons/equipment/chest/vest-leather-tattered-white.webp",
             "name": "Hide Armor",
             "sort": 1700000,
@@ -1353,6 +1362,9 @@
         },
         {
             "_id": "Lr9ykhJaIn18XV6L",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.QbOlqr4lSkeOEfty"
+            },
             "img": "systems/pf2e/icons/equipment/adventuring-gear/holly-and-mistletoe.webp",
             "name": "Primal Symbol",
             "sort": 1800000,
@@ -1406,6 +1418,9 @@
         },
         {
             "_id": "vqRfRJitacRXLlfk",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.MKSeXwUm56c15MZa"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/sling-bullets.webp",
             "name": "Sling Bullets",
             "sort": 1900000,

--- a/packs/pf2e/menace-under-otari-bestiary/secrets-of-the-unlit-star/umbral-gnome-scout-bb.json
+++ b/packs/pf2e/menace-under-otari-bestiary/secrets-of-the-unlit-star/umbral-gnome-scout-bb.json
@@ -112,6 +112,9 @@
         },
         {
             "_id": "z8yxU7lZDb999lzO",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.UCH4myuFnokGv0vF"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/sling.webp",
             "name": "Sling",
             "sort": 300000,
@@ -199,6 +202,9 @@
         },
         {
             "_id": "HsqglvkUyv4YHaqJ",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.ynnBwzkzsR6B73iO"
+            },
             "img": "icons/tools/hand/sickle-steel-grey.webp",
             "name": "Sickle",
             "sort": 400000,
@@ -286,6 +292,9 @@
         },
         {
             "_id": "lAj5MLMgEuc6F4ov",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.MKSeXwUm56c15MZa"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/sling-bullets.webp",
             "name": "Sling Bullets",
             "sort": 500000,

--- a/packs/pf2e/menace-under-otari-bestiary/secrets-of-the-unlit-star/umbral-gnome-warrior-bb.json
+++ b/packs/pf2e/menace-under-otari-bestiary/secrets-of-the-unlit-star/umbral-gnome-warrior-bb.json
@@ -107,6 +107,9 @@
         },
         {
             "_id": "aLyImFbNpONWKtaS",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.giO4LwIKGzJZoaxa"
+            },
             "img": "icons/weapons/crossbows/crossbow-simple-black.webp",
             "name": "Heavy Crossbow",
             "sort": 300000,
@@ -194,6 +197,9 @@
         },
         {
             "_id": "cDzRl5APtk7PXy0x",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.tOhoGvmCMw4JpWcS"
+            },
             "img": "icons/weapons/polearms/spear-flared-steel.webp",
             "name": "Spear",
             "sort": 400000,
@@ -281,6 +287,9 @@
         },
         {
             "_id": "JLFmH33xvvq8LJ6s",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.Yr9yCuJiAlFh3QEB"
+            },
             "img": "systems/pf2e/icons/equipment/shields/steel-shield.webp",
             "name": "Steel Shield",
             "sort": 500000,
@@ -340,6 +349,9 @@
         },
         {
             "_id": "SOKTWOD6ew5LbFuM",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.ewQZ0VeL38v3qFnN"
+            },
             "img": "icons/equipment/chest/breastplate-layered-leather-studded-brown.webp",
             "name": "Studded Leather Armor",
             "sort": 600000,
@@ -406,6 +418,9 @@
         },
         {
             "_id": "vl26g9IsrmFEqXvS",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.AITVZmakiu3RgfKo"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/bolts.webp",
             "name": "Bolts",
             "sort": 700000,

--- a/packs/pf2e/pathfinder-monster-core-2/aphorite-sharpshooter.json
+++ b/packs/pf2e/pathfinder-monster-core-2/aphorite-sharpshooter.json
@@ -407,6 +407,9 @@
         },
         {
             "_id": "2gay2vYlj3Bo7Kzt",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.AITVZmakiu3RgfKo"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/bolts.webp",
             "name": "Bolts",
             "sort": 700000,

--- a/packs/pf2e/pathfinder-monster-core-2/caligni-vanguard.json
+++ b/packs/pf2e/pathfinder-monster-core-2/caligni-vanguard.json
@@ -257,6 +257,9 @@
         },
         {
             "_id": "uZvfti8ur1FmIwsw",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.w2ENw2VMPcsbif8g"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/arrows.webp",
             "name": "Arrows",
             "sort": 400000,

--- a/packs/pf2e/pathfinder-monster-core-2/dragonblood-occultist.json
+++ b/packs/pf2e/pathfinder-monster-core-2/dragonblood-occultist.json
@@ -339,6 +339,9 @@
         },
         {
             "_id": "oTTyH5VRf496owLO",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.AITVZmakiu3RgfKo"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/bolts.webp",
             "name": "Bolts",
             "sort": 500000,

--- a/packs/pf2e/pathfinder-monster-core-2/graveknight-champion.json
+++ b/packs/pf2e/pathfinder-monster-core-2/graveknight-champion.json
@@ -1333,6 +1333,9 @@
         },
         {
             "_id": "lYVRh9XfwXgcaBbO",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.w2ENw2VMPcsbif8g"
+            },
             "img": "icons/weapons/ammunition/arrows-broadhead-white.webp",
             "name": "Arrows",
             "sort": 1600000,

--- a/packs/pf2e/pathfinder-monster-core-2/graveknight-warmaster.json
+++ b/packs/pf2e/pathfinder-monster-core-2/graveknight-warmaster.json
@@ -255,6 +255,9 @@
         },
         {
             "_id": "9GrL4NCuXHAhjt4c",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.AITVZmakiu3RgfKo"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/bolts.webp",
             "name": "Bolts",
             "sort": 400000,

--- a/packs/pf2e/pathfinder-monster-core-2/kuribu.json
+++ b/packs/pf2e/pathfinder-monster-core-2/kuribu.json
@@ -97,6 +97,9 @@
         },
         {
             "_id": "dKqYvGjXzeaZD1TJ",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.w2ENw2VMPcsbif8g"
+            },
             "img": "icons/weapons/ammunition/arrows-broadhead-white.webp",
             "name": "Arrows",
             "sort": 200000,

--- a/packs/pf2e/pathfinder-monster-core-2/nagaji-soldier.json
+++ b/packs/pf2e/pathfinder-monster-core-2/nagaji-soldier.json
@@ -254,6 +254,9 @@
         },
         {
             "_id": "mBstaMIB5FAD62gl",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.w2ENw2VMPcsbif8g"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/arrows.webp",
             "name": "Arrows",
             "sort": 400000,

--- a/packs/pf2e/pathfinder-monster-core-2/poppet-attendant.json
+++ b/packs/pf2e/pathfinder-monster-core-2/poppet-attendant.json
@@ -298,6 +298,9 @@
         },
         {
             "_id": "q27ajFSxzZOvcZFb",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.MKSeXwUm56c15MZa"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/sling-bullets.webp",
             "name": "Sling Bullets",
             "sort": 500000,

--- a/packs/pf2e/pathfinder-monster-core-2/poppet-mage.json
+++ b/packs/pf2e/pathfinder-monster-core-2/poppet-mage.json
@@ -949,6 +949,9 @@
         },
         {
             "_id": "CSFS5IHwqaKUs5xw",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.AITVZmakiu3RgfKo"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/bolts.webp",
             "name": "Bolts",
             "sort": 1300000,

--- a/packs/pf2e/pathfinder-monster-core-2/samsaran-anchorite.json
+++ b/packs/pf2e/pathfinder-monster-core-2/samsaran-anchorite.json
@@ -709,6 +709,9 @@
         },
         {
             "_id": "81SxJMM8OFCGs1bp",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.MKSeXwUm56c15MZa"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/sling-bullets.webp",
             "name": "Sling Bullets",
             "sort": 900000,

--- a/packs/pf2e/pathfinder-monster-core-2/strix-kinmate.json
+++ b/packs/pf2e/pathfinder-monster-core-2/strix-kinmate.json
@@ -253,6 +253,9 @@
         },
         {
             "_id": "PYg6dMkOR31SZEMr",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.w2ENw2VMPcsbif8g"
+            },
             "img": "icons/weapons/ammunition/arrows-broadhead-white.webp",
             "name": "Arrows",
             "sort": 400000,

--- a/packs/pf2e/pathfinder-monster-core-2/urdefhan-warrior.json
+++ b/packs/pf2e/pathfinder-monster-core-2/urdefhan-warrior.json
@@ -494,6 +494,9 @@
         },
         {
             "_id": "WSw8zkMSpRbgtBX2",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.w2ENw2VMPcsbif8g"
+            },
             "img": "icons/weapons/ammunition/arrows-broadhead-white.webp",
             "name": "Arrows",
             "sort": 800000,

--- a/packs/pf2e/pathfinder-monster-core-2/venator.json
+++ b/packs/pf2e/pathfinder-monster-core-2/venator.json
@@ -408,6 +408,9 @@
         },
         {
             "_id": "tpHTEBR85vubsRxN",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.AITVZmakiu3RgfKo"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/bolts.webp",
             "name": "Bolts",
             "sort": 700000,

--- a/packs/pf2e/pathfinder-npc-core/ancestry-npcs/tengu/gambling-companion.json
+++ b/packs/pf2e/pathfinder-npc-core/ancestry-npcs/tengu/gambling-companion.json
@@ -152,6 +152,9 @@
         },
         {
             "_id": "du8Xcuh7ebfiL5Vk",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.69IWSryF5BWkwWXY"
+            },
             "img": "icons/sundries/gaming/dice-pair-white-green.webp",
             "name": "Set of six ivory dice",
             "sort": 300000,

--- a/packs/pf2e/pfs-season-1-bestiary/1-03/desert-wind.json
+++ b/packs/pf2e/pfs-season-1-bestiary/1-03/desert-wind.json
@@ -5,6 +5,9 @@
     "items": [
         {
             "_id": "MrUPAQEkTMR7Z7F5",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.5yL2D3GPAggadZQN"
+            },
             "img": "icons/containers/bags/satchel-leather-white-tan.webp",
             "name": "Light Barding",
             "sort": 100000,

--- a/packs/pf2e/pfs-season-7-bestiary/quests/skeleton-guard.json
+++ b/packs/pf2e/pfs-season-7-bestiary/quests/skeleton-guard.json
@@ -186,6 +186,9 @@
         },
         {
             "_id": "C1Qh67YEkuH7r5lt",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.w2ENw2VMPcsbif8g"
+            },
             "img": "icons/weapons/ammunition/arrows-broadhead-white.webp",
             "name": "Arrows",
             "sort": 300000,

--- a/packs/pf2e/quest-for-the-frozen-flame-bestiary/book-3-burning-tundra/calcifda.json
+++ b/packs/pf2e/quest-for-the-frozen-flame-bestiary/book-3-burning-tundra/calcifda.json
@@ -760,6 +760,9 @@
         },
         {
             "_id": "tSnuNpmimE561PtR",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.ilnc82SKDYHcoEMH"
+            },
             "img": "systems/pf2e/icons/default-icons/treasure.svg",
             "name": "Opal",
             "sort": 1300000,

--- a/packs/pf2e/season-of-ghosts-bestiary/book-4-to-bloom-below-the-web/gurglegut-level-12.json
+++ b/packs/pf2e/season-of-ghosts-bestiary/book-4-to-bloom-below-the-web/gurglegut-level-12.json
@@ -325,6 +325,9 @@
         },
         {
             "_id": "OUv2KBzJxq85hrWA",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.AITVZmakiu3RgfKo"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/bolts.webp",
             "name": "Bolts",
             "sort": 500000,

--- a/packs/pf2e/season-of-ghosts-bestiary/book-4-to-bloom-below-the-web/silkwasp-bandit.json
+++ b/packs/pf2e/season-of-ghosts-bestiary/book-4-to-bloom-below-the-web/silkwasp-bandit.json
@@ -318,6 +318,9 @@
         },
         {
             "_id": "5Pg2bMrJaEWe8cUQ",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.rKknk8odXDBpON5l"
+            },
             "img": "systems/pf2e/icons/equipment/consumables/ammunition/explosive-ammunition.webp",
             "name": "Explosive Ammunition",
             "sort": 500000,

--- a/packs/pf2e/season-of-ghosts-bestiary/season-of-ghosts-hardcover-compilation/mercenary-enforcer.json
+++ b/packs/pf2e/season-of-ghosts-bestiary/season-of-ghosts-hardcover-compilation/mercenary-enforcer.json
@@ -317,6 +317,9 @@
         },
         {
             "_id": "EnwcvfbqjXez5Idj",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.w2ENw2VMPcsbif8g"
+            },
             "img": "icons/weapons/ammunition/arrows-broadhead-white.webp",
             "name": "Arrows",
             "sort": 500000,

--- a/packs/pf2e/shades-of-blood-bestiary/book-3-to-blot-out-the-sun/strigoi-servant.json
+++ b/packs/pf2e/shades-of-blood-bestiary/book-3-to-blot-out-the-sun/strigoi-servant.json
@@ -195,6 +195,9 @@
         },
         {
             "_id": "2lQeUlXJ4ns4J2BU",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.hIgqLgH3YcLZBeoT"
+            },
             "img": "icons/weapons/bows/shortbow-leather.webp",
             "name": "Shortbow",
             "sort": 400000,
@@ -350,6 +353,9 @@
         },
         {
             "_id": "b3J9L4BHnXcsqRqD",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.w2ENw2VMPcsbif8g"
+            },
             "img": "icons/weapons/ammunition/arrows-broadhead-white.webp",
             "name": "Arrows",
             "sort": 600000,

--- a/packs/pf2e/troubles-in-grayce-bestiary/1-the-path-river-peeler/crumbrunk.json
+++ b/packs/pf2e/troubles-in-grayce-bestiary/1-the-path-river-peeler/crumbrunk.json
@@ -107,6 +107,9 @@
         },
         {
             "_id": "Q7Syteo9JjOZLurF",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.7tKkkF8eZ4iCLJtp"
+            },
             "img": "icons/weapons/swords/sword-guard-purple.webp",
             "name": "Shortsword",
             "sort": 300000,
@@ -194,6 +197,9 @@
         },
         {
             "_id": "wCRPglJzgR6GIWA2",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.FPwsiGqMCNPLHmjX"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/blowgun.webp",
             "name": "Blowgun",
             "sort": 400000,
@@ -284,6 +290,9 @@
         },
         {
             "_id": "sns3usmlveyK5VRv",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.Tt4Qw64fwrxhr5gT"
+            },
             "img": "systems/pf2e/icons/equipment/weapons/dart.webp",
             "name": "Dart",
             "sort": 500000,

--- a/packs/pf2e/troubles-in-grayce-bestiary/1-the-path-river-peeler/damarys.json
+++ b/packs/pf2e/troubles-in-grayce-bestiary/1-the-path-river-peeler/damarys.json
@@ -937,6 +937,9 @@
         },
         {
             "_id": "0vwBIzwsnyf0rryI",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.FVjTuBCIefAgloUU"
+            },
             "img": "icons/weapons/staves/staff-simple.webp",
             "name": "Staff",
             "sort": 1400000,
@@ -1021,6 +1024,9 @@
         },
         {
             "_id": "dSCEP0IVPpqqb8VS",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.rQWaJhI5Bko5x14Z"
+            },
             "img": "icons/weapons/daggers/dagger-straight-blue.webp",
             "name": "Dagger",
             "sort": 1500000,
@@ -1110,6 +1116,9 @@
         },
         {
             "_id": "FcedqF32LI299QMI",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.4tIVTg9wj56RrveA"
+            },
             "img": "icons/equipment/chest/breastplate-banded-simple-leather-brown.webp",
             "name": "Leather Armor",
             "sort": 1600000,

--- a/packs/pf2e/troubles-in-grayce-bestiary/1-the-path-river-peeler/shiverscale-kobold.json
+++ b/packs/pf2e/troubles-in-grayce-bestiary/1-the-path-river-peeler/shiverscale-kobold.json
@@ -5,6 +5,9 @@
     "items": [
         {
             "_id": "hxsmLpmP1Te8sypc",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.62nnVQvGhoVLLl2K"
+            },
             "img": "icons/weapons/crossbows/crossbow-simple-brown.webp",
             "name": "Crossbow",
             "sort": 100000,
@@ -92,6 +95,9 @@
         },
         {
             "_id": "PDHmUNhgvYJ9MfUr",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.7tKkkF8eZ4iCLJtp"
+            },
             "img": "icons/weapons/swords/sword-guard-purple.webp",
             "name": "Shortsword",
             "sort": 200000,
@@ -179,6 +185,9 @@
         },
         {
             "_id": "26lBOECSDzvi2Wo4",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.4tIVTg9wj56RrveA"
+            },
             "img": "icons/equipment/chest/breastplate-banded-simple-leather-brown.webp",
             "name": "Leather Armor",
             "sort": 300000,

--- a/packs/pf2e/troubles-in-grayce-bestiary/1-the-path-river-peeler/zoti.json
+++ b/packs/pf2e/troubles-in-grayce-bestiary/1-the-path-river-peeler/zoti.json
@@ -5,6 +5,9 @@
     "items": [
         {
             "_id": "FWGGmjTFnHT8triF",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.tOhoGvmCMw4JpWcS"
+            },
             "img": "icons/weapons/polearms/spear-flared-steel.webp",
             "name": "Spear",
             "sort": 100000,
@@ -92,6 +95,9 @@
         },
         {
             "_id": "q6kzKhDQByx5FwpR",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.Yr9yCuJiAlFh3QEB"
+            },
             "img": "systems/pf2e/icons/equipment/shields/steel-shield.webp",
             "name": "Steel Shield",
             "sort": 200000,
@@ -150,6 +156,9 @@
         },
         {
             "_id": "26lBOECSDzvi2Wo4",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.4tIVTg9wj56RrveA"
+            },
             "img": "icons/equipment/chest/breastplate-banded-simple-leather-brown.webp",
             "name": "Leather Armor",
             "sort": 300000,

--- a/packs/pf2e/troubles-in-grayce-bestiary/1-the-path-river-peeler/zurkurk.json
+++ b/packs/pf2e/troubles-in-grayce-bestiary/1-the-path-river-peeler/zurkurk.json
@@ -881,6 +881,9 @@
         },
         {
             "_id": "FDfZfvewheTHmyjV",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.FVjTuBCIefAgloUU"
+            },
             "img": "icons/weapons/staves/staff-simple.webp",
             "name": "Staff",
             "sort": 1400000,

--- a/packs/pf2e/troubles-in-grayce-bestiary/2-sabotage/durtik.json
+++ b/packs/pf2e/troubles-in-grayce-bestiary/2-sabotage/durtik.json
@@ -280,6 +280,9 @@
         },
         {
             "_id": "cXnqqkz6ZsKHELUM",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.hIgqLgH3YcLZBeoT"
+            },
             "img": "icons/weapons/bows/shortbow-leather.webp",
             "name": "Shortbow",
             "sort": 500000,
@@ -369,6 +372,9 @@
         },
         {
             "_id": "5x6mlShcPIhHRfc6",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.7tKkkF8eZ4iCLJtp"
+            },
             "img": "icons/weapons/swords/sword-guard-purple.webp",
             "name": "Shortsword",
             "sort": 600000,
@@ -456,6 +462,9 @@
         },
         {
             "_id": "kQibauOBQa0LlXPH",
+            "_stats": {
+                "compendiumSource": "Compendium.pf2e.equipment-srd.Item.w2ENw2VMPcsbif8g"
+            },
             "img": "icons/weapons/ammunition/arrows-broadhead-white.webp",
             "name": "Arrows",
             "sort": 700000,


### PR DESCRIPTION
Mostly for ammunition (arrows/bolts), but some weapons and armor were also missing their sources.

Matching was done by name and description (so some cases that could apply, for example, pre-remaster items or NPC core reflavored weapons and armor, are skipped for the time).

