### PR TITLE
Fix Compendium Browser sort by price

### DIFF
--- a/src/module/apps/compendium-browser/tabs/equipment.ts
+++ b/src/module/apps/compendium-browser/tabs/equipment.ts
@@ -106,7 +106,7 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
                         uuid: itemData.uuid,
                         level: itemData.system.level?.value ?? 0,
                         price: priceCoins,
-                        priceInCopper: priceCoins.copperValue,
+                        priceInCopper: coinValue,
                         rarity: itemData.system.traits.rarity,
                         options: new Set(options),
                     });

--- a/src/module/apps/compendium-browser/tabs/equipment.ts
+++ b/src/module/apps/compendium-browser/tabs/equipment.ts
@@ -106,6 +106,7 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
                         uuid: itemData.uuid,
                         level: itemData.system.level?.value ?? 0,
                         price: priceCoins,
+                        priceInCopper: priceCoins.copperValue,
                         rarity: itemData.system.traits.rarity,
                         options: new Set(options),
                     });


### PR DESCRIPTION
~~`priceInCopper` is not a proper field, and `price` should be an actual Coins object, but as the type system doesn't check it, I've added a null check in case it isn't there for some reason.~~

Added `priceInCopper` field instead so it doesn't have to recalculate values for every comparison