### PR TITLE
Fix Spirit Thresher's damage type

### DIFF
--- a/packs/pf2e/equipment/spirit-thresher.json
+++ b/packs/pf2e/equipment/spirit-thresher.json
@@ -17,7 +17,7 @@
         "category": "advanced",
         "containerId": null,
         "damage": {
-            "damageType": "slashing",
+            "damageType": "bludgeoning",
             "dice": 1,
             "die": "d12"
         },


### PR DESCRIPTION
Currently it is 1d12ʺS with Versatile S while the book has it as 1d12ʺB with Versatile S.