### PR TITLE
Adopt shared `TextSearch`/`SearchInput` in ABC picker, formula picker, roll inpsector, and trade dialog.

### DIFF
--- a/src/module/actor/character/apps/abc-picker/app.svelte
+++ b/src/module/actor/character/apps/abc-picker/app.svelte
@@ -1,27 +1,22 @@
 <script lang="ts">
     import { ErrorPF2e } from "@util";
     import type { MouseEventHandler } from "svelte/elements";
+    import SearchInput from "@module/sheet/components/search-input.svelte";
     import type { SvelteAppProps } from "@module/sheet/mixin.svelte.ts";
     import type { ABCPickerContext } from "./app.ts";
 
-    const { actor, foundryApp, getState }: ABCPickerContext & SvelteAppProps<ABCPickerContext> = $props();
+    const { actor, foundryApp, search, getState }: ABCPickerContext & SvelteAppProps<ABCPickerContext> = $props();
     const data = $derived(getState());
-    let searchQuery = $state("");
     const filteredItems = $derived.by(() => {
-        const query = searchQuery.trim();
-        if (!query.length) return data.items;
-
-        const regexp = new RegExp(RegExp.escape(query), "i");
-        return data.items.filter((item) => {
-            if (searchQuery.length === 0) return true;
-            const name = item.name;
-            const originalName = item.originalName;
-            return regexp.test(name) || (originalName && regexp.test(originalName));
-        });
+        const matches = search.matches;
+        return matches ? data.items.filter((item) => matches.has(item.uuid)) : data.items;
     });
 
     const typePlural = $derived(_loc(`PF2E.Item.${data.itemType.capitalize()}.Plural`));
     const searchPlaceholder = $derived(_loc("PF2E.Actor.Character.ABCPicker.SearchPlaceholder", { items: typePlural }));
