### PR TITLE
Improve trade initiation: party-sheet member drops, request expiry with alerts on both sides, prevent sending to familiars

### DIFF
--- a/src/module/actor/creature/sheet.ts
+++ b/src/module/actor/creature/sheet.ts
@@ -9,7 +9,6 @@ import { ItemSourcePF2e } from "@item/base/data/index.ts";
 import { ITEM_CARRY_TYPES } from "@item/base/data/values.ts";
 import { coerceToSpellGroupId, spellSlotGroupIdToNumber } from "@item/spellcasting-entry/helpers.ts";
 import { SpellcastingSheetData } from "@item/spellcasting-entry/index.ts";
-import { TradeDialog } from "@module/apps/trade-dialog/app.ts";
 import { DropCanvasItemData } from "@module/canvas/drop-canvas-data.ts";
 import { OneToTen, ZeroToFour, goesToEleven } from "@module/data.ts";
 import { eventToRollParams } from "@module/sheet/helpers.ts";
@@ -357,46 +356,7 @@ abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends ActorSheet
             }
         }
 
-        return (await this.#attemptTrade(data, event)) ? [] : super._onDropItem(event, data);
-    }
-
-    /**
-     * Determine whether a dropped item can be used for trading and initiate a trade if so.
-     * @returns whether a trade initiation request was sent
-     */
-    async #attemptTrade(data: DropCanvasItemData, event: DragEvent): Promise<boolean> {
-        if (game.user.isGM) return false;
-        const traderActor = this.actor;
-        if (traderActor.isLootableBy(game.user)) return false;
-        const item = await ItemPF2e.fromDropData(data);
-        const selfActor = item?.actor;
-        if (!item?.isOfType("physical") || !selfActor?.isOfType("creature")) return false;
-        const traderUser = game.users
-            .filter((u) => u.active && !u.isSelf && traderActor.testUserPermission(u, "OWNER"))
-            .sort((a, b) => Number(a.isGM) - Number(b.isGM))[0];
-
-        // Check reach separately: if a trade would be possible except for it being out of reach, still proceed no
-        // further in item-drop workflow
-        const args = {
-            self: { actor: selfActor, item, gift: event.shiftKey },
-            trader: { user: traderUser, actor: traderActor },
-        };
-        if (!TradeDialog.canTrade(args)) return false;
-        const checkReach = game.pf2e.settings.automation.reachEnforcement.has("merchants");
-        if (checkReach) {
-            const traderTokens = traderActor.getActiveTokens(true, false);
-            const selfReach = selfActor.system.attributes.reach.manipulate;
-            const traderReach = traderActor.system.attributes.reach.manipulate;
-            const inReach = selfActor.getActiveTokens(true, false).some((selfToken) =>
-                traderTokens.some((traderToken) => {
-                    const distance = selfToken.distanceTo(traderToken);
-                    return selfReach >= distance && traderReach >= distance;
-                }),
-            );
-            if (!inReach) return true;
-        }
-        TradeDialog.requestTrade(args);
-        return true;
+        return super._onDropItem(event, data);
     }
 
     /** Adds support for moving spells between spell levels, spell collections, and spell preparation */

--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -17,6 +17,7 @@ import { isContainerCycle } from "@item/container/helpers.ts";
 import { itemIsOfType } from "@item/helpers.ts";
 import { Coins, sizeItemForActor, transferCredits } from "@item/physical/helpers.ts";
 import { COIN_DENOMINATIONS, PHYSICAL_ITEM_TYPES } from "@item/physical/values.ts";
+import { TradeDialog } from "@module/apps/trade-dialog/app.ts";
 import { DropCanvasItemData } from "@module/canvas/drop-canvas-data.ts";
 import { createUseActionMessage } from "@module/chat-message/helpers.ts";
 import {
@@ -1315,6 +1316,9 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends fav1.sheets.Acto
             throw ErrorPF2e("Unexpected missing actor(s)");
         }
 
+        // If the recipient can't simply be given the item, attempt a trade instead
+        if (await this.#attemptTrade(event, item, recipient)) return;
+
         const containerId = htmlClosest(event.target, "[data-is-container]")?.dataset.itemId?.trim();
         const stackable = !!recipient.inventory.findStackableItem(item._source, { containerId });
         const mode = sourceActor.isOfType("loot") && sourceActor.isMerchant ? "purchase" : "move";
@@ -1344,6 +1348,42 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends fav1.sheets.Acto
                 result.mode === "purchase",
             );
         }
