### PR TITLE
Replace core inline roll with Shove inline action in Bands of Force

### DIFF
--- a/packs/pf2e/equipment/bands-of-force-greater.json
+++ b/packs/pf2e/equipment/bands-of-force-greater.json
@@ -65,7 +65,10 @@
                 "predicate": [
                     "bands-of-force-greater",
                     {
-                        "not": "modifier:slug:bands-of-force-greater"
+                        "or": [
+                            "bonus:type:proficiency",
+                            "modifier:type:ability"
+                        ]
                     }
                 ],
                 "selector": "athletics",

--- a/packs/pf2e/equipment/bands-of-force-greater.json
+++ b/packs/pf2e/equipment/bands-of-force-greater.json
@@ -9,7 +9,7 @@
         },
         "containerId": null,
         "description": {
-            "value": "<p>Decorated with clear gemstones, these thick metal bands spread an inflexible layer of force over your body. The force grants you a +2 item bonus to AC and saving throws, and a maximum Dexterity modifier of +5 as armor. You can affix talismans to the bands as though they were light armor.</p>\n<p><strong>Activate—Return Force</strong> <span class=\"action-glyph\">R</span> (force, manipulate)</p>\n<p><strong>Trigger</strong> A creature critically misses you with a melee Strike</p>\n<hr />\n<p><strong>Effect</strong> You Shove the creature using the bands' Athletics modifier of [[/r d20+21]]{+21}.</p>"
+            "value": "<p>Decorated with clear gemstones, these thick metal bands spread an inflexible layer of force over your body. The force grants you a +2 item bonus to AC and saving throws, and a maximum Dexterity modifier of +5 as armor. You can affix talismans to the bands as though they were light armor.</p>\n<p><strong>Activate—Return Force</strong> <span class=\"action-glyph\">R</span> (force, manipulate)</p>\n<p><strong>Trigger</strong> A creature critically misses you with a melee Strike</p><hr /><p><strong>Effect</strong> You [[/act shove options=bands-of-force-greater]] the creature using the bands' Athletics modifier of +21.</p>"
         },
         "hardness": 0,
         "hp": {
@@ -48,6 +48,28 @@
             {
                 "key": "DexterityModifierCap",
                 "value": 5
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "bands-of-force-greater"
+                ],
+                "selector": [
+                    "athletics"
+                ],
+                "slug": "bands-of-force-greater",
+                "value": 21
+            },
+            {
+                "key": "AdjustModifier",
+                "predicate": [
+                    "bands-of-force-greater",
+                    {
+                        "not": "modifier:slug:bands-of-force-greater"
+                    }
+                ],
+                "selector": "athletics",
+                "suppress": true
             }
         ],
         "size": "med",

--- a/packs/pf2e/equipment/bands-of-force-major.json
+++ b/packs/pf2e/equipment/bands-of-force-major.json
@@ -9,7 +9,7 @@
         },
         "containerId": null,
         "description": {
-            "value": "<p>Decorated with clear gemstones, these thick metal bands spread an inflexible layer of force over your body. The force grants you a +3 item bonus to AC and saving throws, and a maximum Dexterity modifier of +5 as armor. You can affix talismans to the bands as though they were light armor.</p>\n<p><strong>Activate—Return Force</strong> <span class=\"action-glyph\">R</span> (force, manipulate)</p>\n<p><strong>Trigger</strong> A creature critically misses you with a melee Strike</p>\n<hr />\n<p><strong>Effect</strong> You Shove the creature using the bands' Athletics modifier of [[/r d20+33]]{+33}.</p>"
+            "value": "<p>Decorated with clear gemstones, these thick metal bands spread an inflexible layer of force over your body. The force grants you a +3 item bonus to AC and saving throws, and a maximum Dexterity modifier of +5 as armor. You can affix talismans to the bands as though they were light armor.</p>\n<p><strong>Activate—Return Force</strong> <span class=\"action-glyph\">R</span> (force, manipulate)</p>\n<p><strong>Trigger</strong> A creature critically misses you with a melee Strike</p><hr /><p><strong>Effect</strong> You [[/act shove options=bands-of-force-major]] the creature using the bands' Athletics modifier of +33.</p>"
         },
         "hardness": 0,
         "hp": {
@@ -48,6 +48,28 @@
             {
                 "key": "DexterityModifierCap",
                 "value": 5
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "bands-of-force-major"
+                ],
+                "selector": [
+                    "athletics"
+                ],
+                "slug": "bands-of-force-major",
+                "value": 33
+            },
+            {
+                "key": "AdjustModifier",
+                "predicate": [
+                    "bands-of-force-major",
+                    {
+                        "not": "modifier:slug:bands-of-force-major"
+                    }
+                ],
+                "selector": "athletics",
+                "suppress": true
             }
         ],
         "size": "med",

