### PR TITLE
Restore rules accurate measured template coverage

### DIFF
--- a/src/module/canvas/layer/region.ts
+++ b/src/module/canvas/layer/region.ts
@@ -1,5 +1,11 @@
+import type { PlaceablesLayerPointerEvent } from "@client/canvas/layers/base/placeables-layer.d.mts";
+import type { ConeShapeData, LineShapeData } from "@common/data/data.d.mts";
 import { RegionDocumentPF2e } from "@scene";
 import { RegionPF2e } from "../index.ts";
+
+/** Cones fire along the eight grid directions; lines can be aimed at any cell, so they step much finer. */
+const directionSnap = (type: string): number => (type === "cone" ? 45 : 5);
+const isAimable = (type: string): boolean => type === "cone" || type === "line";
 
 export class RegionLayerPF2e extends fc.layers.RegionLayer<RegionPF2e> {
     override placeRegion(
@@ -7,14 +13,72 @@ export class RegionLayerPF2e extends fc.layers.RegionLayer<RegionPF2e> {
         options: fc.layers.RegionPlacementOptions<RegionPF2e> = {},
     ): Promise<RegionDocumentPF2e | null> {
         if (data.displayMeasurements && data.highlightMode === "coverage") {
-            options.onMove = ({ position, preview, snap }) => {
-                if (canvas.grid.type !== CONST.GRID_TYPES.SQUARE || !snap) return;
-                const snappingMode = (preview as RegionPF2e).snappingMode;
-                const { x, y } = canvas.grid.getSnappedPoint(position, { mode: snappingMode });
+            // Cones and lines place in two steps: a click drops the origin, then the cursor aims them
+            const placement = { aiming: false };
+
+            options.onMove = ({ event, position, preview, shape, snap }) => {
+                if (canvas.grid.type !== CONST.GRID_TYPES.SQUARE) return;
+                if (placement.aiming && isAimable(shape.type)) {
+                    // Point the shape at the cursor instead of dragging its origin around. Ctrl rotates freely
+                    const placed = shape as ConeShapeData | LineShapeData;
+                    const angle = Math.toDegrees(Math.atan2(position.y - placed.y, position.x - placed.x));
+                    const snapped = event.ctrlKey || event.metaKey ? angle : angle.toNearest(directionSnap(shape.type));
+                    placed.updateSource({ rotation: snapped });
+                    return false;
+                }
+                if (!snap) return;
+                const { x, y } = canvas.grid.getSnappedPoint(position, { mode: preview.snappingMode });
                 position.x = x;
                 position.y = y;
+                return;
+            };
+
+            // Mouse wheel nudges the direction in the same increments. Ctrl nudges freely in 5-degree steps
+            options.onRotate = ({ event, shape }) => {
+                if (!isAimable(shape.type) || canvas.grid.type !== CONST.GRID_TYPES.SQUARE) return;
+                const placed = shape as ConeShapeData | LineShapeData;
+                const free = event.ctrlKey || event.metaKey;
+                const step = free ? 5 : directionSnap(shape.type);
+                const delta = step * Math.sign(event.deltaY);
+                const rotation = placed.rotation + delta;
+                placed.updateSource({ rotation: free ? rotation : rotation.toNearest(step) });
+                return false;
+            };
+
+            // First click sets the origin and switches to aiming; the second click confirms. Shift places directly
+            options.preConfirm = ({ event, shape }) => {
+                const aim = isAimable(shape.type) && canvas.grid.type === CONST.GRID_TYPES.SQUARE && !event.shiftKey;
+                if (!placement.aiming && aim) {
+                    placement.aiming = true;
+                    return false;
+                }
+                return undefined;
+            };
+
+            // Right-click while aiming drops back to moving the origin rather than cancelling
+            options.preSkip = () => {
+                if (placement.aiming) {
+                    placement.aiming = false;
+                    return false;
+                }
+                return undefined;
             };
         }
         return super.placeRegion(data, options);
+    }
+
+    /** Snap a cone or line direction while drawing a template with the region tools. */
+    protected override _onDragLeftMove(event: PlaceablesLayerPointerEvent<RegionPF2e>): void {
+        super._onDragLeftMove(event);
+        // Only template-mode draws are measured templates; leave plain region shapes alone
+        if (!this.templateMode || canvas.grid.type !== CONST.GRID_TYPES.SQUARE) return;
+        const shape = (event.interactionData as { shape?: { type: string } }).shape;
+        if (!shape || !isAimable(shape.type)) return;
+        const placed = shape as ConeShapeData | LineShapeData;
+        const rotation = placed.rotation.toNearest(directionSnap(shape.type));
+        if (rotation !== placed.rotation) {
+            placed.updateSource({ rotation });
+            this._updateDragPreview(event);
+        }
     }
 }

--- a/src/module/canvas/region.ts
+++ b/src/module/canvas/region.ts
@@ -1,11 +1,20 @@
 import type { PlaceablesLayerPointerEvent } from "@client/canvas/layers/base/placeables-layer.d.mts";
 import type { Point } from "@common/_types.d.mts";
 import type { GridSnappingMode } from "@common/constants.d.mts";
+import type { CircleShapeData, ConeShapeData, LineShapeData } from "@common/data/data.d.mts";
+import type { GridOffset2D } from "@common/grid/_types.d.mts";
 import { EffectAreaShape } from "@item/types.ts";
 import type { RegionDocumentPF2e } from "@scene/region-document/document.ts";
+import { measureDistance } from "./helpers.ts";
 
 /** Add support for drag/drop repositioning of regions. */
 class RegionPF2e<TDocument extends RegionDocumentPF2e = RegionDocumentPF2e> extends fc.placeables.Region<TDocument> {
+    /** Squares in range but walled off from the origin, shaded as blocked rather than covered */
+    #blockedOffsets: GridOffset2D[] = [];
+
+    /** Graphics for the blocked-square shading */
+    #blockedHighlight: PIXI.Graphics | null = null;
+
     get snappingMode(): GridSnappingMode {
         const MODES = CONST.GRID_SNAPPING_MODES;
         switch (this.areaShape) {
@@ -28,6 +37,184 @@ class RegionPF2e<TDocument extends RegionDocumentPF2e = RegionDocumentPF2e> exte
         return this.layer.getSnappedPoint(position ?? this.center);
     }
 
+    /** Cover the squares a burst, cone, or line effect area reaches, counted by PF2e's grid rules. */
+    protected override _getCoveredGridSpaceOffsets(): GridOffset2D[] {
+        this.#blockedOffsets = [];
+        const shapeData = this.document.shapes.at(0);
+        if (!canvas.grid.isSquare || this.document.shapes.length !== 1 || !shapeData) {
+            return super._getCoveredGridSpaceOffsets();
+        }
+        // Bursts and cylinders are circles; only circles, cones, and lines are template shapes we count ourselves
+        if (shapeData.type !== "circle" && shapeData.type !== "cone" && shapeData.type !== "line") {
+            return super._getCoveredGridSpaceOffsets();
+        }
+        // Foundry doesn't give cone/line a literal `type`, so the union won't narrow without a cast
+        const area = this.#areaCoverage(shapeData as CircleShapeData | ConeShapeData | LineShapeData);
+
+        const { size } = canvas.dimensions;
+        const grid = canvas.grid;
+        const { i: col0, j: row0 } = grid.getOffset(grid.getCenterPoint(area.searchCenter));
+        const span = Math.ceil(area.reach) + 1;
+
+        const offsets: GridOffset2D[] = [];
+        const blocked: GridOffset2D[] = [];
+        for (let a = -span; a <= span; a++) {
+            for (let b = -span; b <= span; b++) {
+                const { x: gx, y: gy } = grid.getTopLeftPoint({ i: col0 + a, j: row0 + b });
+                // Cell center, in pixels
+                const destination = { x: gx + size * 0.5, y: gy + size * 0.5 };
+                if (destination.x < 0 || destination.y < 0) continue;
+                if (!area.contains(destination)) continue;
+
+                // A wall between the origin and the cell center means no line of effect: blocked, not covered
+                const offset = { i: col0 + a, j: row0 + b };
+                const hasLineOfEffect =
+                    !canvas.ready ||
+                    !CONFIG.Canvas.polygonBackends.move.testCollision(area.origin, destination, {
+                        type: "move",
+                        mode: "any",
+                    });
+                (hasLineOfEffect ? offsets : blocked).push(offset);
+            }
+        }
+        this.#blockedOffsets = blocked;
+
+        return offsets;
+    }
+
+    /** Resolve a template shape into its line-of-effect origin, a cell-search box, and a coverage test. */
+    #areaCoverage(shape: CircleShapeData | ConeShapeData | LineShapeData): AreaCoverage {
+        const { size, distance } = canvas.dimensions;
+
+        if (shape.type === "circle") {
+            const circle = shape as CircleShapeData;
+            const origin = { x: circle.x, y: circle.y };
+            const radius = (circle.radius / size) * distance;
+            return {
+                origin,
+                searchCenter: origin,
+                reach: circle.radius / size,
+                contains: (destination) => measureDistance(destination, origin) <= radius,
+            };
+        }
+
+        if (shape.type === "cone") {
+            const cone = shape as ConeShapeData;
+            const radius = (cone.radius / size) * distance;
+            const { origin, contains } = this.#coneCoverage(cone, { x: cone.x, y: cone.y });
+            return {
+                origin,
+                searchCenter: origin,
+                reach: cone.radius / size,
+                contains: (destination) => contains(destination) && measureDistance(destination, origin) <= radius,
+            };
+        }
+
+        // A line is a rectangle `length` long and `width` wide running from the origin along its rotation
+        const line = shape as LineShapeData;
+        const radians = Math.toRadians(line.rotation);
+        const along = { x: Math.cos(radians), y: Math.sin(radians) };
+        const perpendicular = { x: -along.y, y: along.x };
+        const halfWidth = line.width / 2;
+        // PF2e lines fire from a grid corner. Step the origin back to that corner along whichever axes it sits mid-cell
+        const toCorner = (coord: number, component: number): number =>
+            coord % size !== 0 ? coord - Math.sign(Math.round(component * 100)) * (size / 2) : coord;
+        const origin = { x: toCorner(line.x, along.x), y: toCorner(line.y, along.y) };
+        return {
+            origin,
+            searchCenter: { x: origin.x + along.x * (line.length / 2), y: origin.y + along.y * (line.length / 2) },
+            reach: (line.length / 2 + halfWidth) / size,
+            contains: (destination) => {
+                const dx = destination.x - origin.x;
+                const dy = destination.y - origin.y;
+                const projection = dx * along.x + dy * along.y;
+                const offset = dx * perpendicular.x + dy * perpendicular.y;
+                return projection >= 0 && projection <= line.length && Math.abs(offset) <= halfWidth;
+            },
+        };
+    }
+
+    /**
+     * Border-aligned apex and wedge test for a cone. The apex is taken as placed: the coordinate perpendicular to the
+     * firing direction is left alone, which is what separates a corner-origin cone (perpendicular on a grid line) from
+     * a side-origin one.
+     */
+    #coneCoverage(shape: ConeShapeData, origin: Point): { origin: Point; contains: (destination: Point) => boolean } {
+        const dimensions = canvas.dimensions;
+        const direction = shape.rotation;
+        const minAngle = (360 + ((direction - shape.angle * 0.5) % 360)) % 360;
+        const maxAngle = (360 + ((direction + shape.angle * 0.5) % 360)) % 360;
+        const withinAngle = (value: number): boolean => {
+            value = (360 + (value % 360)) % 360;
+            return minAngle < maxAngle
+                ? value >= minAngle && value <= maxAngle
+                : value >= minAngle || value <= maxAngle;
+        };
+
+        // Offset the origin by half a cell toward the firing direction along each axis it is not already a border of.
+        // `dir` is degrees anticlockwise from pointing right, in 45-degree increments from 0 to 360.
+        const dir = (direction >= 0 ? 360 - direction : -direction) % 360;
+        const xOffset =
+            origin.x % dimensions.size !== 0 ? Math.sign(Math.round(Math.cos(Math.toRadians(dir)) * 100)) / 2 : 0;
+        // Inverted along Y because screen-space Y increases downward
+        const yOffset =
+            origin.y % dimensions.size !== 0 ? -Math.sign(Math.round(Math.sin(Math.toRadians(dir)) * 100)) / 2 : 0;
+        const coneOrigin = { x: origin.x + xOffset * dimensions.size, y: origin.y + yOffset * dimensions.size };
+
+        return {
+            origin: coneOrigin,
+            contains: (destination: Point): boolean => {
+                const ray = new fc.geometry.Ray(coneOrigin, destination);
+                const rayAngle = (360 + ((ray.angle / (Math.PI / 180)) % 360)) % 360;
+                return ray.distance === 0 || withinAngle(rayAngle);
+            },
+        };
+    }
+
+    override async _draw(options?: object): Promise<void> {
+        await super._draw(options);
+        const highlights = (this.layer as unknown as fc.layers.RegionLayer)._highlights;
+        this.#blockedHighlight = highlights.addChild(new PIXI.Graphics());
+        this.#drawBlockedHighlight();
+    }
+
+    /** Shade the in-range squares a wall cuts off from the origin. */
+    #drawBlockedHighlight(): void {
+        const graphics = this.#blockedHighlight;
+        if (!graphics) return;
+        graphics.clear();
+        graphics.visible = this.visible;
+        graphics.zIndex = this.zIndex;
+        const { sizeX, sizeY } = canvas.grid;
+        for (const offset of this.#blockedOffsets) {
+            const { x, y } = canvas.grid.getTopLeftPoint(offset);
+            graphics
+                .beginFill(0x000000, 0.5)
+                .drawRect(x, y, sizeX, sizeY)
+                .endFill()
+                .lineStyle(1, 0x000000, 0.5)
+                .moveTo(x, y)
+                .lineTo(x + sizeX, y + sizeY);
+        }
+    }
+
+    override _applyRenderFlags(flags: Record<string, boolean>): void {
+        super._applyRenderFlags(flags);
+        if (flags.refreshGeometry || flags.refreshVisibility) this.#drawBlockedHighlight();
+    }
+
+    override _clear(): void {
+        this.#blockedHighlight?.destroy();
+        this.#blockedHighlight = null;
+        super._clear();
+    }
+
+    override _destroy(options?: boolean | PIXI.IDestroyOptions): void {
+        this.#blockedHighlight?.destroy();
+        this.#blockedHighlight = null;
+        super._destroy(options);
+    }
+
     /** Save the coordinates of the new drop location(s). */
     protected override async _onDragLeftDrop(event: PlaceablesLayerPointerEvent<this>): Promise<TDocument[]>;
     protected override async _onDragLeftDrop(event: PlaceablesLayerPointerEvent<this>): Promise<RegionDocument[]> {
@@ -41,6 +228,18 @@ class RegionPF2e<TDocument extends RegionDocumentPF2e = RegionDocumentPF2e> exte
 
         return this.document.parent?.updateEmbeddedDocuments("Region", updates) ?? [];
     }
+}
+
+/** Per-shape geometry for a template's grid coverage. */
+interface AreaCoverage {
+    /** Point line of effect is measured from */
+    origin: Point;
+    /** Center of the cell-search box, in pixels */
+    searchCenter: Point;
+    /** Half-extent of the search box, in grid squares */
+    reach: number;
+    /** Whether a cell center lies within the area, before line of effect is checked */
+    contains: (destination: Point) => boolean;
 }
 
 export { RegionPF2e };

