### PR TITLE
Add missing "archetype", "general" and "skill" traits to feat data and move their automatic assignment from data preparation to preUpdate

### DIFF
--- a/packs/pf2e/feats/archetype/artillerist/level-4/named-artillery.json
+++ b/packs/pf2e/feats/archetype/artillerist/level-4/named-artillery.json
@@ -36,7 +36,8 @@
         "traits": {
             "rarity": "common",
             "value": [
-                "archetype"
+                "archetype",
+                "skill"
             ]
         }
     },

--- a/packs/pf2e/feats/archetype/sanguimancer/sanguimancer-dedication.json
+++ b/packs/pf2e/feats/archetype/sanguimancer/sanguimancer-dedication.json
@@ -29,6 +29,7 @@
         "traits": {
             "rarity": "rare",
             "value": [
+                "archetype",
                 "dedication"
             ]
         }

--- a/packs/pf2e/feats/archetype/trapsmith/gear-gnash.json
+++ b/packs/pf2e/feats/archetype/trapsmith/gear-gnash.json
@@ -36,7 +36,8 @@
         "traits": {
             "rarity": "common",
             "value": [
-                "archetype"
+                "archetype",
+                "skill"
             ]
         }
     },

--- a/packs/pf2e/feats/archetype/trapsmith/propeller-attachment.json
+++ b/packs/pf2e/feats/archetype/trapsmith/propeller-attachment.json
@@ -36,7 +36,8 @@
         "traits": {
             "rarity": "common",
             "value": [
-                "archetype"
+                "archetype",
+                "skill"
             ]
         }
     },

--- a/packs/pf2e/feats/archetype/trick-driver/express-driver.json
+++ b/packs/pf2e/feats/archetype/trick-driver/express-driver.json
@@ -34,7 +34,8 @@
             "rarity": "common",
             "value": [
                 "archetype",
-                "exploration"
+                "exploration",
+                "skill"
             ]
         }
     },

--- a/packs/pf2e/feats/archetype/trick-driver/power-slide.json
+++ b/packs/pf2e/feats/archetype/trick-driver/power-slide.json
@@ -35,7 +35,8 @@
             "value": [
                 "archetype",
                 "move",
-                "reckless"
+                "reckless",
+                "skill"
             ]
         }
     },

--- a/packs/pf2e/feats/archetype/trick-driver/push-it.json
+++ b/packs/pf2e/feats/archetype/trick-driver/push-it.json
@@ -33,7 +33,8 @@
         "traits": {
             "rarity": "common",
             "value": [
-                "archetype"
+                "archetype",
+                "skill"
             ]
         }
     },

--- a/packs/pf2e/feats/archetype/vehicle-mechanic/efficient-controls.json
+++ b/packs/pf2e/feats/archetype/vehicle-mechanic/efficient-controls.json
@@ -36,7 +36,8 @@
         "traits": {
             "rarity": "common",
             "value": [
-                "archetype"
+                "archetype",
+                "skill"
             ]
         }
     },

--- a/packs/pf2e/feats/archetype/vehicle-mechanic/engine-bay.json
+++ b/packs/pf2e/feats/archetype/vehicle-mechanic/engine-bay.json
@@ -42,7 +42,8 @@
         "traits": {
             "rarity": "common",
             "value": [
-                "archetype"
+                "archetype",
+                "skill"
             ]
         }
     },

--- a/packs/pf2e/feats/archetype/verduran-shadow/canopy-predator.json
+++ b/packs/pf2e/feats/archetype/verduran-shadow/canopy-predator.json
@@ -77,7 +77,8 @@
         "traits": {
             "rarity": "uncommon",
             "value": [
-                "archetype"
+                "archetype",
+                "skill"
             ]
         }
     },

--- a/packs/pf2e/feats/general/level-1/speedrun-strats.json
+++ b/packs/pf2e/feats/general/level-1/speedrun-strats.json
@@ -33,7 +33,10 @@
         },
         "traits": {
             "rarity": "common",
-            "value": []
+            "value": [
+                "general",
+                "skill"
+            ]
         }
     },
     "type": "feat"

