### PR TITLE
Limit selection of "coin" category in treasure sheet to standard coin items

### DIFF
--- a/src/module/item/treasure/sheet.ts
+++ b/src/module/item/treasure/sheet.ts
@@ -1,7 +1,5 @@
 import type { ItemSheetOptions } from "@item/base/sheet/sheet.ts";
 import { PhysicalItemSheetData, PhysicalItemSheetPF2e } from "@item/physical/index.ts";
-import { localizer } from "@util";
-import * as R from "remeda";
 import type { TreasureSystemSchema } from "./data.ts";
 import type { TreasurePF2e } from "./document.ts";
 import type { TreasureCategory } from "./types.ts";
@@ -9,8 +7,13 @@ import { TREASURE_CATEGORIES } from "./values.ts";
 
 export class TreasureSheetPF2e extends PhysicalItemSheetPF2e<TreasurePF2e> {
     override async getData(options?: Partial<ItemSheetOptions>): Promise<TreasureSheetData> {
-        const localize = localizer("PF2E.Item.Treasure.FIELDS.category.choices");
         const data = await super.getData(options);
+        const coinSlugs = ["copper-pieces", "silver-pieces", "gold-pieces", "platinum-pieces"];
+        const categories = TREASURE_CATEGORIES.map((c) => ({
+            value: c,
+            label: _loc(`PF2E.Item.Treasure.FIELDS.category.choices.${c}`),
+            disabled: (c === "coin") !== coinSlugs.includes(this.item.slug ?? ""),
+        })).sort((a, b) => Number(a.disabled) - Number(b.disabled) || a.label.localeCompare(b.label, game.i18n.lang));
 
         // Always render the price of credsticks as if it were sf2e, even in pf2e
         if (this.item.system.category === "credstick") {
@@ -18,7 +21,7 @@ export class TreasureSheetPF2e extends PhysicalItemSheetPF2e<TreasurePF2e> {
         }
 
         return Object.assign(data, {
-            categories: R.mapToObj(TREASURE_CATEGORIES, (c) => [c, localize(c)]),
+            categories,
             currencies: CONFIG.PF2E.currencies,
             systemFields: this.item.system.schema.fields,
         });
@@ -27,6 +30,6 @@ export class TreasureSheetPF2e extends PhysicalItemSheetPF2e<TreasurePF2e> {
 
 interface TreasureSheetData extends PhysicalItemSheetData<TreasurePF2e> {
     currencies: ConfigPF2e["PF2E"]["currencies"];
-    categories: Record<TreasureCategory, string>;
+    categories: { value: TreasureCategory; label: string; disabled: boolean }[];
     systemFields: TreasureSystemSchema;
 }

--- a/static/templates/items/physical-sidebar.hbs
+++ b/static/templates/items/physical-sidebar.hbs
@@ -14,7 +14,7 @@
             </select>
         </div>
     {{else if (eq item.type "treasure")}}
-        {{formGroup systemFields.category choices=categories value=item.system.category}}
+        {{formGroup systemFields.category value=item.system.category options=categories}}
     {{else if (nor (eq item.type "armor") (eq item.type "shield") (eq item.type "ammo"))}}
         <div class="form-group">
             <label for="{{fieldIdPrefix}}usage">{{localize "PF2E.Usage"}}</label>


### PR DESCRIPTION
- Closes #23024

Coins have a lot of baked-in handling, and opening it up would require significant refactoring and possible migrations.