### PR TITLE
Prevent icons in advanced alchemy items from wrapping

### DIFF
--- a/src/styles/actor/character/_crafting.scss
+++ b/src/styles/actor/character/_crafting.scss
@@ -278,7 +278,11 @@
             }
 
             .item-controls {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
                 grid-area: controls;
+                justify-content: end;
                 justify-self: end;
                 font-size: var(--font-size-12);
                 margin-right: var(--space-4);


### PR DESCRIPTION
Kudos to @CarlosFdez for the suggestion