### PR TITLE
Remove empty filters and traits not associated with any items in compendium browser

### DIFF
--- a/src/module/apps/compendium-browser/components/filters.svelte
+++ b/src/module/apps/compendium-browser/components/filters.svelte
@@ -108,16 +108,18 @@
         <Traits bind:traits={filter.traits} />
     </FilterContainer>
     {#each Object.entries(filter.checkboxes) as [key, checkbox]}
-        <FilterContainer
-            isExpanded={checkbox.isExpanded}
-            clearButton={{
-                options: { visible: checkbox.selected.length > 0 },
-                clear: getClearFunction(checkbox),
-            }}
-            label={checkbox.label}
-        >
-            <Checkboxes bind:checkbox={filter.checkboxes[key as keyof BrowserFilter["checkboxes"]]} />
-        </FilterContainer>
+        {#if !R.isEmpty(checkbox.options)}
+            <FilterContainer
+                isExpanded={checkbox.isExpanded}
+                clearButton={{
+                    options: { visible: checkbox.selected.length > 0 },
+                    clear: getClearFunction(checkbox),
+                }}
+                label={checkbox.label}
+            >
+                <Checkboxes bind:checkbox={filter.checkboxes[key as keyof BrowserFilter["checkboxes"]]} />
+            </FilterContainer>
+        {/if}
     {/each}
     {#if filter.source}
         <FilterContainer

--- a/src/module/apps/compendium-browser/tabs/base.svelte.ts
+++ b/src/module/apps/compendium-browser/tabs/base.svelte.ts
@@ -250,6 +250,7 @@ export abstract class CompendiumBrowserTab {
     #pruneEmptyFilterOptions(): void {
         if (!this.filterData || !("checkboxes" in this.filterData || "traits" in this.filterData)) return;
         const present = new Set(this.indexData.flatMap((e) => [...(e.options ?? [])]));
+
         if ("checkboxes" in this.filterData) {
             const checkboxes: Record<string, CheckboxData> = this.filterData.checkboxes;
             for (const [key, checkbox] of R.entries(checkboxes)) {

--- a/src/module/apps/compendium-browser/tabs/base.svelte.ts
+++ b/src/module/apps/compendium-browser/tabs/base.svelte.ts
@@ -246,14 +246,21 @@ export abstract class CompendiumBrowserTab {
         };
     }
 
-    /** Removes checkboxes that would provide empty list when toggled */
+    /** Removes checkboxes and traits that would provide empty list when toggled */
     #pruneEmptyFilterOptions(): void {
-        if (!this.filterData || !("checkboxes" in this.filterData)) return;
+        if (!this.filterData || !("checkboxes" in this.filterData || "traits" in this.filterData)) return;
         const present = new Set(this.indexData.flatMap((e) => [...(e.options ?? [])]));
-        const checkboxes: Record<string, CheckboxData> = this.filterData.checkboxes;
-        for (const [key, checkbox] of R.entries(checkboxes)) {
-            const prefix = checkbox.optionPrefix ?? key;
-            checkbox.options = R.pickBy(checkbox.options, (_v, k) => present.has(`${prefix}:${k}`));
+        if ("checkboxes" in this.filterData) {
+            const checkboxes: Record<string, CheckboxData> = this.filterData.checkboxes;
+            for (const [key, checkbox] of R.entries(checkboxes)) {
+                const prefix = checkbox.optionPrefix ?? key;
+                checkbox.options = R.pickBy(checkbox.options, (_v, k) => present.has(`${prefix}:${k}`));
+            }
+        }
+
+        if ("traits" in this.filterData) {
+            const traits = this.filterData.traits;
+            traits.options = traits.options.filter((t) => present.has(`trait:${t.value}`));
         }
     }
 

--- a/src/module/apps/compendium-browser/tabs/base.svelte.ts
+++ b/src/module/apps/compendium-browser/tabs/base.svelte.ts
@@ -76,6 +76,9 @@ export abstract class CompendiumBrowserTab {
         // Load the index and populate filter data
         await this.loadData();
 
+        // Remove checkboxes for empty filters
+        this.#pruneEmptyFilterOptions();
+
         // Initialize MiniSearch
         const wordSegmenter =
             "Segmenter" in Intl
@@ -241,6 +244,17 @@ export abstract class CompendiumBrowserTab {
             inputMin: lower,
             inputMax: upper,
         };
+    }
+
+    /** Removes checkboxes that would provide empty list when toggled */
+    #pruneEmptyFilterOptions(): void {
+        if (!this.filterData || !("checkboxes" in this.filterData)) return;
+        const present = new Set(this.indexData.flatMap((e) => [...(e.options ?? [])]));
+        const checkboxes: Record<string, CheckboxData> = this.filterData.checkboxes;
+        for (const [key, checkbox] of R.entries(checkboxes)) {
+            const prefix = checkbox.optionPrefix ?? key;
+            checkbox.options = R.pickBy(checkbox.options, (_v, k) => present.has(`${prefix}:${k}`));
+        }
     }
 
     /** Generates a localized and sorted options from config data

--- a/src/module/apps/compendium-browser/tabs/base.svelte.ts
+++ b/src/module/apps/compendium-browser/tabs/base.svelte.ts
@@ -76,7 +76,7 @@ export abstract class CompendiumBrowserTab {
         // Load the index and populate filter data
         await this.loadData();
 
-        // Remove checkboxes for empty filters
+        // Remove checkboxes for empty filters and traits with no associated entries
         this.#pruneEmptyFilterOptions();
 
         // Initialize MiniSearch


### PR DESCRIPTION
This change will allow removing some compendium browser filters that would come up with no items in them, in a similar fashion to how publication selection works. As the behavior is identical, the publication source helper also reuses it (but could be removed completely to use the new method).

It will also implement this behavior for weapon and armor groups to remove empty groups, and for armor categories to remove barding in Starfinder. I didn't find it necessary to implement it other categories and tabs.

@jfn4th Pretty much the functionality you've asked for in the other PR.