### PR TITLE
Do not consume charges if trick-magic-item check fails or is canceled…

### DIFF
--- a/src/module/actor/sheet/trick-magic-item-popup.ts
+++ b/src/module/actor/sheet/trick-magic-item-popup.ts
@@ -5,7 +5,7 @@ import { TRICK_MAGIC_SKILLS, TrickMagicItemEntry } from "@item/spellcasting-entr
 import { ErrorPF2e, localizer, tupleHasValue } from "@util";
 
 /** Prompt the user for a skill with which to trick a magic item, then roll the check and cast the embedded spell. */
-async function trickMagicItem(item: ConsumablePF2e): Promise<void> {
+async function trickMagicItem(item: ConsumablePF2e): Promise<boolean> {
     const localize = localizer("PF2E.TrickMagicItemPopup");
     if (!item.isOfType("consumable")) {
         throw ErrorPF2e("Unexpected item used for Trick Magic Item");
@@ -32,15 +32,17 @@ async function trickMagicItem(item: ConsumablePF2e): Promise<void> {
         buttons,
         rejectClose: false,
     });
-    if (!tupleHasValue(TRICK_MAGIC_SKILLS, skill)) return;
+    if (!tupleHasValue(TRICK_MAGIC_SKILLS, skill)) return false;
 
-    actor.skills[skill].check.roll({
+    const check = await actor.skills[skill].check.roll({
         extraRollOptions: ["action:trick-magic-item"],
         dc: { value: checkDC[skill] ?? 0 },
         item: consumable,
     });
+    if (!check?.degreeOfSuccess || check.degreeOfSuccess < 2) return false;
 
     await consumable.castEmbeddedSpell(new TrickMagicItemEntry(actor, skill));
+    return true;
 }
 
 export { trickMagicItem };

--- a/src/module/actor/sheet/trick-magic-item-popup.ts
+++ b/src/module/actor/sheet/trick-magic-item-popup.ts
@@ -2,6 +2,7 @@ import type { CharacterPF2e } from "@actor";
 import type { ConsumablePF2e } from "@item";
 import { calculateTrickMagicItemCheckDC } from "@item/consumable/spell-consumables.ts";
 import { TRICK_MAGIC_SKILLS, TrickMagicItemEntry } from "@item/spellcasting-entry/trick.ts";
+import { DEGREE_OF_SUCCESS } from "@system/degree-of-success.ts";
 import { ErrorPF2e, localizer, tupleHasValue } from "@util";
 
 /** Prompt the user for a skill with which to trick a magic item, then roll the check and cast the embedded spell. */
@@ -39,7 +40,7 @@ async function trickMagicItem(item: ConsumablePF2e): Promise<boolean> {
         dc: { value: checkDC[skill] ?? 0 },
         item: consumable,
     });
-    if (!check?.degreeOfSuccess || check.degreeOfSuccess < 2) return false;
+    if ((check?.degreeOfSuccess ?? 0) < DEGREE_OF_SUCCESS.SUCCESS) return false;
 
     await consumable.castEmbeddedSpell(new TrickMagicItemEntry(actor, skill));
     return true;

--- a/src/module/item/consumable/document.ts
+++ b/src/module/item/consumable/document.ts
@@ -135,7 +135,8 @@ class ConsumablePF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extend
             if (actor.spellcasting?.canCastConsumable(this)) {
                 this.castEmbeddedSpell();
             } else if (actor.itemTypes.feat.some((feat) => feat.slug === "trick-magic-item")) {
-                trickMagicItem(this);
+                const consumed = await trickMagicItem(this);
+                if (!consumed) return;
             } else {
                 const formatParams = { actor: actor.name, spell: this.name };
                 const message = _loc("PF2E.LackCastConsumableCapability", formatParams);


### PR DESCRIPTION
Right now, using `Trick Magic Item` consumes a charge as soon as the button is pressed, even if the user cancel the check all together.

Also, as per the feat's description, you shouldn't be able to use the item at all if you fail the check, which means that is should not be consumed either.

closes #17308