### PR TITLE
Fix compendium migrations silently failing

### DIFF
--- a/src/module/migration/runner/index.ts
+++ b/src/module/migration/runner/index.ts
@@ -110,15 +110,16 @@ export class MigrationRunner extends MigrationRunnerBase {
         updateGroup: TDocument["_source"][],
         pack: string | null,
         progress?: Progress,
+        { diff = true }: { diff?: boolean } = {},
     ): Promise<void> {
         const DocumentClass = collection.documentClass;
         try {
-            await DocumentClass.updateDocuments(updateGroup, { noHook: true, pack });
+            await DocumentClass.updateDocuments(updateGroup, { noHook: true, pack, diff });
         } catch (batchError) {
             console.warn(batchError);
             for (const source of updateGroup) {
                 try {
-                    await DocumentClass.updateDocuments([source], { noHook: true, pack });
+                    await DocumentClass.updateDocuments([source], { noHook: true, pack, diff });
                 } catch (error) {
                     console.warn(error);
                     const uuid = collection.get(source._id ?? "")?.uuid;
@@ -305,10 +306,23 @@ export class MigrationRunner extends MigrationRunnerBase {
 
         ui.notifications.info("PF2E.Migrations.Starting", { format: { version: game.system.version } });
         const documents = await compendium.getDocuments();
-        await compendium.documentClass.updateDocuments(
-            documents.map((d) => d.toObject()),
-            { diff: false, recursive: false, pack },
+
+        // Clear stale failures from a previous run over this pack
+        for (const uuid of MigrationRunner.lastRunFailures.keys()) {
+            if (uuid.startsWith(`Compendium.${pack}.`)) MigrationRunner.lastRunFailures.delete(uuid);
+        }
+
+        // These documents were already migrated in memory when loaded, so a normal update would see nothing to
+        // save. Force-replace every field and skip diffing so the changes actually reach the database.
+        const updates = documents.map(
+            (d) =>
+                R.mapValues(d.toObject() as Record<string, unknown>, (v, k) =>
+                    k === "_id" ? v : foundry.data.operators.ForcedReplacement.create(v),
+                ) as unknown as T["_source"],
         );
+        for (const batch of R.chunk(updates, 100)) {
+            await this.#saveUpdateGroup(compendium, [...batch], pack, undefined, { diff: false });
+        }
         ui.notifications.info("PF2E.Migrations.Finished", { format: { version: game.system.version } });
     }
 


### PR DESCRIPTION
Found this while working on AppV2 compendium migration summary and trying to migrate my own content module from V13. V14 turns any `recursive: false` update into a diff against the client's copy, and since that copy is already migrated on load, the diff is empty for exactly the docs that need saving. Nothing gets written, but the update resolves fine and the UI says success.

I've wrapped each field in a `ForcedReplacement` and keep `diff: false` so core can't strip anything. Also batches the writes through the new `#saveUpdateGroup` from #22570, so failed documents in a batch get retried alone and recorded.