### PR TITLE
Convert `IdentifyItemPopup` to `ApplicationV2`

### DIFF
--- a/src/module/actor/sheet/popups/identify-popup.ts
+++ b/src/module/actor/sheet/popups/identify-popup.ts
@@ -1,78 +1,172 @@
-import { IdentifyAlchemyDCs, IdentifyMagicDCs, getItemIdentificationDCs } from "@item/identification.ts";
+import type { SkillSlug } from "@actor/types.ts";
+import { getIdentificationAdjustment, getIdentificationData, type IdentificationData } from "@item/identification.ts";
 import type { PhysicalItemPF2e } from "@item/physical/index.ts";
 import { ChatMessagePF2e } from "@module/chat-message/index.ts";
-import * as R from "remeda";
-import appv1 = foundry.appv1;
+import { dcAdjustmentOptions, type DCAdjustment } from "@module/dc.ts";
+import { htmlQuery, objectHasKey, signedInteger } from "@util";
 
-export class IdentifyItemPopup extends appv1.api.FormApplication<PhysicalItemPF2e> {
-    static override get defaultOptions(): appv1.api.FormApplicationOptions {
-        return {
-            ...super.defaultOptions,
-            id: "identify-item",
-            title: _loc("PF2E.identification.Identify"),
-            template: `systems/${SYSTEM_ID}/templates/actors/identify-item.hbs`,
-            width: "auto",
-            classes: ["identify-popup"],
-        };
+class IdentifyItemPopup extends fa.api.HandlebarsApplicationMixin<
+    AbstractConstructorOf<fa.api.ApplicationV2> & { DEFAULT_OPTIONS: DeepPartial<IdentifyPopupConfiguration> }
+>(fa.api.ApplicationV2) {
+    declare options: IdentifyPopupConfiguration;
+
+    adjustment!: DCAdjustment;
+
+    constructor(item: PhysicalItemPF2e, options: DeepPartial<fa.ApplicationConfiguration> = {}) {
+        const existing = foundry.applications.instances.get(`identify-item-${item.uuid}`);
+        if (existing instanceof IdentifyItemPopup) return existing;
+
+        super({ ...options, item });
+        this.adjustment = getIdentificationAdjustment(item);
     }
 
-    dcs = getItemIdentificationDCs(this.object, {
-        pwol: game.pf2e.settings.variants.pwol.enabled,
-        notMatchingTraditionModifier: game.settings.get(SYSTEM_ID, "identifyMagicNotMatchingTraditionModifier"),
-    });
+    /** Identification DCs for the currently selected adjustment */
+    get data(): IdentificationData {
+        return getIdentificationData(this.item, {
+            pwol: game.pf2e.settings.variants.pwol.enabled,
+            notMatchingTraditionModifier: game.settings.get(SYSTEM_ID, "identifyMagicNotMatchingTraditionModifier"),
+            adjustment: this.adjustment,
+        });
+    }
 
-    override async getData(): Promise<IdentifyPopupData> {
-        const item = this.object;
+    get item(): PhysicalItemPF2e {
+        return this.options.item;
+    }
+
+    protected override _initializeApplicationOptions(
+        options: Partial<IdentifyPopupConfiguration>,
+    ): IdentifyPopupConfiguration {
+        const initialized = super._initializeApplicationOptions(options) as IdentifyPopupConfiguration;
+        initialized.uniqueId = `identify-item-${initialized.item.uuid}`;
+        return initialized;
+    }
+
+    /** Register with the item so that its deletion closes this application */
+    protected override async _onFirstRender(
+        context: IdentifyPopupContext,
+        options: fa.ApplicationRenderOptions,
+    ): Promise<void> {
+        await super._onFirstRender(context, options);
+        this.item.apps[this.id] = this;
+    }
+
+    protected override _tearDown(options: fa.ApplicationClosingOptions): void {
+        delete this.item.apps[this.id];
+        super._tearDown(options);
+    }
+
+    static override DEFAULT_OPTIONS: DeepPartial<IdentifyPopupConfiguration> = {
+        id: "{id}",
+        classes: ["identify-popup", "column-buttons"],
+        position: { width: "auto" },
+        window: { title: "PF2E.identification.Identify", contentClasses: ["standard-form"] },
+        actions: {
+            postSkillChecks: IdentifyItemPopup.#onClickPostSkillChecks,
+            updateIdentification: IdentifyItemPopup.#onClickUpdateIdentification,
+        },
+    };
+
+    static override PARTS: Record<string, fa.api.HandlebarsTemplatePart> = {
+        base: { template: `systems/${SYSTEM_ID}/templates/actors/identify-item.hbs`, root: true },
+    };
+
+    protected override async _prepareContext(options: fa.ApplicationRenderOptions): Promise<IdentifyPopupContext> {
+        const item = this.item;
+        const data = this.data;
+        const offTradition = new Set<string>(data.offTradition);
+        const modifier = game.settings.get(SYSTEM_ID, "identifyMagicNotMatchingTraditionModifier");
+        const breakdown = (skill: string): string => {
+            const parts = [_loc("PF2E.identification.Breakdown.Base", { level: item.level, dc: data.base })];
+            if (data.adjusted !== data.base) {
+                parts.push(
+                    _loc("PF2E.identification.Breakdown.Adjustment", {
+                        adjustment: _loc(CONFIG.PF2E.dcAdjustments[data.adjustment]).titleCase(),
+                        value: signedInteger(data.adjusted - data.base),
+                    }),
+                );
+            }
+            if (offTradition.has(skill) && modifier) {
+                parts.push(_loc("PF2E.identification.Breakdown.OffTradition", { value: signedInteger(modifier) }));
+            }
+            return parts.join(" · ");
+        };
+
         return {
-            ...(await super.getData()),
+            ...(await super._prepareContext(options)),
+            id: this.id,
+            item,
             isMagic: item.isMagical,
             isAlchemical: item.isAlchemical,
-            dcs: this.dcs,
+            adjustment: this.adjustment,
+            adjustments: dcAdjustmentOptions(),
+            rows: Object.entries(data.dcs).map(([skill, dc]) => ({
+                skill,
+                label: CONFIG.PF2E.skills[skill as SkillSlug]?.label ?? skill,
+                dc,
+                breakdown: breakdown(skill),
+            })),
         };
     }
 
-    override activateListeners($html: JQuery): void {
-        const html = $html[0];
-
-        const updateButton = html.querySelector<HTMLButtonElement>("button.update-identification");
-        updateButton?.addEventListener("click", () => {
-            this.submit({ updateData: { status: updateButton.value } });
-        });
-
-        // Add listener on Post skill checks to chat button that posts item unidentified img and name and skill checks
-        html.querySelector("button.post-skill-checks")?.addEventListener("click", async () => {
-            const item = this.object;
-            const identifiedName = item.system.identification.identified.name;
-            const dcs: Record<string, number> = this.dcs;
-            const action = item.isMagical
-                ? "identify-magic"
-                : item.isAlchemical
-                  ? "identify-alchemy"
-                  : "recall-knowledge";
-
-            const path = `systems/${SYSTEM_ID}/templates/actors/identify-item-chat-skill-checks.hbs`;
-            const content = await fa.handlebars.renderTemplate(path, {
-                identifiedName,
-                action,
-                skills: R.omit(dcs, ["dc"]),
-                unidentified: item.system.identification.unidentified,
-                uuid: item.uuid,
-            });
-
-            await ChatMessagePF2e.create({ author: game.user.id, content });
+    /** Recompute DCs on difficulty adjustment change */
+    protected override async _onRender(
+        context: IdentifyPopupContext,
+        options: fa.ApplicationRenderOptions,
+    ): Promise<void> {
+        await super._onRender(context, options);
+        const select = htmlQuery<HTMLSelectElement>(this.element, "select[data-adjustment]");
+        select?.addEventListener("change", () => {
+            if (objectHasKey(CONFIG.PF2E.dcAdjustments, select.value)) {
+                this.adjustment = select.value;
+                this.render();
+            }
         });
     }
 
-    protected override async _updateObject(_event: Event, formData: Record<string, unknown>): Promise<void> {
-        const status = formData["status"];
-        if (status === "identified") {
-            return this.object.setIdentificationStatus(status);
+    /** Post the item's unidentified image and name along with its identification DCs to chat */
+    static async #onClickPostSkillChecks(this: IdentifyItemPopup): Promise<void> {
+        const item = this.item;
+        const identifiedName = item.system.identification.identified.name;
+        const dcs: Record<string, number> = this.data.dcs;
+        const action = item.isMagical ? "identify-magic" : item.isAlchemical ? "identify-alchemy" : "recall-knowledge";
+
+        const path = `systems/${SYSTEM_ID}/templates/actors/identify-item-chat-skill-checks.hbs`;
+        const content = await fa.handlebars.renderTemplate(path, {
+            identifiedName,
+            action,
+            skills: dcs,
+            unidentified: item.system.identification.unidentified,
+            uuid: item.uuid,
+        });
+
+        await ChatMessagePF2e.create({ author: game.user.id, content });
+    }
+
+    static async #onClickUpdateIdentification(
+        this: IdentifyItemPopup,
+        _event: PointerEvent,
+        target: HTMLElement,
+    ): Promise<void> {
+        // Read the attribute rather than the property: `instanceof` fails for a detached window's elements
+        if (target.getAttribute("value") === "identified") {
+            await this.item.setIdentificationStatus("identified");
         }
+        await this.close();
     }
 }
 
-interface IdentifyPopupData extends appv1.api.FormApplicationData {
+interface IdentifyPopupConfiguration extends fa.ApplicationConfiguration {
+    item: PhysicalItemPF2e;
+}
+
+interface IdentifyPopupContext extends fa.ApplicationRenderContext {
+    id: string;
+    item: PhysicalItemPF2e;
     isMagic: boolean;
     isAlchemical: boolean;
-    dcs: IdentifyMagicDCs | IdentifyAlchemyDCs;
+    adjustment: DCAdjustment;
+    adjustments: { value: DCAdjustment; label: string }[];
+    rows: { skill: string; label: string; dc: number; breakdown: string }[];
 }
+
+export { IdentifyItemPopup };

--- a/src/module/apps/check-prompt-generator.ts
+++ b/src/module/apps/check-prompt-generator.ts
@@ -4,8 +4,8 @@ import type HTMLRangePickerElement from "@client/applications/elements/range-pic
 import type FormDataExtended from "@client/applications/ux/form-data-extended.d.mts";
 import { ChatMessagePF2e } from "@module/chat-message/document.ts";
 import { PROFICIENCY_RANKS } from "@module/data.ts";
-import { adjustDC, calculateDC, calculateSimpleDC, DCAdjustment } from "@module/dc.ts";
-import { signedInteger, tupleHasValue } from "@util";
+import { adjustDC, calculateDC, calculateSimpleDC, dcAdjustmentOptions, DCAdjustment } from "@module/dc.ts";
+import { tupleHasValue } from "@util";
 import { tagify } from "@util/tags.ts";
 import * as R from "remeda";
 
@@ -131,14 +131,7 @@ class CheckPromptGenerator extends fa.api.HandlebarsApplicationMixin(fa.api.Appl
     }
 
     #prepareDCAdjustments(): SelectData[] {
-        return Object.entries(CONFIG.PF2E.dcAdjustments)
-            .filter(([value]) => value !== "normal")
-            .map(([value, label]) => {
-                return {
-                    value,
-                    label: `${_loc(label).titleCase()} (${signedInteger(adjustDC(0, value as DCAdjustment))})`,
-                };
-            });
+        return dcAdjustmentOptions({ includeNormal: false });
     }
 
     protected override async _onRender(context: object, options: fa.ApplicationRenderOptions): Promise<void> {

--- a/src/module/apps/compendium-migration-status/app.svelte
+++ b/src/module/apps/compendium-migration-status/app.svelte
@@ -29,7 +29,7 @@
 </script>
 
 <div class="container" aria-busy={isMigrating}>
-    <dl>
+    <dl class="striped">
         <dt>{_loc("DOCUMENT.FIELDS.name.label")}</dt>
         <dd>{data.label}</dd>
         <dt>{_loc("PF2E.CompendiumMigrationStatus.Document")}</dt>
@@ -102,42 +102,15 @@
         max-width: 20rem;
     }
 
-    dl {
-        display: grid;
-        grid-template-columns: max-content 1fr;
-        margin: 0;
+    dl.striped {
         user-select: text;
 
-        dt,
-        dd {
-            padding: var(--space-3) var(--space-8);
-        }
-
-        // stripe alternating label/value rows
-        dt:nth-of-type(odd),
-        dd:nth-of-type(odd) {
-            background: var(--table-row-color-odd);
-        }
-
-        dt:nth-of-type(even),
-        dd:nth-of-type(even) {
-            background: var(--table-row-color-even);
-        }
-
         dt {
-            font-weight: bold;
-            margin: 0;
             text-align: end;
-            text-shadow: none;
         }
 
-        dd {
-            margin: 0;
-            overflow-wrap: break-word;
-
-            .empty {
-                color: var(--color-text-secondary);
-            }
+        dd .empty {
+            color: var(--color-text-secondary);
         }
     }
 

--- a/src/module/dc.ts
+++ b/src/module/dc.ts
@@ -1,4 +1,5 @@
 import { ProficiencyRank } from "@item/base/data/index.ts";
+import { signedInteger } from "@util";
 import { Rarity } from "./data.ts";
 
 /**
@@ -99,6 +100,16 @@ function adjustDCByRarity(dc: number, rarity: Rarity = "common"): number {
     return adjustDC(dc, rarityToDCAdjustment(rarity));
 }
 
+/** The difficulty adjustments as select options, each labeled with the modifier it applies */
+function dcAdjustmentOptions({ includeNormal = true } = {}): { value: DCAdjustment; label: string }[] {
+    return Object.entries(CONFIG.PF2E.dcAdjustments)
+        .filter(([value]) => includeNormal || value !== "normal")
+        .map(([value, label]) => ({
+            value: value as DCAdjustment,
+            label: `${_loc(label).titleCase()} (${signedInteger(adjustDC(0, value as DCAdjustment))})`,
+        }));
+}
+
 interface DCOptions {
     pwol?: boolean;
     rarity?: Rarity;
@@ -162,6 +173,7 @@ function createDifficultyScale(dc: number, startAt: DCAdjustment): number[] {
 export {
     adjustDC,
     adjustDCByRarity,
+    dcAdjustmentOptions,
     calculateDC,
     calculateSimpleDC,
     calculateSpellDC,

--- a/src/module/item/identification.ts
+++ b/src/module/item/identification.ts
@@ -2,7 +2,7 @@ import type { SkillSlug } from "@actor/types.ts";
 import type { ImageFilePath } from "@common/constants.d.mts";
 import type { Rarity } from "@module/data.ts";
 import { setHasElement } from "@util";
-import { adjustDCByRarity, calculateDC, DCOptions } from "../dc.ts";
+import { adjustDC, calculateDC, DCAdjustment, DCOptions, rarityToDCAdjustment } from "../dc.ts";
 import type { PhysicalItemPF2e } from "./physical/index.ts";
 import type { MagicTradition } from "./spell/types.ts";
 import { MAGIC_TRADITIONS } from "./spell/values.ts";
@@ -26,6 +26,13 @@ function getMagicTraditions(item: PhysicalItemPF2e): Set<MagicTradition> {
 
 type MagicSkill = Extract<SkillSlug, "arcana" | "nature" | "religion" | "occultism">;
 
+const TRADITION_SKILLS: Record<MagicTradition, MagicSkill> = {
+    arcane: "arcana",
+    primal: "nature",
+    divine: "religion",
+    occult: "occultism",
+};
+
 /** All cursed items are incredibly hard to identify */
 function getDcRarity(item: PhysicalItemPF2e): Rarity {
     return item.traits.has("cursed") ? "unique" : item.rarity;
@@ -34,44 +41,66 @@ function getDcRarity(item: PhysicalItemPF2e): Rarity {
 type IdentifyMagicDCs = Record<MagicSkill, number>;
 type IdentifyAlchemyDCs = { crafting: number };
 
-function getIdentifyMagicDCs(
-    item: PhysicalItemPF2e,
-    baseDC: number,
-    notMatchingTraditionModifier: number,
-): IdentifyMagicDCs {
-    const result = {
-        occult: baseDC,
-        primal: baseDC,
-        divine: baseDC,
-        arcane: baseDC,
-    };
+/** Skills whose tradition doesn't match the item's: once an item has a tradition, identifying it with any other is hard */
+function getOffTraditionSkills(item: PhysicalItemPF2e): MagicSkill[] {
     const traditions = getMagicTraditions(item);
-    for (const key of MAGIC_TRADITIONS) {
-        // once an item has a magic tradition, all skills
-        // that don't match the tradition are hard
-        if (traditions.size > 0 && !traditions.has(key)) {
-            result[key] = baseDC + notMatchingTraditionModifier;
-        }
+    if (traditions.size === 0) return [];
+    return Array.from(MAGIC_TRADITIONS)
+        .filter((t) => !traditions.has(t))
+        .map((t) => TRADITION_SKILLS[t]);
+}
+
+function getIdentifyMagicDCs(
+    baseDC: number,
+    offTradition: MagicSkill[],
+    notMatchingModifier: number,
+): IdentifyMagicDCs {
+    const dcs = { arcana: baseDC, nature: baseDC, occultism: baseDC, religion: baseDC };
+    for (const skill of offTradition) {
+        dcs[skill] = baseDC + notMatchingModifier;
     }
-    return { arcana: result.arcane, nature: result.primal, religion: result.divine, occultism: result.occult };
+    return dcs;
 }
 
 interface IdentifyItemOptions extends DCOptions {
     notMatchingTraditionModifier: number;
+    adjustment?: DCAdjustment;
 }
 
-function getItemIdentificationDCs(
+/** The difficulty adjustment an item's DCs starts at */
+function getIdentificationAdjustment(item: PhysicalItemPF2e): DCAdjustment {
+    return rarityToDCAdjustment(getDcRarity(item));
+}
+
+/** Identification DCs along with the parts they were assembled from, for display */
+function getIdentificationData(
     item: PhysicalItemPF2e,
-    { pwol = false, notMatchingTraditionModifier }: IdentifyItemOptions,
-): IdentifyMagicDCs | IdentifyAlchemyDCs {
-    const baseDC = calculateDC(item.level, { pwol });
-    const rarity = getDcRarity(item);
-    const dc = adjustDCByRarity(baseDC, rarity);
-    if (item.isMagical) {
-        return getIdentifyMagicDCs(item, dc, notMatchingTraditionModifier);
-    } else {
-        return { crafting: dc };
-    }
+    { pwol = false, notMatchingTraditionModifier, adjustment }: IdentifyItemOptions,
+): IdentificationData {
+    const base = calculateDC(item.level, { pwol });
+    adjustment ??= getIdentificationAdjustment(item);
+    const dc = adjustDC(base, adjustment);
+    const offTradition = item.isMagical ? getOffTraditionSkills(item) : [];
+
+    return {
+        base,
+        adjustment,
+        adjusted: dc,
+        dcs: item.isMagical ? getIdentifyMagicDCs(dc, offTradition, notMatchingTraditionModifier) : { crafting: dc },
+        offTradition,
+    };
+}
+
+interface IdentificationData {
+    /** The level-based DC, before adjustment */
+    base: number;
+    /** The adjustment applied to the base DC */
+    adjustment: DCAdjustment;
+    /** The base DC after adjustment, and before any not-matching-tradition modifier */
+    adjusted: number;
+    dcs: IdentifyMagicDCs | IdentifyAlchemyDCs;
+    /** Skills whose DC includes the not-matching-tradition modifier */
+    offTradition: MagicSkill[];
 }
 
 function getUnidentifiedPlaceholderImage(item: PhysicalItemPF2e): ImageFilePath {
@@ -132,5 +161,5 @@ function getUnidentifiedPlaceholderImage(item: PhysicalItemPF2e): ImageFilePath 
     return `systems/${SYSTEM_ID}/icons/unidentified_item_icons/${iconName}.webp`;
 }
 
-export { getItemIdentificationDCs, getUnidentifiedPlaceholderImage };
-export type { IdentifyAlchemyDCs, IdentifyMagicDCs };
+export { getIdentificationAdjustment, getIdentificationData, getUnidentifiedPlaceholderImage };
+export type { IdentificationData, IdentifyAlchemyDCs, IdentifyMagicDCs, MagicSkill };

--- a/src/styles/_application.scss
+++ b/src/styles/_application.scss
@@ -1,9 +1,41 @@
 // Application V2
 .application {
-    // Stack a dialog's buttons in full-width rows: for skill/option pickers with several buttons
-    &.dialog.column-buttons .form-footer {
+    // Stack an application's buttons in full-width rows: for skill/option pickers and long button labels
+    &.column-buttons .form-footer {
         align-items: stretch;
         flex-direction: column;
+    }
+
+    // Two-column term/value list with striped rows: terms hug their content, values take the rest
+    dl.striped {
+        display: grid;
+        grid-template-columns: max-content 1fr;
+        margin: 0;
+
+        dt,
+        dd {
+            margin: 0;
+            padding: var(--space-3) var(--space-8);
+        }
+
+        dt:nth-of-type(odd),
+        dd:nth-of-type(odd) {
+            background: var(--table-row-color-odd);
+        }
+
+        dt:nth-of-type(even),
+        dd:nth-of-type(even) {
+            background: var(--table-row-color-even);
+        }
+
+        dt {
+            font-weight: bold;
+            text-shadow: none;
+        }
+
+        dd {
+            overflow-wrap: break-word;
+        }
     }
 
     .window-content.compact {

--- a/src/styles/actor/_identify-popup.scss
+++ b/src/styles/actor/_identify-popup.scss
@@ -1,0 +1,61 @@
+.application.identify-popup {
+    // A little room to breathe, and a cap so longer translations wrap instead of stretching the window
+    min-width: 17rem;
+    max-width: 22rem;
+
+    // Allow a popped-out window to be scrolled if resized
+    .window-content {
+        overflow-y: auto;
+    }
+
+    .item-header {
+        align-items: center;
+        display: flex;
+        gap: var(--space-8);
+
+        img {
+            border: none;
+            flex: 0 0 auto;
+            height: 40px;
+            width: 40px;
+        }
+
+        .name {
+            font-weight: 500;
+        }
+    }
+
+    h2 {
+        background: var(--table-header-bg-color);
+        font-family: inherit;
+        font-size: var(--font-size-16);
+        font-variant: small-caps;
+        letter-spacing: 0.03em;
+        line-height: 1.2;
+        margin: 0;
+        padding: var(--space-2) var(--space-8);
+        text-align: center;
+    }
+
+    // Size the select to its widest option, so longer translations aren't clipped
+    .form-group {
+        label {
+            flex: 0 0 auto;
+        }
+
+        select {
+            max-width: 100%;
+            width: max-content;
+        }
+    }
+
+    // Meet the label and DC in the middle
+    dl.dcs {
+        column-gap: var(--space-16);
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+
+        dt {
+            text-align: end;
+        }
+    }
+}

--- a/src/styles/actor/_index.scss
+++ b/src/styles/actor/_index.scss
@@ -465,3 +465,5 @@
 @import "army";
 
 @import "item-transfer-dialog";
+
+@import "identify-popup";

--- a/src/styles/item/_mystification.scss
+++ b/src/styles/item/_mystification.scss
@@ -1,7 +1,3 @@
-.identify-popup {
-    min-width: 300px;
-}
-
 .sheet-body .tab.mystification.active {
     .mystification-status {
         select {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -7189,6 +7189,12 @@
             }
         },
         "identification": {
+            "Breakdown": {
+                "Adjustment": "{adjustment} {value}",
+                "Base": "Level {level} DC {dc}",
+                "OffTradition": "Off-tradition {value}"
+            },
+            "Difficulty": "Difficulty",
             "DisplayDetails": "Display Details",
             "Identified": "Identified",
             "Identify": "Identify Item",

--- a/static/templates/actors/identify-item.hbs
+++ b/static/templates/actors/identify-item.hbs
@@ -1,44 +1,40 @@
-<form autocomplete="off">
-    {{#if isMagic}}
-        <h1>{{localize "PF2E.identification.IdentifyMagicDCs"}}</h1>
-        <table>
-            <tbody>
-                <tr data-skill="arcana" data-dc="{{dcs.arcana}}">
-                    <th>{{localize "PF2E.Skill.Arcana"}}</th>
-                    <td>{{dcs.arcana}}</td>
-                </tr>
-                <tr data-skill="nature" data-dc="{{dcs.nature}}">
-                    <th>{{localize "PF2E.Skill.Nature"}}</th>
-                    <td>{{dcs.nature}}</td>
-                </tr>
-                <tr data-skill="occultism" data-dc="{{dcs.occultism}}">
-                    <th>{{localize "PF2E.Skill.Occultism"}}</th>
-                    <td>{{dcs.occultism}}</td>
-                </tr>
-                <tr data-skill="religion" data-dc="{{dcs.religion}}">
-                    <th>{{localize "PF2E.Skill.Religion"}}</th>
-                    <td>{{dcs.religion}}</td>
-                </tr>
-            </tbody>
-        </table>
-    {{else}}
-        <h1>
-            {{localize (ifThen isAlchemical "PF2E.identification.IdentifyAlchemyDCs" "PF2E.identification.IdentifyGenericDCs")}}
-        </h1>
-        <table>
-            <tbody>
-                <tr data-skill="crafting" data-dc="{{dcs.crafting}}">
-                    <th>{{localize "PF2E.Skill.Crafting"}}</th>
-                    <td>{{dcs.crafting}}</td>
-                </tr>
-            </tbody>
-        </table>
-    {{/if}}
-    <button type="button" class="post-skill-checks">
-        <i class="fa-solid fa-message fa-fw"></i>{{localize "PF2E.identification.PostSkillsToChat"}}
+<div class="item-header">
+    <img src="{{item.img}}" alt="" />
+    <span class="name">{{item.name}}</span>
+</div>
+<section class="identification-dcs" aria-labelledby="{{id}}-dcs">
+    <h2 id="{{id}}-dcs">
+        {{#if isMagic}}
+            {{localize "PF2E.identification.IdentifyMagicDCs"}}
+        {{else if isAlchemical}}
+            {{localize "PF2E.identification.IdentifyAlchemyDCs"}}
+        {{else}}
+            {{localize "PF2E.identification.IdentifyGenericDCs"}}
+        {{/if}}
+    </h2>
+    <dl class="dcs striped">
+        {{#each rows as |row|}}
+            <dt data-tooltip-text="{{row.breakdown}}">{{localize row.label}}</dt>
+            <dd data-tooltip-text="{{row.breakdown}}">
+                {{row.dc}}
+                <span class="sr-only">({{row.breakdown}})</span>
+            </dd>
+        {{/each}}
+    </dl>
+</section>
+<div class="form-group slim">
+    <label for="{{id}}-adjustment">{{localize "PF2E.identification.Difficulty"}}</label>
+    <div class="form-fields">
+        <select id="{{id}}-adjustment" data-adjustment>
+            {{selectOptions adjustments valueAttr="value" labelAttr="label" selected=adjustment}}
+        </select>
+    </div>
+</div>
+<div class="form-footer">
+    <button type="button" class="post-skill-checks" data-action="postSkillChecks">
+        <i class="fa-solid fa-message" aria-hidden="true"></i>{{localize "PF2E.identification.PostSkillsToChat"}}
     </button>
-    <button type="button" class="update-identification" value="identified">
-        <i class="fa-regular fa-circle-question"></i>{{localize "PF2E.identification.Identify"}}
+    <button type="button" class="update-identification" data-action="updateIdentification" value="identified">
+        <i class="fa-regular fa-circle-question" aria-hidden="true"></i>{{localize "PF2E.identification.Identify"}}
     </button>
-    <input type="hidden" name="status" />
-</form>
+</div>

--- a/tests/module/identification.test.ts
+++ b/tests/module/identification.test.ts
@@ -1,0 +1,79 @@
+import { getIdentificationAdjustment, getIdentificationData } from "@item/identification.ts";
+import type { PhysicalItemPF2e } from "@item/physical/index.ts";
+import type { Rarity } from "@module/data.ts";
+
+function itemStub({
+    level = 4,
+    rarity = "common",
+    traits = [],
+    isMagical = false,
+}: {
+    level?: number;
+    rarity?: Rarity;
+    traits?: string[];
+    isMagical?: boolean;
+} = {}): PhysicalItemPF2e {
+    return {
+        level,
+        rarity,
+        isMagical,
+        traits: new Set(traits),
+        system: { traits: { value: traits } },
+    } as unknown as PhysicalItemPF2e;
+}
+
+const options = { notMatchingTraditionModifier: 5 };
+
+describe("identification DCs", () => {
+    test("adjustment is seeded from rarity, with cursed items treated as unique", () => {
+        expect(getIdentificationAdjustment(itemStub({ rarity: "common" }))).toBe("normal");
+        expect(getIdentificationAdjustment(itemStub({ rarity: "uncommon" }))).toBe("hard");
+        expect(getIdentificationAdjustment(itemStub({ rarity: "rare" }))).toBe("very-hard");
+        expect(getIdentificationAdjustment(itemStub({ rarity: "unique" }))).toBe("incredibly-hard");
+        expect(getIdentificationAdjustment(itemStub({ rarity: "common", traits: ["cursed"] }))).toBe("incredibly-hard");
+    });
+
+    test("non-magical items use a single crafting DC", () => {
+        const data = getIdentificationData(itemStub({ level: 4 }), options);
+        expect(data.base).toBe(19);
+        expect(data.adjusted).toBe(19);
+        expect(data.dcs).toEqual({ crafting: 19 });
+        expect(data.offTradition).toEqual([]);
+    });
+
+    test("rarity raises the DC by its adjustment", () => {
+        expect(getIdentificationData(itemStub({ level: 4, rarity: "uncommon" }), options).adjusted).toBe(21);
+        expect(getIdentificationData(itemStub({ level: 4, rarity: "rare" }), options).adjusted).toBe(24);
+    });
+
+    test("an explicit adjustment overrides the rarity-derived one", () => {
+        const data = getIdentificationData(itemStub({ level: 4, rarity: "rare" }), { ...options, adjustment: "easy" });
+        expect(data.adjustment).toBe("easy");
+        expect(data.adjusted).toBe(17);
+    });
+
+    test("magical items without a tradition share one DC across all four skills", () => {
+        const data = getIdentificationData(itemStub({ level: 3, isMagical: true, traits: ["magical"] }), options);
+        expect(data.dcs).toEqual({ arcana: 18, nature: 18, occultism: 18, religion: 18 });
+        expect(data.offTradition).toEqual([]);
+    });
+
+    test("skills off the item's tradition take the not-matching modifier", () => {
+        const data = getIdentificationData(itemStub({ level: 3, isMagical: true, traits: ["arcane"] }), options);
+        expect(data.dcs).toEqual({ arcana: 18, nature: 23, occultism: 23, religion: 23 });
+        expect(data.offTradition.sort()).toEqual(["nature", "occultism", "religion"]);
+    });
+
+    test("the adjustment applies before the not-matching modifier", () => {
+        const item = itemStub({ level: 3, rarity: "uncommon", isMagical: true, traits: ["divine"] });
+        const data = getIdentificationData(item, options);
+        expect(data.base).toBe(18);
+        expect(data.adjusted).toBe(20);
+        expect(data.dcs).toEqual({ arcana: 25, nature: 25, occultism: 25, religion: 20 });
+    });
+
+    test("proficiency without level lowers the base DC", () => {
+        const data = getIdentificationData(itemStub({ level: 4 }), { ...options, pwol: true });
+        expect(data.base).toBe(15);
+    });
+});


### PR DESCRIPTION
Difficulty adjustments to the DC can now be set from the identify popup, with the adjustment for the item's rarity pre-selected.

<img width="272" height="395" alt="identify-item-dark" src="https://github.com/user-attachments/assets/e50ec60c-90a4-427a-a960-036f77145049" />
<img width="272" height="395" alt="identify-item-light" src="https://github.com/user-attachments/assets/60366333-4b6f-43a2-90fc-c4a709690d68" />
