### PR TITLE
Remove `watch` script from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
         "build:packs:json": "tsx ./build/build-packs.ts --json",
         "build:conditions": "tsx ./build/conditions.ts",
         "build:anachronism": "tsx ./build/anachronism/index.ts",
-        "watch": "npm run build:packs && vite build --watch --mode development",
         "hot": "tsx ./build/hmr.ts",
         "link": "tsx ./build/link-foundry.ts",
         "extractPacks": "tsx ./build/extract-packs.ts",


### PR DESCRIPTION
> because there's `hot`, which is better in every way

also, it doesn't actually work for SF2e