### PR TITLE
Remove manipulate trait from alchemical bomb strikes

### DIFF
--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -1416,12 +1416,7 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
 
         const handsAvailable = !weapon.system.graspingAppendage || handsReallyFree > 0;
 
-        const actionTraits: AbilityTrait[] = [
-            "attack" as const,
-            // CRB p. 544: "Due to the complexity involved in preparing bombs, Strikes to throw alchemical bombs gain
-            // the manipulate trait."
-            weapon.baseType === "alchemical-bomb" ? ("manipulate" as const) : [],
-        ].flat();
+        const actionTraits: AbilityTrait[] = ["attack"];
         for (const adjustment of strikeAdjustments) {
             adjustment.adjustTraits?.(weapon, actionTraits);
         }

--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -492,9 +492,7 @@ function strikeFromMeleeItem(item: MeleePF2e<ActorPF2e>): NPCStrike {
     const attackSlug = item.slug ?? sluggify(item.name);
     const statistic = new StatisticModifier(attackSlug, modifiers, initialRollOptions);
 
-    const actionTraits: AbilityTrait[] = (
-        ["attack", item.baseType === "alchemical-bomb" ? "manipulate" : null] as const
-    ).filter(R.isTruthy);
+    const actionTraits: AbilityTrait[] = ["attack"];
     const strikeAdjustments = [
         actor.synthetics.strikeAdjustments,
         getPropertyRuneStrikeAdjustments(item.system.runes.property),


### PR DESCRIPTION
Noticed this while poking at area attacks. GM Core removed the "Due to the complexity involved in preparing bombs, Strikes to throw alchemical bombs gain the manipulate trait." language. Was not added back in the GM Core Spring 2026 Bomb errata either.