### PR TITLE
Update several TokenLight rule elements to use Adaptive Attenuation

### DIFF
--- a/packs/pf2e/abomination-vaults-bestiary/book-1-ruins-of-gauntlight/flickerwisp.json
+++ b/packs/pf2e/abomination-vaults-bestiary/book-1-ruins-of-gauntlight/flickerwisp.json
@@ -78,7 +78,8 @@
                                 "type": "pulse"
                             },
                             "bright": 5,
-                            "color": "#fff9a3"
+                            "color": "#fff9a3",
+                            "coloration": 101
                         }
                     },
                     {

--- a/packs/pf2e/abomination-vaults-bestiary/book-1-ruins-of-gauntlight/voidglutton.json
+++ b/packs/pf2e/abomination-vaults-bestiary/book-1-ruins-of-gauntlight/voidglutton.json
@@ -235,7 +235,8 @@
                                 "type": "pulse"
                             },
                             "bright": 30,
-                            "color": "#fff9a3"
+                            "color": "#fff9a3",
+                            "coloration": 101
                         }
                     },
                     {

--- a/packs/pf2e/abomination-vaults-bestiary/book-2-hands-of-the-devil/dune-candle.json
+++ b/packs/pf2e/abomination-vaults-bestiary/book-2-hands-of-the-devil/dune-candle.json
@@ -85,7 +85,8 @@
                                 "type": "pulse"
                             },
                             "bright": 20,
-                            "color": "#fff9a3"
+                            "color": "#fff9a3",
+                            "coloration": 101
                         }
                     }
                 ],

--- a/packs/pf2e/abomination-vaults-bestiary/book-2-hands-of-the-devil/groetan-candle.json
+++ b/packs/pf2e/abomination-vaults-bestiary/book-2-hands-of-the-devil/groetan-candle.json
@@ -83,7 +83,8 @@
                                 "type": "pulse"
                             },
                             "bright": 20,
-                            "color": "#fff9a3"
+                            "color": "#fff9a3",
+                            "coloration": 101
                         }
                     }
                 ],

--- a/packs/pf2e/abomination-vaults-bestiary/book-2-hands-of-the-devil/sacuishu.json
+++ b/packs/pf2e/abomination-vaults-bestiary/book-2-hands-of-the-devil/sacuishu.json
@@ -1586,7 +1586,8 @@
                                 "type": "pulse"
                             },
                             "bright": 20,
-                            "color": "#c6fba5"
+                            "color": "#c6fba5",
+                            "coloration": 101
                         }
                     }
                 ],

--- a/packs/pf2e/abomination-vaults-bestiary/book-2-hands-of-the-devil/spellvoid.json
+++ b/packs/pf2e/abomination-vaults-bestiary/book-2-hands-of-the-devil/spellvoid.json
@@ -83,7 +83,8 @@
                                 "type": "pulse"
                             },
                             "bright": 20,
-                            "color": "#fff9a3"
+                            "color": "#fff9a3",
+                            "coloration": 101
                         }
                     }
                 ],

--- a/packs/pf2e/abomination-vaults-bestiary/book-2-hands-of-the-devil/will-o-the-deep.json
+++ b/packs/pf2e/abomination-vaults-bestiary/book-2-hands-of-the-devil/will-o-the-deep.json
@@ -83,7 +83,8 @@
                                 "type": "pulse"
                             },
                             "bright": 20,
-                            "color": "#fff9a3"
+                            "color": "#fff9a3",
+                            "coloration": 101
                         }
                     }
                 ],

--- a/packs/pf2e/ancestry-features/jotunborn/iivlar-weaving.json
+++ b/packs/pf2e/ancestry-features/jotunborn/iivlar-weaving.json
@@ -83,6 +83,7 @@
                     "animation": {},
                     "bright": 0,
                     "color": "{item|flags.system.rulesSelections.iivlarWeavingLit}",
+                    "coloration": 101,
                     "dim": 10,
                     "luminosity": 0.15
                 }

--- a/packs/pf2e/bestiary-effects/effect-bond-in-light.json
+++ b/packs/pf2e/bestiary-effects/effect-bond-in-light.json
@@ -37,6 +37,7 @@
                     },
                     "bright": 20,
                     "color": "#fff9a3",
+                    "coloration": 101,
                     "dim": 40,
                     "gradual": true
                 }

--- a/packs/pf2e/bestiary-effects/effect-discerning-aura.json
+++ b/packs/pf2e/bestiary-effects/effect-discerning-aura.json
@@ -30,6 +30,7 @@
                         "type": "pulse"
                     },
                     "color": "#9affff",
+                    "coloration": 101,
                     "dim": 5,
                     "shadows": 0.1
                 }

--- a/packs/pf2e/bestiary-effects/effect-fiery-form.json
+++ b/packs/pf2e/bestiary-effects/effect-fiery-form.json
@@ -41,6 +41,7 @@
                     },
                     "bright": 20,
                     "color": "#9b7337",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/bestiary-effects/effect-nanite-surge-glow.json
+++ b/packs/pf2e/bestiary-effects/effect-nanite-surge-glow.json
@@ -25,6 +25,7 @@
                 "key": "TokenLight",
                 "value": {
                     "color": "#3b7355",
+                    "coloration": 101,
                     "dim": 10,
                     "luminosity": 0.4,
                     "shadows": 0.1

--- a/packs/pf2e/bestiary-family-ability-glossary/woodblessed/woodblessed-luminant-aura.json
+++ b/packs/pf2e/bestiary-family-ability-glossary/woodblessed/woodblessed-luminant-aura.json
@@ -32,6 +32,7 @@
                 "value": {
                     "bright": 0,
                     "color": "#53d251",
+                    "coloration": 101,
                     "dim": 20
                 }
             }

--- a/packs/pf2e/boons-and-curses/desna-major-boon.json
+++ b/packs/pf2e/boons-and-curses/desna-major-boon.json
@@ -39,6 +39,7 @@
                         "type": "starlight"
                     },
                     "color": "#fffb80",
+                    "coloration": 101,
                     "dim": 20,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/boons-and-curses/effect-shizurus-light.json
+++ b/packs/pf2e/boons-and-curses/effect-shizurus-light.json
@@ -30,7 +30,8 @@
                         "type": "sunburst"
                     },
                     "bright": 60,
-                    "color": "#aeb073"
+                    "color": "#aeb073",
+                    "coloration": 101
                 }
             }
         ],

--- a/packs/pf2e/campaign-effects/season-of-ghosts/effect-spirit-power-passion.json
+++ b/packs/pf2e/campaign-effects/season-of-ghosts/effect-spirit-power-passion.json
@@ -81,6 +81,7 @@
                     },
                     "bright": 40,
                     "color": "{item|flags.system.rulesSelections.color}",
+                    "coloration": 101,
                     "dim": 80,
                     "luminosity": 0.05,
                     "saturation": 0.1

--- a/packs/pf2e/class-features/initiate-benefit-lantern.json
+++ b/packs/pf2e/class-features/initiate-benefit-lantern.json
@@ -56,6 +56,7 @@
                     },
                     "bright": "@actor.flags.system.thaumaturge.lantern",
                     "color": "#fff285",
+                    "coloration": 101,
                     "dim": "2*@actor.flags.system.thaumaturge.lantern"
                 }
             },

