### PR TITLE
Change Stellar Rush to give bonus to all speeds

### DIFF
--- a/packs/sf2e/feats/class/solarian/level-1/stellar-rush.json
+++ b/packs/sf2e/feats/class/solarian/level-1/stellar-rush.json
@@ -40,7 +40,7 @@
                 "predicate": [
                     "stellar-rush"
                 ],
-                "selector": "land-speed",
+                "selector": "all-speeds",
                 "type": "circumstance",
                 "value": 10
             }


### PR DESCRIPTION
Due to `traversal` trait.