### PR TITLE
Fit emanations created from region tools to hovered tokens

### DIFF
--- a/src/module/canvas/layer/region.ts
+++ b/src/module/canvas/layer/region.ts
@@ -94,7 +94,7 @@ export class RegionLayerPF2e extends fc.layers.RegionLayer<RegionPF2e> {
     /** Fit an emanation region shape base to underlying token while drawing with the region tools. */
     protected override _createDragShapeData(event: PlaceablesLayerEvent<RegionPF2e>): BaseShapeData {
         const shape = super._createDragShapeData(event) as EmanationShapeData;
-        if (!canvas?.scene || shape?.type !== "emanation" || shape?.base?.type !== "token") return shape;
+        if (!this.templateMode || shape.type !== "emanation" || shape.base.type !== "token") return shape;
         const { x, y } = event.interactionData.origin;
         const tokens = canvas.tokens.quadtree.getObjects(new PIXI.Rectangle(x, y, 0, 0));
         const token = tokens.values().next().value?.document;

--- a/src/module/canvas/layer/region.ts
+++ b/src/module/canvas/layer/region.ts
@@ -2,7 +2,13 @@ import type {
     PlaceablesLayerEvent,
     PlaceablesLayerPointerEvent,
 } from "@client/canvas/layers/base/placeables-layer.d.mts";
-import type { ConeShapeData, LineShapeData, EmanationShapeData, TokenShapeData } from "@common/data/data.d.mts";
+import type {
+    BaseShapeData,
+    ConeShapeData,
+    LineShapeData,
+    EmanationShapeData,
+    TokenShapeData,
+} from "@common/data/data.d.mts";
 import { RegionDocumentPF2e } from "@scene";
 import { RegionPF2e } from "../index.ts";
 
@@ -86,24 +92,18 @@ export class RegionLayerPF2e extends fc.layers.RegionLayer<RegionPF2e> {
     }
 
     /** Fit an emanation region shape base to underlying token while drawing with the region tools. */
-    protected override _createDragShapeData(event: PlaceablesLayerEvent<RegionPF2e>): foundry.data.BaseShapeData {
+    protected override _createDragShapeData(event: PlaceablesLayerEvent<RegionPF2e>): BaseShapeData {
         const shape = super._createDragShapeData(event) as EmanationShapeData;
-        if (canvas?.scene && shape?.type === "emanation" && shape?.base?.type === "token") {
-            const gridSize = canvas.grid.size;
-            const inBoundTokens = canvas.scene.tokens.filter((token) => {
-                const { x, y, width, height } = token;
-                return (
-                    event.interactionData.origin.x.between(x, x + width * gridSize) &&
-                    event.interactionData.origin.y.between(y, y + height * gridSize)
-                );
-            });
-            if (inBoundTokens.length === 1) {
-                const base = shape.base as TokenShapeData;
-                base.shape = inBoundTokens[0].shape;
-                base.width = inBoundTokens[0].width;
-                base.height = inBoundTokens[0].height;
-                event.interactionData.origin = inBoundTokens[0].getCenterPoint();
-            }
+        if (!canvas?.scene || shape?.type !== "emanation" || shape?.base?.type !== "token") return shape;
+        const { x, y } = event.interactionData.origin;
+        const tokens = canvas.tokens.quadtree.getObjects(new PIXI.Rectangle(x, y, 0, 0));
+        const token = tokens.values().next().value?.document;
+        if (tokens.size === 1 && token) {
+            const base = shape.base as TokenShapeData;
+            base.shape = token.shape;
+            base.width = token.width;
+            base.height = token.height;
+            event.interactionData.origin = token.getCenterPoint();
         }
         return shape;
     }

--- a/src/module/canvas/layer/region.ts
+++ b/src/module/canvas/layer/region.ts
@@ -2,13 +2,7 @@ import type {
     PlaceablesLayerEvent,
     PlaceablesLayerPointerEvent,
 } from "@client/canvas/layers/base/placeables-layer.d.mts";
-import type {
-    BaseShapeData,
-    ConeShapeData,
-    LineShapeData,
-    EmanationShapeData,
-    TokenShapeData,
-} from "@common/data/data.d.mts";
+import type { ConeShapeData, LineShapeData, RingShapeData, SpecificShapeData } from "@common/data/data.d.mts";
 import { RegionDocumentPF2e } from "@scene";
 import { RegionPF2e } from "../index.ts";
 
@@ -92,14 +86,20 @@ export class RegionLayerPF2e extends fc.layers.RegionLayer<RegionPF2e> {
     }
 
     /** Fit an emanation region shape base to underlying token while drawing with the region tools. */
-    protected override _createDragShapeData(event: PlaceablesLayerEvent<RegionPF2e>): BaseShapeData {
-        const shape = super._createDragShapeData(event) as EmanationShapeData;
-        if (!this.templateMode || shape.type !== "emanation" || shape.base.type !== "token") return shape;
+    protected override _createDragShapeData(
+        event: PlaceablesLayerEvent<RegionPF2e>,
+    ): DeepPartial<Exclude<SpecificShapeData, RingShapeData>["_source"]> {
+        const shape = super._createDragShapeData(event);
+        if (!this.templateMode || shape.type !== "emanation" || shape.base?.type !== "token") return shape;
         const { x, y } = event.interactionData.origin;
-        const tokens = canvas.tokens.quadtree.getObjects(new PIXI.Rectangle(x, y, 0, 0));
-        const token = tokens.values().next().value?.document;
-        if (tokens.size === 1 && token) {
-            const base = shape.base as TokenShapeData;
+        const tokens = canvas.tokens.quadtree
+            .getObjects(new PIXI.Rectangle(x, y, 0, 0))
+            .values()
+            .filter((t) => t.actor?.isOfType("creature", "army", "hazard"))
+            .toArray();
+        if (tokens.length === 1) {
+            const token = tokens[0].document;
+            const base = shape.base;
             base.shape = token.shape;
             base.width = token.width;
             base.height = token.height;

--- a/src/module/canvas/layer/region.ts
+++ b/src/module/canvas/layer/region.ts
@@ -1,5 +1,8 @@
-import type { PlaceablesLayerPointerEvent } from "@client/canvas/layers/base/placeables-layer.d.mts";
-import type { ConeShapeData, LineShapeData } from "@common/data/data.d.mts";
+import type {
+    PlaceablesLayerEvent,
+    PlaceablesLayerPointerEvent,
+} from "@client/canvas/layers/base/placeables-layer.d.mts";
+import type { ConeShapeData, LineShapeData, EmanationShapeData, TokenShapeData } from "@common/data/data.d.mts";
 import { RegionDocumentPF2e } from "@scene";
 import { RegionPF2e } from "../index.ts";
 
@@ -80,5 +83,28 @@ export class RegionLayerPF2e extends fc.layers.RegionLayer<RegionPF2e> {
             placed.updateSource({ rotation });
             this._updateDragPreview(event);
         }
+    }
+
+    /** Fit an emanation region shape base to underlying token while drawing with the region tools. */
+    protected override _createDragShapeData(event: PlaceablesLayerEvent<RegionPF2e>): foundry.data.BaseShapeData {
+        const shape = super._createDragShapeData(event) as EmanationShapeData;
+        if (canvas?.scene && shape?.type === "emanation" && shape?.base?.type === "token") {
+            const gridSize = canvas.grid.size;
+            const inBoundTokens = canvas.scene.tokens.filter((token) => {
+                const { x, y, width, height } = token;
+                return (
+                    event.interactionData.origin.x.between(x, x + width * gridSize) &&
+                    event.interactionData.origin.y.between(y, y + height * gridSize)
+                );
+            });
+            if (inBoundTokens.length === 1) {
+                const base = shape.base as TokenShapeData;
+                base.shape = inBoundTokens[0].shape;
+                base.width = inBoundTokens[0].width;
+                base.height = inBoundTokens[0].height;
+                event.interactionData.origin = inBoundTokens[0].getCenterPoint();
+            }
+        }
+        return shape;
     }
 }


### PR DESCRIPTION
Allow emanations placed via region tools to auto fit to a token in measured template mode. This happens only if there is a single token where the emanation is being placed.