### PR TITLE
Add Combination Weapon usage toggle

### DIFF
--- a/src/module/actor/character/auxiliary.ts
+++ b/src/module/actor/character/auxiliary.ts
@@ -14,7 +14,7 @@ import { ChoiceSetSource } from "@module/rules/rule-element/choice-set/data.ts";
 interface AuxiliaryInteractParams {
     weapon: WeaponPF2e<CharacterPF2e>;
     action: "interact";
-    annotation: "draw" | "grip" | "modular" | "pick-up" | "retrieve" | "sheathe" | "boost";
+    annotation: "combination" | "draw" | "grip" | "modular" | "pick-up" | "retrieve" | "sheathe" | "boost";
     hands?: ZeroToTwo;
 }
 
@@ -79,6 +79,8 @@ class WeaponAuxiliaryAction {
                     return [action === "interact" ? 1 : 0, "held", annotation];
                 case "sheathe":
                     return [1, "worn", annotation];
+                case "combination":
+                    return [1, null, annotation];
                 case "modular":
                     return [1, null, annotation];
                 case "drop":
@@ -117,6 +119,20 @@ class WeaponAuxiliaryAction {
 
     get options(): SheetOptions | null {
         const traits = this.weapon.system.traits;
+        if (this.annotation === "combination") {
+            const toggle = traits.toggles.combination;
+            if (!toggle) return null;
+            return R.mapToObj(toggle.options, (value) => [
+                value,
+                {
+                    value,
+                    label: _loc(
+                        value === "melee" ? "PF2E.Item.Weapon.MeleeUsage.Label" : "PF2E.Item.Weapon.RangedUsage.Label",
+                    ),
+                    selected: value === toggle.selected,
+                },
+            ]);
+        }
         if (this.annotation === "modular") {
             const toggles = traits.toggles.modular;
             if (!toggles) return null;
@@ -143,7 +159,7 @@ class WeaponAuxiliaryAction {
 
     /**
      * Execute an auxiliary action.
-     * [options.selection] A choice of some kind: currently only has meaning for modular trait toggling
+     * [options.selection] A choice of some kind: modular trait toggle or combination weapon mode
      */
     async execute({ selection = null }: { selection?: string | null } = {}): Promise<void> {
         const { actor, weapon } = this;
@@ -155,6 +171,12 @@ class WeaponAuxiliaryAction {
             await weapon.rule.toggleGrip(this.hands === 2 ? 2 : 1);
         } else if (this.carryType) {
             await actor.changeCarryType(this.weapon, { carryType: this.carryType, handsHeld: this.hands ?? 0 });
+        } else if (this.annotation === "combination" && (selection === "melee" || selection === "ranged")) {
+            const updated = await weapon.system.traits.toggles.update({
+                trait: "combination",
+                selected: selection,
+            });
+            if (!updated) return;
         } else if (selection && this.annotation === "modular" && selection) {
             const updated = await weapon.system.traits.toggles.update({
                 trait: "modular",
@@ -243,6 +265,14 @@ class WeaponAuxiliaryAction {
                 weapon: weapon.name,
                 shield: weapon.shield?.name ?? weapon.name,
                 modularConfig: modularConfig ? this.#getModularConfigLabel(modularConfig) : null,
+                combinationUsage:
+                    this.annotation === "combination" && (selection === "melee" || selection === "ranged")
+                        ? _loc(
+                              selection === "melee"
+                                  ? "PF2E.Item.Weapon.MeleeUsage.Label"
+                                  : "PF2E.Item.Weapon.RangedUsage.Label",
+                          )
+                        : null,
             }),
         });
 

--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -1122,6 +1122,20 @@ class CharacterPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e
                 // If this is an automatic weapon, add the area usage at the very end
                 attack.altUsages.push(this.prepareAreaAttack(weapon, { handsReallyFree }));
             }
+
+            // Combination weapons only present the selected usage. Thrown attacks of the melee usage remain available
+            // while in melee mode.
+            const comboMode = weapon.system.traits.toggles.combination?.selected;
+            if (comboMode === "melee") {
+                attack.canAttack = false;
+                attack.altUsages = attack.altUsages.filter(
+                    (usage) => usage.type === "strike" && (usage.item.altUsageType === "melee" || usage.item.isThrown),
+                );
+            } else if (comboMode === "ranged") {
+                attack.altUsages = attack.altUsages.filter(
+                    (usage) => usage.item.altUsageType !== "melee" && !(usage.item.isThrown && usage.item.comboSibling),
+                );
+            }
         }
 
         // Finally, position subitem weapons directly below their parents

--- a/src/module/actor/character/helpers.ts
+++ b/src/module/actor/character/helpers.ts
@@ -215,6 +215,9 @@ function getWeaponAuxiliaryActions(weapon: WeaponPF2e<CharacterPF2e>): WeaponAux
     const isRealItem = actor.items.has(weapon.id);
     const traitsArray = weapon.system.traits.value;
 
+    if (weapon.system.traits.toggles.combination) {
+        auxiliaryActions.push(new WeaponAuxiliaryAction({ weapon, action: "interact", annotation: "combination" }));
+    }
     if (weapon.system.traits.toggles.modular) {
         auxiliaryActions.push(new WeaponAuxiliaryAction({ weapon, action: "interact", annotation: "modular" }));
     }

--- a/src/module/item/weapon/data.ts
+++ b/src/module/item/weapon/data.ts
@@ -97,6 +97,7 @@ interface WeaponSystemSource extends Investable<PhysicalSystemSource> {
 interface WeaponTraitsSource extends PhysicalItemTraits<WeaponTrait> {
     otherTags: OtherWeaponTag[];
     toggles?: {
+        combination?: { selected: CombinationWeaponMode } | null;
         doubleBarrel?: { selected: boolean };
         modular?: { selected: number | null } | null;
         versatile?: { selected: DamageType | null };
@@ -189,6 +190,8 @@ interface WeaponRuneData extends WeaponRuneSource {
     effects: WeaponPropertyRuneType[];
 }
 
+type CombinationWeaponMode = "melee" | "ranged";
+
 interface ComboWeaponMeleeUsage {
     damage: { type: DamageType; die: DamageDieSize };
     group: MeleeWeaponGroup;
@@ -197,6 +200,7 @@ interface ComboWeaponMeleeUsage {
 }
 
 export type {
+    CombinationWeaponMode,
     ComboWeaponMeleeUsage,
     SpecificWeaponData,
     WeaponDamage,

--- a/src/module/item/weapon/document.ts
+++ b/src/module/item/weapon/document.ts
@@ -306,6 +306,7 @@ class WeaponPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
         })();
         const rangeIncrement = this.range?.increment;
 
+        const combination = this.system.traits.toggles.combination;
         const rollOptions = super.getRollOptions(prefix, options);
         rollOptions.push(
             ...Object.entries({
@@ -329,6 +330,7 @@ class WeaponPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Ph
                 ranged: this.isRanged,
                 thrown: this.isThrown,
                 "thrown-melee": thrownMelee,
+                [`combination:${combination?.selected}`]: !!combination,
                 ...propertyRunes,
                 ...ammunitionRollOptions,
             })

--- a/src/module/item/weapon/trait-toggles.ts
+++ b/src/module/item/weapon/trait-toggles.ts
@@ -4,6 +4,7 @@ import { ModularConfig } from "@item/base/data/system.ts";
 import { nextDamageDieSize } from "@system/damage/helpers.ts";
 import type { DamageType } from "@system/damage/types.ts";
 import { objectHasKey, tupleHasValue } from "@util";
+import type { CombinationWeaponMode } from "./data.ts";
 import { upgradeWeaponTrait } from "./helpers.ts";
 
 /** A helper class to handle toggleable weapon traits */
@@ -17,6 +18,17 @@ class WeaponTraitToggles {
 
     get actor(): ActorPF2e | null {
         return this.parent.actor;
+    }
+
+    get combination(): { options: CombinationWeaponMode[]; selected: CombinationWeaponMode } | null {
+        const weapon = this.parent;
+        const item = weapon.realItem?.isOfType("weapon") ? weapon.realItem : weapon;
+        if (!item.system.traits.value.includes("combination")) return null;
+
+        const options = ["melee", "ranged"] as const;
+        const sourceSelection = item._source.system.traits.toggles?.combination?.selected ?? "ranged";
+        const selected = tupleHasValue(options, sourceSelection) ? sourceSelection : "ranged";
+        return { options: [...options], selected };
     }
 
     get doubleBarrel(): { selected: boolean } {
@@ -92,7 +104,7 @@ class WeaponTraitToggles {
     }
 
     /**
-     * Update a modular or versatile weapon to change its damage type
+     * Update a toggleable weapon trait
      * @returns A promise indicating whether an update was made
      */
     async update(options: ToggleWeaponTraitParams): Promise<boolean> {
@@ -106,14 +118,14 @@ class WeaponTraitToggles {
         if (current === selected) return false;
 
         const item = weapon.realItem;
-        if (item?.isOfType("weapon") && item === weapon) {
+        if (item?.isOfType("weapon") && (item === weapon || trait === "combination")) {
             const value = property === "doubleBarrel" ? !!selected : selected;
             await item.update({ [`system.traits.toggles.${property}.selected`]: value });
         } else if (item?.isOfType("weapon") && weapon.altUsageType === "melee") {
             item.update({ [`system.meleeUsage.traitToggles.${trait}`]: selected });
         } else if (trait === "versatile" && item?.isOfType("shield")) {
             item.update({ "system.traits.integrated.versatile.selected": selected });
-        } else if (trait !== "double-barrel" && weapon.rule) {
+        } else if ((trait === "modular" || trait === "versatile") && weapon.rule) {
             await weapon.rule.toggleTrait(options);
         } else {
             console.warn(
@@ -131,9 +143,14 @@ interface ToggleDoubleBarrelParams {
     selected: boolean;
 }
 
+interface ToggleCombinationParams {
+    trait: "combination";
+    selected: CombinationWeaponMode;
+}
+
 type ToggleModularVersatileParams =
     { trait: "modular"; selected: number | null } | { trait: "versatile"; selected: DamageType | null };
 
-type ToggleWeaponTraitParams = ToggleDoubleBarrelParams | ToggleModularVersatileParams;
+type ToggleWeaponTraitParams = ToggleCombinationParams | ToggleDoubleBarrelParams | ToggleModularVersatileParams;
 
 export { WeaponTraitToggles };

--- a/static/lang/action-en.json
+++ b/static/lang/action-en.json
@@ -541,6 +541,10 @@
                 "Title": "Impersonate"
             },
             "Interact": {
+                "Combination": {
+                    "Description": "{actor} switches their {weapon} to {combinationUsage}.",
+                    "Title": "Combination"
+                },
                 "Description": "<p>You use your hand or hands to manipulate an object or the terrain. You can grab an unattended or stored object, draw a weapon, swap a held item for another, open a door, or achieve a similar effect. On rare occasions, you might have to attempt a skill check to determine if your Interact action was successful.</p>",
                 "Draw": {
                     "Title": "Draw"

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3139,6 +3139,9 @@
                     "Hint": "Ranged and thrown weapons have a range increment. Attacks with these weapons work normally up to that distance. Attack rolls beyond a weapon's range increment take a -2 penalty for each additional multiple of that increment between you and the target. Attacks beyond the sixth range increment are impossible.",
                     "Label": "Range Increment {range} ft."
                 },
+                "RangedUsage": {
+                    "Label": "Ranged Usage"
+                },
                 "Reload": {
                     "LabelN": "Reload {value}",
                     "OneMinute": "1 min"

--- a/static/templates/actors/character/partials/strike.hbs
+++ b/static/templates/actors/character/partials/strike.hbs
@@ -1,7 +1,9 @@
 <li class="strike{{#if action.ready}} ready{{/if}}" {{#unless action.visible}}hidden{{/unless}} data-strike data-action-index="{{index}}">
-    <div class="item-image variant-strike framed{{#if action.ready}} ready{{/if}}" data-action="strike-attack" data-variant-index="0">
+    <div class="item-image variant-strike framed{{#if action.ready}} ready{{/if}}"
+        {{#if (or action.canAttack action.altUsages.length)}}data-action="strike-attack" data-variant-index="0"{{/if}}
+        {{#unless action.canAttack}}{{#if action.altUsages.length}}data-alt-usage="0"{{/if}}{{/unless}}>
         <img src="{{action.item.img}}" />
-        <i class="fa-solid fa-dice-d20" inert></i>
+        {{#if (or action.canAttack action.altUsages.length)}}<i class="fa-solid fa-dice-d20" inert></i>{{/if}}
     </div>
     <section>
         {{#unless omitName}}
@@ -33,10 +35,7 @@
                              data-tooltip aria-label="{{localize "PF2E.Actions.AutoFire.Title"}}" />
                     {{else if usage.item.isRanged}}
                         <i class="alt-usage-icon fa-regular fa-bullseye-arrow" inert
-                           data-tooltip aria-label="{{localize "PF2E.Item.Weapon.MeleeUsage.Label"}}"></i>
-                    {{else}}
-                        <img class="alt-usage-icon" src="{{resolvePath "icons/mdi/sword.svg"}}"
-                             data-tooltip aria-label="{{localize "PF2E.Item.Weapon.MeleeUsage.Label"}}" />
+                           data-tooltip aria-label="{{localize "PF2E.Item.Weapon.RangedUsage.Label"}}"></i>
                     {{/if}}
                     {{#> attackDamage usage altUsageIndex=index}}{{/attackDamage}}
                 </div>


### PR DESCRIPTION
- Closes https://github.com/foundryvtt/pf2e/issues/21870

Adds toggle similar to Modular, hides attacks that are unavailable in selected mode (not 100% sure about last decision, would appreciate other's input on it)

<img width="1063" height="160" alt="2us64EwL3O" src="https://github.com/user-attachments/assets/00bd2df2-35a5-4488-95ae-36a711cc78eb" />