--- a/packs/pf2e/equipment-effects/effect-assisted-flight.json
+++ b/packs/pf2e/equipment-effects/effect-assisted-flight.json
@@ -93,6 +93,7 @@
                     },
                     "bright": 20,
                     "color": "#975335",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment-effects/effect-daybreak-ammunition.json
+++ b/packs/pf2e/equipment-effects/effect-daybreak-ammunition.json
@@ -32,6 +32,7 @@
                     },
                     "bright": 10,
                     "color": "#975335",
+                    "coloration": 101,
                     "dim": 0,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment-effects/effect-draft-of-stellar-radiance.json
+++ b/packs/pf2e/equipment-effects/effect-draft-of-stellar-radiance.json
@@ -36,6 +36,7 @@
                     },
                     "bright": 20,
                     "color": "#9b7337",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment-effects/effect-energizing-lattice.json
+++ b/packs/pf2e/equipment-effects/effect-energizing-lattice.json
@@ -31,6 +31,7 @@
                     },
                     "bright": 20,
                     "color": "#f5efa1",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment-effects/effect-glow-rod.json
+++ b/packs/pf2e/equipment-effects/effect-glow-rod.json
@@ -31,6 +31,7 @@
                     },
                     "bright": 20,
                     "color": "#ffae3d",
+                    "coloration": 101,
                     "dim": 60,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment-effects/effect-glowing-lantern-fruit-lantern-light.json
+++ b/packs/pf2e/equipment-effects/effect-glowing-lantern-fruit-lantern-light.json
@@ -50,6 +50,7 @@
                     },
                     "bright": 60,
                     "color": "#975335",
+                    "coloration": 101,
                     "dim": 120,
                     "shadows": 0.2
                 }
@@ -68,6 +69,7 @@
                     },
                     "bright": 60,
                     "color": "#975335",
+                    "coloration": 101,
                     "dim": 120,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment-effects/effect-holy-chain.json
+++ b/packs/pf2e/equipment-effects/effect-holy-chain.json
@@ -37,6 +37,7 @@
                     },
                     "bright": 40,
                     "color": "#fffb80",
+                    "coloration": 101,
                     "dim": 80,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment-effects/effect-hongruis-gratitude-lantern.json
+++ b/packs/pf2e/equipment-effects/effect-hongruis-gratitude-lantern.json
@@ -39,6 +39,7 @@
                     "attenuation": 0.4,
                     "bright": 20,
                     "color": "#ffae3d",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment-effects/effect-janns-prism-janns-light.json
+++ b/packs/pf2e/equipment-effects/effect-janns-prism-janns-light.json
@@ -31,6 +31,7 @@
                     },
                     "bright": 20,
                     "color": "#969696",
+                    "coloration": 101,
                     "dim": 40
                 }
             },

--- a/packs/pf2e/equipment-effects/effect-luminous-lure.json
+++ b/packs/pf2e/equipment-effects/effect-luminous-lure.json
@@ -25,6 +25,7 @@
                 "key": "TokenLight",
                 "value": {
                     "color": "#3b7355",
+                    "coloration": 101,
                     "dim": 20,
                     "luminosity": 0.4,
                     "shadows": 0.1

--- a/packs/pf2e/equipment-effects/effect-minds-light-circlet.json
+++ b/packs/pf2e/equipment-effects/effect-minds-light-circlet.json
@@ -29,6 +29,7 @@
                         "type": "rainbowswirl"
                     },
                     "bright": 20,
+                    "coloration": 101,
                     "dim": 40
                 }
             }

--- a/packs/pf2e/equipment-effects/effect-morning-glow.json
+++ b/packs/pf2e/equipment-effects/effect-morning-glow.json
@@ -32,6 +32,7 @@
                     },
                     "bright": 30,
                     "color": "#e7f3f1",
+                    "coloration": 101,
                     "dim": 60
                 }
             }

--- a/packs/pf2e/equipment-effects/effect-potion-of-living-light.json
+++ b/packs/pf2e/equipment-effects/effect-potion-of-living-light.json
@@ -43,6 +43,7 @@
                     },
                     "attenuation": 0.4,
                     "bright": 20,
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment-effects/effect-shimmering-dust.json
+++ b/packs/pf2e/equipment-effects/effect-shimmering-dust.json
@@ -30,6 +30,7 @@
                         "type": "smokepatch"
                     },
                     "color": "#d0cd6c",
+                    "coloration": 101,
                     "dim": 20,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment-effects/effect-shining-ammunition.json
+++ b/packs/pf2e/equipment-effects/effect-shining-ammunition.json
@@ -31,6 +31,7 @@
                     },
                     "bright": 20,
                     "color": "#975335",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment-effects/effect-silver-crescent.json
+++ b/packs/pf2e/equipment-effects/effect-silver-crescent.json
@@ -79,6 +79,7 @@
                     "attenuation": 0.4,
                     "bright": 20,
                     "color": "#343434",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment-effects/effect-sparkler.json
+++ b/packs/pf2e/equipment-effects/effect-sparkler.json
@@ -30,6 +30,7 @@
                     },
                     "bright": 20,
                     "color": "#975335",
+                    "coloration": 101,
                     "dim": 10,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment-effects/effect-spirit-fan.json
+++ b/packs/pf2e/equipment-effects/effect-spirit-fan.json
@@ -33,6 +33,7 @@
                     "attenuation": 0.4,
                     "bright": 20,
                     "color": "#ffae3d",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment-effects/effect-staff-of-illumination.json
+++ b/packs/pf2e/equipment-effects/effect-staff-of-illumination.json
@@ -33,6 +33,7 @@
                     "attenuation": 0.4,
                     "bright": 20,
                     "color": "#aaaaaa",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment-effects/effect-thousand-year-dragonroot.json
+++ b/packs/pf2e/equipment-effects/effect-thousand-year-dragonroot.json
@@ -43,6 +43,7 @@
                     "attenuation": 0.4,
                     "bright": 20,
                     "color": "#f0cf28",
+                    "coloration": 101,
                     "dim": 40,
                     "luminosity": 0.25,
                     "shadows": 0.2

--- a/packs/pf2e/equipment/alicorn-lance.json
+++ b/packs/pf2e/equipment/alicorn-lance.json
@@ -74,6 +74,7 @@
                     },
                     "bright": 20,
                     "color": "#9b7337",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/anglerfish-lantern-submersible.json
+++ b/packs/pf2e/equipment/anglerfish-lantern-submersible.json
@@ -50,6 +50,7 @@
                     },
                     "bright": 60,
                     "color": "#975335",
+                    "coloration": 101,
                     "dim": 120,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/anglerfish-lantern.json
+++ b/packs/pf2e/equipment/anglerfish-lantern.json
@@ -51,6 +51,7 @@
                     },
                     "bright": 60,
                     "color": "#975335",
+                    "coloration": 101,
                     "dim": 120,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/bioluminescence-bomb.json
+++ b/packs/pf2e/equipment/bioluminescence-bomb.json
@@ -59,6 +59,7 @@
                 "key": "TokenLight",
                 "value": {
                     "color": "#9b7337",
+                    "coloration": 101,
                     "dim": 10,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/bioluminescent-stripes.json
+++ b/packs/pf2e/equipment/bioluminescent-stripes.json
@@ -53,6 +53,7 @@
                     },
                     "bright": 20,
                     "color": "#99ffee",
+                    "coloration": 101,
                     "dim": 40
                 }
             },

