### PR TITLE
Bundle all operations into a single server query in the `applyActorGroupUpdate` helper

### DIFF
--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -1030,17 +1030,49 @@ async function applyActorGroupUpdate(
               ? "create"
               : "actorUpdate";
 
+    const operations: foundry.documents.DatabaseWriteOperation[] = [];
+
     if (actorUpdates) {
-        await actor.update(actorUpdates, { render: lastRender === "actorUpdate" });
+        operations.push({
+            action: "update",
+            documentName: "Actor",
+            updates: [actorUpdates],
+            parent: actor.parent,
+            render: lastRender === "actorUpdate",
+        });
     }
     if (itemCreates.length > 0) {
-        await actor.createEmbeddedDocuments("Item", itemCreates, { render: lastRender === "create", keepId });
+        operations.push({
+            action: "create",
+            data: itemCreates,
+            documentName: "Item",
+            keepId,
+            parent: actor,
+            render: lastRender === "create",
+        });
     }
     if (itemUpdates.length > 0) {
-        await actor.updateEmbeddedDocuments("Item", itemUpdates, { render: lastRender === "update" });
+        operations.push({
+            action: "update",
+            documentName: "Item",
+            updates: itemUpdates,
+            parent: actor,
+            render: lastRender === "update",
+        });
     }
     if (itemDeletes.length > 0) {
-        await actor.deleteEmbeddedDocuments("Item", itemDeletes, { render: lastRender === "delete" });
+        operations.push({
+            action: "delete",
+            documentName: "Item",
+            ids: itemDeletes,
+            parent: actor,
+            render: lastRender === "delete",
+        });
+    }
+
+    // we bundle all the operations into a single server query
+    if (operations.length > 0) {
+        await foundry.documents.modifyBatch(operations);
     }
 }
 

--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -1,5 +1,6 @@
 import { ActorProxyPF2e, type ActorPF2e } from "@actor";
 import type { Rolled } from "@client/dice/_module.d.mts";
+import type { DatabaseWriteOperation } from "@common/abstract/_module.mjs";
 import type { HexColorString } from "@common/constants.d.mts";
 import type { ItemPF2e, MeleePF2e, PhysicalItemPF2e, WeaponPF2e } from "@item";
 import type { AbilityTrait } from "@item/ability/types.ts";
