### PR TITLE
Improve visual accessibility of spell slot number input

### DIFF
--- a/src/styles/actor/_spell-collection.scss
+++ b/src/styles/actor/_spell-collection.scss
@@ -93,6 +93,19 @@ ol.spell-list {
                 height: unset;
                 text-align: center;
                 width: 2em;
+
+                &:focus {
+                    background: var(--tertiary);
+                    border-color: var(--alt-dark);
+                    box-shadow: none;
+                    color: var(--color-text-dark-input);
+                    outline: none;
+
+                    &::selection {
+                        background: var(--primary);
+                        color: var(--text-light);
+                    }
+                }
             }
 
             .spell-slots-increment-reset {


### PR DESCRIPTION
Unselected for reference: 
<img width="231" height="57" alt="Screenshot 2026-06-17 at 6 04 01 PM" src="https://github.com/user-attachments/assets/1423f0b2-15c6-42ad-a6c3-f654efe066ee" />


before selected:
<img width="220" height="58" alt="Screenshot 2026-06-17 at 6 04 41 PM" src="https://github.com/user-attachments/assets/a2edd27b-8829-46eb-87cc-2abd21bebcd2" />

before highlighted:
<img width="216" height="58" alt="Screenshot 2026-06-17 at 6 04 45 PM" src="https://github.com/user-attachments/assets/51bf75f1-0cdf-4013-988f-d1fbd8c52fca" />


after selected:
<img width="223" height="58" alt="Screenshot 2026-06-17 at 6 04 06 PM" src="https://github.com/user-attachments/assets/4cdcb017-8a90-43a9-a642-058576548890" />

after highlighted:
<img width="222" height="59" alt="Screenshot 2026-06-17 at 6 04 12 PM" src="https://github.com/user-attachments/assets/69f9c890-d941-4f20-871f-dbe80da36670" />