--- a/packs/pf2e/equipment/blade-of-the-black-sovereign.json
+++ b/packs/pf2e/equipment/blade-of-the-black-sovereign.json
@@ -64,6 +64,7 @@
                         "type": "torch"
                     },
                     "color": "#9b7337",
+                    "coloration": 101,
                     "dim": 5,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/blessed-lantern-flail.json
+++ b/packs/pf2e/equipment/blessed-lantern-flail.json
@@ -66,6 +66,7 @@
                     },
                     "bright": 30,
                     "color": "#975335",
+                    "coloration": 101,
                     "dim": 60,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/candle.json
+++ b/packs/pf2e/equipment/candle.json
@@ -50,6 +50,7 @@
                         "type": "torch"
                     },
                     "color": "#9b7337",
+                    "coloration": 101,
                     "dim": 10,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/candlecap.json
+++ b/packs/pf2e/equipment/candlecap.json
@@ -47,6 +47,7 @@
                         "type": "torch"
                     },
                     "color": "#9b7337",
+                    "coloration": 101,
                     "dim": 20,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/cape-of-illumination-greater.json
+++ b/packs/pf2e/equipment/cape-of-illumination-greater.json
@@ -53,6 +53,7 @@
                     },
                     "bright": 60,
                     "color": "#343434",
+                    "coloration": 101,
                     "dim": 120
                 }
             },

--- a/packs/pf2e/equipment/cape-of-illumination-lesser.json
+++ b/packs/pf2e/equipment/cape-of-illumination-lesser.json
@@ -53,6 +53,7 @@
                     },
                     "bright": 20,
                     "color": "#343434",
+                    "coloration": 101,
                     "dim": 40
                 }
             },

--- a/packs/pf2e/equipment/cape-of-illumination-moderate.json
+++ b/packs/pf2e/equipment/cape-of-illumination-moderate.json
@@ -53,6 +53,7 @@
                     },
                     "bright": 60,
                     "color": "#343434",
+                    "coloration": 101,
                     "dim": 120
                 }
             },

--- a/packs/pf2e/equipment/dawnfire-beacon-major.json
+++ b/packs/pf2e/equipment/dawnfire-beacon-major.json
@@ -87,6 +87,7 @@
                     "alpha": 0.1,
                     "animation": {},
                     "bright": 30,
+                    "coloration": 101,
                     "dim": 60
                 }
             },
@@ -101,6 +102,7 @@
                     "alpha": 0.1,
                     "animation": {},
                     "bright": 60,
+                    "coloration": 101,
                     "dim": 120
                 }
             }

--- a/packs/pf2e/equipment/dawnfire-beacon.json
+++ b/packs/pf2e/equipment/dawnfire-beacon.json
@@ -80,6 +80,7 @@
                     "alpha": 0.1,
                     "animation": {},
                     "bright": 30,
+                    "coloration": 101,
                     "dim": 60
                 }
             },
@@ -94,6 +95,7 @@
                     "alpha": 0.1,
                     "animation": {},
                     "bright": 60,
+                    "coloration": 101,
                     "dim": 120
                 }
             }

--- a/packs/pf2e/equipment/everlight-crystal.json
+++ b/packs/pf2e/equipment/everlight-crystal.json
@@ -46,6 +46,7 @@
                     "attenuation": 0.4,
                     "bright": 20,
                     "color": "#ffdf3d",
+                    "coloration": 101,
                     "dim": 40
                 }
             },

--- a/packs/pf2e/equipment/farlight-stone.json
+++ b/packs/pf2e/equipment/farlight-stone.json
@@ -94,6 +94,7 @@
                     },
                     "bright": 20,
                     "color": "{item|flags.system.rulesSelections.farlightStoneLit}",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/fire-poi.json
+++ b/packs/pf2e/equipment/fire-poi.json
@@ -94,6 +94,7 @@
                         "type": "torch"
                     },
                     "color": "#9b7337",
+                    "coloration": 101,
                     "dim": 10,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/flash-beetle-lantern.json
+++ b/packs/pf2e/equipment/flash-beetle-lantern.json
@@ -45,6 +45,7 @@
                     },
                     "bright": 45,
                     "color": "#fff9a3",
+                    "coloration": 101,
                     "dim": 90
                 }
             },

--- a/packs/pf2e/equipment/fulminating-spear.json
+++ b/packs/pf2e/equipment/fulminating-spear.json
@@ -74,6 +74,7 @@
                     },
                     "bright": 20,
                     "color": "#9b7337",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/ghost-lantern.json
+++ b/packs/pf2e/equipment/ghost-lantern.json
@@ -45,6 +45,7 @@
                     },
                     "bright": 30,
                     "color": "#808080",
+                    "coloration": 101,
                     "dim": 60,
                     "saturation": -0.9,
                     "shadows": 0.2

--- a/packs/pf2e/equipment/ghost-scarf.json
+++ b/packs/pf2e/equipment/ghost-scarf.json
@@ -47,6 +47,7 @@
                         "type": "torch"
                     },
                     "color": "#9b7337",
+                    "coloration": 101,
                     "dim": 10,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/glorious-plate.json
+++ b/packs/pf2e/equipment/glorious-plate.json
@@ -59,7 +59,8 @@
                         "type": "pulse"
                     },
                     "bright": 10,
-                    "color": "#343434"
+                    "color": "#343434",
+                    "coloration": 101
                 }
             },
             {

--- a/packs/pf2e/equipment/golden-blade-of-mzali.json
+++ b/packs/pf2e/equipment/golden-blade-of-mzali.json
@@ -81,6 +81,7 @@
                     },
                     "bright": 60,
                     "color": "#343434",
+                    "coloration": 101,
                     "dim": 120
                 }
             },

--- a/packs/pf2e/equipment/horn-of-the-sun-aurochs.json
+++ b/packs/pf2e/equipment/horn-of-the-sun-aurochs.json
@@ -72,6 +72,7 @@
                     "attenuation": 0.4,
                     "bright": 20,
                     "color": "#eadd99",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/jellyfish-lamp.json
+++ b/packs/pf2e/equipment/jellyfish-lamp.json
@@ -44,6 +44,7 @@
                         "type": "torch"
                     },
                     "color": "#9b7337",
+                    "coloration": 101,
                     "dim": 10,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/lantern-bulls-eye.json
+++ b/packs/pf2e/equipment/lantern-bulls-eye.json
@@ -51,6 +51,7 @@
                     },
                     "bright": 60,
                     "color": "#975335",
+                    "coloration": 101,
                     "dim": 120,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/lantern-hooded.json
+++ b/packs/pf2e/equipment/lantern-hooded.json
@@ -49,6 +49,7 @@
                     },
                     "bright": 30,
                     "color": "#975335",
+                    "coloration": 101,
                     "dim": 60,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/lantern-of-empty-light.json
+++ b/packs/pf2e/equipment/lantern-of-empty-light.json
@@ -51,6 +51,7 @@
                     },
                     "bright": 60,
                     "color": "#4bafaf",
+                    "coloration": 101,
                     "dim": 120,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/life-saver-mail-greater.json
+++ b/packs/pf2e/equipment/life-saver-mail-greater.json
@@ -63,6 +63,7 @@
                     "attenuation": 0.4,
                     "bright": 20,
                     "color": "#88ff88",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/life-saver-mail.json
+++ b/packs/pf2e/equipment/life-saver-mail.json
@@ -63,6 +63,7 @@
                     "attenuation": 0.4,
                     "bright": 20,
                     "color": "#88ff88",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/mask-of-the-mantis-greater.json
