### PR TITLE
Impoves inline template functionality and fixes templates not respecting the width parameter.

### DIFF
--- a/src/module/canvas/helpers.ts
+++ b/src/module/canvas/helpers.ts
@@ -178,20 +178,32 @@ function squareAtPoint(point: Point): PIXI.Rectangle {
 }
 
 function shapeDataFromEffectArea(
-    area: { type: EffectAreaShape; value: number },
+    area: {
+        type: EffectAreaShape;
+        value: number;
+        width?: number;
+        angle?: number;
+        innerWidth?: number;
+        outerWidth?: number;
+    },
     actor: Maybe<ActorPF2e>,
 ): DeepPartial<SpecificShapeSource> | null {
     const distance = (area.value / 5) * canvas.grid.size;
+
     const { x, y } = canvas.mousePosition;
     switch (area.type) {
         case "burst":
         case "cylinder":
             return { type: "circle", radius: distance, x, y };
-        case "cone":
-            return { type: "cone", angle: 90, radius: distance, x, y };
+        case "cone": {
+            const angle = area.angle || 90;
+            return { type: "cone", angle, radius: distance, x, y };
+        }
         case "cube":
-        case "square":
-            return { type: "rectangle", width: distance, height: distance, x, y };
+        case "square": {
+            const width = ((area.width || area.value) / 5) * canvas.grid.size;
+            return { type: "rectangle", width, height: distance, x, y };
+        }
         case "emanation": {
             const tokenSource = actor?.getActiveTokens(true, true).at(0)?._source;
             if (!tokenSource) return null;
@@ -200,11 +212,14 @@ function shapeDataFromEffectArea(
             } as const);
             return { type: "emanation", radius: distance, base, x, y };
         }
-        case "line":
-            return { type: "line", length: distance, width: canvas.dimensions.size, x, y };
+        case "line": {
+            const width = ((area.width || 5) / 5) * canvas.grid.size;
+            return { type: "line", length: distance, width, x, y };
+        }
         case "ring": {
-            const width = Math.floor(canvas.dimensions.size * 0.5);
-            return { type: "ring", radius: distance, innerWidth: width, outerWidth: width, x, y };
+            const innerWidth = ((area.innerWidth || 2.5) / 5) * canvas.grid.size;
+            const outerWidth = ((area.outerWidth || 2.5) / 5) * canvas.grid.size;
+            return { type: "ring", radius: distance, innerWidth, outerWidth, x, y };
         }
     }
 }

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -303,11 +303,55 @@ class TextEditorPF2e extends foundry.applications.ux.TextEditor {
             ui.notifications.error("PF2E.InlineTemplateErrors.WidthNoNumber", { format: { width: params.width } });
             return null;
         }
+        if (params.innerWidth && Number.isNaN(+params.innerWidth)) {
+            ui.notifications.error("PF2E.InlineTemplateErrors.InnerWidthNoNumber", {
+                format: { innerWidth: params.innerWidth },
+            });
+            return null;
+        }
+        if (params.outerWidth && Number.isNaN(+params.outerWidth)) {
+            ui.notifications.error("PF2E.InlineTemplateErrors.OuterWidthNoNumber", {
+                format: { outerWidth: params.outerWidth },
+            });
+            return null;
+        }
+        if (params.angle && Number.isNaN(+params.angle)) {
+            ui.notifications.error("PF2E.InlineTemplateErrors.AngleNoNumber", { format: { width: params.angle } });
+            return null;
+        }
         // If no traits are entered manually use the traits from rollOptions if available
         params.traits ||= item?.system.traits.value?.toString() ?? null;
         params.itemUuid ||= item?.uuid ?? null;
 
         // If no button label is entered directly create default label
