### PR TITLE
Add rotate area region behavior

### DIFF
--- a/src/module/scene/region-behavior/document.ts
+++ b/src/module/scene/region-behavior/document.ts
@@ -27,4 +27,11 @@ class RegionBehaviorPF2e<
     }
 }
 
+interface RegionBehaviorPF2e<
+    TParent extends RegionDocumentPF2e | null = RegionDocumentPF2e | null,
+    TSystem extends foundry.data.regionBehaviors.RegionBehaviorType = foundry.data.regionBehaviors.RegionBehaviorType,
+> extends RegionBehavior<TParent> {
+    system: TSystem;
+}
+
 export { RegionBehaviorPF2e };

--- a/src/module/scene/region-behavior/rotate-area/behavior.ts
+++ b/src/module/scene/region-behavior/rotate-area/behavior.ts
@@ -1,0 +1,482 @@
+import type { DocumentIdField } from "@client/data/fields.mjs";
+import { Point } from "@common/_types.mjs";
+import { ScenePF2e } from "@scene/document.ts";
+import { RegionDocumentPF2e } from "@scene/region-document/document.ts";
+import { TokenDocumentPF2e } from "@scene/token-document/document.ts";
+import { ErrorPF2e } from "@util";
+import { RegionBehaviorPF2e } from "../document.ts";
+import fields = foundry.data.fields;
+
+const DEFAULT_DURATION = 500;
+
+class RotateAreaBehaviorType extends foundry.data.regionBehaviors.RegionBehaviorType<
+    RotateAreaTypeSchema,
+    RegionBehaviorPF2e | null
+> {
+    static override LOCALIZATION_PREFIXES = ["PF2E.Region.RotateArea"];
+
+    static override defineSchema(): RotateAreaTypeSchema {
+        return {
+            time: new fields.SchemaField({
+                value: new fields.NumberField({
+                    required: true,
+                    nullable: false,
+                    min: 0,
+                    initial: DEFAULT_DURATION,
+                    integer: true,
+                }),
+                mode: new fields.StringField({
+                    required: true,
+                    nullable: false,
+                    choices: RotateAreaBehaviorType.SPEED_MODES,
+                    initial: "fixed",
+                }),
+            }),
+            tiles: new fields.SchemaField({
+                ids: new fields.SetField(new fields.DocumentIdField()),
+            }),
+            walls: new fields.SchemaField({
+                ids: new fields.SetField(new fields.DocumentIdField()),
+                link: new fields.BooleanField({ required: true, nullable: false, initial: true }),
+            }),
+            lights: new fields.SchemaField({
+                ids: new fields.SetField(new fields.DocumentIdField()),
+            }),
+            regions: new fields.SchemaField({
+                ids: new fields.SetField(new fields.DocumentIdField()),
+            }),
+            sounds: new fields.SchemaField({
+                ids: new fields.SetField(new fields.DocumentIdField()),
+            }),
+            notes: new fields.SchemaField({
+                ids: new fields.SetField(new fields.DocumentIdField()),
+            }),
+            directionMode: new fields.StringField({
+                required: true,
+                initial: "short",
+                choices: RotateAreaBehaviorType.DIRECTION_MODES,
+            }),
+            positions: new fields.ArrayField(
+                new fields.SchemaField({
+                    angle: new fields.NumberField({ required: true, nullable: false, initial: 0, min: -360, max: 360 }),
+                }),
+                { initial: [{ angle: 0 }] },
+            ),
+            status: new fields.SchemaField({
+                angle: new fields.AngleField({ required: true, initial: 0 }),
+                position: new fields.NumberField({ initial: 0, integer: true, min: 0 }),
+            }),
+        };
+    }
+
+    /** Modes for determining rotation direction when moving to the next point. */
+    static DIRECTION_MODES = Object.seal({
+        cw: "PF2E.Region.RotateArea.DirectionMode.cw",
+        ccw: "PF2E.Region.RotateArea.DirectionMode.ccw",
+        short: "PF2E.Region.RotateArea.DirectionMode.short",
+        long: "PF2E.Region.RotateArea.DirectionMode.long",
+    });
+
+    /** Modes for mapping rotation time to final speed. */
+    static SPEED_MODES = Object.seal({
+        fixed: "PF2E.Region.RotateArea.SpeedMode.fixed",
+        variable: "PF2E.Region.RotateArea.SpeedMode.variable",
+    });
+
+    /**
+     * Used to check if we are mid rotation for a behavior. If true, later rotation attempts will be ignored.
+     * The behavior is not reused every update, and it seems like it can get reinstantiated. Therefore we store the record globally
+     */
+    static #rotating: Set<string> = new Set();
+
+    /**
+     * Rotate to the next position.
+     * @param reverse Rotate to previous position instead of next one.
+     * @returns Resolves once rotation is complete.
+     */
+    async rotate(reverse = false): Promise<boolean> {
+        const index = this.status.position + (reverse ? -1 : 1);
+        const clampedIndex = index >= this.positions.length ? 0 : index < 0 ? this.positions.length - 1 : index;
+        return this.rotateTo({ position: clampedIndex });
+    }
+
+    /**
+     * Trigger the rotator to rotate to a angle or specific position. Either the angle or position must be provided.
+     * @param {object} options
+     * @param {number} [options.angle]     Final angle.
+     * @param {string} [options.position]  Position index to rotate to.
+     * @returns Resolves once rotation is complete. Returns false if it returns early
+     */
+    async rotateTo({ angle: targetAngle, position }: { angle?: number; position: number }): Promise<boolean> {
+        if (!this.behavior) throw ErrorPF2e("Unexpected missing parent behavior");
+        if (!this.region) throw ErrorPF2e("Unexpected missing region document");
+        if (!this.scene) throw ErrorPF2e(`Unexpected missing scene in region behavior \`${this.behavior.uuid}\``);
+        if (RotateAreaBehaviorType.#rotating.has(this.behavior.id) || !this.behavior) return false;
+
+        const positionData = typeof position === "number" ? this.positions.at(position) : null;
+        if (typeof position === "number" && !positionData) {
+            console.warn(`Invalid position \`${position}\` when attempting to rotate \`${this.behavior.uuid}\`.`);
+            return false;
+        }
+
+        targetAngle ??= positionData?.angle;
+        if (targetAngle === undefined) {
+            console.warn(
+                `No target angle or position index provided when attempting to rotate \`${this.behavior.uuid}\`.`,
+            );
+            return false;
+        }
+
+        // Determine rotation angle, time, and pivot point
+        const angle = this.#travelAngle(this.status.angle, targetAngle);
+        const radians = Math.toRadians(angle);
+        const duration = Math.max(
+            this.time.mode === "fixed" ? this.time.value : this.time.value * (Math.abs(angle) / 90),
+            500,
+        );
+        const pivot = this.region.shapes[0].origin;
+
+        const calculateRotationUpdate = (placeable: RotatableDocument) => {
+            if (placeable instanceof TileDocument) {
+                const shape = placeable.shape.clone();
+                shape.rotate(angle, { pivot });
+                return { _id: placeable.id, x: shape.x, y: shape.y, rotation: placeable.rotation + angle };
+            }
+            const { center, offset, rotation } = this.#getPlacementAndRotation(placeable);
+            const shouldRotate =
+                placeable instanceof TokenDocument
+                    ? game.settings.get("core", "tokenAutoRotate") && !placeable.lockRotation
+                    : true;
+            return {
+                _id: placeable.id,
+                ...RotateAreaBehaviorType.#calculatePosition(radians, pivot, center, offset),
+                rotation: rotation !== undefined && shouldRotate ? rotation + angle : rotation,
+            };
+        };
+
+        // Prepare update data for each rotated document type
+        const docs = this.#getAnimatables();
+        const updates = {
+            tiles: docs.tiles.map((t) => calculateRotationUpdate(t)),
+            tokens: docs.tokens.map((t) => calculateRotationUpdate(t)),
+            lights: docs.lights.map((l) => calculateRotationUpdate(l)),
+            regions: docs.regions.map((r) => RotateAreaBehaviorType.#rotateRegionShapes(r, angle, pivot)),
+            sounds: docs.sounds.map((s) => calculateRotationUpdate(s)),
+            notes: docs.notes.map((s) => calculateRotationUpdate(s)),
+            walls: docs.walls.map((wall) => {
+                const first = RotateAreaBehaviorType.#calculatePosition(radians, pivot, {
+                    x: wall.c[0],
+                    y: wall.c[1],
+                });
+                const second = RotateAreaBehaviorType.#calculatePosition(radians, pivot, {
+                    x: wall.c[2],
+                    y: wall.c[3],
+                });
+                return { _id: wall.id, c: [first.x, first.y, second.x, second.y] };
+            }),
+        };
+
+        // Update status to indicate rotation is occurring and trigger visible animation
+        try {
+            RotateAreaBehaviorType.#rotating.add(this.behavior.id);
+            if (canvas.scene === this.scene) {
+                this.#animateRotation(angle, pivot, duration);
+                // Wait for the visible animation to complete before performing document updates
+                await new Promise((resolve) => setTimeout(resolve, duration));
+            }
+
+            await foundry.documents.modifyBatch([
+                {
+                    action: "update",
+                    documentName: "RegionBehavior",
+                    updates: [{ _id: this.behavior.id, "system.status": { angle: targetAngle, position } }],
+                    parent: this.region,
+                },
+                // Tokens must be updated before the regions so they re-enter the rotated region after they briefly leave it
+                // when moved to the new position while the region shapes have not been updated yet
+                {
+                    action: "update",
+                    documentName: "Token",
+                    updates: updates.tokens,
+                    parent: this.scene,
+                    animate: false,
+                    constrainOptions: { ignoreWalls: true, ignoreCost: true },
+                },
+                { action: "update", documentName: "AmbientLight", updates: updates.lights, parent: this.scene },
+                { action: "update", documentName: "AmbientSound", updates: updates.sounds, parent: this.scene },
+                { action: "update", documentName: "Region", updates: updates.regions, parent: this.scene },
+                { action: "update", documentName: "Tile", updates: updates.tiles, parent: this.scene },
+                { action: "update", documentName: "Note", updates: updates.notes, parent: this.scene },
+                { action: "update", documentName: "Wall", updates: updates.walls, parent: this.scene },
+            ]);
+        } finally {
+            RotateAreaBehaviorType.#rotating.delete(this.behavior.id);
+        }
+
+        return true;
+    }
+
+    /**
+     * Calculate the final position based on a rotation.
+     * @param angle Rotation amount in radians.
+     * @param pivot Center point for the rotation.
+     * @param center Center point for the object being rotated.
+     * @param offset How offset the center point is from the stored point.
+     */
+    static #calculatePosition(angle: number, pivot: Point, center: Point, offset = { x: 0, y: 0 }) {
+        const vector = new fc.geometry.Ray(pivot, center).shiftAngle(angle);
+        return { x: vector.B.x - offset.x, y: vector.B.y - offset.y };
+    }
+
+    /** Retrieve and object with canvas documents for anything rotated. */
+    #getAnimatables(): {
+        tiles: fd.TileDocument<ScenePF2e>[];
+        tokens: TokenDocumentPF2e<ScenePF2e>[];
+        lights: fd.AmbientLightDocument<ScenePF2e>[];
+        regions: RegionDocumentPF2e[];
+        sounds: fd.AmbientSoundDocument<ScenePF2e>[];
+        notes: fd.NoteDocument<ScenePF2e>[];
+        walls: fd.WallDocument<ScenePF2e>[];
+    } {
+        const { scene, region } = this;
+        if (!scene || !region) {
+            return { tiles: [], tokens: [], lights: [], regions: [], sounds: [], notes: [], walls: [] };
+        }
+
+        const animatables = {
+            tiles: Array.from(this.tiles.ids)
+                .map((id) => scene.tiles.get(id ?? ""))
+                .filter((d): d is fd.TileDocument<ScenePF2e> => !!d),
+            tokens: Array.from(region.tokens),
+            lights: Array.from(this.lights.ids)
+                .map((id) => scene.lights.get(id ?? ""))
+                .filter((d): d is fd.AmbientLightDocument<ScenePF2e> => !!d),
+            regions: [region.id, ...this.regions.ids]
+                .map((id) => scene.regions.get(id ?? ""))
+                .filter((d): d is RegionDocumentPF2e<ScenePF2e> => !!d),
+            sounds: Array.from(this.sounds.ids)
+                .map((id) => scene.sounds.get(id ?? ""))
+                .filter((d): d is fd.AmbientSoundDocument<ScenePF2e> => !!d),
+            notes: Array.from(this.notes.ids)
+                .map((id) => scene.notes.get(id ?? ""))
+                .filter((d): d is fd.NoteDocument<ScenePF2e> => !!d),
+            walls: Array.from(this.walls.ids)
+                .map((id) => scene.walls.get(id ?? ""))
+                .filter((d): d is fd.WallDocument<ScenePF2e> => !!d),
+        };
+        if (this.walls.link) {
+            animatables.walls = animatables.walls.flatMap(
+                (w) => w.object?.getLinkedSegments().walls.map((w) => w.document) ?? [],
+            );
+        }
+        return animatables;
+    }
+
+    /** Retrieves center, size, and rotation for a document, handling differences bettween document types */
+    #getPlacementAndRotation(doc: RotatableDocument): RotationParams {
+        const center = doc instanceof TokenDocument ? doc.getCenterPoint() : { x: doc.x, y: doc.y };
+        const size =
+            doc instanceof TileDocument
+                ? { width: doc.width, height: doc.height }
+                : doc instanceof TokenDocument
+                  ? doc.getSize()
+                  : { width: 0, height: 0 };
+        const offset = { x: size.width * 0.5, y: size.height * 0.5 };
+        const rotation = "rotation" in doc ? doc.rotation : (doc.object?.rotation ?? 0);
+        return { center, offset, rotation };
+    }
+
+    /**
+     * Create updates needed to rotate a region's shapes.
+     * @param region The region to rotate.
+     * @param angle Rotation amount in degrees.
+     * @param radians Rotation amount in radians.
+     * @param pivot Center point for the rotation.
+     * @returns Update data for the region.
+     */
+    static #rotateRegionShapes(region: RegionDocument, angle: number, pivot: Point) {
+        return {
+            _id: region.id,
+            shapes: region.shapes.map((shape) => {
+                const clone = shape.clone();
+                clone.rotate(angle, { pivot });
+                return clone.toObject();
+            }),
+        };
+    }
+
+    /**
+     * Determine the direction to rotate and the final rotation angle based on the direction mode.
+     * @param start Starting angle.
+     * @param end Ending angle.
+     */
+    #travelAngle(start: number, end: number): number {
+        if (start < 0) start += 360;
+        if (end < 0) end += 360;
+        const cw = (end - start + 360) % 360;
+        const ccw = ((start - end + 360) % 360) * -1;
+        switch (this.directionMode) {
+            case "cw":
+                return cw;
+            case "ccw":
+                return ccw;
+            case "short":
+                return Math.abs(cw) < Math.abs(ccw) ? cw : ccw;
+            case "long":
+                return Math.abs(cw) > Math.abs(ccw) ? cw : ccw;
+        }
+    }
+
+    /**
+     * Handle animating the rotation of the region.
+     * @param {Degrees} angle
+     * @param {Point} pivot
+     * @param {number} duration
+     */
+    #animateRotation(angle: number, pivot: Point, duration: number) {
+        const docs = this.#getAnimatables();
+
+        // Get lights, tiles, and walls and animate them bit by bit
+        // Sounds currently fail to animate, and notes don't need to animate
+        const animatables = [...docs.lights, ...docs.tiles].map((document) => ({
+            document,
+            params: this.#getPlacementAndRotation(document),
+        }));
+        const walls = docs.walls.map((document) => ({ document, initialPoints: fu.duplicate(document.c) }));
+        foundry.canvas.animation.CanvasAnimation.animate([], {
+            duration,
+            easing: foundry.canvas.animation.CanvasAnimation.easeInOutCosine,
+            priority: PIXI.UPDATE_PRIORITY.OBJECTS + 1,
+            ontick: (_, animation) => {
+                const [time, duration] = [animation.time ?? 0, animation.duration ?? DEFAULT_DURATION];
+                const percent = time >= duration ? 1 : time / duration;
+                if (percent > 1) return;
+
+                const easingFunction = typeof animation.easing === "function" ? animation.easing : null;
+                const percentEased = easingFunction?.(percent) ?? percent;
+                const adjustedAngle = Math.toRadians(angle * percentEased);
+                for (const { document, params } of animatables) {
+                    const { center, offset, rotation } = params;
+                    if (document instanceof TileDocument) {
+                        const shape = document.shape.clone();
+                        shape.rotate(angle * percentEased, { pivot });
+                        const updates = { x: shape.x, y: shape.y, rotation: rotation + angle * percentEased };
+                        Object.assign(document.shape, updates);
+                    } else {
+                        const updates = RotateAreaBehaviorType.#calculatePosition(adjustedAngle, pivot, center, offset);
+                        document.x = updates.x;
+                        document.y = updates.y;
+                        if (document instanceof AmbientLightDocument) {
+                            document.rotation = rotation + angle * percentEased;
+                        }
+                    }
+
+                    if (document instanceof AmbientLightDocument) {
+                        document.object?.initializeLightSource();
+                    } else if (document instanceof TileDocument) {
+                        document.object?.renderFlags.set({ refreshTransform: true });
+                    }
+                }
+                for (const { document, initialPoints } of walls) {
+                    const first = RotateAreaBehaviorType.#calculatePosition(adjustedAngle, pivot, {
+                        x: initialPoints[0],
+                        y: initialPoints[1],
+                    });
+                    const second = RotateAreaBehaviorType.#calculatePosition(adjustedAngle, pivot, {
+                        x: initialPoints[2],
+                        y: initialPoints[3],
+                    });
+                    document.c = [first.x, first.y, second.x, second.y];
+                    document.object?.renderFlags.set({ refreshLine: true });
+                    if (game.settings.get("core", "visionAnimation")) document.initializeEdge();
+                }
+            },
+        });
+
+        // Tokens have their own animation function we need to call
+        const rad = Math.toRadians(angle);
+        for (const token of docs.tokens) {
+            const { center, offset, rotation } = this.#getPlacementAndRotation(token);
+            const finalPosition = RotateAreaBehaviorType.#calculatePosition(rad, pivot, center, offset);
+            const shouldRotate = game.settings.get("core", "tokenAutoRotate") && !token.lockRotation;
+            token.object?.animate(finalPosition, {
+                duration,
+                easing: foundry.canvas.animation.CanvasAnimation.easeInOutCosine,
+                ontick: (_elapsedMS, animation, data) => {
+                    const [time, duration] = [animation.time ?? 0, animation.duration ?? DEFAULT_DURATION];
+                    const percent = time >= duration ? 1 : time / duration;
+                    const easingFunction = typeof animation.easing === "function" ? animation.easing : null;
+                    const percentEased = easingFunction?.(percent) ?? percent;
+                    const adjustedAngle = Math.toRadians(angle * percentEased);
+                    const updates = RotateAreaBehaviorType.#calculatePosition(adjustedAngle, pivot, center, offset);
+                    data.x = updates.x;
+                    data.y = updates.y;
+                    if (shouldRotate) data.rotation = rotation + angle * percentEased;
+                },
+            });
+        }
+    }
+}
+
+/** Documents that can be rotated normally. Walls need special handling */
+type RotatableDocument =
+    | fd.TileDocument<ScenePF2e>
+    | AmbientLightDocument<ScenePF2e>
+    | AmbientSoundDocument<ScenePF2e>
+    | TokenDocumentPF2e<ScenePF2e>
+    | NoteDocument<ScenePF2e>;
+
+interface RotationParams {
+    center: Point;
+    offset: Point;
+    rotation: number;
+}
+
+type RotateAreaBehavior = RegionBehaviorPF2e<RegionDocumentPF2e, RotateAreaBehaviorType>;
+
+interface RotateAreaBehaviorType
+    extends
+        foundry.data.regionBehaviors.RegionBehaviorType<RotateAreaTypeSchema, RegionBehaviorPF2e | null>,
+        fields.ModelPropsFromSchema<RotateAreaTypeSchema> {}
+
+type RotateAreaSpeedMode = keyof (typeof RotateAreaBehaviorType)["SPEED_MODES"];
+type RotateAreaDirectionMode = keyof (typeof RotateAreaBehaviorType)["DIRECTION_MODES"];
+
+type RotateAreaTypeSchema = {
+    time: fields.SchemaField<{
+        value: fields.NumberField<number, number, true, false, true>;
+        mode: fields.StringField<RotateAreaSpeedMode, RotateAreaSpeedMode, true, false, true>;
+    }>;
+    tiles: fields.SchemaField<{
+        ids: fields.SetField<DocumentIdField>;
+    }>;
+    walls: fields.SchemaField<{
+        ids: fields.SetField<DocumentIdField>;
+        link: fields.BooleanField<boolean, boolean, true, false, true>;
+    }>;
+    lights: fields.SchemaField<{
+        ids: fields.SetField<DocumentIdField>;
+    }>;
+    regions: fields.SchemaField<{
+        ids: fields.SetField<DocumentIdField>;
+    }>;
+    sounds: fields.SchemaField<{
+        ids: fields.SetField<DocumentIdField>;
+    }>;
+    notes: fields.SchemaField<{
+        ids: fields.SetField<DocumentIdField>;
+    }>;
+    directionMode: fields.StringField<RotateAreaDirectionMode, RotateAreaDirectionMode, true, false, true>;
+    positions: fields.ArrayField<
+        fields.SchemaField<{
+            angle: fields.NumberField<number, number, true, false, true>;
+        }>
+    >;
+    status: fields.SchemaField<{
+        angle: fields.AngleField<true, false, true>;
+        position: fields.NumberField<number, number, true, false, true>;
+    }>;
+};
+
+export { RotateAreaBehaviorType };
+export type { RotateAreaBehavior };

