### PR TITLE
Add missing ellipse shape to footprint function

### DIFF
--- a/src/module/canvas/token/object.ts
+++ b/src/module/canvas/token/object.ts
@@ -42,6 +42,7 @@ class TokenPF2e<TDocument extends TokenDocumentPF2e = TokenDocumentPF2e> extends
                 shape.points = shape.points.map((c, i) => (i % 2 === 0 ? c + bounds.x : c + bounds.y));
                 return shape;
             }
+            case PIXI.SHAPES.ELIP:
             case PIXI.SHAPES.CIRC: {
                 const shape = this.shape.clone();
                 const center = this.center;

--- a/types/foundry/client/canvas/placeables/token.d.mts
+++ b/types/foundry/client/canvas/placeables/token.d.mts
@@ -734,7 +734,7 @@ export default interface Token<TDocument extends TokenDocument = TokenDocument> 
     get layer(): TokenLayer<this>;
 }
 
-type TokenShape = Extract<PlaceableShape, PIXI.Circle | PIXI.Polygon | PIXI.Rectangle>;
+type TokenShape = Extract<PlaceableShape, PIXI.Ellipse | PIXI.Circle | PIXI.Polygon | PIXI.Rectangle>;
 
 interface TokenResourceData {
     attribute: string;


### PR DESCRIPTION
This fixes the `footprint()` function for cases where the token has an ellipse shape on gridless maps. This was causing the hover ruler to not work.