### PR TITLE
Fix missing action variant inlines in Distracting Performance

### DIFF
--- a/packs/pf2e/feats/skill/level-2/distracting-performance.json
+++ b/packs/pf2e/feats/skill/level-2/distracting-performance.json
@@ -12,7 +12,7 @@
         },
         "category": "skill",
         "description": {
-            "value": "<p>Your performances are especially distracting, allowing your allies to @UUID[Compendium.pf2e.actionspf2e.Item.Sneak] away with ease. You [[/act create-a-diversion statistic=performance]], except you roll a Performance check instead of Deception, and the benefits of successful checks apply to an ally of your choice instead of you. The effects of a success last until the end of that ally's turn, and can end early based on the ally's actions. You don't need to be observing your ally or know where they are, but you need to know they're present to choose them.</p>"
+            "value": "<p>Your performances are especially distracting, allowing your allies to @UUID[Compendium.pf2e.actionspf2e.Item.Sneak] away with ease. You @UUID[Compendium.pf2e.actionspf2e.Item.Create a Diversion], except you roll a Performance check instead of Deception, and the benefits of successful checks apply to an ally of your choice instead of you. The effects of a success last until the end of that ally's turn, and can end early based on the ally's actions. You don't need to be observing your ally or know where they are, but you need to know they're present to choose them.</p>\n<p>[[/act create-a-diversion variant=distracting-words statistic=performance]]{Create a Diversion - Distracting Words}</p>\n<p>[[/act create-a-diversion variant=gesture statistic=performance]]{Create a Diversion - Gesture}</p>\n<p>[[/act create-a-diversion variant=trick statistic=performance]]{Create a Diversion - Trick}</p>"
         },
         "level": {
             "value": 2


### PR DESCRIPTION
- replace Create a Diversion inline that doesn't request a variant with compendium link
- include inlines for each Create a Diversion variant

Closes https://github.com/foundryvtt/pf2e/issues/23150