### PR TITLE
Remove Note from Guillotine Golem's Decapitation

### DIFF
--- a/packs/pf2e/night-of-the-gray-death-bestiary/guillotine-golem.json
+++ b/packs/pf2e/night-of-the-gray-death-bestiary/guillotine-golem.json
@@ -194,17 +194,7 @@
                     "remaster": false,
                     "title": ""
                 },
-                "rules": [
-                    {
-                        "key": "Note",
-                        "outcome": [
-                            "criticalSuccess"
-                        ],
-                        "text": "{item|description}",
-                        "title": "{item|id}",
-                        "visibility": "owner"
-                    }
-                ],
+                "rules": [],
                 "slug": null,
                 "traits": {
                     "rarity": "common",


### PR DESCRIPTION
It's already included in attackEffects. Was also missing selector.