### PR TITLE
Apply inline check roll options to defense DCs

### DIFF
--- a/src/module/system/statistic/statistic.ts
+++ b/src/module/system/statistic/statistic.ts
@@ -492,7 +492,20 @@ class StatisticCheck<TParent extends Statistic = Statistic> {
         const originActor = rollContext.origin?.actor ?? self;
         const targetActor = rollContext.target?.actor ?? null;
         const selfActor = (selfIsTarget ? targetActor : originActor) ?? self;
-        const dc = typeof args.dc?.value === "number" ? args.dc : (rollContext?.dc ?? null);
+        const dc = ((): CheckDC | null => {
+            if (typeof args.dc?.value === "number") return args.dc;
+            if (!args.dc?.slug) return rollContext?.dc ?? null;
+            // Resolve a reference from the opposing actor's contextual clone, falling back to the actor itself
+            const { slug, label, modifiers = [] } = args.dc;
+            const opposingActor = selfIsTarget ? args.origin : args.target;
+            const baseStatistic =
+                rollContext?.dc?.statistic?.parent ??
+                opposingActor?.getStatistic(slug.replace(/-dc$/, ""))?.clone({ rollOptions: args.extraRollOptions });
+            const statistic = modifiers.length > 0 ? baseStatistic?.clone({ modifiers }).dc : baseStatistic?.dc;
+            if (!statistic) return null;
+            const scope = rollContext?.dc?.scope ?? (domains.includes("attack") ? "attack" : "check");
+            return { slug, label, scope, statistic, value: statistic.value };
+        })();
 
         // Extract modifiers, unless this is a flat check
         const extraModifiers =
@@ -755,6 +768,10 @@ class StatisticDifficultyClass<TParent extends Statistic = Statistic> {
 
 interface CheckDCReference {
     slug: string;
+    /** An optional label overriding the one derived from the slug */
+    label?: string;
+    /** Additional modifiers applied to the resolved DC statistic */
+    modifiers?: Modifier[];
     value?: never;
 }
 

--- a/src/module/system/text-editor.ts
+++ b/src/module/system/text-editor.ts
@@ -865,9 +865,13 @@ function getCheckDC({
     // We assume that we can actually display the dc if against is provided.
     // This function shouldn't be called otherwise.
     if (!params.dc && params.against && actor) {
-        const rollOptions = item?.isOfType("action", "feat")
-            ? [`origin:action:slug:${item.slug}`, ...item.getRollOptions("item")]
-            : [];
+        const rollOptions = R.unique([
+            ...(item?.isOfType("action", "feat")
+                ? [`origin:action:slug:${item.slug}`, ...item.getRollOptions("item")]
+                : []),
+            ...params.traits.map((t) => `item:trait:${t}`),
+            ...params.extraRollOptions,
+        ]);
         const statistic = actor.getStatistic(params.against)?.clone({ rollOptions });
         return String(statistic?.dc.value ?? 0);
     }

--- a/src/scripts/ui/inline-roll-links.ts
+++ b/src/scripts/ui/inline-roll-links.ts
@@ -11,7 +11,7 @@ import { calculateDC } from "@module/dc.ts";
 import { eventToRollParams } from "@module/sheet/helpers.ts";
 import { resolveActorAndItemFromHTML, resolveSheetDocument } from "@scripts/helpers.ts";
 import type { CheckDC } from "@system/degree-of-success.ts";
-import { Statistic, StatisticRollParameters } from "@system/statistic/index.ts";
+import { CheckDCReference, Statistic, StatisticRollParameters } from "@system/statistic/index.ts";
 import { TextEditorPF2e } from "@system/text-editor.ts";
 import { ErrorPF2e, getActionGlyph, htmlClosest, htmlQueryAll, sluggify, splitListString, tupleHasValue } from "@util";
 import { getSelectedActors } from "@util/token-actor-utils.ts";
@@ -246,42 +246,44 @@ export class InlineRollLinks {
                     ? (itemFromDoc as ItemPF2e<ActorPF2e>)
                     : null;
 
-            const dc = ((): CheckDC | null => {
+            // Defense DCs are passed by reference so the roll resolves them from the opposing actor's contextual clone
+            const dc = ((): CheckDC | CheckDCReference | null => {
                 const dcValue = pf2Dc === "@self.level" ? calculateDC(rollingActor.level) : Number(pf2Dc ?? "NaN");
                 const adjustment = Number(pf2Adjustment) || 0;
 
                 if (Number.isInteger(dcValue)) {
                     return { label: pf2Label, value: dcValue + adjustment };
                 } else if (against) {
-                    const defenseStat = opposingActor?.getStatistic(against)?.clone({
+                    const defenseStat = opposingActor?.getStatistic(against);
+                    if (!defenseStat) return null;
+                    return {
+                        slug: against,
+                        label: defenseStat.dc.label ?? _loc("PF2E.InlineCheck.DCWithName", { name: defenseStat.label }),
                         modifiers: adjustment
                             ? [new Modifier({ label: "PF2E.InlineCheck.DCAdjustment", modifier: adjustment })]
                             : [],
-                        rollOptions: [
-                            item?.isOfType("action", "feat") ? `${opposingRole}:action:slug:${item.slug}` : null,
-                        ].filter(R.isTruthy),
-                    });
-                    if (defenseStat) {
-                        return {
-                            label:
-                                defenseStat.dc.label ??
-                                _loc("PF2E.InlineCheck.DCWithName", { name: defenseStat.label }),
-                            statistic: defenseStat.dc,
-                            scope: "check",
-                            value: defenseStat.dc.value,
-                        };
-                    }
+                    };
                 }
 
                 return null;
             })();
 
+            const rollOptions = R.unique(
+                [
+                    extraRollOptions,
+                    item?.isOfType("action", "feat")
+                        ? `${opposingRole}:action:slug:${item.slug ?? sluggify(item.name)}`
+                        : null,
+                ]
+                    .flat()
+                    .filter(R.isTruthy),
+            );
             const args: StatisticRollParameters = {
                 ...eventRollParams,
-                extraRollOptions,
+                extraRollOptions: rollOptions,
                 origin: originActor,
                 dc,
-                target: dc?.statistic ? targetActor : null,
+                target: dc && "slug" in dc ? targetActor : null,
                 item,
                 traits: abilityTraits,
             };
@@ -304,7 +306,7 @@ export class InlineRollLinks {
                         title: item.name,
                     },
                 );
-                extraRollOptions.push(...TextEditorPF2e.createActionOptions(item));
+                rollOptions.push(...TextEditorPF2e.createActionOptions(item));
             }
 
             statistic.roll(args);


### PR DESCRIPTION
- Closes #20775
- Supersedes #21820

Inline checks with a defense statistic computed the DC from a static clone, so predicated DC modifiers couldn't get the check's roll options. The DC is now resolved during the roll from the opposing actor's contextual clone, same as action macros, so it also picks up origin options, distance, and ephemeral effects.