### PR TITLE
Update Recall Knowledge breakdown and ABC picker on actor updates, brush up Item Transfer and Select Item popups

### DIFF
--- a/src/module/actor/character/apps/abc-picker/app.ts
+++ b/src/module/actor/character/apps/abc-picker/app.ts
@@ -64,6 +64,19 @@ class ABCPicker extends SvelteApplicationMixin<
         return initialized;
     }
 
+    protected override async _onFirstRender(
+        context: ABCPickerContext,
+        options: fa.ApplicationRenderOptions,
+    ): Promise<void> {
+        await super._onFirstRender(context, options);
+        this.options.actor.apps[this.id] = this;
+    }
+
+    protected override _tearDown(options: fa.ApplicationClosingOptions): void {
+        delete this.options.actor.apps[this.id];
+        super._tearDown(options);
+    }
+
     /** Gather all items of the request type from the world and across all item compendiums. */
     async #gatherItems(): Promise<ABCItemRef[]> {
         const { actor, itemType } = this.options;

--- a/src/module/actor/npc/sheet.ts
+++ b/src/module/actor/npc/sheet.ts
@@ -400,7 +400,12 @@ class NPCSheetPF2e extends AbstractNPCSheet {
         };
 
         handlers["open-recall-breakdown"] = () => {
-            return new RecallKnowledgePopup({ identificationData: this.actor.identificationDCs }).render(true);
+            // Reuse an existing popup if one is open: constructing a second instance with the same element ID
+            // would detach the open popup's element without closing it, breaking its render state.
+            const actor = this.actor;
+            const existing = foundry.applications.instances.get("recall-knowledge-breakdown");
+            const popup = existing instanceof RecallKnowledgePopup ? existing : new RecallKnowledgePopup({ actor });
+            return popup.render({ force: true, actor });
         };
 
         handlers["roll-attribute"] = (event, anchor) => {

--- a/src/module/actor/sheet/popups/item-transfer-dialog.ts
+++ b/src/module/actor/sheet/popups/item-transfer-dialog.ts
@@ -97,6 +97,10 @@ class ItemTransferDialog extends fa.api.DialogV2<ItemTransferConfiguration> {
             buttons.push({ type: "submit", icon, label, action: mode, callback });
         }
 
+        // Close the open dialog first to avoid colliding on the shared id; this cancels the prior request.
+        // TODO: re-target in place (no close) once this moves from DialogV2 to a full ApplicationV2.
+        await foundry.applications.instances.get("item-transfer-dialog")?.close();
+
         return super.wait(Object.assign(options, { item, mode, newStack, lockStack, content, buttons }));
     }
 

--- a/src/module/actor/sheet/popups/recall-knowledge-popup.ts
+++ b/src/module/actor/sheet/popups/recall-knowledge-popup.ts
@@ -1,15 +1,22 @@
-import type { CreatureIdentificationData } from "@module/recall-knowledge.ts";
+import type { NPCPF2e } from "@actor";
 import { localizeList } from "@util";
 
