### PR TITLE
Implement Bodyguard's increased Taunt penalty using Ephemeral Effect

### DIFF
--- a/packs/pf2e/feat-effects/effect-bodyguard-penalty.json
+++ b/packs/pf2e/feat-effects/effect-bodyguard-penalty.json
@@ -1,0 +1,47 @@
+{
+    "_id": "e1iDfrbJnqp1p4UD",
+    "img": "icons/skills/melee/shield-block-bash-yellow.webp",
+    "name": "Effect: Bodyguard (Penalty)",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Bodyguard] via Ephemeral Effect</p>\n<p>Your attack roll penalty from Taunt against the target increases to –2.</p>"
+        },
+        "duration": {
+            "expiry": null,
+            "sustained": false,
+            "unit": "unlimited",
+            "value": -1
+        },
+        "fromSpell": false,
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Battlecry!"
+        },
+        "rules": [
+            {
+                "key": "AdjustModifier",
+                "mode": "downgrade",
+                "selectors": [
+                    "attack-roll"
+                ],
+                "slug": "taunt-attack-roll",
+                "value": -2
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/pf2e/feat-effects/effect-bodyguard.json
+++ b/packs/pf2e/feat-effects/effect-bodyguard.json
@@ -1,0 +1,63 @@
+{
+    "_id": "6QFg5v5iW4I3rcAm",
+    "img": "icons/skills/melee/shield-block-bash-yellow.webp",
+    "name": "Effect: Bodyguard",
+    "system": {
+        "description": {
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Bodyguard]</p>\n<p>When the target of the origin's Taunt makes an attack roll against you, or you attempt a saving throw against an action from that target, their circumstance penalty increases to –2.</p>"
+        },
+        "duration": {
+            "expiry": "turn-start",
+            "sustained": false,
+            "unit": "days",
+            "value": 1
+        },
+        "fromSpell": false,
+        "level": {
+            "value": 1
+        },
+        "publication": {
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Battlecry!"
+        },
+        "rules": [
+            {
+                "affects": "origin",
+                "key": "EphemeralEffect",
+                "predicate": [
+                    "origin:effect:taunt:{item|origin.signature}"
+                ],
+                "selectors": [
+                    "attack-roll"
+                ],
+                "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Bodyguard (Penalty)"
+            },
+            {
+                "key": "Note",
+                "predicate": [
+                    "origin:effect:taunt:{item|origin.signature}",
+                    {
+                        "not": "item:tag:bodyguard-taunt"
+                    }
+                ],
+                "selector": [
+                    "saving-throw"
+                ],
+                "text": "PF2E.SpecificRule.Guardian.Bodyguard.PenaltyNote",
+                "title": "{item|name}"
+            }
+        ],
+        "start": {
+            "initiative": null,
+            "value": 0
+        },
+        "tokenIcon": {
+            "show": true
+        },
+        "traits": {
+            "value": []
+        }
+    },
+    "type": "effect"
+}

--- a/packs/pf2e/feat-effects/effect-taunt.json
+++ b/packs/pf2e/feat-effects/effect-taunt.json
@@ -111,6 +111,12 @@
                 ]
             },
             {
+                "disabledIf": [
+                    {
+                        "not": "taunt-dc-penalty"
+                    }
+                ],
+                "disabledValue": false,
                 "key": "RollOption",
                 "label": "PF2E.SpecificRule.Guardian.Bodyguard.ToggleLabel",
                 "option": "bodyguard-taunt",
@@ -123,21 +129,48 @@
                 "key": "AdjustModifier",
                 "mode": "downgrade",
                 "predicate": [
-                    "bodyguard-taunt",
-                    {
-                        "or": [
-                            "penalty:slug:taunt-attack-roll",
-                            "penalty:slug:taunt-dc"
-                        ]
-                    }
+                    "bodyguard-taunt"
                 ],
                 "selectors": [
-                    "attack-roll",
                     "class",
                     "inline-dc",
                     "spell-dc"
                 ],
+                "slug": "taunt-dc",
                 "value": -2
+            },
+            {
+                "itemType": "action",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "parent:origin:item:tag:bodyguard",
+                    "bodyguard-taunt"
+                ],
+                "property": "other-tags",
+                "value": "bodyguard-taunt"
+            },
+            {
+                "itemType": "spell",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "parent:origin:item:tag:bodyguard",
+                    "bodyguard-taunt"
+                ],
+                "property": "other-tags",
+                "value": "bodyguard-taunt"
+            },
+            {
+                "itemType": "feat",
+                "key": "ItemAlteration",
+                "mode": "add",
+                "predicate": [
+                    "parent:origin:item:tag:bodyguard",
+                    "bodyguard-taunt"
+                ],
+                "property": "other-tags",
+                "value": "bodyguard-taunt"
             },
             {
                 "key": "RollOption",

--- a/packs/pf2e/feats/class/guardian/level-1/bodyguard.json
+++ b/packs/pf2e/feats/class/guardian/level-1/bodyguard.json
@@ -12,7 +12,7 @@
         },
         "category": "class",
         "description": {
-            "value": "<p>You swear a vow to protect one of your allies at all costs, regardless of the risk this might pose to you. During your daily preparations, choose one of your allies as your charge. When you Taunt, the penalty your taunted enemy takes increases to –2 against your charge.</p>\n<p>You can take 10 minutes to change who your charge is before your next daily preparations.</p>"
+            "value": "<p>You swear a vow to protect one of your allies at all costs, regardless of the risk this might pose to you. During your daily preparations, choose one of your allies as your charge. When you @UUID[Compendium.pf2e.actionspf2e.Item.Taunt], the penalty your taunted enemy takes increases to –2 against your charge.</p>\n<p>You can take 10 minutes to change who your charge is before your next daily preparations.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Bodyguard]</p>"
         },
         "level": {
             "value": 1

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -6545,7 +6545,8 @@
                     "ToggleLabel": "Armor Break — Reduce bulwark bonus"
                 },
                 "Bodyguard": {
-                    "ToggleLabel": "Bodyguard — Hostile action against the origin's charge"
+                    "PenaltyNote": "The origin's penalty to their DCs from Taunt increases to —2 against you.",
+                    "ToggleLabel": "Bodyguard — Increase penalty to DCs"
                 },
                 "EnergyInterceptor": {
                     "Addendum": "You can use Intercept Attack when an ally would take acid, cold, electricity, fire, or sonic damage, not only when they would take physical damage."


### PR DESCRIPTION
- Closes #22466

Uses an effect with an Ephemeral Effect rule element to downgrade taunt's attack roll penalty.

We can't affect DCs from a rolled saving throw in this way, so instead the current toggle for Bodyguard in Taunt's effect is repurposed to target DCs only (and so it's disabled if there is no penalty to DCs being applied). If the toggle is enabled, then add a tag to actions, feats, and spells to indicate their DCs are being affected. Then, predicate a reminder saving throw Note about Bodyguard's increased Taunt penalty if that tag is not present.