### PR TITLE
Update Extending Rune level to 9

### DIFF
--- a/src/module/item/physical/runes.ts
+++ b/src/module/item/physical/runes.ts
@@ -1243,7 +1243,7 @@ const WEAPON_PROPERTY_RUNES: { [T in WeaponPropertyRuneType]: WeaponPropertyRune
         traits: ["magical"],
     },
     extending: {
-        level: 7,
+        level: 9,
         name: "PF2E.WeaponPropertyRune.extending.Name",
         price: 700,
         rarity: "common",


### PR DESCRIPTION
The Extending Rune's item level has been corrected to 9, ensuring it aligns with the official rules. This change addresses the issue where the rune was not properly increasing the weapon's item level.

Fixes #22710