### PR TITLE
Fix issues with transferring credits

### DIFF
--- a/src/module/actor/sheet/base.ts
+++ b/src/module/actor/sheet/base.ts
@@ -1331,11 +1331,15 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends fav1.sheets.Acto
         const result = await ItemTransferDialog.wait({ item, recipient, lockStack: !stackable, mode });
         if (!result) return;
 
-        // If we're transferring all the credits, transfer the one credstick instead
+        // If we're transferring all credits and it is not a basic credstick, transfer the item instead
         const [resultMode, quantity] =
-            result.mode === "credits" && result.quantity >= item.system.price.value.credits
+            result.mode === "credits" &&
+            item.system.slug !== "credstick" &&
+            result.quantity >= item.system.price.value.credits
                 ? ["move", 1]
                 : [result.mode, result.quantity];
+
+        // Perform the transfer (handling credits or items)
         if (resultMode === "credits") {
             transferCredits({ targetActor: recipient, item, quantity });
         } else if (result) {
@@ -1345,7 +1349,7 @@ abstract class ActorSheetPF2e<TActor extends ActorPF2e> extends fav1.sheets.Acto
                 quantity,
                 containerId,
                 result.newStack,
-                result.mode === "purchase",
+                resultMode === "purchase",
             );
         }
     }

--- a/src/module/item/physical/document.ts
+++ b/src/module/item/physical/document.ts
@@ -634,6 +634,11 @@ abstract class PhysicalItemPF2e<TParent extends ActorPF2e | null = ActorPF2e | n
             return false;
         }
 
+        // Credsticks are not stackable, instead they may transfer credits at certain points
+        if (item.isOfType("treasure") && item.system.category === "credstick") {
+            return false;
+        }
+
         // Additional checks to make sure the worn state is what we want
         // These checks are skipped for sub-items or items that are in a container
         if (!this.parentItem && !this.container) {

--- a/src/module/item/physical/helpers.ts
+++ b/src/module/item/physical/helpers.ts
@@ -403,11 +403,11 @@ async function transferCredits({
         }).request();
     }
 
+    // Perform the updates
     quantity = Math.min(quantity, item.system.price.value.credits);
     await targetActor.inventory.addCurrency({ credits: quantity });
-    await item.update({
-        "system.price.value": new Coins({ credits: item.system.price.value.credits - quantity }).toObject(),
-    });
+    const newPrice = new Coins({ credits: item.system.price.value.credits - quantity }).toObject();
+    await item.update({ "system.price.value": _replace(newPrice) });
 }
 
 export {


### PR DESCRIPTION
This prevents credits from attempting to stack quantity, and makes it so that basic credsticks are always treated as a basic transfer instead of creating new cred stick items. Fancy unique credsticks (if any) should still observe the old behavior.

There is also a v14 regression fix for the actual update of the old item.

Closes https://github.com/foundryvtt/pf2e/issues/22518