--- a/src/module/scene/region-behavior/rotate-area/config.ts
+++ b/src/module/scene/region-behavior/rotate-area/config.ts
@@ -1,0 +1,101 @@
+import type { FormNode } from "@client/applications/_module.mjs";
+import { DocumentSheetRenderContext } from "@client/applications/api/document-sheet.mjs";
+import { DataField } from "@common/data/fields.mjs";
+import { htmlClosest } from "@util";
+import * as R from "remeda";
+import { RotateAreaBehavior } from "./behavior.ts";
+
+class RotateAreaConfig extends foundry.applications.sheets.RegionBehaviorConfig<RotateAreaBehavior> {
+    static override DEFAULT_OPTIONS = {
+        actions: {
+            addPosition: RotateAreaConfig.#onAddPosition,
+            deletePosition: RotateAreaConfig.#onDeletePosition,
+            rotateToPosition: RotateAreaConfig.#onRotateToPosition,
+        },
+        classes: ["rotate-area"],
+    };
+
+    /** @override */
+    static override PARTS = {
+        form: {
+            template: `systems/${SYSTEM_ID}/templates/scene/rotate-area-config.hbs`,
+            scrollable: [""],
+        },
+        footer: {
+            template: "templates/generic/form-footer.hbs",
+        },
+    };
+
+    protected override async _prepareContext(options: fa.api.DocumentSheetRenderOptions): Promise<object> {
+        const context = (await super._prepareContext(options)) as DocumentSheetRenderContext<RotateAreaBehavior>;
+        const positions: PositionSheetData[] = this.document.system._source.positions.map((data, index) => ({
+            data,
+            fields: this.document.system.schema.fields.positions.element.fields,
+            label: `#${index}`,
+        }));
+        return {
+            ...context,
+            positions,
+        };
+    }
+
+    protected override _getFields(): FormNode[] {
+        const fields = super._getFields();
+        for (const fieldset of fields) {
+            fieldset.fields = fieldset.fields?.filter((f) => !f.field?.fieldPath.startsWith("system.status"));
+        }
+        return fields;
+    }
+
+    /** Overriden to convert uuids to ids */
+    protected override _onChangeForm(formConfig: fa.ApplicationFormConfiguration, event: Event): void {
+        super._onChangeForm(formConfig, event);
+        const props = ["tiles", "walls", "lights", "regions", "sounds", "notes"];
+        for (const p of props) {
+            const element = this.form?.elements.namedItem(`system.${p}.ids`);
+            if (!(element instanceof foundry.applications.elements.HTMLStringTagsElement)) continue;
+            const newValue = element.value
+                .map((v) => {
+                    if (!v.includes(".")) return v; // not a uuid
+                    return foundry.utils.parseUuid(v)?.id;
+                })
+                .filter((v): v is string => !!v);
+
+            // Replace if value changed. Test for equality to prevent infinite on change form loop
+            if (!R.isShallowEqual(element.value, newValue)) element.value = newValue;
+        }
+    }
+
+    static async #onAddPosition(this: RotateAreaConfig) {
+        await this.submit();
+        const positions = this.document.system.toObject().positions ?? [];
+        if (positions.length > 1) {
+            const last = positions.at(-1)?.angle ?? 0;
+            const secondToLast = positions.at(-2)?.angle ?? 0;
+            this.document.update({ "system.positions": [...positions, { angle: last * 2 - secondToLast }] });
+        } else {
+            const angle = positions[0] ? positions[0].angle + 90 : 0;
+            this.document.update({ "system.positions": [...positions, { angle }] });
+        }
+    }
+
+    static async #onDeletePosition(this: RotateAreaConfig, _event: Event, target: HTMLElement) {
+        await this.submit();
+        const position = Number(htmlClosest(target, "[data-index]")?.dataset.index);
+        this.document.update({ "system.positions": this.document.system.toObject().positions.toSpliced(position, 1) });
+    }
+
+    static async #onRotateToPosition(this: RotateAreaConfig, _event: Event, target: HTMLElement) {
+        await this.submit();
+        const position = Number(htmlClosest(target, "[data-index]")?.dataset.index);
+        this.document.system.rotateTo({ position });
+    }
+}
+
+interface PositionSheetData {
+    data: { angle: number };
+    fields: Record<string, DataField>;
+    label: string;
+}
+
+export { RotateAreaConfig };

