### PR TITLE
Add header, traits, and publication options to feat embeds

### DIFF
--- a/src/module/item/feat/document.ts
+++ b/src/module/item/feat/document.ts
@@ -379,7 +379,7 @@ class FeatPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
                   (config.hr === false ? "" : "<hr>")
                 : "",
             config.trailingLink === false
-                ? this.description.replace(/<p>@UUID\[[^\]]+\](?:\{[^}]+\})<\/p>$/, "")
+                ? this.description.replace(/<p>@UUID\[[^\]]+\](?:\{[^}]+\})?<\/p>$/, "")
                 : this.description,
             publication,
         ].join("");

--- a/src/module/item/feat/document.ts
+++ b/src/module/item/feat/document.ts
@@ -343,14 +343,46 @@ class FeatPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
         return rollOptions;
     }
 
-    protected override embedHTMLString(config: DocumentHTMLEmbedConfig & { hr?: boolean }): string {
-        const list = this.system.prerequisites?.value?.map((item) => item.value).join(", ") ?? "";
-        return (
-            (list
-                ? `<p><strong>${_loc("PF2E.FeatPrereqLabel")}</strong> ${list}</p>` +
+    protected override embedHTMLString(
+        config: DocumentHTMLEmbedConfig & {
+            hr?: boolean;
+            traits?: boolean;
+            publication?: boolean;
+            header?: boolean;
+            trailingLink?: boolean;
+        },
+    ): string {
+        const header = config.header
+            ? `<h2>@UUID[${this.uuid}] <span style="float:right">${_loc("PF2E.Item.Feat.LevelN", { level: this.level })}</span></h2>`
+            : "";
+
+        const traits = config.traits
+            ? this.system.traits.value
+                  .map((t) => _loc(CONFIG.PF2E.featTraits[t]))
+                  .sort((a, b) => a.localeCompare(b))
+                  .reduce(
+                      (allTraits, t) => allTraits + `<li class="tag traits">${t}</li>`,
+                      this.system.traits.rarity !== "common"
+                          ? `<li class="tag rarity ${this.system.traits.rarity}">${_loc(CONFIG.PF2E.rarityTraits[this.system.traits.rarity])}</li>`
+                          : "",
+                  )
+            : "";
+        const prerequisites = this.system.prerequisites?.value?.map((item) => item.value).join(", ") ?? "";
+        const publication = config.publication
+            ? `<p><span style="float:right"><em>${_loc("PF2E.Item.Feat.PublicationSource", { publication: this.system.publication.title })}</em></span></p>`
+            : "";
+        return [
+            header,
+            traits ? `<ul class="tags paizo-style">${traits}</ul>` : "",
+            prerequisites
+                ? `<p><strong>${_loc("PF2E.FeatPrereqLabel")}</strong> ${prerequisites}</p>` +
                   (config.hr === false ? "" : "<hr>")
-                : "") + this.description
-        );
+                : "",
+            config.trailingLink === false
+                ? this.description.replace(/<p>@UUID\[[^\]]+\](?:\{[^}]+\})<\/p>$/, "")
+                : this.description,
+            publication,
+        ].join("");
     }
 
     /* -------------------------------------------- */

--- a/src/module/item/feat/document.ts
+++ b/src/module/item/feat/document.ts
@@ -352,10 +352,12 @@ class FeatPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
             trailingLink?: boolean;
         },
     ): string {
+        // Add header with Item link and feat level
         const header = config.header
             ? `<h2>@UUID[${this.uuid}] <span style="float:right">${_loc("PF2E.Item.Feat.LevelN", { level: this.level })}</span></h2>`
             : "";
 
+        // Non-common rarity followed by alphabetically ordered traits
         const traits = config.traits
             ? this.system.traits.value
                   .map((t) => _loc(CONFIG.PF2E.featTraits[t]))
@@ -367,22 +369,30 @@ class FeatPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
                           : "",
                   )
             : "";
+
         const prerequisites = this.system.prerequisites?.value?.map((item) => item.value).join(", ") ?? "";
+
+        // For dedication feats, remove the journal link at the end
+        const description =
+            config.trailingLink === false
+                ? this.description.replace(/<p>@UUID\[[^\]]+\](?:\{[^}]+\})?<\/p>$/, "")
+                : this.description;
+
+        // Right-aligned publication label
         const publication = config.publication
             ? `<p><span style="float:right"><em>${_loc("PF2E.Item.Feat.PublicationSource", { publication: this.system.publication.title })}</em></span></p>`
             : "";
-        return [
-            header,
-            traits ? `<ul class="tags paizo-style">${traits}</ul>` : "",
-            prerequisites
+
+        return (
+            header +
+            (traits ? `<ul class="tags paizo-style">${traits}</ul>` : "") +
+            (prerequisites
                 ? `<p><strong>${_loc("PF2E.FeatPrereqLabel")}</strong> ${prerequisites}</p>` +
                   (config.hr === false ? "" : "<hr>")
-                : "",
-            config.trailingLink === false
-                ? this.description.replace(/<p>@UUID\[[^\]]+\](?:\{[^}]+\})?<\/p>$/, "")
-                : this.description,
-            publication,
-        ].join("");
+                : "") +
+            description +
+            publication
+        );
     }
 
     /* -------------------------------------------- */

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2634,6 +2634,7 @@
                 "LevelN": "Feat {level}",
                 "OnlyLevel1": "Must be taken at level 1",
                 "Plural": "Feats",
+                "PublicationSource": "Source: {publication}",
                 "Subfeatures": {
                     "KeyAbilityOptions": {
                         "Label": "Key Attribute Options",


### PR DESCRIPTION
Includes config options:
- header: when `true`, adds UUID link with feat level (no custom link label as that doesn't happen often)
- traits: when `true`, adds non-common rarity trait followed by alphabetically sorted list of traits
- publication: when `true`, adds publication source label
- trailingLink: when `false`, removes a link at the end of the description - intended for dedications that link to the current journal page.

Example
<img width="636" height="595" alt="image" src="https://github.com/user-attachments/assets/c57ec3f3-f31c-4f03-8e59-1d48a26646e4" />

Leaving it as a draft for now.