### PR TITLE
Only count tokens inside an effect area's highlighted squares

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -10,7 +10,6 @@ import type { SettingConfig } from "@client/_types.d.mts";
 import type Hotbar from "@client/applications/ui/hotbar.d.mts";
 import type Config from "@client/config.d.mts";
 import type { ChatMessageMode } from "@client/config.d.mts";
-import type WallDocument from "@client/documents/wall.d.mts";
 import type { FoundryUI } from "@client/ui.d.mts";
 import type { CompendiumUUID } from "@client/utils/_module.d.mts";
 import type { ImageFilePath, UserRole } from "@common/constants.d.mts";
@@ -41,7 +40,7 @@ import type { CombatantPF2e, EncounterPF2e } from "@module/encounter/index.ts";
 import type { MacroPF2e } from "@module/macro.ts";
 import type { RuleElement, RuleElements } from "@module/rules/index.ts";
 import type { UserPF2e } from "@module/user/index.ts";
-import type { RegionBehaviorPF2e, RegionDocumentPF2e, ScenePF2e, TokenDocumentPF2e } from "@scene";
+import type { RegionBehaviorPF2e, RegionDocumentPF2e, ScenePF2e, TokenDocumentPF2e, WallDocumentPF2e } from "@scene";
 import type { PF2ECONFIG, StatusEffectIconTheme } from "@scripts/config/index.ts";
 import type { DicePF2e } from "@scripts/dice.ts";
 import type {
@@ -289,7 +288,7 @@ type ConfiguredConfig = Config<
     RegionBehaviorPF2e,
     fd.TileDocument<ScenePF2e | null>,
     TokenDocumentPF2e,
-    WallDocument<ScenePF2e | null>,
+    WallDocumentPF2e,
     ScenePF2e,
     UserPF2e,
     EffectsCanvasGroupPF2e

--- a/src/module/canvas/region.ts
+++ b/src/module/canvas/region.ts
@@ -1,11 +1,9 @@
 import type { PlaceablesLayerPointerEvent } from "@client/canvas/layers/base/placeables-layer.d.mts";
 import type { Point } from "@common/_types.d.mts";
 import type { GridSnappingMode } from "@common/constants.d.mts";
-import type { CircleShapeData, ConeShapeData, LineShapeData } from "@common/data/data.d.mts";
 import type { GridOffset2D } from "@common/grid/_types.d.mts";
 import { EffectAreaShape } from "@item/types.ts";
 import type { RegionDocumentPF2e } from "@scene/region-document/document.ts";
-import { measureDistance } from "./helpers.ts";
 
 /** Add support for drag/drop repositioning of regions. */
 class RegionPF2e<TDocument extends RegionDocumentPF2e = RegionDocumentPF2e> extends fc.placeables.Region<TDocument> {
@@ -39,136 +37,9 @@ class RegionPF2e<TDocument extends RegionDocumentPF2e = RegionDocumentPF2e> exte
 
     /** Cover the squares a burst, cone, or line effect area reaches, counted by PF2e's grid rules. */
     protected override _getCoveredGridSpaceOffsets(): GridOffset2D[] {
-        this.#blockedOffsets = [];
-        const shapeData = this.document.shapes.at(0);
-        if (!canvas.grid.isSquare || this.document.shapes.length !== 1 || !shapeData) {
-            return super._getCoveredGridSpaceOffsets();
-        }
-        // Bursts and cylinders are circles; only circles, cones, and lines are template shapes we count ourselves
-        if (shapeData.type !== "circle" && shapeData.type !== "cone" && shapeData.type !== "line") {
-            return super._getCoveredGridSpaceOffsets();
-        }
-        // Foundry doesn't give cone/line a literal `type`, so the union won't narrow without a cast
-        const area = this.#areaCoverage(shapeData as CircleShapeData | ConeShapeData | LineShapeData);
-
-        const { size } = canvas.dimensions;
-        const grid = canvas.grid;
-        const { i: col0, j: row0 } = grid.getOffset(grid.getCenterPoint(area.searchCenter));
-        const span = Math.ceil(area.reach) + 1;
-
-        const offsets: GridOffset2D[] = [];
-        const blocked: GridOffset2D[] = [];
-        for (let a = -span; a <= span; a++) {
-            for (let b = -span; b <= span; b++) {
-                const { x: gx, y: gy } = grid.getTopLeftPoint({ i: col0 + a, j: row0 + b });
-                // Cell center, in pixels
-                const destination = { x: gx + size * 0.5, y: gy + size * 0.5 };
-                if (destination.x < 0 || destination.y < 0) continue;
-                if (!area.contains(destination)) continue;
-
-                // A wall between the origin and the cell center means no line of effect: blocked, not covered
-                const offset = { i: col0 + a, j: row0 + b };
-                const hasLineOfEffect =
-                    !canvas.ready ||
-                    !CONFIG.Canvas.polygonBackends.move.testCollision(area.origin, destination, {
-                        type: "move",
-                        mode: "any",
-                    });
-                (hasLineOfEffect ? offsets : blocked).push(offset);
-            }
-        }
-        this.#blockedOffsets = blocked;
-
-        return offsets;
-    }
-
-    /** Resolve a template shape into its line-of-effect origin, a cell-search box, and a coverage test. */
-    #areaCoverage(shape: CircleShapeData | ConeShapeData | LineShapeData): AreaCoverage {
-        const { size, distance } = canvas.dimensions;
-
-        if (shape.type === "circle") {
-            const circle = shape as CircleShapeData;
-            const origin = { x: circle.x, y: circle.y };
-            const radius = (circle.radius / size) * distance;
-            return {
-                origin,
-                searchCenter: origin,
-                reach: circle.radius / size,
-                contains: (destination) => measureDistance(destination, origin) <= radius,
-            };
-        }
-
-        if (shape.type === "cone") {
-            const cone = shape as ConeShapeData;
-            const radius = (cone.radius / size) * distance;
-            const { origin, contains } = this.#coneCoverage(cone, { x: cone.x, y: cone.y });
-            return {
-                origin,
-                searchCenter: origin,
-                reach: cone.radius / size,
-                contains: (destination) => contains(destination) && measureDistance(destination, origin) <= radius,
-            };
-        }
-
-        // A line is a rectangle `length` long and `width` wide running from the origin along its rotation
-        const line = shape as LineShapeData;
-        const radians = Math.toRadians(line.rotation);
-        const along = { x: Math.cos(radians), y: Math.sin(radians) };
-        const perpendicular = { x: -along.y, y: along.x };
-        const halfWidth = line.width / 2;
-        // PF2e lines fire from a grid corner. Step the origin back to that corner along whichever axes it sits mid-cell
-        const toCorner = (coord: number, component: number): number =>
-            coord % size !== 0 ? coord - Math.sign(Math.round(component * 100)) * (size / 2) : coord;
-        const origin = { x: toCorner(line.x, along.x), y: toCorner(line.y, along.y) };
-        return {
-            origin,
-            searchCenter: { x: origin.x + along.x * (line.length / 2), y: origin.y + along.y * (line.length / 2) },
-            reach: (line.length / 2 + halfWidth) / size,
-            contains: (destination) => {
-                const dx = destination.x - origin.x;
-                const dy = destination.y - origin.y;
-                const projection = dx * along.x + dy * along.y;
-                const offset = dx * perpendicular.x + dy * perpendicular.y;
-                return projection >= 0 && projection <= line.length && Math.abs(offset) <= halfWidth;
-            },
-        };
-    }
-
-    /**
-     * Border-aligned apex and wedge test for a cone. The apex is taken as placed: the coordinate perpendicular to the
-     * firing direction is left alone, which is what separates a corner-origin cone (perpendicular on a grid line) from
-     * a side-origin one.
-     */
-    #coneCoverage(shape: ConeShapeData, origin: Point): { origin: Point; contains: (destination: Point) => boolean } {
-        const dimensions = canvas.dimensions;
-        const direction = shape.rotation;
-        const minAngle = (360 + ((direction - shape.angle * 0.5) % 360)) % 360;
-        const maxAngle = (360 + ((direction + shape.angle * 0.5) % 360)) % 360;
-        const withinAngle = (value: number): boolean => {
-            value = (360 + (value % 360)) % 360;
-            return minAngle < maxAngle
-                ? value >= minAngle && value <= maxAngle
-                : value >= minAngle || value <= maxAngle;
-        };
-
-        // Offset the origin by half a cell toward the firing direction along each axis it is not already a border of.
-        // `dir` is degrees anticlockwise from pointing right, in 45-degree increments from 0 to 360.
-        const dir = (direction >= 0 ? 360 - direction : -direction) % 360;
-        const xOffset =
-            origin.x % dimensions.size !== 0 ? Math.sign(Math.round(Math.cos(Math.toRadians(dir)) * 100)) / 2 : 0;
-        // Inverted along Y because screen-space Y increases downward
-        const yOffset =
-            origin.y % dimensions.size !== 0 ? -Math.sign(Math.round(Math.sin(Math.toRadians(dir)) * 100)) / 2 : 0;
-        const coneOrigin = { x: origin.x + xOffset * dimensions.size, y: origin.y + yOffset * dimensions.size };
-
-        return {
-            origin: coneOrigin,
-            contains: (destination: Point): boolean => {
-                const ray = new fc.geometry.Ray(coneOrigin, destination);
-                const rayAngle = (360 + ((ray.angle / (Math.PI / 180)) % 360)) % 360;
-                return ray.distance === 0 || withinAngle(rayAngle);
-            },
-        };
+        const coverage = this.document.getCoverage();
+        this.#blockedOffsets = coverage?.blocked ?? [];
+        return coverage?.covered ?? super._getCoveredGridSpaceOffsets();
     }
 
     override async _draw(options?: object): Promise<void> {
@@ -228,18 +99,6 @@ class RegionPF2e<TDocument extends RegionDocumentPF2e = RegionDocumentPF2e> exte
 
         return this.document.parent?.updateEmbeddedDocuments("Region", updates) ?? [];
     }
