### PR TITLE
Craft prepared formulas at prepared quantity

### DIFF
--- a/src/module/actor/character/crafting/ability.ts
+++ b/src/module/actor/character/crafting/ability.ts
@@ -293,6 +293,8 @@ class CraftingAbility implements CraftingAbilityData {
         })();
         if (!item) return null;
 
+        const preparedFormula = index >= 0 ? preparedFormulas[index] : null;
+
         // Set the slot to expended if this is a prepared entry
         if (this.isPrepared && consume) {
             if (!this.preparedFormulaData[index] || this.preparedFormulaData[index].expended) {
@@ -305,16 +307,18 @@ class CraftingAbility implements CraftingAbilityData {
         const rollOptions = item.getRollOptions("item");
         const matching = this.craftableItems.find((c) => c.predicate.test(rollOptions));
         const batchSize = matching?.batchSize ?? this.batchSize;
+        const craftQuantity = preparedFormula?.quantity ?? batchSize;
 
         // Consume a special resource if we need to
         if (this.resource && consume) {
             const resource = this.actor.getResource(this.resource ?? "");
             const value = resource?.value ?? 0;
-            if (!value) {
+            const resourceCost = preparedFormula?.batches ?? 1;
+            if (value < resourceCost) {
                 ui.notifications.warn("PF2E.Actor.Character.Crafting.MissingResource", { localize: true });
                 return null;
             } else {
-                await this.actor.updateResource(this.resource, value - 1);
+                await this.actor.updateResource(this.resource, value - resourceCost);
             }
         }
 
@@ -325,7 +329,7 @@ class CraftingAbility implements CraftingAbilityData {
 
         // Create the item source, and apply necessary temporary item modifications
         const itemSource = item.toObject(true);
-        itemSource.system.quantity = batchSize;
+        itemSource.system.quantity = craftQuantity;
         itemSource.system.temporary = true;
         itemSource.system.size = this.actor.ancestry?.size === "tiny" ? "tiny" : "med";
         if (item.isAlchemical && itemIsOfType(itemSource, "consumable", "equipment", "weapon")) {
@@ -339,7 +343,7 @@ class CraftingAbility implements CraftingAbilityData {
         // Create the item or update an existing one, then return it
         const stackable = this.actor.inventory.findStackableItem(itemSource);
         if (stackable) {
-            stackable.update({ "system.quantity": stackable.quantity + batchSize });
+            stackable.update({ "system.quantity": stackable.quantity + craftQuantity });
             return stackable;
         } else {
             const created = await this.actor.createEmbeddedDocuments("Item", [itemSource]);

--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -1032,8 +1032,7 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
                 const craftParam = ability.isPrepared && row.dataset.itemIndex ? Number(row.dataset.itemIndex) : null;
                 const consume = !ability.resource || !!this.actor.getResource(ability.resource)?.value;
                 const preparedFormulas = await ability.getPreparedCraftingFormulas();
-                const craftQuantity =
-                    craftParam !== null ? (preparedFormulas[craftParam]?.quantity ?? 1) : 1;
+                const craftQuantity = craftParam !== null ? (preparedFormulas[craftParam]?.quantity ?? 1) : 1;
                 const item = craftParam !== null ? await ability.craft(craftParam, { consume }) : null;
                 if (item) {
                     await ChatMessagePF2e.create({

--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -1031,6 +1031,9 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
             if (ability) {
                 const craftParam = ability.isPrepared && row.dataset.itemIndex ? Number(row.dataset.itemIndex) : null;
                 const consume = !ability.resource || !!this.actor.getResource(ability.resource)?.value;
+                const preparedFormulas = await ability.getPreparedCraftingFormulas();
+                const craftQuantity =
+                    craftParam !== null ? (preparedFormulas[craftParam]?.quantity ?? 1) : 1;
                 const item = craftParam !== null ? await ability.craft(craftParam, { consume }) : null;
                 if (item) {
                     await ChatMessagePF2e.create({
@@ -1038,7 +1041,7 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
                         content: _loc("PF2E.Actions.Craft.Information.ReceiveItem", {
                             actorName: this.actor.name,
                             itemName: item.name,
-                            quantity: 1,
+                            quantity: craftQuantity,
                         }),
                         speaker: { alias: this.actor.name },
                     });


### PR DESCRIPTION
Fixes bug: clicking 'Craft' on an item in Advanced Alchemy expends the formula and creates 1 item, no matter how many there actually are
<img width="936" height="200" alt="image" src="https://github.com/user-attachments/assets/7485a1ec-9a48-4a80-8330-8d61df362b81" />
