### PR TITLE
Fix Draddeth's Edge potency bonus

### DIFF
--- a/packs/pf2e/equipment/draddeths-edge.json
+++ b/packs/pf2e/equipment/draddeths-edge.json
@@ -57,7 +57,7 @@
                 "key": "FlatModifier",
                 "selector": "dying-recovery-check",
                 "type": "item",
-                "value": "{item|system.runes.potency}"
+                "value": "@item.system.runes.potency"
             }
         ],
         "runes": {

--- a/packs/pf2e/equipment/draddeths-edge.json
+++ b/packs/pf2e/equipment/draddeths-edge.json
@@ -57,7 +57,7 @@
                 "key": "FlatModifier",
                 "selector": "dying-recovery-check",
                 "type": "item",
-                "value": "{item|system.runes.potency.value}"
+                "value": "{item|system.runes.potency}"
             }
         ],
         "runes": {


### PR DESCRIPTION
Not sure if it's relevant though, since `dying-recovery-check` bonuses aren't working