### PR TITLE
Improve Dice So Nice integration with Damage Type

### DIFF
--- a/src/module/system/damage/roll.ts
+++ b/src/module/system/damage/roll.ts
@@ -43,6 +43,15 @@ abstract class AbstractDamageRoll extends Roll {
 
     /** The theoretically highest total of this roll */
     abstract get maximumValue(): number;
+
+    /**
+     * Tell the Dice So Nice module where to read this roll's damage type, so its dice use the matching
+     * appearance preset. DSN reads the `type` property per roll scope: on a `DamageRoll` it is `undefined`
+     * (the pool has no single type), and on each `DamageInstance` it resolves to that instance's damage type.
+     */
+    getDSNProperties(): { damageType: string } {
+        return { damageType: "type" };
+    }
 }
 
 class DamageRoll extends AbstractDamageRoll {

--- a/src/scripts/hooks/dice-so-nice-ready.ts
+++ b/src/scripts/hooks/dice-so-nice-ready.ts
@@ -1,4 +1,3 @@
-import type { DamageType } from "@module/system/damage/types.ts";
 import * as R from "remeda";
 
 interface ColorsetOptions {

--- a/src/scripts/hooks/dice-so-nice-ready.ts
+++ b/src/scripts/hooks/dice-so-nice-ready.ts
@@ -1,4 +1,5 @@
 import type { DamageType } from "@module/system/damage/types.ts";
+import * as R from "remeda";
 
 interface ColorsetOptions {
     name: string;
@@ -412,12 +413,10 @@ export const DiceSoNiceReady = {
                 spirit: "spirit",
             };
             dice3d.addDamageTypeDefaults?.(
-                Object.fromEntries(
-                    Object.entries(damageTypeThemes).map(([type, colorset]) => [
-                        type,
-                        { colorset, label: game.i18n.localize(CONFIG.PF2E.damageTypes[type as DamageType]) },
-                    ]),
-                ),
+                R.mapValues(damageTypeThemes, (colorset, type) => ({
+                    colorset,
+                    label: game.i18n.localize(CONFIG.PF2E.damageTypes[type as DamageType]),
+                })),
             );
         });
     },

--- a/src/scripts/hooks/dice-so-nice-ready.ts
+++ b/src/scripts/hooks/dice-so-nice-ready.ts
@@ -1,3 +1,5 @@
+import type { DamageType } from "@module/system/damage/types.ts";
+
 interface ColorsetOptions {
     name: string;
     description: string;
@@ -5,8 +7,10 @@ interface ColorsetOptions {
     texture: string;
     material: string;
     foreground: string;
+    background?: string;
     outline: string;
     edge: string;
+    textureComposite?: string;
     visibility?: "visible" | "hidden";
 }
 
@@ -18,6 +22,8 @@ interface Dice3D {
     ): void;
     addTexture(textureId: string, options: { name: string; composite: string; source: string }): Promise<void>;
     addColorset(options: ColorsetOptions, mode?: "default" | "preferred"): void;
+    // optional: only present in Dice So Nice versions >= 6.2.5
+    addDamageTypeDefaults?(mapping: Record<string, { colorset?: string; preset?: string; label?: string }>): void;
 }
 
 const isDice3D = (obj: unknown): obj is Dice3D =>
@@ -378,6 +384,41 @@ export const DiceSoNiceReady = {
                         visibility: "hidden",
                     });
                 });
+
+            // DAMAGE TYPE THEMES
+
+            // spirit damage
+            dice3d.addColorset({
+                name: "spirit",
+                description: game.i18n.localize(CONFIG.PF2E.damageTypes.spirit),
+                category: "Pathfinder 2e",
+                foreground: "#ffffff",
+                background: "#0aa996",
+                outline: "black",
+                edge: "#0aa996",
+                texture: "skulls",
+                material: "plastic",
+                textureComposite: "soft-light",
+            });
+
+            // suggest a default Dice So Nice theme for damage types whose name doesn't already match one of its
+            // built-in colorsets. The GM can still override any of these in the module's damage-type config.
+            const damageTypeThemes: Partial<Record<DamageType, string>> = {
+                electricity: "lightning",
+                mental: "psychic",
+                sonic: "thunder",
+                vitality: "radiant",
+                void: "necrotic",
+                spirit: "spirit",
+            };
+            dice3d.addDamageTypeDefaults?.(
+                Object.fromEntries(
+                    Object.entries(damageTypeThemes).map(([type, colorset]) => [
+                        type,
+                        { colorset, label: game.i18n.localize(CONFIG.PF2E.damageTypes[type as DamageType]) },
+                    ]),
+                ),
+            );
         });
     },
 };

--- a/src/scripts/hooks/dice-so-nice-ready.ts
+++ b/src/scripts/hooks/dice-so-nice-ready.ts
@@ -404,18 +404,18 @@ export const DiceSoNiceReady = {
 
             // suggest a default Dice So Nice theme for damage types whose name doesn't already match one of its
             // built-in colorsets. The GM can still override any of these in the module's damage-type config.
-            const damageTypeThemes: Partial<Record<DamageType, string>> = {
+            const damageTypeThemes = {
                 electricity: "lightning",
                 mental: "psychic",
                 sonic: "thunder",
                 vitality: "radiant",
                 void: "necrotic",
                 spirit: "spirit",
-            };
+            } as const;
             dice3d.addDamageTypeDefaults?.(
                 R.mapValues(damageTypeThemes, (colorset, type) => ({
                     colorset,
-                    label: game.i18n.localize(CONFIG.PF2E.damageTypes[type as DamageType]),
+                    label: game.i18n.localize(CONFIG.PF2E.damageTypes[type]),
                 })),
             );
         });


### PR DESCRIPTION
Hello!

This PR adds support for recent Dice So Nice Damage Types features.

- Tells DsN to read pf2e native DamageRoll.type instead of trying to read .flavor, fixing issues with persistent damage that have ie. flavor:[persistent,fire]
- Adds support for electricity, mental, sonic, vitality, void and spirit damage types using the new `addDamageTypeDefaults` feature. This lets GMs change the appearance of damage types as they wish. I did not add support for the physical damage types like slashing, etc. I wasn't sure how to represent these types. Could be added in the future, or GMs can add support right now manually in their world using the DsN Damage Type mapping GUI.

These changes are compatible (silent fail) with previous DsN versions, but requires DsN v6.2.5 to work properly.

<img width="817" height="753" alt="image" src="https://github.com/user-attachments/assets/921caab0-f28d-46fb-9684-212f33efa819" />


Docs: 
- https://riccisi.gitlab.io/foundryvtt-dice-so-nice/api/roll/#declaring-roll-properties-with-getdsnproperties
- https://riccisi.gitlab.io/foundryvtt-dice-so-nice/api/customization/#developer-default-mapping

Fixes:
- https://gitlab.com/riccisi/foundryvtt-dice-so-nice/-/work_items/565