### PR TITLE
Add pf2e.aurasChanged hook

### DIFF
--- a/src/module/canvas/token/object.ts
+++ b/src/module/canvas/token/object.ts
@@ -394,7 +394,12 @@ class TokenPF2e<TDocument extends TokenDocumentPF2e = TokenDocumentPF2e> extends
     override async _drawEffects(): Promise<void> {
         await super._drawEffects();
         await this.animation;
-        if (this.auras.size === 0) return this.auras.reset();
+
+        if (this.auras.size === 0) {
+            await this.auras.reset();
+            if (this.document.auras.size > 0) Hooks.callAll("pf2e.aurasChanged", this);
+            return;
+        }
 
         // Determine whether a redraw is warranted by comparing current and updated radius/appearance data
         const changedAndDeletedAuraSlugs = Array.from(this.auras.entries())
@@ -412,7 +417,9 @@ class TokenPF2e<TDocument extends TokenDocumentPF2e = TokenDocumentPF2e> extends
             .map(([slug]) => slug);
         const newAuraSlugs = Array.from(this.document.auras.keys()).filter((s) => !this.auras.has(s));
 
-        return this.auras.reset([changedAndDeletedAuraSlugs, newAuraSlugs].flat());
+        await this.auras.reset([changedAndDeletedAuraSlugs, newAuraSlugs].flat());
+
+        if (changedAndDeletedAuraSlugs.length > 0 || newAuraSlugs.length > 0) Hooks.callAll("pf2e.aurasChanged", this);
     }
 
     /** Emulate a pointer hover ("pointerover") event */


### PR DESCRIPTION
A second go at this, the hook is a very minimalistic notification for modules that a given tokens auras have changed.

This is primarily for animations modules to synchronize their animation sizes with that of the system. All of the relevant data is already available, just not **when** it updates.

```js
Hooks.on("pf2e.aurasChanged", (token) => {
    for (const [slug, aura] of token.auras) {
        console.log(`The aura "${slug}" size is now ${aura.radius} feet.`);
    }
});
```