+++ b/packs/pf2e/equipment/mask-of-the-mantis-greater.json
@@ -61,6 +61,7 @@
                     },
                     "bright": 0,
                     "color": "#a2022a",
+                    "coloration": 101,
                     "dim": 10,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/mask-of-the-mantis-major.json
+++ b/packs/pf2e/equipment/mask-of-the-mantis-major.json
@@ -61,6 +61,7 @@
                     },
                     "bright": 0,
                     "color": "#a2022a",
+                    "coloration": 101,
                     "dim": 10,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/mask-of-the-mantis.json
+++ b/packs/pf2e/equipment/mask-of-the-mantis.json
@@ -61,6 +61,7 @@
                     },
                     "bright": 0,
                     "color": "#a2022a",
+                    "coloration": 101,
                     "dim": 10,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/mechanical-torch.json
+++ b/packs/pf2e/equipment/mechanical-torch.json
@@ -65,6 +65,7 @@
                     },
                     "bright": 20,
                     "color": "#535387",
+                    "coloration": 101,
                     "dim": 60,
                     "shadows": 0.2
                 }
@@ -83,6 +84,7 @@
                     },
                     "bright": 40,
                     "color": "#535387",
+                    "coloration": 101,
                     "dim": 80,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/minds-light-circlet.json
+++ b/packs/pf2e/equipment/minds-light-circlet.json
@@ -59,6 +59,7 @@
                         "type": "rainbowswirl"
                     },
                     "bright": 0,
+                    "coloration": 101,
                     "dim": 10
                 }
             },

--- a/packs/pf2e/equipment/monarch.json
+++ b/packs/pf2e/equipment/monarch.json
@@ -83,6 +83,7 @@
                         "type": "flame"
                     },
                     "color": "#9b7337",
+                    "coloration": 101,
                     "dim": 10,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/morning-glow.json
+++ b/packs/pf2e/equipment/morning-glow.json
@@ -80,6 +80,7 @@
                     },
                     "bright": 0,
                     "color": "#e7f3f1",
+                    "coloration": 101,
                     "dim": 10
                 }
             }

--- a/packs/pf2e/equipment/queasy-lantern-greater.json
+++ b/packs/pf2e/equipment/queasy-lantern-greater.json
@@ -50,6 +50,7 @@
                     },
                     "bright": 60,
                     "color": "#9b7337",
+                    "coloration": 101,
                     "dim": 120,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/queasy-lantern-lesser.json
+++ b/packs/pf2e/equipment/queasy-lantern-lesser.json
@@ -50,6 +50,7 @@
                     },
                     "bright": 60,
                     "color": "#9b7337",
+                    "coloration": 101,
                     "dim": 120,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/queasy-lantern-moderate.json
+++ b/packs/pf2e/equipment/queasy-lantern-moderate.json
@@ -50,6 +50,7 @@
                     },
                     "bright": 60,
                     "color": "#9b7337",
+                    "coloration": 101,
                     "dim": 120,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/radiant-lance.json
+++ b/packs/pf2e/equipment/radiant-lance.json
@@ -73,7 +73,8 @@
                         "type": "pulse"
                     },
                     "bright": 60,
-                    "color": "#343434"
+                    "color": "#343434",
+                    "coloration": 101
                 }
             },
             {

--- a/packs/pf2e/equipment/scarlet-queen.json
+++ b/packs/pf2e/equipment/scarlet-queen.json
@@ -79,6 +79,7 @@
                         "type": "torch"
                     },
                     "color": "#9b7337",
+                    "coloration": 101,
                     "dim": 15,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/searing-blade-greater.json
+++ b/packs/pf2e/equipment/searing-blade-greater.json
@@ -64,6 +64,7 @@
                         "type": "torch"
                     },
                     "color": "#9b7337",
+                    "coloration": 101,
                     "dim": 10,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/searing-blade.json
+++ b/packs/pf2e/equipment/searing-blade.json
@@ -64,6 +64,7 @@
                         "type": "torch"
                     },
                     "color": "#9b7337",
+                    "coloration": 101,
                     "dim": 10,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/serithtial.json
+++ b/packs/pf2e/equipment/serithtial.json
@@ -93,6 +93,7 @@
                     "attenuation": 0.4,
                     "bright": 20,
                     "color": "#aaaaaa",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/shard-of-the-third-seal.json
+++ b/packs/pf2e/equipment/shard-of-the-third-seal.json
@@ -45,6 +45,7 @@
                     },
                     "bright": 20,
                     "color": "#9b7337",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/shining-hackle.json
+++ b/packs/pf2e/equipment/shining-hackle.json
@@ -60,6 +60,7 @@
                     "animation": {},
                     "bright": 20,
                     "color": "#ffe8c7",
+                    "coloration": 101,
                     "dim": 40
                 }
             },

--- a/packs/pf2e/equipment/shining-symbol-greater.json
+++ b/packs/pf2e/equipment/shining-symbol-greater.json
@@ -55,6 +55,7 @@
                         "type": "starlight"
                     },
                     "color": "#bfbfbf",
+                    "coloration": 101,
                     "dim": 20
                 }
             },
@@ -70,7 +71,8 @@
                         "type": "starlight"
                     },
                     "bright": 20,
-                    "color": "#bfbfbf"
+                    "color": "#bfbfbf",
+                    "coloration": 101
                 }
             },
             {

--- a/packs/pf2e/equipment/shining-symbol-major.json
+++ b/packs/pf2e/equipment/shining-symbol-major.json
@@ -55,6 +55,7 @@
                         "type": "starlight"
                     },
                     "color": "#bfbfbf",
+                    "coloration": 101,
                     "dim": 20
                 }
             },
@@ -70,7 +71,8 @@
                         "type": "starlight"
                     },
                     "bright": 20,
-                    "color": "#bfbfbf"
+                    "color": "#bfbfbf",
+                    "coloration": 101
                 }
             },
             {

--- a/packs/pf2e/equipment/shining-symbol.json
+++ b/packs/pf2e/equipment/shining-symbol.json
@@ -55,6 +55,7 @@
                         "type": "starlight"
                     },
                     "color": "#bfbfbf",
+                    "coloration": 101,
                     "dim": 20
                 }
             },
@@ -70,7 +71,8 @@
                         "type": "starlight"
                     },
                     "bright": 20,
-                    "color": "#bfbfbf"
+                    "color": "#bfbfbf",
+                    "coloration": 101
                 }
             },
             {

--- a/packs/pf2e/equipment/silversoul-bomb-greater.json
+++ b/packs/pf2e/equipment/silversoul-bomb-greater.json
@@ -90,6 +90,7 @@
                     "attenuation": 0.4,
                     "bright": 20,
                     "color": "#c4dce9",
+                    "coloration": 101,
                     "dim": 40,
                     "luminosity": 0.25,
                     "shadows": 0.2

--- a/packs/pf2e/equipment/silversoul-bomb-major.json
+++ b/packs/pf2e/equipment/silversoul-bomb-major.json
@@ -90,6 +90,7 @@
                     "attenuation": 0.4,
                     "bright": 20,
                     "color": "#c4dce9",
+                    "coloration": 101,
                     "dim": 40,
                     "luminosity": 0.25,
                     "shadows": 0.2

--- a/packs/pf2e/equipment/silversoul-bomb.json
+++ b/packs/pf2e/equipment/silversoul-bomb.json
@@ -90,6 +90,7 @@
                     "attenuation": 0.4,
                     "bright": 20,
                     "color": "#c4dce9",
+                    "coloration": 101,
                     "dim": 40,
                     "luminosity": 0.25,
                     "shadows": 0.2

--- a/packs/pf2e/equipment/skyfang-crystal.json
+++ b/packs/pf2e/equipment/skyfang-crystal.json
@@ -45,6 +45,7 @@
                         "type": "torch"
                     },
                     "color": "#14b1ff",
