### PR TITLE
Fix weapon trait toggles on attached weapons

### DIFF
--- a/src/module/item/weapon/document.ts
+++ b/src/module/item/weapon/document.ts
@@ -187,6 +187,15 @@ class WeaponPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
         );
     }
 
+    /**
+     * The actor-owned item backing this weapon. This may be the weapon itself, its subitem entry if attached to
+     * another item, the original of a clone (alt usages, shield-generated weapons), or the granting item in the
+     * case of a synthetic weapon from a rule element.
+     */
+    get realItem(): ItemPF2e | null {
+        return this.parentItem?.subitems.get(this.id) ?? this.actor?.items.get(this.id) ?? null;
+    }
+
     get ammo(): AmmoPF2e<TParent> | WeaponPF2e<TParent> | null {
         if (!this.system.ammo) return null; // omit if this usage doesn't support ammo
 

--- a/src/module/item/weapon/trait-toggles.ts
+++ b/src/module/item/weapon/trait-toggles.ts
@@ -105,7 +105,7 @@ class WeaponTraitToggles {
         const current = this[property]?.selected;
         if (current === selected) return false;
 
-        const item = actor.items.get(weapon.id);
+        const item = weapon.realItem;
         if (item?.isOfType("weapon") && item === weapon) {
             const value = property === "doubleBarrel" ? !!selected : selected;
             await item.update({ [`system.traits.toggles.${property}.selected`]: value });
@@ -113,8 +113,11 @@ class WeaponTraitToggles {
             item.update({ [`system.meleeUsage.traitToggles.${trait}`]: selected });
         } else if (trait === "versatile" && item?.isOfType("shield")) {
             item.update({ "system.traits.integrated.versatile.selected": selected });
-        } else if (trait !== "double-barrel") {
-            weapon.rule?.toggleTrait(options);
+        } else if (trait !== "double-barrel" && weapon.rule) {
+            await weapon.rule.toggleTrait(options);
+        } else {
+            console.warn(`PF2e System | Unable to resolve an update target for ${weapon.name}'s ${trait} toggle`);
+            return false;
         }
 
         return true;


### PR DESCRIPTION
Follow-up to #22652

Trait toggles on attached weapons did nothing. `actor.items.get(weapon.id)` returns undefined for subitems, so the toggle fell through while still reporting success. The new `realItem` getter on resolves the actor owned item backing a strike's weapon, and the toggle now warns and returns false when it can't find a target.

The lookup exists because `update()` doesn't seem to be safe to use with synthetic weapons, as they share an id with their granting item and would write to it instead. I think it might be worth having `WeaponPF2e#update` throw or delegate for synthetics, so callers wouldn't need to know what kind of weapon it is before updating it.