+    const searchResults = $derived(
+        _loc("PF2E.Actor.Character.ABCPicker.SearchResults", { items: typePlural, count: filteredItems.length }),
+    );
 
     /** Open an item sheet to show additional details. */
     const viewItemSheet: MouseEventHandler<HTMLButtonElement> = async (event): Promise<void> => {
@@ -43,8 +38,7 @@
 </script>
 
 <search>
-    <i class="fa-solid fa-search"></i>
-    <input type="search" spellcheck="false" placeholder={searchPlaceholder} bind:value={searchQuery} />
+    <SearchInput {search} label={searchPlaceholder} resultsLabel={searchResults} />
 </search>
 
 <menu class="scrollable">
@@ -82,12 +76,12 @@
 
 <style>
     search {
-        align-items: center;
-        flex-flow: row nowrap;
-        gap: var(--space-8);
-        justify-content: start;
+        /* Column so the results line sits under the input */
+        display: flex;
+        flex-flow: column nowrap;
         padding: var(--space-8) var(--space-8) 0;
-        input::placeholder {
+
+        :global(input::placeholder) {
             color: var(--color-form-hint);
         }
     }

--- a/src/module/actor/character/apps/abc-picker/app.ts
+++ b/src/module/actor/character/apps/abc-picker/app.ts
@@ -4,6 +4,7 @@ import type { CompendiumItemUUID, ItemUUID } from "@common/documents/_module.mts
 import { ABCItemPF2e, DeityPF2e, HeritagePF2e, ItemPF2e } from "@item";
 import type { ItemType } from "@item/types.ts";
 import { RARITIES, Rarity } from "@module/data.ts";
+import { TextSearch } from "@module/sheet/components/text-search.svelte.ts";
 import { SvelteApplicationMixin, type SvelteApplicationRenderContext } from "@module/sheet/mixin.svelte.ts";
 import { sluggify } from "@util";
 import { UUIDUtils } from "@util/uuid.ts";
@@ -40,7 +41,14 @@ interface ABCPickerState {
 interface ABCPickerContext extends SvelteApplicationRenderContext {
     actor: CharacterPF2e;
     foundryApp: ABCPicker;
+    search: TextSearch<ABCSearchDoc>;
     state: ABCPickerState;
+}
+
+interface ABCSearchDoc {
+    id: ItemUUID;
+    name: string;
+    originalName?: string;
 }
 
 /** A `Compendium`-like application for presenting A(H)BCD options for a character */
@@ -57,6 +65,12 @@ class ABCPicker extends SvelteApplicationMixin<
     declare options: ABCPickerConfiguration;
 
     protected root = Root;
+
+    #search = new TextSearch<ABCSearchDoc>({
+        fields: ["name", "originalName"],
+        matcher: "substring",
+        minLength: 1,
+    });
 
     override get title(): string {
         const type = _loc(`TYPES.Item.${this.options.itemType}`);
@@ -149,13 +163,16 @@ class ABCPicker extends SvelteApplicationMixin<
 
     protected override async _prepareContext(): Promise<ABCPickerContext> {
         const itemType = this.options.itemType;
+        const items = await this.#gatherItems();
+        this.#search.index(items.map((i) => ({ id: i.uuid, name: i.name, originalName: i.originalName })));
         return {
             actor: this.options.actor,
             foundryApp: this,
+            search: this.#search,
             state: {
                 prompt: _loc(`PF2E.Actor.Character.ABCPicker.Prompt.${itemType}`),
                 itemType,
-                items: await this.#gatherItems(),
+                items,
             },
         };
     }

--- a/src/module/actor/character/apps/formula-picker/app.svelte
+++ b/src/module/actor/character/apps/formula-picker/app.svelte
@@ -4,46 +4,42 @@
     import ItemSummary from "@module/sheet/components/item-summary.svelte";
     import ItemTraits from "@module/sheet/components/item-traits.svelte";
     import HoverIconButton from "@module/sheet/components/hover-icon-button.svelte";
+    import SearchInput from "@module/sheet/components/search-input.svelte";
     import { sendItemToChat } from "@module/sheet/helpers.ts";
 
     const {
         actor,
         ability,
         mode,
-        searchEngine,
+        search,
         onSelect,
         onDeselect,
         getState,
     }: FormulaPickerContext & SvelteAppProps<FormulaPickerContext> = $props();
     const data = $derived(getState());
     const openStates: Record<string, boolean> = $state({});
-    let queryText = $state("");
 
-    // A filtered view of the formula sections based on the search query
     const filteredSections = $derived.by(() => {
-        // Search only starts once at least two characters are inserted
-        if (queryText.trim().length <= 1) return data.sections;
+        const matches = search.matches;
+        if (!matches) return data.sections;
 
-        const results = new Set(searchEngine.search(queryText).map((r) => r.id));
         return data.sections
             .map((s) => ({
                 ...s,
-                formulas: s.formulas.filter((f) => results.has(f.item.id)),
+                formulas: s.formulas.filter((f) => matches.has(f.item.id)),
             }))
             .filter((s) => s.formulas.length);
     });
+    const resultCount = $derived(filteredSections.reduce((sum, s) => sum + s.formulas.length, 0));
 </script>
 
 <header class="sheet-header">
     <p class="hint">{data.prompt}</p>
-    <div class="search">
-        <input
-            type="search"
-            spellcheck="false"
-            bind:value={queryText}
-            placeholder={_loc("PF2E.Actor.Character.Crafting.Search")}
-        />
-    </div>
+    <SearchInput
+        {search}
+        label={_loc("PF2E.Actor.Character.Crafting.Search")}
+        resultsLabel={_loc("PF2E.Actor.Character.Crafting.SearchResults", { count: resultCount })}
+    />
     {#if !ability.isPrepared && !data.resource?.value}
         <p class="notification warning">{_loc("PF2E.Actor.Character.Crafting.MissingResource")}</p>
     {/if}
@@ -138,7 +134,7 @@
         flex-direction: column;
         margin: var(--space-8);
         margin-bottom: 0;
-        .search {
+        :global(.search) {
             margin-top: var(--space-2);
         }
     }

--- a/src/module/actor/character/apps/formula-picker/app.ts
+++ b/src/module/actor/character/apps/formula-picker/app.ts
@@ -7,8 +7,8 @@ import type { AbilityItemPF2e, FeatPF2e, PhysicalItemPF2e } from "@item";
 import type { TraitChatData } from "@item/base/data/index.ts";
 import type { ItemType } from "@item/types.ts";
 import { Rarity } from "@module/data.ts";
+import { TextSearch } from "@module/sheet/components/text-search.svelte.ts";
 import { SvelteApplicationMixin, type SvelteApplicationRenderContext } from "@module/sheet/mixin.svelte.ts";
-import MiniSearch from "minisearch";
 import * as R from "remeda";
 import Root from "./app.svelte";
 
@@ -44,12 +44,7 @@ class FormulaPicker extends SvelteApplicationMixin<
 
     #resolve?: (value: PhysicalItemPF2e | null) => void;
 
-    #searchEngine = new MiniSearch<Pick<PhysicalItemPF2e, "id" | "name">>({
-        fields: ["name"],
-        idField: "id",
-        processTerm: (t) => (t.length > 1 ? t.toLocaleLowerCase(game.i18n.lang) : null),
-        searchOptions: { combineWith: "AND", prefix: true },
-    });
+    #search = new TextSearch<FormulaSearchDoc>({ fields: ["name"] });
 
     selection: PhysicalItemPF2e | null = null;
 
@@ -88,8 +83,7 @@ class FormulaPicker extends SvelteApplicationMixin<
         const formulas = await ability.getValidFormulas();
         const sheetData = await ability.getSheetData();
         const resource = sheetData.resource;
-        this.#searchEngine.removeAll();
-        this.#searchEngine.addAll(formulas.map((f) => R.pick(f.item, ["id", "name"])));
+        this.#search.index(formulas.map((f) => R.pick(f.item, ["id", "name"])));
 
         const prompt =
             mode === "prepare"
@@ -123,7 +117,7 @@ class FormulaPicker extends SvelteApplicationMixin<
                     ability.unprepareFormula(uuid);
                 }
             },
