### PR TITLE
Support choosing ancestry attribute boosts and flaws with multiple options

### DIFF
--- a/src/module/actor/character/apps/attribute-builder/app.svelte
+++ b/src/module/actor/character/apps/attribute-builder/app.svelte
@@ -104,10 +104,22 @@
         return null;
     }
 
+    /** Every attribute still offered by an unselected slot */
+    function getAvailableOptions(
+        slots: Record<string, { value: AttributeString[]; selected: AttributeString | null }>,
+    ): AttributeString[] {
+        return R.unique(
+            Object.values(slots)
+                .filter((s) => !s.selected)
+                .flatMap((s) => s.value),
+        );
+    }
+
     const ancestryBoosts = $derived.by(() => {
         const ancestry = data.ancestry;
         if (!ancestry) return null;
 
+        const alternate = !!ancestry.system.alternateAncestryBoosts;
         const [maxBoosts, selectedBoosts] = (() => {
             const alternateAncestryBoosts = ancestry.system.alternateAncestryBoosts;
             if (alternateAncestryBoosts) return [MAX_ALTERNATE_ANCESTRY_BOOSTS, alternateAncestryBoosts];
@@ -119,29 +131,51 @@
             return [maxBoosts, selectedBoosts];
         })();
 
+        // Alternate ancestry boosts bypass flaws
+        const flawSlots = alternate ? {} : ancestry.system.flaws;
+        const selectedFlaws = Object.values(flawSlots)
+            .map((f) => f.selected)
+            .filter((f): f is AttributeString => !!f);
+        const maxFlaws = Object.values(flawSlots).filter((f) => f.value.length > 0).length;
+        const flawsRemaining = maxFlaws - selectedFlaws.length;
+
         const netBoosted = R.difference(data.build.boosts.ancestry, data.build.flaws.ancestry);
         const remaining = maxBoosts - selectedBoosts.length;
-        const lockedBoosts = ancestry.system.alternateAncestryBoosts ? null : ancestry.lockedBoosts;
-        const lockedFlaws = ancestry.system.alternateAncestryBoosts ? null : ancestry.lockedFlaws;
+        const lockedBoosts = alternate ? null : ancestry.lockedBoosts;
+        const lockedFlaws = alternate ? null : ancestry.lockedFlaws;
+        const availableBoosts = alternate ? null : getAvailableOptions(ancestry.system.boosts);
+        const availableFlaws = getAvailableOptions(flawSlots);
 
         const buttons = createButtonRecord(attributeList, (attribute) => {
             const selected = selectedBoosts.includes(attribute);
+            const flawSelected = selectedFlaws.includes(attribute);
             return {
                 boost: {
                     selected,
                     locked: lockedBoosts?.includes(attribute),
-                    disabled: selected ? false : !remaining || netBoosted.includes(attribute),
+                    disabled: selected
+                        ? false
+                        : !remaining ||
+                          netBoosted.includes(attribute) ||
+                          !(availableBoosts?.includes(attribute) ?? true),
                 },
-                flaw: lockedFlaws?.includes(attribute) ? { selected: true, locked: true } : undefined,
+                flaw:
+                    flawSelected || flawsRemaining > 0
+                        ? {
+                              selected: flawSelected,
+                              locked: lockedFlaws?.includes(attribute),
+                              disabled: flawSelected ? false : !flawsRemaining || !availableFlaws.includes(attribute),
+                          }
+                        : undefined,
             };
         });
 
         return {
             buttons,
-            remaining,
+            remaining: remaining + flawsRemaining,
             labels: getBoostFlawLabels(ancestry.system.boosts),
             flawLabels: getBoostFlawLabels(ancestry.system.flaws),
-            alternate: !!ancestry.system.alternateAncestryBoosts,
+            alternate,
         };
     });
 
@@ -373,7 +407,12 @@
                         {@const buttonState = ancestryBoosts.buttons[attribute]}
                         <div class="row-column">
                             {#if buttonState.flaw}
-                                <AttributeButton type="flaw" {attribute} button={buttonState.flaw} onclick={() => {}} />
+                                <AttributeButton
+                                    type="flaw"
+                                    {attribute}
+                                    button={buttonState.flaw}
+                                    onclick={(attr) => foundryApp.handleAncestryFlaw(attr)}
+                                />
                             {/if}
                             <AttributeButton
                                 type="boost"

--- a/src/module/actor/character/apps/attribute-builder/app.ts
+++ b/src/module/actor/character/apps/attribute-builder/app.ts
@@ -16,6 +16,8 @@ interface AttributeBuilderRenderOptions extends fa.ApplicationRenderOptions {
     actor?: CharacterPF2e;
 }
 
+type BoostFlawSlots = Record<string, { value: AttributeString[]; selected: AttributeString | null }>;
+
 class AttributeBuilder extends SvelteApplicationMixin<
     AbstractConstructorOf<fa.api.ApplicationV2<fa.ApplicationConfiguration, AttributeBuilderRenderOptions>> & {
         DEFAULT_OPTIONS: DeepPartial<AttributeBuilderConfiguration>;
@@ -111,6 +113,15 @@ class AttributeBuilder extends SvelteApplicationMixin<
         };
     }
 