+                    "coloration": 101,
                     "dim": 10,
                     "luminosity": 0.2,
                     "shadows": 0.2

--- a/packs/pf2e/equipment/songbirds-brush.json
+++ b/packs/pf2e/equipment/songbirds-brush.json
@@ -80,6 +80,7 @@
                     "attenuation": 0.4,
                     "bright": 20,
                     "color": "#787878",
+                    "coloration": 101,
                     "dim": 40
                 }
             },

--- a/packs/pf2e/equipment/soulheart-angelic.json
+++ b/packs/pf2e/equipment/soulheart-angelic.json
@@ -47,6 +47,7 @@
                     },
                     "bright": 0,
                     "color": "#d45a47",
+                    "coloration": 101,
                     "dim": 10,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/soulheart-greater.json
+++ b/packs/pf2e/equipment/soulheart-greater.json
@@ -47,6 +47,7 @@
                     },
                     "bright": 0,
                     "color": "#d45a47",
+                    "coloration": 101,
                     "dim": 10,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/soulheart-major.json
+++ b/packs/pf2e/equipment/soulheart-major.json
@@ -47,6 +47,7 @@
                     },
                     "bright": 0,
                     "color": "#d45a47",
+                    "coloration": 101,
                     "dim": 10,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/soulheart-pure.json
+++ b/packs/pf2e/equipment/soulheart-pure.json
@@ -47,6 +47,7 @@
                     },
                     "bright": 0,
                     "color": "#d45a47",
+                    "coloration": 101,
                     "dim": 10,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/soulheart.json
+++ b/packs/pf2e/equipment/soulheart.json
@@ -47,6 +47,7 @@
                     },
                     "bright": 0,
                     "color": "#d45a47",
+                    "coloration": 101,
                     "dim": 10,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/starfaring-cloak.json
+++ b/packs/pf2e/equipment/starfaring-cloak.json
@@ -53,6 +53,7 @@
                         "type": "torch"
                     },
                     "color": "#9b7337",
+                    "coloration": 101,
                     "dim": 10,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/the-hollow-star.json
+++ b/packs/pf2e/equipment/the-hollow-star.json
@@ -47,6 +47,7 @@
                     "attenuation": 0.4,
                     "bright": 60,
                     "color": "#ffdf3d",
+                    "coloration": 101,
                     "dim": 120
                 }
             },

--- a/packs/pf2e/equipment/torch.json
+++ b/packs/pf2e/equipment/torch.json
@@ -50,6 +50,7 @@
                     "attenuation": 0.4,
                     "bright": 20,
                     "color": "#ffae3d",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/vine-of-roses.json
+++ b/packs/pf2e/equipment/vine-of-roses.json
@@ -76,6 +76,7 @@
                     "attenuation": 0.4,
                     "bright": 20,
                     "color": "#fff7a3",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/wand-of-dazzling-rays-3rd-rank.json
+++ b/packs/pf2e/equipment/wand-of-dazzling-rays-3rd-rank.json
@@ -61,6 +61,7 @@
                     },
                     "bright": 20,
                     "color": "#fffb80",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }
@@ -77,6 +78,7 @@
                         "type": "starlight"
                     },
                     "color": "#fffb80",
+                    "coloration": 101,
                     "dim": 20,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/wand-of-dazzling-rays-4th-rank.json
+++ b/packs/pf2e/equipment/wand-of-dazzling-rays-4th-rank.json
@@ -61,6 +61,7 @@
                     },
                     "bright": 20,
                     "color": "#fffb80",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }
@@ -77,6 +78,7 @@
                         "type": "starlight"
                     },
                     "color": "#fffb80",
+                    "coloration": 101,
                     "dim": 20,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/wand-of-dazzling-rays-5th-rank.json
+++ b/packs/pf2e/equipment/wand-of-dazzling-rays-5th-rank.json
@@ -61,6 +61,7 @@
                     },
                     "bright": 20,
                     "color": "#fffb80",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }
@@ -77,6 +78,7 @@
                         "type": "starlight"
                     },
                     "color": "#fffb80",
+                    "coloration": 101,
                     "dim": 20,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/wand-of-dazzling-rays-6th-rank.json
+++ b/packs/pf2e/equipment/wand-of-dazzling-rays-6th-rank.json
@@ -62,6 +62,7 @@
                     },
                     "bright": 20,
                     "color": "#fffb80",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }
@@ -78,6 +79,7 @@
                         "type": "starlight"
                     },
                     "color": "#fffb80",
+                    "coloration": 101,
                     "dim": 20,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/wand-of-dazzling-rays-7th-rank.json
+++ b/packs/pf2e/equipment/wand-of-dazzling-rays-7th-rank.json
@@ -62,6 +62,7 @@
                     },
                     "bright": 20,
                     "color": "#fffb80",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }
@@ -78,6 +79,7 @@
                         "type": "starlight"
                     },
                     "color": "#fffb80",
+                    "coloration": 101,
                     "dim": 20,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/wand-of-dazzling-rays-8th-rank.json
+++ b/packs/pf2e/equipment/wand-of-dazzling-rays-8th-rank.json
@@ -62,6 +62,7 @@
                     },
                     "bright": 20,
                     "color": "#fffb80",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }
@@ -78,6 +79,7 @@
                         "type": "starlight"
                     },
                     "color": "#fffb80",
+                    "coloration": 101,
                     "dim": 20,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/equipment/wand-of-dazzling-rays-9th-rank.json
+++ b/packs/pf2e/equipment/wand-of-dazzling-rays-9th-rank.json
@@ -61,6 +61,7 @@
                     },
                     "bright": 20,
                     "color": "#fffb80",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }
@@ -77,6 +78,7 @@
                         "type": "starlight"
                     },
                     "color": "#fffb80",
+                    "coloration": 101,
                     "dim": 20,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/familiar-abilities/elemental-familiar-fire.json
+++ b/packs/pf2e/familiar-abilities/elemental-familiar-fire.json
@@ -29,6 +29,7 @@
                     },
                     "bright": 20,
                     "color": "#9b7337",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/familiar-abilities/luminous.json
+++ b/packs/pf2e/familiar-abilities/luminous.json
@@ -37,6 +37,7 @@
                     },
                     "bright": 30,
                     "color-intensity": 0.2,
+                    "coloration": 101,
                     "dim": 60
                 }
             }

--- a/packs/pf2e/feat-effects/effect-celestial-armaments-allies.json
+++ b/packs/pf2e/feat-effects/effect-celestial-armaments-allies.json
@@ -44,6 +44,7 @@
                     "attenuation": 0.4,
                     "bright": 20,
                     "color": "#ffae3d",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/feat-effects/effect-celestial-armaments.json
+++ b/packs/pf2e/feat-effects/effect-celestial-armaments.json
@@ -46,6 +46,7 @@
                     "attenuation": 0.4,
                     "bright": 20,
                     "color": "#ffae3d",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/feat-effects/effect-eternal-torch.json