-            searchEngine: this.#searchEngine,
+            search: this.#search,
             state: {
                 name: this.options.item?.name ?? ability.label,
                 resource,
@@ -174,9 +168,11 @@ interface FormulaPickerContext extends SvelteApplicationRenderContext {
     mode: "craft" | "prepare";
     onSelect: (uuid: ItemUUID) => void;
     onDeselect: (uuid: ItemUUID) => void;
-    searchEngine: MiniSearch<Pick<PhysicalItemPF2e, "id" | "name">>;
+    search: TextSearch<FormulaSearchDoc>;
     state: FormulaPickerState;
 }
+
+type FormulaSearchDoc = Pick<PhysicalItemPF2e, "id" | "name">;
 
 interface FormulaSection {
     level: number;

--- a/src/module/apps/compendium-browser/components/filters.svelte
+++ b/src/module/apps/compendium-browser/components/filters.svelte
@@ -65,6 +65,7 @@
             autocomplete="off"
             spellcheck="false"
             placeholder={_loc("PF2E.CompendiumBrowser.Filter.SearchPlaceholder")}
+            aria-label={_loc("PF2E.CompendiumBrowser.Filter.SearchPlaceholder")}
         />
         <div class="order-by-select">
             <label id="sort-order">

--- a/src/module/apps/compendium-browser/components/filters/checkboxes.svelte
+++ b/src/module/apps/compendium-browser/components/filters/checkboxes.svelte
@@ -32,6 +32,7 @@
             class="filter-sources"
             spellcheck="false"
             placeholder={_loc("PF2E.CompendiumBrowser.Filter.FilterSources")}
+            aria-label={_loc("PF2E.CompendiumBrowser.Filter.FilterSources")}
             oninput={onSearchSource}
         />
     {/if}

--- a/src/module/apps/roll-inspector/app.svelte
+++ b/src/module/apps/roll-inspector/app.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { DamageDicePF2e, Modifier } from "@actor/modifiers.ts";
+    import SearchInput from "@module/sheet/components/search-input.svelte";
     import type { SvelteAppProps } from "@module/sheet/mixin.svelte.ts";
     import type { RollInspectorContext } from "./app.ts";
     import * as R from "remeda";
@@ -7,23 +8,26 @@
     import { getDamageDiceOverrideLabel, getDamageDiceValueLabel } from "@system/damage/helpers.ts";
 
     const localize = game.i18n.localize.bind(game.i18n);
-    const { getState }: SvelteAppProps<RollInspectorContext> = $props();
+    const { search, getState }: RollInspectorContext & SvelteAppProps<RollInspectorContext> = $props();
     const data = $derived(getState());
-    let searchTerm = $state("");
 
     const context = $derived(data.context);
     const modifiers = $derived(data.modifiers);
     const dice = $derived(data.dice);
 
-    const results = $derived({
-        rollOptions: data.rollOptions.filter((r) => r.includes(searchTerm)),
-        contextualOptions: data.contextualOptions
-            .map((c) => ({
-                header: c.header,
-                options: c.options.filter((o) => o.includes(searchTerm)),
-            }))
-            .filter((c) => c.options.length > 0),
+    const results = $derived.by(() => {
+        const matches = search.matches;
+        if (!matches) return { rollOptions: data.rollOptions, contextualOptions: data.contextualOptions };
+        return {
+            rollOptions: data.rollOptions.filter((o) => matches.has(o)),
+            contextualOptions: data.contextualOptions
+                .map((c) => ({ header: c.header, options: c.options.filter((o) => matches.has(o)) }))
+                .filter((c) => c.options.length > 0),
+        };
     });
+    const resultCount = $derived(
+        results.rollOptions.length + results.contextualOptions.reduce((sum, c) => sum + c.options.length, 0),
+    );
 
     function getCriticalLabel(critical: boolean | null | undefined) {
         return typeof critical === "boolean" ? _loc(`PF2E.RuleEditor.General.CriticalBehavior.${critical}`) : null;
@@ -61,11 +65,10 @@
 
     <section class="roll-options">
         <header>{localize("PF2E.ChatRollDetails.RollOptions")}</header>
-        <input
-            type="search"
-            class="filter"
-            bind:value={searchTerm}
-            placeholder={localize("PF2E.CompendiumBrowser.Filter.SearchPlaceholder")}
+        <SearchInput
+            {search}
+            label={_loc("PF2E.ChatRollDetails.Search")}
+            resultsLabel={_loc("PF2E.ChatRollDetails.SearchResults", { count: resultCount })}
         />
         <ul class="scrollable">
             {#each results.rollOptions as option}
@@ -219,7 +222,7 @@
     }
 
     .roll-options {
-        .filter {
+        > :global(.search-results) {
             margin-bottom: var(--space-4);
         }
 

--- a/src/module/apps/roll-inspector/app.ts
+++ b/src/module/apps/roll-inspector/app.ts
@@ -2,6 +2,7 @@ import type { RawDamageDice, RawModifier } from "@actor/modifiers.ts";
 import type { ApplicationConfiguration } from "@client/applications/_types.d.mts";
 import type { ChatContextFlag } from "@module/chat-message/data.ts";
 import { ChatMessagePF2e } from "@module/chat-message/document.ts";
+import { TextSearch } from "@module/sheet/components/text-search.svelte.ts";
 import { SvelteApplicationMixin, SvelteApplicationRenderContext } from "@module/sheet/mixin.svelte.ts";
 import * as R from "remeda";
 import Root from "./app.svelte";
@@ -23,6 +24,8 @@ class RollInspector extends SvelteApplicationMixin(fa.api.ApplicationV2) {
 
     message: ChatMessagePF2e;
 
+    #search = new TextSearch<RollOptionDoc>({ fields: ["id"], matcher: "substring", minLength: 1 });
+
     constructor(options: DeepPartial<ApplicationConfiguration> & { message: ChatMessagePF2e }) {
         super(options);
         this.message = options.message;
@@ -36,28 +39,37 @@ class RollInspector extends SvelteApplicationMixin(fa.api.ApplicationV2) {
 
         const contextualOptions = context && "contextualOptions" in context ? context.contextualOptions : {};
         const rollOptions = R.sortBy(context?.options?.sort() ?? [], (o) => o.includes(":"));
+        const contextualLists = Object.entries(contextualOptions ?? {})
+            .map(([key, value]) => ({
+                header: _loc(`PF2E.ChatRollDetails.ContextualOptions.${key}`),
+                options: value ?? [],
+            }))
+            .filter((o) => !!o.options.length);
+        const searchable = new Set([...rollOptions, ...contextualLists.flatMap((l) => l.options)]);
+        this.#search.index([...searchable].map((id) => ({ id })));
 
         return {
             foundryApp: this,
+            search: this.#search,
             state: {
                 context,
                 dice: this.message.flags[SYSTEM_ID].dice ?? [],
                 domains: context?.domains?.sort() ?? [],
                 modifiers: this.message.flags[SYSTEM_ID].modifiers ?? [],
                 rollOptions,
-                contextualOptions: Object.entries(contextualOptions ?? {})
-                    .map(([key, value]) => ({
-                        header: _loc(`PF2E.ChatRollDetails.ContextualOptions.${key}`),
-                        options: value ?? [],
-                    }))
-                    .filter((o) => !!o.options.length),
+                contextualOptions: contextualLists,
             },
         };
     }
 }
 
 interface RollInspectorContext extends SvelteApplicationRenderContext {
+    search: TextSearch<RollOptionDoc>;
     state: RollInspectorState;
+}
+
+interface RollOptionDoc {
+    id: string;
 }
 
 interface RollInspectorState {

--- a/src/module/apps/trade-dialog/app.svelte
+++ b/src/module/apps/trade-dialog/app.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
+    import SearchInput from "@module/sheet/components/search-input.svelte";
     import type { SvelteAppProps } from "@module/sheet/mixin.svelte.ts";
     import type { TradeDialogRenderContext, TradeQueryData, TradeItemData } from "./app.svelte.ts";
 
     const {
         foundryApp: dialog,
         traderUser,
-        searchEngine,
+        search,
         localize,
         getState,
     }: TradeDialogRenderContext & SvelteAppProps<TradeDialogRenderContext> = $props();
@@ -19,11 +20,17 @@
 
     // Item lists and summaries
     const listFormatter = game.i18n.getListFormatter({ style: "narrow" });
-    const selfItemsVisible = $derived(
-        dialog.selfItems
-            .filter((i) => i.matchScore > 0)
-            .sort((a, b) => b.matchScore - a.matchScore || a.name.localeCompare(b.name, game.i18n.lang)),
-    );
+    // Sort by relevance while searching, otherwise by name
+    const selfItemsVisible = $derived.by(() => {
+        const scores = search.scores;
+        return dialog.selfItems
+            .filter((i) => !scores || scores.has(i.id))
+            .sort(
+                (a, b) =>
+                    (scores ? (scores.get(b.id) ?? 0) - (scores.get(a.id) ?? 0) : 0) ||
+                    a.name.localeCompare(b.name, game.i18n.lang),
+            );
+    });
     const withQuantity = (i: { quantity: number; marked: number; name: string }) =>
         i.quantity > 1 ? `${i.marked}x ${i.name}` : i.name;
     const itemsToSend = $derived.by(() => {
@@ -64,16 +71,6 @@
         );
         if (dialog.selfAccepted && dialog.traderAccepted) dialog.close({ success: true });
         sendQuery({ action: "update", marked, accepted: dialog.selfAccepted });
-    }
-
-    function search(event: Event): void {
-        if (!(event.target instanceof HTMLInputElement)) throw Error("Unexpected event received during search");
-        const searchText = event.target.value.trim();
-        const results = new Map(searchEngine.search(searchText).map((r) => [r.id, r.score]));
-        const fallbackScore = results.size > 0 ? 0 : 1;
-        for (const item of dialog.selfItems) {
-            item.matchScore = results.get(item.id) ?? fallbackScore;
-        }
     }
 
     function showQuantityInput(event: Event & { currentTarget: HTMLButtonElement }): void {
@@ -155,9 +152,11 @@
                 <i class="fa-solid fa-{dialog.selfAccepted ? 'check' : 'xmark'}"></i>
             </button>
         </header>
-        <div class="flexrow search">
-            <input type="search" id="{dialog.id}-search" placeholder="&#xf002;" aria-label="Search" oninput={search} />
-        </div>
+        <SearchInput
+            {search}
+            label={_loc("PF2E.Actor.Inventory.Search")}
+            resultsLabel={localize("SearchResults", { count: selfItemsVisible.length })}
+        />
         <ul class="flexcol scrollable">
             {#each selfItemsVisible as item (item.id)}
                 <li class="flexrow" class:marked={item.marked}>
@@ -348,14 +347,9 @@
             }
         }
 
-        input[type="search"] {
-            padding-right: 0;
+        > :global(.search),
+        > :global(.search-results) {
             margin-right: var(--scroll-margin);
-            &::placeholder {
-                font-family: var(--font-awesome);
-                font-weight: 900;
-                padding-left: 0.25em;
-            }
         }
 
         ul {

--- a/src/module/apps/trade-dialog/app.svelte.ts
+++ b/src/module/apps/trade-dialog/app.svelte.ts
@@ -3,11 +3,11 @@ import { ItemTransferDialog } from "@actor/sheet/popups/item-transfer-dialog.ts"
 import type { ActorUUID, UserUUID } from "@common/documents/_module.d.mts";
 import type { ItemPF2e, PhysicalItemPF2e } from "@item";
 import { ChatMessagePF2e } from "@module/chat-message/document.ts";
+import { TextSearch } from "@module/sheet/components/text-search.svelte.ts";
 import { SvelteApplicationMixin, SvelteApplicationRenderContext } from "@module/sheet/mixin.svelte.ts";
 import type { UserPF2e } from "@module/user/document.ts";
 import { ErrorPF2e, localizer } from "@util";
 import { traitSlugToObject } from "@util/tags.ts";
-import MiniSearch from "minisearch";
 import * as R from "remeda";
 import Root from "./app.svelte";
 
@@ -51,6 +51,9 @@ class TradeDialog extends SvelteApplicationMixin(fa.api.ApplicationV2) {
     protected override set $state(value: TradeDialogState) {
         super.$state = value;
     }
+
+    /** Search over the user's own items */
+    #search = new TextSearch<TradeItemData>({ fields: ["name"] });
 
     /** Live trade state. Mutated by both the component and #onUpdate. */
     selfItems: TradeItemData[] = $state([]);
@@ -213,7 +216,6 @@ class TradeDialog extends SvelteApplicationMixin(fa.api.ApplicationV2) {
         return {
             ...R.pick(item, ["id", "name", "img", "quantity"]),
             marked: Math.clamp(marked, 0, item.quantity),
-            matchScore: 1,
             visible: item.actor === selfActor || game.user.isGM || (otherActor.isAllyOf(selfActor) && !item.isStowed),
         };
     }
@@ -223,32 +225,8 @@ class TradeDialog extends SvelteApplicationMixin(fa.api.ApplicationV2) {
         const self = this.#self;
         const trader = this.#trader;
         // Rebuild items, preserving previously-marked counts via the live arrays.
-        this.selfItems = this.#prepareItems(self, this.selfItems);
+        this.#setSelfItems(this.#prepareItems(self, this.selfItems));
         this.traderItems = this.#prepareItems(trader, this.traderItems);
-        const wordSegmenter =
-            "Segmenter" in Intl
-                ? new Intl.Segmenter(game.i18n.lang, { granularity: "word" })
-                : {
-                      // Firefox >:(
-                      segment(term: string): { segment: string }[] {
-                          return [{ segment: term }];
-                      },
-                  };
-        const searchEngine = new MiniSearch({
-            fields: ["name", "originalName"],
-            idField: "id",
-            processTerm: (term): string[] | null => {
-                if (term.length < 2 || CONFIG.i18n.searchStopWords.has(term)) return null;
-                return Array.from(wordSegmenter.segment(term))
-                    .map((t) =>
-                        fa.ux.SearchFilter.cleanQuery(t.segment.toLocaleLowerCase(game.i18n.lang)).replace(/['"]/g, ""),
-                    )
-                    .filter((t) => t.length >= 2);
-            },
-            searchOptions: { combineWith: "AND", prefix: true },
-            storeFields: ["id", "name"],
-        });
-        searchEngine.addAll([...this.selfItems]);
         return Object.assign(context, {
             state: {
                 selfActor: R.pick(self.actor, ["id", "img", "name"]),
@@ -260,7 +238,7 @@ class TradeDialog extends SvelteApplicationMixin(fa.api.ApplicationV2) {
             },
             foundryApp: this,
             traderUser: trader.user,
-            searchEngine,
+            search: this.#search,
             localize: TradeDialog.localize,
         });
     }
@@ -325,6 +303,11 @@ class TradeDialog extends SvelteApplicationMixin(fa.api.ApplicationV2) {
         selfActor.render();
     }
 
+    #setSelfItems(items: TradeItemData[]): void {
+        this.selfItems = items;
+        this.#search.index([...this.selfItems]);
+    }
+
     /** Replace live trade data with gift-only data, used in lieu of data created during dialog render. */
     #setGiftData(): void {
         if (!this.#self.gift && !this.#trader.gift) {
@@ -339,9 +322,11 @@ class TradeDialog extends SvelteApplicationMixin(fa.api.ApplicationV2) {
                 name: TradeDialog.#getObfuscatedActorName(traderActor),
             },
         };
-        this.selfItems = [this.#self.actor.inventory.get(this.#self.initialMarked ?? "")]
-            .filter(R.isDefined)
-            .map((i) => this.#itemToData(i, this.#self.gift));
+        this.#setSelfItems(
+            [this.#self.actor.inventory.get(this.#self.initialMarked ?? "")]
+                .filter(R.isDefined)
+                .map((i) => this.#itemToData(i, this.#self.gift)),
+        );
         this.traderItems = [traderActor.inventory.get(this.#trader.initialMarked ?? "")]
             .filter(R.isDefined)
             .map((i) => this.#itemToData(i, this.#trader.gift));
@@ -566,7 +551,6 @@ interface ConstructorParams extends MaybeValidConstructorParams {
 interface TradeItemData extends Pick<PhysicalItemPF2e, "id" | "name" | "img" | "quantity"> {
     readonly visible: boolean;
     marked: number;
-    matchScore: number;
 }
 
 interface MaybeTradeInitiationData {
@@ -589,7 +573,7 @@ interface TradeDialogRenderContext extends SvelteApplicationRenderContext {
     foundryApp: TradeDialog;
     state: TradeDialogState;
     traderUser: UserPF2e;
-    searchEngine: MiniSearch;
+    search: TextSearch<TradeItemData>;
     localize: ReturnType<typeof localizer>;
 }
 

--- a/src/module/sheet/components/search-input.svelte
+++ b/src/module/sheet/components/search-input.svelte
@@ -13,6 +13,7 @@
 </script>
 
 <div class="search">
+    <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
     <input type="search" spellcheck="false" bind:value={search.query} placeholder={label} aria-label={label} />
 </div>
 <p class="search-results" role="status">
@@ -22,6 +23,21 @@
 </p>
 
 <style>
+    .search {
+        align-items: center;
+        display: flex;
+        gap: var(--space-8);
+
+        > i {
+            color: var(--color-text-secondary, inherit);
+        }
+
+        > input {
+            flex: 1;
+            min-width: 0;
+        }
+    }
+
     .search-results {
         color: var(--color-text-secondary, inherit);
         font-size: var(--font-size-12);

--- a/src/module/sheet/components/text-search.svelte.ts
+++ b/src/module/sheet/components/text-search.svelte.ts
@@ -4,67 +4,116 @@ interface SearchableDoc {
     id: string;
 }
 
-/**
- * The surface a search UI needs: `search-input.svelte` binds against this rather than `TextSearch`
- * itself so it stays independent of the document type parameter.
- */
+/** What `search-input.svelte` binds to, so it doesn't care about the document type */
 interface SearchState {
     query: string;
     readonly active: boolean;
 }
 
 /**
- * Reactive text-search state over a set of documents: owns the query and the index, and exposes the
- * matching ids. Pair with `search-input.svelte` for the UI. Domain layers (e.g. the spell list's
- * `SpellListSearch`) extend this with their document fields and result filtering.
+ * `terms`: word-prefix matching ranked by relevance, stop words dropped.
+ * `substring`: one case-folded fragment anywhere in a field, document order, no stop words.
+ */
+type TextSearchMatcher = "terms" | "substring";
+
+interface TextSearchOptions<TDoc extends SearchableDoc> {
+    /** Document fields to match against */
+    fields: (keyof TDoc & string)[];
+    /** Matching strategy (default `terms`) */
+    matcher?: TextSearchMatcher;
+    /** Characters required before searching starts (default 2) */
+    minLength?: number;
+}
+
+/**
+ * Reactive search state over a set of documents. Pair with `search-input.svelte` for the UI and extend for
+ * domain-specific filtering (see `SpellListSearch`).
  */
 class TextSearch<TDoc extends SearchableDoc> implements SearchState {
     query = $state("");
 
-    /** Bumped on reindex so match sets recompute against the new documents */
+    /** Bumped on reindex so the deriveds recompute */
     #version = $state(0);
 
-    #engine: MiniSearch<TDoc>;
+    #fields: (keyof TDoc & string)[];
 
-    /** Ids matching the current query, or null when the query is too short to search on */
-    #matches: Set<string> | null = $derived.by(() => {
+    #minLength: number;
+
+    /** Null in substring mode, which needs no index */
+    #engine: MiniSearch<TDoc> | null = null;
+
+    /** Substring mode only */
+    #docs: TDoc[] = [];
+
+    /** Score by matching id, or null while the query is too short */
+    #scores: Map<string, number> | null = $derived.by(() => {
         void this.#version;
-        return this.active ? new Set(this.#engine.search(this.query).map((r) => String(r.id))) : null;
+        if (!this.active) return null;
+        const engine = this.#engine;
+        return engine
+            ? new Map(engine.search(this.query).map((r) => [String(r.id), r.score]))
+            : this.#substringScores();
     });
 
-    constructor({ fields }: { fields: (keyof TDoc & string)[] }) {
+    #matches: Set<string> | null = $derived.by(() => (this.#scores ? new Set(this.#scores.keys()) : null));
+
+    constructor({ fields, matcher = "terms", minLength = 2 }: TextSearchOptions<TDoc>) {
+        this.#fields = fields;
+        this.#minLength = minLength;
+        if (matcher === "substring") return;
+
         const segmenter = new Intl.Segmenter(game.i18n.lang, { granularity: "word" });
         this.#engine = new MiniSearch({
             fields,
             idField: "id",
             processTerm: (term): string[] | null => {
-                if (term.length < 2 || CONFIG.i18n.searchStopWords.has(term)) return null;
-                return Array.from(segmenter.segment(term))
-                    .map((t) =>
-                        fa.ux.SearchFilter.cleanQuery(t.segment.toLocaleLowerCase(game.i18n.lang)).replace(/['"]/g, ""),
-                    )
+                // Fold case first so "An" is dropped like "an"
+                const folded = term.toLocaleLowerCase(game.i18n.lang);
+                if (folded.length < 2 || CONFIG.i18n.searchStopWords.has(folded)) return null;
+                return Array.from(segmenter.segment(folded))
+                    .map((t) => fa.ux.SearchFilter.cleanQuery(t.segment).replace(/['"]/g, ""))
                     .filter((t) => t.length >= 2);
             },
             searchOptions: { combineWith: "AND", prefix: true },
         });
     }
 
-    /** Search only starts once at least two characters are entered */
     get active(): boolean {
-        return this.query.trim().length > 1;
+        return this.query.trim().length >= this.#minLength;
     }
 
     get matches(): Set<string> | null {
         return this.#matches;
     }
 
-    /** Replace the indexed documents (call whenever the searchable set changes) */
+    /** For sorting by relevance */
+    get scores(): Map<string, number> | null {
+        return this.#scores;
+    }
+
+    /** Substring mode keeps `docs` by reference and only recomputes here: pass a fresh array */
     index(docs: TDoc[]): void {
-        this.#engine.removeAll();
-        this.#engine.addAll(docs);
+        if (this.#engine) {
+            this.#engine.removeAll();
+            this.#engine.addAll(docs);
+        } else {
+            this.#docs = docs;
+        }
         this.#version += 1;
+    }
+
+    /** Every match scores 1, so relevance sorts fall back to document order */
+    #substringScores(): Map<string, number> {
+        const fragment = this.query.trim().toLocaleLowerCase(game.i18n.lang);
+        const matches = this.#docs.filter((doc) =>
+            this.#fields.some((field) => {
+                const value = doc[field];
+                return typeof value === "string" && value.toLocaleLowerCase(game.i18n.lang).includes(fragment);
+            }),
+        );
+        return new Map(matches.map((doc) => [doc.id, 1]));
     }
 }
 
 export { TextSearch };
-export type { SearchableDoc, SearchState };
+export type { SearchableDoc, SearchState, TextSearchMatcher, TextSearchOptions };

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -154,6 +154,7 @@
             "Character": {
                 "ABCPicker": {
                     "SearchPlaceholder": "Search {items}",
+                    "SearchResults": "Matching {items}: {count}",
                     "Title": "{type} Selection",
                     "Tooltip": {
                         "ConfirmSelection": "Confirm Selection",
@@ -249,7 +250,8 @@
                     "MissingResource": "You have insufficient resources to complete crafting.",
                     "PrepareHint": "Select the items that you want to prepare ({remaining} remaining)",
                     "RemainingSlots": "Empty Slot ({remaining} remaining)",
-                    "Search": "Search Formulas"
+                    "Search": "Search Formulas",
+                    "SearchResults": "Matching formulas: {count}"
                 },
                 "CreateFeat": "Create Feat",
                 "EmptyLabel": "Empty",
@@ -1053,6 +1055,8 @@
             "DiceRollOptionsHint": "Dice and modifier roll options are used when predicating DamageAlteration rule elements.",
             "FlatCheckNoModifiers": "Flat checks never include any modifiers, bonuses, or penalties.",
             "RollOptions": "Roll Options",
+            "Search": "Search Roll Options",
+            "SearchResults": "Matching roll options: {count}",
             "Select": "Inspect Roll",
             "Title": "Roll Inspector"
         },
@@ -4491,6 +4495,7 @@
                 },
                 "MenuLabel": "Request Trade"
             },
+            "SearchResults": "Matching items: {count}",
             "Sending": "Sending: {list}",
             "Success": {
                 "Finished": "{self} has finished trading with {trader}.",


### PR DESCRIPTION
Expands the usage of the search component I added in the Spell Prep conversion.

Stop words are now filtered case-insensitively, so "An" no longer sneaks past when "an" doesn't. The trade dialog no longer falls back to the whole inventory when nothing matches.

The compendium browser doesn't use this shared search, but added some `aria-label`s there.

Input with its new search glyph
<img width="526" height="76" alt="Screenshot 2026-09-06 at 3 51 34 PM" src="https://github.com/user-attachments/assets/73c6f5ff-5edf-4983-aa34-446cdcc912c5" />