+    /** Key of the narrowest unselected slot offering the attribute, so a choice never lands where it isn't offered */
+    #findOpenSlot(slots: BoostFlawSlots | undefined, attribute: AttributeString): string | null {
+        return (
+            R.entries(slots ?? {})
+                .filter(([, s]) => !s.selected && s.value.includes(attribute))
+                .sort(([, a], [, b]) => a.value.length - b.value.length)[0]?.[0] ?? null
+        );
+    }
+
     async toggleAlternateAncestryBoosts(): Promise<void> {
         const ancestry = this.#actor.ancestry;
         const hasAlternateBoosts = !!ancestry?.system.alternateAncestryBoosts;
@@ -150,11 +161,25 @@ class AttributeBuilder extends SvelteApplicationMixin<
             return;
         }
 
-        const freeBoost = Object.entries(ancestry.system.boosts ?? {}).find(
-            ([, b]) => !b.selected && b.value.length > 0,
-        );
-        if (freeBoost) {
-            await ancestry.update({ [`system.boosts.${freeBoost[0]}.selected`]: attribute });
+        const openSlot = this.#findOpenSlot(ancestry.system.boosts, attribute);
+        if (openSlot) {
+            await ancestry.update({ [`system.boosts.${openSlot}.selected`]: attribute });
+        }
+    }
+
+    async handleAncestryFlaw(attribute: AttributeString): Promise<void> {
+        const ancestry = this.#actor.ancestry;
+        if (!ancestry || ancestry.system.alternateAncestryBoosts) return;
+
+        const flawToRemove = Object.entries(ancestry.system.flaws ?? {}).find(([, f]) => f.selected === attribute);
+        if (flawToRemove) {
+            await ancestry.update({ [`system.flaws.${flawToRemove[0]}.selected`]: null });
+            return;
+        }
+
+        const openSlot = this.#findOpenSlot(ancestry.system.flaws, attribute);
+        if (openSlot) {
+            await ancestry.update({ [`system.flaws.${openSlot}.selected`]: attribute });
         }
     }
 
@@ -212,11 +237,9 @@ class AttributeBuilder extends SvelteApplicationMixin<
             return;
         }
 
-        const freeBoost = Object.entries(background.system.boosts ?? {}).find(
-            ([, b]) => !b.selected && b.value.length > 0,
-        );
-        if (freeBoost) {
-            await background.update({ [`system.boosts.${freeBoost[0]}.selected`]: attribute });
+        const openSlot = this.#findOpenSlot(background.system.boosts, attribute);
+        if (openSlot) {
+            await background.update({ [`system.boosts.${openSlot}.selected`]: attribute });
         }
     }
 

--- a/src/module/item/ancestry/document.ts
+++ b/src/module/item/ancestry/document.ts
@@ -39,7 +39,9 @@ class AncestryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends 
 
     /** Returns all flaws enforced by this ancestry normally */
     get lockedFlaws(): AttributeString[] {
-        return Object.values(this.system.flaws).flatMap((f) => f.selected ?? []);
+        return Object.values(this.system.flaws)
+            .filter((f) => f.value.length === 1)
+            .flatMap((f) => f.selected ?? []);
     }
 
     /** Include all ancestry features in addition to any with the expected location ID */
@@ -56,14 +58,15 @@ class AncestryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends 
 
     override prepareBaseData(): void {
         super.prepareBaseData();
-        for (const boost of Object.values(this.system.boosts)) {
-            if (boost.value.length === 1) {
-                boost.selected = boost.value[0];
-            }
-        }
-        for (const flaw of Object.values(this.system.flaws)) {
-            if (flaw.value.length === 1) {
-                flaw.selected = flaw.value[0];
+        for (const slots of [this.system.boosts, this.system.flaws]) {
+            for (const slot of Object.values(slots)) {
+                // `prepareActorData` applies any selection, so clear ones the slot no longer offers
+                if (slot.selected && !slot.value.includes(slot.selected)) {
+                    slot.selected = null;
+                }
+                if (slot.value.length === 1) {
+                    slot.selected = slot.value[0];
+                }
             }
         }
     }


### PR DESCRIPTION
- Closes #11577

This one traces back to the old attribute builder. Multi-option flaws couldn't be selected at all so they applied nothing, and multi-option boosts let you pick any attribute, not just the ones offered. Flaws are now selectable in the attribute builder, buttons are limited to attributes some unselected slot offers, and a pick writes to the narrowest slot that offers it.