### PR TITLE
Fix remaining thaumaturge weapon implement critical specialization

### DIFF
--- a/packs/pf2e/iconics/mios/mios-level-5.json
+++ b/packs/pf2e/iconics/mios/mios-level-5.json
@@ -3597,7 +3597,7 @@
                         "key": "CriticalSpecialization",
                         "predicate": [
                             "item:id:{actor|flags.system.thaumaturge.weaponImplement}",
-                            "feature:thaumaturge-weapon-expertise"
+                            "feature:weapon-expertise"
                         ]
                     }
                 ],

--- a/src/module/migration/migrations/960-thaumaturge-weapon-crit-spec.ts
+++ b/src/module/migration/migrations/960-thaumaturge-weapon-crit-spec.ts
@@ -1,0 +1,23 @@
+import { ItemSourcePF2e } from "@item/base/data/index.ts";
+import { sluggify } from "@util";
+import { MigrationBase } from "../base.ts";
+
+/** Weapon Expertise is a shared class feature; the old thaumaturge-specific slug never matches. */
+export class Migration960ThaumaturgeWeaponCritSpec extends MigrationBase {
+    static override version = 0.96;
+
+    override async updateItem(source: ItemSourcePF2e): Promise<void> {
+        if (source.type !== "feat") return;
+
+        const slug = source.system.slug || sluggify(source.name);
+        if (slug !== "initiate-benefit-weapon") return;
+
+        const rules: { key: string; predicate?: JSONValue }[] = source.system.rules;
+        for (const rule of rules) {
+            if (rule.key !== "CriticalSpecialization" || !Array.isArray(rule.predicate)) continue;
+            rule.predicate = rule.predicate.map((entry) =>
+                entry === "feature:thaumaturge-weapon-expertise" ? "feature:weapon-expertise" : entry,
+            );
+        }
+    }
+}

--- a/src/module/migration/migrations/index.ts
+++ b/src/module/migration/migrations/index.ts
@@ -117,3 +117,4 @@ export { Migration956DragonChoiceLocalizationKeys } from "./956-dragonchoice-loc
 export { Migration957SF2eAnachronismImages } from "./957-sf2e-anachronism-images.ts";
 export { Migration958GnollGrippliRemaster } from "./958-gnoll-grippli-remaster.ts";
 export { Migration959ChangeShapeLocalizationKeys } from "./959-changeshape-localization-keys.ts";
+export { Migration960ThaumaturgeWeaponCritSpec } from "./960-thaumaturge-weapon-crit-spec.ts";

--- a/src/module/migration/runner/base.ts
+++ b/src/module/migration/runner/base.ts
@@ -14,7 +14,7 @@ interface CollectionDiff<T extends foundry.documents.ActiveEffectSource | ItemSo
 export class MigrationRunnerBase {
     migrations: MigrationBase[];
 
-    static LATEST_SCHEMA_VERSION = 0.959;
+    static LATEST_SCHEMA_VERSION = 0.96;
 
     static MINIMUM_SAFE_VERSION = 0.841;
 


### PR DESCRIPTION
## Summary
- The Weapon implement initiate benefit pack item on `v14-dev` already uses `feature:weapon-expertise` (#22527), but existing characters and iconic Mios still gate crit spec on `feature:thaumaturge-weapon-expertise`, which is never created.
- Add migration 960 to rewrite that predicate on `initiate-benefit-weapon` items, and update Mios level 5 to match.

Supersedes the closed draft #23174 (that one targeted `v13-dev`).

## Test plan
- [ ] Open a level 5 thaumaturge whose Initiate Benefit (Weapon) still has the old predicate; run world migration
- [ ] Confirm the rule now uses `feature:weapon-expertise`
- [ ] Strike with the stored implement and click **Critical**; confirm the weapon group’s critical specialization appears
- [ ] Confirm a normal **Damage** roll does not include specialization
- [ ] Confirm iconic Mios (level 5) uses the corrected predicate


Made with [Cursor](https://cursor.com)