### PR TITLE
Cleanup some Myth-Speakers entries

### DIFF
--- a/packs/pf2e/deities/hero-gods/ytildos.json
+++ b/packs/pf2e/deities/hero-gods/ytildos.json
@@ -33,7 +33,6 @@
         "sanctification": {
             "modal": "can",
             "what": [
-                "holy",
                 "unholy"
             ]
         },

--- a/packs/pf2e/equipment/death-tusk-helm.json
+++ b/packs/pf2e/equipment/death-tusk-helm.json
@@ -44,7 +44,7 @@
             ]
         },
         "usage": {
-            "value": "held-in-one-hand"
+            "value": "wornheadwear"
         }
     },
     "type": "equipment"

--- a/packs/pf2e/equipment/hydra-head-club.json
+++ b/packs/pf2e/equipment/hydra-head-club.json
@@ -52,7 +52,7 @@
         "quantity": 1,
         "range": null,
         "reload": {
-            "value": "-"
+            "value": null
         },
         "rules": [
             {
@@ -92,9 +92,22 @@
             "value": 0
         },
         "traits": {
+            "config": {
+                "modular": [
+                    {
+                        "damageType": "bludgeoning",
+                        "traits": []
+                    },
+                    {
+                        "damageType": "piercing",
+                        "traits": []
+                    }
+                ]
+            },
             "rarity": "rare",
             "value": [
                 "magical",
+                "modular",
                 "thrown-10"
             ]
         },

--- a/packs/pf2e/myth-speaker-bestiary/book-1-the-acropolis-pyre/bristled-reef-shark.json
+++ b/packs/pf2e/myth-speaker-bestiary/book-1-the-acropolis-pyre/bristled-reef-shark.json
@@ -9,6 +9,8 @@
             "name": "Jaws",
             "sort": 100000,
             "system": {
+                "action": "strike",
+                "area": null,
                 "attackEffects": {
                     "value": []
                 },
@@ -32,17 +34,48 @@
                 "range": null,
                 "rules": [],
                 "slug": null,
+                "subjectToMAP": true,
                 "traits": {
+                    "config": {},
                     "value": []
                 }
             },
             "type": "melee"
         },
         {
+            "_id": "P5wCCIimJAhU5s68",
+            "img": "systems/pf2e/icons/default-icons/action.svg",
+            "name": "Blood Scent",
+            "sort": 200000,
+            "system": {
+                "actionType": {
+                    "value": "passive"
+                },
+                "actions": {
+                    "value": null
+                },
+                "category": "interaction",
+                "description": {
+                    "value": "<p>The shark can smell blood in the water from up to 1 mile away.</p>"
+                },
+                "publication": {
+                    "license": "OGL",
+                    "remaster": false,
+                    "title": ""
+                },
+                "rules": [],
+                "slug": null,
+                "traits": {
+                    "value": []
+                }
+            },
+            "type": "action"
+        },
+        {
             "_id": "ElkNFMZXJWORukPW",
             "img": "systems/pf2e/icons/default-icons/action.svg",
             "name": "Bristle",
-            "sort": 200000,
+            "sort": 300000,
             "system": {
                 "actionType": {
                     "value": "reaction"
@@ -71,7 +104,7 @@
             "_id": "eaOzB2ZpMqmJxXYx",
             "img": "systems/pf2e/icons/default-icons/action.svg",
             "name": "Compression",
-            "sort": 300000,
+            "sort": 400000,
             "system": {
                 "actionType": {
                     "value": "passive"
@@ -100,7 +133,7 @@
             "_id": "5F76CHIBn0QyTqHn",
             "img": "systems/pf2e/icons/default-icons/action.svg",
             "name": "Reef Rake",
-            "sort": 400000,
+            "sort": 500000,
             "system": {
                 "actionType": {
                     "value": "action"

--- a/packs/pf2e/myth-speaker-bestiary/book-2-death-sails-a-wine-dark-sea/lava-spitter.json
+++ b/packs/pf2e/myth-speaker-bestiary/book-2-death-sails-a-wine-dark-sea/lava-spitter.json
@@ -9,6 +9,8 @@
             "name": "Fangs",
             "sort": 100000,
             "system": {
+                "action": "strike",
+                "area": null,
                 "attackEffects": {
                     "value": []
                 },
@@ -37,7 +39,9 @@
                 "range": null,
                 "rules": [],
                 "slug": null,
+                "subjectToMAP": true,
                 "traits": {
+                    "config": {},
                     "value": [
                         "agile",
                         "finesse",
@@ -53,6 +57,8 @@
             "name": "Lava Spit",
             "sort": 200000,
             "system": {
+                "action": "strike",
+                "area": null,
                 "attackEffects": {
                     "value": []
                 },
@@ -84,7 +90,9 @@
                 },
                 "rules": [],
                 "slug": null,
+                "subjectToMAP": true,
                 "traits": {
+                    "config": {},
                     "value": []
                 }
             },
@@ -287,7 +295,19 @@
             "speed": {
                 "otherSpeeds": [],
                 "value": 25
-            }
+            },
+            "weaknesses": [
+                {
+                    "exceptions": [],
+                    "type": "cold",
+                    "value": 5
+                },
+                {
+                    "exceptions": [],
+                    "type": "water",
+                    "value": 5
+                }
+            ]
         },
         "details": {
             "blurb": "",

--- a/packs/pf2e/myth-speaker-bestiary/book-3-titanbane/painted-landscape.json
+++ b/packs/pf2e/myth-speaker-bestiary/book-3-titanbane/painted-landscape.json
@@ -35,7 +35,9 @@
                 "rules": [],
                 "slug": null,
                 "traits": {
-                    "value": []
+                    "value": [
+                        "reach-20"
+                    ]
                 }
             },
             "type": "melee"
@@ -272,6 +274,9 @@
             "allSaves": {
                 "value": ""
             },
+            "hardness": {
+                "value": 15
+            },
             "hp": {
                 "details": "",
                 "max": 155,
@@ -281,7 +286,14 @@
             "speed": {
                 "otherSpeeds": [],
                 "value": 15
-            }
+            },
+            "weaknesses": [
+                {
+                    "exceptions": [],
+                    "type": "acid",
+                    "value": 10
+                }
+            ]
         },
         "details": {
             "blurb": "",
@@ -343,7 +355,8 @@
                 "value": "grg"
             },
             "value": [
-                "construct"
+                "construct",
+                "mindless"
             ]
         }
     },

--- a/packs/pf2e/myth-speaker-bestiary/book-3-titanbane/painted-pontifex.json
+++ b/packs/pf2e/myth-speaker-bestiary/book-3-titanbane/painted-pontifex.json
@@ -43,6 +43,7 @@
                     "invested": null
                 },
                 "expend": 1,
+                "grade": null,
                 "group": "sling",
                 "hardness": 0,
                 "hp": {
@@ -101,6 +102,7 @@
             "name": "Staff",
             "sort": 200000,
             "system": {
+                "ammo": null,
                 "baseItem": "staff",
                 "bonus": {
                     "value": 0
@@ -127,6 +129,7 @@
                     "invested": null
                 },
                 "expend": null,
+                "grade": null,
                 "group": "club",
                 "hardness": 0,
                 "hp": {
@@ -195,8 +198,20 @@
                 "description": {
                     "value": "<p>These are small metal balls, typically either iron or lead, designed to be used as ammunition in slings.</p>"
                 },
+                "equipped": {
+                    "carryType": "worn"
+                },
+                "hardness": 0,
+                "hp": {
+                    "max": 0,
+                    "value": 0
+                },
                 "level": {
                     "value": 0
+                },
+                "material": {
+                    "grade": null,
+                    "type": null
                 },
                 "price": {
                     "per": 10,
@@ -536,7 +551,14 @@
             "speed": {
                 "otherSpeeds": [],
                 "value": 25
-            }
+            },
+            "weaknesses": [
+                {
+                    "exceptions": [],
+                    "type": "acid",
+                    "value": 10
+                }
+            ]
         },
         "details": {
             "blurb": "",
@@ -593,7 +615,8 @@
                 "value": "med"
             },
             "value": [
-                "construct"
+                "construct",
+                "mindless"
             ]
         }
     },

--- a/packs/pf2e/myth-speaker-bestiary/book-3-titanbane/painted-ram.json
+++ b/packs/pf2e/myth-speaker-bestiary/book-3-titanbane/painted-ram.json
@@ -76,6 +76,7 @@
                 "slug": null,
                 "traits": {
                     "value": [
+                        "agile",
                         "unarmed"
                     ]
                 }
@@ -326,9 +327,21 @@
                 "value": 120
             },
             "speed": {
-                "otherSpeeds": [],
-                "value": 25
-            }
+                "otherSpeeds": [
+                    {
+                        "type": "climb",
+                        "value": 20
+                    }
+                ],
+                "value": 30
+            },
+            "weaknesses": [
+                {
+                    "exceptions": [],
+                    "type": "acid",
+                    "value": 10
+                }
+            ]
         },
         "details": {
             "blurb": "",
@@ -385,7 +398,8 @@
                 "value": "med"
             },
             "value": [
-                "construct"
+                "construct",
+                "mindless"
             ]
         }
     },

--- a/packs/pf2e/spells/focus/gift-of-the-anemos.json
+++ b/packs/pf2e/spells/focus/gift-of-the-anemos.json
@@ -4,7 +4,10 @@
     "img": "icons/magic/air/wind-tornado-funnel-damage-blue.webp",
     "name": "Gift of the Anemos",
     "system": {
-        "area": null,
+        "area": {
+            "type": "emanation",
+            "value": 10
+        },
         "cost": {
             "value": ""
         },


### PR DESCRIPTION
This is a quick pass over the Myth-Speakers compendium entries.

Fixes:
- Missing traits, weaknesses, and rules for certain creatures
- Fixed a few items with incorrect usages or missing rules
- Fix an incorrect sanctification on a hero-god
- Adding an area to a spell that was missing it

A note on the painted creatures: it looks like whoever wrote them originally kinda forgot how they work. The toolbox ones have different recurring rules than the ones used in the adventure itself. I strove to fix the entries exactly how the book has them, so the acid weakness doesn't appear on the in-adventure ones as-written.