### PR TITLE
Fix total price not updating on item transfer dialogs

### DIFF
--- a/src/module/actor/sheet/popups/item-transfer-dialog.ts
+++ b/src/module/actor/sheet/popups/item-transfer-dialog.ts
@@ -117,6 +117,11 @@ class ItemTransferDialog extends fa.api.DialogV2<ItemTransferConfiguration> {
         options: fa.api.HandlebarsRenderOptions,
     ): Promise<void> {
         await super._onRender(context, options);
+        // DialogV2 never attaches a change listener to its form, so wire one up manually to drive `_onChangeForm`.
+        this.element.querySelector("form")?.addEventListener("change", (event) => {
+            const formConfig = this.options.form;
+            if (formConfig) this._onChangeForm(formConfig, event);
+        });
         this.#renderPurchasePrice();
     }
 
@@ -131,7 +136,8 @@ class ItemTransferDialog extends fa.api.DialogV2<ItemTransferConfiguration> {
     #renderPurchasePrice(): void {
         const { mode, item } = this.options;
         if (mode !== "purchase") return;
-        const quantityInput = this.element.querySelector<fa.elements.HTMLRangePickerElement>("input[name=quantity]");
+        const quantityInput =
+            this.element.querySelector<fa.elements.HTMLRangePickerElement>("range-picker[name=quantity]");
         const purchaseButton = this.element.querySelector("button[data-action=purchase]");
         if (!quantityInput || !purchaseButton) return;
         const quantity = Math.clamp(Number(quantityInput.value) || 1, 1, item.quantity);


### PR DESCRIPTION
- Closes #22533

This is a minimal fix to unblock the credstick issue. I used the selector fix from the issue. For the `_onChangeForm` half, the reason it never fires is that DialogV2 only ever attaches a `submit` listener to its form and never a `change` one, so there's nothing to trigger it. Wired up a change listener manually in `_onRender` to get it going again.

imo this should eventually move off DialogV2 and into a full AppV2 + Svelte since it's really a live form rather than static content + buttons like DialogV2 is meant for, but I kept this minimal for now.

~~@CarlosFdez I'd mark you explicitly as reviewer, but I'm not a collaborator. Any chance I could get added so I can start tagging my things properly?~~ thanks shark!