--- a/src/scripts/hooks/load.ts
+++ b/src/scripts/hooks/load.ts
@@ -50,6 +50,7 @@ import {
     TokenDocumentPF2e,
 } from "@scene/index.ts";
 import { DifficultTerrainBehaviorType } from "@scene/region-behavior/difficult-terrain.ts";
+import { RotateAreaBehaviorType } from "@scene/region-behavior/rotate-area/behavior.ts";
 import { PrototypeTokenConfigPF2e } from "@scene/token-document/index.ts";
 import { monkeyPatchFoundry } from "@scripts/🐵🩹.ts";
 import { CheckRoll, StrikeAttackRoll } from "@system/check/roll.ts";
@@ -81,11 +82,11 @@ export class Load {
         CONFIG.RegionBehavior.dataModels.environment = EnvironmentBehaviorType;
         CONFIG.RegionBehavior.dataModels.environmentFeature = EnvironmentFeatureBehaviorType;
         CONFIG.RegionBehavior.dataModels.modifyMovementCost = DifficultTerrainBehaviorType;
+        CONFIG.RegionBehavior.dataModels["system.rotateArea"] = RotateAreaBehaviorType;
         CONFIG.RegionBehavior.documentClass = RegionBehaviorPF2e;
         CONFIG.RegionBehavior.typeIcons.environment = "fa-solid fa-mountain-sun";
         CONFIG.RegionBehavior.typeIcons.environmentFeature = "fa-solid fa-wind";
-        CONFIG.RegionBehavior.typeLabels.environment = "PF2E.Region.Environment.Label";
-        CONFIG.RegionBehavior.typeLabels.environmentFeature = "PF2E.Region.EnvironmentFeature.Label";
+        CONFIG.RegionBehavior.typeIcons["system.rotateArea"] = "fa-solid fa-arrows-spin";
         CONFIG.Scene.documentClass = ScenePF2e;
         CONFIG.Token.documentClass = TokenDocumentPF2e;
         CONFIG.Token.movement.TerrainData = TerrainDataPF2e;

--- a/src/scripts/register-sheets.ts
+++ b/src/scripts/register-sheets.ts
@@ -34,6 +34,7 @@ import { SpellSheetPF2e } from "@item/spell/sheet.ts";
 import { TreasureSheetPF2e } from "@item/treasure/sheet.ts";
 import { WeaponSheetPF2e } from "@item/weapon/sheet.ts";
 import { UserConfigPF2e } from "@module/user/sheet.ts";
+import { RotateAreaConfig } from "@scene/region-behavior/rotate-area/config.ts";
 import { SceneConfigPF2e } from "@scene/sheet.ts";
 import { TokenDocumentPF2e } from "@scene/token-document/document.ts";
 import { TokenConfigPF2e } from "@scene/token-document/index.ts";
@@ -173,5 +174,13 @@ export function registerSheets(): void {
     fd.collections.Users.registerSheet("pf2e", UserConfigPF2e, {
         makeDefault: true,
         label: () => _loc("SHEETS.DefaultDocumentSheet", { document: _loc("DOCUMENT.User") }),
+    });
+
+    // Region Behaviors
+    fa.apps.DocumentSheetConfig.unregisterSheet(RegionBehavior, "core", fa.sheets.RegionBehaviorConfig, {
+        types: ["system.rotateArea"],
+    });
+    fa.apps.DocumentSheetConfig.registerSheet(RegionBehavior, "pf2e", RotateAreaConfig, {
+        types: ["system.rotateArea"],
     });
 }

--- a/src/styles/scene/_index.scss
+++ b/src/styles/scene/_index.scss
@@ -1,5 +1,5 @@
 @use "sass:color";
-@import "darkness-adjuster", "sheet", "token-config";
+@import "darkness-adjuster", "sheet", "rotate-area-config", "token-config";
 
 #scene-controls li button.gm-vision {
     $gm-vision: #d1ccff;

--- a/src/styles/scene/_rotate-area-config.scss
+++ b/src/styles/scene/_rotate-area-config.scss
@@ -1,0 +1,8 @@
+.application.rotate-area.region-behavior-config {
+    .position {
+        gap: 8px;
+        .control {
+            flex: 0;
+        }
+    }
+}

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3679,6 +3679,81 @@
                         "None": "None"
                     }
                 }
