### PR TITLE
Correct Giant Monitor Lizard AC

### DIFF
--- a/packs/pf2e/pathfinder-monster-core/giant-monitor-lizard.json
+++ b/packs/pf2e/pathfinder-monster-core/giant-monitor-lizard.json
@@ -214,7 +214,7 @@
         "attributes": {
             "ac": {
                 "details": "",
-                "value": 18
+                "value": 16
             },
             "allSaves": {
                 "value": ""


### PR DESCRIPTION
Giant Monitor Lizard AC was changed in its Monster Core printing compared to its Bestiary printing.