### PR TITLE
Always use action image for unusable actions in character sheet

### DIFF
--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -428,13 +428,14 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
                 ...baseData,
                 img: ((): ImageFilePath => {
                     const actionIcon = getActionIcon(item.actionCost);
+                    if (!baseData.usable) return actionIcon;
+
                     const defaultIcon = ItemPF2e.getDefaultArtwork(item._source).img;
                     const commonFeatIcon = "icons/sundries/books/book-red-exclamation.webp";
                     const isDefaultImage = [actionIcon, defaultIcon, commonFeatIcon].includes(item.img);
-                    if (item.isOfType("action") && !isDefaultImage) {
-                        return item.img;
-                    }
-                    return item.system.selfEffect?.img ?? (baseData.usable && !isDefaultImage ? item.img : actionIcon);
+                    return !isDefaultImage && item.isOfType("action")
+                        ? item.img
+                        : (item.system.selfEffect?.img ?? actionIcon);
                 })(),
                 feat: item.isOfType("feat") ? item : null,
                 toggles: item.system.traits.toggles?.getSheetData() ?? [],


### PR DESCRIPTION
If an action on the character sheet has no use button, it will now always show the action cost image in the character sheet. Before if someone changed the icon of an action, it'd be impossible to see the action cost.

## Before

<img width="519" height="251" alt="image" src="https://github.com/user-attachments/assets/73599e55-d0cc-45e5-b500-daa5fca43082" />

## After

<img width="521" height="244" alt="image" src="https://github.com/user-attachments/assets/9f58f1b7-4779-47e2-84ea-c6c1a1a03adc" />
