### PR TITLE
Add shared spell tracking for troops

### DIFF
--- a/src/module/actor/creature/sheet.ts
+++ b/src/module/actor/creature/sheet.ts
@@ -243,19 +243,27 @@ abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends ActorSheet
         handlers["reset-spell-slots"] = (event): Promise<unknown> | void => {
             const row = htmlClosest(event.target, "[data-item-id]");
             const itemId = row?.dataset.itemId;
-            const item = actor.items.get(itemId, { strict: true });
+            const actors = actor.isOfType("npc") ? [actor, ...(actor.otherSegments ?? [])] : [actor];
+            const items = actors.flatMap((actor) => actor.items.contents.filter((item) => item.id === itemId));
 
-            if (item.isOfType("spellcastingEntry")) {
-                const { system } = item.toObject();
-                if (!system.slots) return;
+            if (items[0]?.isOfType("spellcastingEntry")) {
                 const groupNumber = spellSlotGroupIdToNumber(row?.dataset.groupId) || 0;
                 const propertyKey = goesToEleven(groupNumber) ? (`slot${groupNumber}` as const) : "slot0";
-                system.slots[propertyKey].value = system.slots[propertyKey].max;
-                return item.update({ system });
-            } else if (item.isOfType("spell")) {
-                const max = item.system.location.uses?.max;
-                if (!max) return;
-                return item.update({ "system.location.uses.value": max });
+                return Promise.all(
+                    items.map((item) => {
+                        if (!item.isOfType("spellcastingEntry") || !item.system.slots) return;
+                        const max = item.system.slots[propertyKey].max;
+                        return item.update({ [`system.slots.${propertyKey}.value`]: max });
+                    }),
+                );
+            } else if (items[0]?.isOfType("spell")) {
+                return Promise.all(
+                    items.map((item) => {
+                        if (!item.isOfType("spell")) return;
+                        const max = item.system.location.uses?.max;
+                        return max ? item.update({ "system.location.uses.value": max }) : undefined;
+                    }),
+                );
             }
         };
 

--- a/src/module/actor/creature/sheet.ts
+++ b/src/module/actor/creature/sheet.ts
@@ -244,24 +244,27 @@ abstract class CreatureSheetPF2e<TActor extends CreaturePF2e> extends ActorSheet
             const row = htmlClosest(event.target, "[data-item-id]");
             const itemId = row?.dataset.itemId;
             const actors = actor.isOfType("npc") ? [actor, ...(actor.otherSegments ?? [])] : [actor];
-            const items = actors.flatMap((actor) => actor.items.contents.filter((item) => item.id === itemId));
+            const items = actors.flatMap((actor) => {
+                const contents = actor.items.contents as unknown as ItemPF2e[];
+                return contents.filter((item) => item.id === itemId);
+            });
 
             if (items[0]?.isOfType("spellcastingEntry")) {
                 const groupNumber = spellSlotGroupIdToNumber(row?.dataset.groupId) || 0;
                 const propertyKey = goesToEleven(groupNumber) ? (`slot${groupNumber}` as const) : "slot0";
                 return Promise.all(
-                    items.map((item) => {
+                    items.map(async (item) => {
                         if (!item.isOfType("spellcastingEntry") || !item.system.slots) return;
                         const max = item.system.slots[propertyKey].max;
-                        return item.update({ [`system.slots.${propertyKey}.value`]: max });
+                        await item.update({ [`system.slots.${propertyKey}.value`]: max });
                     }),
                 );
             } else if (items[0]?.isOfType("spell")) {
                 return Promise.all(
-                    items.map((item) => {
+                    items.map(async (item) => {
                         if (!item.isOfType("spell")) return;
                         const max = item.system.location.uses?.max;
-                        return max ? item.update({ "system.location.uses.value": max }) : undefined;
+                        if (max) await item.update({ "system.location.uses.value": max });
                     }),
                 );
             }

--- a/src/module/actor/npc/document.ts
+++ b/src/module/actor/npc/document.ts
@@ -10,8 +10,10 @@ import { ActorInitiative } from "@actor/initiative.ts";
 import { Modifier, StatisticModifier } from "@actor/modifiers.ts";
 import type { MovementType } from "@actor/types.ts";
 import { SAVE_TYPES } from "@actor/values.ts";
+import type { DatabaseUpdateOperation, Document } from "@common/abstract/_module.d.mts";
 import type { UserAction } from "@common/constants.d.mts";
-import type { ItemPF2e, MeleePF2e } from "@item";
+import { ItemPF2e } from "@item";
+import type { MeleePF2e } from "@item";
 import type { ItemType } from "@item/types.ts";
 import { calculateDC } from "@module/dc.ts";
 import { RollNotePF2e } from "@module/notes.ts";
@@ -549,6 +551,9 @@ class NPCPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | nul
                 if (attributes.hp) update["system.attributes.hp"] = attributes.hp;
                 if ("adjustment" in attributes) update["system.attributes.adjustment"] = attributes.adjustment;
             }
+            if (changed.system.resources?.focus) {
+                update["system.resources.focus"] = changed.system.resources.focus;
+            }
             if (!R.isEmpty(update)) {
                 const damageTaken = options.damageTaken;
                 for (const actor of this.otherSegments) {
@@ -576,6 +581,48 @@ class NPCPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | nul
         super._onUpdate(changed, options, userId);
         for (const troop of this.otherSegments ?? []) {
             NPCPF2e.#resetBatch.reset(troop);
+        }
+    }
+
+    protected override _onUpdateDescendantDocuments(
+        parent: Document,
+        collection: string,
+        documents: Document<Document>[],
+        changes: Record<string, unknown>[],
+        options: DatabaseUpdateOperation<Document> & { fromTroop?: boolean },
+        userId: string,
+    ): void {
+        super._onUpdateDescendantDocuments(parent, collection, documents, changes, options, userId);
+        if (
+            this !== parent ||
+            collection !== "items" ||
+            options.fromTroop ||
+            game.user.id !== userId ||
+            !this.otherSegments
+        ) {
+            return;
+        }
+
+        for (const [index, document] of documents.entries()) {
+            if (!(document instanceof ItemPF2e) || !document.isOfType("spellcastingEntry")) continue;
+            const change = changes[index];
+            const slots = fu.getProperty(change, "system.slots");
+            if (!slots) {
+                continue;
+            }
+
+            for (const actor of this.otherSegments) {
+                const siblingEntry = actor.items.get(document.id);
+                if (siblingEntry?.isOfType("spellcastingEntry")) {
+                    actor.updateEmbeddedDocuments(
+                        "Item",
+                        [{ _id: document.id, system: { slots: fu.deepClone(slots) } }],
+                        { fromTroop: true } as Partial<DatabaseUpdateOperation<NPCPF2e>> & {
+                            fromTroop?: boolean;
+                        },
+                    );
+                }
+            }
         }
     }
 

--- a/src/module/actor/npc/document.ts
+++ b/src/module/actor/npc/document.ts
@@ -10,9 +10,8 @@ import { ActorInitiative } from "@actor/initiative.ts";
 import { Modifier, StatisticModifier } from "@actor/modifiers.ts";
 import type { MovementType } from "@actor/types.ts";
 import { SAVE_TYPES } from "@actor/values.ts";
-import type { DatabaseUpdateOperation, Document } from "@common/abstract/_module.d.mts";
 import type { UserAction } from "@common/constants.d.mts";
-import { ItemPF2e } from "@item";
+import type { ItemPF2e } from "@item";
 import type { MeleePF2e } from "@item";
 import type { ItemType } from "@item/types.ts";
 import { calculateDC } from "@module/dc.ts";
@@ -581,48 +580,6 @@ class NPCPF2e<TParent extends TokenDocumentPF2e | null = TokenDocumentPF2e | nul
         super._onUpdate(changed, options, userId);
         for (const troop of this.otherSegments ?? []) {
             NPCPF2e.#resetBatch.reset(troop);
-        }
-    }
-
-    protected override _onUpdateDescendantDocuments(
-        parent: Document,
-        collection: string,
-        documents: Document<Document>[],
-        changes: Record<string, unknown>[],
-        options: DatabaseUpdateOperation<Document> & { fromTroop?: boolean },
-        userId: string,
-    ): void {
-        super._onUpdateDescendantDocuments(parent, collection, documents, changes, options, userId);
-        if (
-            this !== parent ||
-            collection !== "items" ||
-            options.fromTroop ||
-            game.user.id !== userId ||
-            !this.otherSegments
-        ) {
-            return;
-        }
-
-        for (const [index, document] of documents.entries()) {
-            if (!(document instanceof ItemPF2e) || !document.isOfType("spellcastingEntry")) continue;
-            const change = changes[index];
-            const slots = fu.getProperty(change, "system.slots");
-            if (!slots) {
-                continue;
-            }
-
-            for (const actor of this.otherSegments) {
-                const siblingEntry = actor.items.get(document.id);
-                if (siblingEntry?.isOfType("spellcastingEntry")) {
-                    actor.updateEmbeddedDocuments(
-                        "Item",
-                        [{ _id: document.id, system: { slots: fu.deepClone(slots) } }],
-                        { fromTroop: true } as Partial<DatabaseUpdateOperation<NPCPF2e>> & {
-                            fromTroop?: boolean;
-                        },
-                    );
-                }
-            }
         }
     }
 

--- a/src/module/item/spellcasting-entry/document.ts
+++ b/src/module/item/spellcasting-entry/document.ts
@@ -334,11 +334,11 @@ class SpellcastingEntryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null>
             if (rank.between(1, 10)) {
                 const groupId = rank as SpellSlotGroupId;
                 await Promise.all(
-                    actors.map((actor) => {
+                    actors.map(async (actor) => {
                         const entry = getItem(actor, this.id);
-                        return entry?.isOfType("spellcastingEntry")
-                            ? entry.spells?.setSlotExpendedState(groupId, resolvedIndex, true)
-                            : undefined;
+                        if (entry?.isOfType("spellcastingEntry")) {
+                            await entry.spells?.setSlotExpendedState(groupId, resolvedIndex, true);
+                        }
                     }),
                 );
                 return true;
@@ -353,9 +353,11 @@ class SpellcastingEntryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null>
             }
             const uses = remainingUses - 1;
             await Promise.all(
-                actors.map((actor) => {
+                actors.map(async (actor) => {
                     const item = getItem(actor, spell.id);
-                    return item?.isOfType("spell") ? item.update({ "system.location.uses.value": uses }) : undefined;
+                    if (item?.isOfType("spell")) {
+                        await item.update({ "system.location.uses.value": uses });
+                    }
                 }),
             );
             return true;
@@ -367,11 +369,11 @@ class SpellcastingEntryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null>
         });
         if (slots.every((slot) => slot && slot.value > 0)) {
             await Promise.all(
-                actors.map((actor, index) => {
+                actors.map(async (actor, index) => {
                     const entry = getItem(actor, this.id);
-                    return entry?.isOfType("spellcastingEntry")
-                        ? entry.update({ [`system.slots.${slotKey}.value`]: slots[index]!.value - 1 })
-                        : undefined;
+                    if (entry?.isOfType("spellcastingEntry")) {
+                        await entry.update({ [`system.slots.${slotKey}.value`]: slots[index]!.value - 1 });
+                    }
                 }),
             );
             return true;

--- a/src/module/item/spellcasting-entry/document.ts
+++ b/src/module/item/spellcasting-entry/document.ts
@@ -273,6 +273,17 @@ class SpellcastingEntryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null>
         if (!actor?.isOfType("character", "npc")) {
             throw ErrorPF2e("Spellcasting entries require an actor");
         }
+        type ResourceActor = {
+            system: { resources: { focus?: { value?: number | null } } };
+            items: { contents: ItemPF2e[] };
+            update: (changes: Record<string, unknown>) => Promise<unknown>;
+        };
+        const actors: ResourceActor[] = [actor as unknown as ResourceActor];
+        if (actor.isOfType("npc")) {
+            actors.push(...((actor.otherSegments ?? []) as unknown as ResourceActor[]));
+        }
+        const getItem = (actor: ResourceActor, id: string): ItemPF2e | undefined =>
+            actor.items.contents.find((item) => item.id === id);
         const fpCost = spell.system.cast.focusPoints;
         if (this.isRitual || ((spell.isFocusSpell || spell.isCantrip) && fpCost === 0)) {
             return true;
@@ -280,9 +291,13 @@ class SpellcastingEntryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null>
         spell = spell.original ? spell.original : spell;
 
         if (actor.isOfType("character", "npc") && fpCost > 0) {
-            const currentPoints = actor.system.resources.focus?.value ?? 0;
-            if (currentPoints >= fpCost) {
-                await actor.update({ "system.resources.focus.value": currentPoints - fpCost });
+            const currentPoints = actors.map((actor) => actor.system.resources.focus?.value ?? 0);
+            if (currentPoints.every((points) => points >= fpCost)) {
+                await Promise.all(
+                    actors.map((actor, index) =>
+                        actor.update({ "system.resources.focus.value": currentPoints[index] - fpCost }),
+                    ),
+                );
                 return true;
             } else {
                 ui.notifications.warn(_loc("PF2E.Focus.NotEnoughFocusPointsError"));
@@ -318,7 +333,15 @@ class SpellcastingEntryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null>
 
             if (rank.between(1, 10)) {
                 const groupId = rank as SpellSlotGroupId;
-                return !!(await this.spells.setSlotExpendedState(groupId, resolvedIndex, true));
+                await Promise.all(
+                    actors.map((actor) => {
+                        const entry = getItem(actor, this.id);
+                        return entry?.isOfType("spellcastingEntry")
+                            ? entry.spells?.setSlotExpendedState(groupId, resolvedIndex, true)
+                            : undefined;
+                    }),
+                );
+                return true;
             }
         }
 
@@ -328,13 +351,29 @@ class SpellcastingEntryPF2e<TParent extends ActorPF2e | null = ActorPF2e | null>
                 ui.notifications.warn(_loc("PF2E.SpellSlotExpendedError", { spell: spell.name }));
                 return false;
             }
-            await spell.update({ "system.location.uses.value": remainingUses - 1 });
+            const uses = remainingUses - 1;
+            await Promise.all(
+                actors.map((actor) => {
+                    const item = getItem(actor, spell.id);
+                    return item?.isOfType("spell") ? item.update({ "system.location.uses.value": uses }) : undefined;
+                }),
+            );
             return true;
         }
 
-        const slots = this.system.slots[slotKey];
-        if (slots.value > 0) {
-            await this.update({ [`system.slots.${slotKey}.value`]: slots.value - 1 });
+        const slots = actors.map((actor) => {
+            const entry = getItem(actor, this.id);
+            return entry?.isOfType("spellcastingEntry") ? entry.system.slots?.[slotKey] : null;
+        });
+        if (slots.every((slot) => slot && slot.value > 0)) {
+            await Promise.all(
+                actors.map((actor, index) => {
+                    const entry = getItem(actor, this.id);
+                    return entry?.isOfType("spellcastingEntry")
+                        ? entry.update({ [`system.slots.${slotKey}.value`]: slots[index]!.value - 1 })
+                        : undefined;
+                }),
+            );
             return true;
         } else {
             const rank = game.i18n.lang === "de" ? rankLabel : rankLabel.toLocaleLowerCase(game.i18n.lang);


### PR DESCRIPTION
Troops are represented by up to four sibling tokens whose actor data is partially synchronized. The existing synchronization handles:
* HP
* Elite/weak adjustments

This change extends actor synchronization to include focus points and spell slots.

Fixes #22866 