--- a/packs/pf2e/equipment/bands-of-force-major.json
+++ b/packs/pf2e/equipment/bands-of-force-major.json
@@ -65,7 +65,10 @@
                 "predicate": [
                     "bands-of-force-major",
                     {
-                        "not": "modifier:slug:bands-of-force-major"
+                        "or": [
+                            "bonus:type:proficiency",
+                            "modifier:type:ability"
+                        ]
                     }
                 ],
                 "selector": "athletics",

--- a/packs/pf2e/equipment/bands-of-force.json
+++ b/packs/pf2e/equipment/bands-of-force.json
@@ -9,7 +9,7 @@
         },
         "containerId": null,
         "description": {
-            "value": "<p>Decorated with clear gemstones, these thick metal bands spread an inflexible layer of force over your body. The force grants you a +1 item bonus to AC and saving throws, and a maximum Dexterity modifier of +5 as armor. You can affix talismans to the bands as though they were light armor.</p>\n<p><strong>Activate—Return Force</strong> <span class=\"action-glyph\">R</span> (force, manipulate)</p>\n<p><strong>Trigger</strong> A creature critically misses you with a melee Strike</p>\n<hr />\n<p><strong>Effect</strong> You Shove the creature using the bands' Athletics modifier of [[/r d20+14]]{+14}.</p>"
+            "value": "<p>Decorated with clear gemstones, these thick metal bands spread an inflexible layer of force over your body. The force grants you a +1 item bonus to AC and saving throws, and a maximum Dexterity modifier of +5 as armor. You can affix talismans to the bands as though they were light armor.</p>\n<p><strong>Activate—Return Force</strong> <span class=\"action-glyph\">R</span> (force, manipulate)</p>\n<p><strong>Trigger</strong> A creature critically misses you with a melee Strike</p><hr /><p><strong>Effect</strong> You [[/act shove options=bands-of-force]] the creature using the bands' Athletics modifier of +14.</p>"
         },
         "hardness": 0,
         "hp": {
@@ -48,6 +48,28 @@
             {
                 "key": "DexterityModifierCap",
                 "value": 5
+            },
+            {
+                "key": "FlatModifier",
+                "predicate": [
+                    "bands-of-force"
+                ],
+                "selector": [
+                    "athletics"
+                ],
+                "slug": "bands-of-force",
+                "value": 14
+            },
+            {
+                "key": "AdjustModifier",
+                "predicate": [
+                    "bands-of-force",
+                    {
+                        "not": "modifier:slug:bands-of-force"
+                    }
+                ],
+                "selector": "athletics",
+                "suppress": true
             }
         ],
         "size": "med",

--- a/packs/pf2e/equipment/bands-of-force.json
+++ b/packs/pf2e/equipment/bands-of-force.json
@@ -65,7 +65,10 @@
                 "predicate": [
                     "bands-of-force",
                     {
-                        "not": "modifier:slug:bands-of-force"
+                        "or": [
+                            "bonus:type:proficiency",
+                            "modifier:type:ability"
+                        ]
                     }
                 ],
                 "selector": "athletics",


### PR DESCRIPTION
Is this Shove supposed to be affected by bonuses and penalties affecting the character? Who knows, but this at least maintains current functionality while making it a real Shove. This idea could probably be used in other similar items, if any.