--- a/packs/pf2e/feats/general/level-11/sanguine-tenacity.json
+++ b/packs/pf2e/feats/general/level-11/sanguine-tenacity.json
@@ -74,7 +74,9 @@
         ],
         "traits": {
             "rarity": "uncommon",
-            "value": []
+            "value": [
+                "general"
+            ]
         }
     },
     "type": "feat"

--- a/packs/pf2e/feats/general/level-7/bloodsense.json
+++ b/packs/pf2e/feats/general/level-7/bloodsense.json
@@ -39,7 +39,9 @@
         ],
         "traits": {
             "rarity": "uncommon",
-            "value": []
+            "value": [
+                "general"
+            ]
         }
     },
     "type": "feat"

--- a/packs/pf2e/feats/skill/level-1/acupuncturist.json
+++ b/packs/pf2e/feats/skill/level-1/acupuncturist.json
@@ -34,7 +34,9 @@
             "rarity": "common",
             "value": [
                 "downtime",
-                "manipulate"
+                "general",
+                "manipulate",
+                "skill"
             ]
         }
     },

--- a/packs/pf2e/feats/skill/level-1/myth-hunter.json
+++ b/packs/pf2e/feats/skill/level-1/myth-hunter.json
@@ -41,7 +41,10 @@
         },
         "traits": {
             "rarity": "uncommon",
-            "value": []
+            "value": [
+                "general",
+                "skill"
+            ]
         }
     },
     "type": "feat"

--- a/packs/pf2e/feats/skill/level-1/prepare-elemental-medicine.json
+++ b/packs/pf2e/feats/skill/level-1/prepare-elemental-medicine.json
@@ -34,8 +34,10 @@
             "rarity": "uncommon",
             "value": [
                 "exploration",
+                "general",
                 "manipulate",
-                "secret"
+                "secret",
+                "skill"
             ]
         }
     },

--- a/packs/pf2e/feats/skill/level-2/energy-fortification.json
+++ b/packs/pf2e/feats/skill/level-2/energy-fortification.json
@@ -46,7 +46,10 @@
         ],
         "traits": {
             "rarity": "uncommon",
-            "value": []
+            "value": [
+                "general",
+                "skill"
+            ]
         }
     },
     "type": "feat"

--- a/packs/pf2e/feats/skill/level-2/godless-healing.json
+++ b/packs/pf2e/feats/skill/level-2/godless-healing.json
@@ -49,7 +49,10 @@
         ],
         "traits": {
             "rarity": "common",
-            "value": []
+            "value": [
+                "general",
+                "skill"
+            ]
         }
     },
     "type": "feat"

--- a/packs/pf2e/feats/skill/level-2/pei-zing-adept.json
+++ b/packs/pf2e/feats/skill/level-2/pei-zing-adept.json
@@ -35,7 +35,10 @@
         "rules": [],
         "traits": {
             "rarity": "uncommon",
-            "value": []
+            "value": [
+                "general",
+                "skill"
+            ]
         }
     },
     "type": "feat"

--- a/packs/pf2e/feats/skill/level-2/vasodilation.json
+++ b/packs/pf2e/feats/skill/level-2/vasodilation.json
@@ -49,7 +49,10 @@
         ],
         "traits": {
             "rarity": "uncommon",
-            "value": []
+            "value": [
+                "general",
+                "skill"
+            ]
         }
     },
     "type": "feat"

--- a/packs/pf2e/feats/skill/level-3/aurochs-headed.json
+++ b/packs/pf2e/feats/skill/level-3/aurochs-headed.json
@@ -52,6 +52,7 @@
         "traits": {
             "rarity": "uncommon",
             "value": [
+                "general",
                 "skill"
             ]
         }

--- a/packs/pf2e/feats/skill/level-7/break-curse.json
+++ b/packs/pf2e/feats/skill/level-7/break-curse.json
@@ -35,6 +35,7 @@
             "value": [
                 "concentrate",
                 "exploration",
+                "general",
                 "healing",
                 "skill"
             ]

