### PR TITLE
Fix Undead Familiar and Glyph Familiar number of abilities

### DIFF
--- a/packs/pf2e/feats/class/necromancer/level-1/undead-familiar.json
+++ b/packs/pf2e/feats/class/necromancer/level-1/undead-familiar.json
@@ -31,7 +31,7 @@
                 "mode": "upgrade",
                 "path": "system.attributes.familiarAbilities.value",
                 "priority": 19,
-                "value": 2
+                "value": 1
             }
         ],
         "subfeatures": {

--- a/packs/pf2e/feats/class/runesmith/level-1/glyph-familiar.json
+++ b/packs/pf2e/feats/class/runesmith/level-1/glyph-familiar.json
@@ -25,7 +25,15 @@
             "remaster": true,
             "title": "Pathfinder Impossible Magic"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "system.attributes.familiarAbilities.value",
+                "priority": 19,
+                "value": 1
+            }
+        ],
         "subfeatures": {
             "proficiencies": {},
             "senses": {},

--- a/packs/pf2e/feats/class/runesmith/level-2/enhanced-glyph-familiar.json
+++ b/packs/pf2e/feats/class/runesmith/level-2/enhanced-glyph-familiar.json
@@ -29,7 +29,15 @@
             "remaster": true,
             "title": "Pathfinder Impossible Magic"
         },
-        "rules": [],
+        "rules": [
+            {
+                "key": "ActiveEffectLike",
+                "mode": "upgrade",
+                "path": "system.attributes.familiarAbilities.value",
+                "priority": 19,
+                "value": 2
+            }
+        ],
         "subfeatures": {
             "proficiencies": {},
             "senses": {},


### PR DESCRIPTION
Undead Familiar and Glyph Familiar only grant 1 familiar ability
Enhanced Glyph Familiar grants a second familiar ability
