### PR TITLE
Add RE to Supramarine Chairs

### DIFF
--- a/packs/pf2e/equipment/land-delvers-chair.json
+++ b/packs/pf2e/equipment/land-delvers-chair.json
@@ -34,7 +34,24 @@
             "title": "Pathfinder Howl of the Wild"
         },
         "quantity": 1,
-        "rules": [],
+        "rules": [
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Equipment.Chair.ToggleLabel",
+                "option": "in-the-chair",
+                "toggleable": true,
+                "value": true
+            },
+            {
+                "force": true,
+                "key": "BaseSpeed",
+                "predicate": [
+                    "in-the-chair"
+                ],
+                "selector": "land",
+                "value": "min(20,@actor.system.movement.speeds.swim.value)"
+            }
+        ],
         "size": "med",
         "traits": {
             "rarity": "common",

--- a/packs/pf2e/equipment/supramarine-chair.json
+++ b/packs/pf2e/equipment/supramarine-chair.json
@@ -34,7 +34,24 @@
             "title": "Pathfinder Howl of the Wild"
         },
         "quantity": 1,
-        "rules": [],
+        "rules": [
+            {
+                "key": "RollOption",
+                "label": "PF2E.SpecificRule.Equipment.Chair.ToggleLabel",
+                "option": "in-the-chair",
+                "toggleable": true,
+                "value": true
+            },
+            {
+                "force": true,
+                "key": "BaseSpeed",
+                "predicate": [
+                    "in-the-chair"
+                ],
+                "selector": "land",
+                "value": "min(20,@actor.system.movement.speeds.swim.value)"
+            }
+        ],
         "size": "med",
         "traits": {
             "rarity": "common",

--- a/static/lang/re-en.json
+++ b/static/lang/re-en.json
@@ -5856,6 +5856,9 @@
                 "CaressOfTheGreatSerpent": {
                     "SerpentsKiss": "Serpent's Kiss"
                 },
+                "Chair": {
+                    "ToggleLabel": "In the chair"
+                },
                 "ChaliceOfJustice": {
                     "SipOfJustice": {
                         "Note": "Whenever you critically hit an unholy creature with the <em>chalice of justice</em>, the creature is @UUID[Compendium.pf2e.conditionitems.Item.xYTAsEpcJE1Ccni3]{Slowed 1} for 1 round."


### PR DESCRIPTION
- Closes https://github.com/foundryvtt/pf2e/issues/16253

Had to add a toggle, since we can't predicate on "item:worn" and chairs don't have an equipped state - maybe we should add it? Would appreciate other's thoughts