### PR TITLE
Add rule for Guerrilla Weaponry weapon die override

### DIFF
--- a/packs/pf2e/feats/archetype/guerrilla/level-4/guerrilla-weaponry.json
+++ b/packs/pf2e/feats/archetype/guerrilla/level-4/guerrilla-weaponry.json
@@ -31,6 +31,10 @@
         },
         "rules": [
             {
+                "key": "GrantItem",
+                "uuid": "Compendium.pf2e.actionspf2e.Item.Guerrilla Assault"
+            },
+            {
                 "itemType": "weapon",
                 "key": "ItemAlteration",
                 "mode": "override",

--- a/packs/pf2e/feats/archetype/guerrilla/level-4/guerrilla-weaponry.json
+++ b/packs/pf2e/feats/archetype/guerrilla/level-4/guerrilla-weaponry.json
@@ -33,6 +33,26 @@
             {
                 "itemType": "weapon",
                 "key": "ItemAlteration",
+                "mode": "override",
+                "predicate": [
+                    "item:base:blowgun"
+                ],
+                "property": "damage-dice-faces",
+                "value": 4
+            },
+            {
+                "key": "DamageDice",
+                "override": {
+                    "diceNumber": "max(1 + @weapon.system.runes.striking, @weapon.system.damage.dice)"
+                },
+                "predicate": [
+                    "item:base:blowgun"
+                ],
+                "selector": "blowgun-damage"
+            },
+            {
+                "itemType": "weapon",
+                "key": "ItemAlteration",
                 "mode": "add",
                 "predicate": [
                     "item:base:blowgun"


### PR DESCRIPTION
P.S. had to add a hacky rule for DamageDice, otherwise striking runes wouldn't apply