### PR TITLE
Add text filter and slot-header toggle to PC spellcasting tab

### DIFF
--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -18,7 +18,7 @@ import type {
     HeritagePF2e,
     PhysicalItemPF2e,
 } from "@item";
-import { ItemPF2e, ItemProxyPF2e } from "@item";
+import { ItemPF2e, ItemProxyPF2e, type SpellPF2e } from "@item";
 import { TraitToggleViewData } from "@item/ability/trait-toggles.ts";
 import { ItemSourcePF2e } from "@item/base/data/index.ts";
 import { isSpellConsumableUUID } from "@item/consumable/spell-consumables.ts";
@@ -50,6 +50,7 @@ import {
 } from "@util";
 import { createTooltipster } from "@util/destroyables.ts";
 import { UUIDUtils } from "@util/uuid.ts";
+import MiniSearch from "minisearch";
 import * as R from "remeda";
 import { CreatureSheetPF2e } from "../creature/sheet.ts";
 import { ManageAttackProficiencies } from "../sheet/popups/manage-attack-proficiencies.ts";
@@ -85,6 +86,14 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
     /** Non-persisted tweaks to formula data */
     #formulaQuantities: Record<string, number> = {};
 
+    /** Index of this PC's spells for the spell tab text filter */
+    #spellSearchEngine = new MiniSearch<Pick<SpellPF2e<TActor>, "id" | "name">>({
+        fields: ["name"],
+        idField: "id",
+        processTerm: (t) => (t.length > 1 ? t.toLocaleLowerCase(game.i18n.lang) : null),
+        searchOptions: { combineWith: "AND", prefix: true },
+    });
+
     static override get defaultOptions(): ActorSheetOptions {
         const options = super.defaultOptions;
         options.classes = [...options.classes, "character"];
@@ -92,6 +101,13 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
         options.height = 750;
         options.scrollY.push(".tab[data-tab=spellcasting] > [data-panels]", ".tab.active .tab-content");
         options.dragDrop.push({ dragSelector: "ol[data-strikes] > li, ol[data-elemental-blasts] > li" });
+        options.filters = [
+            ...options.filters,
+            {
+                inputSelector: ".tab[data-tab=spellcasting] > .search input[type=search]",
+                contentSelector: ".tab[data-tab=spellcasting]",
+            },
+        ];
         options.tabs = [
             { navSelector: "nav.sheet-navigation", contentSelector: ".sheet-content", initial: "character" },
             { navSelector: "nav.actions-nav", contentSelector: ".actions-panels", initial: "encounter" },
@@ -393,7 +409,25 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
             };
         });
 
+        this.#spellSearchEngine.removeAll();
+        this.#spellSearchEngine.addAll(actor.itemTypes.spell.map((s) => R.pick(s, ["id", "name"])));
+
         return sheetData;
+    }
+
+    protected override _onSearchFilter(
+        event: KeyboardEvent,
+        query: string,
+        rgx: RegExp,
+        html: HTMLElement | null,
+    ): void {
+        super._onSearchFilter(event, query, rgx, html);
+        if (!html?.classList.contains("spellcasting")) return;
+        const matches: Set<string> =
+            query.length > 1 ? new Set(this.#spellSearchEngine.search(query).map((s) => String(s.id))) : new Set();
+        for (const row of htmlQueryAll(html, "li.spell[data-item-id]")) {
+            row.hidden = query.length > 1 && !matches.has(row.dataset.itemId ?? "");
+        }
     }
 
     /** Prepares all ability-type items that create an action in the sheet */

--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -285,6 +285,7 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
         sheetData.hasNormalSpellcasting = sheetData.spellCollectionGroups["known-spells"].some(
             (s) => s.usesSpellProficiency,
         );
+        sheetData.hideSpellSlotHeaders = !!game.settings.get(SYSTEM_ID, "spellcasting.hideSlotHeaders");
 
         // ensure saves are displayed in the following order:
         sheetData.data.saves = {
@@ -847,6 +848,13 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
 
         handlers["rest"] = async (event) => {
             return game.pf2e.actions.restForTheNight({ event, actors: this.actor });
+        };
+
+        // SPELLCASTING
+
+        handlers["toggle-slot-headers"] = () => {
+            const current = game.settings.get(SYSTEM_ID, "spellcasting.hideSlotHeaders");
+            return game.settings.set(SYSTEM_ID, "spellcasting.hideSlotHeaders", !current);
         };
 
         // MAIN TAB
@@ -1688,6 +1696,8 @@ interface CharacterSheetData<TActor extends CharacterPF2e = CharacterPF2e> exten
     showPFSTab: boolean;
     spellCollectionGroups: Record<SpellcastingTabSlug, SpellcastingSheetData[]>;
     hasNormalSpellcasting: boolean;
+    /** Whether the user has collapsed the spell slot rank headers on the spellcasting tab */
+    hideSpellSlotHeaders: boolean;
     tabVisibility: CharacterSheetTabVisibility;
     actions: {
         encounter: Record<"action" | "reaction" | "free", { label: string; actions: CharacterAbilityViewData[] }>;

--- a/src/module/system/settings/index.ts
+++ b/src/module/system/settings/index.ts
@@ -297,6 +297,19 @@ export function registerSettings(): void {
         }),
     });
 
