### PR TITLE
Add pf2e.castSpell hook

### DIFF
--- a/src/module/item/spellcasting-entry/document.ts
+++ b/src/module/item/spellcasting-entry/document.ts
@@ -264,6 +264,7 @@ class SpellcastingEntryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null>
         if (message && valid) {
             spell.system.location.value ??= this.id;
             const castRank = spell.computeCastRank(rank);
+            Hooks.callAll("pf2e.castSpell", spell, this, { ...options, castRank });
             await spell.toMessage(null, { mode: options.messageMode, data: { castRank } });
         }
     }

--- a/src/module/item/spellcasting-entry/document.ts
+++ b/src/module/item/spellcasting-entry/document.ts
@@ -257,6 +257,7 @@ class SpellcastingEntryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null>
 
     /** Cast the given spell as if it was part of this spellcasting entry. */
     async cast(spell: SpellPF2e<ActorPF2e>, options: CastOptions = {}): Promise<void> {
+        if (Hooks.call("pf2e.preCastSpell", spell, this, options) === false) return;
         const consume = options.consume ?? true;
         const message = options.message ?? true;
         const rank = options.rank ?? spell.rank;

--- a/src/module/item/spellcasting-entry/item-spellcasting.ts
+++ b/src/module/item/spellcasting-entry/item-spellcasting.ts
@@ -87,6 +87,7 @@ class ItemSpellcasting<TActor extends CreaturePF2e = CreaturePF2e> implements Sp
     }
 
     async cast(spell: SpellPF2e, options: CastOptions = {}): Promise<void> {
+        if (Hooks.call("pf2e.preCastSpell", spell, this, options) === false) return;
         const message = options.message ?? true;
         if (message && this.canCast(spell, { origin: spell.parentItem })) {
             spell.system.location.value = this.id;

--- a/src/module/item/spellcasting-entry/item-spellcasting.ts
+++ b/src/module/item/spellcasting-entry/item-spellcasting.ts
@@ -90,6 +90,7 @@ class ItemSpellcasting<TActor extends CreaturePF2e = CreaturePF2e> implements Sp
         const message = options.message ?? true;
         if (message && this.canCast(spell, { origin: spell.parentItem })) {
             spell.system.location.value = this.id;
+            Hooks.callAll("pf2e.castSpell", spell, this, { ...options, castRank: spell.rank });
             await spell.toMessage(null, { mode: options.messageMode, data: { castRank: spell.rank } });
         }
     }

--- a/src/module/item/spellcasting-entry/rituals.ts
+++ b/src/module/item/spellcasting-entry/rituals.ts
@@ -60,6 +60,7 @@ export class RitualSpellcasting<TActor extends ActorPF2e> implements BaseSpellca
 
     async cast(spell: SpellPF2e, options: CastOptions = {}): Promise<void> {
         if (!spell.isRitual) throw ErrorPF2e("Attempted to cast non-ritual from `RitualSpellcasting`");
+        Hooks.callAll("pf2e.castSpell", spell, this, { ...options, castRank: spell.rank });
         await spell.toMessage(undefined, { mode: options.messageMode });
     }
 

--- a/src/module/item/spellcasting-entry/rituals.ts
+++ b/src/module/item/spellcasting-entry/rituals.ts
@@ -60,6 +60,7 @@ export class RitualSpellcasting<TActor extends ActorPF2e> implements BaseSpellca
 
     async cast(spell: SpellPF2e, options: CastOptions = {}): Promise<void> {
         if (!spell.isRitual) throw ErrorPF2e("Attempted to cast non-ritual from `RitualSpellcasting`");
+        if (Hooks.call("pf2e.preCastSpell", spell, this, options) === false) return;
         Hooks.callAll("pf2e.castSpell", spell, this, { ...options, castRank: spell.rank });
         await spell.toMessage(undefined, { mode: options.messageMode });
     }

--- a/src/module/item/spellcasting-entry/trick.ts
+++ b/src/module/item/spellcasting-entry/trick.ts
@@ -138,6 +138,7 @@ class TrickMagicItemEntry<TActor extends ActorPF2e = ActorPF2e> implements Spell
     }
 
     async cast(spell: SpellPF2e, options: CastOptions = {}): Promise<void> {
+        if (Hooks.call("pf2e.preCastSpell", spell, this, options) === false) return;
         const { messageMode, message } = options;
         const castRank = spell.computeCastRank(spell.rank);
         if (message === false) return;

--- a/src/module/item/spellcasting-entry/trick.ts
+++ b/src/module/item/spellcasting-entry/trick.ts
@@ -143,6 +143,7 @@ class TrickMagicItemEntry<TActor extends ActorPF2e = ActorPF2e> implements Spell
         if (message === false) return;
 
         spell = spell.loadVariant({ entryId: this.id }) ?? spell;
+        Hooks.callAll("pf2e.castSpell", spell, this, { ...options, castRank });
         await spell.toMessage(null, { mode: messageMode, data: { castRank } });
     }
 


### PR DESCRIPTION
Closes #20761. Thanks @MrVauxs for the design input on the pre-hook shape.

Adds two hooks fired from each `BaseSpellcastingEntry.cast()` (document, rituals, item-spellcasting, trick):

- `Hooks.call("pf2e.preCastSpell", spell, feature, options)` at the top of `cast()`. Handlers can mutate `options` (rank, consume, message) in place to alter the cast, or return `false` to cancel entirely. Motivated by Vauxs's use cases: Essence Casting needs to skip slot consume and advance its own resource; spellshapes need to mutate cast rank.
- `Hooks.callAll("pf2e.castSpell", spell, feature, { ...options, castRank })` right before `spell.toMessage()`. Fire-and-forget post-cast, distinguishes deliberate casts from spell-icon chat prints.

## Test plan
- [x] Post-hook fires with `(spell, feature, { ..., castRank })` on Cast button click (verified Caustic Blast @ rank 3 via Arcane Spontaneous)
- [x] Pre-hook mutating `opts.consume = false` produces a chat card but does not decrement the spell slot
- [x] Pre-hook returning `false` cancels the cast: no chat card, no consume, no error
- [x] No-hook regression: with all `pf2e.preCastSpell` / `pf2e.castSpell` listeners removed, Cast button decrements slots and renders the chat card as before
