### PR TITLE
Make `_validateType` throw errors instead of returning them

### DIFF
--- a/src/module/rules/rule-element/damage-alteration/rule-element.ts
+++ b/src/module/rules/rule-element/damage-alteration/rule-element.ts
@@ -7,7 +7,6 @@ import type { ModelPropsFromRESchema, RuleElementSchema } from "../data.ts";
 import { ResolvableValueField, RuleElement } from "../index.ts";
 import { DamageAlteration } from "./alteration.ts";
 import fields = foundry.data.fields;
-import DataModelValidationFailure = foundry.data.validation.DataModelValidationFailure;
 
 /** Alter certain aspects of individual components (modifiers and dice) of a damage roll. */
 class DamageAlterationRuleElement extends RuleElement<DamageAlterationSchema> {
@@ -31,7 +30,7 @@ class DamageAlterationRuleElement extends RuleElement<DamageAlterationSchema> {
                 required: true,
                 nullable: true,
                 initial: null,
-                validate: (value, options): boolean | DataModelValidationFailure => {
+                validate: (value, options): boolean => {
                     if (typeof value === "string" && /^\{\w+\|.+\}$/.test(value)) return true;
                     const source = options.source ?? options.model?._source;
                     if (!R.isPlainObject(source)) throw Error("unexpected missing source object");

--- a/src/module/system/schema-data-fields.ts
+++ b/src/module/system/schema-data-fields.ts
@@ -341,10 +341,7 @@ class DataUnionField<
         return super.clean(value, options, _state) as MaybeProp;
     }
 
-    protected override _validateType(
-        value: unknown,
-        options?: DataFieldValidationOptions | undefined,
-    ): boolean | void | validation.DataModelValidationFailure {
+    protected override _validateType(value: unknown, options?: DataFieldValidationOptions | undefined): boolean | void {
         const errors: { field: TField; result: validation.DataModelValidationFailure }[] = [];
         for (const field of this.fields) {
             const result = field.validate(value, options);
@@ -360,15 +357,15 @@ class DataUnionField<
 
         // Attempt to determine which error is the most relevant based on simple heuristics
         if (Array.isArray(value)) {
-            return errors.findLast((e) => e.field instanceof fields.ArrayField)?.result ?? lastError;
+            throw errors.findLast((e) => e.field instanceof fields.ArrayField)?.result ?? lastError;
         } else if (typeof value === "object") {
             // This is not exhaustive, but it only needs to catch the most common cases
-            return (
+            throw (
                 errors.findLast((e) => e.field instanceof fields.ObjectField || e.field instanceof fields.SchemaField)
                     ?.result ?? lastError
             );
         } else {
-            return lastError;
+            throw lastError;
         }
     }
 
@@ -619,12 +616,10 @@ class RecordField<
         return upstreamCleaned;
     }
 
-    protected override _validateType(
-        values: unknown,
-        options?: DataFieldValidationOptions,
-    ): boolean | validation.DataModelValidationFailure | void {
+    protected override _validateType(values: unknown, options?: DataFieldValidationOptions): boolean | void {
         super._validateType(values, options);
-        return this.validateValues(values, options);
+        const failure = this.validateValues(values, options);
+        if (failure) throw failure;
     }
 
     override initialize(

--- a/types/foundry/common/data/_types.d.mts
+++ b/types/foundry/common/data/_types.d.mts
@@ -26,10 +26,7 @@ import { DataModelValidationFailure } from "./validation-failure.mjs";
  *
  * An Error may be thrown which provides a custom error message explaining the reason the value is invalid.
  */
-type DataFieldValidator = (
-    value: unknown,
-    options: DataFieldValidationOptions,
-) => boolean | DataModelValidationFailure | void;
+type DataFieldValidator = (value: unknown, options: DataFieldValidationOptions) => boolean | void;
 
 export interface DataFieldOptions<
     TSourceProp,

--- a/types/foundry/common/data/fields.d.mts
+++ b/types/foundry/common/data/fields.d.mts
@@ -273,10 +273,7 @@ export abstract class DataField<
      * @returns A boolean to indicate with certainty whether the value is valid
      * @throws An error with a specific reason the value is invalid
      */
-    protected _validateType(
-        value: unknown,
-        options?: DataFieldValidationOptions,
-    ): boolean | DataModelValidationFailure | void;
+    protected _validateType(value: unknown, options?: DataFieldValidationOptions): boolean | void;
 
     /**
      * For fields which have hierarchical data structures, define how their inner fields should be validated.
@@ -683,10 +680,7 @@ export class SchemaField<
     /*  Data Validation                             */
     /* -------------------------------------------- */
 
-    protected override _validateType(
-        data: object,
-        options?: DataFieldValidationOptions,
-    ): boolean | DataModelValidationFailure | void;
+    protected override _validateType(data: object, options?: DataFieldValidationOptions): boolean | void;
 
     protected override _validateRecursive(value: unknown, options?: DataFieldValidationOptions): boolean | void;
 
@@ -908,7 +902,7 @@ export class TypedObjectField<
 
     protected override _cleanType(data: object, options: DataModelCleaningOptions): object;
 
-    protected override _validateType(data: object, options?: object): DataModelValidationFailure | void;
+    protected override _validateType(data: object, options?: object): boolean | void;
 
     override _validateModel(
         changes: Record<string, SourceFromDataField<TField>>,
@@ -1538,10 +1532,7 @@ export class JSONField<
 export class AnyField extends DataField {
     protected override _cast(value: unknown): unknown;
 
-    protected override _validateType(
-        value: unknown,
-        options?: DataFieldValidationOptions,
-    ): boolean | DataModelValidationFailure | void;
+    protected override _validateType(value: unknown, options?: DataFieldValidationOptions): boolean | void;
 }
 
 /**
@@ -1691,10 +1682,7 @@ export class TypeDataField<
         options?: Record<string, unknown>,
     ): MaybeSchemaProp<TModelProp, true, false, true>;
 
-    protected override _validateType(
-        data: unknown,
-        options?: DataFieldValidationOptions,
-    ): void | DataModelValidationFailure;
+    protected override _validateType(data: unknown, options?: DataFieldValidationOptions): boolean | void;
 
     override _validateModel(changes: TSourceProp, options?: DataFieldValidationOptions): void;
 
@@ -1752,10 +1740,7 @@ export class TypedSchemaField<
 
     protected override _validateSpecial(value: JSONValue | undefined): boolean | void;
 
-    protected override _validateType(
-        value: unknown,
-        options?: DataFieldValidationOptions,
-    ): boolean | DataModelValidationFailure | void;
+    protected override _validateType(value: unknown, options?: DataFieldValidationOptions): boolean | void;
 
     override initialize(
         value: MaybeSchemaProp<SourceFromTypedSchemaTypes<TTypes>, TRequired, TNullable, THasInitial>,


### PR DESCRIPTION
v13 allowed returning `DataModelValidationFailure` in validators (`DataField.validate` in `common/data/field.mjs`), but v14 only checks if the returned value is `true` or `false`.
Returned errors get ignored, so invalid REs like `{"key":"RollOption","label":"Test","option":"test","suboptions":"invalid","toggleable":true}` get processed and cause exciting problems. 
Having just that RollOption RE on a feat just causes the feat to not get added to the sheet, but more complex setups can break actor data prep (https://discord.com/channels/170995199584108546/697845559435853865/1540673817754603610)