### PR TITLE
Fix spelling of 'effect' in zhuraita

### DIFF
--- a/packs/pf2e/pathfinder-monster-core-2/zhuraita.json
+++ b/packs/pf2e/pathfinder-monster-core-2/zhuraita.json
@@ -734,7 +734,7 @@
                 },
                 "category": "defensive",
                 "description": {
-                    "value": "<p><strong>Trigger</strong> The zhuraita is targeted by an efect with the linguistic or mental trait</p><hr /><p><strong>Effect</strong> The zhuraita critiques their enemy's theoretical underpinnings, attempting a counteract check with a bonus of [[/r 1d20+28#Counteract]] (counteract rank 8). If the efect is counteracted, the triggering enemy becomes @UUID[Compendium.pf2e.conditionitems.Item.Frightened]{Frightened 1} (@UUID[Compendium.pf2e.conditionitems.Item.Frightened]{Frightened 2} if the zhuraita critically succeeded).</p>"
+                    "value": "<p><strong>Trigger</strong> The zhuraita is targeted by an effect with the linguistic or mental trait</p><hr /><p><strong>Effect</strong> The zhuraita critiques their enemy's theoretical underpinnings, attempting a counteract check with a bonus of [[/r 1d20+28#Counteract]] (counteract rank 8). If the effect is counteracted, the triggering enemy becomes @UUID[Compendium.pf2e.conditionitems.Item.Frightened]{Frightened 1} (@UUID[Compendium.pf2e.conditionitems.Item.Frightened]{Frightened 2} if the zhuraita critically succeeded).</p>"
                 },
                 "publication": {
                     "license": "OGL",


### PR DESCRIPTION
Corrected the spelling of 'effect' in the zhuraita JSON file.