### PR TITLE
Accept a leading "+" in modifier dialog inputs on Firefox

### DIFF
--- a/src/module/system/check/dialog.ts
+++ b/src/module/system/check/dialog.ts
@@ -133,10 +133,23 @@ export class CheckModifiersDialog extends fav1.api.Application {
             });
         }
 
+        // Restrict manual entry to a signed integer: a leading +/- followed by digits.
+        const modifierValueInput = html.querySelector<HTMLInputElement>(".add-modifier-value");
+        modifierValueInput?.addEventListener("beforeinput", (event) => {
+            if (!(event instanceof InputEvent) || event.data === null) return;
+            const input = event.currentTarget as HTMLInputElement;
+            const newValue =
+                input.value.slice(0, input.selectionStart ?? 0) +
+                event.data +
+                input.value.slice(input.selectionEnd ?? input.value.length);
+            if (!/^[+-]?\d*$/.test(newValue)) event.preventDefault();
+        });
+
         const addModifierButton = html.querySelector("button.add-modifier");
         addModifierButton?.addEventListener("click", () => {
             const parent = addModifierButton.parentElement as HTMLDivElement;
-            const value = Number(parent.querySelector<HTMLInputElement>(".add-modifier-value")?.value || 1);
+            const valueInput = parent.querySelector<HTMLInputElement>(".add-modifier-value");
+            const value = Number(valueInput?.value || 1);
             const type = String(parent.querySelector<HTMLSelectElement>(".add-modifier-type")?.value);
             let name = String(parent.querySelector<HTMLInputElement>(".add-modifier-name")?.value);
             const errors: string[] = [];

--- a/src/module/system/damage/dialog.ts
+++ b/src/module/system/damage/dialog.ts
@@ -241,10 +241,23 @@ class DamageModifierDialog extends fav1.api.Application {
             }
         });
 
+        // Restrict manual entry to a signed integer: a leading +/- followed by digits.
+        const modifierValueInput = html.querySelector<HTMLInputElement>(".add-modifier-value");
+        modifierValueInput?.addEventListener("beforeinput", (event) => {
+            if (!(event instanceof InputEvent) || event.data === null) return;
+            const input = event.currentTarget as HTMLInputElement;
+            const newValue =
+                input.value.slice(0, input.selectionStart ?? 0) +
+                event.data +
+                input.value.slice(input.selectionEnd ?? input.value.length);
+            if (!/^[+-]?\d*$/.test(newValue)) event.preventDefault();
+        });
+
         const addModifierButton = html.querySelector("button.add-modifier");
         addModifierButton?.addEventListener("click", () => {
             const parent = addModifierButton.parentElement as HTMLDivElement;
-            const value = Number(parent.querySelector<HTMLInputElement>(".add-modifier-value")?.value || 1);
+            const valueInput = parent.querySelector<HTMLInputElement>(".add-modifier-value");
+            const value = Number(valueInput?.value || 1);
             const type = String(parent.querySelector<HTMLSelectElement>(".add-modifier-type")?.value);
             const damageType = (parent.querySelector<HTMLSelectElement>(".add-modifier-damage-type")?.value ??
                 null) as DamageType;

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3737,6 +3737,11 @@
                     "TitleCritical": "Critical Damage Roll",
                     "Title": "Damage Roll"
                 },
+                "ModifierDamageCategory": "Damage Category",
+                "ModifierDamageType": "Damage Type",
+                "ModifierName": "Modifier Name",
+                "ModifierType": "Modifier Type",
+                "ModifierValue": "Modifier Value",
                 "ShowDefault": "Always Show Dialog",
                 "ShowDefaultHint": "If enabled, this dialog is always shown unless you hold Shift. If disabled, you can open this dialog by holding Shift."
             },

--- a/static/templates/chat/check-modifiers-dialog.hbs
+++ b/static/templates/chat/check-modifiers-dialog.hbs
@@ -44,9 +44,9 @@
     </div>
     <hr />
     <section class="add-entry-row add-modifier-panel">
-        <input type="text" class="add-modifier-name" placeholder={{localize "PF2E.ModifierTitle"}}>
-        <input type="number" class="add-modifier-value" placeholder="+1" />
-        <select class="add-modifier-type">
+        <input type="text" class="add-modifier-name" placeholder={{localize "PF2E.ModifierTitle"}} aria-label="{{localize "PF2E.Roll.Dialog.ModifierName"}}">
+        <input type="text" class="add-modifier-value" placeholder="1" aria-label="{{localize "PF2E.Roll.Dialog.ModifierValue"}}" />
+        <select class="add-modifier-type" aria-label="{{localize "PF2E.Roll.Dialog.ModifierType"}}">
             <option value="circumstance" selected>{{localize "PF2E.ModifierType.circumstance"}}</option>
             <option value="item">{{localize "PF2E.ModifierType.item"}}</option>
             <option value="status">{{localize "PF2E.ModifierType.status"}}</option>

--- a/static/templates/chat/damage/damage-modifier-dialog.hbs
+++ b/static/templates/chat/damage/damage-modifier-dialog.hbs
@@ -64,9 +64,9 @@
     <hr />
 
     <section class="add-entry-row add-modifier-panel">
-        <input type="text" class="add-modifier-name" placeholder={{localize "PF2E.Roll.Dialog.Damage.Label"}}>
-        <input type="number" class="add-modifier-value" placeholder="+1">
-        <select class="add-modifier-type">
+        <input type="text" class="add-modifier-name" placeholder={{localize "PF2E.Roll.Dialog.Damage.Label"}} aria-label="{{localize "PF2E.Roll.Dialog.ModifierName"}}">
+        <input type="text" class="add-modifier-value" placeholder="1" aria-label="{{localize "PF2E.Roll.Dialog.ModifierValue"}}">
+        <select class="add-modifier-type" aria-label="{{localize "PF2E.Roll.Dialog.ModifierType"}}">
             <option value="circumstance">{{localize "PF2E.ModifierType.circumstance"}}</option>
             <option value="item">{{localize "PF2E.ModifierType.item"}}</option>
             <option value="status">{{localize "PF2E.ModifierType.status"}}</option>
@@ -74,13 +74,13 @@
             <option value="ability">{{localize "PF2E.ModifierType.ability"}}</option>
             <option value="proficiency">{{localize "PF2E.ModifierType.proficiency"}}</option>
         </select>
-        <select class="add-modifier-category">
+        <select class="add-modifier-category" aria-label="{{localize "PF2E.Roll.Dialog.ModifierDamageCategory"}}">
             <option value=""></option>
             {{#each damageSubtypes as |name type|}}
                 <option value="{{type}}">{{localize name}}</option>
             {{/each}}
         </select>
-        <select class="add-modifier-damage-type">
+        <select class="add-modifier-damage-type" aria-label="{{localize "PF2E.Roll.Dialog.ModifierDamageType"}}">
             {{#each damageTypes as |name type|}}
                 <option value="{{type}}">{{localize name}}</option>
             {{/each}}


### PR DESCRIPTION
- Closes #22597

While Chrome sanitizes the input and strips the character, Firefox more strictly adheres to the html spec and treats anything with a leading "+" as invalid, returning "".