### PR TITLE
Fix background color on dragged equipment

### DIFF
--- a/src/styles/actor/_inventory.scss
+++ b/src/styles/actor/_inventory.scss
@@ -300,7 +300,8 @@
             }
 
             &.drag-preview {
-                box-shadow: 0 0 6px inset var(--color-shadow-highlight);
+                background-color: white;
+                background-image: linear-gradient(rgba($alt-color, 0.1), rgba($alt-color, 0.1));
             }
 
             // The gap left by an item being dragged to a new position


### PR DESCRIPTION
This much more closely matches the appearance of items using Foundry's native drag handler (actions, spells, feats, etc).

Before:
<img width="801" height="99" alt="Screenshot 2026-06-17 at 3 17 24 PM" src="https://github.com/user-attachments/assets/c0c14279-d925-45ed-a817-010690cf6479" />

After:
<img width="627" height="116" alt="Screenshot 2026-06-17 at 3 46 47 PM" src="https://github.com/user-attachments/assets/32397b65-8f91-4673-aa4d-e54860a46753" />