-}
-
-/** Per-shape geometry for a template's grid coverage. */
-interface AreaCoverage {
-    /** Point line of effect is measured from */
-    origin: Point;
-    /** Center of the cell-search box, in pixels */
-    searchCenter: Point;
-    /** Half-extent of the search box, in grid squares */
-    reach: number;
-    /** Whether a cell center lies within the area, before line of effect is checked */
-    contains: (destination: Point) => boolean;
 }
 
 export { RegionPF2e };

--- a/src/module/scene/index.ts
+++ b/src/module/scene/index.ts
@@ -4,3 +4,4 @@ export { ScenePF2e } from "./document.ts";
 export * from "./region-behavior/index.ts";
 export { RegionDocumentPF2e } from "./region-document/document.ts";
 export { TokenDocumentPF2e } from "./token-document/index.ts";
+export { WallDocumentPF2e } from "./wall-document/document.ts";

--- a/src/module/scene/region-document/coverage.ts
+++ b/src/module/scene/region-document/coverage.ts
@@ -1,0 +1,108 @@
+import type { Point } from "@common/_types.d.mts";
+import type { CircleShapeData, ConeShapeData, LineShapeData } from "@common/data/data.d.mts";
+import { measureDistance } from "@module/canvas/helpers.ts";
+
+/** Per-shape geometry for a template's grid coverage. */
+interface AreaCoverage {
+    /** Point line of effect is measured from */
+    origin: Point;
+    /** Center of the cell-search box, in pixels */
+    searchCenter: Point;
+    /** Half-extent of the search box, in grid squares */
+    reach: number;
+    /** Whether a cell center lies within the area, before line of effect is checked */
+    contains: (destination: Point) => boolean;
+}
+
+/** Resolve a template shape into its line-of-effect origin, a cell-search box, and a coverage test. */
+function areaCoverage(shape: CircleShapeData | ConeShapeData | LineShapeData): AreaCoverage {
+    const { size, distance } = canvas.dimensions;
+
+    if (shape.type === "circle") {
+        const circle = shape as CircleShapeData;
+        const origin = { x: circle.x, y: circle.y };
+        const radius = (circle.radius / size) * distance;
+        return {
+            origin,
+            searchCenter: origin,
+            reach: circle.radius / size,
+            contains: (destination) => measureDistance(destination, origin) <= radius,
+        };
+    }
+
+    if (shape.type === "cone") {
+        const cone = shape as ConeShapeData;
+        const radius = (cone.radius / size) * distance;
+        const { origin, contains } = coneCoverage(cone, { x: cone.x, y: cone.y });
+        return {
+            origin,
+            searchCenter: origin,
+            reach: cone.radius / size,
+            contains: (destination) => contains(destination) && measureDistance(destination, origin) <= radius,
+        };
+    }
+
+    // A line is a rectangle `length` long and `width` wide running from the origin along its rotation
+    const line = shape as LineShapeData;
+    const radians = Math.toRadians(line.rotation);
+    const along = { x: Math.cos(radians), y: Math.sin(radians) };
+    const perpendicular = { x: -along.y, y: along.x };
+    const halfWidth = line.width / 2;
+    // PF2e lines fire from a grid corner. Step the origin back to that corner along whichever axes it sits mid-cell
+    const toCorner = (coord: number, component: number): number =>
+        coord % size !== 0 ? coord - Math.sign(Math.round(component * 100)) * (size / 2) : coord;
+    const origin = { x: toCorner(line.x, along.x), y: toCorner(line.y, along.y) };
+    return {
+        origin,
+        searchCenter: { x: origin.x + along.x * (line.length / 2), y: origin.y + along.y * (line.length / 2) },
+        reach: (line.length / 2 + halfWidth) / size,
+        contains: (destination) => {
+            const dx = destination.x - origin.x;
+            const dy = destination.y - origin.y;
+            const projection = dx * along.x + dy * along.y;
+            const offset = dx * perpendicular.x + dy * perpendicular.y;
+            return projection >= 0 && projection <= line.length && Math.abs(offset) <= halfWidth;
+        },
+    };
+}
+
+/**
+ * Border-aligned apex and wedge test for a cone. The apex is taken as placed: the coordinate perpendicular to the
+ * firing direction is left alone, which is what separates a corner-origin cone (perpendicular on a grid line) from
+ * a side-origin one.
+ */
+function coneCoverage(
+    shape: ConeShapeData,
+    origin: Point,
+): { origin: Point; contains: (destination: Point) => boolean } {
+    const dimensions = canvas.dimensions;
+    const direction = shape.rotation;
+    const minAngle = (360 + ((direction - shape.angle * 0.5) % 360)) % 360;
+    const maxAngle = (360 + ((direction + shape.angle * 0.5) % 360)) % 360;
+    const withinAngle = (value: number): boolean => {
+        value = (360 + (value % 360)) % 360;
+        return minAngle < maxAngle ? value >= minAngle && value <= maxAngle : value >= minAngle || value <= maxAngle;
+    };
+
+    // Offset the origin by half a cell toward the firing direction along each axis it is not already a border of.
+    // `dir` is degrees anticlockwise from pointing right, in 45-degree increments from 0 to 360.
+    const dir = (direction >= 0 ? 360 - direction : -direction) % 360;
+    const xOffset =
+        origin.x % dimensions.size !== 0 ? Math.sign(Math.round(Math.cos(Math.toRadians(dir)) * 100)) / 2 : 0;
+    // Inverted along Y because screen-space Y increases downward
+    const yOffset =
+        origin.y % dimensions.size !== 0 ? -Math.sign(Math.round(Math.sin(Math.toRadians(dir)) * 100)) / 2 : 0;
+    const coneOrigin = { x: origin.x + xOffset * dimensions.size, y: origin.y + yOffset * dimensions.size };
+
+    return {
+        origin: coneOrigin,
+        contains: (destination: Point): boolean => {
+            const ray = new fc.geometry.Ray(coneOrigin, destination);
+            const rayAngle = (360 + ((ray.angle / (Math.PI / 180)) % 360)) % 360;
+            return ray.distance === 0 || withinAngle(rayAngle);
+        },
+    };
+}
+
+export { areaCoverage };
+export type { AreaCoverage };

