### PR TITLE
Fix Shobhad Longrifle missing analog trait

### DIFF
--- a/packs/sf2e/equipment/weapons/shobhad-longrifle.json
+++ b/packs/sf2e/equipment/weapons/shobhad-longrifle.json
@@ -26,7 +26,7 @@
             "value": "<p><strong>Upgrades:</strong> 0</p><hr /><p>This martial sniper rifle is the traditional weapon of the shobhad-neh. It comes with a built-in @UUID[Compendium.sf2e.equipment.Item.Silencer (Commercial)]{commercial silencer} and @UUID[Compendium.sf2e.equipment.Item.Sniper's Scope (Commercial)]{commercial sniper's scope} that must be upgraded separately from the weapon but are integrated into the shobhad longrifle and do not occupy upgrade slots.</p>"
         },
         "expend": 1,
-        "grade": null,
+        "grade": "commercial",
         "group": "sniper",
         "hardness": 0,
         "hp": {
@@ -232,6 +232,7 @@
         "traits": {
             "rarity": "common",
             "value": [
+                "analog",
                 "backstabber",
                 "concussive",
                 "fatal-d12",


### PR DESCRIPTION
Closes #22760 

This is an opinionated change since the gun doesn't have either analog or tech in print but is logical - it doesn't read like a tech weapon at all.