### PR TITLE
Apply roll options to inline damage rolled from effect tooltips

### DIFF
--- a/src/module/apps/effects-panel.ts
+++ b/src/module/apps/effects-panel.ts
@@ -197,6 +197,9 @@ export class EffectsPanel extends fa.api.HandlebarsApplicationMixin(fa.api.Appli
                 }).firstElementChild;
                 if (!(content instanceof HTMLElement)) return null;
 
+                // Provide item context so inline damage rolls can resolve the actor and item
+                content.dataset.itemUuid = effect.uuid;
+
                 content.querySelector("[data-action=recover-persistent-damage]")?.addEventListener("click", () => {
                     if (effect.isOfType("condition")) {
                         effect.rollRecovery();


### PR DESCRIPTION
Closes #21979
Inline damage links in effect tooltips resolved no item, so they rolled without roll options and badge-value formulas couldn't evaluate.