### PR TITLE
Fix light mode parchment backgrounds

### DIFF
--- a/src/module/apps/compendium-browser/components/filters/filter-container.svelte
+++ b/src/module/apps/compendium-browser/components/filters/filter-container.svelte
@@ -77,7 +77,7 @@
 
             button.clear-filter {
                 &:not(:hover) {
-                    background-color: var(--background);
+                    background: var(--background);
                 }
                 line-height: 1.5em;
                 position: absolute;

--- a/src/styles/_application.scss
+++ b/src/styles/_application.scss
@@ -53,6 +53,13 @@
     }
 }
 
+// Chromium resolves core's relative parchment URL against the stylesheet using the var,
+// which 404s from this one. Redeclare it with a path that resolves.
+body.theme-light .application.pf2e:not(.themed),
+.application.pf2e.themed.theme-light {
+    --background: var(--parchment-texture) repeat;
+}
+
 body > .pf2e.absolute {
     position: absolute;
     z-index: var(--z-index-tooltip);

--- a/src/styles/_globals.scss
+++ b/src/styles/_globals.scss
@@ -22,6 +22,9 @@
     --space-15: 0.9375rem;
     --space-17: var(--font-size-17);
     --space-21: var(--font-size-21);
+
+    // Core's parchment texture, resolved from this stylesheet
+    --parchment-texture: url("../../../ui/parchment.jpg");
 }
 
 /* ----------------------------------------- */

--- a/src/styles/_tags.scss
+++ b/src/styles/_tags.scss
@@ -394,7 +394,8 @@ tagify-tags {
     .tagify {
         --placeholder-color: var(--color-text-subtle);
         --placeholder-color-focus: var(--color-text-subtle);
-        --tag-bg: var(--background);
+        // Tagify applies this with box-shadow, so it must be a color rather than core's --background
+        --tag-bg: light-dark(var(--bg), var(--color-cool-5-90));
         --tag-hover: var(--color-data-border);
         --tag-remove-bg: var(--color-data-border);
         --tag-remove-btn-bg--hover: var(--color-border);

--- a/src/styles/item/_rules.scss
+++ b/src/styles/item/_rules.scss
@@ -140,7 +140,7 @@
         padding-bottom: 0.5rem;
 
         &.drag-preview {
-            background: url(../ui/parchment.jpg) repeat;
+            background: var(--parchment-texture) repeat;
         }
 
         &.drag-gap {

--- a/src/styles/ui/sidebar/_compendium-directory.scss
+++ b/src/styles/ui/sidebar/_compendium-directory.scss
@@ -64,27 +64,3 @@ section.compendium-sidebar {
         }
     }
 }
-
-#pack-search-drag-preview {
-    background: url(../../../ui/parchment.jpg) repeat;
-    border-bottom: 1px solid var(--color-border-light-1);
-    border-top: 1px solid transparent;
-    box-shadow: none;
-    display: flex;
-    height: 50px;
-    line-height: 48px;
-    position: absolute;
-    text-shadow: 0 0 0.5rem var(--color-shadow-primary);
-    top: -1000px;
-    width: 328px;
-
-    img {
-        border: none;
-        height: 48px;
-    }
-
-    h4 {
-        color: var(--color-text-dark-primary);
-        font-size: var(--font-size-14);
-    }
-}


### PR DESCRIPTION
- Closes #22862

When a relative url is used is a css var, chrome will resolve it relative to the file in which it's used, not the one it's declared in. This 404'd everything using `--background` in light mode. HMR conveniently hides this issue, hence not noticing it earlier. Also clears out the old unused `#pack-search-drag-preview` styles.

here's a few examples
dragging RE's
<img width="730" height="250" alt="rule-drag-before" src="https://github.com/user-attachments/assets/e7b7ef1c-3131-49ab-bc9e-97d45ce62819" />
<img width="730" height="250" alt="rule-drag-after" src="https://github.com/user-attachments/assets/fabdb273-8bce-44db-a698-1ea8d2dc23c1" />

spell prep (original issue)
<img width="655" height="650" alt="spell-prep-before" src="https://github.com/user-attachments/assets/a45d9da7-7262-403a-a835-793ac4ac3017" />
<img width="655" height="650" alt="spell-prep-after" src="https://github.com/user-attachments/assets/b3c467e5-8585-41f4-808d-f2f705a94d65" />


tagify in check prompt macro
<img width="427" height="397" alt="tagify-before" src="https://github.com/user-attachments/assets/8c1e87e2-3a3b-4587-9204-f16bcd1f1e0e" />
<img width="459" height="365" alt="tagify-after" src="https://github.com/user-attachments/assets/5442a7e9-b392-4f94-b8f9-8e28bacc7b3e" />
