### PR TITLE
Ignore empty ancestry boost slots when checking remaining boosts

### DIFF
--- a/src/module/actor/character/apps/attribute-builder/app.svelte
+++ b/src/module/actor/character/apps/attribute-builder/app.svelte
@@ -114,7 +114,8 @@
 
             const baseBoosts = Object.values(ancestry.system.boosts);
             const selectedBoosts = baseBoosts.map((b) => b.selected).filter((b): b is AttributeString => !!b);
-            const maxBoosts = baseBoosts.filter((b) => b.value.length > 0 || b.selected).length;
+            // Count only slots that offer options. Empty slots grant nothing
+            const maxBoosts = baseBoosts.filter((b) => b.value.length > 0).length;
             return [maxBoosts, selectedBoosts];
         })();
 

--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -201,11 +201,13 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
 
             const keyAttributeSelected =
                 !sheetData.class || build.attributes.keyOptions.includes(sheetData.data.details.keyability.value);
+            // Complete when selections cover every slot that offers options
+            const unfilledAncestryBoosts = Object.values(sheetData.ancestry?.system.boosts ?? {}).reduce(
+                (count, b) => count + (b.value.length > 0 ? 1 : 0) - (b.selected ? 1 : 0),
+                0,
+            );
             const ancestryBoostsSelected =
-                (sheetData.ancestry?.system.alternateAncestryBoosts?.length === 2 ||
-                    Object.values(sheetData.ancestry?.system.boosts ?? {}).every(
-                        (b) => b.value.length === 0 || !!b.selected,
-                    )) &&
+                (sheetData.ancestry?.system.alternateAncestryBoosts?.length === 2 || unfilledAncestryBoosts <= 0) &&
                 sheetData.ancestry?.system.voluntary?.boost !== null;
             const backgroundBoostsSelected = Object.values(sheetData.background?.system.boosts ?? {}).every(
                 (b) => b.value.length === 0 || !!b.selected,


### PR DESCRIPTION
- Closes #22676

Handles the empty boost slots that ancestries like Nagaji have.