--- a/src/module/scene/region-document/document.ts
+++ b/src/module/scene/region-document/document.ts
@@ -1,3 +1,4 @@
+import type { Level } from "@client/documents/_module.d.mts";
 import type { DocumentConstructionContext } from "@common/_types.mjs";
 import type { DatabaseCreateCallbackOptions, DatabaseDeleteCallbackOptions } from "@common/abstract/_module.d.mts";
 import type EmbeddedCollection from "@common/abstract/embedded-collection.d.mts";
@@ -9,8 +10,21 @@ import type { ChatMessagePF2e } from "@module/chat-message/document.ts";
 import { toggleClearEffectAreaButton } from "@module/chat-message/helpers.ts";
 import type { ScenePF2e } from "@scene";
 import type { SpecificRegionBehavior } from "@scene/region-behavior/types.ts";
+import type { GridOffset2D } from "@common/grid/_types.d.mts";
+import { areaCoverage } from "./coverage.ts";
+
+/** The grid spaces an effect area reaches, along with those in range but walled off from its origin */
+interface EffectAreaOffsets {
+    covered: GridOffset2D[];
+    blocked: GridOffset2D[];
+    /** Is the grid space at this offset covered? */
+    covers: (offset: GridOffset2D) => boolean;
+}
 
 class RegionDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> extends RegionDocument<TParent> {
+    /** Memoized grid coverage, keyed by level, since walls are per-level */
+    declare private coverageByLevel: Map<string, EffectAreaOffsets>;
+
     /** The chat message from which this effect area was spawned */
     get message(): ChatMessagePF2e | null {
         return game.messages.get(this.flags[SYSTEM_ID]?.messageId ?? "") ?? null;
@@ -24,6 +38,91 @@ class RegionDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ex
     /** Whether this region is a Pathfinder 2e effect area */
     get isEffectArea(): boolean {
         return this.shapes.length === 1 && !!this.areaShape;
+    }
+
+    /** Whether PF2e counts this region's grid spaces itself rather than leaving containment to its polygon */
+    get isMeasuredArea(): boolean {
+        if (!canvas.ready || !canvas.grid.isSquare || this.parent !== canvas.scene) return false;
+        const shape = this.shapes.at(0);
+        // Bursts and cylinders are circles; only circles, cones, and lines are template shapes we count ourselves
+        return this.shapes.length === 1 && !!shape && ["circle", "cone", "line"].includes(shape.type);
+    }
+
+    /**
+     * The grid spaces this area covers by PF2e's rules, which differ from the region's polygon in that spaces are
+     * counted whole and cut off by walls. Null if core should measure the region itself.
+     * @param level The level whose walls block line of effect, defaulting to the viewed one
+     */
+    getCoverage(level: Level | null = canvas.level): EffectAreaOffsets | null {
+        const key = level?.id ?? "";
+        const cached = this.coverageByLevel.get(key);
+        if (cached) return cached;
+        // A null result means the canvas can't measure right now, so don't cache it
+        const computed = this.#measureCoverage(level);
+        if (computed) this.coverageByLevel.set(key, computed);
+        return computed;
+    }
+
+    /**
+     * Count the grid spaces this area reaches by PF2e's rules rather than by intersection with its polygon. Walls are
+     * per-level, so line of effect is measured against `level`.
+     */
+    #measureCoverage(level: Level | null): EffectAreaOffsets | null {
+        if (!this.isMeasuredArea) return null;
+        // Foundry doesn't give cone/line a literal `type`, so the union won't narrow without a cast
+        const area = areaCoverage(this.shapes[0] as Parameters<typeof areaCoverage>[0]);
+
+        const { size } = canvas.dimensions;
+        const grid = canvas.grid;
+        const { i: col0, j: row0 } = grid.getOffset(grid.getCenterPoint(area.searchCenter));
+        const span = Math.ceil(area.reach) + 1;
+
+        const covered: GridOffset2D[] = [];
+        const blocked: GridOffset2D[] = [];
+        const coveredKeys = new Set<string>();
+        const key = (offset: GridOffset2D): string => `${offset.i},${offset.j}`;
+        for (let a = -span; a <= span; a++) {
+            for (let b = -span; b <= span; b++) {
+                const { x: gx, y: gy } = grid.getTopLeftPoint({ i: col0 + a, j: row0 + b });
+                // Cell center, in pixels
+                const destination = { x: gx + size * 0.5, y: gy + size * 0.5 };
+                if (destination.x < 0 || destination.y < 0) continue;
+                if (!area.contains(destination)) continue;
+
+                // A wall between the origin and the cell center means no line of effect: blocked, not covered
+                const offset = { i: col0 + a, j: row0 + b };
+                const hasLineOfEffect = !CONFIG.Canvas.polygonBackends.move.testCollision(area.origin, destination, {
+                    type: "move",
+                    mode: "any",
+                    level,
+                });
+                if (hasLineOfEffect) {
+                    covered.push(offset);
+                    coveredKeys.add(key(offset));
+                } else {
+                    blocked.push(offset);
+                }
+            }
+        }
+
+        return { covered, blocked, covers: (offset) => coveredKeys.has(key(offset)) };
+    }
+
+    /** Walls moved, line of effect may have changed */
+    clearCoverage(): void {
+        this.coverageByLevel.clear();
+    }
+
+    /** Coverage is stale once the region's data is (re)initialized, drag previews included */
+    protected override _initialize(options?: Record<string, unknown>): void {
+        this.coverageByLevel = new Map();
+        super._initialize(options);
+    }
+
+    /** The grid changed beneath the region, or its shape was constrained */
+    protected override _onPolygonTreeChange(): void {
+        super._onPolygonTreeChange();
+        this.clearCoverage();
     }
 
     /** Ensure the source has a `pf2e` flag along with an `areaShape` if directly inferable. */
@@ -65,3 +164,4 @@ interface RegionDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null
 }
 
 export { RegionDocumentPF2e };
