### PR TITLE
Revert "Always use action image for unusable actions in character sheet"

### DIFF
--- a/src/module/actor/character/sheet.ts
+++ b/src/module/actor/character/sheet.ts
@@ -430,14 +430,13 @@ class CharacterSheetPF2e<TActor extends CharacterPF2e> extends CreatureSheetPF2e
                 ...baseData,
                 img: ((): ImageFilePath => {
                     const actionIcon = getActionIcon(item.actionCost);
-                    if (!baseData.usable) return actionIcon;
-
                     const defaultIcon = ItemPF2e.getDefaultArtwork(item._source).img;
                     const commonFeatIcon = "icons/sundries/books/book-red-exclamation.webp";
                     const isDefaultImage = [actionIcon, defaultIcon, commonFeatIcon].includes(item.img);
-                    return !isDefaultImage && item.isOfType("action")
-                        ? item.img
-                        : (item.system.selfEffect?.img ?? actionIcon);
+                    if (item.isOfType("action") && !isDefaultImage) {
+                        return item.img;
+                    }
+                    return item.system.selfEffect?.img ?? (baseData.usable && !isDefaultImage ? item.img : actionIcon);
                 })(),
                 feat: item.isOfType("feat") ? item : null,
                 toggles: item.system.traits.toggles?.getSheetData() ?? [],


### PR DESCRIPTION
- Reverts foundryvtt/pf2e#22669
- Closes #22916