### PR TITLE
Fix attribute builder breaking after opening it for a second character

### DIFF
--- a/src/module/actor/character/apps/attribute-builder/app.ts
+++ b/src/module/actor/character/apps/attribute-builder/app.ts
@@ -61,8 +61,8 @@ class AttributeBuilder extends SvelteApplicationMixin<
 
     protected override _configureRenderOptions(options: DeepPartial<AttributeBuilderRenderOptions>): void {
         super._configureRenderOptions(options);
-        const actor = options.actor;
-        if (actor && actor !== this.#actor) {
+        const actor = options.actor ?? this.#actor;
+        if (actor !== this.#actor) {
             delete this.#actor.apps[this.id];
             this.#actor = actor;
             // Registration with the actor on first render is handled by `_onFirstRender`

--- a/src/module/actor/character/apps/attribute-builder/app.ts
+++ b/src/module/actor/character/apps/attribute-builder/app.ts
@@ -11,8 +11,15 @@ interface AttributeBuilderConfiguration extends fa.ApplicationConfiguration {
     actor: CharacterPF2e;
 }
 
+interface AttributeBuilderRenderOptions extends fa.ApplicationRenderOptions {
+    /** A character to which this application should switch its focus */
+    actor?: CharacterPF2e;
+}
+
 class AttributeBuilder extends SvelteApplicationMixin<
-    AbstractConstructorOf<fa.api.ApplicationV2> & { DEFAULT_OPTIONS: DeepPartial<AttributeBuilderConfiguration> }
+    AbstractConstructorOf<fa.api.ApplicationV2<fa.ApplicationConfiguration, AttributeBuilderRenderOptions>> & {
+        DEFAULT_OPTIONS: DeepPartial<AttributeBuilderConfiguration>;
+    }
 >(fa.api.ApplicationV2) {
     /** Number of attributes in the game (str, dex, con, int, wis, cha) */
     static ALL_ATTRIBUTES_COUNT = 6;
@@ -39,8 +46,12 @@ class AttributeBuilder extends SvelteApplicationMixin<
 
     protected root = Root;
 
-    get #actor(): CharacterPF2e {
-        return this.options.actor;
+    /** The character whose attributes are being built. Switchable via render options */
+    #actor: CharacterPF2e;
+
+    constructor(options: DeepPartial<AttributeBuilderConfiguration> & { actor: CharacterPF2e }) {
+        super(options);
+        this.#actor = options.actor;
     }
 
     /** Re-evaluate ABP status on each access rather than caching at construction to avoid need for page reload */
@@ -48,16 +59,27 @@ class AttributeBuilder extends SvelteApplicationMixin<
         return game.pf2e.variantRules.AutomaticBonusProgression.isEnabled(this.#actor);
     }
 
+    protected override _configureRenderOptions(options: DeepPartial<AttributeBuilderRenderOptions>): void {
+        super._configureRenderOptions(options);
+        const actor = options.actor;
+        if (actor && actor !== this.#actor) {
+            delete this.#actor.apps[this.id];
+            this.#actor = actor;
+            // Registration with the actor on first render is handled by `_onFirstRender`
+            if (!options.isFirstRender) actor.apps[this.id] = this;
+        }
+    }
+
     protected override async _onFirstRender(
         context: AttributeBuilderContext,
         options: fa.ApplicationRenderOptions,
     ): Promise<void> {
         await super._onFirstRender(context, options);
-        this.options.actor.apps[this.id] = this;
+        this.#actor.apps[this.id] = this;
     }
 
     protected override _tearDown(options: fa.ApplicationClosingOptions): void {
-        delete this.options.actor.apps[this.id];
+        delete this.#actor.apps[this.id];
         super._tearDown(options);
     }
 

--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -827,10 +827,12 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
         };
 
         handlers["edit-attribute-boosts"] = () => {
+            // Reuse an existing attribute builder if one is open: constructing a second instance with the same
+            // element ID would detach the open builder's element without closing it, breaking its render state.
+            const existing = foundry.applications.instances.get("attribute-builder");
             const builder =
-                Object.values(this.actor.apps).find((a) => a instanceof AttributeBuilder) ??
-                new AttributeBuilder({ actor: this.actor });
-            return builder.render({ force: true });
+                existing instanceof AttributeBuilder ? existing : new AttributeBuilder({ actor: this.actor });
+            return builder.render({ force: true, actor: this.actor });
         };
 
         handlers["select-apex-attribute"] = (event) => {


### PR DESCRIPTION
Closes #22487

The old attribute builder allowed multiple instances to be open, but when I rewrote it to AppV2 it was moved to a single instance with a static ID in review. Needs to be closed before another can be opened.

When a second instance renders with the same static ID, core never closes the first. It just evicts it from the instances registry and detaches its element. `_tearDown` never runs, leaving a zombie app in actor.apps that throws on any later render.