### PR TITLE
Fix DOM helpers returning null cross-window in PopOut!

### DIFF
--- a/src/util/dom.ts
+++ b/src/util/dom.ts
@@ -89,7 +89,7 @@ function htmlQuery<K extends keyof HTMLElementTagNameMap>(
 function htmlQuery(parent: MaybeHTML, selectors: string): HTMLElement | null;
 function htmlQuery<E extends HTMLElement = HTMLElement>(parent: MaybeHTML, selectors: string): E | null;
 function htmlQuery(parent: MaybeHTML, selectors: string): HTMLElement | null {
-    if (!(parent instanceof Element || parent instanceof Document)) return null;
+    if (!parent || !("querySelector" in parent)) return null;
     return parent.querySelector<HTMLElement>(selectors);
 }
 
@@ -100,7 +100,7 @@ function htmlQueryAll<K extends keyof HTMLElementTagNameMap>(
 function htmlQueryAll(parent: MaybeHTML, selectors: string): HTMLElement[];
 function htmlQueryAll<E extends HTMLElement = HTMLElement>(parent: MaybeHTML, selectors: string): E[];
 function htmlQueryAll(parent: MaybeHTML, selectors: string): HTMLElement[] {
-    if (!(parent instanceof Element || parent instanceof Document)) return [];
+    if (!parent || !("querySelectorAll" in parent)) return [];
     return Array.from(parent.querySelectorAll<HTMLElement>(selectors));
 }
 
@@ -111,7 +111,7 @@ function htmlClosest<K extends keyof HTMLElementTagNameMap>(
 function htmlClosest(child: MaybeHTML, selectors: string): HTMLElement | null;
 function htmlClosest<E extends HTMLElement = HTMLElement>(parent: MaybeHTML, selectors: string): E | null;
 function htmlClosest(child: MaybeHTML, selectors: string): HTMLElement | null {
-    if (!(child instanceof Element)) return null;
+    if (!child || !("closest" in child)) return null;
     return child.closest<HTMLElement>(selectors);
 }
 


### PR DESCRIPTION
Partial fix for #22408 (the visible-error symptoms on popped-out sheets, not the underlying ApplicationV1-to-V2 migration).

`instanceof Element` and `instanceof Document` return false when the node belongs to a different window's globals, which is what PopOut! does. Switched the guards to duck-typed property presence (`"querySelector"`, `"querySelectorAll"`, `"closest"`); prototype-agnostic but still rejects `EventTarget`s that lack the methods.

## Test plan
- [x] Foundry v14.363 + PopOut! v2.23, PF2e and SF2e v8.1.2 dev worlds
- [x] Pre-patch: clicking a roll-option toggle on a popped sheet throws `Sheet navigation not found` and the sheet stops rendering
- [x] Post-patch: toggle flips cleanly, sheet re-renders, no error
- [x] Repro: drag any feat with a togglable RollOption (Devise a Stratagem, Hunt Prey) onto a character, pop the sheet, click the toggle