+    }
+
+    /**
+     * Determine whether a dropped item can be used for trading and initiate a trade if so.
+     * @returns whether a trade initiation request was sent
+     */
+    async #attemptTrade(event: DragEvent, item: PhysicalItemPF2e, recipient: ActorPF2e): Promise<boolean> {
+        if (game.user.isGM || recipient.isLootableBy(game.user)) return false;
+        const selfActor = item.actor;
+        if (!selfActor?.isOfType("character", "npc")) return false;
+        const traderUser = game.users
+            .filter((u) => u.active && !u.isSelf && recipient.testUserPermission(u, "OWNER"))
+            .sort((a, b) => Number(a.isGM) - Number(b.isGM))[0];
+
+        // Check reach separately: if a trade would be possible except for it being out of reach, proceed no
+        // further in item-drop workflow
+        const args = {
+            self: { actor: selfActor, item, gift: event.shiftKey },
+            trader: { user: traderUser, actor: recipient },
+        };
+        if (!TradeDialog.canTrade(args)) return false;
+        const checkReach = game.pf2e.settings.automation.reachEnforcement.has("merchants");
+        if (checkReach) {
+            const traderTokens = recipient.getActiveTokens(true, false);
+            const selfReach = selfActor.system.attributes.reach.manipulate;
+            const traderReach = args.trader.actor.system.attributes.reach.manipulate;
+            const inReach = selfActor.getActiveTokens(true, false).some((selfToken) =>
+                traderTokens.some((traderToken) => {
+                    const distance = selfToken.distanceTo(traderToken);
+                    return selfReach >= distance && traderReach >= distance;
+                }),
+            );
+            if (!inReach) return true;
+        }
+        TradeDialog.requestTrade(args);
+        return true;
     }
 
     /** Handle creating a new Owned Item for the actor using initial data defined in the HTML dataset */

