### PR TITLE
Fix empty damage card when target is fully immune

### DIFF
--- a/src/module/actor/base.ts
+++ b/src/module/actor/base.ts
@@ -1297,7 +1297,7 @@ class ActorPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | n
                 return hitPoints.value === hitPoints.max ? `${locPrefix}.AtFullHealth` : `${locPrefix}.HealedForN`;
             }
             if (!hitPoints.max || finalDamage - damageAbsorbedByActor === 0) {
-                return persistentCreated ? null : `${locPrefix}.TakesNoDamage`;
+                return persistentCreated.length ? null : `${locPrefix}.TakesNoDamage`;
             }
             return damageAbsorbedByShield > 0
                 ? damageResult.totalApplied > 0


### PR DESCRIPTION
Fixes #22364.

`persistentCreated` is always an array, so the truthy check always returned `null` and the `TakesNoDamage` message never rendered. `.length` instead.

## Test plan
- [x] Apply fire damage from chat to an actor immune to fire, follow-up card reads "X takes no damage" instead of being empty