--- a/packs/pf2e/feats/skill/level-7/monster-crafting.json
+++ b/packs/pf2e/feats/skill/level-7/monster-crafting.json
@@ -33,6 +33,7 @@
         "traits": {
             "rarity": "common",
             "value": [
+                "general",
                 "skill"
             ]
         }

--- a/packs/pf2e/feats/skill/level-7/seasoned-command.json
+++ b/packs/pf2e/feats/skill/level-7/seasoned-command.json
@@ -40,8 +40,10 @@
             "value": [
                 "auditory",
                 "concentrate",
+                "general",
                 "linguistic",
-                "mental"
+                "mental",
+                "skill"
             ]
         }
     },

--- a/packs/pf2e/feats/skill/level-7/temperature-adjustment.json
+++ b/packs/pf2e/feats/skill/level-7/temperature-adjustment.json
@@ -32,7 +32,10 @@
         "rules": [],
         "traits": {
             "rarity": "uncommon",
-            "value": []
+            "value": [
+                "general",
+                "skill"
+            ]
         }
     },
     "type": "feat"

--- a/packs/sf2e/feats/archetype/ghost-courier/level-2/ghost-courier-dedication.json
+++ b/packs/sf2e/feats/archetype/ghost-courier/level-2/ghost-courier-dedication.json
@@ -43,6 +43,7 @@
         "traits": {
             "rarity": "uncommon",
             "value": [
+                "archetype",
                 "dedication"
             ]
         }

--- a/packs/sf2e/feats/skill/level-1/express-driver.json
+++ b/packs/sf2e/feats/skill/level-1/express-driver.json
@@ -32,7 +32,10 @@
         "rules": [],
         "traits": {
             "rarity": "common",
-            "value": []
+            "value": [
+                "general",
+                "skill"
+            ]
         }
     },
     "type": "feat"

--- a/packs/sf2e/feats/skill/level-2/inventor.json
+++ b/packs/sf2e/feats/skill/level-2/inventor.json
@@ -38,7 +38,9 @@
         "traits": {
             "rarity": "common",
             "value": [
-                "downtime"
+                "downtime",
+                "general",
+                "skill"
             ]
         }
     },

--- a/src/module/apps/compendium-browser/tabs/feat.ts
+++ b/src/module/apps/compendium-browser/tabs/feat.ts
@@ -3,6 +3,7 @@ import { CompendiumBrowser } from "../browser.svelte.ts";
 import { ContentTabName } from "../data.ts";
 import { CompendiumBrowserTab } from "./base.svelte.ts";
 import { CompendiumBrowserIndexData, FeatFilters } from "./data.ts";
+import { adjustFeatTraitsAndCategory } from "@item/feat/helpers.ts";
 
 export class CompendiumBrowserFeatTab extends CompendiumBrowserTab {
     tabName: ContentTabName = "feat";
@@ -87,9 +88,12 @@ export class CompendiumBrowserFeatTab extends CompendiumBrowserTab {
                         }
                     }
                 }
+
+                adjustFeatTraitsAndCategory(system);
                 const category = system.category;
                 const type = featData.type;
                 const traits: string[] = system.traits.value;
