### PR TITLE
Fix flanking for tiny creatures (#23127)

### DIFF
--- a/src/module/canvas/token/object.ts
+++ b/src/module/canvas/token/object.ts
@@ -202,9 +202,9 @@ class TokenPF2e<TDocument extends TokenDocumentPF2e = TokenDocumentPF2e> extends
      */
     protected onOppositeSides(flankerA: TokenPF2e, flankerB: TokenPF2e, flankee: TokenPF2e): boolean {
         const boundsA = flankerA.mechanicalBounds;
-        const centerA = { x: flankerA.document.x + boundsA.width / 2, y: flankerA.document.y + boundsA.height / 2 };
+        const centerA = { x: boundsA.x + boundsA.width / 2, y: boundsA.y + boundsA.height / 2 };
         const boundsB = flankerB.mechanicalBounds;
-        const centerB = { x: flankerB.document.x + boundsB.width / 2, y: flankerB.document.y + boundsB.height / 2 };
+        const centerB = { x: boundsB.x + boundsB.width / 2, y: boundsB.y + boundsB.height / 2 };
         const bounds = flankee.mechanicalBounds;
         const left = new fc.geometry.Ray({ x: bounds.left, y: bounds.top }, { x: bounds.left, y: bounds.bottom });
         const right = new fc.geometry.Ray({ x: bounds.right, y: bounds.top }, { x: bounds.right, y: bounds.bottom });


### PR DESCRIPTION
When a creature attacks a targeted enemy and the target's space is occupied by a Tiny creature, the Tiny creature would be considered flanking despite rules specifying this should not be the case. https://2e.aonprd.com/Rules.aspx?ID=2375

A Tiny creature occupies only one quarter of an enemy's space. The incorrect flanking behavior only seemed to occur when the Tiny creature occupied the top-right quadrant of the target's space with the attacker to the left. This was because of an incorrect computation done to determine if the Tiny creature was on the opposite side from the attacker which seems to use different coordinate systems.

The fix here normalizes the computation to consistently use the mechanical bounds.