+++ b/packs/pf2e/feat-effects/effect-eternal-torch.json
@@ -33,6 +33,7 @@
                     "attenuation": 0.4,
                     "bright": "ternary(gte(@item.origin.level,8),60,20)",
                     "color": "#ffae3d",
+                    "coloration": 101,
                     "dim": "ternary(gte(@item.origin.level,8),120,40)",
                     "shadows": 0.2
                 }

--- a/packs/pf2e/feat-effects/effect-nanite-surge.json
+++ b/packs/pf2e/feat-effects/effect-nanite-surge.json
@@ -25,6 +25,7 @@
                 "key": "TokenLight",
                 "value": {
                     "color": "#9b7337",
+                    "coloration": 101,
                     "dim": 10,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/feat-effects/effect-radiant-circuitry.json
+++ b/packs/pf2e/feat-effects/effect-radiant-circuitry.json
@@ -26,6 +26,7 @@
                 "value": {
                     "bright": 20,
                     "color": "#9b7337",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/feat-effects/effect-starlight-armor.json
+++ b/packs/pf2e/feat-effects/effect-starlight-armor.json
@@ -35,6 +35,7 @@
                 "value": {
                     "bright": 20,
                     "color": "#9b7337",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/feats/ancestry/kashrishi/level-1/crystal-luminescence.json
+++ b/packs/pf2e/feats/ancestry/kashrishi/level-1/crystal-luminescence.json
@@ -38,6 +38,7 @@
                     },
                     "bright": "@actor.flags.system.crystalLuminescence.dimRadius",
                     "color": "{item|flags.system.rulesSelections.color}",
+                    "coloration": 101,
                     "dim": "@actor.flags.system.crystalLuminescence.brightRadius"
                 }
             },

--- a/packs/pf2e/feats/ancestry/versatile-heritages/nephilim/halo.json
+++ b/packs/pf2e/feats/ancestry/versatile-heritages/nephilim/halo.json
@@ -46,6 +46,7 @@
                     },
                     "bright": "ternary(gte(ceil(@actor.level / 2),4),60,20)",
                     "color": "#e7f3f1",
+                    "coloration": 101,
                     "dim": "ternary(gte(ceil(@actor.level / 2),4),120,40)"
                 }
             },

--- a/packs/pf2e/feats/archetype/ascended-celestial/level-12/ascended-celestial-dedication.json
+++ b/packs/pf2e/feats/archetype/ascended-celestial/level-12/ascended-celestial-dedication.json
@@ -79,6 +79,7 @@
                     },
                     "bright": "@actor.flags.system.ascendedCelestial.aura",
                     "color": "#ffc629",
+                    "coloration": 101,
                     "dim": "2*@actor.flags.system.ascendedCelestial.aura"
                 }
             },

--- a/packs/pf2e/feats/archetype/exorcist/exorcist-dedication.json
+++ b/packs/pf2e/feats/archetype/exorcist/exorcist-dedication.json
@@ -57,6 +57,7 @@
                     },
                     "attenuation": 0.4,
                     "color": "#90b4b4",
+                    "coloration": 101,
                     "dim": 10,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/feats/archetype/soul-warden/soul-warden-dedication.json
+++ b/packs/pf2e/feats/archetype/soul-warden/soul-warden-dedication.json
@@ -41,6 +41,7 @@
                 "value": {
                     "bright": "ternary(gte(@actor.flags.system.soulWarden.featCount,3),10,0)",
                     "color": "#0056a1",
+                    "coloration": 101,
                     "dim": "ternary(gte(@actor.flags.system.soulWarden.featCount,3),20,10)",
                     "luminosity": 0.4
                 }

--- a/packs/pf2e/heritages/azarketi/ancient-scale-azarketi.json
+++ b/packs/pf2e/heritages/azarketi/ancient-scale-azarketi.json
@@ -44,6 +44,7 @@
                     "attenuation": 0.35,
                     "bright": 0,
                     "color": "#b5dedd",
+                    "coloration": 101,
                     "dim": 10,
                     "luminosity": 0.4,
                     "shadows": 0.2

--- a/packs/pf2e/heritages/fetchling/bright-fetchling.json
+++ b/packs/pf2e/heritages/fetchling/bright-fetchling.json
@@ -25,6 +25,7 @@
                 ],
                 "value": {
                     "color": "#c4abab",
+                    "coloration": 101,
                     "dim": 5,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/heritages/sprite/luminous-sprite.json
+++ b/packs/pf2e/heritages/sprite/luminous-sprite.json
@@ -76,6 +76,7 @@
                     "animation": {},
                     "bright": 20,
                     "color": "{item|flags.system.rulesSelections.luminousSpriteLit}",
+                    "coloration": 101,
                     "dim": 40,
                     "luminosity": 0.15
                 }

--- a/packs/pf2e/heritages/surki/elytron-surki.json
+++ b/packs/pf2e/heritages/surki/elytron-surki.json
@@ -61,6 +61,7 @@
                     },
                     "bright": 20,
                     "color": "#4ee9fd",
+                    "coloration": 101,
                     "dim": 40,
                     "luminosity": 0.1,
                     "saturation": -0.2

--- a/packs/pf2e/heritages/surki/lantern-surki.json
+++ b/packs/pf2e/heritages/surki/lantern-surki.json
@@ -103,6 +103,7 @@
                     "alpha": 0.1,
                     "bright": 20,
                     "color": "{item|flags.system.rulesSelections.lanternSurkiLit}",
+                    "coloration": 101,
                     "dim": 40,
                     "luminosity": 0.15
                 }

--- a/packs/pf2e/iconics/korakai/korakai-level-5.json
+++ b/packs/pf2e/iconics/korakai/korakai-level-5.json
@@ -3744,7 +3744,8 @@
                                 "type": "starlight"
                             },
                             "bright": 20,
-                            "color": "#bfbfbf"
+                            "color": "#bfbfbf",
+                            "coloration": 101
                         }
                     },
                     {

--- a/packs/pf2e/iconics/samo/samo-level-5.json
+++ b/packs/pf2e/iconics/samo/samo-level-5.json
@@ -4714,7 +4714,8 @@
                                 "type": "starlight"
                             },
                             "bright": 20,
-                            "color": "#bfbfbf"
+                            "color": "#bfbfbf",
+                            "coloration": 101
                         }
                     },
                     {

--- a/packs/pf2e/kingmaker-bestiary/ancient-wisp.json
+++ b/packs/pf2e/kingmaker-bestiary/ancient-wisp.json
@@ -85,7 +85,8 @@
                                 "type": "pulse"
                             },
                             "bright": 20,
-                            "color": "#fff9a3"
+                            "color": "#fff9a3",
+                            "coloration": 101
                         }
                     },
                     {
@@ -103,7 +104,8 @@
                                 "type": "pulse"
                             },
                             "bright": 1,
-                            "color": "#fff9a3"
+                            "color": "#fff9a3",
+                            "coloration": 101
                         }
                     },
                     {

--- a/packs/pf2e/kingmaker-bestiary/spirit-of-stisshak.json
+++ b/packs/pf2e/kingmaker-bestiary/spirit-of-stisshak.json
@@ -410,7 +410,8 @@
                                 "type": "pulse"
                             },
                             "bright": 20,
-                            "color": "#fff9a3"
+                            "color": "#fff9a3",
+                            "coloration": 101
                         }
                     }
                 ],

--- a/packs/pf2e/lost-omens-bestiary/mwangi-expanse/solar-ibis.json
+++ b/packs/pf2e/lost-omens-bestiary/mwangi-expanse/solar-ibis.json
@@ -123,7 +123,8 @@
                                 "type": "pulse"
                             },
                             "bright": 30,
