### PR TITLE
Add physical item usage filters to Compendium Browser

### DIFF
--- a/src/module/apps/compendium-browser/tabs/data.ts
+++ b/src/module/apps/compendium-browser/tabs/data.ts
@@ -108,6 +108,7 @@ interface CampaignFeatureFilters extends BaseFilterData {
 interface EquipmentFilters extends BaseFilterData {
     checkboxes: {
         armorTypes: CheckboxData;
+        equipmentUsage: CheckboxData;
         itemTypes: CheckboxData;
         rarity: CheckboxData;
         weaponTypes: CheckboxData;

--- a/src/module/apps/compendium-browser/tabs/data.ts
+++ b/src/module/apps/compendium-browser/tabs/data.ts
@@ -108,9 +108,9 @@ interface CampaignFeatureFilters extends BaseFilterData {
 interface EquipmentFilters extends BaseFilterData {
     checkboxes: {
         armorTypes: CheckboxData;
-        equipmentUsage: CheckboxData;
         itemTypes: CheckboxData;
         rarity: CheckboxData;
+        usageTypes: CheckboxData;
         weaponTypes: CheckboxData;
     };
     ranges: {

--- a/src/module/apps/compendium-browser/tabs/equipment.ts
+++ b/src/module/apps/compendium-browser/tabs/equipment.ts
@@ -6,6 +6,7 @@ import { CompendiumBrowser } from "../browser.svelte.ts";
 import { ContentTabName } from "../data.ts";
 import { CompendiumBrowserTab } from "./base.svelte.ts";
 import { CompendiumBrowserIndexData, EquipmentFilters, RangesInputData } from "./data.ts";
+import { getUsageDetails } from "@item/physical/usage.ts";
 
 export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
     tabName: ContentTabName = "equipment";
@@ -34,7 +35,8 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
         const physicalItemFields = [...baseFields, "system.level.value"];
         const runedItemFields = [...physicalItemFields, "system.runes"];
         const armorAndWeaponFields = [...runedItemFields, "system.category", "system.group"];
-        const indexFields = R.unique([...armorAndWeaponFields]).sort();
+        const equipmentFields = [...physicalItemFields, "system.usage.value"];
+        const indexFields = R.unique([...armorAndWeaponFields, "system.usage.value"]).sort();
         const publications = new Set<string>();
 
         for await (const { pack, index } of this.browser.packLoader.loadPacks(
@@ -57,6 +59,8 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
                                 return !this.hasAllIndexFields(itemData, baseFields);
                             case "shield":
                                 return !this.hasAllIndexFields(itemData, runedItemFields);
+                            case "equipment":
+                                return !this.hasAllIndexFields(itemData, equipmentFields);
                             default:
                                 return !this.hasAllIndexFields(itemData, physicalItemFields);
                         }
@@ -87,6 +91,9 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
                         typeof priceValue === "string" ? Coins.fromString(priceValue) : new Coins(priceValue);
                     const coinValue = priceCoins.copperValue;
 
+                    const usageValue = system.usage?.value;
+                    const usageType = typeof usageValue === "string" ? getUsageDetails(usageValue).type : "none";
+
                     const pubSource = String(system.publication?.title ?? system.source?.value ?? "").trim();
                     const options: string[] = [
                         ...traits.map((t) => `trait:${t.replace(/^hb_/, "")}`),
@@ -96,6 +103,7 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
                         `type:group:${itemData.system.group ?? "none"}`,
                         `rarity:${itemData.system.traits.rarity}`,
                         `type:${itemData.type}`,
+                        `type:usage:${usageType}`,
                         this.preparePublicationSource(pubSource, publications),
                     ];
 
@@ -107,6 +115,7 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
                         level: itemData.system.level?.value ?? 0,
                         price: priceCoins,
                         rarity: itemData.system.traits.rarity,
+                        usage: usageType,
                         options: new Set(options),
                     });
                 }
@@ -124,6 +133,9 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
         this.filterData.checkboxes.weaponTypes.options = {
             ...this.generateCheckboxOptions(CONFIG.PF2E.weaponCategories, { prefix: "category" }),
             ...this.generateCheckboxOptions(CONFIG.PF2E.weaponGroups, { prefix: "group" }),
+        };
+        this.filterData.checkboxes.equipmentUsage.options = {
+            ...this.generateCheckboxOptions(CONFIG.PF2E.usageTypes, { prefix: "usage" }),
         };
 
         this.filterData.traits.options = this.generateMultiselectOptions({
@@ -199,6 +211,13 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
                 weaponTypes: {
                     isExpanded: false,
                     label: "PF2E.CompendiumBrowser.Filter.WeaponFilters",
+                    options: {},
+                    optionPrefix: "type",
+                    selected: [],
+                },
+                equipmentUsage: {
+                    isExpanded: false,
+                    label: "PF2E.CompendiumBrowser.Filter.UsageFilters",
                     options: {},
                     optionPrefix: "type",
                     selected: [],

--- a/src/module/apps/compendium-browser/tabs/equipment.ts
+++ b/src/module/apps/compendium-browser/tabs/equipment.ts
@@ -103,7 +103,7 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
                         `type:group:${itemData.system.group ?? "none"}`,
                         `rarity:${itemData.system.traits.rarity}`,
                         `type:${itemData.type}`,
-                        `type:usage:${usageType}`,
+                        `usage:${usageType}`,
                         this.preparePublicationSource(pubSource, publications),
                     ];
 
@@ -134,8 +134,8 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
             ...this.generateCheckboxOptions(CONFIG.PF2E.weaponCategories, { prefix: "category" }),
             ...this.generateCheckboxOptions(CONFIG.PF2E.weaponGroups, { prefix: "group" }),
         };
-        this.filterData.checkboxes.equipmentUsage.options = {
-            ...this.generateCheckboxOptions(CONFIG.PF2E.usageTypes, { prefix: "usage" }),
+        this.filterData.checkboxes.usageTypes.options = {
+            ...this.generateCheckboxOptions(CONFIG.PF2E.usageTypes),
         };
 
         this.filterData.traits.options = this.generateMultiselectOptions({
@@ -215,11 +215,11 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
                     optionPrefix: "type",
                     selected: [],
                 },
-                equipmentUsage: {
+                usageTypes: {
                     isExpanded: false,
                     label: "PF2E.CompendiumBrowser.Filter.UsageFilters",
                     options: {},
-                    optionPrefix: "type",
+                    optionPrefix: "usage",
                     selected: [],
                 },
             },

--- a/src/module/item/physical/usage.ts
+++ b/src/module/item/physical/usage.ts
@@ -1,51 +1,49 @@
 import { EquippedData } from "./data.ts";
 import type { OneToTwo } from "@module/data.ts";
 
-interface HeldUsage {
+interface BaseUsage<T extends UsageType> {
+    type: T;
+}
+
+interface HeldUsage extends BaseUsage<"held"> {
     value: string;
-    type: "held";
     where?: never;
     hands: OneToTwo;
 }
 
-interface WornUsage {
+interface WornUsage extends BaseUsage<"worn"> {
     value: string;
-    type: "worn";
     where?: string | null;
     hands?: 0;
 }
 
-interface AttachedUsage {
+interface AttachedUsage extends BaseUsage<"attached"> {
     value: string;
-    type: "attached";
     where: string;
     hands?: 0;
 }
 
-interface InstalledUsage {
+interface InstalledUsage extends BaseUsage<"installed"> {
     value: string;
-    type: "installed";
     where: string;
     hands?: 0;
 }
 
-interface CarriedUsage {
+interface CarriedUsage extends BaseUsage<"carried"> {
     value: "carried";
-    type: "carried";
     where?: never;
     hands?: 0;
 }
 
-interface ImplantedUsage {
+interface ImplantedUsage extends BaseUsage<"implanted"> {
     value: string;
-    type: "implanted";
     where?: never;
     hands?: 0;
 }
 
 type UsageDetails = HeldUsage | WornUsage | AttachedUsage | InstalledUsage | CarriedUsage | ImplantedUsage;
 
-type UsageType = UsageDetails["type"];
+type UsageType = keyof typeof CONFIG.PF2E.usageTypes;
 
 function isEquipped(usage: UsageDetails, equipped: EquippedData): boolean {
     if (equipped.carryType === "dropped") return false;

--- a/src/scripts/config/index.ts
+++ b/src/scripts/config/index.ts
@@ -710,6 +710,14 @@ export const PF2ECONFIG = {
     },
 
     usages: USAGES,
+    usageTypes: {
+        attached: "PF2E.UsageAttached",
+        carried: "PF2E.UsageCarried",
+        held: "PF2E.UsageHeld",
+        implanted: "PF2E.UsageImplanted",
+        installed: "PF2E.UsageInstalled",
+        worn: "PF2E.UsageWorn",
+    },
 
     magicTraditions,
     deityDomains,

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1132,6 +1132,7 @@
                 "Sizes": "Sizes",
                 "Source": "Sources",
                 "Traditions": "Traditions",
+                "UsageFilters": "Usage Filters",
                 "WeaponFilters": "Weapon Filters",
                 "SearchPlaceholder": "Search Text",
                 "WarnPackNotLoaded": "Compendium \"{pack}\" could not be loaded."
@@ -5991,6 +5992,12 @@
         "UnprepareItemTitle": "Unprepare Item",
         "UpdateLabelUniversal": "Update",
         "Usage": "Usage",
+        "UsageAttached": "Attached",
+        "UsageCarried": "Carried",
+        "UsageHeld": "Held",
+        "UsageImplanted": "Implanted",
+        "UsageInstalled": "Installed",
+        "UsageWorn": "Worn",
         "UserSettings": {
             "DarkvisionFilter": {
                 "Hint": "Add a (usually monochrome) filter when viewing a scene through the sight of a creature with darkvision",


### PR DESCRIPTION
<img width="779" height="323" alt="image" src="https://github.com/user-attachments/assets/8f8d2800-ae0d-4cde-b84a-9d4e0247a504" />
There is currently no good way to search for SF2e gear upgrades, and users have to refer to AoN instead of using the compendium browser.

Considering that the same usage types are being used to check if items can be attached, it seemed reasonable to use it as a filter.

Types of usages have been modified to tie them to the config object data, but somebody more knowledgeable of TS than me should check if its ok.