### PR TITLE
Make Catfolk Dance effect apply off-guard on a critical success

### DIFF
--- a/packs/pf2e/feat-effects/effect-catfolk-dance.json
+++ b/packs/pf2e/feat-effects/effect-catfolk-dance.json
@@ -16,9 +16,9 @@
             "value": 1
         },
         "publication": {
-            "license": "OGL",
-            "remaster": false,
-            "title": "Pathfinder Lost Omens Ancestry Guide"
+            "license": "ORC",
+            "remaster": true,
+            "title": "Pathfinder Player Core 2"
         },
         "rules": [
             {

--- a/packs/pf2e/feat-effects/effect-catfolk-dance.json
+++ b/packs/pf2e/feat-effects/effect-catfolk-dance.json
@@ -4,7 +4,7 @@
     "name": "Effect: Catfolk Dance",
     "system": {
         "description": {
-            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Catfolk Dance]</p>\n<p>The target creature gains a -2 circumstance penalty to Reflex saves</p>"
+            "value": "<p>Granted by @UUID[Compendium.pf2e.feats-srd.Item.Catfolk Dance]</p>\n<p>You gain a −2 circumstance penalty to Reflex saves. On a critical success, you are also off-guard.</p>"
         },
         "duration": {
             "expiry": "turn-start",
@@ -21,6 +21,29 @@
             "title": "Pathfinder Lost Omens Ancestry Guide"
         },
         "rules": [
+            {
+                "choices": [
+                    {
+                        "label": "PF2E.Check.Result.Degree.Check.success",
+                        "value": "success"
+                    },
+                    {
+                        "label": "PF2E.Check.Result.Degree.Check.criticalSuccess",
+                        "value": "critical-success"
+                    }
+                ],
+                "key": "ChoiceSet",
+                "prompt": "PF2E.SpecificRule.Prompt.DegreeOfSuccess",
+                "rollOption": "catfolk-dance"
+            },
+            {
+                "inMemoryOnly": true,
+                "key": "GrantItem",
+                "predicate": [
+                    "catfolk-dance:critical-success"
+                ],
+                "uuid": "Compendium.pf2e.conditionitems.Item.Off-Guard"
+            },
             {
                 "key": "FlatModifier",
                 "selector": "reflex",

--- a/packs/pf2e/feats/ancestry/catfolk/level-1/catfolk-dance.json
+++ b/packs/pf2e/feats/ancestry/catfolk/level-1/catfolk-dance.json
@@ -12,7 +12,7 @@
         },
         "category": "ancestry",
         "description": {
-            "value": "<p>You have a habit of always being in the way when other creatures attempt to move. Attempt an @Check[acrobatics|defense:reflex] check against an adjacent creature's Reflex DC.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Catfolk Dance]</p><hr /><p><strong>Critical Success</strong> The target creature gains a −2 circumstance penalty to Reflex saves and is @UUID[Compendium.pf2e.conditionitems.Item.Off-Guard] until the start of your next turn.</p>\n<p><strong>Success</strong> The target creature gains a −2 circumstance penalty to Reflex saves until the start of your next turn.</p>"
+            "value": "<p>You have a habit of always being in the way when other creatures attempt to move. Attempt an @Check[acrobatics|against:reflex] check against an adjacent creature's Reflex DC.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Catfolk Dance]</p><hr /><p><strong>Critical Success</strong> The target creature gains a −2 circumstance penalty to Reflex saves and is @UUID[Compendium.pf2e.conditionitems.Item.Off-Guard] until the start of your next turn.</p>\n<p><strong>Success</strong> The target creature gains a −2 circumstance penalty to Reflex saves until the start of your next turn.</p>"
         },
         "level": {
             "value": 1

--- a/packs/pf2e/feats/ancestry/catfolk/level-1/catfolk-dance.json
+++ b/packs/pf2e/feats/ancestry/catfolk/level-1/catfolk-dance.json
@@ -12,7 +12,7 @@
         },
         "category": "ancestry",
         "description": {
-            "value": "<p>You have a habit of always being in the way when other creatures attempt to move. Attempt an @Check[acrobatics|defense:reflex] check against an adjacent creature's Reflex DC.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Catfolk Dance]</p><hr /><p><strong>Critical Success</strong> The target creature gains a -2 circumstance penalty to Reflex saves and is @UUID[Compendium.pf2e.conditionitems.Item.Off-Guard] until the start of your next turn.</p>\n<p><strong>Success</strong> The target creature gains a -2 circumstance penalty to Reflex saves until the start of your next turn.</p>"
+            "value": "<p>You have a habit of always being in the way when other creatures attempt to move. Attempt an @Check[acrobatics|defense:reflex] check against an adjacent creature's Reflex DC.</p>\n<p>@UUID[Compendium.pf2e.feat-effects.Item.Effect: Catfolk Dance]</p><hr /><p><strong>Critical Success</strong> The target creature gains a −2 circumstance penalty to Reflex saves and is @UUID[Compendium.pf2e.conditionitems.Item.Off-Guard] until the start of your next turn.</p>\n<p><strong>Success</strong> The target creature gains a −2 circumstance penalty to Reflex saves until the start of your next turn.</p>"
         },
         "level": {
             "value": 1


### PR DESCRIPTION
There is an unrelated issue of the effect lasting longer than it should, because the system has no way to handle "until the start of the applier's next turn"