### PR TITLE
Pin pnpm to 10.34.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches: [v13-dev, v14-dev]
   workflow_dispatch:
-    branches: [v13-dev, v14-dev]
 
 jobs:
   build:
@@ -24,8 +23,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Cache NPM Deps
         id: cache-npm

--- a/.github/workflows/release-anachronism.yml
+++ b/.github/workflows/release-anachronism.yml
@@ -2,7 +2,6 @@ name: Anachronism Release
 
 on:
   workflow_dispatch:
-    branches: [v13-dev]
     inputs:
       module:
         description: Module
@@ -28,8 +27,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Cache NPM Deps
         id: cache-npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@ name: System Release
 
 on:
   workflow_dispatch:
-    branches: [v13-dev, v14-dev]
     inputs:
       system:
         description: System
@@ -28,8 +27,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Cache NPM Deps
         id: cache-npm

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,18 @@ If you would like to contribute to the project then I welcome all support. If yo
 
 ## Setup
 
+### Prerequisites
+
+- Node.js 24.14 or newer.
+- pnpm, which is used to run the project's scripts. The version is pinned in the `packageManager` field of `package.json`. pnpm switches to the pinned version automatically, so you do not need to install a matching version by hand; the latest will do. See https://pnpm.io/installation for installation instructions. The standalone script is the recommended method.
+
+### Building
+
 The project uses vite to bundle the ES module and compile the SASS files needed for a build and can create a local distribution for your own Foundry server. If you want to give it a go yourself follow these steps:
 
 - Clone the repo into a local folder in your dev environment `git clone https://github.com/foundryvtt/pf2e.git`
 
-- From within the clone's folder, Install dependencies with `npm ci`.
+- From within the clone's folder, Install dependencies with `npm ci`. The repo's lockfile is `package-lock.json`, so dependencies are installed with npm; pnpm is currently only used to run the scripts below.
 
 - You'll now need to create a symbolic link between the build folder ("dist") and your Foundry data folder. This can be done manually or by running `npm run link` and following the instructions.
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "engines": {
         "node": ">=24.14.0"
     },
+    "packageManager": "pnpm@10.34.5",
     "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@eslint/json": "^1.2.0",


### PR DESCRIPTION
pnpm will auto switch to the version set on the `packageManager` field in `package.json`. Ideally with pnpm, everyone should be using the exact same pnpm version, though that doesn't matter as much for us until we move package installation to it. But this makes life easier if you have to juggle multiple pnpm versions for other things like I do.

`branches` also does nothing on `workflow_dispatch` triggers, so cleared those out.