### PR TITLE
Make Crossbow Crack Shot's bonus damage and backstabber upgrade mutually exclusive

### DIFF
--- a/packs/pf2e/feats/class/gunslinger/level-1/crossbow-crack-shot.json
+++ b/packs/pf2e/feats/class/gunslinger/level-1/crossbow-crack-shot.json
@@ -39,7 +39,7 @@
                     {
                         "nand": [
                             "item:trait:backstabber",
-                            "target:trait:off-guard"
+                            "target:condition:off-guard"
                         ]
                     }
                 ],

--- a/packs/pf2e/feats/class/gunslinger/level-1/crossbow-crack-shot.json
+++ b/packs/pf2e/feats/class/gunslinger/level-1/crossbow-crack-shot.json
@@ -27,7 +27,6 @@
         },
         "rules": [
             {
-                "domain": "damage",
                 "key": "RollOption",
                 "option": "crossbow-crack-shot",
                 "toggleable": true
@@ -36,7 +35,13 @@
                 "damageCategory": "precision",
                 "key": "FlatModifier",
                 "predicate": [
-                    "crossbow-crack-shot"
+                    "crossbow-crack-shot",
+                    {
+                        "nand": [
+                            "item:trait:backstabber",
+                            "target:trait:off-guard"
+                        ]
+                    }
                 ],
                 "selector": "crossbow-weapon-group-damage",
                 "slug": "crossbow-crack-shot-bonus",
@@ -65,6 +70,7 @@
             },
             {
                 "damageCategory": "precision",
+                "hideIfDisabled": true,
                 "key": "FlatModifier",
                 "label": "PF2E.TraitBackstabber",
                 "predicate": [


### PR DESCRIPTION
Also remove unnecessary domain from its Roll Option toggle.

One might also read that backstabber weapons don't get the range increment upgrade when their target is off-guard. Seems RAW but I couldn't get the automation for it to work anyway. Someone else might want to look into it.

- Closes #22377