### PR TITLE
Fix PF2e style table borders in AppV2

### DIFF
--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -92,6 +92,7 @@ body,
     --color-border-divider: #baa991;
     --color-border-dark-input: #d3ccbc;
     --color-border-medium: gray;
+    --color-border-book: #7a7971;
 
     /* Inventory headers boxes */
     --color-pf-inventory-header-text: var(--color-light-1);

--- a/src/styles/_globals.scss
+++ b/src/styles/_globals.scss
@@ -84,36 +84,32 @@ i.action-glyph {
 
 table.pf2e,
 table.pf2-table {
+    --pf2-table-header-bg: var(--color-pf-primary-dark);
+    --pf2-table-stripe-odd: var(--tertiary-light);
+    --pf2-table-stripe-even: var(--text-light);
+
     border-collapse: collapse;
     color: var(--text-dark);
     font-size: var(--font-size-13);
     user-select: text;
 
-    thead,
-    tbody,
-    th,
-    td {
-        box-sizing: border-box;
-        user-select: text;
-        word-break: auto-phrase;
-    }
-
     tr:nth-child(odd) {
-        background-color: var(--tertiary-light);
+        background-color: var(--pf2-table-stripe-odd);
     }
 
     tr:nth-child(even) {
-        background-color: var(--text-light);
+        background-color: var(--pf2-table-stripe-even);
     }
 
     th,
     td {
-        border: solid 1px var(--color-border-light-tertiary);
+        border: solid 1px var(--color-border-book);
         text-align: center;
+        word-break: auto-phrase;
     }
 
     th {
-        background-color: var(--color-pf-primary-dark);
+        background-color: var(--pf2-table-header-bg);
         color: var(--text-light);
         font-weight: bold;
         padding: var(--spacer-8) var(--spacer-4);
@@ -124,41 +120,15 @@ table.pf2-table {
     }
 
     &.remaster {
-        tr:nth-child(odd) {
-            background-color: #eee3c8;
-        }
-
-        tr:nth-child(even) {
-            background-color: #f5efe0;
-        }
-
-        th,
-        td {
-            border-color: var(--color-border-light-tertiary);
-        }
-
-        th {
-            background-color: #002a17;
-        }
+        --pf2-table-header-bg: #002a17;
+        --pf2-table-stripe-odd: #eee3c8;
+        --pf2-table-stripe-even: #f5efe0;
     }
 
     &.lost-omens {
-        tr:nth-child(odd) {
-            background-color: #efe5ca;
-        }
-
-        tr:nth-child(even) {
-            background-color: #f6f2e2;
-        }
-
-        th,
-        td {
-            border-color: var(--color-border-light-tertiary);
-        }
-
-        th {
-            background-color: #042564;
-        }
+        --pf2-table-header-bg: #042564;
+        --pf2-table-stripe-odd: #efe5ca;
+        --pf2-table-stripe-even: #f6f2e2;
     }
 }
 


### PR DESCRIPTION
Plus a little cleanup of the surrounding styles.

Before:
<img width="653" height="278" alt="Screenshot 2026-07-25 at 10 25 06 AM" src="https://github.com/user-attachments/assets/66a16447-d56b-4bd4-a286-8da3f23bbabb" />

After:
<img width="652" height="288" alt="Screenshot 2026-07-25 at 10 36 22 AM" src="https://github.com/user-attachments/assets/353be57b-9b34-4ad3-bf29-904e51584c2b" />
