### PR TITLE
Make solarian potency crystal bonus apply to maneuvers

### DIFF
--- a/packs/sf2e/equipment/solarian-crystals/1-weapon-potency-crystal.json
+++ b/packs/sf2e/equipment/solarian-crystals/1-weapon-potency-crystal.json
@@ -92,6 +92,69 @@
                 "slug": "weapon-potency",
                 "type": "item",
                 "value": 1
+            },
+            {
+                "key": "FlatModifier",
+                "label": "PF2E.Item.Weapon.Rune.Potency",
+                "predicate": [
+                    {
+                        "or": [
+                            {
+                                "and": [
+                                    "action:disarm",
+                                    "1-potency-crystal:solar-weapon",
+                                    {
+                                        "or": [
+                                            "solar-weapon-trait-one:disarm",
+                                            "solar-weapon-trait-two:disarm"
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "and": [
+                                    "action:grapple",
+                                    "1-potency-crystal:solar-weapon",
+                                    {
+                                        "or": [
+                                            "solar-weapon-trait-one:grapple",
+                                            "solar-weapon-trait-two:grapple"
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "and": [
+                                    "action:shove",
+                                    "1-potency-crystal:solar-weapon",
+                                    {
+                                        "or": [
+                                            "solar-weapon-trait-one:shove",
+                                            "solar-weapon-trait-two:shove"
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "and": [
+                                    "action:trip",
+                                    "1-potency-crystal:solar-weapon",
+                                    {
+                                        "or": [
+                                            "solar-weapon-trait-one:trip",
+                                            "solar-weapon-trait-two:trip"
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "selector": [
+                    "skill-check"
+                ],
+                "type": "item",
+                "value": 1
             }
         ],
         "size": "med",

--- a/packs/sf2e/equipment/solarian-crystals/1-weapon-potency-crystal.json
+++ b/packs/sf2e/equipment/solarian-crystals/1-weapon-potency-crystal.json
@@ -151,7 +151,7 @@
                     }
                 ],
                 "selector": [
-                    "skill-check"
+                    "athletics"
                 ],
                 "type": "item",
                 "value": 1

--- a/packs/sf2e/equipment/solarian-crystals/2-weapon-potency-crystal.json
+++ b/packs/sf2e/equipment/solarian-crystals/2-weapon-potency-crystal.json
@@ -89,6 +89,70 @@
                 "slug": "weapon-potency",
                 "type": "item",
                 "value": 2
+            },
+            {
+                "hideIfDisabled": true,
+                "key": "FlatModifier",
+                "label": "PF2E.Item.Weapon.Rune.Potency",
+                "predicate": [
+                    {
+                        "or": [
+                            {
+                                "and": [
+                                    "action:disarm",
+                                    "2-potency-crystal:solar-weapon",
+                                    {
+                                        "or": [
+                                            "solar-weapon-trait-one:disarm",
+                                            "solar-weapon-trait-two:disarm"
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "and": [
+                                    "action:grapple",
+                                    "2-potency-crystal:solar-weapon",
+                                    {
+                                        "or": [
+                                            "solar-weapon-trait-one:grapple",
+                                            "solar-weapon-trait-two:grapple"
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "and": [
+                                    "action:shove",
+                                    "2-potency-crystal:solar-weapon",
+                                    {
+                                        "or": [
+                                            "solar-weapon-trait-one:shove",
+                                            "solar-weapon-trait-two:shove"
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "and": [
+                                    "action:trip",
+                                    "2-potency-crystal:solar-weapon",
+                                    {
+                                        "or": [
+                                            "solar-weapon-trait-one:trip",
+                                            "solar-weapon-trait-two:trip"
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "selector": [
+                    "skill-check"
+                ],
+                "type": "item",
+                "value": 2
             }
         ],
         "size": "med",

--- a/packs/sf2e/equipment/solarian-crystals/2-weapon-potency-crystal.json
+++ b/packs/sf2e/equipment/solarian-crystals/2-weapon-potency-crystal.json
@@ -149,7 +149,7 @@
                     }
                 ],
                 "selector": [
-                    "skill-check"
+                    "athletics"
                 ],
                 "type": "item",
                 "value": 2

--- a/packs/sf2e/equipment/solarian-crystals/3-weapon-potency-crystal.json
+++ b/packs/sf2e/equipment/solarian-crystals/3-weapon-potency-crystal.json
@@ -92,6 +92,70 @@
                 "slug": "weapon-potency",
                 "type": "item",
                 "value": 3
+            },
+            {
+                "hideIfDisabled": true,
+                "key": "FlatModifier",
+                "label": "PF2E.Item.Weapon.Rune.Potency",
+                "predicate": [
+                    {
+                        "or": [
+                            {
+                                "and": [
+                                    "action:disarm",
+                                    "3-potency-crystal:solar-weapon",
+                                    {
+                                        "or": [
+                                            "solar-weapon-trait-one:disarm",
+                                            "solar-weapon-trait-two:disarm"
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "and": [
+                                    "action:grapple",
+                                    "3-potency-crystal:solar-weapon",
+                                    {
+                                        "or": [
+                                            "solar-weapon-trait-one:grapple",
+                                            "solar-weapon-trait-two:grapple"
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "and": [
+                                    "action:shove",
+                                    "3-potency-crystal:solar-weapon",
+                                    {
+                                        "or": [
+                                            "solar-weapon-trait-one:shove",
+                                            "solar-weapon-trait-two:shove"
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "and": [
+                                    "action:trip",
+                                    "3-potency-crystal:solar-weapon",
+                                    {
+                                        "or": [
+                                            "solar-weapon-trait-one:trip",
+                                            "solar-weapon-trait-two:trip"
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "selector": [
+                    "skill-check"
+                ],
+                "type": "item",
+                "value": 3
             }
         ],
         "size": "med",

--- a/packs/sf2e/equipment/solarian-crystals/3-weapon-potency-crystal.json
+++ b/packs/sf2e/equipment/solarian-crystals/3-weapon-potency-crystal.json
@@ -152,7 +152,7 @@
                     }
                 ],
                 "selector": [
-                    "skill-check"
+                    "athletics"
                 ],
                 "type": "item",
                 "value": 3


### PR DESCRIPTION
As per weapon traits:
_This uses the weapon's reach (if different from your own) and adds the weapon's item bonus to attack rolls as an item bonus to the Athletics check._