--- a/types/foundry/client/canvas/layers/_types.d.mts
+++ b/types/foundry/client/canvas/layers/_types.d.mts
@@ -163,7 +163,7 @@ interface RegionPlacementOptions<TRegion extends Region> {
      * placement of the Region shape and display a warning.
      */
     preConfirm?: (args: {
-        event: PIXI.FederatedEvent;
+        event: PIXI.FederatedPointerEvent;
         document: TRegion["document"];
         regionIndex: number;
         regionCount: number;
@@ -177,7 +177,7 @@ interface RegionPlacementOptions<TRegion extends Region> {
      * the Region shape and display a warning.
      */
     preSkip?: (args: {
-        event: PIXI.FederatedEvent;
+        event: PIXI.FederatedPointerEvent;
         document: TRegion["document"];
         regionIndex: number;
         regionCount: number;

--- a/types/foundry/client/canvas/layers/regions.d.mts
+++ b/types/foundry/client/canvas/layers/regions.d.mts
@@ -230,6 +230,9 @@ export default class RegionLayer<TObject extends Region = Region> extends Placea
 
     protected override _onDragLeftMove(event: PlaceablesLayerPointerEvent<TObject>): void;
 
+    /** Update the drag preview. Called when the shape has changed. */
+    protected _updateDragPreview(event: PlaceablesLayerPointerEvent<TObject>): void;
+
     protected override _onDragLeftDrop(event: PlaceablesLayerPointerEvent<TObject>): void;
 
     protected override _onDragLeftCancel(event: PlaceablesLayerPointerEvent<TObject>): void;

--- a/types/foundry/client/canvas/placeables/region.d.mts
+++ b/types/foundry/client/canvas/placeables/region.d.mts
@@ -4,8 +4,9 @@ import RegionDocument from "@client/documents/region.mjs";
 import Scene from "@client/documents/scene.mjs";
 import User from "@client/documents/user.mjs";
 import { DatabaseUpdateCallbackOptions } from "@common/abstract/_types.mjs";
+import { GridOffset2D } from "@common/grid/_types.mjs";
+import { Point } from "@common/_types.mjs";
 import * as ClipperLib from "js-angusj-clipper";
-import { Point } from "../../../common/_types.mjs";
 import PlaceableObject from "./placeable-object.mjs";
 import RegionGeometry from "./regions/geometry.mjs";
 
@@ -76,6 +77,8 @@ export default class Region<
 
     override _draw(options?: object): Promise<void>;
 
+    protected _clear(): void;
+
     /* -------------------------------------------- */
     /*  Incremental Refresh                         */
     /* -------------------------------------------- */
@@ -85,8 +88,14 @@ export default class Region<
     /** Refresh the state of the Region. */
     protected _refreshState(): void;
 
+    /** Refresh the geometry of the Region. */
+    protected _refreshGeometry(): void;
+
     /** Refresh the border of the Region. */
     protected _refreshBorder(): void;
+
+    /** Get the grid space offsets that are covered by this Region. */
+    protected _getCoveredGridSpaceOffsets(): GridOffset2D[];
 
     /** @override */
     protected override _canDrag(user: User, event: PIXI.FederatedPointerEvent): boolean;


### PR DESCRIPTION
This only affects regions with coverage highlighting (`highlightMode: "coverage"`), the measured templates. Regions using the default shape highlighting aren't touched.

Circles, cones, and lines are grid counted again instead of using Foundry's geometric shapes. Also restores cursor aiming after placement and walls cutting off line of effect.

A few decisions worth a look:

- Blocked squares are shaded (v13 behavior), not dropped. Could exclude them entirely instead and would be simpler.
- Blocking uses `move` collision and could read the origin's traits later, like auras do for auditory and visual.
- Lines measure from the grid corner they fire from. Measuring from the center could consistently result in an extra 5ft being highlighted at certain angles. The outline box isn't re-snapped, so it can sit up to half a cell off the highlighted squares for off-corner placements.

<img width="372" height="551" alt="Screenshot 2026-05-30 at 10 24 57 PM" src="https://github.com/user-attachments/assets/9ae0f432-5525-4af2-a588-f4ccb1b1f183" />
<img width="435" height="502" alt="Screenshot 2026-05-30 at 10 25 04 PM" src="https://github.com/user-attachments/assets/79a0cfca-85d5-4e06-a1a7-250d62e487f8" />
<img width="480" height="546" alt="Screenshot 2026-05-30 at 10 25 36 PM" src="https://github.com/user-attachments/assets/b45012c6-1518-4681-9d45-8072b8d473a4" />
<img width="429" height="547" alt="Screenshot 2026-05-30 at 10 25 48 PM" src="https://github.com/user-attachments/assets/8f5884af-6cd0-42a3-b334-62cceed8e9a7" />
<img width="206" height="258" alt="Screenshot 2026-05-30 at 10 26 02 PM" src="https://github.com/user-attachments/assets/24ea0510-94d4-432b-baf5-3c81ce66834c" />
<img width="226" height="287" alt="Screenshot 2026-05-30 at 10 26 24 PM" src="https://github.com/user-attachments/assets/047d5b41-e40a-4364-8ad1-fe099484a482" />
<img width="396" height="378" alt="Screenshot 2026-05-30 at 10 26 40 PM" src="https://github.com/user-attachments/assets/b120ee01-58db-4873-8b29-39dad8cbe480" />
<img width="737" height="731" alt="Screenshot 2026-05-30 at 10 27 42 PM" src="https://github.com/user-attachments/assets/6544f1ed-90e4-4cbd-9648-2d1c06e459a3" />
<img width="293" height="293" alt="Screenshot 2026-05-30 at 10 28 06 PM" src="https://github.com/user-attachments/assets/1d192a03-7693-4198-962c-254aa530eb02" />
<img width="685" height="683" alt="Screenshot 2026-05-30 at 10 28 32 PM" src="https://github.com/user-attachments/assets/8d3c91bc-3bd8-41f2-8112-91d3bcc8ded6" />
<img width="690" height="680" alt="Screenshot 2026-05-30 at 10 28 58 PM" src="https://github.com/user-attachments/assets/a96fe4a8-e9bd-4e43-a179-a0c1fabd08e6" />
<img width="354" height="190" alt="Screenshot 2026-05-30 at 10 58 59 PM" src="https://github.com/user-attachments/assets/e0d4601c-6d1b-44b6-9cfc-a7e0270d5c1f" />
<img width="350" height="305" alt="Screenshot 2026-05-30 at 11 29 28 PM" src="https://github.com/user-attachments/assets/bb238b22-c5dc-464b-8f90-474d43a3c3b9" />