+export type { EffectAreaOffsets };

--- a/src/module/scene/token-document/document.ts
+++ b/src/module/scene/token-document/document.ts
@@ -13,7 +13,8 @@ import type {
 } from "@common/abstract/_types.d.mts";
 import type Document from "@common/abstract/document.d.mts";
 import type { ImageFilePath, TokenDisplayMode, VideoFilePath } from "@common/constants.d.mts";
-import type { GridMeasurePathResult } from "@common/grid/_types.d.mts";
+import type { TokenPosition } from "@common/documents/_types.d.mts";
+import type { GridMeasurePathResult, GridOffset2D } from "@common/grid/_types.d.mts";
 import type { TokenPF2e } from "@module/canvas/index.ts";
 import { ChatMessagePF2e } from "@module/chat-message/document.ts";
 import { CombatantPF2e, EncounterPF2e } from "@module/encounter/index.ts";
@@ -289,6 +290,38 @@ class TokenDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> ext
               }))
             : waypoints;
         return super.measureMovementPath(normalized, options);
+    }
+
+    /**
+     * Test containment against an effect area's covered squares rather than its polygon, so that region membership
+     * matches the highlighted squares. Elevation and level gating mirrors core's.
+     */
+    override testInsideRegion(region: RegionDocumentPF2e, data: Partial<TokenPosition> = {}): boolean {
+        const level = data.level ?? this._source.level;
+        const coverage = region.getCoverage(this.parent?.levels.get(level) ?? null);
+        if (!coverage) return super.testInsideRegion(region, data);
+        if (!region.includedInLevel(level)) return false;
+
+        const { bottom, top, topInclusive } = region.elevation;
+        const elevation = data.elevation ?? this._source.elevation;
+        const depth = data.depth ?? this._source.depth;
+        if (topInclusive ? elevation > top : elevation !== bottom && elevation >= top) return false;
+        const head = elevation + depth * (this.parent?.grid.distance ?? 0);
+        if (depth === 0 ? head < bottom : head <= bottom) return false;
+
+        return this.#occupiedOffsets(data).some((o) => coverage.covers(o));
+    }
+
+    /** The grid spaces this token sits on, taken from square centers so unsnapped tokens count the right ones */
+    #occupiedOffsets(data: Partial<TokenPosition>): GridOffset2D[] {
+        const { sizeX, sizeY } = canvas.grid;
+        const size = this.getSize(data);
+        const x = (data.x ?? this._source.x) + Math.min(size.width, sizeX) / 2;
+        const y = (data.y ?? this._source.y) + Math.min(size.height, sizeY) / 2;
+        const { i: i0, j: j0 } = canvas.grid.getOffset({ x, y });
+        const rows = Math.max(1, Math.round(size.height / sizeY));
+        const columns = Math.max(1, Math.round(size.width / sizeX));
+        return Array.fromRange(rows).flatMap((i) => Array.fromRange(columns).map((j) => ({ i: i0 + i, j: j0 + j })));
     }
 
     protected override _initialize(options?: Record<string, unknown>): void {

--- a/src/module/scene/wall-document/document.ts
+++ b/src/module/scene/wall-document/document.ts
@@ -1,0 +1,49 @@
+import type {
+    DatabaseCreateCallbackOptions,
+    DatabaseDeleteCallbackOptions,
+    DatabaseUpdateCallbackOptions,
+} from "@common/abstract/_types.d.mts";
+import type { ScenePF2e } from "@scene";
+
+/** Source keys that change a wall's edge, and with it what the wall blocks */
+const EDGE_KEYS = ["c", "levels", "light", "move", "sight", "sound", "dir", "door", "ds", "threshold"] as const;
+
+class WallDocumentPF2e<TParent extends ScenePF2e | null = ScenePF2e | null> extends WallDocument<TParent> {
+    protected override _onCreate(data: this["_source"], options: DatabaseCreateCallbackOptions, userId: string): void {
+        super._onCreate(data, options, userId);
+        this.#onEdgeChange();
+    }
+
+    protected override _onUpdate(
+        changed: DeepPartial<this["_source"]>,
+        options: DatabaseUpdateCallbackOptions,
+        userId: string,
+    ): void {
+        super._onUpdate(changed, options, userId);
+        if (EDGE_KEYS.some((k) => k in changed)) this.#onEdgeChange();
+    }
+
+    protected override _onDelete(options: DatabaseDeleteCallbackOptions, userId: string): void {
+        super._onDelete(options, userId);
+        this.#onEdgeChange();
+    }
+
+    /**
+     * Line of effect is part of an effect area's coverage, so a wall can move tokens in or out of one without the
+     * region changing. Core only rechecks containment when a region or token changes.
+     */
+    #onEdgeChange(): void {
+        const scene = this.parent;
+        if (scene !== canvas.scene) return;
+        const areas = scene?.regions.filter((r) => r.isMeasuredArea) ?? [];
+        if (areas.length === 0) return;
+
+        for (const area of areas) {
+            area.clearCoverage();
+            area.object?.renderFlags.set({ refreshGeometry: true });
+        }
+        if (game.user.isActiveGM) scene?.updateTokenRegions();
+    }
+}
+
+export { WallDocumentPF2e };