+        if (params.width) {
+            label ||= _loc("PF2E.TemplateWidthLabel", {
+                size: params.distance,
+                width: params.width,
+                unit: _loc("PF2E.Foot.Label"),
+                shape: _loc(`PF2E.Area.Shape.${params.type}`),
+            });
+        }
+
+        if (params.angle) {
+            label ||= _loc("PF2E.TemplateAngleLabel", {
+                size: params.distance,
+                angle: params.angle,
+                unit: _loc("PF2E.Foot.Label"),
+                shape: _loc(`PF2E.Area.Shape.${params.type}`),
+            });
+        }
+
+        if (params.innerWidth || params.outerWidth) {
+            label ||= _loc("PF2E.TemplateRingLabel", {
+                size: params.distance,
+                innerWidth: params.innerWidth || 2.5,
+                outerWidth: params.outerWidth || 2.5,
+                unit: _loc("PF2E.Foot.Label"),
+                shape: _loc(`PF2E.Area.Shape.${params.type}`),
+            });
+        }
+
         label ||= _loc("PF2E.TemplateLabel", {
             size: params.distance,
             unit: _loc("PF2E.Foot.Label"),
@@ -343,9 +387,20 @@ class TextEditorPF2e extends foundry.applications.ux.TextEditor {
         const html = createHTMLElement("a", {
             children: [icon, label],
             classes: ["effect-area"],
-            dataset: { effectArea: "", ...R.pick(params, ["type", "distance", "traits", "itemUuid"]) },
+            dataset: {
+                effectArea: "",
+                ...R.pick(params, [
+                    "type",
+                    "distance",
+                    "width",
+                    "angle",
+                    "innerWidth",
+                    "outerWidth",
+                    "traits",
+                    "itemUuid",
+                ]),
+            },
         });
-        if (params.type === "line") html.dataset.width = params.width || "1";
         return html;
     }
 

--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -320,7 +320,14 @@ export class InlineRollLinks {
         }
         const { actor: actorFromHTML, item, message } = resolveActorAndItemFromHTML(link);
         const actor = actorFromHTML ?? game.user.character;
-        const area = { type: dataset.type, value: Number(dataset.distance) || 5 };
+        const area = {
+            type: dataset.type,
+            value: Number(dataset.distance),
+            width: Number(dataset.width) || undefined,
+            angle: Number(dataset.angle) || undefined,
+            innerWidth: Number(dataset.innerWidth) || undefined,
+            outerWidth: Number(dataset.outerWidth) || undefined,
+        };
         const shape = shapeDataFromEffectArea(area, actor);
         if (!shape) return;
         const data: DeepPartial<fd.RegionSource> = {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1806,7 +1806,10 @@
             "DistanceNoNumber": "Error in @Template: dimension {distance} is not a number",
             "TypeMissing": "Error in @Template: type parameter is mandatory",
             "TypeUnsupported": "Error in @Template: type {type} is not supported",
-            "WidthNoNumber": "Error in @Template: width {width} is not a number"
+            "WidthNoNumber": "Error in @Template: width {width} is not a number",
+            "InnerWidthNoNumber": "Error in @Template: innerWidth {innerWidth} is not a number",
+            "OuterWidthNoNumber": "Error in @Template: outerWidth {outerWidth} is not a number",
+            "AngleNoNumber": "Error in @Template: angle {angle} is not a number"
         },
         "InvestedLabel": "Invested",
         "Item": {
@@ -4336,6 +4339,9 @@
         "TabSpellbookLabel": "Spellcasting",
         "TempHitPointsShortLabel": "Temp HP",
         "TemplateLabel": "{size}-{unit} {shape}",
+        "TemplateWidthLabel": "{size}x{width}-{unit} {shape}",
+        "TemplateAngleLabel": "{size}-{unit} {angle}° {shape}",
+        "TemplateRingLabel": "{size} (in:{innerWidth} out:{outerWidth})-{unit} {shape}",
         "TemporaryItemToolTip": "This item is temporary and will expire after a duration or during daily preparations. It has no value and cannot be sold.",
         "Time": {
             "Duration": "Duration",


### PR DESCRIPTION
This PR generally broadens the capabilities of the inline `@Template` functionality while also fixing lines and other shapes to properly respect the width parameter when one is specified. This resolves at least a portion of issue #21958 (though more specifically #22539 and #22630). 

New parameters exist for both rings and cones, specifically `innerWidth` and `outerWidth` for rings, and `angle` for cones. 

The item in the first screenshot has the following for each template, with the example placements after that comparing the two:
```
Ring Specifying Widths
@Template[type:ring|distance:20|innerWidth:10|outerWidth:10]

Ring No Widths
@Template[type:ring|distance:20]

Square With Width
@Template[type:square|distance:20|width:10]

Square With No Width
@Template[type:square|distance:20]

Line With Width
@Template[type:line|distance:20|width:10]

Line With No Width
@Template[type:line|distance:20]

Cone With Angle
@Template[type:cone|distance:20|angle:10]

Cone With No Angle
@Template[type:cone|distance:20]
```
<img width="335" height="620" alt="Screenshot_20260715_111952" src="https://github.com/user-attachments/assets/bbf51c5f-fa28-4ca7-8845-5558945430ee" />
<img width="1438" height="859" alt="Screenshot_20260715_112032" src="https://github.com/user-attachments/assets/1bf959f0-90de-4f2e-9e20-bca7006e2dd0" />
<img width="1075" height="563" alt="Screenshot_20260715_112105" src="https://github.com/user-attachments/assets/debabafc-3e4b-47c8-a7aa-9ac99cfc7997" />
<img width="682" height="649" alt="Screenshot_20260715_112122" src="https://github.com/user-attachments/assets/295cd19c-965e-4d3e-a186-dc9c46e70745" />
<img width="645" height="970" alt="Screenshot_20260715_112143" src="https://github.com/user-attachments/assets/43786e1f-675c-4e0c-b879-41370a719232" />
