### PR TITLE
Fix hiding roll opposer names

### DIFF
--- a/src/module/system/check/check.ts
+++ b/src/module/system/check/check.ts
@@ -716,7 +716,8 @@ class Check {
                 return fromUuid(opposer.token) as Promise<TokenDocumentPF2e<ScenePF2e> | null>;
             })();
 
-            const canSeeTokenName = token ?? (await opposingActor?.getTokenDocument())?.playersCanSeeName;
+            const canSeeTokenName =
+                token?.playersCanSeeName ?? (await opposingActor?.getTokenDocument())?.playersCanSeeName;
             const canSeeName = canSeeTokenName || !game.pf2e.settings.tokens.nameVisibility;
             return {
                 name: token?.name ?? opposingActor?.name ?? "",


### PR DESCRIPTION
Closes #22396, opposer is the only thing I found not respecting the setting.