### PR TITLE
Fix thaumaturge weapon implement critical specialization

### DIFF
--- a/packs/pf2e/class-features/initiate-benefit-weapon.json
+++ b/packs/pf2e/class-features/initiate-benefit-weapon.json
@@ -33,7 +33,7 @@
                 "key": "CriticalSpecialization",
                 "predicate": [
                     "item:id:{actor|flags.system.thaumaturge.weaponImplement}",
-                    "feature:thaumaturge-weapon-expertise"
+                    "feature:weapon-expertise"
                 ]
             }
         ],

--- a/packs/pf2e/iconics/mios/mios-level-5.json
+++ b/packs/pf2e/iconics/mios/mios-level-5.json
@@ -3597,7 +3597,7 @@
                         "key": "CriticalSpecialization",
                         "predicate": [
                             "item:id:{actor|flags.system.thaumaturge.weaponImplement}",
-                            "feature:thaumaturge-weapon-expertise"
+                            "feature:weapon-expertise"
                         ]
                     }
                 ],

--- a/src/module/migration/migrations/956-thaumaturge-weapon-crit-spec.ts
+++ b/src/module/migration/migrations/956-thaumaturge-weapon-crit-spec.ts
@@ -1,0 +1,23 @@
+import { ItemSourcePF2e } from "@item/base/data/index.ts";
+import { sluggify } from "@util";
+import { MigrationBase } from "../base.ts";
+
+/** Weapon Expertise is a shared class feature; the old thaumaturge-specific slug never matches. */
+export class Migration956ThaumaturgeWeaponCritSpec extends MigrationBase {
+    static override version = 0.956;
+
+    override async updateItem(source: ItemSourcePF2e): Promise<void> {
+        if (source.type !== "feat") return;
+
+        const slug = source.system.slug || sluggify(source.name);
+        if (slug !== "initiate-benefit-weapon") return;
+
+        const rules: { key: string; predicate?: JSONValue }[] = source.system.rules;
+        for (const rule of rules) {
+            if (rule.key !== "CriticalSpecialization" || !Array.isArray(rule.predicate)) continue;
+            rule.predicate = rule.predicate.map((entry) =>
+                entry === "feature:thaumaturge-weapon-expertise" ? "feature:weapon-expertise" : entry,
+            );
+        }
+    }
+}

--- a/src/module/migration/migrations/index.ts
+++ b/src/module/migration/migrations/index.ts
@@ -254,3 +254,4 @@ export { Migration952AmmoTraitsAndOptions } from "./952-ammo-traits-options.ts";
 export { Migration953NotStrikeDamage } from "./953-not-strike-damage.ts";
 export { Migration954ExplicitBleedImmunity } from "./954-explicit-bleed-immunity.ts";
 export { Migration955HazardNullSaves } from "./955-hazard-null-saves.ts";
+export { Migration956ThaumaturgeWeaponCritSpec } from "./956-thaumaturge-weapon-crit-spec.ts";

--- a/src/module/migration/runner/base.ts
+++ b/src/module/migration/runner/base.ts
@@ -14,7 +14,7 @@ interface CollectionDiff<T extends foundry.documents.ActiveEffectSource | ItemSo
 export class MigrationRunnerBase {
     migrations: MigrationBase[];
 
-    static LATEST_SCHEMA_VERSION = 0.955;
+    static LATEST_SCHEMA_VERSION = 0.956;
 
     static MINIMUM_SAFE_VERSION = 0.7;
 


### PR DESCRIPTION
## Summary
- The Weapon implement initiate benefit gated critical specialization on `feature:thaumaturge-weapon-expertise`, a roll option that is never created after Weapon Expertise was unified into a shared class feature.
- Point the predicate at `feature:weapon-expertise` and migrate existing `initiate-benefit-weapon` items so level 5 thaumaturges get the implement’s critical specialization automatically.

## Test plan
- [ ] Create or open a level 5 thaumaturge with a Weapon implement
- [ ] Confirm **Initiate Benefit (Weapon)** uses `feature:weapon-expertise` (new characters and migrated existing ones)
- [ ] Strike with the stored implement and click **Critical**
- [ ] Confirm the weapon group’s critical specialization appears (note, bleed, or extra pick damage)
- [ ] Confirm a normal **Damage** roll does not include specialization


Made with [Cursor](https://cursor.com)