### PR TITLE
Add augmentation automation to IM Automaton feats (#22808)

### DIFF
--- a/packs/pf2e/feats/ancestry/automaton/level-1/expressive-face.json
+++ b/packs/pf2e/feats/ancestry/automaton/level-1/expressive-face.json
@@ -27,6 +27,34 @@
         },
         "rules": [
             {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.system.automaton.enhancements.lesser",
+                "value": {
+                    "label": "PF2E.SpecificRule.Automaton.EnhanceableFeats.ExpressiveFace",
+                    "predicate": [
+                        {
+                            "not": "enhancement:expressive-face"
+                        }
+                    ],
+                    "value": "expressive-face"
+                }
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.system.automaton.enhancements.greater",
+                "value": {
+                    "label": "PF2E.SpecificRule.Automaton.EnhanceableFeats.ExpressiveFace",
+                    "predicate": [
+                        {
+                            "not": "enhancement:expressive-face"
+                        }
+                    ],
+                    "value": "expressive-face"
+                }
+            },
+            {
                 "key": "GrantItem",
                 "uuid": "Compendium.pf2e.feats-srd.Item.Glad-Hand"
             },

--- a/packs/pf2e/feats/ancestry/automaton/level-1/messenger.json
+++ b/packs/pf2e/feats/ancestry/automaton/level-1/messenger.json
@@ -25,7 +25,36 @@
             "remaster": true,
             "title": "Pathfinder Impossible Magic"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.system.automaton.enhancements.lesser",
+                "value": {
+                    "label": "PF2E.SpecificRule.Automaton.EnhanceableFeats.Messenger",
+                    "predicate": [
+                        {
+                            "not": "enhancement:messenger"
+                        }
+                    ],
+                    "value": "messenger"
+                }
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.system.automaton.enhancements.greater",
+                "value": {
+                    "label": "PF2E.SpecificRule.Automaton.EnhanceableFeats.Messenger",
+                    "predicate": [
+                        {
+                            "not": "enhancement:messenger"
+                        }
+                    ],
+                    "value": "messenger"
+                }
+            }
+        ],
         "subfeatures": {
             "proficiencies": {},
             "senses": {},

--- a/packs/pf2e/feats/ancestry/automaton/level-1/powerful-tail.json
+++ b/packs/pf2e/feats/ancestry/automaton/level-1/powerful-tail.json
@@ -27,6 +27,34 @@
         },
         "rules": [
             {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.system.automaton.enhancements.lesser",
+                "value": {
+                    "label": "PF2E.SpecificRule.Automaton.EnhanceableFeats.PowerfulTail",
+                    "predicate": [
+                        {
+                            "not": "enhancement:powerful-tail"
+                        }
+                    ],
+                    "value": "powerful-tail"
+                }
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.system.automaton.enhancements.greater",
+                "value": {
+                    "label": "PF2E.SpecificRule.Automaton.EnhanceableFeats.PowerfulTail",
+                    "predicate": [
+                        {
+                            "not": "enhancement:powerful-tail"
+                        }
+                    ],
+                    "value": "powerful-tail"
+                }
+            },
+            {
                 "category": "unarmed",
                 "damage": {
                     "base": {

--- a/packs/pf2e/feats/ancestry/automaton/level-1/undead-hunter.json
+++ b/packs/pf2e/feats/ancestry/automaton/level-1/undead-hunter.json
@@ -29,7 +29,36 @@
             "remaster": true,
             "title": "Pathfinder Impossible Magic"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.system.automaton.enhancements.lesser",
+                "value": {
+                    "label": "PF2E.SpecificRule.Automaton.EnhanceableFeats.UndeadHunter",
+                    "predicate": [
+                        {
+                            "not": "enhancement:undead-hunter"
+                        }
+                    ],
+                    "value": "undead-hunter"
+                }
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.system.automaton.enhancements.greater",
+                "value": {
+                    "label": "PF2E.SpecificRule.Automaton.EnhanceableFeats.UndeadHunter",
+                    "predicate": [
+                        {
+                            "not": "enhancement:undead-hunter"
+                        }
+                    ],
+                    "value": "undead-hunter"
+                }
+            }
+        ],
         "subfeatures": {
             "proficiencies": {},
             "senses": {},

--- a/packs/pf2e/feats/ancestry/automaton/level-5/hardened-chassis.json
+++ b/packs/pf2e/feats/ancestry/automaton/level-5/hardened-chassis.json
@@ -27,6 +27,34 @@
         },
         "rules": [
             {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.system.automaton.enhancements.lesser",
+                "value": {
+                    "label": "PF2E.SpecificRule.Automaton.EnhanceableFeats.HardenedChassis",
+                    "predicate": [
+                        {
+                            "not": "enhancement:hardened-chassis"
+                        }
+                    ],
+                    "value": "hardened-chassis"
+                }
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.system.automaton.enhancements.greater",
+                "value": {
+                    "label": "PF2E.SpecificRule.Automaton.EnhanceableFeats.HardenedChassis",
+                    "predicate": [
+                        {
+                            "not": "enhancement:hardened-chassis"
+                        }
+                    ],
+                    "value": "hardened-chassis"
+                }
+            },
+            {
                 "choices": [
                     {
                         "label": "PF2E.TraitBludgeoning",

--- a/packs/pf2e/feats/ancestry/automaton/level-5/infiltration-automaton.json
+++ b/packs/pf2e/feats/ancestry/automaton/level-5/infiltration-automaton.json
@@ -25,7 +25,36 @@
             "remaster": true,
             "title": "Pathfinder Impossible Magic"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.system.automaton.enhancements.lesser",
+                "value": {
+                    "label": "PF2E.SpecificRule.Automaton.EnhanceableFeats.InfiltrationAutomaton",
+                    "predicate": [
+                        {
+                            "not": "enhancement:infiltration-automaton"
+                        }
+                    ],
+                    "value": "infiltration-automaton"
+                }
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.system.automaton.enhancements.greater",
+                "value": {
+                    "label": "PF2E.SpecificRule.Automaton.EnhanceableFeats.InfiltrationAutomaton",
+                    "predicate": [
+                        {
+                            "not": "enhancement:infiltration-automaton"
+                        }
+                    ],
+                    "value": "infiltration-automaton"
+                }
+            }
+        ],
         "subfeatures": {
             "proficiencies": {},
             "senses": {},

--- a/packs/pf2e/feats/ancestry/automaton/level-5/inscribed-blast.json
+++ b/packs/pf2e/feats/ancestry/automaton/level-5/inscribed-blast.json
@@ -25,7 +25,36 @@
             "remaster": true,
             "title": "Pathfinder Impossible Magic"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.system.automaton.enhancements.lesser",
+                "value": {
+                    "label": "PF2E.SpecificRule.Automaton.EnhanceableFeats.InscribedBlast",
+                    "predicate": [
+                        {
+                            "not": "enhancement:inscribed-blast"
+                        }
+                    ],
+                    "value": "inscribed-blast"
+                }
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.system.automaton.enhancements.greater",
+                "value": {
+                    "label": "PF2E.SpecificRule.Automaton.EnhanceableFeats.InscribedBlast",
+                    "predicate": [
+                        {
+                            "not": "enhancement:inscribed-blast"
+                        }
+                    ],
+                    "value": "inscribed-blast"
+                }
+            }
+        ],
         "subfeatures": {
             "proficiencies": {},
             "senses": {},

--- a/packs/pf2e/feats/ancestry/automaton/level-5/resilient-chassis.json
+++ b/packs/pf2e/feats/ancestry/automaton/level-5/resilient-chassis.json
@@ -33,7 +33,36 @@
             "remaster": true,
             "title": "Pathfinder Impossible Magic"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.system.automaton.enhancements.lesser",
+                "value": {
+                    "label": "PF2E.SpecificRule.Automaton.EnhanceableFeats.ResilientChassis",
+                    "predicate": [
+                        {
+                            "not": "enhancement:resilient-chassis"
+                        }
+                    ],
+                    "value": "resilient-chassis"
+                }
+            },
+            {
+                "key": "ActiveEffectLike",
+                "mode": "add",
+                "path": "flags.system.automaton.enhancements.greater",
+                "value": {
+                    "label": "PF2E.SpecificRule.Automaton.EnhanceableFeats.ResilientChassis",
+                    "predicate": [
+                        {
+                            "not": "enhancement:resilient-chassis"
+                        }
+                    ],
+                    "value": "resilient-chassis"
+                }
+            }
+        ],
         "selfEffect": {
             "name": "Effect: Resilient Chassis",
             "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Resilient Chassis"


### PR DESCRIPTION
The Automaton feat Lesser Augmentation allows a player to select one of
their 1st- or 5th-level automaton ancestry feats to gain its
enhancement benefits.

Lesser Augmentation already enables selection of some feats, such as
Arcane Eye or Resilient Chassis, but Hardened Chassis did not have the
active effect rules which enable it to be selected.

This commit allows Hardened Chassis and the remaining unselectable
1st- or 5th-level feats to be selected for either Lesser
Augmentation or Greater Augmentation.