### PR TITLE
Truncate effect link if it doesn't fit in a single line

### DIFF
--- a/src/styles/ui/sidebar/chat/_action.scss
+++ b/src/styles/ui/sidebar/chat/_action.scss
@@ -110,12 +110,8 @@
             padding-bottom: 0.1rem;
         }
 
-        .effect-applied > a.content-link {
-            flex: 0 1 auto;
-            max-width: calc(100% - 5rem);
-            min-width: 0;
-            overflow: hidden;
-            text-overflow: ellipsis;
+        .effect-applied {
+            white-space: nowrap;
         }
     }
 }

--- a/src/styles/ui/sidebar/chat/_action.scss
+++ b/src/styles/ui/sidebar/chat/_action.scss
@@ -109,5 +109,13 @@
             min-height: 2.1rem;
             padding-bottom: 0.1rem;
         }
+
+        .effect-applied > a.content-link {
+            flex: 0 1 auto;
+            max-width: calc(100% - 5rem);
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
     }
 }


### PR DESCRIPTION
Cuts effect's name if it wouldn't fit in a single line
Before/After
<img width="298" height="525" alt="image" src="https://github.com/user-attachments/assets/898273e4-9b76-495d-9643-5409f3b28ca3" /><img width="310" height="524" alt="image" src="https://github.com/user-attachments/assets/8bb96a78-790a-4aef-839f-54ede7514efd" />
