### PR TITLE
Set includesSelf explicitly on Thermal Nimbus aura effect

### DIFF
--- a/packs/pf2e/feat-effects/stance-thermal-nimbus.json
+++ b/packs/pf2e/feat-effects/stance-thermal-nimbus.json
@@ -46,6 +46,7 @@
                 "effects": [
                     {
                         "affects": "allies",
+                        "includesSelf": true,
                         "uuid": "Compendium.pf2e.feat-effects.Item.Effect: Thermal Nimbus"
                     }
                 ],


### PR DESCRIPTION
The Stance: Thermal Nimbus aura grants "Effect: Thermal Nimbus" (the chosen fire/cold resistance) to allies and relies on the Aura schema default for includesSelf. On v14 that default is computed across the whole aura, so an allies effect resolves to includesSelf: false as soon as any effect in the same aura targets enemies. Set includesSelf: true explicitly so the kineticist's own resistance is not implicitly coupled to unrelated aura effects. No behavior change for the base data.