### PR TITLE
Allow Strike RE for PC's to use own or fixed attack modifier

### DIFF
--- a/src/module/rules/helpers.ts
+++ b/src/module/rules/helpers.ts
@@ -309,6 +309,44 @@ function processChoicesFromData(data: unknown): PickableThing<string>[] {
     return [];
 }
 
+/** Status/circumstance bonuses, non-ability penalties, and battle-form slugs apply on both sides of a fixed-vs-own comparison. */
+function isSharedStatisticModifier(modifier: Modifier): boolean {
+    if (modifier.slug === "battle-form") return true;
+    if (modifier.type === "ability") return false;
+    return ["status", "circumstance"].includes(modifier.type) || modifier.modifier < 0;
+}
+
+/** Whether a listed/fixed modifier should replace the actor's own statistic. */
+function useFixedStatisticModifier({
+    fixed,
+    own,
+    modifiers,
+    ownIfHigher,
+}: {
+    fixed: number;
+    own: number;
+    modifiers: readonly Modifier[];
+    ownIfHigher: boolean;
+}): boolean {
+    const shared = modifiers
+        .filter((m) => m.enabled && isSharedStatisticModifier(m))
+        .reduce((sum, m) => sum + m.modifier, 0);
+    return !ownIfHigher || fixed + shared >= own;
+}
+
+/** Disable ineligible statistic modifiers that do not apply on top of a fixed value. */
+function suppressUnsharedModifiers(statistic: { modifiers: readonly Modifier[] }): void {
+    for (const modifier of statistic.modifiers) {
+        if (isSharedStatisticModifier(modifier)) continue;
+        modifier.adjustments.push({ slug: null, test: () => true, suppress: true });
+        modifier.ignored = true;
+        modifier.enabled = false;
+    }
+    if (statistic instanceof StatisticModifier) {
+        statistic.calculateTotal();
+    }
+}
+
 export {
     createBatchRuleElementUpdate,
     extractDamageAlterations,
@@ -320,7 +358,10 @@ export {
     extractNotes,
     extractRollSubstitutions,
     extractRollTwice,
+    isSharedStatisticModifier,
     processChoicesFromData,
     processDamageCategoryStacking,
     processPreUpdateActorHooks,
+    suppressUnsharedModifiers,
+    useFixedStatisticModifier,
 };

--- a/src/module/rules/rule-element/battle-form/rule-element.ts
+++ b/src/module/rules/rule-element/battle-form/rule-element.ts
@@ -2,7 +2,7 @@ import type { ActorType, CharacterPF2e } from "@actor";
 import { CharacterAttack } from "@actor/character/data.ts";
 import { SENSE_TYPES } from "@actor/creature/values.ts";
 import { ActorInitiative } from "@actor/initiative.ts";
-import { DamageDicePF2e, Modifier, StatisticModifier } from "@actor/modifiers.ts";
+import { DamageDicePF2e, Modifier } from "@actor/modifiers.ts";
 import { MOVEMENT_TYPES } from "@actor/values.ts";
 import { WeaponPF2e } from "@item";
 import { RollNotePF2e } from "@module/notes.ts";
@@ -11,6 +11,7 @@ import { RecordField } from "@system/schema-data-fields.ts";
 import { LandSpeedStatisticTraceData, SpeedStatistic } from "@system/statistic/speed.ts";
 import { objectHasKey, setHasElement, sluggify, tupleHasValue } from "@util";
 import * as R from "remeda";
+import { isSharedStatisticModifier, suppressUnsharedModifiers, useFixedStatisticModifier } from "../../helpers.ts";
 import { RuleElement } from "../base.ts";
 import { CreatureSizeRuleElement } from "../creature-size.ts";
 import { ModelPropsFromRESchema, ResolvableValueField, RuleElementSource } from "../data.ts";
@@ -223,15 +224,15 @@ class BattleFormRuleElement extends RuleElement<BattleFormRuleSchema> {
         const acOverride = Number(this.resolveValue(overrides.armorClass.modifier, armorClass.value)) || 0;
         if (!acOverride) return;
 
-        const useForm = this.#useFormModifier({
-            form: acOverride,
+        const useForm = useFixedStatisticModifier({
+            fixed: acOverride,
             own: armorClass.value,
             modifiers: armorClass.modifiers,
             ownIfHigher: overrides.armorClass.ownIfHigher,
         });
         if (!useForm) return;
 
-        this.#suppressModifiers(armorClass);
+        suppressUnsharedModifiers(armorClass);
         const newModifier = (Number(this.resolveValue(overrides.armorClass.modifier)) || 0) - 10;
         armorClass.modifiers.push(new Modifier(this.modifierLabel, newModifier, "untyped"));
         actor.system.attributes.ac = fu.mergeObject(actor.system.attributes.ac, armorClass.parent.getTraceData());
@@ -267,8 +268,8 @@ class BattleFormRuleElement extends RuleElement<BattleFormRuleSchema> {
 
             const currentSkill = actor.skills[key];
             const newModifier = Number(this.resolveValue(newSkill.modifier)) || 0;
-            const useForm = this.#useFormModifier({
-                form: newModifier,
+            const useForm = useFixedStatisticModifier({
+                fixed: newModifier,
                 own: currentSkill.mod,
                 modifiers: currentSkill.check.modifiers,
                 ownIfHigher: newSkill.ownIfHigher,
@@ -282,7 +283,7 @@ class BattleFormRuleElement extends RuleElement<BattleFormRuleSchema> {
                 type: "untyped",
             });
 
-            actor.skills[key] = currentSkill.extend({ modifiers: [baseMod], filter: this.#filterModifier });
+            actor.skills[key] = currentSkill.extend({ modifiers: [baseMod], filter: isSharedStatisticModifier });
             actor.system.skills[key] = fu.mergeObject(actor.system.skills[key], actor.skills[key].getTraceData());
         }
     }
@@ -353,15 +354,15 @@ class BattleFormRuleElement extends RuleElement<BattleFormRuleSchema> {
         for (const action of strikeActions) {
             const strike = strikes[action.slug ?? ""];
             if (!strike || action.type !== "strike") continue;
-            const useForm = this.#useFormModifier({
-                form: Number(this.resolveValue(strike.modifier)),
+            const useForm = useFixedStatisticModifier({
+                fixed: Number(this.resolveValue(strike.modifier)),
                 own: action.totalModifier,
                 modifiers: action.modifiers,
                 ownIfHigher: !!strike.ownIfHigher,
             });
             if (!this.ownUnarmed && useForm) {
                 // Replace inapplicable attack-roll modifiers with the battle form's
-                this.#suppressModifiers(action);
+                suppressUnsharedModifiers(action);
                 this.#suppressNotes(
                     Object.entries(synthetics.rollNotes).flatMap(([key, note]) => (/\bdamage\b/.test(key) ? note : [])),
                 );
@@ -413,45 +414,9 @@ class BattleFormRuleElement extends RuleElement<BattleFormRuleSchema> {
             }
 
             const statistic = new SpeedStatistic(actor, { type, base: speedOverride });
-            this.#suppressModifiers(statistic);
+            suppressUnsharedModifiers(statistic);
             actor.system.movement.speeds[type] = statistic.getTraceData() as LandSpeedStatisticTraceData;
         }
-    }
-
-    /** Disable ineligible check modifiers */
-    #suppressModifiers(statistic: { modifiers: readonly Modifier[] }): void {
-        for (const modifier of statistic.modifiers) {
-            if (!this.#filterModifier(modifier)) {
-                modifier.adjustments.push({ slug: null, test: () => true, suppress: true });
-                modifier.ignored = true;
-                modifier.enabled = false;
-            }
-        }
-        if (statistic instanceof StatisticModifier) {
-            statistic.calculateTotal();
-        }
-    }
-
-    #filterModifier(modifier: Modifier) {
-        if (modifier.slug === "battle-form") return true;
-        if (modifier.type === "ability") return false;
-        return ["status", "circumstance"].includes(modifier.type) || modifier.modifier < 0;
-    }
-
-    /**
-     * Whether the battle form's fixed modifier should replace the actor's own statistic: modifiers that apply on
-     * top of the form's modifier (status penalties, etc.) count on both sides of the comparison.
-     */
-    #useFormModifier(args: {
-        form: number;
-        own: number;
-        modifiers: readonly Modifier[];
-        ownIfHigher: boolean;
-    }): boolean {
-        const shared = args.modifiers
-            .filter((m) => m.enabled && this.#filterModifier(m))
-            .reduce((sum, m) => sum + m.modifier, 0);
-        return !args.ownIfHigher || args.form + shared >= args.own;
     }
 
     #suppressNotes(notes: RollNotePF2e[]): void {

--- a/src/module/rules/rule-element/strike.ts
+++ b/src/module/rules/rule-element/strike.ts
@@ -1,4 +1,6 @@
 import type { ActorPF2e, ActorType, CharacterPF2e, NPCPF2e } from "@actor";
+import type { CharacterStrike } from "@actor/character/data.ts";
+import { Modifier } from "@actor/modifiers.ts";
 import type { ImageFilePath } from "@common/constants.d.mts";
 import { WeaponPF2e } from "@item";
 import { performLatePreparation } from "@item/helpers.ts";
@@ -15,6 +17,7 @@ import type {
 import type { OneToTwo } from "@module/data.ts";
 import type { DamageDieSize, DamageType } from "@system/damage/index.ts";
 import { objectHasKey, sluggify } from "@util";
+import { suppressUnsharedModifiers, useFixedStatisticModifier } from "../helpers.ts";
 import { RuleElement, RuleElementOptions } from "./base.ts";
 import type { BattleFormSource } from "./battle-form/types.ts";
 import { ModelPropsFromRESchema, ResolvableValueField, RuleElementSchema, RuleElementSource } from "./data.ts";
@@ -136,6 +139,7 @@ class StrikeRuleElement extends RuleElement<StrikeSchema> {
                         : `systems/${SYSTEM_ID}/icons/default-icons/melee.svg`,
             }),
             attackModifier: new fields.NumberField({ integer: true, positive: true, nullable: true, initial: null }),
+            ownIfHigher: new fields.BooleanField({ required: false, nullable: false, initial: true }),
             replaceAll: new fields.BooleanField({ required: false, nullable: false, initial: undefined }),
             replaceBasicUnarmed: new fields.BooleanField({ required: false, nullable: false, initial: undefined }),
             battleForm: new fields.BooleanField({ required: false, nullable: false, initial: undefined }),
@@ -190,7 +194,7 @@ class StrikeRuleElement extends RuleElement<StrikeSchema> {
         this.actor.synthetics.strikes[slug] = (unarmedRunes) => this.#constructWeapon({ slug, unarmedRunes });
     }
 
-    /** Exclude other strikes if this rule element specifies that its strike replaces all others */
+    /** Exclude other strikes if specified, then apply a PC fixed attack modifier if present */
     override afterPrepareData(): void {
         if (this.ignored || !this.actor.isOfType("character")) return;
 
@@ -210,6 +214,31 @@ class StrikeRuleElement extends RuleElement<StrikeSchema> {
         } else if (this.replaceBasicUnarmed) {
             const systemData = this.actor.system;
             systemData.actions.findSplice((a) => a.item?.slug === "basic-unarmed");
+        }
+
+        const attackModifier = this.attackModifier;
+        if (!attackModifier) return;
+
+        const actions = this.actor.system.actions.flatMap((action) =>
+            [action, ...(action.altUsages ?? [])].filter(
+                (a): a is CharacterStrike => a.type === "strike" && a.item.rule === this,
+            ),
+        );
+        for (const action of actions) {
+            const useFixed = useFixedStatisticModifier({
+                fixed: attackModifier,
+                own: action.totalModifier,
+                modifiers: action.modifiers,
+                ownIfHigher: this.ownIfHigher,
+            });
+            if (!useFixed) continue;
+
+            suppressUnsharedModifiers(action);
+            action.unshift(new Modifier(this.getReducedLabel(this.item.name), attackModifier, "untyped"));
+            action.breakdown = action.modifiers
+                .filter((m) => m.enabled)
+                .map((m) => `${m.label} ${m.signedValue}`)
+                .join(", ");
         }
     }
 
@@ -366,10 +395,12 @@ type StrikeSchema = RuleElementSchema & {
         true
     >;
     /**
-     * A fixed attack modifier: usable only if the strike is generated for an NPC
+     * A fixed attack modifier: for NPCs this becomes the strike's attack bonus; for PCs it replaces base
+     * attack-roll modifiers unless the character's own modifier is greater (`ownIfHigher`, default true)
      * Also causes the damage to not be recalculated when converting the resulting weapon to an NPC attack
      */
     attackModifier: fields.NumberField<number, number, false, true, true>;
+    ownIfHigher: fields.BooleanField<boolean, boolean, false, false, true>;
     range: fields.SchemaField<
         {
             increment: fields.NumberField<number, number, false, true, true>;


### PR DESCRIPTION
- Closes https://github.com/foundryvtt/pf2e/issues/23172

Uses own attack modifier if higher by default, ownIfHigher allows to enforce the value from attackModifier