-class RecallKnowledgePopup extends fa.api.HandlebarsApplicationMixin(fa.api.ApplicationV2) {
-    #identificationData: CreatureIdentificationData;
+interface RecallKnowledgePopupRenderOptions extends fa.api.HandlebarsRenderOptions {
+    /** An NPC to which this application should switch its focus */
+    actor?: NPCPF2e;
+}
 
-    constructor(
-        options: Partial<RecallKnowledgePopupConfiguration> &
-            Required<Pick<RecallKnowledgePopupConfiguration, "identificationData">>,
-    ) {
+class RecallKnowledgePopup extends fa.api.HandlebarsApplicationMixin<
+    AbstractConstructorOf<fa.api.ApplicationV2<fa.ApplicationConfiguration, RecallKnowledgePopupRenderOptions>> & {
+        DEFAULT_OPTIONS: DeepPartial<RecallKnowledgePopupConfiguration>;
+    }
+>(fa.api.ApplicationV2) {
+    /** The NPC whose identification DCs are being displayed. Switchable via render options */
+    #actor: NPCPF2e;
+
+    constructor(options: Partial<RecallKnowledgePopupConfiguration> & { actor: NPCPF2e }) {
         super(options);
-        this.#identificationData = options.identificationData;
+        this.#actor = options.actor;
     }
 
     static override DEFAULT_OPTIONS: DeepPartial<RecallKnowledgePopupConfiguration> = {
@@ -24,10 +31,36 @@ class RecallKnowledgePopup extends fa.api.HandlebarsApplicationMixin(fa.api.Appl
         base: { template: `systems/${SYSTEM_ID}/templates/actors/recall-knowledge.hbs`, root: true },
     };
 
+    protected override _configureRenderOptions(
+        options: DeepPartial<fa.api.HandlebarsRenderOptions> & Partial<RecallKnowledgePopupRenderOptions>,
+    ): void {
+        super._configureRenderOptions(options);
+        const actor = options.actor ?? this.#actor;
+        if (actor !== this.#actor) {
+            delete this.#actor.apps[this.id];
+            this.#actor = actor;
+            // Registration with the actor on first render is handled by `_onFirstRender`
+            if (!options.isFirstRender) actor.apps[this.id] = this;
+        }
+    }
+
+    protected override async _onFirstRender(
+        context: RecallKnowledgePopupContext,
+        options: fa.ApplicationRenderOptions,
+    ): Promise<void> {
+        await super._onFirstRender(context, options);
+        this.#actor.apps[this.id] = this;
+    }
+
+    protected override _tearDown(options: fa.ApplicationClosingOptions): void {
+        delete this.#actor.apps[this.id];
+        super._tearDown(options);
+    }
+
     protected override async _prepareContext(
         options: fa.ApplicationRenderOptions,
     ): Promise<RecallKnowledgePopupContext> {
-        const { skills, standard, lore } = this.#identificationData;
+        const { skills, standard, lore } = this.#actor.identificationDCs;
 
         return {
             ...(await super._prepareContext(options)),
@@ -50,7 +83,7 @@ class RecallKnowledgePopup extends fa.api.HandlebarsApplicationMixin(fa.api.Appl
 }
 
 interface RecallKnowledgePopupConfiguration extends fa.ApplicationConfiguration {
-    identificationData: CreatureIdentificationData;
+    actor: NPCPF2e;
 }
 
 interface RecallKnowledgePopupContext extends fa.ApplicationRenderContext {

--- a/src/module/item/condition/persistent-damage-editor.ts
+++ b/src/module/item/condition/persistent-damage-editor.ts
@@ -10,8 +10,13 @@ interface PersistentDamageEditorConfiguration extends fa.ApplicationConfiguratio
     selectedItemId: string | null;
 }
 
+interface PersistentDamageEditorRenderOptions extends fa.api.HandlebarsRenderOptions {
+    /** The id of a persistent damage condition on which this application should focus its editing */
+    selectedItemId?: string;
+}
+
 class PersistentDamageEditor extends fa.api.HandlebarsApplicationMixin<
-    AbstractConstructorOf<fa.api.ApplicationV2> & {
+    AbstractConstructorOf<fa.api.ApplicationV2<fa.ApplicationConfiguration, PersistentDamageEditorRenderOptions>> & {
         DEFAULT_OPTIONS: DeepPartial<PersistentDamageEditorConfiguration>;
     }
 >(fa.api.ApplicationV2) {
@@ -20,7 +25,6 @@ class PersistentDamageEditor extends fa.api.HandlebarsApplicationMixin<
         tag: "form",
         window: { icon: "fa-solid fa-droplet", contentClasses: ["standard-form"] },
         position: { width: 420 },
-        selectedItemId: null,
         actions: {
             add: PersistentDamageEditor.#onClickAdd,
             delete: PersistentDamageEditor.#onClickDelete,
@@ -37,12 +41,16 @@ class PersistentDamageEditor extends fa.api.HandlebarsApplicationMixin<
 
     declare options: PersistentDamageEditorConfiguration;
 
-    get #actor(): ActorPF2e {
-        return this.options.actor;
+    /** The id of the persistent damage condition currently focused for editing. Switchable via render options */
+    #selectedItemId: string | null;
+
+    constructor(options: DeepPartial<PersistentDamageEditorConfiguration> & { actor: ActorPF2e }) {
+        super(options);
+        this.#selectedItemId = options.selectedItemId ?? null;
     }
 
-    get #selectedItemId(): string | null {
-        return this.options.selectedItemId;
+    get #actor(): ActorPF2e {
+        return this.options.actor;
     }
 
     protected override _initializeApplicationOptions(
@@ -51,6 +59,23 @@ class PersistentDamageEditor extends fa.api.HandlebarsApplicationMixin<
         const initialized = super._initializeApplicationOptions(options) as PersistentDamageEditorConfiguration;
         initialized.uniqueId = `persistent-damage-editor-${initialized.actor.uuid}`;
         return initialized;
+    }
+
+    protected override _canRender(options: fa.ApplicationRenderOptions): boolean | void {
+        // Hand off to an already-open editor for this actor, forwarding any requested selection
+        const existing = foundry.applications.instances.get(this.id);
+        if (existing instanceof PersistentDamageEditor && existing !== this) {
+            existing.render({ selectedItemId: this.#selectedItemId ?? undefined });
+            if (existing.minimized) existing.maximize();
+            else existing.bringToFront();
+            return false;
+        }
+        return super._canRender(options);
+    }
+
+    protected override _configureRenderOptions(options: DeepPartial<PersistentDamageEditorRenderOptions>): void {
+        super._configureRenderOptions(options);
+        if (options.selectedItemId !== undefined) this.#selectedItemId = options.selectedItemId;
     }
 
     protected override async _onFirstRender(

--- a/src/module/system/action-macros/crafting/select-item.ts
+++ b/src/module/system/action-macros/crafting/select-item.ts
@@ -64,6 +64,18 @@ class SelectItemDialog extends SvelteApplicationMixin(fa.api.ApplicationV2) {
     }
 
     static async getItem(action: ItemAction): Promise<PhysicalItemPF2e | null> {
+        // Reuse the open dialog instead of colliding on the shared id: cancel the prior request and re-target.
+        const existing = foundry.applications.instances.get("select-item-dialog");
+        if (existing instanceof SelectItemDialog) {
+            existing.#resolve?.(null);
+            existing.#action = action;
+            existing.selection = null;
+            await existing.render({ force: true });
+            return new Promise((resolve) => {
+                existing.#resolve = resolve;
+            });
+        }
+
         const dialog = new this({ action });
         return dialog.resolveSelection();
     }


### PR DESCRIPTION
Following up on #22488

- Moved item transfer, select item, update currency, distribute coins, scroll/wand creator, earn income, and item attacher from static to templated IDs (`earn-income-{id}`). These kept static IDs from appv1 where duplicates didn't matter, but can legitimately have multiple instances open. Item transfer and select item also resolve a promise on close, so refocusing or retargeting an existing instance would leave the new caller hanging.
- Actual singletons (check prompt, browser settings, license viewer, variant rules, world clock, ABC picker, persistent damage editor) get a `_canRender` guard that refocuses the open instance instead of rendering over it.
- Recall knowledge breakdown reuses the open instance and switches its data via render option, like the attribute builder.

Also registers the ABC picker with its actor's apps.