+            },
+            "RotateArea": {
+                "Action": {
+                    "AddPosition": "Add Position",
+                    "DeletePosition": "Delete Position",
+                    "RotateToPosition": "Rotate to Position"
+                },
+                "DirectionMode": {
+                    "cw": "Clockwise",
+                    "ccw": "Counter Clockwise",
+                    "long": "Longest",
+                    "short": "Shortest"
+                },
+                "FIELDS": {
+                    "directionMode": {
+                        "label": "Direction Mode",
+                        "hint": "How the rotation direction is decided when moving to the next position."
+                    },
+                    "lights": {
+                        "ids": {
+                            "label": "Lights"
+                        }
+                    },
+                    "notes": {
+                        "ids": {
+                            "label": "Notes"
+                        }
+                    },
+                    "positions": {
+                        "label": "Positions",
+                        "element": {
+                            "angle": {
+                                "label": "Angle"
+                            }
+                        }
+                    },
+                    "regions": {
+                        "ids": {
+                            "label": "Regions"
+                        }
+                    },
+                    "sounds": {
+                        "ids": {
+                            "label": "Ambient Sounds"
+                        }
+                    },
+                    "tiles": {
+                        "ids": {
+                            "label": "Tiles"
+                        }
+                    },
+                    "time": {
+                        "mode": {
+                            "label": "Speed Mode",
+                            "hint": "How the rotation speed is determined from the rotation time, either the same regardless of the distance moved (fixed) or dependant on the distance rotated (variable)."
+                        },
+                        "value": {
+                            "label": "Rotation Time",
+                            "hint": "Time in miliseconds to rotate to the next position (in fixed mode) or to rotate 90˚ (in variable mode)."
+                        }
+                    },
+                    "walls": {
+                        "ids": {
+                            "label": "Walls"
+                        },
+                        "link": {
+                            "label": "Link Walls",
+                            "hint": "Rotate any wall segments attached to the ones specified."
+                        }
+                    }
+                },
+                "SpeedMode": {
+                    "fixed": "Fixed (total rotation time)",
+                    "variable": "Variable (time to rotate 90˚)"
+                }
             }
         },
         "RemoveCoinsByValueLabel": "Remove by value",
