### PR TITLE
Add support for module flag to redirect links between mirrored PF/SF packs

### DIFF
--- a/src/scripts/hooks/init.ts
+++ b/src/scripts/hooks/init.ts
@@ -64,6 +64,23 @@ export const Init = {
                 CONFIG.compendium.uuidRedirects[from] = to;
             }
 
+            // Register mirror packs redirects from active modules
+            const activeModules = [...game.modules.entries()].filter(([_key, foundryModule]) => foundryModule.active);
+            for (const [key, foundryModule] of activeModules) {
+                const flags = foundryModule.flags[key];
+                if (!R.isPlainObject(flags)) continue;
+                const mirrorPacks = flags["pf2e-sf2e-mirror-packs"];
+                if (!R.isArray(mirrorPacks)) continue;
+                for (const pair of mirrorPacks) {
+                    if (!R.isPlainObject(pair)) continue;
+                    if (R.isString(pair.pf2e) && R.isString(pair.sf2e)) {
+                        const from = game.system.id === "pf2e" ? pair.sf2e : pair.pf2e;
+                        const to = game.system.id === "pf2e" ? pair.pf2e : pair.sf2e;
+                        CONFIG.compendium.uuidRedirects[`Compendium.${key}.${from}`] = `Compendium.${key}.${to}`;
+                    }
+                }
+            }
+
             // Register custom enricher
             CONFIG.ux.TextEditor = TextEditorPF2e;
             CONFIG.TextEditor.enrichers.push({

--- a/src/scripts/hooks/init.ts
+++ b/src/scripts/hooks/init.ts
@@ -74,8 +74,7 @@ export const Init = {
                 for (const pair of mirrorPacks) {
                     if (!R.isPlainObject(pair)) continue;
                     if (R.isString(pair.pf2e) && R.isString(pair.sf2e)) {
-                        const from = game.system.id === "pf2e" ? pair.sf2e : pair.pf2e;
-                        const to = game.system.id === "pf2e" ? pair.pf2e : pair.sf2e;
+                        const [from, to] = game.system.id === "pf2e" ? [pair.sf2e, pair.pf2e] : [pair.pf2e, pair.sf2e];
                         CONFIG.compendium.uuidRedirects[`Compendium.${key}.${from}`] = `Compendium.${key}.${to}`;
                     }
                 }


### PR DESCRIPTION
This is a draft change to simplify module maintainability.

The proposed changes will scan active module manifests for flags with the following structure
```
"flags": {
  "pf2e-animal-companions": {
    "pf2e-sf2e-mirror-packs": [
      {
        "pf2e": "AC-effects",
        "sf2e": "sf-AC-effects"
      },
      {
        "pf2e": "AC-Support",
        "sf2e": "sf-AC-Support"
      }
    ]
  }
}
```
(example provided for Companion compendia module and follows the structure from homebrew flag).
On initialization the system will scan active module manifests to find these flags, then add them to redirects.
This way module creators won't have to keep track of replacing links to their own packs which often end up broken still.

By itself this change won't solve the issue entirely, as links to the base system itself would need to be redirected as well. But for that, adding anachronism redirects to the system itself seems like a solid solution, which I would like to explore further.

The end result that I expect is that module developers could just keep one pack when making content, then just clone it and rebuild for the other system.