### PR TITLE
Fix `TagSelectorBasic` not displaying current selections for `number` values

### DIFF
--- a/src/module/data.ts
+++ b/src/module/data.ts
@@ -14,7 +14,7 @@ type Size = (typeof SIZES)[number];
 const RARITIES = Object.freeze(["common", "uncommon", "rare", "unique"] as const);
 type Rarity = (typeof RARITIES)[number];
 
-interface ValuesList<T extends string = string> {
+interface ValuesList<T extends string | number = string | number> {
     value: T[];
 }
 

--- a/src/module/system/tag-selector/basic.ts
+++ b/src/module/system/tag-selector/basic.ts
@@ -15,7 +15,7 @@ function isValuesList(obj: unknown): obj is ValuesList {
         R.isObjectType(obj) &&
         "value" in obj &&
         Array.isArray(obj.value) &&
-        obj.value.every((v) => typeof v === "string")
+        obj.value.every((v) => R.isIncludedIn(typeof v, ["string", "number"]))
     );
 }
 
@@ -58,9 +58,11 @@ class TagSelectorBasic<TDocument extends ActorPF2e | ItemPF2e> extends BaseTagSe
                 const chosen = Array.from(new Set([...manuallyChosen, ...automaticallyChosen]));
                 return { chosen, flat: true, disabled: automaticallyChosen };
             } else if (isValuesList(preparedProperty) && isValuesList(sourceProperty)) {
-                const manuallyChosen: string[] = sourceProperty.value.map((v) => v.toString());
-                const automaticallyChosen = preparedProperty.value.filter(
-                    (v): v is string => !manuallyChosen.includes(v),
+                const manuallyChosen = sourceProperty.value.map((v) => v.toString());
+                const automaticallyChosen = R.pipe(
+                    preparedProperty.value,
+                    R.map((v) => v.toString()),
+                    R.filter((v) => !manuallyChosen.includes(v)),
                 );
                 const chosen = Array.from(new Set([...manuallyChosen, ...automaticallyChosen]));
                 return { chosen, flat: false, disabled: automaticallyChosen };


### PR DESCRIPTION
Currently, when editing some of properties of a `Class` item, the `TagSelectorBasic` doesn't display the current selections if the values are of `number` type, this fixes that.

closes #23063