### PR TITLE
Fix two-handed grip toggle on strike rule elements

### DIFF
--- a/src/module/actor/actions/types.ts
+++ b/src/module/actor/actions/types.ts
@@ -3,8 +3,9 @@ import type { AbilityTrait } from "@item/ability/index.ts";
 import type { ProficiencyRank } from "@item/base/data/index.ts";
 import type { TokenPF2e } from "@module/canvas/index.ts";
 import type { ChatMessagePF2e } from "@module/chat-message/document.ts";
+import type { ZeroToThree } from "@module/data.ts";
 
-type ActionCost = "free" | "reaction" | 0 | 1 | 2 | 3;
+type ActionCost = "free" | "reaction" | ZeroToThree;
 type ActionSection = "basic" | "skill" | "specialty-basic";
 
 interface ActionMessageOptions {

--- a/src/module/actor/army/document.ts
+++ b/src/module/actor/army/document.ts
@@ -10,6 +10,7 @@ import type { CampaignFeaturePF2e } from "@item";
 import type { ItemSourcePF2e } from "@item/base/data/index.ts";
 import type { ItemType } from "@item/types.ts";
 import { ChatMessagePF2e } from "@module/chat-message/document.ts";
+import type { OneToTwo } from "@module/data.ts";
 import { extractDamageDice, extractModifierAdjustments, extractModifiers } from "@module/rules/helpers.ts";
 import { eventToRollParams } from "@module/sheet/helpers.ts";
 import type { TokenDocumentPF2e } from "@scene/index.ts";
@@ -327,7 +328,7 @@ class ArmyPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | nu
             type: "strike",
             glyph: "A",
             variants: [0, 1, 2].map((idx) => {
-                const mapModifier = idx === 0 ? null : createMapModifier(`map${idx as 1 | 2}`);
+                const mapModifier = idx === 0 ? null : createMapModifier(`map${idx as OneToTwo}`);
                 const penalty = mapModifier?.modifier ?? 0;
                 return {
                     label:

--- a/src/module/actor/character/auxiliary.ts
+++ b/src/module/actor/character/auxiliary.ts
@@ -152,7 +152,11 @@ class WeaponAuxiliaryAction {
         const { actor, weapon } = this;
         const COVER_UUID = `Compendium.${SYSTEM_ID}.other-effects.Item.I9lfZUiCwMiGogVi`;
 
-        if (this.carryType) {
+        if (this.annotation === "grip" && weapon.rule) {
+            // Synthetic strikes (from a Strike rule element) aren't real items, so their grip can't be
+            // changed via carry type. Persist the change to the rule element instead
+            await weapon.rule.toggleGrip(this.hands === 2 ? 2 : 1);
+        } else if (this.carryType) {
             await actor.changeCarryType(this.weapon, { carryType: this.carryType, handsHeld: this.hands ?? 0 });
         } else if (selection && this.annotation === "modular" && selection) {
             const updated = await weapon.system.traits.toggles.update({

--- a/src/module/actor/character/elemental-blast.ts
+++ b/src/module/actor/character/elemental-blast.ts
@@ -11,6 +11,7 @@ import type { EffectTrait } from "@item/abstract-effect/types.ts";
 import type { RangeData } from "@item/types.ts";
 import type { WeaponDamage } from "@item/weapon/data.ts";
 import type { WeaponTrait } from "@item/weapon/types.ts";
+import type { OneToTwo } from "@module/data.ts";
 import {
     extractDamageDice,
     extractModifierAdjustments,
@@ -135,7 +136,7 @@ class ElementalBlast {
         });
     })();
 
-    get actionCost(): 1 | 2 {
+    get actionCost(): OneToTwo {
         const cost = this.item?.flags[SYSTEM_ID].rulesSelections.actionCost ?? 1;
         if (cost !== 1 && cost !== 2) throw ErrorPF2e("Action cost must be 1 or 2");
         return cost;
@@ -616,7 +617,7 @@ interface ElementalBlastConfig extends Omit<fields.ModelPropsFromSchema<BlastCon
     range: RangeData & { label: string };
     statistic: Statistic;
     item: AbilityItemPF2e<CharacterPF2e>;
-    actionCost: 1 | 2;
+    actionCost: OneToTwo;
     ready: boolean;
     maps: {
         melee: { map0: string; map1: string; map2: string };

--- a/src/module/data.ts
+++ b/src/module/data.ts
@@ -40,6 +40,7 @@ interface TraitsWithRarity<T extends string> {
 
 /** Literal numeric types */
 type ZeroToTwo = 0 | 1 | 2;
+type OneToTwo = Exclude<ZeroToTwo, 0>;
 type ZeroToThree = ZeroToTwo | 3; // +1!
 type OneToThree = Exclude<ZeroToThree, 0>;
 type TwoToThree = Exclude<OneToThree, 1>;
@@ -162,6 +163,7 @@ export type {
     OneToSix,
     OneToTen,
     OneToThree,
+    OneToTwo,
     PublicationData,
     Rarity,
     Size,

--- a/src/module/item/physical/usage.ts
+++ b/src/module/item/physical/usage.ts
@@ -1,10 +1,11 @@
 import { EquippedData } from "./data.ts";
+import type { OneToTwo } from "@module/data.ts";
 
 interface HeldUsage {
     value: string;
     type: "held";
     where?: never;
-    hands: 1 | 2;
+    hands: OneToTwo;
 }
 
 interface WornUsage {

--- a/src/module/rules/rule-element/strike.ts
+++ b/src/module/rules/rule-element/strike.ts
@@ -12,6 +12,7 @@ import type {
     WeaponRangeIncrement,
     WeaponTrait,
 } from "@item/weapon/types.ts";
+import type { OneToTwo } from "@module/data.ts";
 import type { DamageDieSize, DamageType } from "@system/damage/index.ts";
 import { objectHasKey, sluggify } from "@util";
 import { RuleElement, RuleElementOptions } from "./base.ts";
@@ -88,6 +89,12 @@ class StrikeRuleElement extends RuleElement<StrikeSchema> {
                 },
                 { required: true, nullable: false, initial: { modular: null, versatile: null } },
             ),
+            handsHeld: new fields.NumberField({
+                required: false,
+                nullable: false,
+                choices: [1, 2],
+                initial: 1,
+            }),
             otherTags: new fields.ArrayField(
                 new fields.StringField({ required: true, blank: false, choices: CONFIG.PF2E.otherWeaponTags }),
                 { required: false, nullable: false, initial: [] },
@@ -279,7 +286,7 @@ class StrikeRuleElement extends RuleElement<StrikeSchema> {
                 usage: { value: "held-in-one-hand" },
                 equipped: {
                     carryType: "held",
-                    handsHeld: 1,
+                    handsHeld: this.handsHeld,
                 },
                 graspingAppendage: this.graspingAppendage,
             },
@@ -292,14 +299,24 @@ class StrikeRuleElement extends RuleElement<StrikeSchema> {
         return weapon;
     }
 
-    /** Toggle the modular or versatile trait of this strike's weapon */
-    async toggleTrait({ trait, selected }: UpdateToggleParams): Promise<void> {
+    /** Persist changes to this rule element's own source on the parent item */
+    async #persistSource(changes: Partial<StrikeSource>): Promise<void> {
         const ruleSources = fu.deepClone(this.item._source.system.rules);
         const rule: StrikeSource | undefined = ruleSources.at(this.sourceIndex ?? NaN);
         if (rule?.key === "Strike") {
-            rule.traitToggles = { ...this.traitToggles, [trait]: selected };
+            Object.assign(rule, changes);
             await this.item.update({ "system.rules": ruleSources });
         }
+    }
+
+    /** Toggle the modular or versatile trait of this strike's weapon */
+    async toggleTrait({ trait, selected }: UpdateToggleParams): Promise<void> {
+        await this.#persistSource({ traitToggles: { ...this.traitToggles, [trait]: selected } });
+    }
+
+    /** Toggle whether this strike's weapon is wielded in one or two hands */
+    async toggleGrip(handsHeld: OneToTwo): Promise<void> {
+        await this.#persistSource({ handsHeld });
     }
 }
 
@@ -332,6 +349,8 @@ type StrikeSchema = RuleElementSchema & {
         false,
         true
     >;
+    /** Whether this strike's weapon is currently wielded in one or two hands */
+    handsHeld: fields.NumberField<OneToTwo, OneToTwo, false, false, true>;
     otherTags: fields.ArrayField<
         fields.StringField<OtherWeaponTag, OtherWeaponTag, true, false, false>,
         OtherWeaponTag[],
@@ -402,6 +421,7 @@ interface StrikeSource extends RuleElementSource {
     range?: unknown;
     traits?: unknown;
     traitToggles?: unknown;
+    handsHeld?: unknown;
     replaceAll?: unknown;
     replaceBasicUnarmed?: unknown;
     battleForm?: unknown;

--- a/src/module/system/action-macros/types.ts
+++ b/src/module/system/action-macros/types.ts
@@ -5,13 +5,14 @@ import type { DCSlug } from "@actor/types.ts";
 import type { Rolled } from "@client/dice/_module.d.mts";
 import type { ItemPF2e } from "@item";
 import type { WeaponTrait } from "@item/weapon/types.ts";
+import type { OneToThree } from "@module/data.ts";
 import type { RollNotePF2e } from "@module/notes.ts";
 import type { TokenDocumentPF2e } from "@scene";
 import type { CheckRoll, CheckType } from "@system/check/index.ts";
 import type { CheckDC, DegreeOfSuccessString } from "@system/degree-of-success.ts";
 import type { Statistic } from "@system/statistic/index.ts";
 
-type ActionGlyph = "A" | "D" | "T" | "R" | "F" | "a" | "d" | "t" | "r" | "f" | 1 | 2 | 3 | "1" | "2" | "3";
+type ActionGlyph = "A" | "D" | "T" | "R" | "F" | "a" | "d" | "t" | "r" | "f" | "1" | "2" | "3" | OneToThree;
 
 interface BuildCheckContextOptions<TItem extends ItemPF2e<ActorPF2e>> {
     actor: ActorPF2e;


### PR DESCRIPTION
- Closes #18891

This persists the grip state of rule-element strikes on the rule element itself (like the modular/versatile toggles already do). Also a little bit of numeric literal type cleanup.