### PR TITLE
Add spell requirements entry to the spell description header

### DIFF
--- a/src/module/item/spell/helpers.ts
+++ b/src/module/item/spell/helpers.ts
@@ -63,6 +63,7 @@ async function createDescriptionPrepend(
         secondaryCasters: spell.system.ritual?.secondary.casters || null,
         primaryCheck: spell.system.ritual?.primary.check?.trim() || null,
         secondaryChecks: spell.system.ritual?.secondary.checks.trim() || null,
+        requirements: spell.system.requirements?.trim() || null,
         range: spell.system.range.value.trim() || null,
         targets: spell.system.target.value.trim() || null,
         area: areaLabel,

--- a/static/templates/items/partials/spell-description-prepend.hbs
+++ b/static/templates/items/partials/spell-description-prepend.hbs
@@ -1,4 +1,6 @@
-{{#if traditions}}<p><strong>{{localize "PF2E.SpellTraditionsLabel"}}</strong> {{traditions}}</p>{{/if}}
+{{#if traditions}}
+    <p><strong>{{localize "PF2E.SpellTraditionsLabel"}}</strong> {{traditions}}</p>
+{{/if}}
 {{#if (or cast cost secondaryCasters)}}
     <p class="item-block-line">
         {{#if cast}}
@@ -40,6 +42,14 @@
         {{/if}}
     </p>
 {{/if}}
+{{#if requirements}}
+    <p class="item-block-line">
+        <span>
+            <strong>{{localize "PF2E.SpellRequirementsLabel"}}</strong>
+            {{requirements}}
+        </span>
+    </p>
+{{/if}}
 {{#if (or range targets area)}}
     <p class="item-block-line{{#unless (or defense duration)}} last{{/unless}}">
         {{#if range}}
@@ -52,7 +62,8 @@
         {{#if area}}
             <span>
                 <strong>{{localize "PF2E.Area.Label"}}</strong>
-                <span {{#unless (eq area.label area.baseLabel)}}class="adjusted" data-tooltip="{{localize "PF2E.Item.Spell.BaseValue" value=area.baseLabel}}"{{/unless}}>
+                <span {{#unless (eq area.label area.baseLabel)}}class="adjusted"
+                    data-tooltip="{{localize "PF2E.Item.Spell.BaseValue" value=area.baseLabel}}" {{/unless}}>
                     {{area.label}}
                 </span>
             </span>
@@ -83,4 +94,6 @@
     </p>
 {{/if}}
 
-{{#if (or traditions cast cost secondaryCasters primaryCheck secondaryChecks range targets area defense duration)}}<hr class="item-block-divider" />{{/if}}
+{{#if (or traditions cast cost secondaryCasters requirements primaryCheck secondaryChecks range targets area defense duration)}}
+    <hr class="item-block-divider" />
+{{/if}}


### PR DESCRIPTION
<img width="642" height="214" alt="image" src="https://github.com/user-attachments/assets/25fe3f5a-a22a-4ea0-86f7-73f43ee1fc4b" />
<img width="298" height="433" alt="image" src="https://github.com/user-attachments/assets/95fe9ba4-d182-46f9-bf1a-1443ded39322" />

Nullcheck is for safety - spells are not datamodeled.