+    // Per-user toggle for collapsing the spell slot rank headers on the PC spellcasting tab
+    game.settings.register(SYSTEM_ID, "spellcasting.hideSlotHeaders", {
+        name: "Hide Spell Slot Headers",
+        scope: "client",
+        config: false,
+        type: new fields.BooleanField(),
+        onChange: () => {
+            for (const sheet of Object.values(ui.windows).filter((w) => w instanceof ActorSheetPF2e)) {
+                sheet.render();
+            }
+        },
+    });
+
     registerTrackingSettings();
 
     if (BUILD_MODE === "production") {

--- a/src/styles/actor/character/_spellcasting.scss
+++ b/src/styles/actor/character/_spellcasting.scss
@@ -11,7 +11,7 @@
         align-items: center;
         display: flex;
         position: relative;
-        padding: var(--space-4) var(--space-8) 0;
+        padding: var(--space-10) var(--space-8) 0;
 
         &::before {
             content: "\f002";

--- a/src/styles/actor/character/_spellcasting.scss
+++ b/src/styles/actor/character/_spellcasting.scss
@@ -7,6 +7,31 @@
         flex-basis: 20%;
     }
 
+    > .search {
+        align-items: center;
+        display: flex;
+        position: relative;
+        padding: var(--space-4) var(--space-8) 0;
+
+        &::before {
+            content: "\f002";
+            color: var(--input-text-color);
+            font-family: var(--font-awesome);
+            font-weight: bold;
+            position: absolute;
+            left: 1rem;
+        }
+
+        input {
+            border: 1px solid var(--color-pf-alternate);
+            background-color: rgba(28, 28, 28, 0.1);
+            padding-left: 1.75rem;
+            height: 1.625rem;
+            line-height: 1.625rem;
+            width: 100%;
+        }
+    }
+
     .spell-collections {
         overflow-y: auto;
         scrollbar-gutter: stable;

--- a/src/styles/actor/character/_spellcasting.scss
+++ b/src/styles/actor/character/_spellcasting.scss
@@ -28,8 +28,24 @@
             padding-left: 1.75rem;
             height: 1.625rem;
             line-height: 1.625rem;
-            width: 100%;
+            flex: 1;
+            min-width: 0;
         }
+
+        a.toggle-slot-headers {
+            color: var(--color-pf-alternate);
+            flex: 0 0 auto;
+            margin-left: var(--space-6);
+
+            &:hover,
+            &.active {
+                color: var(--color-pf-primary);
+            }
+        }
+    }
+
+    &.hide-slot-headers .header-row {
+        display: none;
     }
 
     .spell-collections {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -304,6 +304,7 @@
                     "Label": "Rest for the Night"
                 },
                 "Spellcasting": {
+                    "Search": "Search Spells",
                     "Tab": {
                         "Activations": "Activations",
                         "KnownSpells": "Known Spells",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -309,7 +309,8 @@
                         "Activations": "Activations",
                         "KnownSpells": "Known Spells",
                         "Rituals": "Rituals"
-                    }
+                    },
+                    "ToggleSlotHeaders": "Toggle Spell Slot Headers"
                 }
             },
             "Creature": {

--- a/static/templates/actors/character/tabs/spellcasting.hbs
+++ b/static/templates/actors/character/tabs/spellcasting.hbs
@@ -5,6 +5,10 @@
         <a data-tab="activations" data-group="spell-collections">{{localize "PF2E.Actor.Character.Spellcasting.Tab.Activations"}}</a>
     </nav>
 
+    <div class="search">
+        <input type="search" spellcheck="false" placeholder="{{localize "PF2E.Actor.Character.Spellcasting.Search"}}" />
+    </div>
+
     <div class="spell-collections" data-panels>
         {{#if toggles.spellcasting}}{{> (resolvePath "templates/actors/partials/toggles.hbs") toggles=toggles.spellcasting}}{{/if}}
 

--- a/static/templates/actors/character/tabs/spellcasting.hbs
+++ b/static/templates/actors/character/tabs/spellcasting.hbs
@@ -1,4 +1,4 @@
-<div class="tab spellcasting spellbook-pane" data-group="primary" data-tab="spellcasting">
+<div class="tab spellcasting spellbook-pane{{#if hideSpellSlotHeaders}} hide-slot-headers{{/if}}" data-group="primary" data-tab="spellcasting">
     <nav class="sub-nav" data-group="spell-collections">
         <a data-tab="known-spells" data-group="spell-collections">{{localize "PF2E.Actor.Character.Spellcasting.Tab.KnownSpells"}}</a>
         <a class="rituals" data-tab="rituals" data-group="spell-collections">{{localize "PF2E.Actor.Character.Spellcasting.Tab.Rituals"}}</a>
@@ -7,6 +7,11 @@
 
     <div class="search">
         <input type="search" spellcheck="false" placeholder="{{localize "PF2E.Actor.Character.Spellcasting.Search"}}" />
+        <a
+            class="toggle-slot-headers{{#if hideSpellSlotHeaders}} active{{/if}}"
+            data-action="toggle-slot-headers"
+            data-tooltip="PF2E.Actor.Character.Spellcasting.ToggleSlotHeaders"
+        ><i class="fa-solid fa-fw fa-list-ul"></i></a>
     </div>
 
     <div class="spell-collections" data-panels>


### PR DESCRIPTION
Closes #19937 (text portion).

Adds a name search and a per-user toggle to collapse the spell slot rank headers, both in the spellcasting tab header.

## Test plan
- [x] Type in the search: non-matching spell rows hide, clearing restores
- [x] Click the toggle: rank headers collapse and restore, persists across reload