-                            "color": "#fff9a3"
+                            "color": "#fff9a3",
+                            "coloration": 101
                         }
                     },
                     {

--- a/packs/pf2e/paizo-pregens/things-go-to-hell/hila.json
+++ b/packs/pf2e/paizo-pregens/things-go-to-hell/hila.json
@@ -3626,7 +3626,8 @@
                                 "type": "starlight"
                             },
                             "bright": 20,
-                            "color": "#bfbfbf"
+                            "color": "#bfbfbf",
+                            "coloration": 101
                         }
                     },
                     {

--- a/packs/pf2e/pathfinder-monster-core/flash-beetle.json
+++ b/packs/pf2e/pathfinder-monster-core/flash-beetle.json
@@ -79,7 +79,8 @@
                                 "type": "pulse"
                             },
                             "bright": 10,
-                            "color": "#fff9a3"
+                            "color": "#fff9a3",
+                            "coloration": 101
                         }
                     },
                     {

--- a/packs/pf2e/pathfinder-monster-core/shining-child.json
+++ b/packs/pf2e/pathfinder-monster-core/shining-child.json
@@ -945,7 +945,8 @@
                         "value": {
                             "alpha": 0.2,
                             "bright": 60,
-                            "color": "#AAAAAA"
+                            "color": "#AAAAAA",
+                            "coloration": 101
                         }
                     },
                     {

--- a/packs/pf2e/pathfinder-monster-core/will-o-wisp.json
+++ b/packs/pf2e/pathfinder-monster-core/will-o-wisp.json
@@ -82,7 +82,8 @@
                                 "type": "pulse"
                             },
                             "bright": 20,
-                            "color": "#fff9a3"
+                            "color": "#fff9a3",
+                            "coloration": 101
                         }
                     }
                 ],

--- a/packs/pf2e/pathfinder-npc-core/devotee/traveling-priest-of-desna.json
+++ b/packs/pf2e/pathfinder-npc-core/devotee/traveling-priest-of-desna.json
@@ -2036,7 +2036,8 @@
                                 "type": "starlight"
                             },
                             "bright": 20,
-                            "color": "#bfbfbf"
+                            "color": "#bfbfbf",
+                            "coloration": 101
                         }
                     },
                     {

--- a/packs/pf2e/revenge-of-the-runelords-bestiary/book-1-lord-of-the-trinity-star/ayavah.json
+++ b/packs/pf2e/revenge-of-the-runelords-bestiary/book-1-lord-of-the-trinity-star/ayavah.json
@@ -3478,7 +3478,8 @@
                                 "type": "starlight"
                             },
                             "bright": 20,
-                            "color": "#bfbfbf"
+                            "color": "#bfbfbf",
+                            "coloration": 101
                         }
                     },
                     {

--- a/packs/pf2e/spell-effects/spell-effect-angelic-wings.json
+++ b/packs/pf2e/spell-effects/spell-effect-angelic-wings.json
@@ -35,7 +35,8 @@
                         "type": "starlight"
                     },
                     "bright": 30,
-                    "color": "#8f8f8f"
+                    "color": "#8f8f8f",
+                    "coloration": 101
                 }
             }
         ],

--- a/packs/pf2e/spell-effects/spell-effect-chromatic-armor.json
+++ b/packs/pf2e/spell-effects/spell-effect-chromatic-armor.json
@@ -267,6 +267,7 @@
                     },
                     "bright": 20,
                     "color": "#343434",
+                    "coloration": 101,
                     "dim": 40
                 }
             }

--- a/packs/pf2e/spell-effects/spell-effect-cloak-of-light.json
+++ b/packs/pf2e/spell-effects/spell-effect-cloak-of-light.json
@@ -31,6 +31,7 @@
                     },
                     "bright": 30,
                     "color": "#343434",
+                    "coloration": 101,
                     "dim": 60
                 }
             }

--- a/packs/pf2e/spell-effects/spell-effect-diadem-of-divine-radiance.json
+++ b/packs/pf2e/spell-effects/spell-effect-diadem-of-divine-radiance.json
@@ -31,6 +31,7 @@
                     },
                     "bright": 60,
                     "color": "#ccfff0",
+                    "coloration": 101,
                     "dim": 120
                 }
             }

--- a/packs/pf2e/spell-effects/spell-effect-everlight.json
+++ b/packs/pf2e/spell-effects/spell-effect-everlight.json
@@ -32,6 +32,7 @@
                     "attenuation": 0.4,
                     "bright": 20,
                     "color": "#ffdf3d",
+                    "coloration": 101,
                     "dim": 40
                 }
             }

--- a/packs/pf2e/spell-effects/spell-effect-funeral-flames.json
+++ b/packs/pf2e/spell-effects/spell-effect-funeral-flames.json
@@ -64,6 +64,7 @@
                     "attenuation": 0.4,
                     "bright": 20,
                     "color": "#ffae3d",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/spell-effects/spell-effect-life-giving-form.json
+++ b/packs/pf2e/spell-effects/spell-effect-life-giving-form.json
@@ -33,6 +33,7 @@
                     "attenuation": 0.4,
                     "bright": 20,
                     "color": "#ffae3d",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/spell-effects/spell-effect-light.json
+++ b/packs/pf2e/spell-effects/spell-effect-light.json
@@ -32,6 +32,7 @@
                     },
                     "bright": "ternary(gte(@item.level,4),60,20)",
                     "color": "#e7f3f1",
+                    "coloration": 101,
                     "dim": "ternary(gte(@item.level,4),120,40)"
                 }
             }

--- a/packs/pf2e/spell-effects/spell-effect-palm-held-sun.json
+++ b/packs/pf2e/spell-effects/spell-effect-palm-held-sun.json
@@ -33,6 +33,7 @@
                     "attenuation": 0.4,
                     "bright": 30,
                     "color": "#fff0a3",
+                    "coloration": 101,
                     "dim": 60
                 }
             },

--- a/packs/pf2e/spell-effects/spell-effect-suns-fury.json
+++ b/packs/pf2e/spell-effects/spell-effect-suns-fury.json
@@ -57,6 +57,7 @@
                     "attenuation": 0.4,
                     "bright": 20,
                     "color": "#ffae3d",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/spell-effects/spell-effect-tomorrows-dawn.json
+++ b/packs/pf2e/spell-effects/spell-effect-tomorrows-dawn.json
@@ -33,6 +33,7 @@
                     "attenuation": 0.4,
                     "bright": 20,
                     "color": "#ffae3d",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/spell-effects/spell-effect-touch-of-the-moon.json
+++ b/packs/pf2e/spell-effects/spell-effect-touch-of-the-moon.json
@@ -41,6 +41,7 @@
                         "type": "pulse"
                     },
                     "color": "#343434",
+                    "coloration": 101,
                     "dim": 20,
                     "shadows": 0.2
                 }

--- a/packs/pf2e/spell-effects/spell-effect-vital-luminance.json
+++ b/packs/pf2e/spell-effects/spell-effect-vital-luminance.json
@@ -36,6 +36,7 @@
                     },
                     "bright": 30,
                     "color": "#dfbc0c",
+                    "coloration": 101,
                     "dim": 60
                 }
             }

