### PR TITLE
Add automation for Battle Scars

### DIFF
--- a/packs/pf2e/feats/archetype/hellbreaker/level-10/battle-scars.json
+++ b/packs/pf2e/feats/archetype/hellbreaker/level-10/battle-scars.json
@@ -29,7 +29,33 @@
             "remaster": true,
             "title": "Pathfinder Adventure Path: Hellbreakers"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "RollOption",
+                "option": "self:battle-scars",
+                "toggleable": true
+            },
+            {
+                "definition": [
+                    {
+                        "or": [
+                            "self:battle-scars",
+                            "origin:trait:devil"
+                        ]
+                    },
+                    {
+                        "or": [
+                            "damage:type:bludgeoning",
+                            "damage:type:slashing"
+                        ]
+                    }
+                ],
+                "key": "Resistance",
+                "label": "{item|name}",
+                "type": "custom",
+                "value": "floor(@actor.level/2)"
+            }
+        ],
         "subfeatures": {
             "proficiencies": {},
             "senses": {},

--- a/packs/pf2e/feats/skill/level-2/tactical-acumen.json
+++ b/packs/pf2e/feats/skill/level-2/tactical-acumen.json
@@ -12,7 +12,7 @@
         },
         "category": "skill",
         "description": {
-            "value": "<p>Even if you don't know much about its constituent creatures, you can always recognize a troop's capabilities through features like the formation they move in or even more subtle hints others might miss. You can always use Warfare Lore when you @UUID[Compendium.pf2e.actionspf2e.Item.Recall Knowledge] to identify a troop. This works like using an applicable Lore to identify a creature. If you're legendary in Warfare Lore, reduce any adjustment to the Recall Knowledge check's DC caused by the troop's rarity by 5.</p>\n<p>If you lead a troop, when you successfully use Warfare Lore to identify a troop, that troop takes a –1 circumstance penalty to saves against your troop's offensive abilities until the end of your next turn.</p>"
+            "value": "<p>Even if you don't know much about its constituent creatures, you can always recognize a troop's capabilities through features like the formation they move in or even more subtle hints others might miss. You can always use Warfare Lore when you [[/act recall-knowledge skill=warfare-lore]] to identify a troop. This works like using an applicable Lore to identify a creature. If you're legendary in Warfare Lore, reduce any adjustment to the Recall Knowledge check's DC caused by the troop's rarity by 5.</p>\n<p>If you lead a troop, when you successfully use Warfare Lore to identify a troop, that troop takes a –1 circumstance penalty to saves against your troop's offensive abilities until the end of your next turn.</p>"
         },
         "level": {
             "value": 2


### PR DESCRIPTION
Need `self:` prefix so it's accessible in the damage context