### PR TITLE
Include origin item roll options in effects dragged from a sheet

### DIFF
--- a/src/scripts/system/dragstart-handler.ts
+++ b/src/scripts/system/dragstart-handler.ts
@@ -63,7 +63,10 @@ export function extendDragData(): void {
                         token: token?.uuid ?? null,
                         item: originItem?.uuid ?? null,
                         spellcasting,
-                        rollOptions: message?.flags[SYSTEM_ID].origin?.rollOptions ?? [],
+                        rollOptions:
+                            message?.flags[SYSTEM_ID].origin?.rollOptions ??
+                            originItem?.getOriginData().rollOptions ??
+                            [],
                     },
                     target: target ? { actor: target.actor.uuid, token: target.token.uuid } : null,
                     roll: roll


### PR DESCRIPTION
Implements #20090

Before: Had to select item when applying effect

https://github.com/user-attachments/assets/d5e94b1d-53e2-4fa2-bedd-f252fe503c2c

After:

https://github.com/user-attachments/assets/9518ecdb-33b2-4263-aa2f-399407b9e3a4