+
                 const pubSource = system.publication?.title ?? system.source?.value ?? "";
                 const options: string[] = [
                     ...traits.map((t: string) => `trait:${t.replace(/^hb_/, "")}`),

--- a/src/module/item/feat/document.ts
+++ b/src/module/item/feat/document.ts
@@ -14,7 +14,7 @@ import { EnrichmentOptionsPF2e } from "@system/text-editor.ts";
 import { ErrorPF2e, objectHasKey, setHasElement, sluggify } from "@util";
 import * as R from "remeda";
 import { FeatSource, FeatSystemData } from "./data.ts";
-import { featCanHaveKeyOptions, suppressFeats } from "./helpers.ts";
+import { adjustFeatTraitsAndCategory, featCanHaveKeyOptions, suppressFeats } from "./helpers.ts";
 import { FeatOrFeatureCategory, FeatTrait } from "./types.ts";
 import { FEATURE_CATEGORIES, FEAT_CATEGORIES } from "./values.ts";
 
@@ -96,28 +96,7 @@ class FeatPF2e<TParent extends ActorPF2e | null = ActorPF2e | null> extends Item
         this.suppressed = false;
         this.crafting = null;
 
-        const traits = this.system.traits.value;
-
-        // Add the General trait if of the general feat type
-        if (this.category === "general" && !traits.includes("general")) {
-            traits.push("general");
-        }
-
-        if (this.category === "skill") {
-            // Add the Skill trait
-            if (!traits.includes("skill")) traits.push("skill");
-
-            // Add the General trait only if the feat is not an archetype skill feat
-            if (!traits.includes("general") && !traits.includes("archetype")) {
-                traits.push("general");
-            }
-        }
-
-        // Only archetype feats can have the dedication trait
-        if (traits.includes("dedication")) {
-            this.system.category = "class";
-            if (!traits.includes("archetype")) traits.push("archetype");
-        }
+        adjustFeatTraitsAndCategory(this.system);
 
         // Feats with the Lineage trait can only ever be taken at level 1
         if (this.system.traits.value.includes("lineage")) {

--- a/src/module/item/feat/helpers.ts
+++ b/src/module/item/feat/helpers.ts
@@ -27,4 +27,30 @@ function suppressFeats(feats: (FeatPF2e | AbilityItemPF2e)[]): void {
     }
 }
 
-export { featCanHaveKeyOptions, suppressFeats };
+/** Mutates the data to prevent certain combinations of traits and categories. */
+function adjustFeatTraitsAndCategory(featSystemData: FeatPF2e["system"] | FeatPF2e["_source"]["system"]): void {
+    const traits = featSystemData.traits.value;
+
+    // Add the General trait if of the general feat type
+    if (featSystemData.category === "general" && !traits.includes("general")) {
+        traits.push("general");
+    }
+
+    if (featSystemData.category === "skill") {
+        // Add the Skill trait
+        if (!traits.includes("skill")) traits.push("skill");
+
+        // Add the General trait only if the feat is not an archetype skill feat
+        if (!traits.includes("general") && !traits.includes("archetype")) {
+            traits.push("general");
+        }
+    }
+
+    // Only archetype feats can have the dedication trait
+    if (traits.includes("dedication")) {
+        featSystemData.category = "class";
+        if (!traits.includes("archetype")) traits.push("archetype");
+    }
+}
+
+export { adjustFeatTraitsAndCategory, featCanHaveKeyOptions, suppressFeats };


### PR DESCRIPTION
Attempts to handle https://github.com/foundryvtt/pf2e/issues/23091

As noted in the issue, traits that are automatically added in `prepareBaseData` due to the feat being of either skill or general category don't get assigned to the source data, and as such are invisible to the compendium browser filter.

It seemed fairly logical to move the check to `_preUpdate` so that this behavior would be set in the data. However, as it is, this behavior causes issues with current behavior of traits tagify field on the item sheet. As these traits are now in data, they are no longer considered readonly by `createTagifyTraits` and can be removed from the list. This will result in a visual disappearance of the trait until some other change happens that affects the trait list (such as a change of the feat category).

Currently I see several approaches on how to handle the issue so that it doesn't happen in the future
1. Remove all the automatically assigned traits, and require them all to be held in the source data. This will remove any surprises, but might result in longer time needed for the addition of data from new publications.
2. Duplicate the logic to the compendium browser (as it doesn't work with feat objects, just with data), and let it assign appropriate filter options based on other filter options
3. Have some data on the feat object that stores information about which traits are actually readonly, instead of `createTagifyTags` just checking which of them are or aren't in the source data (but this will probably need to be handled in multiple places, ex. ItemAlteration).