--- a/packs/pf2e/strength-of-thousands-bestiary/book-4-secrets-of-the-temple-city/sunburst-corpse.json
+++ b/packs/pf2e/strength-of-thousands-bestiary/book-4-secrets-of-the-temple-city/sunburst-corpse.json
@@ -126,7 +126,8 @@
                         ],
                         "value": {
                             "bright": 60,
-                            "color": "#ffffff"
+                            "color": "#ffffff",
+                            "coloration": 101
                         }
                     },
                     {

--- a/packs/sf2e/ancestry-features/novian/solar-luminance.json
+++ b/packs/sf2e/ancestry-features/novian/solar-luminance.json
@@ -37,6 +37,7 @@
                     "alpha": 0.1,
                     "bright": 20,
                     "color": "#e9b80e",
+                    "coloration": 101,
                     "dim": 40,
                     "luminosity": 0.15
                 }

--- a/packs/sf2e/equipment-effects/effect-let-the-sun-shine.json
+++ b/packs/sf2e/equipment-effects/effect-let-the-sun-shine.json
@@ -34,6 +34,7 @@
                     "attenuation": 0.4,
                     "bright": 20,
                     "color": "#ffae3d",
+                    "coloration": 101,
                     "dim": 40,
                     "shadows": 0.2
                 }

--- a/packs/sf2e/equipment/adventuring-gear/comm-unit.json
+++ b/packs/sf2e/equipment/adventuring-gear/comm-unit.json
@@ -51,6 +51,7 @@
                     "attenuation": 0.4,
                     "bright": 5,
                     "color": "#ffae3d",
+                    "coloration": 101,
                     "dim": 10,
                     "shadows": 0.2
                 }

--- a/packs/sf2e/equipment/adventuring-gear/flashlight-commercial.json
+++ b/packs/sf2e/equipment/adventuring-gear/flashlight-commercial.json
@@ -52,6 +52,7 @@
                     "animation": {},
                     "bright": 30,
                     "color": "#dfeaf1",
+                    "coloration": 101,
                     "dim": 60,
                     "luminosity": 0.3
                 }

--- a/packs/sf2e/equipment/adventuring-gear/flashlight-tactical.json
+++ b/packs/sf2e/equipment/adventuring-gear/flashlight-tactical.json
@@ -52,6 +52,7 @@
                     "animation": {},
                     "bright": 60,
                     "color": "#dfeaf1",
+                    "coloration": 101,
                     "dim": 120,
                     "luminosity": 0.3
                 }

--- a/packs/sf2e/equipment/adventuring-gear/revealing-flashlight.json
+++ b/packs/sf2e/equipment/adventuring-gear/revealing-flashlight.json
@@ -51,6 +51,7 @@
                     "alpha": 0.1,
                     "bright": 0,
                     "color": "#dfeaf1",
+                    "coloration": 101,
                     "dim": 30,
                     "luminosity": 0.3
                 }

--- a/packs/sf2e/feat-effects/effect-bursting-surge.json
+++ b/packs/sf2e/feat-effects/effect-bursting-surge.json
@@ -27,6 +27,7 @@
                 "value": {
                     "bright": 10,
                     "color": "#9b7337",
+                    "coloration": 101,
                     "dim": 20,
                     "shadows": 0.2
                 }

--- a/packs/sf2e/feat-effects/effect-kindle-blaze.json
+++ b/packs/sf2e/feat-effects/effect-kindle-blaze.json
@@ -26,6 +26,7 @@
                 "key": "TokenLight",
                 "value": {
                     "bright": 30,
+                    "coloration": 101,
                     "dim": 60
                 }
             },

--- a/packs/sf2e/feat-effects/effect-solar-weapon-twin-weapons.json
+++ b/packs/sf2e/feat-effects/effect-solar-weapon-twin-weapons.json
@@ -448,6 +448,7 @@
                     },
                     "bright": 5,
                     "color": "#ffd35c",
+                    "coloration": 101,
                     "dim": 10
                 }
             }

--- a/packs/sf2e/feat-effects/effect-solar-weapon.json
+++ b/packs/sf2e/feat-effects/effect-solar-weapon.json
@@ -531,6 +531,7 @@
                     },
                     "bright": 5,
                     "color": "#ffd35c",
+                    "coloration": 101,
                     "dim": 10
                 }
             }

--- a/packs/sf2e/feats/ancestry/kalo/level-1/bioluminescence.json
+++ b/packs/sf2e/feats/ancestry/kalo/level-1/bioluminescence.json
@@ -47,6 +47,7 @@
                     },
                     "bright": "@actor.flags.system.kalo.bioluminescence.range",
                     "color": "#2ba269",
+                    "coloration": 101,
                     "dim": "@actor.flags.system.kalo.bioluminescence.range",
                     "shadows": 0.2
                 }

--- a/packs/sf2e/feats/ancestry/sarcesian/level-1/luminous-wings.json
+++ b/packs/sf2e/feats/ancestry/sarcesian/level-1/luminous-wings.json
@@ -39,6 +39,7 @@
                 ],
                 "value": {
                     "bright": 20,
+                    "coloration": 101,
                     "dim": 40
                 }
             }

--- a/packs/sf2e/feats/ancestry/shirren/level-1/bioluminescence-shirren.json
+++ b/packs/sf2e/feats/ancestry/shirren/level-1/bioluminescence-shirren.json
@@ -34,6 +34,7 @@
                 "value": {
                     "alpha": 0.15,
                     "bright": "@actor.flags.sf2e.shirren.bioluminescence.bright",
+                    "coloration": 101,
                     "dim": "@actor.flags.sf2e.shirren.bioluminescence.dim"
                 }
             },

--- a/packs/sf2e/feats/ancestry/talphi/level-1/glow-painter.json
+++ b/packs/sf2e/feats/ancestry/talphi/level-1/glow-painter.json
@@ -52,6 +52,7 @@
                     "alpha": 0.2,
                     "bright": 0,
                     "color": "#e49449",
+                    "coloration": 101,
                     "dim": 15
                 }
             }

--- a/packs/sf2e/heritages/brenneri/bioluminescent-brenneri.json
+++ b/packs/sf2e/heritages/brenneri/bioluminescent-brenneri.json
@@ -26,6 +26,7 @@
                 "value": {
                     "alpha": 0.15,
                     "bright": 4,
+                    "coloration": 101,
                     "dim": 8
                 }
             },

--- a/packs/sf2e/heritages/leshy/moonflower-leshy.json
+++ b/packs/sf2e/heritages/leshy/moonflower-leshy.json
@@ -79,6 +79,7 @@
                     "alpha": 0.3,
                     "bright": 4,
                     "color": "{item|flags.system.rulesSelections.moonflowerLeshyLit}",
+                    "coloration": 101,
                     "dim": 8
                 }
             }

--- a/packs/sf2e/heritages/vlaka/star-marked-vlaka.json
+++ b/packs/sf2e/heritages/vlaka/star-marked-vlaka.json
@@ -31,6 +31,7 @@
                 ],
                 "value": {
                     "bright": 40,
+                    "coloration": 101,
                     "dim": 80
                 }
             }


### PR DESCRIPTION
A party with light spells and some will-o'-wisps. Adaptive Attenuation (2nd screenshot) handles light stacking much better
<img width="984" height="653" alt="image" src="https://github.com/user-attachments/assets/b7f856f5-c87c-48f9-ae92-6eb11cc8d68c" />
<img width="1174" height="813" alt="image" src="https://github.com/user-attachments/assets/34eb05cf-888b-4694-be75-173daf51652c" />

