### PR TITLE
Change Remaining Air effect to floor con modifier

### DIFF
--- a/packs/pf2e/other-effects/effect-remaining-air.json
+++ b/packs/pf2e/other-effects/effect-remaining-air.json
@@ -31,7 +31,7 @@
                 "key": "ActiveEffectLike",
                 "mode": "add",
                 "path": "flags.system.remainingAir.rounds",
-                "value": "5 + @actor.abilities.con.mod"
+                "value": "5 + floor(@actor.abilities.con.mod)"
             },
             {
                 "itemId": "{item|id}",


### PR DESCRIPTION
A character with partially boosted con gets 9.5 rounds of air when it is not floored, and then end up with 600 rounds of air. Not sure why, as `@actor.abilities.con.mod` gives 4, but presumably the activeeffectlike gets a version of con before it gets set down to 4 or something.