### PR TITLE
fix attaching loudener to weapons

### DIFF
--- a/src/module/item/physical/usage.ts
+++ b/src/module/item/physical/usage.ts
@@ -67,8 +67,8 @@ function getUsageDetails(usage: string): UsageDetails {
         return { value: usage, type: "attached", where };
     }
 
-    if (usage.startsWith("installed-in") || usage.startsWith("installed-on")) {
-        const where = usage.replace(/^installed-in-/, "").replace(/^installed-on-/, "");
+    if (/^installed-(?:i|o)n-/.test(usage)) {
+        const where = usage.replace(/^installed-(?:i|o)n-/, "");
         return { value: usage, type: "installed", where };
     }
 

--- a/src/module/item/physical/usage.ts
+++ b/src/module/item/physical/usage.ts
@@ -67,8 +67,8 @@ function getUsageDetails(usage: string): UsageDetails {
         return { value: usage, type: "attached", where };
     }
 
-    if (usage.startsWith("installed-in")) {
-        const where = usage.replace(/^installed-in-/, "");
+    if (usage.startsWith("installed-in") || usage.startsWith("installed-on")) {
+        const where = usage.replace(/^installed-in-/, "").replace(/^installed-on-/, "");
         return { value: usage, type: "installed", where };
     }
 


### PR DESCRIPTION
Closes #22291

@CarlosFdez was right, the issue is the `installed-on` instead of `installed-in` for the usage value. Below are links to a before and after of this change. I didn't end up changing the `TraitInstalledOnAWeaponWithoutASilencer` trait name it doesn't have a functional impact, but can change that to avoid confusion later on (all installed-in values start with `TraitInstalledIn`).

Before 

https://github.com/user-attachments/assets/4bff9997-03d1-4155-8bd6-981a4dd15863

After

https://github.com/user-attachments/assets/e3dbb7fd-471d-45ae-a09f-0cfc5116b393