@@ -7298,7 +7373,10 @@
             "weapon": "Weapon"
         },
         "RegionBehavior": {
-            "modifyMovementCost": "Difficult Terrain"
+            "environment": "Environment",
+            "environmentFeature": "Environment Feature",
+            "modifyMovementCost": "Difficult Terrain",
+            "system.rotateArea": "Rotate Area"
         }
     }
 }

--- a/static/templates/scene/rotate-area-config.hbs
+++ b/static/templates/scene/rotate-area-config.hbs
@@ -1,0 +1,33 @@
+<section class="standard-form scrollable">
+    {{#if hint}}
+        <p class="hint">{{localize hint}}</p>
+    {{/if}}
+    {{#each fields as |outer|}}
+        {{#if outer.fieldset}}
+            <fieldset>
+                <legend>{{localize outer.legend}}</legend>
+                {{#each outer.fields as |f|}}
+                {{formField f.field value=f.value localize=true model=../../model}}
+                {{/each}}
+            </fieldset>
+        {{else}}
+            {{formField outer.field value=outer.value localize=true model=../model}}
+        {{/if}}
+    {{/each}}
+    <fieldset>
+        <legend>
+            {{localize "PF2E.Region.RotateArea.FIELDS.positions.label"}}
+            <a class="control icon fa-solid fa-plus fa-fw" data-action="addPosition" data-tooltip
+                aria-label="{{localize 'PF2E.Region.RotateArea.Action.AddPosition'}}"></a>
+        </legend>
+        {{#each positions}}
+            <div class="flexrow position" data-index="{{@index}}">
+                {{formField fields.angle name=(concat "system.positions." @index ".angle") value=data.angle}}
+                <a class="control icon fa-solid fa-arrows-rotate fa-fw" data-action="rotateToPosition" data-tooltip
+                    aria-label="{{localize 'PF2E.Region.RotateArea.Action.RotateToPosition'}}"></a>
+                <a class="control icon fa-solid fa-trash fa-fw" data-action="deletePosition" data-tooltip
+                    aria-label="{{localize 'PF2E.Region.RotateArea.Action.DeletePosition'}}"></a>
+            </div>
+        {{/each}}
+    </fieldset>
+</section>

--- a/system.pf2e.json
+++ b/system.pf2e.json
@@ -81,7 +81,8 @@
         },
         "RegionBehavior": {
             "environment": {},
-            "environmentFeature": {}
+            "environmentFeature": {},
+            "system.rotateArea": {}
         }
     },
     "languages": [

--- a/types/foundry/client/applications/sheets/_module.d.mts
+++ b/types/foundry/client/applications/sheets/_module.d.mts
@@ -1,4 +1,5 @@
 export { default as ItemSheetV2 } from "./item-sheet.mjs";
+export { default as RegionBehaviorConfig } from "./region-behavior-config.mjs";
 export * from "./scene-config.mjs";
 export { default as SceneConfig } from "./scene-config.mjs";
 export { default as TokenApplicationMixin } from "./token/mixin.mts";

--- a/types/foundry/client/applications/sheets/region-behavior-config.d.mts
+++ b/types/foundry/client/applications/sheets/region-behavior-config.d.mts
@@ -1,0 +1,17 @@
+import { FormNode } from "../_module.d.mjs";
+import DocumentSheetV2, { DocumentSheetConfiguration, DocumentSheetRenderOptions } from "../api/document-sheet.d.mjs";
+import HandlebarsApplicationMixin from "../api/handlebars-application.d.mjs";
+
+export default class RegionBehaviorConfig<TDocument extends RegionBehavior> extends HandlebarsApplicationMixin(
+    DocumentSheetV2<DocumentSheetConfiguration<RegionBehavior>>,
+) {
+    override get document(): TDocument;
+
+    /**
+     * Prepare form field structure for rendering.
+     */
+    protected _getFields(): FormNode[];
+
+    // @ts-expect-error avoids type instantiation is excessively deep
+    protected _prepareContext(options: DocumentSheetRenderOptions): Promise<object>;
+}

--- a/types/foundry/client/data/region-behaviors/base.d.mts
+++ b/types/foundry/client/data/region-behaviors/base.d.mts
@@ -32,13 +32,13 @@ export default abstract class RegionBehaviorType<
     events: fields.ModelPropFromDataField<EventsField>;
 
     /** A convenience reference to the RegionBehavior which contains this behavior sub-type. */
-    get behavior(): RegionBehavior | null;
+    get behavior(): TParent;
 
     /** A convenience reference to the RegionDocument which contains this behavior sub-type. */
-    get region(): RegionBehavior["region"];
+    get region(): NonNullable<TParent>["region"];
 
     /** A convenience reference to the Scene which contains this behavior sub-type. */
-    get scene(): RegionBehavior["scene"];
+    get scene(): NonNullable<TParent>["scene"];
 
     /**
      * Handle the Region event.

--- a/types/foundry/client/documents/_module.d.mts
+++ b/types/foundry/client/documents/_module.d.mts
@@ -12,6 +12,7 @@ export * as collections from "./collections/_module.mjs";
 
 export { default as Setting } from "./setting.mjs";
 
+import { DatabaseWriteOperation } from "@common/abstract/_module.mjs";
 import { default as Actor } from "./actor.mjs";
 import Adventure from "./adventure.mjs";
 import { default as Cards } from "./cards.mjs";
@@ -92,3 +93,42 @@ export type CompendiumDocument =
     | Playlist
     | RollTable
     | Scene;
+
+/**
+ * Bundle multiple {@link Document}-modification operations into a single, batched request. The modifications
+ * are made in sequence without a network delay between each. This can be useful when, for example, it is desirable that
+ * there not be an unpredictable delay between operations due to latency. For certain operations there may also be a
+ * need to ensure there will never be a mixed state: either all must succeed, or all must fail.
+ *
+ * The nature of batched modifications does have some limitations:
+ * - Unlike with a sequence of unbatched operations, a batched operation is unable to reference the result of a prior
+ *   operation in the same batch.
+ * - A cancellation (via, for example, {@link Document#_preUpdate}) or exception thrown by a single operation will
+ *   cancel the entire batch. No changes will be made.
+ *
+ * @example Modify an Actor and two TokenDocuments
+ * Update an Actor's size category along with the dimensions of that Actor's related TokenDocuments across multiple
+ * Scenes.
+ * ```js
+ * foundry.documents.modifyBatch([
+ *   {
+ *     action: "update",
+ *     documentName: "Actor",
+ *     updates: [{_id: "Ay52yVxCgusBct1b", "system.size": "big"}],
+ *   },
+ *   {
+ *     action: "update",
+ *     documentName: "Token",
+ *     updates: [{_id: "30pnHJciHu4CvPnz", width: 2, height: 2}],
+ *     parent: sceneA
+ *   },
+ *   {
+ *     action: "update",
+ *     documentName: "Token",
+ *     updates: [{_id: "knSU5NQVXeIQQeHi", width: 2, height: 2}],
+ *     parent: sceneB
+ *   }
+ * ]);
+ * ```
+ */
+export function modifyBatch(operations: DatabaseWriteOperation[]): Promise<Document[][]>;

--- a/types/foundry/client/documents/ambient-light.d.mts
+++ b/types/foundry/client/documents/ambient-light.d.mts
@@ -1,4 +1,5 @@
 import AmbientLight from "@client/canvas/placeables/light.mjs";
+import { CircleShapeData, ConeShapeData } from "@client/data/shapes.mjs";
 import { DatabaseUpdateCallbackOptions } from "@common/abstract/_types.mjs";
 import { BaseAmbientLight } from "./_module.mjs";
 import { CanvasDocument, CanvasDocumentStatic } from "./abstract/canvas-document.mjs";
@@ -21,6 +22,9 @@ export default class AmbientLightDocument<TParent extends Scene | null> extends 
 
     /** Is this ambient light source global in nature? */
     get isGlobal(): boolean;
+
+    /** The circle or cone shape of this AmbientLight document. */
+    shape: CircleShapeData | ConeShapeData;
 
     /* -------------------------------------------- */
     /*  Event Handlers                              */

--- a/types/foundry/client/documents/ambient-sound.d.mts
+++ b/types/foundry/client/documents/ambient-sound.d.mts
@@ -1,4 +1,5 @@
 import AmbientSound from "@client/canvas/placeables/sound.mjs";
+import { CircleShapeData } from "@client/data/shapes.mjs";
 import { BaseAmbientSound } from "./_module.mjs";
 import { CanvasDocument } from "./abstract/canvas-document.mjs";
 import Scene from "./scene.mjs";
@@ -11,7 +12,10 @@ interface CanvasBaseAmbientSound<TParent extends Scene | null> extends InstanceT
     typeof CanvasBaseAmbientSound<TParent>
 > {}
 
-export default class AmbientSoundDocument<TParent extends Scene | null> extends CanvasBaseAmbientSound<TParent> {}
+export default class AmbientSoundDocument<TParent extends Scene | null> extends CanvasBaseAmbientSound<TParent> {
+    /** The circle shape of this AmbientSound document. */
+    shape: CircleShapeData;
+}
 
 export default interface AmbientSoundDocument<TParent extends Scene | null> extends CanvasBaseAmbientSound<TParent> {
     readonly _object: AmbientSound<this> | null;

--- a/types/foundry/client/documents/tile.d.mts
+++ b/types/foundry/client/documents/tile.d.mts
@@ -1,3 +1,4 @@
+import { RectangleShapeData } from "@client/data/shapes.mjs";
 import Tile from "../canvas/placeables/tile.mjs";
 import { BaseTile } from "./_module.mjs";
 import { CanvasDocument, CanvasDocumentStatic } from "./abstract/canvas-document.mjs";
@@ -12,6 +13,9 @@ declare const CanvasBaseTile: {
 interface CanvasBaseTile<TParent extends Scene | null> extends InstanceType<typeof CanvasBaseTile<TParent>> {}
 
 export default class TileDocument<TParent extends Scene | null> extends CanvasBaseTile<TParent> {
+    /** The rectangle shape of this Tile document. */
+    shape: RectangleShapeData;
+
     override prepareDerivedData(): void;
 }
 

--- a/types/foundry/common/abstract/_types.d.mts
+++ b/types/foundry/common/abstract/_types.d.mts
@@ -61,6 +61,8 @@ export interface DatabaseGetOperation<TParent extends Document | null> {
     action: "get";
     /** A query object which identifies the set of Documents retrieved */
     query: Record<string, unknown>;
+    /** The Document name */
+    documentName?: string;
     /** Get requests are never broadcast */
     broadcast?: false;
     /** Return indices only instead of full Document records */
@@ -78,7 +80,9 @@ export interface DatabaseGetOperation<TParent extends Document | null> {
 export interface DatabaseCreateOperation<TParent extends Document | null> {
     action: "create";
     /** Whether the database operation is broadcast to other connected clients */
-    broadcast: boolean;
+    broadcast?: boolean;
+    /** The Document name */
+    documentName?: string;
     /** An array of data objects from which to create Documents */
     data: object[];
     /** Retain the _id values of provided data instead of generating new ids */
@@ -109,7 +113,9 @@ export interface DatabaseCreateCallbackOptions extends Omit<
 export interface DatabaseUpdateOperation<TParent extends Document | null> {
     action: "update";
     /** Whether the database operation is broadcast to other connected clients */
-    broadcast: boolean;
+    broadcast?: boolean;
+    /** The Document name */
+    documentName?: string;
     /**
      * An array of data objects used to update existing Documents.
      * Each update object must contain the _id of the target Document
@@ -134,6 +140,8 @@ export interface DatabaseUpdateOperation<TParent extends Document | null> {
     pack?: string | null;
     /** A parent Document UUID provided when the parent instance is unavailable */
     parentUuid?: DocumentUUID;
+    animate?: boolean;
+    constrainOptions?: { ignoreWalls?: boolean; ignoreCost?: boolean };
 }
 
 export interface DatabaseUpdateCallbackOptions extends Omit<
@@ -144,7 +152,9 @@ export interface DatabaseUpdateCallbackOptions extends Omit<
 export interface DatabaseDeleteOperation<TParent extends Document | null> {
     action: "delete";
     /** Whether the database operation is broadcast to other connected clients */
-    broadcast: boolean;
+    broadcast?: boolean;
+    /** The Document name */
+    documentName?: string;
     /** An array of Document ids which should be deleted */
     ids: string[];
     /** Delete all documents in the Collection, regardless of _id */
@@ -175,6 +185,8 @@ export type DatabaseOperation<TParent extends Document | null> =
     | DatabaseCreateOperation<TParent>
     | DatabaseUpdateOperation<TParent>
     | DatabaseDeleteOperation<TParent>;
+
+export type DatabaseWriteOperation = Exclude<DatabaseOperation<Document | null>, DatabaseGetOperation<Document | null>>;
 
 export interface DocumentSocketRequest {
     /** The type of Document being transacted */

--- a/types/foundry/common/documents/region.d.mts
+++ b/types/foundry/common/documents/region.d.mts
@@ -1,3 +1,4 @@
+import { ClientShapeData } from "@client/data/shapes.mjs";
 import {
     DatabaseUpdateCallbackOptions,
     Document,
@@ -43,10 +44,13 @@ export default class BaseRegion<TParent extends BaseScene | null = BaseScene | n
 }
 
 export default interface BaseRegion<TParent extends BaseScene | null = BaseScene | null>
-    extends Document<TParent, RegionSchema>, fields.ModelPropsFromSchema<RegionSchema> {
+    extends Document<TParent, RegionSchema>, Omit<fields.ModelPropsFromSchema<RegionSchema>, "shapes"> {
     get documentName(): RegionMetadata["name"];
 
     readonly behaviors: EmbeddedCollection<BaseRegionBehavior<this>>;
+
+    /** The shapes that make up the Region */
+    shapes: ClientShapeData[];
 }
 
 interface RegionMetadata extends DocumentMetadata {


### PR DESCRIPTION
This ports the 5e specific rotate area region behavior to PF2e. This was something asked for because of premium modules. Time for it is very limited, but if it gets in the next couple of days we might be good.

https://github.com/user-attachments/assets/03e06b6e-bd07-4c31-9b46-1c926a94ccde

Like the 5e version, this does not snap tokens on animation finish. I asked if snapping would be desired and apparently it isn't due to something about smoothness. Sounds nor notes smoothly rotate (but they didn't in 5e either). I removed sounds from the animation loop since it wasn't working regardless (it snaps after the animation).

I've made a few changes from the 5e version of the behavior, which are:
* Support for rotating Journal Notes
* Check if token lock and auto rotate tokens is set before updating the tokens' rotation. 5e always rotates the tokens, relying on the token lock. This isn't how we do things in pf2e, so I had to change it.
* "is rotating" is now a variable rather than stored in the data model. In 5e its possible for the behavior to get stuck if the update in the end to unset the rotating status doesn't go through.
* When adding a uuid to the form, it converts to an id. In 5e it silently fails.

I have a few uncertainties
* I chose `system.rotateArea` as the type. In 5e it was called dnd5e.rotateArea, and I thought that adding some sort of prefix was actually a pretty good idea to void future conflicts, but let me know if you'd rather I just call it "rotateArea".
* How I got system data typing on region behavior