--- a/src/module/apps/trade-dialog/app.ts
+++ b/src/module/apps/trade-dialog/app.ts
@@ -78,11 +78,9 @@ class TradeDialog extends SvelteApplicationMixin(fa.api.ApplicationV2) {
         if (TradeDialog.#userTrading) return false;
         const { self, trader } = args;
         const traderActor = trader.actor;
-        if (!traderActor?.isOfType("creature") || !trader.user?.active || trader.user.isSelf) return false;
+        if (!traderActor?.isOfType("character", "npc") || !trader.user?.active || trader.user.isSelf) return false;
         if (!self.actor?.isOwner || !self.actor.isOfType("character", "npc")) return false;
-        if (!self.actor.testUserPermission(game.user, "OWNER")) return false;
-        if (self.actor.uuid === traderActor?.uuid) return false;
-        if (!self.actor.isOfType("character", "npc")) return false;
+        if (self.actor.uuid === traderActor.uuid) return false;
         if (!self.actor.isAllyOf(traderActor) && traderActor.alliance !== null) return false;
         if (self.gift && !self.item) return false;
         if (self.item) {
@@ -132,7 +130,9 @@ class TradeDialog extends SvelteApplicationMixin(fa.api.ApplicationV2) {
         const traderName = TradeDialog.#getObfuscatedActorName(trader.actor);
         ui.notifications.info(TradeDialog.localize("Request.Requesting", { trader: traderName }));
         try {
-            const response = await trader.user.query(`${SYSTEM_ID}.trade`, queryData, { timeout: 30_000 });
+            // The receiving side auto-declines after 30 seconds: the sender's extra 5 are a buffer in case the
+            // request/response are slow to send/arrive.
+            const response = await trader.user.query(`${SYSTEM_ID}.trade`, queryData, { timeout: 35_000 });
             if (!response) throw ErrorPF2e("No response from other side.");
             if (response.ok) {
                 const dialog = new TradeDialog({ self: { ...self, gift: giftQuantity, initiator: true }, trader });
@@ -142,10 +142,36 @@ class TradeDialog extends SvelteApplicationMixin(fa.api.ApplicationV2) {
                 TradeDialog.#userTrading = false;
             }
         } catch {
-            const message = TradeDialog.localize("Request.Timeout", { user: trader.user.name });
+            const message = TradeDialog.localize("Request.Expired.Initiator", { user: trader.user.name });
             ui.notifications.error(message, { console: false });
             TradeDialog.#userTrading = false;
         }
+    }
+
+    /**
+     * Present a confirmation dialog for a trade request, auto dismissing it if left unanswered for too long.
+     * @returns `true` or `false` according to the user's answer, `null` if the request expired
+     */
+    static async #confirmRequest(options: Parameters<(typeof fa.api.DialogV2)["confirm"]>[0]): Promise<boolean | null> {
+        const id = "trade-request-prompt";
+        const confirmation: Promise<boolean | null> = fa.api.DialogV2.confirm({ ...options, id, rejectClose: false });
+        const expiry = new Promise<"expired">((resolve) => {
+            setTimeout(() => resolve("expired"), 30_000);
+        });
+        const result = await Promise.race([confirmation, expiry]);
+        if (result === "expired") {
+            await foundry.applications.instances.get(id)?.close();
+            return null;
+        }
+        return !!result;
+    }
+
+    static #notifyRequestExpired(initiatorName: string, initiatorUser: UserPF2e): void {
+        const message = TradeDialog.localize("Request.Expired.Receiver", {
+            trader: initiatorName,
+            user: initiatorUser.name,
+        });
+        ui.notifications.warn(message, { console: false });
     }
 
     static #validateConstructorParams(data: MaybeValidConstructorParams): asserts data is ConstructorParams {
@@ -447,7 +473,7 @@ class TradeDialog extends SvelteApplicationMixin(fa.api.ApplicationV2) {
         if (args.trader.item && args.trader.gift) {
             const { user, item, gift: quantity } = args.trader;
             const title = TradeDialog.localize("Gift.Prompt.Title", { trader: initiatorName });
-            const ok = await fa.api.DialogV2.confirm({
+            const ok = await TradeDialog.#confirmRequest({
                 window: { icon: "fa-solid fa-gift", title },
                 content: TradeDialog.localize("Gift.Prompt.Content", {
                     trader: initiatorName,
@@ -463,14 +489,21 @@ class TradeDialog extends SvelteApplicationMixin(fa.api.ApplicationV2) {
                 return { ok };
             }
             dialog.close({ aborted: true });
+            if (ok === null) {
+                TradeDialog.#notifyRequestExpired(initiatorName, user);
+                return {
+                    ok: false,
+                    message: TradeDialog.localize("Request.Expired.Initiator", { user: game.user.name }),
+                };
+            }
             const selfName = TradeDialog.#getObfuscatedActorName(args.self.actor, args.trader.user);
-            return { ok, message: TradeDialog.localize("Gift.Declined", { trader: selfName, user: user.name }) };
+            return { ok: false, message: TradeDialog.localize("Gift.Declined", { trader: selfName, user: user.name }) };
         }
 
         // Confirm with user before initiating
         const windowIcon = TradeDialog.DEFAULT_OPTIONS.window.icon;
         const title = TradeDialog.localize("Request.Prompt.Title", { trader: initiatorName });
-        const ok = await fa.api.DialogV2.confirm({
+        const ok = await TradeDialog.#confirmRequest({
             window: { icon: windowIcon, title },
             content: TradeDialog.localize("Request.Prompt.Content", {
                 trader: initiatorName,
@@ -483,10 +516,14 @@ class TradeDialog extends SvelteApplicationMixin(fa.api.ApplicationV2) {
             await dialog.render({ force: true });
             return { ok };
         }
+        dialog.close({ aborted: true });
+        if (ok === null) {
+            TradeDialog.#notifyRequestExpired(initiatorName, args.trader.user);
+            return { ok: false, message: TradeDialog.localize("Request.Expired.Initiator", { user: game.user.name }) };
+        }
         const selfName = TradeDialog.#getObfuscatedActorName(args.self.actor, args.trader.user);
         const message = TradeDialog.localize("Request.Declined", { trader: selfName, user: game.user.name });
-        dialog.close({ aborted: true });
-        return { ok, message };
+        return { ok: false, message };
     }
 
     /** Handle a trade-update query from another user. */

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -4411,13 +4411,16 @@
             "Receiving": "Receiving: {list}",
             "Request": {
                 "Declined": "{trader} ({user}) has declined your request to trade.",
+                "Expired": {
+                    "Initiator": "There was no response from {user} to your trade request after 30 seconds.",
+                    "Receiver": "You did not respond to the trade request from {trader} ({user}) after 30 seconds."
+                },
                 "Requesting": "Requesting to trade with {trader} ...",
                 "Prompt": {
                     "Content": "{trader} ({user}) would like to trade with {self}.",
                     "Title": "Trade with {trader}?"
                 },
-                "MenuLabel": "Request Trade",
-                "Timeout": "There was no response from {user} to your trade request after 30 seconds."
+                "MenuLabel": "Request Trade"
             },
             "Sending": "Sending: {list}",
             "Success": {


### PR DESCRIPTION
- Closes #20988

Moves trade initiation into `ActorSheetPF2e#moveItemBetweenActors` so party sheet drops request a trade instead of erroring. Auto-decline unanswered prompts after 30 seconds with alerts on both sides. Previously the request would time out on the sender's end while the receiver's prompt stayed open and, if accepted, opened the trade dialog for that user alone.

Also removes some redundant checks and restrict trade recipients to PCs and NPCs explicitly. `canTrade` only required that the recipient be a creature, so a familiar passed the sender-side check and the request was sent, but the receiver threw during validation (requires PCs/NPCs) before showing any prompt, and the sender was immediately shown a "no response after 30 seconds" timeout error.