@@ -1030,7 +1031,7 @@ async function applyActorGroupUpdate(
               ? "create"
               : "actorUpdate";
 
-    const operations: foundry.documents.DatabaseWriteOperation[] = [];
+    const operations: DatabaseWriteOperation[] = [];
 
     if (actorUpdates) {
         operations.push({
@@ -1069,11 +1070,7 @@ async function applyActorGroupUpdate(
             render: lastRender === "delete",
         });
     }
-
-    // we bundle all the operations into a single server query
-    if (operations.length > 0) {
-        await foundry.documents.modifyBatch(operations);
-    }
+    await foundry.documents.modifyBatch(operations);
 }
 
 export {

--- a/src/module/actor/helpers.ts
+++ b/src/module/actor/helpers.ts
@@ -1036,7 +1036,7 @@ async function applyActorGroupUpdate(
         operations.push({
             action: "update",
             documentName: "Actor",
-            updates: [actorUpdates],
+            updates: [{ ...actorUpdates, _id: actor.id }],
             parent: actor.parent,
             render: lastRender === "actorUpdate",
         });

--- a/src/scripts/macros/rest-for-the-night.ts
+++ b/src/scripts/macros/rest-for-the-night.ts
@@ -1,5 +1,7 @@
 import { CharacterPF2e } from "@actor";
 import { CharacterAttributesSource, CharacterResourcesSource } from "@actor/character/data.ts";
+import { applyActorGroupUpdate } from "@actor/helpers.ts";
+import { ActorGroupUpdate } from "@actor/types.ts";
 import type { ItemSourcePF2e } from "@item/base/data/index.ts";
 import { ChatMessageSourcePF2e } from "@module/chat-message/data.ts";
 import { ChatMessagePF2e } from "@module/chat-message/index.ts";
@@ -135,22 +137,15 @@ export async function restForTheNight(options: RestForTheNightOptions): Promise<
             }
         }
 
-        // Updated actor with the sweet fruits of rest
+        const operations: Partial<ActorGroupUpdate> = { itemCreates, itemUpdates };
         const hasActorUpdates = Object.keys({ ...actorUpdates.attributes, ...actorUpdates.resources }).length > 0;
         if (hasActorUpdates || actor.flags[SYSTEM_ID].dailyCraftingComplete) {
-            await actor.update(
-                { [`flags.${SYSTEM_ID}.dailyCraftingComplete`]: false, system: actorUpdates },
-                { render: false },
-            );
+            operations.actorUpdates = {
+                [`flags.${SYSTEM_ID}.dailyCraftingComplete`]: false,
+                system: actorUpdates,
+            };
         }
-
-        if (itemCreates.length > 0) {
-            await actor.createEmbeddedDocuments("Item", itemCreates, { render: false });
-        }
-
-        if (itemUpdates.length > 0) {
-            await actor.updateEmbeddedDocuments("Item", itemUpdates, { render: false });
-        }
+        await applyActorGroupUpdate(actor, operations, { render: false });
 
         if (recharges.affected.frequencies) {
             statements.push(localize("Message.Frequencies"));

--- a/src/scripts/macros/rest-for-the-night.ts
+++ b/src/scripts/macros/rest-for-the-night.ts
@@ -1,7 +1,7 @@
 import { CharacterPF2e } from "@actor";
 import { CharacterAttributesSource, CharacterResourcesSource } from "@actor/character/data.ts";
 import { applyActorGroupUpdate } from "@actor/helpers.ts";
-import { ActorGroupUpdate } from "@actor/types.ts";
+import type { ActorGroupUpdate } from "@actor/types.ts";
 import type { ItemSourcePF2e } from "@item/base/data/index.ts";
 import { ChatMessageSourcePF2e } from "@module/chat-message/data.ts";
 import { ChatMessagePF2e } from "@module/chat-message/index.ts";

--- a/types/foundry/client/documents/_module.d.mts
+++ b/types/foundry/client/documents/_module.d.mts
@@ -12,6 +12,7 @@ export * as collections from "./collections/_module.mjs";
 
 export { default as Setting } from "./setting.mjs";
 
+import { DatabaseGetOperation, DatabaseOperation } from "@common/abstract/_module.mjs";
 import { default as Actor } from "./actor.mjs";
 import Adventure from "./adventure.mjs";
 import { default as Cards } from "./cards.mjs";
@@ -27,6 +28,7 @@ import { default as Playlist } from "./playlist.mjs";
 import { default as RollTable } from "./roll-table.mjs";
 import { default as Scene } from "./scene.mjs";
 import { default as User } from "./user.mjs";
+import Document = foundry.abstract.Document;
 
 export {
     Actor,
@@ -84,3 +86,47 @@ export type WorldDocument =
 
 export type CompendiumDocument =
     Actor<null> | Adventure | Cards | Item<null> | JournalEntry | Macro | Playlist | RollTable | Scene;
+
+export type DatabaseWriteOperation<TParent extends Document | null = Document | null> = Exclude<
+    DatabaseOperation<TParent>,
+    DatabaseGetOperation<TParent>
+>;
+
+/**
+ * Bundle multiple {@link Document}-modification operations into a single, batched request. The modifications
+ * are made in sequence without a network delay between each. This can be useful when, for example, it is desirable that
+ * there not be an unpredictable delay between operations due to latency. For certain operations there may also be a
+ * need to ensure there will never be a mixed state: either all must succeed, or all must fail.
+ *
+ * The nature of batched modifications does have some limitations:
+ * - Unlike with a sequence of unbatched operations, a batched operation is unable to reference the result of a prior
+ *   operation in the same batch.
+ * - A cancellation (via, for example, {@link Document#_preUpdate}) or exception thrown by a single operation will
+ *   cancel the entire batch. No changes will be made.
+ *
+ * @example Modify an Actor and two TokenDocuments
+ * Update an Actor's size category along with the dimensions of that Actor's related TokenDocuments across multiple
+ * Scenes.
+ * ```js
+ * foundry.documents.modifyBatch([
+ *   {
+ *     action: "update",
+ *     documentName: "Actor",
+ *     updates: [{_id: "Ay52yVxCgusBct1b", "system.size": "big"}],
+ *   },
+ *   {
+ *     action: "update",
+ *     documentName: "Token",
+ *     updates: [{_id: "30pnHJciHu4CvPnz", width: 2, height: 2}],
+ *     parent: sceneA
+ *   },
+ *   {
+ *     action: "update",
+ *     documentName: "Token",
+ *     updates: [{_id: "knSU5NQVXeIQQeHi", width: 2, height: 2}],
+ *     parent: sceneB
+ *   }
+ * ]);
+ * ```
+ */
+export function modifyBatch(operations: DatabaseWriteOperation[]): Promise<Document[][]>;

--- a/types/foundry/client/documents/_module.d.mts
+++ b/types/foundry/client/documents/_module.d.mts
@@ -12,7 +12,7 @@ export * as collections from "./collections/_module.mjs";
 
 export { default as Setting } from "./setting.mjs";
 
-import { DatabaseGetOperation, DatabaseOperation } from "@common/abstract/_module.mjs";
+import { DatabaseWriteOperation, Document } from "@common/abstract/_module.mjs";
 import { default as Actor } from "./actor.mjs";
 import Adventure from "./adventure.mjs";
 import { default as Cards } from "./cards.mjs";
@@ -28,7 +28,6 @@ import { default as Playlist } from "./playlist.mjs";
 import { default as RollTable } from "./roll-table.mjs";
 import { default as Scene } from "./scene.mjs";
 import { default as User } from "./user.mjs";
-import Document = foundry.abstract.Document;
 
 export {
     Actor,
@@ -86,11 +85,6 @@ export type WorldDocument =
 
 export type CompendiumDocument =
     Actor<null> | Adventure | Cards | Item<null> | JournalEntry | Macro | Playlist | RollTable | Scene;
-
-export type DatabaseWriteOperation<TParent extends Document | null = Document | null> = Exclude<
-    DatabaseOperation<TParent>,
-    DatabaseGetOperation<TParent>
->;
 
 /**
  * Bundle multiple {@link Document}-modification operations into a single, batched request. The modifications

--- a/types/foundry/client/documents/token.d.mts
+++ b/types/foundry/client/documents/token.d.mts
@@ -813,7 +813,7 @@ export interface TokenUpdateOperation<TParent extends Scene | null> extends Data
 
 export interface TokenUpdateCallbackOptions extends Omit<
     TokenUpdateOperation<null>,
-    "action" | "pack" | "parent" | "restoreDelta" | "noHook" | "updates"
+    "action" | "documentName" | "pack" | "parent" | "restoreDelta" | "noHook" | "updates"
 > {}
 
 export {};

--- a/types/foundry/common/abstract/_types.d.mts
+++ b/types/foundry/common/abstract/_types.d.mts
@@ -204,6 +204,11 @@ export type DatabaseOperation<TParent extends Document | null> =
     | DatabaseUpdateOperation<TParent>
     | DatabaseDeleteOperation<TParent>;
 
+export type DatabaseWriteOperation<TParent extends Document | null = Document | null> = Exclude<
+    DatabaseOperation<TParent>,
+    DatabaseGetOperation<TParent>
+>;
+
 export interface DocumentSocketRequest {
     /** The type of Document being transacted */
     type: string;

--- a/types/foundry/common/abstract/_types.d.mts
+++ b/types/foundry/common/abstract/_types.d.mts
@@ -113,7 +113,7 @@ export interface DatabaseCreateOperation<TParent extends Document | null> {
 
 export interface DatabaseCreateCallbackOptions extends Omit<
     Partial<DatabaseCreateOperation<null>>,
-    "action" | "data" | "pack" | "parent" | "noHook"
+    "action" | "documentName" | "data" | "pack" | "parent" | "noHook"
 > {}
 
 export interface DatabaseUpdateOperation<TParent extends Document | null> {
@@ -156,7 +156,7 @@ export interface DatabaseUpdateOperation<TParent extends Document | null> {
 
 export interface DatabaseUpdateCallbackOptions extends Omit<
     Partial<DatabaseUpdateOperation<null>>,
-    "action" | "pack" | "parent" | "restoreDelta" | "noHook" | "updates"
+    "action" | "documentName" | "pack" | "parent" | "restoreDelta" | "noHook" | "updates"
 > {}
 
 export interface DatabaseDeleteOperation<TParent extends Document | null> {
@@ -193,7 +193,7 @@ export interface DatabaseDeleteOperation<TParent extends Document | null> {
 
 export interface DatabaseDeleteCallbackOptions extends Omit<
     Partial<DatabaseDeleteOperation<null>>,
-    "action" | "deleteAll" | "ids" | "pack" | "parent" | "noHook"
+    "action" | "documentName" | "deleteAll" | "ids" | "pack" | "parent" | "noHook"
 > {}
 
 export type DatabaseAction = "get" | "create" | "update" | "delete";

--- a/types/foundry/common/abstract/_types.d.mts
+++ b/types/foundry/common/abstract/_types.d.mts
@@ -76,11 +76,21 @@ export interface DatabaseGetOperation<TParent extends Document | null> {
 }
 
 export interface DatabaseCreateOperation<TParent extends Document | null> {
+    /** The action of this database operation **/
     action: "create";
-    /** Whether the database operation is broadcast to other connected clients */
-    broadcast: boolean;
     /** An array of data objects from which to create Documents */
     data: object[];
+    /** The Document name **/
+    documentName: string;
+    /** Whether the database operation is broadcast to other connected clients */
+    broadcast?: boolean;
+    /** Control the object of any created Documents */
+    controlObject?: boolean;
+    /**
+     * Is the operation a dry run?
+     * If so, an empty result array is returned before the Documents are created.
+     */
+    dryRun?: boolean;
     /** Retain the _id values of provided data instead of generating new ids */
     keepId?: boolean;
     /** Retain the _id values of embedded document data instead of generating new ids for each embedded document */
@@ -107,19 +117,27 @@ export interface DatabaseCreateCallbackOptions extends Omit<
 > {}
 
 export interface DatabaseUpdateOperation<TParent extends Document | null> {
+    /** The action of this database operation **/
     action: "update";
-    /** Whether the database operation is broadcast to other connected clients */
-    broadcast: boolean;
+    /** The Document name **/
+    documentName: string;
     /**
      * An array of data objects used to update existing Documents.
      * Each update object must contain the _id of the target Document
      */
     updates: object[];
+    /** Whether the database operation is broadcast to other connected clients */
+    broadcast?: boolean;
     /**
      * Difference each update object against current Document data and only use differential data for the update
      * operation
      */
     diff?: boolean;
+    /**
+     * Is the operation a dry run?
+     * If so, an empty result array is returned before the Documents are created.
+     */
+    dryRun?: boolean;
     /** The timestamp when the operation was performed */
     modifiedTime?: number;
     /** Merge objects recursively. If false, inner objects will be replaced explicitly. Use with caution! */
@@ -142,13 +160,21 @@ export interface DatabaseUpdateCallbackOptions extends Omit<
 > {}
 
 export interface DatabaseDeleteOperation<TParent extends Document | null> {
+    /** The action of this database operation **/
     action: "delete";
-    /** Whether the database operation is broadcast to other connected clients */
-    broadcast: boolean;
+    /** The Document name **/
+    documentName: string;
     /** An array of Document ids which should be deleted */
     ids: string[];
+    /** Whether the database operation is broadcast to other connected clients */
+    broadcast?: boolean;
     /** Delete all documents in the Collection, regardless of _id */
     deleteAll?: boolean;
+    /**
+     * Is the operation a dry run?
+     * If so, an empty result array is returned before the Documents are created.
+     */
+    dryRun?: boolean;
     /** The timestamp when the operation was performed */
     modifiedTime?: number;
     /** Block the dispatch of hooks related to this operation */
@@ -161,6 +187,8 @@ export interface DatabaseDeleteOperation<TParent extends Document | null> {
     pack?: string | null;
     /** A parent Document UUID provided when the parent instance is unavailable */
     parentUuid?: DocumentUUID;
+    /** The mapping of IDs of deleted Documents to the UUIDs of the Documents that replace the deleted Documents */
+    replacements?: Record<string, string>;
 }
 
 export interface DatabaseDeleteCallbackOptions extends Omit<


### PR DESCRIPTION
Considering the `applyActorGroupUpdate` is there to group operations to begin with, i thought it would be fitting to use the new `modifyBatch` foundry helper, bundling all create/delete/update operations into a single server query.

I added and updated the different related types.

Edit: I also took the opportunity to use `applyActorGroupUpdate` in the `restForTheNight` function as it was pretty much reproducing the logic.