### PR TITLE
Localize Compendium Browser option to sort by name

### DIFF
--- a/src/module/apps/compendium-browser/tabs/action.ts
+++ b/src/module/apps/compendium-browser/tabs/action.ts
@@ -119,7 +119,7 @@ export class CompendiumBrowserActionTab extends CompendiumBrowserTab {
                 by: "name",
                 direction: "asc",
                 options: {
-                    name: { label: "Name", type: "alpha" },
+                    name: { label: "PF2E.NameLabel", type: "alpha" },
                 },
                 type: "alpha",
             },

--- a/src/module/apps/compendium-browser/tabs/bestiary.ts
+++ b/src/module/apps/compendium-browser/tabs/bestiary.ts
@@ -123,7 +123,7 @@ export class CompendiumBrowserBestiaryTab extends CompendiumBrowserTab {
                 by: "level",
                 direction: "asc",
                 options: {
-                    name: { label: "Name", type: "alpha" },
+                    name: { label: "PF2E.NameLabel", type: "alpha" },
                     level: { label: "PF2E.LevelLabel", type: "numeric" },
                 },
                 type: "numeric",

--- a/src/module/apps/compendium-browser/tabs/campaign-feature.ts
+++ b/src/module/apps/compendium-browser/tabs/campaign-feature.ts
@@ -112,7 +112,7 @@ export class CompendiumBrowserCampaignFeaturesTab extends CompendiumBrowserTab {
                 by: "level",
                 direction: "asc",
                 options: {
-                    name: { label: "Name", type: "alpha" },
+                    name: { label: "PF2E.NameLabel", type: "alpha" },
                     level: { label: "PF2E.LevelLabel", type: "numeric" },
                 },
                 type: "numeric",

--- a/src/module/apps/compendium-browser/tabs/equipment.ts
+++ b/src/module/apps/compendium-browser/tabs/equipment.ts
@@ -220,7 +220,7 @@ export class CompendiumBrowserEquipmentTab extends CompendiumBrowserTab {
                 by: "level",
                 direction: "asc",
                 options: {
-                    name: { label: "Name", type: "alpha" },
+                    name: { label: "PF2E.NameLabel", type: "alpha" },
                     level: { label: "PF2E.LevelLabel", type: "numeric" },
                     price: { label: "PF2E.PriceLabel", type: "numeric" },
                 },

--- a/src/module/apps/compendium-browser/tabs/feat.ts
+++ b/src/module/apps/compendium-browser/tabs/feat.ts
@@ -169,7 +169,7 @@ export class CompendiumBrowserFeatTab extends CompendiumBrowserTab {
                 by: "level",
                 direction: "asc",
                 options: {
-                    name: { label: "Name", type: "alpha" },
+                    name: { label: "PF2E.NameLabel", type: "alpha" },
                     level: { label: "PF2E.LevelLabel", type: "numeric" },
                 },
                 type: "numeric",

--- a/src/module/apps/compendium-browser/tabs/hazard.ts
+++ b/src/module/apps/compendium-browser/tabs/hazard.ts
@@ -123,7 +123,7 @@ export class CompendiumBrowserHazardTab extends CompendiumBrowserTab {
                 by: "level",
                 direction: "asc",
                 options: {
-                    name: { label: "Name", type: "alpha" },
+                    name: { label: "PF2E.NameLabel", type: "alpha" },
                     level: { label: "PF2E.LevelLabel", type: "numeric" },
                 },
                 type: "numeric",

--- a/src/module/apps/compendium-browser/tabs/spell.ts
+++ b/src/module/apps/compendium-browser/tabs/spell.ts
@@ -199,7 +199,7 @@ export class CompendiumBrowserSpellTab extends CompendiumBrowserTab {
                 by: "rank",
                 direction: "asc",
                 options: {
-                    name: { label: "Name", type: "alpha" },
+                    name: { label: "PF2E.NameLabel", type: "alpha" },
                     rank: { label: "PF2E.Item.Spell.Rank.Label", type: "numeric" },
                 },
                 type: "numeric",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3361,6 +3361,7 @@
         "ModifiersTitle": "Modifiers",
         "MultipleAttackPenalty": "Multiple Attack Penalty",
         "MysticStrikes": "Mystical Strikes",
+        "NameLabel": "Name",
         "NPC": {
             "Abilities": {
                 "Glossary": {


### PR DESCRIPTION
I think it stopped working in v14 because core localization strings got namespaced (and the generic "Name" key is now gone)