--- a/src/scripts/hooks/canvas-ready.ts
+++ b/src/scripts/hooks/canvas-ready.ts
@@ -17,6 +17,13 @@ export const CanvasReady = {
             game.pf2e.effectPanel.render({ force: true });
 
             if (!canvas.scene) return;
+
+            // Effect-area containment is only measurable while the scene is viewed. Pick up walls that changed
+            // while it wasn't
+            if (game.user.isActiveGM && canvas.scene.regions.some((r) => r.isMeasuredArea)) {
+                canvas.scene.updateTokenRegions();
+            }
+
             for (const token of canvas.tokens.placeables) {
                 // Redraw effects on visible tokens
                 if (token.visible) token.renderFlags.set({ redrawEffects: true });

--- a/src/scripts/hooks/load.ts
+++ b/src/scripts/hooks/load.ts
@@ -46,6 +46,7 @@ import {
     EnvironmentFeatureBehaviorType,
     RegionBehaviorPF2e,
     RegionDocumentPF2e,
+    WallDocumentPF2e,
     ScenePF2e,
     TokenDocumentPF2e,
 } from "@scene/index.ts";
@@ -92,6 +93,7 @@ export class Load {
         CONFIG.Token.objectClass = TokenPF2e;
         CONFIG.Token.prototypeSheetClass = PrototypeTokenConfigPF2e;
         CONFIG.Token.rulerClass = TokenRulerPF2e;
+        CONFIG.Wall.documentClass = WallDocumentPF2e;
         Load.#configureMovement();
 
         CONFIG.User.documentClass = UserPF2e;

--- a/types/foundry/client/canvas/board.d.mts
+++ b/types/foundry/client/canvas/board.d.mts
@@ -2,7 +2,7 @@ import { CanvasDimensions } from "@client/_types.mjs";
 import { Point } from "@common/_types.mjs";
 import { CanvasPerformanceMode } from "@common/constants.mjs";
 import { GridlessGrid, HexagonalGrid, SquareGrid } from "@common/grid/_module.mjs";
-import { AmbientLightDocument, RegionDocument, Scene, TokenDocument, User } from "../documents/_module.mjs";
+import { AmbientLightDocument, Level, RegionDocument, Scene, TokenDocument, User } from "../documents/_module.mjs";
 import { CanvasEdges } from "./geometry/edges/edges.mjs";
 import {
     CanvasVisibility,
@@ -194,6 +194,9 @@ export default class Canvas<
 
     /** A reference to the grid of the currently displayed Scene document, or null if the Canvas is currently blank. */
     get grid(): SquareGrid | HexagonalGrid | GridlessGrid;
+
+    /** The level currently being viewed, or null if the canvas is blank. */
+    get level(): Level | null;
 
     /** A flag for whether the game Canvas is ready to be used. False if the canvas is not yet drawn, true otherwise. */
     get ready(): boolean;

--- a/types/foundry/client/canvas/geometry/_types.d.mts
+++ b/types/foundry/client/canvas/geometry/_types.d.mts
@@ -1,3 +1,4 @@
+import { Level } from "@client/documents/_module.mjs";
 import { EdgeDirectionMode } from "@common/constants.mjs";
 import { PointEffectSource } from "../sources/point-effect-source.mjs";
 import { Ray } from "./_module.mjs";
@@ -16,6 +17,8 @@ export type PointSourcePolygonType = "light" | "darkness" | "sight" | "sound" | 
 export interface PointSourcePolygonConfig {
     /** The type of polygon being computed */
     type: PointSourcePolygonType;
+    /** The level whose edges constrain the polygon, defaulting to the viewed one */
+    level?: Level | null;
     /** The angle of emission, if limited */
     angle?: number;
     /** The desired density of padding rays, a number per PI */

--- a/types/foundry/client/documents/region.d.mts
+++ b/types/foundry/client/documents/region.d.mts
@@ -42,6 +42,15 @@ export default class RegionDocument<TParent extends Scene | null = Scene | null>
     get polygonTree(): RegionPolygonTree;
 
     /**
+     * Clear the polygon tree.
+     * @internal
+     */
+    _clearPolygonTree(): void;
+
+    /** Called when the polygon tree of the Region has changed. */
+    protected _onPolygonTreeChange(): void;
+
+    /**
      * Activate the Socket event listeners.
      * @param    socket    The active game socket
      * @internal
@@ -77,6 +86,9 @@ export default class RegionDocument<TParent extends Scene | null = Scene | null>
 }
 
 export default interface RegionDocument<TParent extends Scene | null = Scene | null> extends CanvasBaseRegion<TParent> {
+    /** Prepared elevation: `bottom` and `top` are resolved from null to -Infinity and Infinity. */
+    elevation: { bottom: number; top: number; topInclusive: boolean };
+
     get object(): Region<this>;
 
     readonly behaviors: EmbeddedCollection<RegionBehavior<this>>;

--- a/types/foundry/global-external.d.mts
+++ b/types/foundry/global-external.d.mts
@@ -35,6 +35,7 @@ declare global {
         export import TileDocument = foundry.documents.TileDocument;
         export import TokenDocument = foundry.documents.TokenDocument;
         export import User = foundry.documents.User;
+        export import WallDocument = foundry.documents.WallDocument;
 
         export import Roll = foundry.dice.Roll;
 


### PR DESCRIPTION
- Closes #23044

Half of this is just pulling the coverage math from #22455 out of `RegionPF2e` and into `region-document/coverage.ts` so both the placeable and `testInsideRegion` can use it.

Coverage is cached per level since walls are, and `WallDocumentPF2e` exists to clear that cache. Walls don't affect region membership in core so nothing rechecks it when one changes, but they do affect ours through line of effect.

Separately, I'm finding core splits movement at the region boundary when there's an enter/exit behavior, which leaves the movement readout showing odd fractions like `50 ft (+8.9)`. It splits on the region's polygon rather than our covered squares, so those splits can happen on squares we don't count. The fractions issue predates my v14 region work though (probably was the case in v13 but I haven't checked) and overriding `segmentizeRegionMovementPath` isn't trivial, so not touching that here.