### PR TITLE
Make all actions usable

### DIFF
--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -430,8 +430,6 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
                 ...baseData,
                 img: ((): ImageFilePath => {
                     const actionIcon = getActionIcon(item.actionCost);
-                    if (!baseData.usable) return actionIcon;
-
                     const defaultIcon = ItemPF2e.getDefaultArtwork(item._source).img;
                     const commonFeatIcon = "icons/sundries/books/book-red-exclamation.webp";
                     const isDefaultImage = [actionIcon, defaultIcon, commonFeatIcon].includes(item.img);

--- a/src/module/actor/sheet/data-types.ts
+++ b/src/module/actor/sheet/data-types.ts
@@ -88,7 +88,6 @@ interface AbilityViewData {
     traits: TraitViewData[];
     glyph: string | null;
     frequency: Frequency | null;
-    usable: boolean;
     has: {
         aura: boolean;
         deathNote: boolean;

--- a/src/module/actor/sheet/helpers.ts
+++ b/src/module/actor/sheet/helpers.ts
@@ -68,7 +68,6 @@ function createAbilityViewData(item: AbilityItemPF2e | FeatPF2e): AbilityViewDat
     return {
         ...R.pick(item, ["id", "uuid", "img", "name", "actionCost", "frequency"]),
         glyph: getActionGlyph(item.actionCost),
-        usable: !!item.system.selfEffect || !!item.system?.frequency || !!item.crafting,
         traits: item.system.traits.value.map((t) => traitSlugToObject(t, CONFIG.PF2E.actionTraits)),
         has: {
             aura: item.traits.has("aura") || item.system.rules.some((r) => r.key === "Aura"),

--- a/static/templates/actors/npc/partials/action.hbs
+++ b/static/templates/actors/npc/partials/action.hbs
@@ -25,24 +25,22 @@
             <a data-action="delete-item" data-tooltip="Delete"><i class="fa-solid fa-fw fa-trash"></i></a>
         {{/if}}
     </div>
-    {{#if action.usable}}
-        <div class="button-group">
-            <button type="button" class="use-action" data-action="use-action">
-                <span>{{localize "PF2E.Action.Use"}}</span>
-            </button>
-            {{#if action.frequency}}
-                <div class="frequency">
-                    <input type="number" value="{{action.frequency.value}}" data-item-id="{{action.id}}" data-item-property="system.frequency.value" />
-                        <span>
-                        /
-                        {{action.frequency.max}}
-                        {{localize "PF2E.Frequency.per"}}
-                        {{localize (lookup @root.frequencies action.frequency.per)}}
-                        </span>
-                    </div>
-            {{/if}}
-        </div>
-    {{/if}}
+    <div class="button-group">
+        <button type="button" class="use-action" data-action="use-action">
+            <span>{{localize "PF2E.Action.Use"}}</span>
+        </button>
+        {{#if action.frequency}}
+            <div class="frequency">
+                <input type="number" value="{{action.frequency.value}}" data-item-id="{{action.id}}" data-item-property="system.frequency.value" />
+                    <span>
+                    /
+                    {{action.frequency.max}}
+                    {{localize "PF2E.Frequency.per"}}
+                    {{localize (lookup @root.frequencies action.frequency.per)}}
+                    </span>
+                </div>
+        {{/if}}
+    </div>
 
     <div class="item-summary" hidden></div>
 </li>

--- a/static/templates/actors/partials/action.hbs
+++ b/static/templates/actors/partials/action.hbs
@@ -21,12 +21,10 @@
     </h4>
 
     <div class="button-group">
-        {{#if action.usable}}
-            <button type="button" class="use-action" data-action="use-action">
-                <span>{{localize "PF2E.Action.Use"}}</span>
-                <span class="action-glyph">{{action.glyph}}</span>
-            </button>
-        {{/if}}
+        <button type="button" class="use-action" data-action="use-action">
+            <span>{{localize "PF2E.Action.Use"}}</span>
+            <span class="action-glyph">{{action.glyph}}</span>
+        </button>
     </div>
 
     {{#if action.frequency}}


### PR DESCRIPTION
This makes all actions have the `Use` button instead of limiting it to the those that have uses, have a self-applied effect, or are part of the crafting feature.

The reasons for such change are threefold:
- Consistency between all actions, instead of having to sometimes click on the `Use` button and other times the icon
- Being able to use custom icons for any action while still showing the action cost (it is in the use btn)
- Being able to add a rollOption to differentiate an actual use of the action from a plain send-to-chat (which would come as another PR later if this is accepted)

related #22380