### PR TITLE
Add missing traditions to Spectral Blade

### DIFF
--- a/packs/pf2e/spells/spells/rank-3/spectral-blade.json
+++ b/packs/pf2e/spells/spells/rank-3/spectral-blade.json
@@ -58,7 +58,10 @@
         },
         "traits": {
             "rarity": "common",
-            "traditions": [],
+            "traditions": [
+                "divine",
+                "occult"
+            ],
             "value": [
                 "attack",
                 "concentrate",

--- a/packs/pf2e/spells/spells/rank-3/spectral-blade.json
+++ b/packs/pf2e/spells/spells/rank-3/spectral-blade.json
@@ -23,7 +23,7 @@
         },
         "defense": null,
         "description": {
-            "value": "<p>You conjure a spectral throwing blade that always returns to your hand. You throw the blade when you Cast this Spell and the first time you Sustain this spell on subsequent turns, making a ranged spell attack against the AC of a creature within 20 feet. On a hit, you deal @Damage[3d6[spirit]] damage (or double damage on a critical hit). These attacks ignore any circumstance bonuses the target has to AC.</p><hr /><p><strong>Heightened (+1)</strong> The damage increases by 1d6.</p>"
+            "value": "<p>You conjure a spectral throwing blade that always returns to your hand. You throw the blade when you Cast this Spell and the first time you Sustain this spell on subsequent turns, making a ranged spell attack against the AC of a creature within 20 feet. On a hit, you deal 3d6 spirit damage (or double damage on a critical hit). These attacks ignore any circumstance bonuses the target has to AC.</p><hr /><p><strong>Heightened (+1)</strong> The damage increases by 1d6.</p>"
         },
         "duration": {
             "sustained": false,


### PR DESCRIPTION
The tradition field for this spell was left empty. The traditions should be divine and occult as per Impossible Magic.