### PR TITLE
Fix Multishot Stance not applying to Triple Shot

### DIFF
--- a/packs/pf2e/feat-effects/stance-multishot-stance.json
+++ b/packs/pf2e/feat-effects/stance-multishot-stance.json
@@ -27,6 +27,7 @@
                 "predicate": [
                     "double-shot"
                 ],
+                "priority": 75,
                 "relabel": "{item|name}",
                 "selector": "ranged-attack-roll",
                 "slug": "double-shot",
@@ -38,6 +39,7 @@
                 "predicate": [
                     "triple-shot"
                 ],
+                "priority": 75,
                 "relabel": "{item|name}",
                 "selector": "ranged-attack-roll",
                 "slug": "double-shot",


### PR DESCRIPTION
Closes #22426 

This alters the priority of Multishot Stance to make sure it applies to Triple Shot. I tested Double and Triple with Multishot Stance applied and everything functioned as intended.