### PR TITLE
Fix infinite HMR loop when editing localizations

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -174,7 +174,7 @@ const config = Vite.defineConfig(({ command, mode }): Vite.UserConfig => {
                 name: "hmr-handler",
                 apply: "serve",
                 handleHotUpdate(context) {
-                    if (context.file.startsWith(outDir)) return;
+                    if (context.file.startsWith(path.resolve(outDir))) return;
                     if (context.file.endsWith("en.json")) {
                         const basePath = context.file.slice(context.file.indexOf("lang/"));
                         console.debug(`Updating lang file at ${basePath}`);


### PR DESCRIPTION
Editing en.json with hot running started an infinite loop until hot was restarted. The ui would stutter, apps would constantly rerender, and other fun things. `handleHotUpdate`'s early return was bugged, it compared the relative `outDir` (dist/pf2e) against the absolute path Vite passes, so it never matched and every write retriggered the handler.