### PR TITLE
Update Hellknight-Errant to not increase Hellknight feat count by 5

### DIFF
--- a/packs/pf2e/feats/archetype/hellknight/level-6/hellknight-errant.json
+++ b/packs/pf2e/feats/archetype/hellknight/level-6/hellknight-errant.json
@@ -34,11 +34,10 @@
         },
         "rules": [
             {
-                "key": "ActiveEffectLike",
-                "mode": "add",
-                "path": "flags.system.hellknightArchetype.featCount",
-                "value": 5
-            },
+  "key": "Resistance",
+  "type": "mental",
+  "value": "@actor.flags.system.hellknightArchetype.featCount + 5"
+},
             {
                 "key": "GrantItem",
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Warding Shift"

--- a/packs/pf2e/feats/archetype/hellknight/level-6/hellknight-errant.json
+++ b/packs/pf2e/feats/archetype/hellknight/level-6/hellknight-errant.json
@@ -34,10 +34,10 @@
         },
         "rules": [
             {
-  "key": "Resistance",
-  "type": "mental",
-  "value": "@actor.flags.system.hellknightArchetype.featCount + 5"
-},
+                "key": "Resistance",
+                "type": "mental",
+                "value": "@actor.flags.system.hellknightArchetype.featCount + 5"
+            },
             {
                 "key": "GrantItem",
                 "uuid": "Compendium.pf2e.actionspf2e.Item.Warding Shift"


### PR DESCRIPTION
Other feats, such as Mortification, check the "flags.system.hellknightArchetype.featCount" value. The old implementation of Hellknight-Errant would erroneously set this value.