### PR TITLE
Fix Overflowing's bonus type

### DIFF
--- a/packs/pf2e/feat-effects/effect-overflowing.json
+++ b/packs/pf2e/feat-effects/effect-overflowing.json
@@ -37,6 +37,7 @@
                 "selector": [
                     "saving-throw"
                 ],
+                "type": "status",
                 "value": "ternary(gte(@actor.level,15),2,1)"
             }
         ],


### PR DESCRIPTION
- Closes https://github.com/foundryvtt/pf2e/issues/23205