### PR TITLE
Prevent Actor sheet from erroring when IWR references a homebrew damage type that doesn't exist in the world

### DIFF
--- a/src/module/actor/data/iwr.ts
+++ b/src/module/actor/data/iwr.ts
@@ -47,10 +47,10 @@ abstract class IWR<TType extends IWRType> {
         const type = this.typeLabel;
         const disjunctor = game.i18n.getListFormatter({ style: "long", type: "disjunction" });
         const exceptions = disjunctor.format(
-            this.exceptions.map((e) => _loc(typeof e === "string" ? this.typeLabels[e] : e.label)),
+            this.exceptions.map((e) => _loc(typeof e === "string" ? (this.typeLabels[e] ?? e) : e.label)),
         );
         const doubleVs = disjunctor.format(
-            this.doubleVs?.map((e) => _loc(typeof e === "string" ? this.typeLabels[e] : e.label)) ?? [],
+            this.doubleVs?.map((e) => _loc(typeof e === "string" ? (this.typeLabels[e] ?? e) : e.label)) ?? [],
         );
         const key =
             this.exceptions.length > 0


### PR DESCRIPTION
Based on the recently encountered issue - list formatter will error if there is `undefined` in the array.