### PR TITLE
Add master spellcasting into the Master Eldritch Archer Spellcasting

### DIFF
--- a/packs/pf2e/feats/archetype/blessed-one/blessed-one-dedication.json
+++ b/packs/pf2e/feats/archetype/blessed-one/blessed-one-dedication.json
@@ -26,6 +26,13 @@
             "title": "Pathfinder Player Core 2"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 1
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/pf2e/feats/archetype/cathartic-mage/master-cathartic-spellcasting.json
+++ b/packs/pf2e/feats/archetype/cathartic-mage/master-cathartic-spellcasting.json
@@ -30,6 +30,13 @@
             "title": "Pathfinder Secrets of Magic"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 3
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/pf2e/feats/archetype/eldritch-archer/master-eldritch-archer-spellcasting.json
+++ b/packs/pf2e/feats/archetype/eldritch-archer/master-eldritch-archer-spellcasting.json
@@ -30,6 +30,13 @@
             "title": "Pathfinder Player Core 2"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 3
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/pf2e/feats/archetype/prophet-of-kalistrade/prophet-of-kalistrade-dedication.json
+++ b/packs/pf2e/feats/archetype/prophet-of-kalistrade/prophet-of-kalistrade-dedication.json
@@ -34,7 +34,12 @@
         },
         "rules": [],
         "subfeatures": {
-            "proficiencies": {},
+            "proficiencies": {
+                "spellcasting": {
+                    "attribute": null,
+                    "rank": 1
+                }
+            },
             "senses": {},
             "suppressedFeatures": []
         },

--- a/packs/pf2e/feats/archetype/prophet-of-kalistrade/prophet-of-kalistrade-dedication.json
+++ b/packs/pf2e/feats/archetype/prophet-of-kalistrade/prophet-of-kalistrade-dedication.json
@@ -36,7 +36,6 @@
         "subfeatures": {
             "proficiencies": {
                 "spellcasting": {
-                    "attribute": null,
                     "rank": 1
                 }
             },

--- a/packs/pf2e/feats/archetype/starlit-sentinel/special-sentinel-technique.json
+++ b/packs/pf2e/feats/archetype/starlit-sentinel/special-sentinel-technique.json
@@ -31,6 +31,13 @@
             "title": "Pathfinder Lost Omens Tian Xia Character Guide"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 1
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [

--- a/packs/pf2e/feats/archetype/summoner/master-summoning-spellcasting.json
+++ b/packs/pf2e/feats/archetype/summoner/master-summoning-spellcasting.json
@@ -33,6 +33,13 @@
             "title": "Pathfinder Secrets of Magic"
         },
         "rules": [],
+        "subfeatures": {
+            "proficiencies": {
+                "spellcasting": {
+                    "rank": 3
+                }
+            }
+        },
         "traits": {
             "rarity": "common",
             "value": [


### PR DESCRIPTION
- Closes https://github.com/foundryvtt/pf2e/issues/22552#issuecomment-4735036737

Also fixes:
- Master Cathartic Spellcasting
- Master Summoning Spellcasting
- Prophet of Kalistrade Dedication
- Blessed One Dedication
- Special Sentinel Technique